### PR TITLE
Belos: Expose iteration details through the API.

### DIFF
--- a/packages/belos/src/BelosBiCGStabSolMgr.hpp
+++ b/packages/belos/src/BelosBiCGStabSolMgr.hpp
@@ -150,6 +150,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const BiCGStabIter<ScalarType,MV,OP>& getIteration() const {
+      return *block_cg_iter;
+    }
+
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -298,6 +302,8 @@ namespace Belos {
 
     // Internal state variables.
     bool isSet_;
+
+    Teuchos::RCP<BiCGStabIter<ScalarType,MV,OP> > block_cg_iter;
   };
 
 
@@ -697,7 +703,7 @@ ReturnType BiCGStabSolMgr<ScalarType,MV,OP>::solve ()
   //////////////////////////////////////////////////////////////////////////////////////
   // Pseudo-Block BiCGStab solver
 
-  Teuchos::RCP<BiCGStabIter<ScalarType,MV,OP> > block_cg_iter
+  block_cg_iter
     = Teuchos::rcp( new BiCGStabIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations

--- a/packages/belos/src/BelosBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosBlockCGSolMgr.hpp
@@ -231,6 +231,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const CGIteration<ScalarType,MV,OP>& getIteration() const {
+      return *block_cg_iter;
+    }
+
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -402,6 +406,8 @@ namespace Belos {
 
     //! Whether or not the parameters have been set (via \c setParameters()).
     bool isSet_;
+
+    Teuchos::RCP<CGIteration<ScalarType,MV,OP> > block_cg_iter;
   };
 
 
@@ -853,7 +859,6 @@ ReturnType BlockCGSolMgr<ScalarType,MV,OP,true>::solve() {
   ////////////////////////////////////////////////////////////////////////////
   // Set up the BlockCG Iteration subclass.
 
-  RCP<CGIteration<ScalarType,MV,OP> > block_cg_iter;
   if (blockSize_ == 1) {
     // Standard (nonblock) CG is faster for the special case of a
     // block size of 1.

--- a/packages/belos/src/BelosBlockGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGCRODRSolMgr.hpp
@@ -197,6 +197,10 @@ public:
     return *problem_;
   }
 
+  const BlockGmresIter<ScalarType,MV,OP> >& getIteration() const {
+    return *block_gmres_iter;
+  }
+
   //! Get a parameter list containing the valid parameters for this object.
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
@@ -298,7 +302,7 @@ private:
   //  "AugKryl" indicates  it is specialized for building a recycle space from the augmented Krylov subspace
 
   // Functions which control the building of a recycle space
-  void buildRecycleSpaceKryl(int& keff, Teuchos::RCP<BlockGmresIter<ScalarType,MV,OP> > block_gmres_iter);
+  void buildRecycleSpaceKryl(int& keff, block_gmres_iter);
   void buildRecycleSpaceAugKryl(Teuchos::RCP<BlockGCRODRIter<ScalarType,MV,OP> > gcrodr_iter);
 
   // Recycling with Harmonic Ritz Vectors
@@ -1051,6 +1055,8 @@ private:
 
      // Inform the solver manager that the current parameters were set.
      isSet_ = true;
+
+     Teuchos:: RCP<BlockGmresIter<ScalarType,MV,OP> > block_gmres_iter;
    }
 
   // initializeStateStorage.

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -179,6 +179,10 @@ public:
     return *problem_;
   }
 
+  const GmresIteration<ScalarType,MV,OP>& getIteration() const {
+    return *block_gmres_iter;
+  }
+
   /*! \brief Get a parameter list containing the valid parameters for this object.
    */
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -292,6 +296,7 @@ private:
 
   // Linear problem.
   Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
+  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > block_gmres_iter;
 
   // Output manager.
   Teuchos::RCP<OutputManager<ScalarType> > printer_;
@@ -1001,8 +1006,6 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
 
   //////////////////////////////////////////////////////////////////////////////////////
   // BlockGmres solver
-
-  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > block_gmres_iter;
 
   if (isFlexible_)
     block_gmres_iter = Teuchos::rcp( new BlockFGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );

--- a/packages/belos/src/BelosFixedPointSolMgr.hpp
+++ b/packages/belos/src/BelosFixedPointSolMgr.hpp
@@ -75,10 +75,10 @@
  */
 
 namespace Belos {
-  
+
   //! @name FixedPointSolMgr Exceptions
   //@{
-  
+
   /** \brief FixedPointSolMgrLinearProblemFailure is thrown when the linear problem is
    * not setup (i.e. setProblem() was not called) when solve() is called.
    *
@@ -88,21 +88,21 @@ namespace Belos {
   class FixedPointSolMgrLinearProblemFailure : public BelosError {public:
     FixedPointSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   template<class ScalarType, class MV, class OP>
   class FixedPointSolMgr : public SolverManager<ScalarType,MV,OP> {
-    
+
   private:
     typedef MultiVecTraits<ScalarType,MV> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    
+
   public:
-    
+
     //! @name Constructors/Destructor
-    //@{ 
+    //@{
 
     /*! \brief Empty constructor for FixedPointSolMgr.
      * This constructor takes no arguments and sets the default values for the solver.
@@ -115,42 +115,46 @@ namespace Belos {
      *
      * This constructor accepts the LinearProblem to be solved in addition
      * to a parameter list of options for the solver manager. These options include the following:
-     *   - "Block Size" - an \c int specifying the block size to be used by the underlying block 
+     *   - "Block Size" - an \c int specifying the block size to be used by the underlying block
      *                    conjugate-gradient solver. Default: 1
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Output Stream" - a reference-counted pointer to the output stream where all
      *                       solver output is sent.  Default: Teuchos::rcp(&std::cout,false)
-     *   - "Output Frequency" - an \c int specifying how often convergence information should be 
+     *   - "Output Frequency" - an \c int specifying how often convergence information should be
      *                          outputted.  Default: -1 (never)
      *   - "Show Maximum Residual Norm Only" - a \c bool specifying whether that only the maximum
-     *                                         relative residual norm is printed if convergence 
+     *                                         relative residual norm is printed if convergence
      *                                         information is printed. Default: false
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
      */
     FixedPointSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 		   const Teuchos::RCP<Teuchos::ParameterList> &pl );
-    
+
     //! Destructor.
     virtual ~FixedPointSolMgr() {};
     //@}
-    
+
     //! @name Accessor methods
-    //@{ 
-    
+    //@{
+
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
+    }
+
+    const FixedPointIteration<ScalarType,MV,OP>& getIteration() const {
+      return *block_fp_iter;
     }
 
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    
+
     /*! \brief Get a parameter list containing the current parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const { return params_; }
-    
-    /*! \brief Return the timers for this object. 
+
+    /*! \brief Return the timers for this object.
      *
      * The timers are ordered as follows:
      *   - time spent in solve() routine
@@ -160,7 +164,7 @@ namespace Belos {
     }
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -176,18 +180,18 @@ namespace Belos {
     /*! \brief Return whether a loss of accuracy was detected by this solver during the most current solve.
      */
     bool isLOADetected() const { return false; }
- 
+
     //@}
-    
+
     //! @name Set methods
     //@{
-   
-    //! Set the linear problem that needs to be solved. 
+
+    //! Set the linear problem that needs to be solved.
     void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) { problem_ = problem; }
-   
-    //! Set the parameters the solver manager should use to solve the linear problem. 
+
+    //! Set the parameters the solver manager should use to solve the linear problem.
     void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params );
