### PR TITLE
Xpetra: `rm -rf html`

### DIFF
--- a/packages/xpetra/doc/build_docs
+++ b/packages/xpetra/doc/build_docs
@@ -3,7 +3,7 @@
 # Remove the directories to make sure that we don't have rebuild problems
 # that can sometimes happen with doxygen
 
-rm -r html
+rm -rf html
 
 # Create new directories manually since the doxygen exe under windows
 # seems to be messing this up.


### PR DESCRIPTION
Makes sure the script doesn't fail if `html` isn't present.