### PR TITLE
thyra: remove excessive indentation in parameters output

### DIFF
--- a/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_SolveSupportTypes.hpp
+++ b/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_SolveSupportTypes.hpp
@@ -472,7 +472,7 @@ std::ostream& operator<<( std::ostream& out_arg, const SolveStatus<Scalar> &solv
   if(solveStatus.extraParameters.get()) {
     *out << "\n";
     Teuchos::OSTab tab3(out);
-    solveStatus.extraParameters->print(*out, 1000, true);
+    solveStatus.extraParameters->print(*out, 10, true);
   }
   else {
     *out << " NONE\n";


### PR DESCRIPTION
Fixes Sandia bug https://software.sandia.gov/bugzilla/show_bug.cgi?id=6401.