-    
+
     //! Set user-defined convergence status test.
     void replaceUserConvStatusTest( const Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP> > &userConvStatusTest )
     {
@@ -205,7 +209,7 @@ namespace Belos {
     }
 
     //@}
-   
+
     //! @name Reset methods
     //@{
     /*! \brief Performs a reset of the solver manager specified by the \c ResetType.  This informs the
@@ -214,21 +218,21 @@ namespace Belos {
      */
     void reset( const ResetType type ) { if ((type & Belos::Problem) && !Teuchos::is_null(problem_)) problem_->setProblem(); }
     //@}
- 
+
     //! @name Solver application methods
-    //@{ 
-    
-    /*! \brief This method performs possibly repeated calls to the underlying linear solver's 
-     *         iterate() routine until the problem has been solved (as decided by the solver manager) 
+    //@{
+
+    /*! \brief This method performs possibly repeated calls to the underlying linear solver's
+     *         iterate() routine until the problem has been solved (as decided by the solver manager)
      *         or the solver manager decides to quit.
      *
-     * This method calls FixedPointIter::iterate() or CGIter::iterate(), which will return either because a 
+     * This method calls FixedPointIter::iterate() or CGIter::iterate(), which will return either because a
      * specially constructed status test evaluates to ::Passed or an std::exception is thrown.
      *
      * A return from FixedPointIter::iterate() signifies one of the following scenarios:
-     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions 
+     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions
      *      to the linear system will be placed in the linear problem and return ::Unconverged.
-     *    - global convergence has been met. In this case, the current solutions to the linear system 
+     *    - global convergence has been met. In this case, the current solutions to the linear system
      *      will be placed in the linear problem and the solver manager will return ::Converged
      *
      * \returns ::ReturnType specifying:
@@ -236,22 +240,22 @@ namespace Belos {
      *     - ::Unconverged: the linear problem was not solved to the specification desired by the solver manager.
      */
     ReturnType solve();
-    
+
     //@}
-    
+
     /** \name Overridden from Teuchos::Describable */
     //@{
-    
+
     /** \brief Method to return description of the block CG solver manager */
     std::string description() const;
-    
+
     //@}
-    
+
   private:
 
     //! The linear problem to solve.
     Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
-    
+
     //! Output manager, that handles printing of different kinds of messages.
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
     //! Output stream to which the output manager prints.
@@ -274,7 +278,7 @@ namespace Belos {
 
     //! Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
-    
+
     //
     // Default solver parameters.
     //
@@ -296,7 +300,7 @@ namespace Belos {
     MagnitudeType convtol_;
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -310,7 +314,7 @@ namespace Belos {
 
     int blockSize_, verbosity_, outputStyle_, outputFreq_;
     bool showMaxResNormOnly_;
-    
+
     //! Prefix label for all the timers.
     std::string label_;
 
@@ -319,6 +323,8 @@ namespace Belos {
 
     //! Whether or not the parameters have been set (via \c setParameters()).
     bool isSet_;
+
+    Teuchos::RCP<FixedPointIteration<ScalarType,MV,OP> > block_fp_iter;
   };
 
 
@@ -373,7 +379,7 @@ FixedPointSolMgr<ScalarType,MV,OP>::FixedPointSolMgr() :
 template<class ScalarType, class MV, class OP>
 FixedPointSolMgr<ScalarType,MV,OP>::
 FixedPointSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-	      const Teuchos::RCP<Teuchos::ParameterList> &pl) : 
+	      const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
   outputStream_(outputStream_default_),
   convtol_(convtol_default_),
@@ -388,19 +394,19 @@ FixedPointSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
   label_(label_default_),
   isSet_(false)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(problem_.is_null(), std::invalid_argument, 
+  TEUCHOS_TEST_FOR_EXCEPTION(problem_.is_null(), std::invalid_argument,
     "FixedPointSolMgr's constructor requires a nonnull LinearProblem instance.");
 
   // If the user passed in a nonnull parameter list, set parameters.
   // Otherwise, the next solve() call will use default parameters,
   // unless the user calls setParameters() first.
   if (! pl.is_null()) {
-    setParameters (pl);  
+    setParameters (pl);
   }
 }
 
 template<class ScalarType, class MV, class OP>
-void 
+void
 FixedPointSolMgr<ScalarType,MV,OP>::
 setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 {
@@ -424,7 +430,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 
   // Check for blocksize
   if (params->isParameter("Block Size")) {
-    blockSize_ = params->get("Block Size",blockSize_default_);    
+    blockSize_ = params->get("Block Size",blockSize_default_);
     TEUCHOS_TEST_FOR_EXCEPTION(blockSize_ <= 0, std::invalid_argument,
 		       "Belos::FixedPointSolMgr: \"Block Size\" must be strictly positive.");
 
@@ -499,8 +505,8 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
-  }  
-  
+  }
+
   // Convergence
   typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
   typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP>  StatusTestResNorm_t;
@@ -514,7 +520,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
     if (convTest_ != Teuchos::null)
       convTest_->setTolerance( convtol_ );
   }
-  
+
   if (params->isParameter("Show Maximum Residual Norm Only")) {
     showMaxResNormOnly_ = Teuchos::getParameter<bool>(*params,"Show Maximum Residual Norm Only");
 
@@ -529,14 +535,14 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   // Basic test checks maximum iterations and native residual.
   if (maxIterTest_ == Teuchos::null)
     maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
-  
+
   // Implicit residual test, using the native residual to determine if convergence was achieved.
   if (convTest_ == Teuchos::null)
     convTest_ = Teuchos::rcp( new StatusTestResNorm_t( convtol_, 1 ) );
-  
+
   if (sTest_ == Teuchos::null)
     sTest_ = Teuchos::rcp( new StatusTestCombo_t( StatusTestCombo_t::OR, maxIterTest_, convTest_ ) );
-  
+
   if (outputTest_ == Teuchos::null) {
 
     // Create the status test output class.
@@ -562,13 +568,13 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   isSet_ = true;
 }
 
-    
+
 template<class ScalarType, class MV, class OP>
-Teuchos::RCP<const Teuchos::ParameterList> 
+Teuchos::RCP<const Teuchos::ParameterList>
 FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
-  
+
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
@@ -588,7 +594,7 @@ FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "to the output stream.");
     pl->set("Output Frequency", outputFreq_default_,
       "How often convergence information should be outputted\n"
-      "to the output stream.");  
+      "to the output stream.");
     pl->set("Output Stream", outputStream_default_,
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
@@ -603,7 +609,7 @@ FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
   return validPL;
 }
 
-  
+
 // solve()
 template<class ScalarType, class MV, class OP>
 ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
@@ -622,8 +628,8 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
 
   Teuchos::BLAS<int,ScalarType> blas;
   Teuchos::LAPACK<int,ScalarType> lapack;
-  
-  TEUCHOS_TEST_FOR_EXCEPTION( !problem_->isProblemSet(), 
+
+  TEUCHOS_TEST_FOR_EXCEPTION( !problem_->isProblemSet(),
     FixedPointSolMgrLinearProblemFailure,
     "Belos::FixedPointSolMgr::solve(): Linear problem is not ready, setProblem() "
     "has not been called.");
@@ -636,9 +642,9 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   std::vector<int> currIdx, currIdx2;
   currIdx.resize( blockSize_ );
   currIdx2.resize( blockSize_ );
-  for (int i=0; i<numCurrRHS; ++i) 
+  for (int i=0; i<numCurrRHS; ++i)
     { currIdx[i] = startPtr+i; currIdx2[i]=i; }
-  for (int i=numCurrRHS; i<blockSize_; ++i) 
+  for (int i=numCurrRHS; i<blockSize_; ++i)
     { currIdx[i] = -1; currIdx2[i] = i; }
 
   // Inform the linear problem of the current linear system to solve.
@@ -648,18 +654,17 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   // Set up the parameter list for the Iteration subclass.
   Teuchos::ParameterList plist;
   plist.set("Block Size",blockSize_);
-  
+
   // Reset the output status test (controls all the other status tests).
   outputTest_->reset();
 
   // Assume convergence is achieved, then let any failed convergence
   // set this to false.  "Innocent until proven guilty."
-  bool isConverged = true;	
+  bool isConverged = true;
 
   ////////////////////////////////////////////////////////////////////////////
   // Set up the FixedPoint Iteration subclass.
 
-  RCP<FixedPointIteration<ScalarType,MV,OP> > block_fp_iter;
   block_fp_iter = rcp (new FixedPointIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, plist));
 
   // Enter solve() iterations
@@ -690,7 +695,7 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
       block_fp_iter->initializeFixedPoint(newstate);
 
       while(1) {
-	
+
 	// tell block_fp_iter to iterate
 	try {
 	  block_fp_iter->iterate();
@@ -698,7 +703,7 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
 	  // Check whether any of the linear systems converged.
 	  //
 	  if (convTest_->getStatus() == Passed) {
-	    // At least one of the linear system(s) converged.  
+	    // At least one of the linear system(s) converged.
 	    //
 	    // Get the column indices of the linear systems that converged.
 	    std::vector<int> convIdx = convTest_->convIndices();
@@ -730,7 +735,7 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
 		currRHSIdx[have++] = currRHSIdx[i];
 	      }
               else {
-              } 
+              }
 	    }
 	    currRHSIdx.resize(have);
 	    currIdx2.resize(have);
@@ -773,47 +778,47 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
 	catch (const std::exception &e) {
 	  std::ostream& err = printer_->stream (Errors);
 	  err << "Error! Caught std::exception in FixedPointIteration::iterate() at "
-	      << "iteration " << block_fp_iter->getNumIters() << std::endl 
+	      << "iteration " << block_fp_iter->getNumIters() << std::endl
 	      << e.what() << std::endl;
 	  throw;
 	}
       }
