### PR TITLE
Ifpack2,Tpetra: Optimize BlockCrs Jacobi & (S)GS per Issue #96

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Relaxation_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_decl.hpp
@@ -708,25 +708,6 @@ private:
   /// \endcode
   block_diag_type blockDiag_;
 
-  typedef Kokkos::View<int**, typename block_crs_matrix_type::device_type> pivots_type;
-  typedef Kokkos::View<int**, typename block_crs_matrix_type::device_type,
-                       Kokkos::MemoryUnmanaged> unmanaged_pivots_type;
-
-  /// \brief Pivots from LU factorization (with partial pivoting) of
-  ///   the BlockCrsMatrix's block diagonal.
-  ///
-  /// This is only allocated and used if the input matrix is a
-  /// Tpetra::BlockCrsMatrix.  In that case, Ifpack2::Relaxation does
-  /// block relaxation, using the (small dense) blocks in the
-  /// BlockCrsMatrix.
-  ///
-  /// To get the 1-D array of pivots corresponding to local (graph
-  /// a.k.a. "mesh") row index i, do the following:
-  /// \code
-  /// auto ipiv_i = Kokkos::subview (blockDiagFactPivots_, i, Kokkos::ALL ());
-  /// \endcode
-  pivots_type blockDiagFactPivots_;
-
   Teuchos::RCP<block_multivector_type> yBlockColumnPointMap_;
 
   //! How many times to apply the relaxation per apply() call.

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -347,27 +347,23 @@ public:
   /// \param Solution [in/out] On input: the initial guess / current
   ///   approximate solution.  On output: the new approximate
   ///   solution.
-  /// \param factoredDiagonal [in] Block diagonal, whose blocks have
-  ///   been factored using LU with partial pivoting, and have the
-  ///   same format as that produced by LAPACK's _GETRF routine.
-  /// \param factorizationPivots [in] Pivots from the block
-  ///   factorizations
+  /// \param D_inv [in] Block diagonal, the explicit inverse of this
+  ///   matrix's block diagonal (possibly modified for algorithmic
+  ///   reasons).
   /// \param omega [in] (S)SOR relaxation coefficient
   /// \param direction [in] Forward, Backward, or Symmetric.
   ///
-  /// One may access block i in \c factoredDiagonal using the
+  /// One may access block i in \c D_inv using the
   /// following code:
   /// \code
-  /// auto D_ii = Kokkos::subview(factoredDiagonal, j, Kokkos::ALL(), Kokkos::ALL());
+  /// auto D_ii = Kokkos::subview(D_inv, i, Kokkos::ALL(), Kokkos::ALL());
   /// \endcode
   /// The resulting block is b x b, where <tt>b = this->getBlockSize()</tt>.
   void
   localGaussSeidel (const BlockMultiVector<Scalar, LO, GO, Node>& Residual,
                           BlockMultiVector<Scalar, LO, GO, Node>& Solution,
                     const Kokkos::View<impl_scalar_type***, device_type,
-                          Kokkos::MemoryUnmanaged>& factoredDiagonal,
-                    const Kokkos::View<int**, device_type,
-                          Kokkos::MemoryUnmanaged>& factorizationPivots,
+                          Kokkos::MemoryUnmanaged>& D_inv,
                     const Scalar& omega,
                     const ESweepDirection direction) const;
 

