### PR TITLE
add more Simmetrix TPLs used by SCOREC packages

### DIFF
--- a/TPLsList.cmake
+++ b/TPLsList.cmake
@@ -206,6 +206,9 @@ SET( Trilinos_TPLS_FINDMODS_CLASSIFICATIONS
   ArrayFireCPU    "cmake/TPLs/"    EX
   SimMesh         "SCOREC/cmake/TPLs/"    EX
   SimModel        "SCOREC/cmake/TPLs/"    EX
+  SimParasolid    "SCOREC/cmake/TPLs/"    EX
+  SimAcis         "SCOREC/cmake/TPLs/"    EX
+  SimField        "SCOREC/cmake/TPLs/"    EX
   )
 
 # NOTES:


### PR DESCRIPTION
This PR is a follow-up to #250.
The Additive Manufacturing Project which uses

Albany + Trilinos + SCOREC + Simmetrix

could use these additional Simmetrix TPLs.