### PR TITLE
Zoltan2 test driver memory deletes

### DIFF
--- a/packages/zoltan2/test/driver/test_driver.cpp
+++ b/packages/zoltan2/test/driver/test_driver.cpp
@@ -219,19 +219,23 @@ bool run(const UserInputForTests &uinput,
   comparison_source->timers["adapter construction time"]->start();
 
   // a pointer to a basic type
-  base_adapter_t *ia = AdapterForTests::getAdapterForInput(
+  AdapterWithOptionalCoordinateAdapter adapters = AdapterForTests::getAdapterForInput(
                                         const_cast<UserInputForTests*>(&uinput),
                                         adapterPlist,comm); 
   comparison_source->timers["adapter construction time"]->stop();
 
-  if(ia == nullptr)
+  if(adapters.mainAdapter == nullptr)
   {
     if(rank == 0) {
       cout << "Get adapter for input failed" << endl;
     }
     return false;
   }
-  RCP<basic_id_t> iaRCP = rcp(reinterpret_cast<basic_id_t *>(ia), true);
+  RCP<basic_id_t> iaRCP = rcp(reinterpret_cast<basic_id_t *>
+    (adapters.mainAdapter), true);
+
+  RCP<basic_id_t> coordinateAdapterRCP = rcp(reinterpret_cast<basic_id_t *>
+    (adapters.coordinateAdapter), true);
 
   ////////////////////////////////////////////////////////////
   // 2. construct a Zoltan2 problem
@@ -253,14 +257,16 @@ bool run(const UserInputForTests &uinput,
   }
 #ifdef HAVE_ZOLTAN2_MPI
   base_problem_t * problem = 
-    Zoltan2_TestingFramework::ProblemFactory::newProblem(problem_kind, 
-                                                         adapter_name, ia, 
-                                                         &zoltan2_parameters, 
+    Zoltan2_TestingFramework::ProblemFactory::newProblem(problem_kind,
+                                                         adapter_name,
+                                                         adapters.mainAdapter,
+                                                         &zoltan2_parameters,
                                                          MPI_COMM_WORLD);
 #else
   base_problem_t * problem = 
-    Zoltan2_TestingFramework::ProblemFactory::newProblem(problem_kind, 
-                                                         adapter_name, ia, 
+    Zoltan2_TestingFramework::ProblemFactory::newProblem(problem_kind,
+                                                         adapter_name,
+                                                         adapters.mainAdapter,
                                                          &zoltan2_parameters);
 #endif
 
@@ -297,8 +303,8 @@ bool run(const UserInputForTests &uinput,
 #ifdef KDDKDD
   {
   const base_adapter_t::gno_t *kddIDs = NULL;
-  ia->getIDsView(kddIDs);
-    for (size_t i = 0; i < ia->getLocalNumIDs(); i++) {
+  adapters.mainAdapter->getIDsView(kddIDs);
+    for (size_t i = 0; i < adapters.mainAdapter->getLocalNumIDs(); i++) {
       std::cout << rank << " LID " << i
                 << " GID " << kddIDs[i]
                 << " PART " 
@@ -312,21 +318,23 @@ bool run(const UserInputForTests &uinput,
     typedef xcrsGraph_adapter::gno_t gno_t;
     typedef xcrsGraph_adapter::scalar_t scalar_t;
     int ewgtDim = 
-        reinterpret_cast<const xcrsGraph_adapter *>(ia)->getNumWeightsPerEdge();
+        reinterpret_cast<const xcrsGraph_adapter *>(adapters.mainAdapter)->
+          getNumWeightsPerEdge();
     lno_t localNumObj = 
-        reinterpret_cast<const xcrsGraph_adapter *>(ia)->getLocalNumVertices();
+        reinterpret_cast<const xcrsGraph_adapter *>(adapters.mainAdapter)->
+          getLocalNumVertices();
     const gno_t *vertexIds;
-    reinterpret_cast<const xcrsGraph_adapter *>(ia)->getVertexIDsView(vertexIds);
+    reinterpret_cast<const xcrsGraph_adapter *>(adapters.mainAdapter)->
+      getVertexIDsView(vertexIds);
     const lno_t *offsets;
     const gno_t *adjIds;
-    reinterpret_cast<const xcrsGraph_adapter *>(ia)->getEdgesView(offsets,
-                                                                  adjIds);
+    reinterpret_cast<const xcrsGraph_adapter *>(adapters.mainAdapter)->
+      getEdgesView(offsets, adjIds);
     for (int edim = 0; edim < ewgtDim; edim++) {
       const scalar_t *weights;
       int stride=0;
-      reinterpret_cast<xcrsGraph_adapter *>(ia)->getEdgeWeightsView(weights, 
-                                                                    stride,
-                                                                    edim);
+      reinterpret_cast<xcrsGraph_adapter *>(adapters.mainAdapter)->
+        getEdgeWeightsView(weights, stride, edim);
       for (lno_t i=0; i < localNumObj; i++)
         for (lno_t j=offsets[i]; j < offsets[i+1]; j++)
           std::cout << edim << " " << vertexIds[i] << " " 
@@ -358,7 +366,7 @@ bool run(const UserInputForTests &uinput,
     RCP<EvaluatePartition<basic_id_t> > metricObject = rcp(
        Zoltan2_TestingFramework::EvaluatePartitionFactory::newEvaluatePartition(
                reinterpret_cast<partitioning_problem_t*> (problem), 
-               adapter_name, ia, &zoltan2_parameters));
+               adapter_name, adapters.mainAdapter, &zoltan2_parameters));
 
     std::ostringstream msgSummary;
     metricObject->printMetrics(msgSummary, true); //
@@ -437,12 +445,14 @@ bool run(const UserInputForTests &uinput,
     ////////////////////////////////////////////////////////////
 
     comparison_source->adapter = iaRCP;
+    comparison_source->coordinateAdapter = coordinateAdapterRCP;
     comparison_source->problem = problemRCP;
     comparison_source->metricObject = metricObject;
     comparison_source->problem_kind = (problem_parameters.isParameter("kind") ? 
                                        problem_parameters.get<string>("kind") :
                                        "?");
     comparison_source->adapter_kind = adapter_name;
+
   
     // write mesh solution
     //  auto sol = reinterpret_cast<partitioning_problem_t *>(problem)->getSolution();

--- a/packages/zoltan2/test/driver/test_driver.cpp
+++ b/packages/zoltan2/test/driver/test_driver.cpp
@@ -445,7 +445,6 @@ bool run(const UserInputForTests &uinput,
     ////////////////////////////////////////////////////////////
 
     comparison_source->adapter = iaRCP;
-    comparison_source->coordinateAdapter = coordinateAdapterRCP;
     comparison_source->problem = problemRCP;
     comparison_source->metricObject = metricObject;
     comparison_source->problem_kind = (problem_parameters.isParameter("kind") ? 
@@ -514,6 +513,7 @@ bool mainExecute(int argc, char *argv[], RCP<const Comm<int> > &comm)
   
   // get the user input for all tests
   UserInputForTests uinput(inputParameters,comm);
+
   problems.pop();
   comm->barrier();
 

--- a/packages/zoltan2/test/driver/test_driver.cpp
+++ b/packages/zoltan2/test/driver/test_driver.cpp
@@ -234,8 +234,8 @@ bool run(const UserInputForTests &uinput,
   RCP<basic_id_t> iaRCP = rcp(reinterpret_cast<basic_id_t *>
     (adapters.mainAdapter), true);
 
-  RCP<basic_id_t> coordinateAdapterRCP = rcp(reinterpret_cast<basic_id_t *>
-    (adapters.coordinateAdapter), true);
+  RCP<Zoltan2::VectorAdapter<tMVector_t>> coordinateAdapterRCP = 
+    rcp(adapters.coordinateAdapter, true);
 
   ////////////////////////////////////////////////////////////
   // 2. construct a Zoltan2 problem
@@ -445,6 +445,7 @@ bool run(const UserInputForTests &uinput,
     ////////////////////////////////////////////////////////////
 
     comparison_source->adapter = iaRCP;
+    comparison_source->coordinateAdapterRCP = coordinateAdapterRCP;
     comparison_source->problem = problemRCP;
     comparison_source->metricObject = metricObject;
     comparison_source->problem_kind = (problem_parameters.isParameter("kind") ? 

--- a/packages/zoltan2/test/helpers/AdapterForTests.hpp
+++ b/packages/zoltan2/test/helpers/AdapterForTests.hpp
@@ -91,6 +91,14 @@ using Teuchos::ParameterList;
 using std::string;
 using namespace Zoltan2_TestingFramework;
 
+// helper struct to store both an adapter and the coordinate adapter
+struct AdapterWithOptionalCoordinateAdapter
+{
+  Zoltan2_TestingFramework::base_adapter_t * mainAdapter = nullptr;
+  Zoltan2_TestingFramework::base_adapter_t * coordinateAdapter = nullptr;  // may be NULL if coordinates are not available
+};
+
+
 /* \brief A class for constructing Zoltan2 input adapters */
 class AdapterForTests{
 public:
@@ -131,7 +139,9 @@ public:
    *
    * \return Ptr to the constructed adapter cast to the base class
    */
-  static base_adapter_t* getAdapterForInput(UserInputForTests *uinput, const ParameterList &pList, const RCP<const Comm<int> > &comm);
+  static AdapterWithOptionalCoordinateAdapter getAdapterForInput(
+    UserInputForTests *uinput, const ParameterList &pList,
+    const RCP<const Comm<int> > &comm);
   
 private:
   /*! \brief Method to choose and call the correct constructor
@@ -164,7 +174,7 @@ private:
    *
    * \return Ptr to the constructed adapter cast to the base class
    */
-  static base_adapter_t*
+  static AdapterWithOptionalCoordinateAdapter
   getXpetraCrsGraphAdapterForInput(UserInputForTests *uinput, const ParameterList &pList, const RCP<const Comm<int> > &comm);
   
   /*! \brief Method to choose and call the correct constructor
@@ -175,7 +185,7 @@ private:
    *
    * \return Ptr to the constructed adapter cast to the base class
    */
-  static base_adapter_t*
+  static AdapterWithOptionalCoordinateAdapter
   getXpetraCrsMatrixAdapterForInput(UserInputForTests *uinput, const ParameterList &pList, const RCP<const Comm<int> > &comm);
   
   /*! \brief Method to choose and call the correct constructor
@@ -233,36 +243,37 @@ private:
 };
 
 
-Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getAdapterForInput(UserInputForTests *uinput,
-                                                                      const ParameterList &pList,
-                                                                      const RCP<const Comm<int> > &comm)
+AdapterWithOptionalCoordinateAdapter AdapterForTests::getAdapterForInput(
+  UserInputForTests *uinput,
+  const ParameterList &pList,
+  const RCP<const Comm<int> > &comm)
 {
-  Zoltan2_TestingFramework::base_adapter_t * ia = nullptr; // input adapter
-  
+  AdapterWithOptionalCoordinateAdapter adapters; // input adapter
+
   if(!pList.isParameter("input adapter"))
   {
     std::cerr << "Input adapter unspecified" << std::endl;
-    return ia;
+    return adapters;
   }
   
   // pick method for chosen adapter
   string adapter_name = pList.get<string>("input adapter");
   if(adapter_name == "BasicIdentifier")
-    ia = AdapterForTests::getBasicIdentiferAdapterForInput(uinput, pList, comm);
+    adapters.mainAdapter = AdapterForTests::getBasicIdentiferAdapterForInput(uinput, pList, comm);
   else if(adapter_name == "XpetraMultiVector")
-    ia = AdapterForTests::getXpetraMVAdapterForInput(uinput, pList, comm);
+    adapters.mainAdapter = AdapterForTests::getXpetraMVAdapterForInput(uinput, pList, comm);
   else if(adapter_name == "XpetraCrsGraph")
-    ia = getXpetraCrsGraphAdapterForInput(uinput,pList, comm);
+    adapters = getXpetraCrsGraphAdapterForInput(uinput,pList, comm);
   else if(adapter_name == "XpetraCrsMatrix")
-    ia = getXpetraCrsMatrixAdapterForInput(uinput,pList, comm);
+    adapters = getXpetraCrsMatrixAdapterForInput(uinput,pList, comm);
   else if(adapter_name == "BasicVector")
-    ia = getBasicVectorAdapterForInput(uinput,pList, comm);
+    adapters.mainAdapter = getBasicVectorAdapterForInput(uinput,pList, comm);
   else if(adapter_name == "PamgenMesh")
-    ia = getPamgenMeshAdapterForInput(uinput,pList, comm);
+    adapters.mainAdapter = getPamgenMeshAdapterForInput(uinput,pList, comm);
   else
     std::cerr << "Input adapter type: " + adapter_name + ", is unavailable, or misspelled." << std::endl;
   
-  return ia;
+  return adapters;
 }
 
 
@@ -484,18 +495,18 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraMVAdapterFo
 }
 
 
-Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsGraphAdapterForInput(
+AdapterWithOptionalCoordinateAdapter AdapterForTests::getXpetraCrsGraphAdapterForInput(
   UserInputForTests *uinput,
   const ParameterList &pList,
   const RCP<const Comm<int> > &comm)
 {
   
-  Zoltan2_TestingFramework::base_adapter_t * adapter = nullptr;
+  AdapterWithOptionalCoordinateAdapter adapters;
 
   if(!pList.isParameter("data type"))
   {
     std::cerr << "Input data type unspecified" << std::endl;
-    return adapter;
+    return adapters;
   }
   
   string input_type = pList.get<string>("data type");
@@ -503,7 +514,7 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsGraphAda
   {
     std::cerr << "Input type: " + input_type + ", unavailable or misspelled." 
               << std::endl; // bad type
-    return adapter;
+    return adapters;
   }
   
   vector<const zscalar_t *> vtx_weights;
@@ -557,7 +568,7 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsGraphAda
         ia->setEdgeWeights(edge_weights[i],edge_weightStride[i],i);
     }
     
-    adapter =  reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
+    adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
   }
   else if(input_type == "xpetra_crs_graph")
   {
@@ -579,7 +590,7 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsGraphAda
         ia->setEdgeWeights(edge_weights[i],edge_weightStride[i],i);
     }
     
-    adapter =  reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
+    adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
   }
 #ifdef HAVE_EPETRA_DATA_TYPES
   
@@ -603,16 +614,15 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsGraphAda
         ia->setEdgeWeights(edge_weights[i],edge_weightStride[i],i);
     }
     
-    adapter =  reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
-    
+    adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
   }
 #endif
   
-  if(adapter == nullptr)
+  if(adapters.mainAdapter == nullptr)
   {
     std::cerr << "Input data chosen not compatible with "
               << "XpetraCrsGraph adapter." << std::endl;
-    return adapter;
+    return adapters;
   }
   else if (uinput->hasUICoordinates()) {
     // make the coordinate adapter
@@ -628,27 +638,31 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsGraphAda
     {
       std::cerr << "Failed to create coordinate vector adapter for "
                 << "XpetraCrsMatrix adapter." << std::endl;
-      return ca;
+      return adapters;
     }
     
     // set the coordinate adapter
-    reinterpret_cast<Zoltan2_TestingFramework::xcrsGraph_adapter *>(adapter)->setCoordinateInput(reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca));
+    reinterpret_cast<Zoltan2_TestingFramework::xcrsGraph_adapter *>
+      (adapters.mainAdapter)->setCoordinateInput(
+        reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca));
+
+    adapters.coordinateAdapter = ca;
   }
-  return adapter;
+  return adapters;
 }
 
 
-Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsMatrixAdapterForInput(
+AdapterWithOptionalCoordinateAdapter AdapterForTests::getXpetraCrsMatrixAdapterForInput(
   UserInputForTests *uinput,
   const ParameterList &pList,
   const RCP<const Comm<int> > &comm)
 {
-  Zoltan2_TestingFramework::base_adapter_t * adapter = nullptr;
+  AdapterWithOptionalCoordinateAdapter adapters;
 
   if(!pList.isParameter("data type"))
   {
     std::cerr << "Input data type unspecified" << std::endl;
-    return adapter;
+    return adapters;
   }
   
   string input_type = pList.get<string>("data type");
@@ -656,7 +670,7 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsMatrixAd
   {
     std::cerr << "Input type:" + input_type + ", unavailable or misspelled."
               << std::endl; // bad type
-    return adapter;
+    return adapters;
   }
   
   vector<const zscalar_t *> weights;
@@ -698,7 +712,7 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsMatrixAd
     }
     
     // cast to base type
-    adapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
+    adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
     
   }
   else if(input_type == "xpetra_crs_matrix")
@@ -719,7 +733,7 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsMatrixAd
          ia->setWeights(weights[i],strides[i],i);
     }
     
-    adapter =  reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
+    adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
     
   }
 #ifdef HAVE_EPETRA_DATA_TYPES
@@ -740,16 +754,16 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsMatrixAd
       for(int i = 0; i < (int)weights.size(); i++)
          ia->setWeights(weights[i],strides[i],i);
     }
-    
-    adapter =  reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
+
+    adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
   }
 #endif
   
-  if(adapter == nullptr)
+  if(adapters.mainAdapter == nullptr)
   {
     std::cerr << "Input data chosen not compatible with "
               << "XpetraCrsMatrix adapter." << std::endl;
-    return adapter;
+    return adapters;
   }
   else if (uinput->hasUICoordinates()) {
     // make the coordinate adapter
@@ -764,13 +778,15 @@ Zoltan2_TestingFramework::base_adapter_t * AdapterForTests::getXpetraCrsMatrixAd
     if(ca == nullptr){
       std::cerr << "Failed to create coordinate vector adapter for "
                 << "XpetraCrsMatrix adapter." << std::endl;
-      return ca;
+      return adapters;
     }
     
     // set the coordinate adapter
-    reinterpret_cast<Zoltan2_TestingFramework::xcrsMatrix_adapter *>(adapter)->setCoordinateInput(reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca));
+    reinterpret_cast<Zoltan2_TestingFramework::xcrsMatrix_adapter *>(adapters.mainAdapter)->setCoordinateInput(reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca));
+
+    adapters.coordinateAdapter = ca;
   }
-  return adapter;
+  return adapters;
 }
 
 

--- a/packages/zoltan2/test/helpers/AdapterForTests.hpp
+++ b/packages/zoltan2/test/helpers/AdapterForTests.hpp
@@ -95,7 +95,7 @@ using namespace Zoltan2_TestingFramework;
 struct AdapterWithOptionalCoordinateAdapter
 {
   Zoltan2_TestingFramework::base_adapter_t * mainAdapter = nullptr;
-  Zoltan2_TestingFramework::base_adapter_t * coordinateAdapter = nullptr;  // may be NULL if coordinates are not available
+  Zoltan2::VectorAdapter<tMVector_t> * coordinateAdapter = nullptr;  // may be NULL if coordinates are not available
 };
 
 
@@ -640,13 +640,14 @@ AdapterWithOptionalCoordinateAdapter AdapterForTests::getXpetraCrsGraphAdapterFo
                 << "XpetraCrsMatrix adapter." << std::endl;
       return adapters;
     }
-    
+
+    adapters.coordinateAdapter = reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca);
+
     // set the coordinate adapter
     reinterpret_cast<Zoltan2_TestingFramework::xcrsGraph_adapter *>
       (adapters.mainAdapter)->setCoordinateInput(
-        reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca));
+        adapters.coordinateAdapter);
 
-    adapters.coordinateAdapter = ca;
   }
   return adapters;
 }
@@ -713,7 +714,7 @@ AdapterWithOptionalCoordinateAdapter AdapterForTests::getXpetraCrsMatrixAdapterF
     
     // cast to base type
     adapters.mainAdapter = reinterpret_cast<Zoltan2_TestingFramework::base_adapter_t *>(ia);
-    
+
   }
   else if(input_type == "xpetra_crs_matrix")
   {
@@ -782,9 +783,13 @@ AdapterWithOptionalCoordinateAdapter AdapterForTests::getXpetraCrsMatrixAdapterF
     }
     
     // set the coordinate adapter
-    reinterpret_cast<Zoltan2_TestingFramework::xcrsMatrix_adapter *>(adapters.mainAdapter)->setCoordinateInput(reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca));
+    adapters.coordinateAdapter =
+      reinterpret_cast<Zoltan2_TestingFramework::xpetra_mv_adapter *>(ca);
 
-    adapters.coordinateAdapter = ca;
+    reinterpret_cast<Zoltan2_TestingFramework::xcrsMatrix_adapter *>
+      (adapters.mainAdapter)->setCoordinateInput(adapters.coordinateAdapter);
+
+
   }
   return adapters;
 }

--- a/packages/zoltan2/test/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/helpers/UserInputForTests.hpp
@@ -1075,7 +1075,7 @@ void UserInputForTests::readMatrixMarketFile(string path, string testData, bool 
   M_ = toMatrix;
 
   xM_ = Zoltan2::XpetraTraits<tcrsMatrix_t>::convertToXpetra(M_);
-  
+
   // Open the coordinate file.
   
   fname.str("");
@@ -1298,7 +1298,7 @@ void UserInputForTests::buildCrsMatrix(int xdim, int ydim, int zdim,
                       "UserInputForTests Galeri::Xpetra::BuildProblem failed");
   
   xM_ = Zoltan2::XpetraTraits<tcrsMatrix_t>::convertToXpetra(M_);
-  
+
   // Compute the coordinates for the matrix rows.
   
   if (verbose_ && tcomm_->getRank() == 0)
@@ -2569,7 +2569,7 @@ void UserInputForTests::readPamgenMeshFile(string path, string testData)
   }
   
   char * file_data = new char[len];
-  file_data[len] = '\0'; // critical to null terminate buffer
+  file_data[len-1] = '\0'; // critical to null terminate buffer // MDM added -1 as this was a buffer overwrite
   if(rank == 0){
     file.read(file_data,len); // if proc 0 then read file
   }

--- a/packages/zoltan2/test/helpers/Zoltan2_ComparisonHelper.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_ComparisonHelper.hpp
@@ -84,18 +84,6 @@ class ComparisonSource
 {
   
 public:
-  
-  /*! \brief Destructor.
-   */
-  ~ComparisonSource()
-  {
-    // KDD Why are these deletes here?  Very odd.  Why would we change the 
-    // KDD adapters in the comparison source?
-    if(adapter_kind == "XpetraCrsGraph")
-      delete reinterpret_cast<xcrsGraph_adapter *>(adapter.getRawPtr())->getCoordinateInput();
-    if(adapter_kind == "XpetraCrsMatrix")
-      delete reinterpret_cast<xcrsMatrix_adapter *>(adapter.getRawPtr())->getCoordinateInput();
-  }
   /* \brief Add a timer by name to the comparison sources timers map.
    * \param name is the name of the timer to be defined
    */
@@ -108,6 +96,7 @@ public:
   RCP<Zoltan2::EvaluatePartition<basic_id_t> > metricObject;
   RCP<base_problem_t> problem;
   RCP<basic_id_t> adapter;
+  RCP<basic_id_t> coordinateAdapter;
   string problem_kind;
   string adapter_kind;
   std::map<const std::string, RCP<Time> > timers;

--- a/packages/zoltan2/test/helpers/Zoltan2_ComparisonHelper.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_ComparisonHelper.hpp
@@ -96,7 +96,6 @@ public:
   RCP<Zoltan2::EvaluatePartition<basic_id_t> > metricObject;
   RCP<base_problem_t> problem;
   RCP<basic_id_t> adapter;
-  RCP<basic_id_t> coordinateAdapter;
   string problem_kind;
   string adapter_kind;
   std::map<const std::string, RCP<Time> > timers;

--- a/packages/zoltan2/test/helpers/Zoltan2_ComparisonHelper.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_ComparisonHelper.hpp
@@ -96,6 +96,7 @@ public:
   RCP<Zoltan2::EvaluatePartition<basic_id_t> > metricObject;
   RCP<base_problem_t> problem;
   RCP<basic_id_t> adapter;
+  RCP<Zoltan2::VectorAdapter<tMVector_t> > coordinateAdapterRCP;
   string problem_kind;
   string adapter_kind;
   std::map<const std::string, RCP<Time> > timers;


### PR DESCRIPTION
Removes deletes in the ComparisonHelper by converting the coordinate input adapter to use an RCP pattern.