-      
+
       // Inform the linear problem that we are finished with this
       // block linear system.
       problem_->setCurrLS();
-      
+
       // Update indices for the linear systems to be solved.
       startPtr += numCurrRHS;
       numRHS2Solve -= numCurrRHS;
       if ( numRHS2Solve > 0 ) {
 	numCurrRHS = ( numRHS2Solve < blockSize_) ? numRHS2Solve : blockSize_;
 
-	
+
 	currIdx.resize( blockSize_ );
 	currIdx2.resize( blockSize_ );
-	for (int i=0; i<numCurrRHS; ++i) 
+	for (int i=0; i<numCurrRHS; ++i)
 	  { currIdx[i] = startPtr+i; currIdx2[i] = i; }
-	for (int i=numCurrRHS; i<blockSize_; ++i) 
+	for (int i=numCurrRHS; i<blockSize_; ++i)
 	  { currIdx[i] = -1; currIdx2[i] = i; }
 
 	// Set the next indices.
 	problem_->setLSIndex( currIdx );
 
 	// Set the new blocksize for the solver.
-	block_fp_iter->setBlockSize( blockSize_ );	
+	block_fp_iter->setBlockSize( blockSize_ );
       }
       else {
         currIdx.resize( numRHS2Solve );
       }
-      
+
     }// while ( numRHS2Solve > 0 )
-    
+
   }
 
   // print final summary
   sTest_->print( printer_->stream(FinalSummary) );
- 
+
   // print timing information
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   // Calling summarize() requires communication in general, so don't
@@ -824,7 +829,7 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
     Teuchos::TimeMonitor::summarize( printer_->stream(TimingDetails) );
   }
 #endif
- 
+
   // Save the iteration count for this solve.
   numIters_ = maxIterTest_->getNumIters();
 
@@ -832,11 +837,11 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   {
     // testValues is nonnull and not persistent.
     const std::vector<MagnitudeType>* pTestValues = convTest_->getTestValue();
-    
+
     TEUCHOS_TEST_FOR_EXCEPTION(pTestValues == NULL, std::logic_error,
       "Belos::FixedPointSolMgr::solve(): The convergence test's getTestValue() "
       "method returned NULL.  Please report this bug to the Belos developers.");
-    
+
     TEUCHOS_TEST_FOR_EXCEPTION(pTestValues->size() < 1, std::logic_error,
       "Belos::FixedPointSolMgr::solve(): The convergence test's getTestValue() "
       "method returned a vector of length zero.  Please report this bug to the "
@@ -847,11 +852,11 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
     // just for the vectors from the last deflation?
     achievedTol_ = *std::max_element (pTestValues->begin(), pTestValues->end());
   }
- 
+
   if (!isConverged) {
-    return Unconverged; // return from FixedPointSolMgr::solve() 
+    return Unconverged; // return from FixedPointSolMgr::solve()
   }
-  return Converged; // return from FixedPointSolMgr::solve() 
+  return Converged; // return from FixedPointSolMgr::solve()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
@@ -862,7 +867,7 @@ std::string FixedPointSolMgr<ScalarType,MV,OP>::description() const
   oss << "Belos::FixedPointSolMgr<...,"<<Teuchos::ScalarTraits<ScalarType>::name()<<">";
   return oss.str();
 }
-  
+
 } // end Belos namespace
 
 #endif /* BELOS_FIXEDPOINT_SOLMGR_HPP */

--- a/packages/belos/src/BelosGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosGCRODRSolMgr.hpp
@@ -284,6 +284,10 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
       return *problem_;
     }
 
+    const GCRODRIter<ScalarType,MV,OP>& getIteration() const {
+      return *gcrodr_iter;
+    }
+
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -517,6 +521,8 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
 
     // Have we generated or regenerated a recycle space yet this solve?
     bool builtRecycleSpace_;
+
+    Teuchos::RCP<GCRODRIter<ScalarType,MV,OP> > gcrodr_iter;
   };
 
 
@@ -1394,7 +1400,6 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // GCRODR solver
 
-  RCP<GCRODRIter<ScalarType,MV,OP> > gcrodr_iter;
   gcrodr_iter = rcp( new GCRODRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
   // Number of iterations required to generate initial recycle space (if needed)
   int prime_iterations = 0;

--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -201,6 +201,10 @@ public:
     return *problem_;
   }
 
+  const BlockGmresIter<ScalarType,MV,OP>& getIteration() const {
+    return *gmres_iter;
+  }
+
   /*! \brief Get a parameter list containing the valid parameters for this object.
    */
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -364,6 +368,8 @@ private:
 
   //! Cached default (valid) parameters.
   mutable Teuchos::RCP<const Teuchos::ParameterList> validPL_;
+
+  Teuchos::RCP<BlockGmresIter<ScalarType,MV,OP> > gmres_iter;
 };
 
 
@@ -980,7 +986,6 @@ bool GmresPolySolMgr<ScalarType,MV,OP>::generatePoly()
     Teuchos::rcp( new StatusTestCombo<ScalarType,MV,OP>( StatusTestCombo<ScalarType,MV,OP>::OR, maxItrTst, convTst ) );
 
   // Create Gmres iteration object to perform one cycle of Gmres.
-  Teuchos::RCP<BlockGmresIter<ScalarType,MV,OP> > gmres_iter;
   gmres_iter = Teuchos::rcp( new BlockGmresIter<ScalarType,MV,OP>(newProblem,printer_,polyTest,ortho_,polyList) );
 
   // Create the first block in the current Krylov basis (residual).

--- a/packages/belos/src/BelosLSQRSolMgr.hpp
+++ b/packages/belos/src/BelosLSQRSolMgr.hpp
@@ -321,6 +321,10 @@ public:
     return *problem_;
   }
 
