### PR TITLE
Make exodiff find int64_t

### DIFF
--- a/packages/seacas/applications/exodiff/iqsort.C
+++ b/packages/seacas/applications/exodiff/iqsort.C
@@ -31,6 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #include "iqsort.h"
+#include <cstdint>
 
 namespace {
   template <typename INT> void swap_(INT v[], size_t i, size_t j);


### PR DESCRIPTION
This adds a standard library header so that int64_t (bottom of the file) can be found.

A little more info: I'm building a fully static build on [Alpine Linux](http://www.alpinelinux.org/), which uses musl-libc instead of gnu-libc. As a pre-requisite, I supply my own BLAS and LAPACK (static libs) and the system-wide gcc (musl-gcc wrapper) needed this include to find int64_t.