### PR TITLE
stk: fix underlinking in two stkclassic libraries

### DIFF
--- a/packages/stk/stk_classic/stk_util/stk_util/environment/CMakeLists.txt
+++ b/packages/stk/stk_classic/stk_util/stk_util/environment/CMakeLists.txt
@@ -75,7 +75,7 @@ ENDIF()
 
 TRIBITS_ADD_LIBRARY(
   stkclassic_util_env
-  DEPLIBS stkclassic_util_util
+  DEPLIBS stkclassic_util_util stkclassic_util_parallel
   NOINSTALLHEADERS ${HEADERS}
   SOURCES ${SOURCES}
   )

--- a/packages/stk/stk_classic/stk_util/stk_util/unit_test_support/CMakeLists.txt
+++ b/packages/stk/stk_classic/stk_util/stk_util/unit_test_support/CMakeLists.txt
@@ -46,7 +46,7 @@ ENDIF()
 TRIBITS_ADD_LIBRARY(
   stkclassic_util_unit_test_support
   NOINSTALLHEADERS ${HEADERS}
-  DEPLIBS 
+  DEPLIBS stkclassic_util_util
   SOURCES ${SOURCES}
   )
 


### PR DESCRIPTION
Revealed by `-Wl,--no-undefined`, e.g.,

```
cmake \
  -DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_SHARED_LINKER_FLAGS -Wl,--no-undefined" \
  -DBUILD_SHARED_LIBS:BOOL=ON \
  -DTrilinos_ENABLE_Panzer:BOOL=ON \
  -DTPL_ENABLE_MPI:BOOL=ON \
  -DTrilinos_ENABLE_TESTS:BOOL=ON \
  -DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
  -DSEACASExodus_ENABLE_MPI:BOOL=OFF \
  ../../source-upstream/
```

```
[...]
Linking CXX shared library libstkclassic_util_env.so
CMakeFiles/stkclassic_util_env.dir/RuntimeMessage.cpp.o: In function `stk_classic::aggregate_messages(ompi_communicator_t*, std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >&, char const*)':
RuntimeMessage.cpp:(.text+0x4369): undefined reference to `stk_classic::parallel_machine_size(ompi_communicator_t*)'
RuntimeMessage.cpp:(.text+0x4374): undefined reference to `stk_classic::parallel_machine_rank(ompi_communicator_t*)'
CMakeFiles/stkclassic_util_env.dir/RuntimeMessage.cpp.o: In function `stk_classic::report_deferred_messages(ompi_communicator_t*)':
RuntimeMessage.cpp:(.text+0x6505): undefined reference to `stk_classic::parallel_machine_size(ompi_communicator_t*)'
RuntimeMessage.cpp:(.text+0x6511): undefined reference to `stk_classic::parallel_machine_rank(ompi_communicator_t*)'
```
