### PR TITLE
support for builds using SCOREC core-sim

### DIFF
--- a/PackagesList.cmake
+++ b/PackagesList.cmake
@@ -65,9 +65,9 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
   RTOp                  packages/rtop                     PS
   Sacado                packages/sacado                   PS
   Epetra                packages/epetra                   PS
+  SCORECpcu             SCOREC/pcu                        SS
   SCORECgmi             SCOREC/gmi                        SS
   SCORECgmi_sim         SCOREC/gmi_sim                    SS
-  SCORECpcu             SCOREC/pcu                        SS
   SCORECapf             SCOREC/apf                        SS
   SCORECapf_sim         SCOREC/apf_sim                    SS
   SCORECmds             SCOREC/mds                        SS

--- a/PackagesList.cmake
+++ b/PackagesList.cmake
@@ -66,8 +66,10 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
   Sacado                packages/sacado                   PS
   Epetra                packages/epetra                   PS
   SCORECgmi             SCOREC/gmi                        SS
+  SCORECgmi_sim         SCOREC/gmi_sim                    SS
   SCORECpcu             SCOREC/pcu                        SS
   SCORECapf             SCOREC/apf                        SS
+  SCORECapf_sim         SCOREC/apf_sim                    SS
   SCORECmds             SCOREC/mds                        SS
   SCORECparma           SCOREC/parma                      SS
   SCORECspr             SCOREC/spr                        SS
@@ -137,8 +139,10 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
 
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCOREC)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECgmi)
+TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECgmi_sim)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECpcu)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECapf)
+TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECapf_sim)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECmds)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECparma)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECspr)

--- a/TPLsList.cmake
+++ b/TPLsList.cmake
@@ -203,6 +203,8 @@ SET( Trilinos_TPLS_FINDMODS_CLASSIFICATIONS
   VTune           "cmake/TPLs/"    SS
   TASMANIAN       "cmake/TPLs/"    EX
   ArrayFireCPU    "cmake/TPLs/"    EX
+  SimMesh         "SCOREC/cmake/TPLs/"    EX
+  SimModel        "SCOREC/cmake/TPLs/"    EX
   )
 
 # NOTES:


### PR DESCRIPTION
The packages that wrap the Simmetrix API are added to the package and TPL list to support builds against SCOREC/core-sim .