### PR TITLE
ROL: Fixed examples that failed to build

### DIFF
--- a/packages/rol/example/PDE-OPT/TOOLS/PDE_FEM.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/PDE_FEM.hpp
@@ -892,17 +892,16 @@ public:
 
   void outputTpetraData() const {
     Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> >   matWriter;
-    Tpetra::MatrixMarket::Writer< Tpetra::MultiVector<> > vecWriter;
     matWriter.writeSparseFile("stiffness_mat", matA_);
     matWriter.writeSparseFile("dirichlet_mat", matA_dirichlet_);
     matWriter.writeSparseFile("mass_mat", matM_);
-    vecWriter.writeDenseFile("Ud_vec", vecUd_);
+    matWriter.writeDenseFile("Ud_vec", vecUd_);
   }
 
 
   void outputTpetraVector(const Teuchos::RCP<const Tpetra::MultiVector<> > &vec,
                           const std::string &filename) const {
-    Tpetra::MatrixMarket::Writer<Tpetra::MultiVector<> > vecWriter;
+    Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> > vecWriter;
     vecWriter.writeDenseFile(filename, vec);
   }
 

--- a/packages/rol/example/PDE-OPT/adv-diff-react/data.hpp
+++ b/packages/rol/example/PDE-OPT/adv-diff-react/data.hpp
@@ -890,17 +890,16 @@ public:
 
   void outputTpetraData() const {
     Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> >   matWriter;
-    Tpetra::MatrixMarket::Writer< Tpetra::MultiVector<> > vecWriter;
     matWriter.writeSparseFile("stiffness_mat", matA_);
     matWriter.writeSparseFile("dirichlet_mat", matA_dirichlet_);
     matWriter.writeSparseFile("mass_mat", matM_);
-    vecWriter.writeDenseFile("Ud_vec", vecUd_);
+    matWriter.writeDenseFile("Ud_vec", vecUd_);
   }
 
 
   void outputTpetraVector(const Teuchos::RCP<const Tpetra::MultiVector<> > &vec,
                           const std::string &filename) const {
-    Tpetra::MatrixMarket::Writer<Tpetra::MultiVector<> > vecWriter;
+    Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> > vecWriter;
     vecWriter.writeDenseFile(filename, vec);
   }
 

--- a/packages/rol/example/PDE-OPT/elasticitySIMP_topologyOptimization/filter.hpp
+++ b/packages/rol/example/PDE-OPT/elasticitySIMP_topologyOptimization/filter.hpp
@@ -516,7 +516,7 @@ public:
 
   void outputTpetraVector(const Teuchos::RCP<const Tpetra::MultiVector<> > &vec,
                           const std::string &filename) const {
-    Tpetra::MatrixMarket::Writer<Tpetra::MultiVector<> > vecWriter;
+    Tpetra::MatrixMarket::Writer<Tpetra::CrsMatrix<> > vecWriter;
     vecWriter.writeDenseFile(filename, vec);
   }
 

--- a/packages/rol/example/PDE-OPT/poisson/data.hpp
+++ b/packages/rol/example/PDE-OPT/poisson/data.hpp
@@ -762,17 +762,16 @@ public:
 
   void outputTpetraData() const {
     Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> >   matWriter;
-    Tpetra::MatrixMarket::Writer< Tpetra::MultiVector<> > vecWriter;
     matWriter.writeSparseFile("stiffness_mat", matA_);
     matWriter.writeSparseFile("dirichlet_mat", matA_dirichlet_);
     matWriter.writeSparseFile("mass_mat", matM_);
-    vecWriter.writeDenseFile("Ud_vec", vecUd_);
+    matWriter.writeDenseFile("Ud_vec", vecUd_);
   }
 
 
   void outputTpetraVector(const Teuchos::RCP<const Tpetra::MultiVector<> > &vec,
                           const std::string &filename) const {
-    Tpetra::MatrixMarket::Writer<Tpetra::MultiVector<> > vecWriter;
+    Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> > vecWriter;
     vecWriter.writeDenseFile(filename, vec);
   }
 

--- a/packages/rol/example/PDE-OPT/stefan-boltzmann/data.hpp
+++ b/packages/rol/example/PDE-OPT/stefan-boltzmann/data.hpp
@@ -910,17 +910,16 @@ public:
 
   void outputTpetraData() const {
     Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> >   matWriter;
-    Tpetra::MatrixMarket::Writer< Tpetra::MultiVector<> > vecWriter;
     matWriter.writeSparseFile("stiffness_mat", matA_);
     matWriter.writeSparseFile("dirichlet_mat", matA_dirichlet_);
     matWriter.writeSparseFile("mass_mat", matM_);
-    vecWriter.writeDenseFile("Ud_vec", vecUd_);
+    matWriter.writeDenseFile("Ud_vec", vecUd_);
   }
 
 
   void outputTpetraVector(const Teuchos::RCP<const Tpetra::MultiVector<> > &vec,
                           const std::string &filename) const {
-    Tpetra::MatrixMarket::Writer<Tpetra::MultiVector<> > vecWriter;
+    Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> > vecWriter;
     vecWriter.writeDenseFile(filename, vec);
   }
 


### PR DESCRIPTION
These examples were broken by a recent commit to Tpetra that added
a MatrixMarket reader for graphs.  The Tpetra MatrixMarket readers
and writers are all templated on the matrix type (even the vector
readers and writers), and the ROL examples were templating them
on the vector type.