### PR TITLE
Epetra Package Warning Fixes.

### DIFF
--- a/packages/epetra/test/BasicPerfTest_LL/cxx_main.cpp
+++ b/packages/epetra/test/BasicPerfTest_LL/cxx_main.cpp
@@ -742,10 +742,10 @@ void GenerateVbrProblem(int numNodesX, int numNodesY, int numProcsX, int numProc
   map = new Epetra_BlockMap((long long)-1, numMyElements, ptMap.MyGlobalElements64(), elementSizes.Values(),
 			    ptMap.IndexBase64(), ptMap.Comm());
 
-  int profile = 0; if (StaticProfile) profile = numPoints;
 
 // FIXME: Won't compile until Epetra_VbrMatrix is modified.
 #if 0
+  int profile = 0; if (StaticProfile) profile = numPoints;
   int j;
   long long numGlobalEquations = ptMap.NumGlobalElements64();
 

--- a/packages/epetra/test/Bugs/Bug_6079_DistObject_CombineMode_flags/cxx_main.cpp
+++ b/packages/epetra/test/Bugs/Bug_6079_DistObject_CombineMode_flags/cxx_main.cpp
@@ -93,7 +93,7 @@ void test ()
   v_ghosted.PutScalar(1.);
 
   Epetra_Import data_exchange (v_distributed.Map(), v_ghosted.Map());
-  int ierr = v_distributed.Import(v_ghosted, data_exchange, Epetra_AddLocalAlso);
+  v_distributed.Import(v_ghosted, data_exchange, Epetra_AddLocalAlso);
  
   std::cout << "Distributed:" << std::endl;
   for (int i=begin_index; i<end_index; ++i)

--- a/packages/epetra/test/FusedImportExport/cxx_main.cpp
+++ b/packages/epetra/test/FusedImportExport/cxx_main.cpp
@@ -169,7 +169,7 @@ int build_matrix_unfused(const Epetra_CrsMatrix & SourceMatrix, Epetra_Export & 
 
 
 
-int build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *&A){
+void build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *&A){
   int NumProc = Comm.NumProc();
   int MyPID   = Comm.MyPID();
 
@@ -242,7 +242,6 @@ int build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *
     delete [] Indices;
 
   }
-  return 0;
 }
 
 
