### PR TITLE
Techx ml warnings

### DIFF
--- a/packages/ml/examples/Other/ml_example2d.c
+++ b/packages/ml/examples/Other/ml_example2d.c
@@ -33,6 +33,12 @@
 #include "az_aztec.h"
 #include "ml_read_utils.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 extern int AZ_using_fortran;
 int    parasails_factorized = 0;
 int    parasails_sym        = 1;
@@ -114,8 +120,16 @@ int coarse_iterations = 0, use_cg = 0, num_levels = 2;
 
 int main(int argc, char *argv[])
 {
+
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int    i, j, input_option, precon_flag, N_elements_coarse;
   double *b, *x;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /* See Aztec User's Guide for more information on the */
   /* variables that follow.                             */
@@ -135,6 +149,10 @@ int main(int argc, char *argv[])
   /* data structures for multilevel grid, discrete operators */
   /* and preconditioners                                     */
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
   AZ_PRECOND  *Pmat = NULL;
   AZ_MATRIX   *Amat = NULL;
   ML          *ml   = NULL;
@@ -146,6 +164,9 @@ int main(int argc, char *argv[])
 #endif
 #ifdef MATLAB
 	FILE *xfile, *rhsfile;
+#endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
   /* ----------------------- execution begins --------------------------------*/

--- a/packages/ml/examples/Other/ml_example3d.c
+++ b/packages/ml/examples/Other/ml_example3d.c
@@ -28,6 +28,13 @@
 
 #include "az_aztec.h"
 #include "ml_read_utils.h"
+
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 extern int AZ_using_fortran;
 
 /*****************************************************************************/
@@ -87,6 +94,10 @@ extern void add_row_3D(int row,int location,double val[],int bindx[], int *n);
 
 int main(int argc, char *argv[])
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
   int    i, input_option, precon_flag, N_elements_coarse;
   double *b, *x;
 #ifdef ML_BENCHMARK
@@ -116,6 +127,10 @@ int main(int argc, char *argv[])
   FILE *ifp;
 #endif
   char filename[80];
+
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /* ----------------------- execution begins --------------------------------*/
 
@@ -1105,9 +1120,16 @@ void add_row_3D(int row, int location, double val[], int bindx[], int *n)
 
 {
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int        m;
   int        k, NP;
-int nx,ny,nz;
+  int nx,ny,nz;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /* determine grid dimensions */
 

--- a/packages/ml/examples/Other/ml_read_salsa.c
+++ b/packages/ml/examples/Other/ml_read_salsa.c
@@ -26,6 +26,11 @@
 #include "az_aztec.h"
 #include <math.h>
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
 
 extern int AZ_using_fortran;
 int    parasails_factorized = 0;
@@ -39,6 +44,10 @@ double parasails_loadbal    = 0.;
 
 int main(int argc, char *argv[])
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 	int num_PDE_eqns=5, N_levels=3;
     /* int nsmooth=1; */
 
@@ -74,6 +83,10 @@ int *vbr_cnptr, *vbr_rnptr, *vbr_indx, *vbr_bindx, *vbr_bnptr, total_blk_rows;
 int total_blk_cols, blk_space, nz_space;
 double *vbr_val;
 struct ML_CSR_MSRdata *csr_data;
+#endif
+
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
 

--- a/packages/ml/examples/Other/ml_recirc.c
+++ b/packages/ml/examples/Other/ml_recirc.c
@@ -26,6 +26,17 @@
 #include "az_aztec.h"
 #include "ml_read_utils.h"
 
+#ifdef ML_BENCHMARK
+#if !defined(SUPERLU) && !defined(HAVE_ML_AMESOS)
+#define ML_NO_DIRECT_SOLVER
+#endif
+#endif
+
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
 int    parasails_factorized = 0;
 int    parasails_sym        = 0;
 double parasails_thresh     = 0.0;
@@ -102,6 +113,10 @@ struct reader_context *context;
 
 int main(int argc, char *argv[])
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int    i, j, input_option, precon_flag, N_elements_coarse;
   double *b, *x;
   FILE *ifp;
@@ -133,6 +148,10 @@ int main(int argc, char *argv[])
   ML_Aggregate *ml_ag = NULL;
 #ifdef MATLAB
 	FILE *xfile, *rhsfile;
+#endif
+
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
 

--- a/packages/ml/src/Coarsen/ml_agg_METIS.c
+++ b/packages/ml/src/Coarsen/ml_agg_METIS.c
@@ -28,6 +28,13 @@
 #include "ml_agg_info.h"
 #include "limits.h"
 
+
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 #if defined(OUTPUT_AGGREGATES) || defined(INPUT_AGGREGATES) || (ML_AGGR_INAGGR) || (ML_AGGR_OUTAGGR) || (ML_AGGR_MARKINAGGR)
 #ifndef MAXWELL
 #ifndef ALEGRA
@@ -451,7 +458,14 @@ static int ML_LocalReorder_with_METIS( int Nrows, int xadj[], int adjncy[] ,
   int MaxNnzRow;
   indextype * xadj2 = NULL, * adjncy2 = NULL;
   indextype * perm = NULL, * iperm = NULL;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   indextype options[8];
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
   size_t used_mem;
   int bandwidth_orig, bandwidth_perm;
   int mypid = comm->ML_mypid;
@@ -748,6 +762,10 @@ static int ML_DecomposeGraph_with_METIS( ML_Operator *Amatrix,
                                          int *total_nz)
 {
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int i, j,jj,  count, count2, count_start;
   int Nrows, Nrows_global,NrowsMETIS, N_nonzeros, N_bdry_nodes;
   int *wgtflag=NULL, numflag;
@@ -782,6 +800,9 @@ static int ML_DecomposeGraph_with_METIS( ML_Operator *Amatrix,
   int * perm = NULL;
   char str[80];
   char *ptrToBdry;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /* ------------------- execution begins --------------------------------- */
 

--- a/packages/ml/src/Coarsen/ml_agg_ParMETIS.c
+++ b/packages/ml/src/Coarsen/ml_agg_ParMETIS.c
@@ -48,6 +48,12 @@
 #include "ml_agg_ParMETIS.h"
 #include "ml_op_utils.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 #ifndef ML_CPP
 #ifdef __cplusplus
 extern "C"
@@ -469,7 +475,10 @@ int ML_DecomposeGraph_with_ParMETIS( ML_Operator *Amatrix,
 					    int N_nonzeros,
 					    int current_level)
 {
-
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int i, j,jj,  count;
   int Nrows;
   int *wgtflag=NULL, numflag, *options=NULL, edgecut;
@@ -507,6 +516,9 @@ int ML_DecomposeGraph_with_ParMETIS( ML_Operator *Amatrix,
   int skip_check = 0;
   double t0;
   double debug_starting_time = 0.;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /* ------------------- execution begins --------------------------------- */
 

--- a/packages/ml/src/Coarsen/ml_agg_VBMETIS.c
+++ b/packages/ml/src/Coarsen/ml_agg_VBMETIS.c
@@ -27,6 +27,12 @@
 #include "ml_viz_stats.h"
 #include "ml_agg_info.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 #if defined(OUTPUT_AGGREGATES) || defined(INPUT_AGGREGATES) || (ML_AGGR_INAGGR) || (ML_AGGR_OUTAGGR) || (ML_AGGR_MARKINAGGR)
 #ifndef MAXWELL
 #ifndef ALEGRA
@@ -2079,6 +2085,10 @@ static int ML_DecomposeGraph_with_VBMETIS( ML_Operator *Amatrix,
                                            int *total_nz)
 {
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int i, j,jj,  count, count2;
   int Nrows, Nrows_global,NrowsMETIS, N_nonzeros, N_bdry_nodes;
   int *wgtflag=NULL, numflag;
@@ -2112,10 +2122,21 @@ static int ML_DecomposeGraph_with_VBMETIS( ML_Operator *Amatrix,
   int * perm = NULL;
   char str[80];
   char *ptrToBdry;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /* ------------------- execution begins --------------------------------- */
 
   t0 = GetClock();
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
 
   sprintf( str, "VBMETIS (level %d) :", current_level );
 

--- a/packages/ml/src/Coarsen/ml_agg_reitzinger.c
+++ b/packages/ml/src/Coarsen/ml_agg_reitzinger.c
@@ -8,6 +8,12 @@
 #include "ml_viz_stats.h"
 #include "ml_mat_formats.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 #ifdef GREG
 #endif
 #define ML_NOTALWAYS_LOWEST
@@ -2255,10 +2261,17 @@ void ML_Reitzinger_CheckCommutingProperty(ML *ml_nodes, ML *ml_edges,
                                   ML_Operator **Tmat_trans_array,
                                   int finelevel, int coarselevel)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int i;
   double d1, *vec, *Pn_vec, *Tfine_Pn_vec;
   char filename[80];
   ML_Operator *Pn, *Tfine, *Tcoarse, *Pe, *Ttrans;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /*********************** start of execution *******************************/
 

--- a/packages/ml/src/Coarsen/ml_agg_user.c
+++ b/packages/ml/src/Coarsen/ml_agg_user.c
@@ -23,6 +23,10 @@
 #include "ml_viz_stats.h"
 #include "ml_agg_info.h"
 
+#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION __GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__
+#endif
+
 /* ---------------------------------- */
 /* Set label for user's defined label */
 /* ---------------------------------- */
@@ -96,6 +100,10 @@ int ML_Aggregate_CoarsenUser(ML_Aggregate *ml_ag, ML_Operator *Amatrix,
   int * graph_decomposition = NULL;
   ML_Aggregate_Viz_Stats * aggr_viz_and_stats;
   ML_Aggregate_Viz_Stats * grid_info;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int Nprocs;
   char * unamalg_bdry = NULL;
   char* label;
@@ -120,6 +128,9 @@ int ML_Aggregate_CoarsenUser(ML_Aggregate *ml_ag, ML_Operator *Amatrix,
   nullspace_dim           = ml_ag->nullspace_dim;
   nullspace_vect          = ml_ag->nullspace_vect;
   Nrows                   = Amatrix->outvec_leng;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   if (mypid == 0 && 5 < ML_Get_PrintLevel()) {
     printf("%s num PDE eqns = %d\n",

--- a/packages/ml/src/Coarsen/ml_agg_user.c
+++ b/packages/ml/src/Coarsen/ml_agg_user.c
@@ -23,8 +23,10 @@
 #include "ml_viz_stats.h"
 #include "ml_agg_info.h"
 
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#define GCC_VERSION __GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
 #endif
 
 /* ---------------------------------- */

--- a/packages/ml/src/Coarsen/ml_aggregate.c
+++ b/packages/ml/src/Coarsen/ml_aggregate.c
@@ -25,6 +25,11 @@
 #include "ml_agg_VBMETIS.h"
 #include "ml_viz_stats.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
 
 /* ************************************************************************* */
 /* variables used for parallel debugging  (Ray)                              */
@@ -2094,7 +2099,14 @@ int ML_repartition_matrix(ML_Operator *mat, ML_Operator **new_mat,
 #if defined(ML_TIMING)
   t0 = GetClock() - t0;
 #endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#endif
   ML_Operator_Copy_Statistics(mat,permuted_Amat);
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 #if defined(ML_TIMING)
   permuted_Amat->build_time += t0;
 #endif
@@ -2188,6 +2200,10 @@ int ML_Aggregate_Set_Dimensions(ML_Aggregate *ag, int N_dimensions)
 ML_Operator** ML_repartition_Acoarse(ML *ml, int fine, int coarse,
                ML_Aggregate *ag, int R_is_Ptranspose, int ReturnPerm)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   ML_Operator *Amatrix, *Rmat, *Pmat, *perm, *permt, *newA, *newP, *newR;
   ML_Operator **permvec=NULL;
   int status, offset1, offset2, j, flag = 0;
@@ -2202,6 +2218,9 @@ ML_Operator** ML_repartition_Acoarse(ML *ml, int fine, int coarse,
   int N_dimensions=0;
   int haveCoordinates = 0;
   double t0=0.0,delta=0.0;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   StartTimer(&t0);
 

--- a/packages/ml/src/Main/ml_ggb.c
+++ b/packages/ml/src/Main/ml_ggb.c
@@ -26,6 +26,11 @@
 
 #include "ml_ggb.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
 
 
 void ML_ARPACK_GGB( struct ML_Eigenvalue_Struct *eigen_struct,ML *ml,
@@ -118,6 +123,10 @@ void  ML_ARPACK_driver(char which[],
     int Debug_Flag, int GGB_alp_flag)
 {
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int        j, kk, ldv, lworkl;
   int        nloc,  nloc2, ido, flag, counter;
   int        count, nconv, ierr, info;
@@ -135,6 +144,9 @@ void  ML_ARPACK_driver(char which[],
 
 
   USR_COMM  comm;                                      /* MPI communicator */
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
   /********************************  Begin ************************************/
 
@@ -1035,6 +1047,10 @@ extern double  ML_subspace (int nrows, double *inp1, int ncols1, double *inp2, i
 int  ML_MGGB_angle( struct ML_Eigenvalue_Struct *eigen_struct,ML *ml,
     struct ML_CSR_MSRdata *mydata)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int            Nrows, Ncols, level;
   int            ggb_flag = 0, count;
   double         tm;
@@ -1043,6 +1059,9 @@ int  ML_MGGB_angle( struct ML_Eigenvalue_Struct *eigen_struct,ML *ml,
 #ifndef HAVE_ML_PARPACK
   int             i, kk;
   double          *rhs, *rhs1, epsilon = 30.0, theta, *Rq, *dumm;
+#endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
 

--- a/packages/ml/src/Main/ml_struct.c
+++ b/packages/ml/src/Main/ml_struct.c
@@ -26,6 +26,11 @@
 #include "mpi.h"
 #endif
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
 
 /* ************************************************************************* *
  * Structure to hold user-selected ML output level.                          *
@@ -40,6 +45,10 @@ ML_PrintControl ML_PrintLevel = {0};
 int ml_defines_have_printed = 0;
 int ML_Create(ML **ml_ptr, int Nlevels)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
    int             i, length;
    double          *max_eigen;
    ML_Operator     *Amat, *Rmat, *Pmat;
@@ -57,6 +66,9 @@ int ML_Create(ML **ml_ptr, int Nlevels)
 
 #ifdef ML_TIMING
    struct ML_Timing *timing;
+#endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
    ML_memory_alloc( (void**) ml_ptr, sizeof(ML), "MLM" );
@@ -5872,6 +5884,10 @@ int ML_Gen_Blocks_Metis(ML *ml, int level, int *nblocks, int **block_list)
 
 int ML_Gen_CoarseSolverAggregation(ML *ml_handle, int level, ML_Aggregate *ag)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
    int            i, j, k, offset, N_local;
    int            reuse, coarsest_level, flag, space, *cols = NULL, nz_ptr;
    int            getrow_flag, osize, *row_ptr, length, zero_flag;
@@ -5888,6 +5904,9 @@ int ML_Gen_CoarseSolverAggregation(ML *ml_handle, int level, ML_Aggregate *ag)
 #ifdef ML_TIMING
    double t0;
    t0 = GetClock();
+#endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
    /* ----------------------------------------------------------------- */
@@ -6425,6 +6444,10 @@ int ML_Gen_Smoother_Petsc(ML *ml, int level, int pre_or_post, int ntimes, ML_Pet
 int ML_build_ggb(ML *ml, void *data)
 {
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   ML                    *ml_ggb=NULL;
   int                    Nrows, Ncols, Nlocal, Nnz;
   ML_Operator           *Pmat=NULL, *Qtilde=NULL;
@@ -6438,6 +6461,9 @@ int ML_build_ggb(ML *ml, void *data)
 #ifdef ML_TIMING
    double t0;
    t0 = GetClock();
+#endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
 
@@ -6729,6 +6755,10 @@ int ML_build_ggb(ML *ml, void *data)
 
 void ML_build_ggb_cheap(ML *ml, void *data)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   ML                    *ml_ggb;
   int                    Nrows, Ncols, Nlocal, Nnz;
   ML_Operator           *Pmat,  *Qtilde;
@@ -6738,6 +6768,9 @@ void ML_build_ggb_cheap(ML *ml, void *data)
 #ifdef ML_TIMING
    double t0;
    t0 = GetClock();
+#endif
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
 #endif
 
 

--- a/packages/ml/src/Operator/ml_matmat_mult.c
+++ b/packages/ml/src/Operator/ml_matmat_mult.c
@@ -13,6 +13,12 @@
 #include "ml_mat_formats.h"
 #include <limits.h>
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 /* ******************************************************************** */
 /* matrix matrix multiplication                                         */
 /* Cmatrix = Amatrix * Bmatrix                                          */
@@ -27,6 +33,10 @@ void ML_blkmatmat_mult(ML_Operator *Amatrix, ML_Operator *Bmatrix,
 		       ML_Operator **Cmatrix)
 /* -------------------------------------------------------------------- */
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   int    i,k, jj, next_nz, Ncols, N, Nnz_estimate, sub_i, accum_size, row;
   int    *Cbpntr, *Cbindx, *A_i_cols, rowi_N, *accum_col, row2_N;
   int    *Cindx, *Aindx;
@@ -66,6 +76,9 @@ void ML_blkmatmat_mult(ML_Operator *Amatrix, ML_Operator *Bmatrix,
   int hashTableIsPowerOfTwo = 0;
   int nearbyIndex;
   int blocks;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
 
 /*  printf("This is an experimental routine. It basically works but ...\n");
@@ -1572,6 +1585,10 @@ void ML_matmat_mult(ML_Operator *Amatrix, ML_Operator *Bmatrix,
 /*Where data is being exchanged things can become more efficient with an isend though this has risks.  Only works on matrices with one submatrix*/
 void ML_convert2vbr(ML_Operator *in_matrix, int row_block_size, int rpntr[], int col_block_size, int cpntr[], int submatrix)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
    int i, j, k, kk, ii, ll, m;
    int jj = 0;
    int blockrows = 0;
@@ -1609,6 +1626,9 @@ void ML_convert2vbr(ML_Operator *in_matrix, int row_block_size, int rpntr[], int
    int mats = 0;
    ML_CommInfoOP *pre_comm;
    USR_COMM USR_comm;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
    if(submatrix == 1)
    {

--- a/packages/ml/src/Utils/ml_eigf2c.c
+++ b/packages/ml/src/Utils/ml_eigf2c.c
@@ -17,6 +17,12 @@
 #define TRUE_ (1)
 #include "ml_eigf2c.h"
 
+#ifndef GCC_VERSION
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__)) && defined(__GNUC_PATCHLEVEL__)
+#define GCC_VERSION  (__GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__)
+#endif
+#endif
+
 int ml_pdmout__(USR_COMM *comm, int *lout, int *m, int *n, double *a,
 		  int *lda, int *idigit)
 {
@@ -56,6 +62,10 @@ int ml_pdneupc__(USR_COMM *comm,
 		int *lworkl, int *ierr, ftnlen howmny_len, ftnlen bmat_len,
 		ftnlen which_len)
 {
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
     /* System generated locals */
     integer v_dim1, v_offset, i__1;
 
@@ -71,6 +81,9 @@ int ml_pdneupc__(USR_COMM *comm,
 #endif
 
     static logical *select;
+#if defined(GCC_VERSION) && GCC_VERSION >= 460
+#pragma GCC diagnostic pop
+#endif
 
     /* Parameter adjustments */
 


### PR DESCRIPTION
Techx ml warnings-as-errors

Attention:
@jwillenbring 

Silenced majority of warnings emitted by ml package for gcc >= 4.6 using preprocessor directives.
Please review, and if acceptable pull. 
