### PR TITLE
Sacado_cmath.hpp: Change_preprocessor_directive

### DIFF
--- a/packages/sacado/src/Sacado_cmath.hpp
+++ b/packages/sacado/src/Sacado_cmath.hpp
@@ -34,8 +34,7 @@
 #include "Sacado_ConfigDefs.h"
 
 // Define some math functions that aren't usually in cmath
-#define HAS_GXX_CMATH_11 defined(_GLIBCXX_USE_C99_MATH_TR1) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#if !( HAS_GXX_CMATH_11 || defined(HAVE_SACADO_CXX11) || defined(HAS_C99_TR1_CMATH) || defined(USER_DISABLE_SACADO_TR1_CMATH) )
+#if !( (defined(_GLIBCXX_USE_C99_MATH_TR1) && defined(__GXX_EXPERIMENTAL_CXX0X__)) || defined(HAVE_SACADO_CXX11) || defined(HAS_C99_TR1_CMATH) || defined(USER_DISABLE_SACADO_TR1_CMATH) )
 namespace std {
   inline float acosh(float x) {
     return std::log(x + std::sqrt(x*x - float(1.0))); }


### PR DESCRIPTION
Eliminate preprocessor directive by moving
the two "defined" directives into the
statement in which they are used.

This allows for Trilinos to build on Windows (packages required for Xyce) with Intel and the Intel MKL.

Intel throws a warning about "defined" is always false in a macro expansion in Microsoft mode. This macro appears to only be used in this file, so I simply moved the macro into the statement in which it is used.

Moved from pull request #633 