### PR TITLE
Ifpack2: performance speedup for getLocalRowCopy in LocalFilter

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
@@ -585,6 +585,12 @@ getLocalRowCopy (local_ordinal_type LocalRow,
     return;
   }
 
+  if (A_->getRowMap()->getComm()->getSize() == 1) {
+    A_->getLocalRowCopy (LocalRow, Indices (), Values (), NumEntries);
+    return;
+  }
+
+
   const size_t numEntInLclRow = NumEntries_[LocalRow];
   if (static_cast<size_t> (Indices.size ()) < numEntInLclRow ||
       static_cast<size_t> (Values.size ()) < numEntInLclRow) {


### PR DESCRIPTION
If we have a single processor or in serial, there is no reason to go through each
element in a row to determine whether it belongs to us.

On a serial run, I was getting around 15-20% improvement for Vanka
smoothing (BLOCK_RELAXATION).