### PR TITLE
Pamgen Package Warnings Fixes

### DIFF
--- a/packages/pamgen/mesh_spec_lt/pamgen_element_dictionary.C
+++ b/packages/pamgen/mesh_spec_lt/pamgen_element_dictionary.C
@@ -150,7 +150,7 @@ extern const int hex_side_to_node_table[6][8] = {
 
 extern const int face_bit_mask[6] = {1, 2, 4, 8, 16, 32};
  
-extern const char* Element_Type_Names[NUM_ELEMENT_TYPES] = {
+const char* Element_Type_Names[NUM_ELEMENT_TYPES] = {
                                                 "UNKNOWN_ELEMENT",
                                                 "CIRCLE",
                                                 "SPHERE",


### PR DESCRIPTION
### Applied patch 0010-Pamgen-Package-Warnings-Fixes

##### Attention:
@jwillenbring 
@trilinos/pamgen

 - Removed second extern in C file that was already in h.
 - Please refer to issue #66 for full summary of patch

Signed-off-by: bddavid <davidson@txcorp.com>