### PR TITLE
Ifpack2 reuse introduction

### DIFF
--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -399,6 +399,26 @@ class RILUK:
   virtual void
   setMatrix (const Teuchos::RCP<const row_matrix_type>& A);
 
+  /// \brief Change the matrix to be preconditioned.
+  ///
+  /// \param A [in] The new matrix.
+  ///
+  /// \post <tt>  isInitialized ()</tt>
+  /// \post <tt>! isComputed ()</tt>
+  ///
+  /// Calling this method replaces the preconditioner's matrix.  After
+  /// calling this method with a nonnull input, you must first call
+  /// compute() (in that order) before you may call apply().
+  ///
+  /// You cannot call this method with a null input. This method does not
+  /// invalidate any previous factorization, so calling
+  /// setMatrix() with a null input does not make sense.
+  ///
+  /// The new matrix A must necessarily have the same maps and graph
+  /// as the original matrix.
+  virtual void
+  resetMatrix (const Teuchos::RCP<const row_matrix_type>& A);
+
   //@}
   //! @name Implementation of Teuchos::Describable interface
   //@{

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -693,6 +693,19 @@ void RILUK<MatrixType>::compute ()
     initialize (); // Don't count this in the compute() time
   }
 
+  if (isComputed()) {
+    // We have to return here. Otherwise, the following sequence of calls
+    //   initialize()
+    //   compute()
+    //   compute()
+    // results in the second compute() producing different results from the
+    // first one. This is due to the fact that during the compute() call,
+    // matrices L_, U_, and D_ (which were originally set to be submatrices of
+    // A_) change to store the computed factors. So the second compute() call
+    // actually operates on a different matrix.
+    return;
+  }
+
   Teuchos::Time timer ("RILUK::compute");
   { // Start timing
     isComputed_ = false;


### PR DESCRIPTION
@trilinos/ifpack2 @mhoemmen @jhux2 

This PR only serves to solicit comments on the feature. It should not be merged in the current form.

Brief introduction: 
The goal is to reuse some data from preconditioner for consecutive preconditioner constructions. The poster child for this is ILU, where we can reuse the symbolic factorization, and only do the numeric factorization during the second setup.

Work done so far:
1. I've introduced a call resetMatrix() to Ifpack2::RILUK, which mimics initialize() but skips few steps in it, assuming that the matrix graph is unchanged. I've run few experiments through MueLu, and it seems to work as expected.
2. I've also fixed the compute() call to prevent it to being run twice.

Things to discuss:
- Where should resetMatrix() call go?
   My thinking is that it should go to CanChangeMatrix class.
- What are the limitations?
  Maps, graph, things like that
- What code is required to be written?
   Unit tests, ....