+  const LSQRIter<ScalarType,MV,OP>& getIteration() const {
+    return *lsqr_iter;
+  }
+
   /*! \brief Get a parameter list containing the valid parameters for this object.
    */
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -495,6 +499,8 @@ private:
   // Internal state variables.
   bool isSet_;
   bool loaDetected_;
+
+  Teuchos::RCP<LSQRIter<ScalarType,MV,OP> > lsqr_iter;
 };
 
 template<class ScalarType, class MV, class OP>
@@ -933,7 +939,7 @@ LSQRSolMgr<ScalarType,MV,OP,false>::solve ()
   plist.set ("Lambda", lambda_);
 
   typedef LSQRIter<ScalarType,MV,OP> iter_type;
-  RCP<iter_type> lsqr_iter =
+  lsqr_iter =
     rcp (new iter_type (problem_, printer_, outputTest_, plist));
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   Teuchos::TimeMonitor slvtimer (*timerSolve_);

--- a/packages/belos/src/BelosMinresSolMgr.hpp
+++ b/packages/belos/src/BelosMinresSolMgr.hpp
@@ -195,6 +195,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const MinresIter<ScalarType,MV,OP>& getIteration() const {
+      return *minres_iter;
+    }
+
     //! Return the list of default parameters for this object.
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const {
       if (defaultParams_.is_null()) {
@@ -391,6 +395,8 @@ namespace Belos {
     /// components are null.
     static void
     validateProblem (const Teuchos::RCP<LinearProblem<ScalarType, MV, OP> >& problem);
+
+    Teuchos::RCP<MinresIter<ScalarType, MV, OP> > minres_iter;
   };
 
 
@@ -697,7 +703,7 @@ namespace Belos {
     // Create MINRES iteration object.  Pass along the solver
     // manager's parameters, which have already been validated.
     typedef MinresIter<ScalarType, MV, OP> iter_type;
-    RCP<iter_type> minres_iter =
+    minres_iter =
       rcp (new iter_type (problem_, printer_, outputTest_, *params_));
 
     // The index/indices of the right-hand sides for which MINRES did

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -247,6 +247,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const PCPGIter<ScalarType,MV,OP>& getIteration() const {
+      return *pcpg_iter;
+    }
+
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -408,6 +412,8 @@ namespace Belos {
 
     // Internal state variables.
     bool isSet_;
+
+    Teuchos::RCP<PCPGIter<ScalarType,MV,OP> > pcpg_iter;
   };
 
 
@@ -819,7 +825,6 @@ ReturnType PCPGSolMgr<ScalarType,MV,OP,true>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // PCPG solver
 
-  Teuchos::RCP<PCPGIter<ScalarType,MV,OP> > pcpg_iter;
   pcpg_iter = Teuchos::rcp( new PCPGIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
   // Number of iterations required to generate initial recycle space (if needed)
 

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -171,7 +171,7 @@ namespace Belos {
      *			<iframe src="belos_PseudoBlockCG.xml" width=100% scrolling="no" frameborder="0">
      *			</iframe>
      *			<hr />
-     *			\endhtmlonly   
+     *			\endhtmlonly
      */
     PseudoBlockCGSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                          const Teuchos::RCP<Teuchos::ParameterList> &pl );
@@ -185,6 +185,10 @@ namespace Belos {
 
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
+    }
+
+    const PseudoBlockCGIter<ScalarType,MV,OP>& getIteration() const {
+      return *block_cg_iter;
     }
 
     /*! \brief Get a parameter list containing the valid parameters for this object.
@@ -354,6 +358,8 @@ namespace Belos {
 
     // Internal state variables.
     bool isSet_;
+
+    Teuchos::RCP<PseudoBlockCGIter<ScalarType,MV,OP> > block_cg_iter;
   };
 
 
@@ -816,7 +822,7 @@ ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
   //////////////////////////////////////////////////////////////////////////////////////
   // Pseudo-Block CG solver
 
-  Teuchos::RCP<PseudoBlockCGIter<ScalarType,MV,OP> > block_cg_iter
+  block_cg_iter
     = Teuchos::rcp( new PseudoBlockCGIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -269,6 +269,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const PseudoBlockGmresIter<ScalarType,MV,OP>& getIteration() const {
+      return *block_gmres_iter;
+    }
+
     //! A list of valid default parameters for this solver.
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
@@ -525,6 +529,8 @@ namespace Belos {
     // Internal state variables.
     bool isSet_, isSTSet_, expResTest_;
     bool loaDetected_;
+
+    Teuchos::RCP<PseudoBlockGmresIter<ScalarType,MV,OP> > block_gmres_iter;
   };
 
 
@@ -1329,7 +1335,7 @@ ReturnType PseudoBlockGmresSolMgr<ScalarType,MV,OP>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // BlockGmres solver
 
-  Teuchos::RCP<PseudoBlockGmresIter<ScalarType,MV,OP> > block_gmres_iter
+  block_gmres_iter
     = Teuchos::rcp( new PseudoBlockGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
 
   // Enter solve() iterations

--- a/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
@@ -142,6 +142,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const PseudoBlockStochasticCGIter<ScalarType,MV,OP>& getIteration() const {
+      return *block_cg_iter;
+    }
+
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -284,6 +288,7 @@ namespace Belos {
     // Stashed copy of the stochastic vector
     Teuchos::RCP<MV> Y_;
 
+    Teuchos::RCP<PseudoBlockStochasticCGIter<ScalarType,MV,OP> > block_cg_iter;
   };
 
 

--- a/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
@@ -69,17 +69,17 @@
 /*! \class Belos::PseudoBlockTFQMRSolMgr
  *
  *  \brief The Belos::PseudoBlockTFQMRSolMgr provides a powerful and fully-featured solver manager over the pseudo-block TFQMR linear solver.
- 
+
  \ingroup belos_solver_framework
- 
+
  \author Heidi Thornquist
 */
 
 namespace Belos {
-  
+
   //! @name PseudoBlockTFQMRSolMgr Exceptions
   //@{
-  
+
   /** \brief PseudoBlockTFQMRSolMgrLinearProblemFailure is thrown when the linear problem is
    * not setup (i.e. setProblem() was not called) when solve() is called.
    *
@@ -89,7 +89,7 @@ namespace Belos {
   class PseudoBlockTFQMRSolMgrLinearProblemFailure : public BelosError {public:
     PseudoBlockTFQMRSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   /** \brief PseudoBlockTFQMRSolMgrOrthoFailure is thrown when the orthogonalization manager is
    * unable to generate orthonormal columns from the initial basis vectors.
    *
@@ -99,21 +99,21 @@ namespace Belos {
   class PseudoBlockTFQMRSolMgrOrthoFailure : public BelosError {public:
     PseudoBlockTFQMRSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   template<class ScalarType, class MV, class OP>
   class PseudoBlockTFQMRSolMgr : public SolverManager<ScalarType,MV,OP> {
-    
+
   private:
     typedef MultiVecTraits<ScalarType,MV> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    
+
   public:
-    
+
     //! @name Constructors/Destructor
-    //@{ 
+    //@{
 
     /*! \brief Empty constructor for PseudoBlockTFQMRSolMgr.
      * This constructor takes no arguments and sets the default values for the solver.
@@ -126,41 +126,45 @@ namespace Belos {
      *
      * This constructor accepts the LinearProblem to be solved in addition
      * to a parameter list of options for the solver manager. These options include the following:
-     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the 
+     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the
      *                            underlying solver is allowed to perform. Default: 1000
-     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms 
+     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms
      *                               must reach to decide convergence. Default: 1e-8.
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Output Stream" - a reference-counted pointer to the output stream where all
      *                       solver output is sent.  Default: Teuchos::rcp(&std::cout,false)
-     *   - "Output Frequency" - an \c int specifying how often convergence information should be 
+     *   - "Output Frequency" - an \c int specifying how often convergence information should be
      *                          outputted.  Default: -1 (never)
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
      */
     PseudoBlockTFQMRSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 		 const Teuchos::RCP<Teuchos::ParameterList> &pl );
-    
+
     //! Destructor.
     virtual ~PseudoBlockTFQMRSolMgr() {};
     //@}
-    
+
     //! @name Accessor methods
-    //@{ 
-    
+    //@{
+
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
+    }
+
+    const PseudoBlockTFQMRIter<ScalarType,MV,OP>& getIteration() const {
+      return *block_tfqmr_iter;
     }
 
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    
+
     /*! \brief Get a parameter list containing the current parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const { return params_; }
-    
-    /*! \brief Return the timers for this object. 
+
+    /*! \brief Return the timers for this object.
      *
      * The timers are ordered as follows:
      *   - time spent in solve() routine
@@ -170,7 +174,7 @@ namespace Belos {
     }
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -182,7 +186,7 @@ namespace Belos {
     int getNumIters() const {
       return numIters_;
     }
-    
+
     /// \brief Whether loss of accuracy was detected during the last \c solve() invocation.
     ///
     /// In solvers that can detect a loss of accuracy, this method
@@ -191,20 +195,20 @@ namespace Belos {
     /// not currently detect a loss of accuracy, so this method always
     /// returns false.
     bool isLOADetected() const { return false; }
-    
+
     //@}
-    
+
     //! @name Set methods
     //@{
-    
-    //! Set the linear problem that needs to be solved. 
+
+    //! Set the linear problem that needs to be solved.
     void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) { problem_ = problem; }
-    
-    //! Set the parameters the solver manager should use to solve the linear problem. 
+
+    //! Set the parameters the solver manager should use to solve the linear problem.
     void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params );
-    
+
     //@}
-    
+
     //! @name Reset methods
     //@{
     /*! \brief Performs a reset of the solver manager specified by the \c ResetType.  This informs the
@@ -213,21 +217,21 @@ namespace Belos {
      */
     void reset( const ResetType type ) { if ((type & Belos::Problem) && !Teuchos::is_null(problem_)) problem_->setProblem(); }
     //@}
-    
+
     //! @name Solver application methods
-    //@{ 
-    
-    /*! \brief This method performs possibly repeated calls to the underlying linear solver's 
-     *         iterate() routine until the problem has been solved (as decided by the solver manager) 
+    //@{
+
+    /*! \brief This method performs possibly repeated calls to the underlying linear solver's
+     *         iterate() routine until the problem has been solved (as decided by the solver manager)
      *         or the solver manager decides to quit.
      *
-     * This method calls PseudoBlockTFQMRIter::iterate(), which will return either because a 
+     * This method calls PseudoBlockTFQMRIter::iterate(), which will return either because a
      * specially constructed status test evaluates to ::Passed or an std::exception is thrown.
      *
      * A return from PseudoBlockTFQMRIter::iterate() signifies one of the following scenarios:
-     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions 
+     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions
      *      to the linear system will be placed in the linear problem and return ::Unconverged.
-     *    - global convergence has been met. In this case, the current solutions to the linear system 
+     *    - global convergence has been met. In this case, the current solutions to the linear system
      *      will be placed in the linear problem and the solver manager will return ::Converged
      *
      * \returns ::ReturnType specifying:
@@ -235,39 +239,39 @@ namespace Belos {
      *     - ::Unconverged: the linear problem was not solved to the specification desired by the solver manager.
      */
     ReturnType solve();
-    
+
     //@}
-    
+
     /** \name Overridden from Teuchos::Describable */
     //@{
-    
+
     /** \brief Method to return description of the pseudo-block TFQMR solver manager */
     std::string description() const;
-    
+
     //@}
-    
+
   private:
 
     // Method for checking current status test against defined linear problem.
     bool checkStatusTest();
-    
+
     // Linear problem.
     Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
-    
+
     // Output manager.
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
     Teuchos::RCP<std::ostream> outputStream_;
-    
+
     // Status test.
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
     Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > convTest_;
     Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > expConvTest_, impConvTest_;
     Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
-    
+
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
-    
+
     // Default solver values.
     static const MagnitudeType convtol_default_;
     static const MagnitudeType impTolScale_default_;
@@ -277,8 +281,8 @@ namespace Belos {
     static const int outputStyle_default_;
     static const int outputFreq_default_;
     static const int defQuorum_default_;
-    static const std::string impResScale_default_; 
-    static const std::string expResScale_default_; 
+    static const std::string impResScale_default_;
+    static const std::string expResScale_default_;
     static const std::string label_default_;
     static const Teuchos::RCP<std::ostream> outputStream_default_;
 
@@ -288,13 +292,15 @@ namespace Belos {
     int verbosity_, outputStyle_, outputFreq_, defQuorum_;
     bool expResTest_;
     std::string impResScale_, expResScale_;
-    
+
     // Timers.
     std::string label_;
     Teuchos::RCP<Teuchos::Time> timerSolve_;
 
     // Internal state variables.
     bool isSet_, isSTSet_;
+
+    Teuchos::RCP<PseudoBlockTFQMRIter<ScalarType,MV,OP> > block_tfqmr_iter;
   };
 
 
@@ -360,9 +366,9 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr() :
 
 // Basic Constructor
 template<class ScalarType, class MV, class OP>
-PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr( 
+PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr(
 					     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) : 
+					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(outputStream_default_),
   convtol_(convtol_default_),
@@ -382,13 +388,13 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr(
   isSTSet_(false)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null, std::invalid_argument, "Problem not given to solver manager.");
-  
+
   // If the parameter list pointer is null, then set the current parameters to the default parameter list.
   if ( !is_null(pl) ) {
-    setParameters( pl );  
+    setParameters( pl );
   }
 }
-  
+
 template<class ScalarType, class MV, class OP>
 void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
 {
@@ -477,8 +483,8 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
-  }  
-  
+  }
+
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
     convtol_ = params->get("Convergence Tolerance",convtol_default_);
@@ -487,7 +493,7 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
     params_->set("Convergence Tolerance", convtol_);
     isSTSet_ = false;
   }
- 
+
   if (params->isParameter("Implicit Tolerance Scale Factor")) {
     impTolScale_ = params->get("Implicit Tolerance Scale Factor",impTolScale_default_);
 
@@ -506,9 +512,9 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
       // Update parameter in our list.
       params_->set("Implicit Residual Scaling", impResScale_);
       isSTSet_ = false;
-    }      
+    }
   }