--- a/packages/tpetra/core/test/Block/ExpBlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/ExpBlockCrsMatrix.cpp
@@ -1687,7 +1687,7 @@ namespace {
     typedef Tpetra::CrsGraph<LO, GO, Node> graph_type;
     typedef Tpetra::Map<LO, GO, Node> map_type;
     typedef typename graph_type::device_type device_type;
-    typedef typename BCM::impl_scalar_type impl_scalar_type;
+    typedef typename BCM::impl_scalar_type IST;
     typedef Teuchos::ScalarTraits<ST> STS;
 
     const ST two = STS::one () + STS::one ();
@@ -1785,7 +1785,7 @@ namespace {
     Kokkos::View<size_t*, device_type> diagonalOffsets ("offsets", numLocalMeshPoints);
     graph.getLocalDiagOffsets (diagonalOffsets);
 
-    typedef Kokkos::View<impl_scalar_type***, device_type> block_diag_type;
+    typedef Kokkos::View<IST***, device_type> block_diag_type;
     block_diag_type blockDiag ("blockDiag", numLocalMeshPoints,
                                blockSize, blockSize);
     blockMat.getLocalDiagCopy (blockDiag, diagonalOffsets);
@@ -1818,9 +1818,16 @@ namespace {
       int info = 0;
       Tpetra::Experimental::GETF2 (diagBlock, ipiv, info);
       TEST_EQUALITY( info, 0 );
+
+      // GETRI needs workspace.  Use host space for now.
+      Teuchos::Array<IST> workVec (blockSize);
+      Kokkos::View<IST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
+        work (workVec.getRawPtr (), blockSize);
+      Tpetra::Experimental::GETRI (diagBlock, ipiv, work, info);
+      TEST_EQUALITY( info, 0 );
     }
 
-    blockMat.localGaussSeidel (residual, solution, blockDiag, pivots,
+    blockMat.localGaussSeidel (residual, solution, blockDiag,
                                STS::one(), Tpetra::Forward);
 
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
@@ -1834,7 +1841,7 @@ namespace {
       }
     }
 
-    blockMat.localGaussSeidel (residual, solution, blockDiag, pivots,
+    blockMat.localGaussSeidel (residual, solution, blockDiag,
                                STS::one (), Tpetra::Backward);
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex (); ++lclRowInd) {
@@ -1860,7 +1867,7 @@ namespace {
     using Kokkos::ALL;
     typedef Tpetra::Experimental::BlockVector<ST, LO, GO, Node> BV;
     typedef Tpetra::Experimental::BlockCrsMatrix<ST, LO, GO, Node> BCM;
-    typedef typename BCM::impl_scalar_type impl_scalar_type;
+    typedef typename BCM::impl_scalar_type IST;
     typedef Tpetra::CrsGraph<LO, GO, Node> graph_type;
     typedef typename graph_type::device_type device_type;
     typedef Tpetra::Map<LO, GO, Node> map_type;
@@ -1985,7 +1992,7 @@ namespace {
     Kokkos::View<size_t*, device_type> diagonalOffsets ("offsets", numLocalMeshPoints);
     graph.getLocalDiagOffsets(diagonalOffsets);
 
-    typedef Kokkos::View<impl_scalar_type***, device_type> block_diag_type;
+    typedef Kokkos::View<IST***, device_type> block_diag_type;
     block_diag_type blockDiag ("blockDiag", numLocalMeshPoints,
                                blockSize, blockSize);
     blockMat.getLocalDiagCopy (blockDiag, diagonalOffsets);
@@ -2000,9 +2007,16 @@ namespace {
       int info = 0;
       Tpetra::Experimental::GETF2 (diagBlock, ipiv, info);
       TEST_EQUALITY( info, 0 );
+
+      // GETRI needs workspace.  Use host space for now.
+      Teuchos::Array<IST> workVec (blockSize);
+      Kokkos::View<IST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
+        work (workVec.getRawPtr (), blockSize);
+      Tpetra::Experimental::GETRI (diagBlock, ipiv, work, info);
+      TEST_EQUALITY( info, 0 );
     }
 
-    blockMat.localGaussSeidel (residual, solution, blockDiag, pivots,
+    blockMat.localGaussSeidel (residual, solution, blockDiag,
                                STS::one (), Tpetra::Forward);
 
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
@@ -2058,9 +2072,16 @@ namespace {
       int info = 0;
       Tpetra::Experimental::GETF2 (diagBlock, ipiv, info);
       TEST_EQUALITY( info, 0 );
+
+      // GETRI needs workspace.  Use host space for now.
+      Teuchos::Array<IST> workVec (blockSize);
+      Kokkos::View<IST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
+        work (workVec.getRawPtr (), blockSize);
+      Tpetra::Experimental::GETRI (diagBlock, ipiv, work, info);
+      TEST_EQUALITY( info, 0 );
     }
 
-    blockMat.localGaussSeidel (residual, solution, blockDiag, pivots,
+    blockMat.localGaussSeidel (residual, solution, blockDiag,
                                STS::one (), Tpetra::Symmetric);
 
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/tpetra @amklinv 

This is a pull request and not just a commit, because I'm not convinced that the unit tests fully exercise correctness of the algorithms in question.  The algorithms _do_ have unit tests, but the test problems might not be as hard as the ones in the applications.  I would like interested parties to try out the changes first, before I commit them to master.

Per Issue #96, I optimized Ifpack2's implementation of block Jacobi and block (Symmetric) Gauss-Seidel, in `Ifpack2::Relaxation`.  I did the following:

  1. Ifpack2 now stores and applies the inverse of the matrix's block diagonal explicitly.

  2. Use the new `BlockMultiVector::blockWiseMultiply` method to optimize the first sweep of block Jacobi

  3. Use the new `BlockMultiVector::blockJacobiUpdate` method for subsequent sweeps, rather than hard-coding the low-level kernel in `Ifpack2::Relaxation`

In (1), "explicitly" means that each block's inverse is computed in place (LU factorization (GETF2) + GETRI) and applied using a matrix-vector product (GEMV).  Before, `Ifpack2::Relaxation` would store
the LU factorization of each block (result of GETF2), and apply it using a linear solve (GETRS).

`Ifpack2::Relaxation` uses the same storage format for the block diagonal, for both (block) Jacobi and (block) (Symmetric) Gauss-Seidel.  Thus, I had to change both at the same time.  I also had to change `Tpetra::Experimental::BlockCrsMatrix`'s `localGaussSeidel` interface, because it no longer needs the array of pivots from the LU factorizations (GETRS needs the pivots, but GEMV does not).  This makes `BlockCrsMatrix`'s `localGaussSeidel` interface more consistent with `CrsMatrix`'s interface.