### PR TITLE
NOX: fix NormWRMS status check for adaptive case

### DIFF
--- a/packages/nox/src/NOX_StatusTest_NormWRMS.C
+++ b/packages/nox/src/NOX_StatusTest_NormWRMS.C
@@ -141,10 +141,11 @@ checkStatus(const NOX::Solver::Generic& problem,
   // **** Begin check for convergence criteria #1 ****
 
   // Create the working vectors if this is the first time this
-  // operator is called.
-  if (Teuchos::is_null(u))
+  // operator is called, or if mesh adaptation has altered
+  // the solution vector size.
+  if (Teuchos::is_null(u) || (u->length() != x.length()))
     u = x.clone(NOX::ShapeCopy);
-  if (Teuchos::is_null(v))
+  if (Teuchos::is_null(v) || (v->length() != x.length()))
     v = x.clone(NOX::ShapeCopy);
 
   // Create the weighting vector u = RTOL |x| + ATOL


### PR DESCRIPTION
This change allows us to use the NOX NormWRMS Status Test in runs of Albany where the mesh connectivity is being adapted.

@etphipp @mperego @gahansen 