-  
+
   if (params->isParameter("Explicit Residual Scaling")) {
     std::string tempExpResScale = Teuchos::getParameter<std::string>( *params, "Explicit Residual Scaling" );
 
@@ -519,7 +525,7 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
       // Update parameter in our list.
       params_->set("Explicit Residual Scaling", expResScale_);
       isSTSet_ = false;
-    }      
+    }
   }
 
   if (params->isParameter("Explicit Residual Test")) {
@@ -568,7 +574,7 @@ bool PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
 
   if (expResTest_) {
-   
+
     // Implicit residual test, using the native residual to determine if convergence was achieved.
     Teuchos::RCP<StatusTestGenResNorm_t> tmpImpConvTest =
       Teuchos::rcp( new StatusTestGenResNorm_t( impTolScale_*convtol_, defQuorum_ ) );
@@ -608,20 +614,20 @@ bool PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   std::string solverDesc = " Pseudo Block TFQMR ";
   outputTest_->setSolverDesc( solverDesc );
 
-  
+
   // The status test is now set.
   isSTSet_ = true;
 
   return false;
 }
 
-    
+
 template<class ScalarType, class MV, class OP>
-Teuchos::RCP<const Teuchos::ParameterList> 
+Teuchos::RCP<const Teuchos::ParameterList>
 PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
-  
+
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
@@ -642,7 +648,7 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "to the output stream.");
     pl->set("Output Frequency", outputFreq_default_,
       "How often convergence information should be outputted\n"
-      "to the output stream.");  
+      "to the output stream.");
     pl->set("Deflation Quorum", defQuorum_default_,
       "The number of linear systems that need to converge before they are deflated.");
     pl->set("Output Stream", outputStream_default_,
@@ -662,13 +668,13 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
   return validPL;
 }
 
