### PR TITLE
Intrepid HGRAD Bases: avoid potential buffer overrun, eliminate extraneous console output, and avoid exceptions thrown when run in Debug mode

### DIFF
--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HDIV_TRI_In_FEMDef.hpp
@@ -131,17 +131,20 @@ namespace Intrepid {
     // first 3 * degree nodes are normals at each edge
     // get the points on the line
     FieldContainer<Scalar> linePts( n , 1 );
-    
-    // change by Nate Roberts 8/25/16: use getLattice() for warp blend points, too
-    // (under previous approach--which used Gauss cubature points on the line--the
-    //  resulting RT basis would be numerically linearly dependent for orders >= 5.)
-    shards::CellTopology linetop(shards::getCellTopologyData<shards::Line<2> >() );
+    if (pointType == POINTTYPE_WARPBLEND) {
+      CubatureDirectLineGauss<Scalar> edgeRule( n );
+      FieldContainer<Scalar> edgeCubWts( n );
+      edgeRule.getCubature( linePts , edgeCubWts );
+    }
+    else if (pointType == POINTTYPE_EQUISPACED ) {
+      shards::CellTopology linetop(shards::getCellTopologyData<shards::Line<2> >() );
 
-    PointTools::getLattice<Scalar,FieldContainer<Scalar> >( linePts ,
-                                                            linetop ,
-                                                            n+1 , 1 ,
-                                                            pointType );
-    // holds the image of the line points
+      PointTools::getLattice<Scalar,FieldContainer<Scalar> >( linePts , 
+                                                              linetop ,
+                                                              n+1 , 1 ,
+                                                              POINTTYPE_EQUISPACED );
+    }
+    // holds the image of the line points 
     FieldContainer<Scalar> edgePts( n , 2 );
     FieldContainer<Scalar> phisAtEdgePoints( scalarBigN , n );
 

--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HDIV_TRI_In_FEMDef.hpp
@@ -131,20 +131,17 @@ namespace Intrepid {
     // first 3 * degree nodes are normals at each edge
     // get the points on the line
     FieldContainer<Scalar> linePts( n , 1 );
-    if (pointType == POINTTYPE_WARPBLEND) {
-      CubatureDirectLineGauss<Scalar> edgeRule( n );
-      FieldContainer<Scalar> edgeCubWts( n );
-      edgeRule.getCubature( linePts , edgeCubWts );
-    }
-    else if (pointType == POINTTYPE_EQUISPACED ) {
-      shards::CellTopology linetop(shards::getCellTopologyData<shards::Line<2> >() );
+    
+    // change by Nate Roberts 8/25/16: use getLattice() for warp blend points, too
+    // (under previous approach--which used Gauss cubature points on the line--the
+    //  resulting RT basis would be numerically linearly dependent for orders >= 5.)
+    shards::CellTopology linetop(shards::getCellTopologyData<shards::Line<2> >() );
 
-      PointTools::getLattice<Scalar,FieldContainer<Scalar> >( linePts , 
-                                                              linetop ,
-                                                              n+1 , 1 ,
-                                                              POINTTYPE_EQUISPACED );
-    }
-    // holds the image of the line points 
+    PointTools::getLattice<Scalar,FieldContainer<Scalar> >( linePts ,
+                                                            linetop ,
+                                                            n+1 , 1 ,
+                                                            pointType );
+    // holds the image of the line points
     FieldContainer<Scalar> edgePts( n , 2 );
     FieldContainer<Scalar> phisAtEdgePoints( scalarBigN , n );
 

--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_HEX_Cn_FEMDef.hpp
@@ -204,7 +204,6 @@ namespace Intrepid {
 	  int dofdim;
 	  int dofent;
 	  ProductTopology::lineProduct3d( xdim , xent , ydim , yent , zdim , zent , dofdim , dofent );
-	  std::cout << i << " " << j << " " << k << "\t" << dofdim << " " << dofent << std::endl;
 	  total_dof_per_entity[dofdim][dofent] += 1;
 
 	}
@@ -419,9 +418,9 @@ void Basis_HGRAD_HEX_Cn_FEM<Scalar, ArrayScalar>::getValues(ArrayScalar&        
 	  {
 	    for (int i=0;i<ptsx_.dimension(0);i++)
 	      {
-		dofCoords(cur,0) = ptsx_(i);
-		dofCoords(cur,1) = ptsy_(j);
-		dofCoords(cur,2) = ptsz_(k);
+		dofCoords(cur,0) = ptsx_(i,0);
+		dofCoords(cur,1) = ptsy_(j,0);
+		dofCoords(cur,2) = ptsz_(k,0);
 		cur++;
 	      }
 	  }

--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_HEX_Cn_FEMDef.hpp
@@ -204,6 +204,7 @@ namespace Intrepid {
 	  int dofdim;
 	  int dofent;
 	  ProductTopology::lineProduct3d( xdim , xent , ydim , yent , zdim , zent , dofdim , dofent );
+	  std::cout << i << " " << j << " " << k << "\t" << dofdim << " " << dofent << std::endl;
 	  total_dof_per_entity[dofdim][dofent] += 1;
 
 	}
@@ -418,9 +419,9 @@ void Basis_HGRAD_HEX_Cn_FEM<Scalar, ArrayScalar>::getValues(ArrayScalar&        
 	  {
 	    for (int i=0;i<ptsx_.dimension(0);i++)
 	      {
-		dofCoords(cur,0) = ptsx_(i,0);
-		dofCoords(cur,1) = ptsy_(j,0);
-		dofCoords(cur,2) = ptsz_(k,0);
+		dofCoords(cur,0) = ptsx_(i);
+		dofCoords(cur,1) = ptsy_(j);
+		dofCoords(cur,2) = ptsz_(k);
 		cur++;
 	      }
 	  }

--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_TRI_Cn_FEMDef.hpp
@@ -58,6 +58,7 @@ namespace Intrepid {
     Vinv((n+1)*(n+2)/2,(n+1)*(n+2)/2),
     latticePts( (n+1)*(n+2)/2 , 2 )
   {
+    TEUCHOS_TEST_FOR_EXCEPTION( n <= 0, std::invalid_argument, "polynomial order must be >= 1");
 
     const int N = (n+1)*(n+2)/2;
     this -> basisCardinality_  = N;

--- a/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid/src/Discretization/Basis/Intrepid_HGRAD_TRI_Cn_FEMDef.hpp
@@ -58,7 +58,6 @@ namespace Intrepid {
     Vinv((n+1)*(n+2)/2,(n+1)*(n+2)/2),
     latticePts( (n+1)*(n+2)/2 , 2 )
   {
-    TEUCHOS_TEST_FOR_EXCEPTION( n <= 0, std::invalid_argument, "polynomial order must be >= 1");
 
     const int N = (n+1)*(n+2)/2;
     this -> basisCardinality_  = N;


### PR DESCRIPTION
Fixes for HGRAD bases on hexahedra and triangles.