@@ -268,7 +267,7 @@ void build_test_map(const Epetra_Map & oldMap, Epetra_Map *& newMap) {
 
 int main(int argc, char *argv[])
 {
-  int ierr = 0, total_err=0;
+  int total_err=0;
 
   // Initialize MPI
 
@@ -320,7 +319,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_1
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     int num_global = A->RowMap().NumGlobalElements();
 
     // New map with all on Proc1
@@ -359,7 +358,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_2
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     int num_local = A->RowMap().NumMyElements();
 
     std::vector<int> MyGIDS(num_local);
@@ -400,7 +399,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_3
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     int num_local  = A->RowMap().NumMyElements();
     int num_global = A->RowMap().NumGlobalElements();
     int num_scansum = 0;
@@ -446,7 +445,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_4
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
 
     // Assume we always own the diagonal
     int num_local = A->NumMyCols()-A->NumMyRows();
@@ -499,7 +498,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_5
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
 
     // New map with all on Procs 0 and 2
     build_test_map(A->RowMap(),Map1);
@@ -536,7 +535,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_6
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
 
     // New map with all on Procs 0 and 2
     build_test_map(A->RowMap(),Map1);

--- a/packages/epetra/test/FusedImportExport_LL/cxx_main.cpp
+++ b/packages/epetra/test/FusedImportExport_LL/cxx_main.cpp
@@ -166,7 +166,7 @@ int build_matrix_unfused(const Epetra_CrsMatrix & SourceMatrix, Epetra_Export & 
 
 
 
-int build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *&A){
+void build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *&A){
   int NumProc = Comm.NumProc();
   int MyPID   = Comm.MyPID();
 
@@ -239,7 +239,6 @@ int build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *
     delete [] Indices;
 
   }
-  return 0;
 }
 
 
@@ -247,7 +246,7 @@ int build_test_matrix(Epetra_MpiComm & Comm, int test_number, Epetra_CrsMatrix *
 
 int main(int argc, char *argv[])
 {
-  int ierr = 0, total_err=0;
+  int total_err=0;
 
   // Initialize MPI
 
@@ -299,7 +298,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_1
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     long long num_global = A->RowMap().NumGlobalElements64();
 
     // New map with all on Proc1
@@ -338,7 +337,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_2
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     int num_local = A->RowMap().NumMyElements();
 
     std::vector<long long> MyGIDS(num_local);
@@ -379,7 +378,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_3
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     int num_local  = A->RowMap().NumMyElements();
     long long num_global = A->RowMap().NumGlobalElements64();
     int num_scansum = 0;
@@ -424,7 +423,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_4
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
 
     // Assume we always own the diagonal
     int num_local = A->NumMyCols()-A->NumMyRows();
@@ -476,7 +475,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_5
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     long long num_global = A->RowMap().NumGlobalElements64();
 
     // New map with all on Proc1
@@ -515,7 +514,7 @@ int main(int argc, char *argv[])
 #ifdef ENABLE_TEST_6
   {
     double diff;
-    ierr=build_test_matrix(Comm,1,A);
+    build_test_matrix(Comm,1,A);
     long long num_global = A->RowMap().NumGlobalElements64();
 
     // New map with all on Proc1

--- a/packages/epetra/test/IntSerialDense/cxx_main.cpp
+++ b/packages/epetra/test/IntSerialDense/cxx_main.cpp
@@ -450,7 +450,6 @@ int matrixExceptions(bool verbose, bool debug) {
 	int returnierr = 0;
 	int ierr = 0;
 	bool caught = false;
-	Epetra_IntSerialDenseMatrix* matrix;
 
 	if(verbose) printHeading("Testing matrix error-reporting.\nExpect error messages if EPETRA_NO_ERROR_REPORTS is not defined.");
 	
@@ -458,7 +457,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "Checking Epetra_IntSerialDenseMatrix(-1, 6) - invalid rows";
-		matrix = new Epetra_IntSerialDenseMatrix(-1, 6);
+		new Epetra_IntSerialDenseMatrix(-1, 6);
 	}
 	catch(int error) {
 		caught = true;
@@ -470,7 +469,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(3, -5) - invalid cols";
-		matrix = new Epetra_IntSerialDenseMatrix(3, -5);
+		new Epetra_IntSerialDenseMatrix(3, -5);
 	}
 	catch(int error) {
 		caught = true;
@@ -485,7 +484,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, int*, -1, 2, 2) - invalid lda";
-		matrix = new Epetra_IntSerialDenseMatrix(Copy, rand2, -1, 2, 2);
+		new Epetra_IntSerialDenseMatrix(Copy, rand2, -1, 2, 2);
 	}
 	catch(int error) {
 		caught = true;
@@ -497,7 +496,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, int*, 3, -2, 3) - invalid rows";
-		matrix = new Epetra_IntSerialDenseMatrix(Copy, rand2, 3, -2, 3);
+		new Epetra_IntSerialDenseMatrix(Copy, rand2, 3, -2, 3);
 	}
 	catch(int error) {
 		caught = true;
@@ -509,7 +508,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, int*, 4, 4, -4) - invalid cols";
-		matrix = new Epetra_IntSerialDenseMatrix(Copy, rand2, -4, 4, -4);
+		new Epetra_IntSerialDenseMatrix(Copy, rand2, -4, 4, -4);
 	}
 	catch(int error) {
 		caught = true;
@@ -524,7 +523,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, 0, 5, 5, 5) - null pointer";
-		matrix = new Epetra_IntSerialDenseMatrix(Copy, 0, 5, 5, 5);
+		new Epetra_IntSerialDenseMatrix(Copy, 0, 5, 5, 5);
 	}
 	catch(int error) {
 		caught = true;
@@ -1322,14 +1321,13 @@ int vectorExceptions(bool verbose, bool debug) {
 	int returnierr = 0;
 	int ierr = 0;
 	bool caught = false;
-	Epetra_IntSerialDenseVector* vector;
 
 	if(verbose) printHeading("Testing vector error-reporting.\nExpect error messages if EPETRA_NO_ERROR_REPORTS is not defined.");
 	
 	try { // invalid dimension to sized ctr
 		caught = false;
 		if(verbose) cout << "Checking Epetra_IntSerialDenseVector(-1)";
-		vector = new Epetra_IntSerialDenseVector(-1);
+		new Epetra_IntSerialDenseVector(-1);
 	}
 	catch(int error) {
 		caught = true;
@@ -1343,7 +1341,7 @@ int vectorExceptions(bool verbose, bool debug) {
 	try { // invalid dimension to user-data ctr
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseVector(Copy, int*, -3)";
-		vector = new Epetra_IntSerialDenseVector(Copy, rand2, -3);
+		new Epetra_IntSerialDenseVector(Copy, rand2, -3);
 	}
 	catch(int error) {
 		caught = true;
@@ -1357,7 +1355,7 @@ int vectorExceptions(bool verbose, bool debug) {
 	try { // null pointer to user-data ctr
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseVector(Copy, 0, 5)";
-		vector = new Epetra_IntSerialDenseVector(Copy, 0, 5);
+		new Epetra_IntSerialDenseVector(Copy, 0, 5);
 	}
 	catch(int error) {
 		caught = true;

--- a/packages/epetra/test/IntSerialDense/cxx_main.cpp
+++ b/packages/epetra/test/IntSerialDense/cxx_main.cpp
@@ -450,6 +450,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	int returnierr = 0;
 	int ierr = 0;
 	bool caught = false;
+	Epetra_IntSerialDenseMatrix* matrix;
 
 	if(verbose) printHeading("Testing matrix error-reporting.\nExpect error messages if EPETRA_NO_ERROR_REPORTS is not defined.");
 	
@@ -457,7 +458,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "Checking Epetra_IntSerialDenseMatrix(-1, 6) - invalid rows";
-		new Epetra_IntSerialDenseMatrix(-1, 6);
+		matrix = new Epetra_IntSerialDenseMatrix(-1, 6);
 	}
 	catch(int error) {
 		caught = true;
@@ -469,7 +470,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(3, -5) - invalid cols";
-		new Epetra_IntSerialDenseMatrix(3, -5);
+		matrix = new Epetra_IntSerialDenseMatrix(3, -5);
 	}
 	catch(int error) {
 		caught = true;
@@ -484,7 +485,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, int*, -1, 2, 2) - invalid lda";
-		new Epetra_IntSerialDenseMatrix(Copy, rand2, -1, 2, 2);
+		matrix = new Epetra_IntSerialDenseMatrix(Copy, rand2, -1, 2, 2);
 	}
 	catch(int error) {
 		caught = true;
@@ -496,7 +497,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, int*, 3, -2, 3) - invalid rows";
-		new Epetra_IntSerialDenseMatrix(Copy, rand2, 3, -2, 3);
+		matrix = new Epetra_IntSerialDenseMatrix(Copy, rand2, 3, -2, 3);
 	}
 	catch(int error) {
 		caught = true;
@@ -508,7 +509,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, int*, 4, 4, -4) - invalid cols";
-		new Epetra_IntSerialDenseMatrix(Copy, rand2, -4, 4, -4);
+		matrix = new Epetra_IntSerialDenseMatrix(Copy, rand2, -4, 4, -4);
 	}
 	catch(int error) {
 		caught = true;
@@ -523,7 +524,7 @@ int matrixExceptions(bool verbose, bool debug) {
 	try {
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseMatrix(Copy, 0, 5, 5, 5) - null pointer";
-		new Epetra_IntSerialDenseMatrix(Copy, 0, 5, 5, 5);
+		matrix = new Epetra_IntSerialDenseMatrix(Copy, 0, 5, 5, 5);
 	}
 	catch(int error) {
 		caught = true;
@@ -660,7 +661,7 @@ int matrixExceptions(bool verbose, bool debug) {
 			if(verbose) cout << "Checked OK." << endl;
 	}
 	EPETRA_TEST_ERR(!caught, returnierr);
-	
+  if (matrix != NULL) delete matrix;	
 	return(returnierr);
 }
 
@@ -1321,13 +1322,14 @@ int vectorExceptions(bool verbose, bool debug) {
 	int returnierr = 0;
 	int ierr = 0;
 	bool caught = false;
+	Epetra_IntSerialDenseVector* vector;
 
 	if(verbose) printHeading("Testing vector error-reporting.\nExpect error messages if EPETRA_NO_ERROR_REPORTS is not defined.");
 	
 	try { // invalid dimension to sized ctr
 		caught = false;
 		if(verbose) cout << "Checking Epetra_IntSerialDenseVector(-1)";
-		new Epetra_IntSerialDenseVector(-1);
+		vector = new Epetra_IntSerialDenseVector(-1);
 	}
 	catch(int error) {
 		caught = true;
@@ -1341,7 +1343,7 @@ int vectorExceptions(bool verbose, bool debug) {
 	try { // invalid dimension to user-data ctr
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseVector(Copy, int*, -3)";
-		new Epetra_IntSerialDenseVector(Copy, rand2, -3);
+		vector = new Epetra_IntSerialDenseVector(Copy, rand2, -3);
 	}
 	catch(int error) {
 		caught = true;
@@ -1355,7 +1357,7 @@ int vectorExceptions(bool verbose, bool debug) {
 	try { // null pointer to user-data ctr
 		caught = false;
 		if(verbose) cout << "\nChecking Epetra_IntSerialDenseVector(Copy, 0, 5)";
-		new Epetra_IntSerialDenseVector(Copy, 0, 5);
+		vector = new Epetra_IntSerialDenseVector(Copy, 0, 5);
 	}
 	catch(int error) {
 		caught = true;
@@ -1440,7 +1442,7 @@ int vectorExceptions(bool verbose, bool debug) {
 #endif // end of HAVE_EPETRA_ARRAY_BOUNDS_CHECK conditional
 
 	// we don't need to check for ISDV = ISDM, as that is a compile-time error
-	
+  if (vector != NULL) delete vector;	
 	return(returnierr);
 }
 


### PR DESCRIPTION
<h3> Applied patch 0001-Epetra-Package-Warning-Fixes </h3>

<h5> Attention: </h5>
@jwillenbring 
@trilinos/epetra 

 - Removed unused variables.
 - Changed functions to return void instead of int,
      when the int was superfulous
 - Please refer to issue #66  for full summary of patch

Signed-off-by: bddavid <davidson@txcorp.com>

<h5><em>Patch file: </em></hf>
[0001-Epetra-Package-Warning-Fixes.patch.txt](https://github.com/trilinos/Trilinos/files/78701/0001-Epetra-Package-Warning-Fixes.patch.txt)