-  
+
 // solve()
 template<class ScalarType, class MV, class OP>
 ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
 
   // Set the current parameters if they were not set before.
-  // NOTE:  This may occur if the user generated the solver manager with the default constructor and 
+  // NOTE:  This may occur if the user generated the solver manager with the default constructor and
   // then didn't set any parameters using setParameters().
   if (!isSet_) {
     setParameters(Teuchos::parameterList(*getValidParameters()));
@@ -701,17 +707,17 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // Parameter list
   Teuchos::ParameterList plist;
-  
-  // Reset the status test.  
+
+  // Reset the status test.
   outputTest_->reset();
 
   // Assume convergence is achieved, then let any failed convergence set this to false.
-  bool isConverged = true;	
+  bool isConverged = true;
 
   //////////////////////////////////////////////////////////////////////////////////////
   // TFQMR solver
 
-  Teuchos::RCP<PseudoBlockTFQMRIter<ScalarType,MV,OP> > block_tfqmr_iter = 
+  block_tfqmr_iter =
     Teuchos::rcp( new PseudoBlockTFQMRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations
@@ -742,11 +748,11 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
       block_tfqmr_iter->initializeTFQMR(newstate);
 
       while(1) {
-	
+
 	// tell block_tfqmr_iter to iterate
 	try {
 	  block_tfqmr_iter->iterate();
-	  
+
 	  ////////////////////////////////////////////////////////////////////////////////////
 	  //
 	  // check convergence first
@@ -814,7 +820,7 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
               defstate.tau.push_back( currentState.tau[ *uIter ] );
               defstate.theta.push_back( currentState.theta[ *uIter ] );
             }
- 
+
             block_tfqmr_iter->initializeTFQMR(defstate);
 	  }
 	  ////////////////////////////////////////////////////////////////////////////////////
@@ -841,19 +847,19 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
 	  }
 	}
 	catch (const std::exception &e) {
-	  printer_->stream(Errors) << "Error! Caught std::exception in PseudoBlockTFQMRIter::iterate() at iteration " 
-				   << block_tfqmr_iter->getNumIters() << std::endl 
+	  printer_->stream(Errors) << "Error! Caught std::exception in PseudoBlockTFQMRIter::iterate() at iteration "
+				   << block_tfqmr_iter->getNumIters() << std::endl
 				   << e.what() << std::endl;
 	  throw;
 	}
       }
-     
+
       // Update the current solution with the update computed by the iteration object.
       problem_->updateSolution( block_tfqmr_iter->getCurrentUpdate(), true );
- 
+
       // Inform the linear problem that we are finished with this block linear system.
       problem_->setCurrLS();
-      
+
       // Update indices for the linear systems to be solved.
       startPtr += numCurrRHS;
       numRHS2Solve -= numCurrRHS;
@@ -879,12 +885,12 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
       }
 
     }// while ( numRHS2Solve > 0 )
-    
+
   }
 
   // print final summary
   sTest_->print( printer_->stream(FinalSummary) );
- 
+
   // print timing information
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   // Calling summarize() can be expensive, so don't call unless the
@@ -893,7 +899,7 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
   if (verbosity_ & TimingDetails)
     Teuchos::TimeMonitor::summarize( printer_->stream(TimingDetails) );
 #endif
- 
+
   // get iteration information for this solve
   numIters_ = maxIterTest_->getNumIters();
 
@@ -914,7 +920,7 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
       if (pTestValues == NULL || pTestValues->size() < 1) {
 	pTestValues = impConvTest_->getTestValue();
       }
-    } 
+    }
     else {
       // Only the implicit residual norm test is being used.
       pTestValues = impConvTest_->getTestValue();
@@ -933,11 +939,11 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
     // just for the vectors from the last deflation?
     achievedTol_ = *std::max_element (pTestValues->begin(), pTestValues->end());
   }
- 
+
   if (!isConverged) {
-    return Unconverged; // return from PseudoBlockTFQMRSolMgr::solve() 
+    return Unconverged; // return from PseudoBlockTFQMRSolMgr::solve()
   }
-  return Converged; // return from PseudoBlockTFQMRSolMgr::solve() 
+  return Converged; // return from PseudoBlockTFQMRSolMgr::solve()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
@@ -949,7 +955,7 @@ std::string PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::description() const
   oss << "{}";
   return oss.str();
 }
-  
+
 } // end Belos namespace
 
 #endif /* BELOS_PSEUDO_BLOCK_TFQMR_SOLMGR_HPP */

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -233,6 +233,10 @@ namespace Belos {
       return *problem_;
     }
 
+    const RCGIter<ScalarType,MV,OP>& getIteration() const {
+      return *rcg_iter;
+    }
+
     /*! \brief Get a parameter list containing the valid parameters for this object. */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
@@ -461,6 +465,8 @@ namespace Belos {
 
     // Internal state variables.
     bool params_Set_;
+
+    Teuchos::RCP<RCGIter<ScalarType,MV,OP> > rcg_iter;
   };
 
 
@@ -1182,7 +1188,6 @@ ReturnType RCGSolMgr<ScalarType,MV,OP,true>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // RCG solver
 
