### PR TITLE
Fixed incorrect reference ROL_TeuchosVector.hpp

### DIFF
--- a/packages/rol/adapters/teuchos/src/CMakeLists.txt
+++ b/packages/rol/adapters/teuchos/src/CMakeLists.txt
@@ -31,7 +31,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/vector)
   APPEND_SET(HEADERS 
-    vector/ROL_TeuchoVector.hpp
+    vector/ROL_TeuchosVector.hpp
 )
 
 


### PR DESCRIPTION
This incorrect reference caused Trilinos build to fail after compilation during the 'make install' step. 