-  Teuchos::RCP<RCGIter<ScalarType,MV,OP> > rcg_iter;
   rcg_iter = Teuchos::rcp( new RCGIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations

--- a/packages/belos/src/BelosSolverManager.hpp
+++ b/packages/belos/src/BelosSolverManager.hpp
@@ -50,6 +50,7 @@
 #include "BelosConfigDefs.hpp"
 #include "BelosTypes.hpp"
 #include "BelosLinearProblem.hpp"
+#include "BelosIteration.hpp"
 #include "BelosStatusTestCombo.hpp"
 
 #include "Teuchos_ParameterList.hpp"
@@ -88,6 +89,8 @@ class SolverManager : virtual public Teuchos::Describable {
 
   //! Return a reference to the linear problem being solved by this solver manager.
   virtual const LinearProblem<ScalarType,MV,OP>& getProblem() const = 0;
+
+  virtual const Iteration<ScalarType,MV,OP>& getIteration() const = 0;
 
   //! Return the valid parameters for this solver manager.
   virtual Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const = 0;

--- a/packages/belos/src/BelosTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosTFQMRSolMgr.hpp
@@ -69,17 +69,17 @@
 /*! \class Belos::TFQMRSolMgr
  *
  *  \brief The Belos::TFQMRSolMgr provides a powerful and fully-featured solver manager over the TFQMR linear solver.
- 
+
  \ingroup belos_solver_framework
- 
+
  \author Heidi Thornquist
 */
 
 namespace Belos {
-  
+
   //! @name TFQMRSolMgr Exceptions
   //@{
-  
+
   /** \brief TFQMRSolMgrLinearProblemFailure is thrown when the linear problem is
    * not setup (i.e. setProblem() was not called) when solve() is called.
    *
@@ -89,7 +89,7 @@ namespace Belos {
   class TFQMRSolMgrLinearProblemFailure : public BelosError {public:
     TFQMRSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   /** \brief TFQMRSolMgrOrthoFailure is thrown when the orthogonalization manager is
    * unable to generate orthonormal columns from the initial basis vectors.
    *
@@ -99,21 +99,21 @@ namespace Belos {
   class TFQMRSolMgrOrthoFailure : public BelosError {public:
     TFQMRSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   template<class ScalarType, class MV, class OP>
   class TFQMRSolMgr : public SolverManager<ScalarType,MV,OP> {
-    
+
   private:
     typedef MultiVecTraits<ScalarType,MV> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    
+
   public:
-    
+
     //! @name Constructors/Destructor
-    //@{ 
+    //@{
 
     /*! \brief Empty constructor for TFQMRSolMgr.
      * This constructor takes no arguments and sets the default values for the solver.
@@ -126,41 +126,45 @@ namespace Belos {
      *
      * This constructor accepts the LinearProblem to be solved in addition
      * to a parameter list of options for the solver manager. These options include the following:
-     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the 
+     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the
      *                            underlying solver is allowed to perform. Default: 1000
-     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms 
+     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms
      *                               must reach to decide convergence. Default: 1e-8.
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Output Stream" - a reference-counted pointer to the output stream where all
      *                       solver output is sent.  Default: Teuchos::rcp(&std::cout,false)
-     *   - "Output Frequency" - an \c int specifying how often convergence information should be 
+     *   - "Output Frequency" - an \c int specifying how often convergence information should be
      *                          outputted.  Default: -1 (never)
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
      */
     TFQMRSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 		 const Teuchos::RCP<Teuchos::ParameterList> &pl );
-    
+
     //! Destructor.
     virtual ~TFQMRSolMgr() {};
     //@}
-    
+
     //! @name Accessor methods
-    //@{ 
-    
+    //@{
+
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
+    }
+
+    const TFQMRIter<ScalarType,MV,OP>& getIteration() const {
+      return *tfqmr_iter;
     }
 
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    
+
     /*! \brief Get a parameter list containing the current parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const { return params_; }
-    
-    /*! \brief Return the timers for this object. 
+
+    /*! \brief Return the timers for this object.
      *
      * The timers are ordered as follows:
      *   - time spent in solve() routine
@@ -170,7 +174,7 @@ namespace Belos {
     }
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -182,7 +186,7 @@ namespace Belos {
     int getNumIters() const {
       return numIters_;
     }
-    
+
     /// \brief Whether loss of accuracy was detected during the last \c solve() invocation.
     ///
     /// In solvers that can detect a loss of accuracy, this method
@@ -191,20 +195,20 @@ namespace Belos {
     /// not currently detect a loss of accuracy, so this method always
     /// returns false.
     bool isLOADetected() const { return false; }
-    
+
     //@}
-    
+
     //! @name Set methods
     //@{
-    
-    //! Set the linear problem that needs to be solved. 
+
+    //! Set the linear problem that needs to be solved.
     void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) { problem_ = problem; }
-    
-    //! Set the parameters the solver manager should use to solve the linear problem. 
+
+    //! Set the parameters the solver manager should use to solve the linear problem.
     void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params );
-    
+
     //@}
-    
+
     //! @name Reset methods
     //@{
     /*! \brief Performs a reset of the solver manager specified by the \c ResetType.  This informs the
@@ -213,21 +217,21 @@ namespace Belos {
      */
     void reset( const ResetType type ) { if ((type & Belos::Problem) && !Teuchos::is_null(problem_)) problem_->setProblem(); }
     //@}
-    
+
     //! @name Solver application methods
-    //@{ 
-    
-    /*! \brief This method performs possibly repeated calls to the underlying linear solver's 
-     *         iterate() routine until the problem has been solved (as decided by the solver manager) 
+    //@{
+
+    /*! \brief This method performs possibly repeated calls to the underlying linear solver's
+     *         iterate() routine until the problem has been solved (as decided by the solver manager)
      *         or the solver manager decides to quit.
      *
-     * This method calls TFQMRIter::iterate(), which will return either because a 
+     * This method calls TFQMRIter::iterate(), which will return either because a
      * specially constructed status test evaluates to ::Passed or an std::exception is thrown.
      *
      * A return from TFQMRIter::iterate() signifies one of the following scenarios:
-     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions 
+     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions
      *      to the linear system will be placed in the linear problem and return ::Unconverged.
-     *    - global convergence has been met. In this case, the current solutions to the linear system 
+     *    - global convergence has been met. In this case, the current solutions to the linear system
      *      will be placed in the linear problem and the solver manager will return ::Converged
      *
      * \returns ::ReturnType specifying:
@@ -235,39 +239,39 @@ namespace Belos {
      *     - ::Unconverged: the linear problem was not solved to the specification desired by the solver manager.
      */
     ReturnType solve();
-    
+
     //@}
-    
+
     /** \name Overridden from Teuchos::Describable */
     //@{
-    
+
     /** \brief Method to return description of the TFQMR solver manager */
     std::string description() const;
-    
+
     //@}
-    
+
   private:
 
     // Method for checking current status test against defined linear problem.
     bool checkStatusTest();
-    
+
     // Linear problem.
     Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
-    
+
     // Output manager.
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
     Teuchos::RCP<std::ostream> outputStream_;
-    
+
     // Status test.
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
     Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > convTest_;
     Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > expConvTest_, impConvTest_;
     Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
-    
+
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
-    
+
     // Default solver values.
     static const MagnitudeType convtol_default_;
     static const MagnitudeType impTolScale_default_;
@@ -276,8 +280,8 @@ namespace Belos {
     static const int verbosity_default_;
     static const int outputStyle_default_;
     static const int outputFreq_default_;
-    static const std::string impResScale_default_; 
-    static const std::string expResScale_default_; 
+    static const std::string impResScale_default_;
+    static const std::string expResScale_default_;
     static const std::string label_default_;
     static const Teuchos::RCP<std::ostream> outputStream_default_;
 
@@ -288,13 +292,15 @@ namespace Belos {
     int blockSize_;
     bool expResTest_;
     std::string impResScale_, expResScale_;
-    
+
     // Timers.
     std::string label_;
     Teuchos::RCP<Teuchos::Time> timerSolve_;
 
     // Internal state variables.
     bool isSet_, isSTSet_;
+
+    Teuchos::RCP<TFQMRIter<ScalarType,MV,OP> > tfqmr_iter;
   };
 
 
@@ -357,9 +363,9 @@ TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr() :
 
 // Basic Constructor
 template<class ScalarType, class MV, class OP>
-TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr( 
+TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr(
 					     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) : 
+					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(outputStream_default_),
   convtol_(convtol_default_),
@@ -379,13 +385,13 @@ TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr(
   isSTSet_(false)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null, std::invalid_argument, "Problem not given to solver manager.");
-  
+
   // If the parameter list pointer is null, then set the current parameters to the default parameter list.
   if ( !is_null(pl) ) {
-    setParameters( pl );  
+    setParameters( pl );
   }
 }
-  
+
 template<class ScalarType, class MV, class OP>
 void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
 {
@@ -409,7 +415,7 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
 
   // Check for blocksize
   if (params->isParameter("Block Size")) {
-    blockSize_ = params->get("Block Size",1);    
+    blockSize_ = params->get("Block Size",1);
     TEUCHOS_TEST_FOR_EXCEPTION(blockSize_ != 1, std::invalid_argument,
 		       "Belos::TFQMRSolMgr: \"Block Size\" must be 1.");
 
@@ -484,8 +490,8 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
-  }  
-  
+  }
+
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
     convtol_ = params->get("Convergence Tolerance",convtol_default_);
@@ -494,7 +500,7 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
     params_->set("Convergence Tolerance", convtol_);
     isSTSet_ = false;
   }
-  
+
   // Check for implicit residual scaling
   if (params->isParameter("Implicit Tolerance Scale Factor")) {
     impTolScale_ = params->get("Implicit Tolerance Scale Factor",impTolScale_default_);
@@ -517,9 +523,9 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
 
       // Make sure the convergence test gets constructed again.
       isSTSet_ = false;
-    }      
+    }
   }
-  
+
   if (params->isParameter("Explicit Residual Scaling")) {
     std::string tempExpResScale = Teuchos::getParameter<std::string>( *params, "Explicit Residual Scaling" );
 
@@ -532,7 +538,7 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
 
       // Make sure the convergence test gets constructed again.
       isSTSet_ = false;
-    }      
+    }
   }
 
   if (params->isParameter("Explicit Residual Test")) {
@@ -569,7 +575,7 @@ bool TFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
 
   if (expResTest_) {
-   
+
     // Implicit residual test, using the native residual to determine if convergence was achieved.
     Teuchos::RCP<StatusTestGenResNorm_t> tmpImpConvTest =
       Teuchos::rcp( new StatusTestGenResNorm_t( impTolScale_*convtol_ ) );
@@ -609,20 +615,20 @@ bool TFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   std::string solverDesc = " TFQMR ";
   outputTest_->setSolverDesc( solverDesc );
 
-  
+
   // The status test is now set.
   isSTSet_ = true;
 
   return false;
 }
 
-    
+
 template<class ScalarType, class MV, class OP>
-Teuchos::RCP<const Teuchos::ParameterList> 
+Teuchos::RCP<const Teuchos::ParameterList>
 TFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
-  
+
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
@@ -643,7 +649,7 @@ TFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "to the output stream.");
     pl->set("Output Frequency", outputFreq_default_,
       "How often convergence information should be outputted\n"
-      "to the output stream.");  
+      "to the output stream.");
     pl->set("Output Stream", outputStream_default_,
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
@@ -661,13 +667,13 @@ TFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
   return validPL;
 }
 
-  
+
 // solve()
 template<class ScalarType, class MV, class OP>
 ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
 
   // Set the current parameters if they were not set before.
-  // NOTE:  This may occur if the user generated the solver manager with the default constructor and 
+  // NOTE:  This may occur if the user generated the solver manager with the default constructor and
   // then didn't set any parameters using setParameters().
   if (!isSet_) {
     setParameters(Teuchos::parameterList(*getValidParameters()));
@@ -694,7 +700,7 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
   //  The index set is generated that informs the linear problem that some linear systems are augmented.
   currIdx.resize( blockSize_ );
   currIdx2.resize( blockSize_ );
-  for (int i=0; i<numCurrRHS; ++i) 
+  for (int i=0; i<numCurrRHS; ++i)
     { currIdx[i] = startPtr+i; currIdx2[i]=i; }
 
   // Inform the linear problem of the current linear system to solve.
@@ -704,17 +710,17 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
   // Parameter list
   Teuchos::ParameterList plist;
   plist.set("Block Size",blockSize_);
-  
-  // Reset the status test.  
+
+  // Reset the status test.
   outputTest_->reset();
 
   // Assume convergence is achieved, then let any failed convergence set this to false.
-  bool isConverged = true;	
+  bool isConverged = true;
 
   //////////////////////////////////////////////////////////////////////////////////////
   // TFQMR solver
 
-  Teuchos::RCP<TFQMRIter<ScalarType,MV,OP> > tfqmr_iter = 
+  tfqmr_iter =
     Teuchos::rcp( new TFQMRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations
@@ -745,11 +751,11 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
       tfqmr_iter->initializeTFQMR(newstate);
 
       while(1) {
-	
+
 	// tell tfqmr_iter to iterate
 	try {
 	  tfqmr_iter->iterate();
-	  
+
 	  ////////////////////////////////////////////////////////////////////////////////////
 	  //
 	  // check convergence first
@@ -783,8 +789,8 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
 	  }
 	}
 	catch (const std::exception &e) {
-	  printer_->stream(Errors) << "Error! Caught std::exception in TFQMRIter::iterate() at iteration " 
-				   << tfqmr_iter->getNumIters() << std::endl 
+	  printer_->stream(Errors) << "Error! Caught std::exception in TFQMRIter::iterate() at iteration "
+				   << tfqmr_iter->getNumIters() << std::endl
 				   << e.what() << std::endl;
 	  throw;
 	}
@@ -792,10 +798,10 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
 
       // Update the current solution with the update computed by the iteration object.
       problem_->updateSolution( tfqmr_iter->getCurrentUpdate(), true );
-      
+
       // Inform the linear problem that we are finished with this block linear system.
       problem_->setCurrLS();
-      
+
       // Update indices for the linear systems to be solved.
       startPtr += numCurrRHS;
       numRHS2Solve -= numCurrRHS;
@@ -804,25 +810,25 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
 
 	currIdx.resize( blockSize_ );
 	currIdx2.resize( blockSize_ );
-	for (int i=0; i<numCurrRHS; ++i) 
+	for (int i=0; i<numCurrRHS; ++i)
 	  { currIdx[i] = startPtr+i; currIdx2[i] = i; }
 	// Set the next indices.
 	problem_->setLSIndex( currIdx );
 
 	// Set the new blocksize for the solver.
-	tfqmr_iter->setBlockSize( blockSize_ );	
+	tfqmr_iter->setBlockSize( blockSize_ );
       }
       else {
         currIdx.resize( numRHS2Solve );
       }
-      
+
     }// while ( numRHS2Solve > 0 )
-    
+
   }
 
   // print final summary
   sTest_->print( printer_->stream(FinalSummary) );
- 
+
   // print timing information
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   // Calling summarize() can be expensive, so don't call unless the
@@ -831,7 +837,7 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
   if (verbosity_ & TimingDetails)
     Teuchos::TimeMonitor::summarize( printer_->stream(TimingDetails) );
 #endif
- 
+
   // get iteration information for this solve
   numIters_ = maxIterTest_->getNumIters();
 
@@ -852,7 +858,7 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
       if (pTestValues == NULL || pTestValues->size() < 1) {
 	pTestValues = impConvTest_->getTestValue();
       }
-    } 
+    }
     else {
       // Only the implicit residual norm test is being used.
       pTestValues = impConvTest_->getTestValue();
@@ -871,11 +877,11 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
     // just for the vectors from the last deflation?
     achievedTol_ = *std::max_element (pTestValues->begin(), pTestValues->end());
   }
- 
+
   if (!isConverged) {
-    return Unconverged; // return from TFQMRSolMgr::solve() 
+    return Unconverged; // return from TFQMRSolMgr::solve()
   }
-  return Converged; // return from TFQMRSolMgr::solve() 
+  return Converged; // return from TFQMRSolMgr::solve()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
@@ -887,7 +893,7 @@ std::string TFQMRSolMgr<ScalarType,MV,OP>::description() const
   oss << "{}";
   return oss.str();
 }
-  
+
 } // end Belos namespace
 
 #endif /* BELOS_TFQMR_SOLMGR_HPP */


### PR DESCRIPTION
When a Belos SolverManager object is created for solving a problem iteratively, and the application of an operator to a vector involves an inner iteration (because the operator itself involves an inverse or because a preconditioner is involved in the application of the operator), then access to the current residual is needed when the action of the operator on a vector is being calculated. This is so that the inner iteration tolerance can be varied for computational efficiency. The residual was not available through existing accessors in the SolverManager classes in Belos. New accessors to the underlying Iteration objects contained in the SolverManagers are made available in the patch because the Iteration objects do have an accessor (getNativeResiduals) that can provide the necessary information.
