### PR TITLE
Zoltan2: Xpetra CrsMatrix Adapter: reduce memory footprint

### DIFF
--- a/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
+++ b/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
@@ -130,8 +130,8 @@ class AlgSerialGreedy : public Algorithm<Adapter>
     // Find max degree, since (max degree)+1 is an upper bound.
     lno_t maxDegree = 0; 
     for (size_t i=0; i<nVtx; i++){
-      if (offsets[i+1]-offsets[i] > maxDegree)
-        maxDegree = offsets[i+1]-offsets[i];
+      if (offsets[i+1]-offsets[i] > static_cast<offset_t>(maxDegree))
+        maxDegree = static_cast<lno_t>(offsets[i+1]-offsets[i]);
     }
 
     // Greedy coloring.

--- a/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
+++ b/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
@@ -61,6 +61,7 @@ class AlgSerialGreedy : public Algorithm<Adapter>
   private:
     typedef typename Adapter::lno_t lno_t;
     typedef typename Adapter::gno_t gno_t;
+    typedef typename Adapter::offset_t offset_t;
     typedef typename Adapter::scalar_t scalar_t;
     // Class member variables
     RCP<GraphModel<typename Adapter::base_adapter_t> > model_;
@@ -88,7 +89,7 @@ class AlgSerialGreedy : public Algorithm<Adapter>
     // Color local graph. Global coloring is supported in Zoltan (not Zoltan2).
     // Get local graph.
     ArrayView<const gno_t> edgeIds;
-    ArrayView<const lno_t> offsets;
+    ArrayView<const offset_t> offsets;
     ArrayView<StridedData<lno_t, scalar_t> > wgts; // Not used; needed by getLocalEdgeList
   
     const size_t nVtx = model_->getLocalNumVertices(); // Assume (0,nvtx-1)
@@ -120,7 +121,7 @@ class AlgSerialGreedy : public Algorithm<Adapter>
   void colorCrsGraph(
     const size_t nVtx,
     ArrayView<const gno_t> edgeIds,
-    ArrayView<const lno_t> offsets,
+    ArrayView<const offset_t> offsets,
     ArrayRCP<int> colors
   )
   {
@@ -151,7 +152,7 @@ class AlgSerialGreedy : public Algorithm<Adapter>
     for (size_t i=0; i<nVtx; i++){
       //std::cout << "Debug: i= " << i << std::endl;
       lno_t v=i; // TODO: Use ordering here.
-      for (lno_t j=offsets[v]; j<offsets[v+1]; j++){
+      for (offset_t j=offsets[v]; j<offsets[v+1]; j++){
         gno_t nbor = edgeIds[j];
         //std::cout << "Debug: nbor= " << nbor << ", color= " << colors[nbor] << std::endl;
         if (colors[nbor] > 0){

--- a/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
+++ b/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
@@ -128,10 +128,10 @@ class AlgSerialGreedy : public Algorithm<Adapter>
     HELLO;
   
     // Find max degree, since (max degree)+1 is an upper bound.
-    lno_t maxDegree = 0; 
+    offset_t maxDegree = 0; 
     for (size_t i=0; i<nVtx; i++){
-      if (offsets[i+1]-offsets[i] > static_cast<offset_t>(maxDegree))
-        maxDegree = static_cast<lno_t>(offsets[i+1]-offsets[i]);
+      if (offsets[i+1]-offsets[i] > maxDegree)
+        maxDegree = offsets[i+1]-offsets[i];
     }
 
     // Greedy coloring.

--- a/packages/zoltan2/src/algorithms/color/Zoltan2_RebalanceColoring.hpp
+++ b/packages/zoltan2/src/algorithms/color/Zoltan2_RebalanceColoring.hpp
@@ -58,7 +58,7 @@
    int rebalanceColoring(
      const lno_t nVtx,
      ArrayView<const lno_t> edgeIds,
-     ArrayView<const lno_t> offsets,
+     ArrayView<const offset_t> offsets,
      ArrayRCP<int> colors,
      const int balanceColors,
      const lno_t minSize
@@ -92,7 +92,7 @@
    for (lno_t i=0; i < nVtx; i++){
      if (colorSize[colors[i]] > targetSize){
        // Find first available color that is not full yet
-       for (lno_t j=offsets[i]; j<offsets[i+1]; j++){
+       for (offset_t j=offsets[i]; j<offsets[i+1]; j++){
          lno_t nbor = edgeIds[j];
          if (colors[nbor] > 0){
            // Neighbors' colors are forbidden

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
@@ -142,6 +142,7 @@ class AlgAMD : public Algorithm<Adapter>
 #else
       typedef typename Adapter::gno_t gno_t;
       typedef typename Adapter::lno_t lno_t;
+      typedef typename Adapter::offset_t offset_t;
       typedef typename Adapter::scalar_t scalar_t;
 
       int ierr= 0;
@@ -150,7 +151,7 @@ class AlgAMD : public Algorithm<Adapter>
 
       //cout << "Local num vertices" << nVtx << endl;
       ArrayView<const gno_t> edgeIds;
-      ArrayView<const lno_t> offsets;
+      ArrayView<const offset_t> offsets;
       ArrayView<StridedData<lno_t, scalar_t> > wgts;
 
       // wgts are ignored in AMD
@@ -169,7 +170,7 @@ class AlgAMD : public Algorithm<Adapter>
       perm = (lno_t *) (solution->getPermutationRCP().getRawPtr());
 
       SuiteSparse_long *amd_offsets, *amd_edgeIds;
-      TPL_Traits<SuiteSparse_long, const lno_t>::ASSIGN_ARRAY(&amd_offsets,
+      TPL_Traits<SuiteSparse_long, const offset_t>::ASSIGN_ARRAY(&amd_offsets,
              offsets);
       // This might throw depending on how SuiteSparse was compiled
       // with long or long long and the size of both of them

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgND.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgND.hpp
@@ -423,6 +423,7 @@ void AlgND<Adapter>::getBoundLayer(int levelIndx, const std::vector<part_t> &par
   std::cout << "HI1" << std::endl;
 
   typedef typename Adapter::lno_t lno_t;         // local ids
+  typedef typename Adapter::offset_t offset_t;   // offset_t
   typedef typename Adapter::scalar_t scalar_t;   // scalars
   typedef StridedData<lno_t, scalar_t> input_t;
 
@@ -430,7 +431,7 @@ void AlgND<Adapter>::getBoundLayer(int levelIndx, const std::vector<part_t> &par
 
   //Teuchos ArrayView
   ArrayView< const lno_t > eIDs;
-  ArrayView< const lno_t > vOffsets;
+  ArrayView< const offset_t > vOffsets;
   ArrayView< input_t > wgts;
 
   // For some reason getLocalEdgeList seems to be returning empty eIDs
@@ -468,7 +469,7 @@ void AlgND<Adapter>::getBoundLayer(int levelIndx, const std::vector<part_t> &par
 
     //Loop over edges connected to v1
     //MMW figure out how to get this from Zoltan2
-    for(int j=vOffsets[v1];j<vOffsets[v1+1];j++)
+    for(offset_t j=vOffsets[v1];j<vOffsets[v1+1];j++)
     {
 
       int v2 = eIDs[j];

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
@@ -228,7 +228,7 @@ class AlgRCM : public Algorithm<Adapter>
     Teuchos::Array<bool> mark(nVtx);
 
     // Do BFS and compute smallest degree as we go
-    lno_t smallestDegree = nVtx;
+    offset_t smallestDegree = nVtx;
     gno_t smallestVertex = 0;
 
     // Clear mark array - nothing marked yet

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
@@ -72,6 +72,7 @@ class AlgRCM : public Algorithm<Adapter>
 
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
 
   AlgRCM(
@@ -95,7 +96,7 @@ class AlgRCM : public Algorithm<Adapter>
   
     // Get local graph.
     ArrayView<const gno_t> edgeIds;
-    ArrayView<const lno_t> offsets;
+    ArrayView<const offset_t> offsets;
     ArrayView<StridedData<lno_t, scalar_t> > wgts;
   
     const size_t nVtx = model->getLocalNumVertices();
@@ -138,7 +139,7 @@ class AlgRCM : public Algorithm<Adapter>
     std::queue<gno_t> Q;
     size_t count = 0; // CM label, reversed later
     size_t next = 0;  // next unmarked vertex
-    Teuchos::Array<std::pair<gno_t, size_t> >  children; // children and their degrees
+    Teuchos::Array<std::pair<gno_t, offset_t> >  children; // children and their degrees
   
     while (count < nVtx) {
   
@@ -173,11 +174,11 @@ class AlgRCM : public Algorithm<Adapter>
   
         // Add unmarked children to list of pairs, to be added to queue.
         children.resize(0);
-        for (lno_t ptr = offsets[v]; ptr < offsets[v+1]; ++ptr){
+        for (offset_t ptr = offsets[v]; ptr < offsets[v+1]; ++ptr){
           gno_t child = edgeIds[ptr];
           if (static_cast<Tpetra::global_size_t>(invPerm[child]) == INVALID){
             // Not visited yet; add child to list of pairs.
-            std::pair<gno_t,size_t> newchild;
+            std::pair<gno_t,offset_t> newchild;
             newchild.first = child;
             newchild.second = offsets[child+1] - offsets[child];
             children.push_back(newchild); 
@@ -185,10 +186,10 @@ class AlgRCM : public Algorithm<Adapter>
         }
         // Sort children by increasing degree
         // TODO: If edge weights, sort children by decreasing weight,
-        SortPairs<gno_t,size_t> zort;
+        SortPairs<gno_t,offset_t> zort;
         zort.sort(children);
 
-        typename Teuchos::Array<std::pair<gno_t,size_t> >::iterator it = children.begin ();
+        typename Teuchos::Array<std::pair<gno_t,offset_t> >::iterator it = children.begin ();
         for ( ; it != children.end(); ++it){
           // Push children on the queue in sorted order.
           gno_t child = it->first;
@@ -221,7 +222,7 @@ class AlgRCM : public Algorithm<Adapter>
     gno_t v,
     lno_t nVtx,
     ArrayView<const gno_t> edgeIds,
-    ArrayView<const lno_t> offsets)
+    ArrayView<const offset_t> offsets)
   {
     std::queue<gno_t> Q;
     Teuchos::Array<bool> mark(nVtx);
@@ -241,13 +242,13 @@ class AlgRCM : public Algorithm<Adapter>
       v = Q.front();
       Q.pop();
       // Check degree of v
-      lno_t deg = offsets[v+1] - offsets[v];
+      offset_t deg = offsets[v+1] - offsets[v];
       if (deg < smallestDegree){
         smallestDegree = deg;
         smallestVertex = v;
       }
       // Add unmarked children to queue
-      for (lno_t ptr = offsets[v]; ptr < offsets[v+1]; ++ptr){
+      for (offset_t ptr = offsets[v]; ptr < offsets[v+1]; ++ptr){
         gno_t child = edgeIds[ptr];
         if (!mark[child]){
           mark[child] = true; 
@@ -263,7 +264,7 @@ class AlgRCM : public Algorithm<Adapter>
     gno_t v,
     lno_t nVtx,
     ArrayView<const gno_t> edgeIds,
-    ArrayView<const lno_t> offsets)
+    ArrayView<const offset_t> offsets)
   {
     std::queue<gno_t> Q;
     Teuchos::Array<bool> mark(nVtx);
@@ -281,7 +282,7 @@ class AlgRCM : public Algorithm<Adapter>
         v = Q.front();
         Q.pop();
         // Add unmarked children to queue
-        for (lno_t ptr = offsets[v]; ptr < offsets[v+1]; ++ptr){
+        for (offset_t ptr = offsets[v]; ptr < offsets[v+1]; ++ptr){
           gno_t child = edgeIds[ptr];
           if (!mark[child]){
             mark[child] = true; 

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSortedDegree.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSortedDegree.hpp
@@ -72,6 +72,7 @@ class AlgSortedDegree : public Algorithm<Adapter>
 
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
 
   AlgSortedDegree(
@@ -104,20 +105,20 @@ class AlgSortedDegree : public Algorithm<Adapter>
     // Get local graph.
     const size_t nVtx = model->getLocalNumVertices();
     ArrayView<const gno_t> edgeIds;
-    ArrayView<const lno_t> offsets;
+    ArrayView<const offset_t> offsets;
     ArrayView<StridedData<lno_t, scalar_t> > wgts;
     model->getEdgeList(edgeIds, offsets, wgts);
 
   
     // Store degrees together with index so we can sort.
-    Teuchos::Array<std::pair<lno_t, size_t> >  degrees(nVtx);
+    Teuchos::Array<std::pair<lno_t, offset_t> >  degrees(nVtx);
     for (lno_t i=0; i<(lno_t)nVtx; i++){
       degrees[i].first = i;
       degrees[i].second  = offsets[i+1] - offsets[i];
     }
   
     // Sort degrees.
-    SortPairs<lno_t,size_t> zort;
+    SortPairs<lno_t,offset_t> zort;
     bool inc = true; // TODO: Add user parameter
     zort.sort(degrees, inc);
   

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSpectral.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSpectral.hpp
@@ -81,6 +81,7 @@ int AlgSpectral(
 
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
 
   int ierr= 0;
@@ -98,7 +99,7 @@ int AlgSpectral(
 
   // Get local graph.
   ArrayView<const gno_t> edgeIds;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<StridedData<lno_t, scalar_t> > wgts;
 
   model->getEdgeList(edgeIds, offsets, wgts);

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
@@ -220,14 +220,14 @@ private:
 
 
   //APF Mesh construction helper functions modified and placed here to support arbitrary entity types
-  void constructElements(const gno_t* conn, lno_t nelem, const lno_t* offsets, 
+  void constructElements(const gno_t* conn, lno_t nelem, const offset_t* offsets,
                          const EntityTopologyType* tops, apf::GlobalToVert& globalToVert)
   {
     apf::ModelEntity* interior = m->findModelEntity(m->getDimension(), 0);
     for (lno_t i = 0; i < nelem; ++i) {
       apf::Mesh::Type etype = topologyZ2toAPF(tops[i]);
       apf::Downward verts;
-      for (int j = offsets[i]; j < offsets[i+1]; ++j)
+      for (offset_t j = offsets[i]; j < offsets[i+1]; ++j)
 	verts[j-offsets[i]] = globalToVert[conn[j]];
       buildElement(m, interior, etype, verts);
     }
@@ -441,7 +441,7 @@ public:
     //Get first adjacencies from elements to vertices
     if (!adapter->availAdjs(primary_type,MESH_VERTEX))
       throw "APF needs adjacency information from elements to vertices";
-    const lno_t* offsets;
+    const offset_t* offsets;
     const gno_t* adjacent_vertex_gids;
     adapter->getAdjsView(primary_type, MESH_VERTEX,offsets,adjacent_vertex_gids);
     

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
@@ -121,6 +121,7 @@ private:
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
   typedef typename Adapter::scalar_t scalar_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::part_t part_t;
   typedef typename Adapter::user_t user_t;
   typedef typename Adapter::userCoord_t userCoord_t;

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMETIS.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMETIS.hpp
@@ -116,6 +116,7 @@ public:
   typedef GraphModel<typename Adapter::base_adapter_t> graphModel_t;
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
   typedef typename Adapter::part_t part_t;
 
@@ -181,7 +182,7 @@ void AlgParMETIS<Adapter>::partition(
 
   // Get edge info
   ArrayView<const gno_t> adjgnos;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<StridedData<lno_t, scalar_t> > ewgts;
   int nEwgt = model->getNumWeightsPerEdge();
   size_t nEdge = model->getEdgeList(adjgnos, offsets, ewgts);
@@ -194,7 +195,7 @@ void AlgParMETIS<Adapter>::partition(
 
   // Convert index types for edges, if needed
   pm_idx_t *pm_offsets;  
-  TPL_Traits<pm_idx_t,const lno_t>::ASSIGN_ARRAY(&pm_offsets, offsets);
+  TPL_Traits<pm_idx_t,const offset_t>::ASSIGN_ARRAY(&pm_offsets, offsets);
   pm_idx_t *pm_adjs;  
   pm_idx_t pm_dummy_adj;
   if (nEdge)

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -114,6 +114,7 @@ public:
   typedef typename Adapter::base_adapter_t base_adapter_t;
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
   typedef typename Adapter::part_t part_t;
   typedef typename Adapter::user_t user_t;
@@ -349,7 +350,7 @@ void AlgPuLP<Adapter>::partition(
 
   // Get edge info
   ArrayView<const gno_t> adjs;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<StridedData<lno_t, scalar_t> > ewgts;
   size_t nEdge = model->getEdgeList(adjs, offsets, ewgts);
   int nEwgts = model->getNumWeightsPerEdge();
@@ -371,7 +372,7 @@ void AlgPuLP<Adapter>::partition(
   int* out_edges = NULL;
   long* out_offsets = NULL;
   TPL_Traits<int, const gno_t>::ASSIGN_ARRAY(&out_edges, adjs);
-  TPL_Traits<long, const lno_t>::ASSIGN_ARRAY(&out_offsets, offsets);
+  TPL_Traits<long, const offset_t>::ASSIGN_ARRAY(&out_offsets, offsets);
 
   pulp_graph_t g = {num_verts, num_edges, 
                     out_edges, out_offsets,
@@ -382,7 +383,7 @@ void AlgPuLP<Adapter>::partition(
   unsigned long* out_edges = NULL;
   unsigned long* out_offsets = NULL;
   TPL_Traits<unsigned long, const gno_t>::ASSIGN_ARRAY(&out_edges, adjs);
-  TPL_Traits<unsigned long, const lno_t>::ASSIGN_ARRAY(&out_offsets, offsets);
+  TPL_Traits<unsigned long, const offset_t>::ASSIGN_ARRAY(&out_offsets, offsets);
 
   const size_t modelVertsGlobal = model->getGlobalNumVertices();
   const size_t modelEdgesGlobal = model->getGlobalNumEdges();

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgScotch.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgScotch.hpp
@@ -170,6 +170,7 @@ public:
   typedef GraphModel<typename Adapter::base_adapter_t> graphModel_t;
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
   typedef typename Adapter::part_t part_t;
   typedef typename Adapter::user_t user_t;
@@ -409,7 +410,7 @@ void AlgPTScotch<Adapter>::partition(
 
   // Get edge info
   ArrayView<const gno_t> edgeIds;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<StridedData<lno_t, scalar_t> > ewgts;
 
   size_t nEdge = model->getEdgeList(edgeIds, offsets, ewgts);
@@ -419,7 +420,7 @@ void AlgPTScotch<Adapter>::partition(
   const SCOTCH_Num edgelocsize = edgelocnbr;  // Assumes adj array is compact.
 
   SCOTCH_Num *vertloctab;  // starting adj/vtx
-  TPL_Traits<SCOTCH_Num, const lno_t>::ASSIGN_ARRAY(&vertloctab, offsets);
+  TPL_Traits<SCOTCH_Num, const offset_t>::ASSIGN_ARRAY(&vertloctab, offsets);
 
   SCOTCH_Num *edgeloctab;  // adjacencies
   TPL_Traits<SCOTCH_Num, const gno_t>::ASSIGN_ARRAY(&edgeloctab, edgeIds);
@@ -759,7 +760,7 @@ int AlgPTScotch<Adapter>::localOrder(
 
   // Get edge info
   ArrayView<const gno_t> edgeIds;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<StridedData<lno_t, scalar_t> > ewgts;
 
   size_t nEdge = model->getEdgeList(edgeIds, offsets, ewgts);
@@ -767,7 +768,7 @@ int AlgPTScotch<Adapter>::localOrder(
   TPL_Traits<SCOTCH_Num, size_t>::ASSIGN(edgenbr, nEdge);
   
   SCOTCH_Num *verttab;  // starting adj/vtx
-  TPL_Traits<SCOTCH_Num, const lno_t>::ASSIGN_ARRAY(&verttab, offsets);
+  TPL_Traits<SCOTCH_Num, const offset_t>::ASSIGN_ARRAY(&verttab, offsets);
 
   SCOTCH_Num *edgetab;  // adjacencies
   TPL_Traits<SCOTCH_Num, const gno_t>::ASSIGN_ARRAY(&edgetab, edgeIds);

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
@@ -247,6 +247,7 @@ void getCoarsenedPartGraph(
   typedef typename Adapter::lno_t t_lno_t;
   typedef typename Adapter::gno_t t_gno_t;
   typedef typename Adapter::scalar_t t_scalar_t;
+  typedef typename Adapter::offset_t t_offset_t;
   typedef typename Zoltan2::GraphModel<typename Adapter::base_adapter_t>::input_t t_input_t;
 
   //int numRanks = comm->getSize();
@@ -273,7 +274,7 @@ void getCoarsenedPartGraph(
 
   //get the edge ids, and weights
   ArrayView<const t_gno_t> edgeIds;
-  ArrayView<const t_lno_t> offsets;
+  ArrayView<const t_offset_t> offsets;
   ArrayView<t_input_t> e_wgts;
   graph->getEdgeList(edgeIds, offsets, e_wgts);
 
@@ -369,7 +370,7 @@ void getCoarsenedPartGraph(
       //get part i, and first vertex in this part v.
       while (v != -1){
         //now get the neightbors of v.
-        for (t_lno_t j = offsets[v]; j < offsets[v+1]; ++j){
+        for (t_offset_t j = offsets[v]; j < offsets[v+1]; ++j){
           //get the part of the second vertex.
           part_t ep = e_parts[j];
 
@@ -434,7 +435,7 @@ void getCoarsenedPartGraph(
       //get part i, and first vertex in this part v.
       while (v != -1){
         //now get the neightbors of v.
-        for (t_lno_t j = offsets[v]; j < offsets[v+1]; ++j){
+        for (t_offset_t j = offsets[v]; j < offsets[v+1]; ++j){
           //get the part of the second vertex.
           part_t ep = e_parts[j];
 

--- a/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
+++ b/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
@@ -340,7 +340,7 @@ static void zoltanHGCS_withMeshAdapter(
 {
   *ierr = ZOLTAN_OK;
   typedef typename Adapter::gno_t gno_t;
-  typedef typename Adapter::lno_t lno_t;  
+  // typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::user_t user_t;
   typedef typename Adapter::offset_t offset_t;
   const MeshAdapter<user_t>* madp = static_cast<MeshAdapter<user_t>*>(data);

--- a/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
+++ b/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
@@ -231,13 +231,14 @@ static void zoltanHGCS_withMatrixAdapter(void *data, int nGidEnt, int nLists,
 {
   *ierr = ZOLTAN_OK;  
   typedef typename Adapter::gno_t gno_t;
-  typedef typename Adapter::lno_t lno_t;  
+  // typedef typename Adapter::lno_t lno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::user_t user_t;
   const MatrixAdapter<user_t>* madp = static_cast<MatrixAdapter<user_t>* >(data);
 
   const gno_t *Ids;
   const gno_t *pIds;
-  const lno_t *offsets;
+  const offset_t *offsets;
 
   // Get the pins and list IDs.
   if (madp->CRSViewAvailable()) {
@@ -341,6 +342,7 @@ static void zoltanHGCS_withMeshAdapter(
   typedef typename Adapter::gno_t gno_t;
   typedef typename Adapter::lno_t lno_t;  
   typedef typename Adapter::user_t user_t;
+  typedef typename Adapter::offset_t offset_t;
   const MeshAdapter<user_t>* madp = static_cast<MeshAdapter<user_t>*>(data);
 
   // Select listType and pinType based on format specified in ZOLTAN_HG_CS_SIZE_FN
@@ -371,7 +373,7 @@ static void zoltanHGCS_withMeshAdapter(
     }
 
     // get pins
-    const lno_t* offsets;
+    const offset_t* offsets;
     const gno_t* adjIds;
     try {
       madp->getAdjsView(listType, pinType, offsets, adjIds);
@@ -494,6 +496,7 @@ static void zoltanHGCS_withModel(void *data, int nGidEnt, int nEdges, int nPins,
                                   static_cast<HyperGraphModel<Adapter>* >(data);
   typedef typename Adapter::gno_t       gno_t;
   typedef typename Adapter::lno_t       lno_t;
+  typedef typename Adapter::offset_t    offset_t;
   typedef typename Adapter::scalar_t    scalar_t;
   typedef StridedData<lno_t, scalar_t>  input_t;
 
@@ -501,7 +504,7 @@ static void zoltanHGCS_withModel(void *data, int nGidEnt, int nEdges, int nPins,
   ArrayView<input_t> wgts;
   mdl->getEdgeList(Ids,wgts);
   ArrayView<const gno_t> pinIds_;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<input_t> pin_wgts;
   mdl->getPinList(pinIds_,offsets,pin_wgts);
   for (int i=0;i<nEdges;i++) {

--- a/packages/zoltan2/src/input/Zoltan2_APFMeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_APFMeshAdapter.hpp
@@ -123,6 +123,7 @@ public:
   typedef typename InputTraits<User>::scalar_t    scalar_t;
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef typename InputTraits<User>::part_t   part_t;
   typedef typename InputTraits<User>::node_t   node_t;
   typedef User user_t;

--- a/packages/zoltan2/src/input/Zoltan2_APFMeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_APFMeshAdapter.hpp
@@ -299,7 +299,7 @@ public:
   }
 
   void getAdjsView(MeshEntityType source, MeshEntityType target,
-		   const lno_t *&offsets, const gno_t *& adjacencyIds) const
+		   const offset_t *&offsets, const gno_t *& adjacencyIds) const
   {
     int dim_source = entityZ2toAPF(source);
     int dim_target = entityZ2toAPF(target);
@@ -342,7 +342,7 @@ public:
   }
 
   void get2ndAdjsView(MeshEntityType sourcetarget, MeshEntityType through, 
-		      const lno_t *&offsets, const gno_t *&adjacencyIds) const
+		      const offset_t *&offsets, const gno_t *&adjacencyIds) const
   {
     int dim_source = entityZ2toAPF(sourcetarget);
     int dim_target = entityZ2toAPF(through);
@@ -430,9 +430,9 @@ private:
   gno_t** gid_mapping; //[dimension][lid] corresponding global id numbers
   size_t* num_local; //[dimension] number of local entities
   EntityTopologyType** topologies; //[dimension] topologies for each entity
-  lno_t*** adj_offsets; //[first_dimension][second_dimension] array of offsets
+  offset_t*** adj_offsets; //[first_dimension][second_dimension] array of offsets
   std::vector<gno_t>** adj_gids; //[first_dimension][second_dimension] global_ids of first adjacencies
-  lno_t*** adj2_offsets; //[first_dimension][second_dimension] array of offsets for second adjacencies
+  offset_t*** adj2_offsets; //[first_dimension][second_dimension] array of offsets for second adjacencies
   std::vector<gno_t>** adj2_gids; //[first_dimension][second_dimension] global_ids of second adjacencies
   int coord_dimension; //dimension of coordinates (always 3 for APF)
   scalar_t** ent_coords; //[dimension] array of coordinates [xs ys zs]
@@ -552,10 +552,10 @@ APFMeshAdapter<User>::APFMeshAdapter(const Comm<int> &comm,
   }
   //First Adjacency and Second Adjacency data
   adj_gids = new std::vector<gno_t>*[m_dimension+1];
-  adj_offsets = new lno_t**[m_dimension+1];
+  adj_offsets = new offset_t**[m_dimension+1];
   if (needSecondAdj) {
     adj2_gids = new std::vector<gno_t>*[m_dimension+1];
-    adj2_offsets = new lno_t**[m_dimension+1];
+    adj2_offsets = new offset_t**[m_dimension+1];
   }
   else {
     adj2_gids=NULL;
@@ -571,10 +571,10 @@ APFMeshAdapter<User>::APFMeshAdapter(const Comm<int> &comm,
     if (!has(i))
       continue;
     adj_gids[i] = new std::vector<gno_t>[m_dimension+1];
-    adj_offsets[i] = new lno_t*[m_dimension+1];
+    adj_offsets[i] = new offset_t*[m_dimension+1];
     if (needSecondAdj) {
       adj2_gids[i] = new std::vector<gno_t>[m_dimension+1];
-      adj2_offsets[i] = new lno_t*[m_dimension+1];
+      adj2_offsets[i] = new offset_t*[m_dimension+1];
     }
     for (int j=0;j<=m_dimension;j++) {
       
@@ -589,10 +589,10 @@ APFMeshAdapter<User>::APFMeshAdapter(const Comm<int> &comm,
       apf::MeshIterator* itr = m->begin(i);
       apf::MeshEntity* ent;
       
-      adj_offsets[i][j] = new lno_t[num_local[i]+1];
+      adj_offsets[i][j] = new offset_t[num_local[i]+1];
       adj_offsets[i][j][0] =0;
       if (needSecondAdj) {
-        adj2_offsets[i][j] = new lno_t[num_local[i]+1];
+        adj2_offsets[i][j] = new offset_t[num_local[i]+1];
         adj2_offsets[i][j][0] =0;
       }
       int k=1;
@@ -878,12 +878,12 @@ void APFMeshAdapter<User>::print(int me,int verbosity)
           if (k==i)
             continue;
           std::cout<<"     First Adjacency of Dimension "<<k<<":";
-          for (lno_t l=adj_offsets[i][k][j];l<adj_offsets[i][k][j+1];l++)
+          for (offset_t l=adj_offsets[i][k][j];l<adj_offsets[i][k][j+1];l++)
             std::cout<<" "<<adj_gids[i][k][l];
           std::cout<<"\n";
           if (verbosity>=3) {
             std::cout<<"     Second Adjacency through Dimension "<<k<<":";
-            for (lno_t l=adj2_offsets[i][k][j];l<adj2_offsets[i][k][j+1];l++)
+            for (offset_t l=adj2_offsets[i][k][j];l<adj2_offsets[i][k][j+1];l++)
               std::cout<<" "<<adj2_gids[i][k][l];
             std::cout<<"\n";
           }

--- a/packages/zoltan2/src/input/Zoltan2_Adapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_Adapter.hpp
@@ -105,6 +105,7 @@ public:
   typedef typename InputTraits<User>::gno_t gno_t;
   typedef typename InputTraits<User>::scalar_t scalar_t;
   typedef typename InputTraits<User>::part_t part_t;  
+  typedef typename InputTraits<User>::offset_t offset_t;
 
   /*! \brief Returns the type of adapter.
    */

--- a/packages/zoltan2/src/input/Zoltan2_BasicVectorAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_BasicVectorAdapter.hpp
@@ -87,6 +87,7 @@ public:
   typedef typename InputTraits<User>::scalar_t scalar_t;
   typedef typename InputTraits<User>::lno_t lno_t;
   typedef typename InputTraits<User>::gno_t gno_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef typename InputTraits<User>::part_t part_t;
   typedef typename InputTraits<User>::node_t node_t;
   typedef User user_t;

--- a/packages/zoltan2/src/input/Zoltan2_GraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_GraphAdapter.hpp
@@ -119,6 +119,7 @@ public:
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::node_t   node_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef User user_t;
   typedef UserCoord userCoord_t;
   typedef GraphAdapter<User, UserCoord> base_adapter_t;
@@ -161,7 +162,7 @@ public:
       \param adjIds on return will point to the array of adjacent vertices for
          for each vertex.
    */
-  virtual void getEdgesView(const lno_t *&offsets,
+  virtual void getEdgesView(const offset_t *&offsets,
                             const gno_t *&adjIds) const = 0;
 
   /*! \brief Returns the number (0 or greater) of weights per vertex

--- a/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
@@ -76,6 +76,9 @@ typedef int default_lno_t;
 // Default global ordinal
 typedef int default_gno_t;
 
+// Default offset type
+typedef int default_offset_t;
+
 // Default scalar type (for weights, coordinates)
 typedef double default_scalar_t;
 
@@ -186,6 +189,10 @@ struct InputTraits {
    */
   typedef default_gno_t gno_t;
 
+  /*! \brief The data type to represent offsets.
+   */
+  typedef default_offset_t offset_t;
+
   /*! \brief The data type to represent part numbers.
    */
   typedef default_part_t part_t;
@@ -243,6 +250,7 @@ struct InputTraits<BasicUserTypes<Scalar, LocalOrdinal, GlobalOrdinal> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "BasicUserTypes";}
@@ -259,6 +267,7 @@ struct InputTraits<Xpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::CrsMatrix";}
@@ -275,6 +284,7 @@ struct InputTraits<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::CrsMatrix";}
@@ -289,8 +299,10 @@ struct InputTraits<Epetra_CrsMatrix>
   typedef double scalar_t;
   typedef int lno_t;
   typedef int gno_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
+  typedef Zoltan2::default_offset_t offset_t;
   static inline std::string name() {return "Epetra_CrsMatrix";}
 };
 #endif
@@ -304,6 +316,7 @@ struct InputTraits<Xpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::RowMatrix";}
@@ -320,6 +333,7 @@ struct InputTraits<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::RowMatrix";}
@@ -335,6 +349,7 @@ struct InputTraits<Tpetra::RowGraph<LocalOrdinal,GlobalOrdinal,Node> >
   typedef default_scalar_t scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::RowGraph";}
@@ -348,6 +363,7 @@ struct InputTraits<Xpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> >
   typedef default_scalar_t scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::CrsGraph";}
@@ -363,6 +379,7 @@ struct InputTraits<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> >
   typedef default_scalar_t scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::CrsGraph";}
@@ -377,6 +394,7 @@ struct InputTraits<Epetra_CrsGraph>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_CrsGraph";}
@@ -392,6 +410,7 @@ struct InputTraits<Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::Vector";}
@@ -411,6 +430,7 @@ struct InputTraits<Tpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::Vector";}
@@ -425,6 +445,7 @@ struct InputTraits<Epetra_Vector>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
+  typedef int offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_Vector";}
@@ -440,6 +461,7 @@ struct InputTraits<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::MultiVector";}
@@ -458,6 +480,7 @@ struct InputTraits<Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef GlobalOrdinal gno_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
+  typedef Zoltan2::default_offset_t offset_t;
   static inline std::string name() {return "Tpetra::MultiVector";}
 
   Z2_STATIC_ASSERT_TYPES // validate the types
@@ -470,6 +493,7 @@ struct InputTraits<Epetra_MultiVector>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_MultiVector";}

--- a/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
@@ -250,7 +250,7 @@ struct InputTraits<BasicUserTypes<Scalar, LocalOrdinal, GlobalOrdinal> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef LocalOrdinal  offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "BasicUserTypes";}
@@ -302,7 +302,6 @@ struct InputTraits<Epetra_CrsMatrix>
   typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
-  typedef Zoltan2::default_offset_t offset_t;
   static inline std::string name() {return "Epetra_CrsMatrix";}
 };
 #endif
@@ -363,7 +362,7 @@ struct InputTraits<Xpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> >
   typedef default_scalar_t scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::CrsGraph";}
@@ -379,7 +378,7 @@ struct InputTraits<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> >
   typedef default_scalar_t scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::CrsGraph";}
@@ -445,7 +444,7 @@ struct InputTraits<Epetra_Vector>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
-  typedef int offset_t;
+  typedef Zoltan2::default_offset_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_Vector";}
@@ -478,9 +477,9 @@ struct InputTraits<Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
+  typedef LocalOrdinal offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
-  typedef Zoltan2::default_offset_t offset_t;
   static inline std::string name() {return "Tpetra::MultiVector";}
 
   Z2_STATIC_ASSERT_TYPES // validate the types
@@ -493,7 +492,7 @@ struct InputTraits<Epetra_MultiVector>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
-  typedef size_t offset_t;
+  typedef Zoltan2::default_offset_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_MultiVector";}

--- a/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
@@ -315,7 +315,7 @@ struct InputTraits<Xpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::RowMatrix";}
@@ -332,7 +332,7 @@ struct InputTraits<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::RowMatrix";}
@@ -348,7 +348,7 @@ struct InputTraits<Tpetra::RowGraph<LocalOrdinal,GlobalOrdinal,Node> >
   typedef default_scalar_t scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::RowGraph";}
@@ -409,7 +409,7 @@ struct InputTraits<Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::Vector";}
@@ -429,7 +429,7 @@ struct InputTraits<Tpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::Vector";}
@@ -444,7 +444,7 @@ struct InputTraits<Epetra_Vector>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
-  typedef Zoltan2::default_offset_t offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_Vector";}
@@ -460,7 +460,7 @@ struct InputTraits<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Xpetra::MultiVector";}
@@ -477,7 +477,7 @@ struct InputTraits<Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   typedef Scalar        scalar_t;
   typedef LocalOrdinal  lno_t;
   typedef GlobalOrdinal gno_t;
-  typedef LocalOrdinal offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Node          node_t;
   static inline std::string name() {return "Tpetra::MultiVector";}
@@ -492,7 +492,7 @@ struct InputTraits<Epetra_MultiVector>
   typedef double scalar_t;
   typedef int   lno_t;
   typedef int   gno_t;
-  typedef Zoltan2::default_offset_t offset_t;
+  typedef size_t offset_t;
   typedef Zoltan2::default_part_t  part_t;
   typedef Zoltan2::default_node_t node_t;
   static inline std::string name() {return "Epetra_MultiVector";}

--- a/packages/zoltan2/src/input/Zoltan2_MatrixAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_MatrixAdapter.hpp
@@ -117,6 +117,7 @@ public:
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::part_t   part_t;
   typedef typename InputTraits<User>::node_t   node_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef User user_t;
   typedef UserCoord userCoord_t;
   typedef MatrixAdapter<User,UserCoord> base_adapter_t;
@@ -174,8 +175,7 @@ public:
       \param colIds on return will point to the global column Ids for
          the non-zeros for each row.
    */
-  virtual void getCRSView(const lno_t *&offsets,
-                          const gno_t *&colIds) const
+  virtual void getCRSView(const offset_t *&offsets, const gno_t *&colIds) const
   {
     // Default implementation; no CRS view provided.
     offsets = NULL;
@@ -197,7 +197,7 @@ public:
       \param values on return will point to the values stored in the
          non-zeros for each row.
    */
-  virtual void getCRSView(const lno_t *&offsets,
+  virtual void getCRSView(const offset_t *&offsets,
                           const gno_t *& colIds,
                           const scalar_t *&values) const
   {
@@ -263,7 +263,7 @@ public:
       \param rowIds on return will point to the global row Ids for
          the non-zeros for each column.
    */
-  virtual void getCCSView(const lno_t *&offsets,
+  virtual void getCCSView(const offset_t *&offsets,
                           const gno_t *&rowIds) const
   {
     // Default implementation; no CCS view provided.
@@ -286,7 +286,7 @@ public:
       \param values on return will point to the values stored in the
          non-zeros for each column.
    */
-  virtual void getCCSView(const lno_t *&offsets,
+  virtual void getCCSView(const offset_t *&offsets,
                           const gno_t *&rowIds,
                           const scalar_t *&values) const
   {

--- a/packages/zoltan2/src/input/Zoltan2_MeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_MeshAdapter.hpp
@@ -127,7 +127,7 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   typedef typename InputTraits<User>::scalar_t scalar_t;
-  typedef typename InputTraits<User>::lno_t offset_t; // default to lno_t
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef typename InputTraits<User>::lno_t lno_t;
   typedef typename InputTraits<User>::gno_t gno_t;
   typedef typename InputTraits<User>::part_t part_t;

--- a/packages/zoltan2/src/input/Zoltan2_MeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_MeshAdapter.hpp
@@ -127,6 +127,7 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   typedef typename InputTraits<User>::scalar_t scalar_t;
+  typedef typename InputTraits<User>::lno_t offset_t; // default to lno_t
   typedef typename InputTraits<User>::lno_t lno_t;
   typedef typename InputTraits<User>::gno_t gno_t;
   typedef typename InputTraits<User>::part_t part_t;
@@ -270,7 +271,7 @@ public:
          Ids for each entity.
   */
   virtual void getAdjsView(MeshEntityType source, MeshEntityType target,
-     const lno_t *&offsets, const gno_t *& adjacencyIds) const
+     const offset_t *&offsets, const gno_t *& adjacencyIds) const
   {
     offsets = NULL;
     adjacencyIds = NULL;
@@ -309,7 +310,7 @@ public:
    */
   virtual void get2ndAdjsView(MeshEntityType sourcetarget,
                               MeshEntityType through,
-                              const lno_t *&offsets,
+                              const offset_t *&offsets,
                               const gno_t *&adjacencyIds) const
   {
     offsets = NULL;

--- a/packages/zoltan2/src/input/Zoltan2_PamgenMeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_PamgenMeshAdapter.hpp
@@ -95,7 +95,7 @@ public:
   typedef typename InputTraits<User>::scalar_t scalar_t;
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
-  typedef typename InputTraits<User>::lno_t offset_t; // use lno_t
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef typename InputTraits<User>::part_t   part_t;
   typedef typename InputTraits<User>::node_t   node_t;
   typedef User user_t;

--- a/packages/zoltan2/src/input/Zoltan2_PamgenMeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_PamgenMeshAdapter.hpp
@@ -95,6 +95,7 @@ public:
   typedef typename InputTraits<User>::scalar_t scalar_t;
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
+  typedef typename InputTraits<User>::lno_t offset_t; // use lno_t
   typedef typename InputTraits<User>::part_t   part_t;
   typedef typename InputTraits<User>::node_t   node_t;
   typedef User user_t;
@@ -238,7 +239,7 @@ public:
   }
 
   void getAdjsView(MeshEntityType source, MeshEntityType target,
-		   const lno_t *&offsets, const gno_t *& adjacencyIds) const
+		   const offset_t *&offsets, const gno_t *& adjacencyIds) const
   {
     if ((MESH_REGION == source && MESH_VERTEX == target && 3 == dimension_) ||
 	(MESH_FACE == source && MESH_VERTEX == target && 2 == dimension_)) {
@@ -292,7 +293,7 @@ public:
   }
 
   void get2ndAdjsView(MeshEntityType sourcetarget, MeshEntityType through, 
-		      const lno_t *&offsets, const gno_t *&adjacencyIds) const
+		      const offset_t *&offsets, const gno_t *&adjacencyIds) const
   {
     if (through == MESH_VERTEX &&
 	((sourcetarget == MESH_REGION && dimension_ == 3) ||
@@ -327,15 +328,15 @@ private:
   int dimension_, num_nodes_global_, num_elems_global_, num_nodes_, num_elem_;
   gno_t *element_num_map_, *node_num_map_;
   gno_t *elemToNode_;
-  lno_t tnoct_, *elemOffsets_;
+  offset_t tnoct_, *elemOffsets_;
   gno_t *nodeToElem_; 
-  lno_t telct_, *nodeOffsets_;
+  offset_t telct_, *nodeOffsets_;
 
   int nWeightsPerEntity_;
   bool *entityDegreeWeight_;
 
   scalar_t *coords_, *Acoords_;
-  lno_t *eStart_, *nStart_;
+  offset_t *eStart_, *nStart_;
   gno_t *eAdj_, *nAdj_;
   size_t nEadj_, nNadj_;
   EntityTopologyType* nodeTopology;
@@ -495,7 +496,7 @@ PamgenMeshAdapter<User>::PamgenMeshAdapter(const Comm<int> &comm,
   int nnodes_per_elem = num_nodes_per_elem[0];
   elemToNode_ = new gno_t[num_elem_ * nnodes_per_elem];
   int telct = 0;
-  elemOffsets_ = new lno_t [num_elem_+1];
+  elemOffsets_ = new offset_t [num_elem_+1];
   tnoct_ = 0;
   int **reconnect = new int * [num_elem_];
   size_t max_nsur = 0;
@@ -559,7 +560,7 @@ PamgenMeshAdapter<User>::PamgenMeshAdapter(const Comm<int> &comm,
   }
 
   nodeToElem_ = new gno_t[num_nodes_ * max_nsur];
-  nodeOffsets_ = new lno_t[num_nodes_+1];
+  nodeOffsets_ = new offset_t[num_nodes_+1];
   telct_ = 0;
 
   for (int ncnt = 0; ncnt < num_nodes_; ncnt++) {

--- a/packages/zoltan2/src/input/Zoltan2_TpetraRowGraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_TpetraRowGraphAdapter.hpp
@@ -254,7 +254,7 @@ private:
 
   RCP<const User> graph_;
 
-  ArrayRCP<const lno_t> offs_;
+  ArrayRCP<const offset_t> offs_;
   ArrayRCP<const gno_t> adjids_;
 
   int nWeightsPerVertex_;
@@ -295,7 +295,7 @@ template <typename User, typename UserCoord>
   // because edge Ids are not usually stored in vertex id order.
 
   size_t n = nvtx + 1;
-  lno_t *offs = new lno_t [n];
+  offset_t *offs = new offset_t [n];
 
   if (!offs)
   {
@@ -323,7 +323,7 @@ template <typename User, typename UserCoord>
   for (size_t v=0; v < nvtx; v++){
     graph_->getLocalRowCopy(v, nbors(), nedges);  // Diff from CrsGraph
     offs[v+1] = offs[v] + nedges;
-    for (lno_t e=offs[v], i=0; e < offs[v+1]; e++) {
+    for (offset_t e=offs[v], i=0; e < offs[v+1]; e++) {
         adjids[e] = graph_->getColMap()->getGlobalElement(nbors[i++]);
     }
   }

--- a/packages/zoltan2/src/input/Zoltan2_TpetraRowGraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_TpetraRowGraphAdapter.hpp
@@ -85,6 +85,7 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   typedef typename InputTraits<User>::scalar_t    scalar_t;
+  typedef typename InputTraits<User>::offset_t    offset_t;
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::part_t   part_t;
@@ -199,7 +200,7 @@ public:
 
   size_t getLocalNumEdges() const { return graph_->getNodeNumEntries(); }
 
-  void getEdgesView(const lno_t *&offsets, const gno_t *&adjIds) const
+  void getEdgesView(const offset_t *&offsets, const gno_t *&adjIds) const
   {
     offsets = offs_.getRawPtr();
     adjIds = (getLocalNumEdges() ? adjids_.getRawPtr() : NULL);

--- a/packages/zoltan2/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
@@ -78,6 +78,7 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   typedef typename InputTraits<User>::scalar_t scalar_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::part_t   part_t;
@@ -167,13 +168,13 @@ public:
     rowIds = rowView.getRawPtr();
   }
 
-  void getCRSView(const lno_t *&offsets, const gno_t *&colIds) const
+  void getCRSView(const offset_t *&offsets, const gno_t *&colIds) const
   {
     offsets = offset_.getRawPtr();
     colIds = columnIds_.getRawPtr();
   }
 
-  void getCRSView(const lno_t *&offsets, const gno_t *&colIds,
+  void getCRSView(const offset_t *&offsets, const gno_t *&colIds,
                     const scalar_t *&values) const
   {
     offsets = offset_.getRawPtr();

--- a/packages/zoltan2/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
@@ -216,7 +216,7 @@ private:
   RCP<const User> matrix_;
   RCP<const Tpetra::Map<lno_t, gno_t, node_t> > rowMap_;
   RCP<const Tpetra::Map<lno_t, gno_t, node_t> > colMap_;
-  ArrayRCP<lno_t> offset_;
+  ArrayRCP<offset_t> offset_;
   ArrayRCP<gno_t> columnIds_;  // TODO:  KDD Is it necessary to copy and store
   ArrayRCP<scalar_t> values_;  // TODO:  the matrix here?  Would prefer views.
 

--- a/packages/zoltan2/src/input/Zoltan2_VectorAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_VectorAdapter.hpp
@@ -106,6 +106,7 @@ public:
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::part_t   part_t;
   typedef typename InputTraits<User>::node_t   node_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef User user_t;
   typedef User userCoord_t;
   typedef VectorAdapter<User> base_adapter_t;

--- a/packages/zoltan2/src/input/Zoltan2_XpetraCrsGraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_XpetraCrsGraphAdapter.hpp
@@ -87,6 +87,7 @@ public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   typedef typename InputTraits<User>::scalar_t    scalar_t;
+  typedef typename InputTraits<User>::offset_t    offset_t;
   typedef typename InputTraits<User>::lno_t    lno_t;
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::part_t   part_t;
@@ -210,7 +211,7 @@ public:
 
   size_t getLocalNumEdges() const { return graph_->getNodeNumEntries(); }
 
-  void getEdgesView(const lno_t *&offsets, const gno_t *&adjIds) const
+  void getEdgesView(const offset_t *&offsets, const gno_t *&adjIds) const
   {
     offsets = offs_.getRawPtr();
     adjIds = (getLocalNumEdges() ? adjids_.getRawPtr() : NULL);
@@ -268,7 +269,7 @@ private:
   RCP<const xgraph_t > graph_;
   RCP<const Comm<int> > comm_;
 
-  ArrayRCP<const lno_t> offs_;
+  ArrayRCP<const offset_t> offs_;
   ArrayRCP<const gno_t> adjids_;
 
   int nWeightsPerVertex_;
@@ -311,7 +312,7 @@ template <typename User, typename UserCoord>
   // because edge Ids are not usually stored in vertex id order.
 
   size_t n = nvtx + 1;
-  lno_t *offs = new lno_t [n];
+  offset_t *offs = new offset_t [n];
 
   if (!offs)
   {

--- a/packages/zoltan2/src/input/Zoltan2_XpetraCrsGraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_XpetraCrsGraphAdapter.hpp
@@ -339,7 +339,7 @@ template <typename User, typename UserCoord>
     ArrayView<const lno_t> nbors;
     graph_->getLocalRowView(v, nbors);
     offs[v+1] = offs[v] + nbors.size();
-    for (lno_t e=offs[v], i=0; e < offs[v+1]; e++)
+    for (offset_t e=offs[v], i=0; e < offs[v+1]; e++)
       adjids[e] = graph_->getColMap()->getGlobalElement(nbors[i++]);
   }
 

--- a/packages/zoltan2/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
@@ -92,6 +92,7 @@ public:
   typedef typename InputTraits<User>::gno_t    gno_t;
   typedef typename InputTraits<User>::part_t   part_t;
   typedef typename InputTraits<User>::node_t   node_t;
+  typedef typename InputTraits<User>::offset_t offset_t;
   typedef Xpetra::CrsMatrix<scalar_t, lno_t, gno_t, node_t> xmatrix_t;
   typedef User user_t;
   typedef UserCoord userCoord_t;
@@ -178,13 +179,13 @@ public:
     rowIds = rowView.getRawPtr();
   }
 
-  void getCRSView(const lno_t *&offsets, const gno_t *&colIds) const
+  void getCRSView(const offset_t *&offsets, const gno_t *&colIds) const
   {
     offsets = offset_.getRawPtr();
     colIds = columnIds_.getRawPtr();
   }
 
-  void getCRSView(const lno_t *&offsets, const gno_t *&colIds,
+  void getCRSView(const offset_t *&offsets, const gno_t *&colIds,
                     const scalar_t *&values) const
   {
     offsets = offset_.getRawPtr();
@@ -226,9 +227,11 @@ private:
   RCP<const xmatrix_t> matrix_;
   RCP<const Xpetra::Map<lno_t, gno_t, node_t> > rowMap_;
   RCP<const Xpetra::Map<lno_t, gno_t, node_t> > colMap_;
-  ArrayRCP<lno_t> offset_;
-  ArrayRCP<gno_t> columnIds_;  // TODO:  KDD Is it necessary to copy and store
-  ArrayRCP<scalar_t> values_;  // TODO:  the matrix here?  Would prefer views.
+  lno_t base_;
+  ArrayRCP< const offset_t > offset_;
+  ArrayRCP< const lno_t > localColumnIds_;
+  ArrayRCP< const scalar_t > values_;
+  ArrayRCP<gno_t> columnIds_;  // TODO:  Refactor adapter to localColumnIds_
 
   int nWeightsPerRow_;
   ArrayRCP<StridedData<lno_t, scalar_t> > rowWeights_;
@@ -261,26 +264,24 @@ template <typename User, typename UserCoord>
 
   size_t nrows = matrix_->getNodeNumRows();
   size_t nnz = matrix_->getNodeNumEntries();
+
+  // Get ArrayRCP pointers to the structures in the underlying matrix
+  matrix_->getAllValues(offset_,localColumnIds_,values_);
  
-  offset_.resize(nrows+1, 0);
-  columnIds_.resize(nnz);
-  values_.resize(nnz);
-  ArrayView<const lno_t> indices;
-  ArrayView<const scalar_t> nzs;
+  //offset_.resize(nrows+1, 0);
+  columnIds_.resize(nnz, 0);
   lno_t next = 0;
-//TODO WE ARE COPYING THE MATRIX HERE.  IS THERE A WAY TO USE VIEWS?
-//TODO THEY ARE AVAILABLE IN EPETRA; ARE THEY AVAIL IN TPETRA AND XPETRA?
+  // TODO: Refactor the Adapter to use local column ids rather than global ids.
+  // TODO: Refactor the adapter so that offset_ has type size_t, rather than lno_t
+  // This will remove the need for this loop
   for (size_t i=0; i < nrows; i++){
     lno_t row = i;
     nnz = matrix_->getNumEntriesInLocalRow(row);
-    matrix_->getLocalRowView(row, indices, nzs);
     for (size_t j=0; j < nnz; j++){
-      values_[next] = nzs[j];
-      // TODO - this will be slow
-      //   Is it possible that global columns ids might be stored in order?
-      columnIds_[next++] = colMap_->getGlobalElement(indices[j]);
+      columnIds_[next++] = colMap_->getGlobalElement(localColumnIds_[j+offset_[i]]);
     }
-    offset_[i+1] = offset_[i] + nnz;
+    //offset_[i] = (lno_t) myOffset[i];
+    //if (i==(nrows-1)) offset_[i+1]=offset_[i] + nnz;
   } 
 
   if (nWeightsPerRow_ > 0){

--- a/packages/zoltan2/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
@@ -267,22 +267,11 @@ template <typename User, typename UserCoord>
 
   // Get ArrayRCP pointers to the structures in the underlying matrix
   matrix_->getAllValues(offset_,localColumnIds_,values_);
- 
-  //offset_.resize(nrows+1, 0);
   columnIds_.resize(nnz, 0);
-  lno_t next = 0;
-  // TODO: Refactor the Adapter to use local column ids rather than global ids.
-  // TODO: Refactor the adapter so that offset_ has type size_t, rather than lno_t
-  // This will remove the need for this loop
-  for (size_t i=0; i < nrows; i++){
-    lno_t row = i;
-    nnz = matrix_->getNumEntriesInLocalRow(row);
-    for (size_t j=0; j < nnz; j++){
-      columnIds_[next++] = colMap_->getGlobalElement(localColumnIds_[j+offset_[i]]);
-    }
-    //offset_[i] = (lno_t) myOffset[i];
-    //if (i==(nrows-1)) offset_[i+1]=offset_[i] + nnz;
-  } 
+
+  for(offset_t i = 0; i < offset_[nrows]; i++) {
+    columnIds_[i] = colMap_->getGlobalElement(localColumnIds_[i]);
+  }
 
   if (nWeightsPerRow_ > 0){
     rowWeights_ = arcp(new input_t [nWeightsPerRow_], 0, nWeightsPerRow_, true);

--- a/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
@@ -206,7 +206,7 @@ public:
          will on return point to a StridedData object of weights.
        \return The number of ids in the edgeIds list.
    */
-  // Implied Vertex offset_t from getVertexList are used as indices to offsets
+  // Implied Vertex LNOs from getVertexList are used as indices to offsets
   // array.
   // Vertex GNOs are returned as neighbors in edgeIds.
 

--- a/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
@@ -89,6 +89,7 @@ public:
   typedef typename Adapter::user_t      user_t;
   typedef typename Adapter::userCoord_t userCoord_t;
   typedef StridedData<lno_t, scalar_t>  input_t;
+  typedef typename Adapter::offset_t    offset_t;
 #endif
 
   //!  Destructor
@@ -205,12 +206,12 @@ public:
          will on return point to a StridedData object of weights.
        \return The number of ids in the edgeIds list.
    */
-  // Implied Vertex LNOs from getVertexList are used as indices to offsets
+  // Implied Vertex offset_t from getVertexList are used as indices to offsets
   // array.
   // Vertex GNOs are returned as neighbors in edgeIds.
 
   size_t getEdgeList( ArrayView<const gno_t> &edgeIds,
-    ArrayView<const lno_t> &offsets,
+    ArrayView<const offset_t> &offsets,
     ArrayView<input_t> &wgts) const
   {
     edgeIds = eGids_.view(0, nLocalEdges_);
@@ -277,7 +278,7 @@ private:
   size_t nLocalEdges_;                  // # local edges in built graph
   size_t nGlobalEdges_;                 // # global edges in built graph
   ArrayRCP<gno_t> eGids_;                 // edges of graph built in model
-  ArrayRCP<lno_t> eOffsets_;              // edge offsets build in model
+  ArrayRCP<offset_t> eOffsets_;           // edge offsets build in model
                                           // May be same as adapter's input 
                                           // or may differ
                                           // due to renumbering, self-edge
@@ -336,7 +337,7 @@ GraphModel<Adapter>::GraphModel(
 
   // Get the matrix from the input adapter
   gno_t const *vtxIds=NULL, *nborIds=NULL;
-  lno_t const *offsets=NULL;
+  offset_t const *offsets=NULL;
   try{
     nLocalVertices_ = ia->getLocalNumIDs();
     ia->getIDsView(vtxIds);
@@ -360,8 +361,8 @@ GraphModel<Adapter>::GraphModel(
                 arcp<const gno_t>(vtxIds, 0, nLocalVertices_, false));
   eGids_ = arcp_const_cast<gno_t>(
                 arcp<const gno_t>(nborIds, 0, nLocalEdges_, false));
-  eOffsets_ = arcp_const_cast<lno_t>(
-                   arcp<const lno_t>(offsets, 0, nLocalVertices_+1, false));
+  eOffsets_ = arcp_const_cast<offset_t>(
+                   arcp<const offset_t>(offsets, 0, nLocalVertices_+1, false));
 
   // Edge weights
   nWeightsPerEdge_ = 0;   // no edge weights from a matrix yet.
@@ -418,7 +419,7 @@ GraphModel<Adapter>::GraphModel(
   // Get the graph from the input adapter
 
   gno_t const *vtxIds=NULL, *nborIds=NULL;
-  lno_t const *offsets=NULL;
+  offset_t const *offsets=NULL;
   try{
     nLocalVertices_ = ia->getLocalNumVertices();
     ia->getVertexIDsView(vtxIds);
@@ -432,8 +433,8 @@ GraphModel<Adapter>::GraphModel(
                 arcp<const gno_t>(vtxIds, 0, nLocalVertices_, false));
   eGids_ = arcp_const_cast<gno_t>(
                 arcp<const gno_t>(nborIds, 0, nLocalEdges_, false));
-  eOffsets_ = arcp_const_cast<lno_t>(
-                   arcp<const lno_t>(offsets, 0, nLocalVertices_+1, false));
+  eOffsets_ = arcp_const_cast<offset_t>(
+                   arcp<const offset_t>(offsets, 0, nLocalVertices_+1, false));
 
   // Edge weights
   nWeightsPerEdge_ = ia->getNumWeightsPerEdge();
@@ -535,7 +536,7 @@ GraphModel<Adapter>::GraphModel(
     // Get the edges
     try {
       gno_t const *nborIds=NULL;
-      lno_t const *offsets=NULL;
+      offset_t const *offsets=NULL;
 
       ia->get2ndAdjsView(primaryEType, secondAdjEType, offsets, nborIds);
       // Save the pointers from the input adapter; we do not control the
@@ -543,8 +544,8 @@ GraphModel<Adapter>::GraphModel(
       nLocalEdges_ = offsets[nLocalVertices_];
       eGids_ = arcp_const_cast<gno_t>(
                arcp<const gno_t>(nborIds, 0, nLocalEdges_, false));
-      eOffsets_ = arcp_const_cast<lno_t>(
-                  arcp<const lno_t>(offsets, 0, nLocalVertices_+1, false));
+      eOffsets_ = arcp_const_cast<offset_t>(
+                  arcp<const offset_t>(offsets, 0, nLocalVertices_+1, false));
     }
     Z2_FORWARD_EXCEPTIONS;
   }
@@ -602,7 +603,7 @@ void GraphModel<Adapter>::shared_constructor(
   size_t adapterNLocalEdges = nLocalEdges_;
   ArrayRCP<gno_t> adapterVGids = vGids_;     // vertices of graph from adapter
   ArrayRCP<gno_t> adapterEGids = eGids_;     // edges of graph from adapter
-  ArrayRCP<lno_t> adapterEOffsets = eOffsets_;    // edge offsets from adapter
+  ArrayRCP<offset_t> adapterEOffsets = eOffsets_;    // edge offsets from adapter
   ArrayRCP<input_t> adapterEWeights = eWeights_;  // edge weights from adapter
 
   if (localGraph_) {
@@ -618,7 +619,7 @@ void GraphModel<Adapter>::shared_constructor(
                   0, nLocalVertices_, true);
     eGids_ = arcp(new gno_t[adapterNLocalEdges],
                   0, adapterNLocalEdges, true);  
-    eOffsets_ = arcp(new lno_t[nLocalVertices_+1],
+    eOffsets_ = arcp(new offset_t[nLocalVertices_+1],
                      0, nLocalVertices_+1, true);
 
     scalar_t **tmpEWeights = NULL;
@@ -642,7 +643,7 @@ void GraphModel<Adapter>::shared_constructor(
     lno_t ecnt = 0;
     for (size_t i = 0; i < nLocalVertices_; i++) {
       vGids_[i] = gno_t(i);
-      for (lno_t j = adapterEOffsets[i]; j < adapterEOffsets[i+1]; j++) {
+      for (offset_t j = adapterEOffsets[i]; j < adapterEOffsets[i+1]; j++) {
 
         if (removeSelfEdges && (adapterEGids[j] == adapterVGids[i]))
           continue;  // Skipping self edge
@@ -703,7 +704,7 @@ void GraphModel<Adapter>::shared_constructor(
     scalar_t **tmpEWeights = NULL;
     if (subsetGraph || removeSelfEdges) {
       // May change number of edges and, thus, the offsets 
-      eOffsets_ = arcp(new lno_t[nLocalVertices_+1],
+      eOffsets_ = arcp(new offset_t[nLocalVertices_+1],
                        0, nLocalVertices_+1, true);
       eOffsets_[0] = 0;
 
@@ -771,7 +772,7 @@ void GraphModel<Adapter>::shared_constructor(
       if (consecutiveIdsRequired)
         vGids_[i] = vtxDist_[me] + i;
 
-      for (lno_t j = adapterEOffsets[i]; j < adapterEOffsets[i+1]; j++) {
+      for (offset_t j = adapterEOffsets[i]; j < adapterEOffsets[i+1]; j++) {
 
         if (removeSelfEdges && (adapterVGids[i] == adapterEGids[j]))
           continue;  // Skipping self edge
@@ -910,7 +911,7 @@ void GraphModel<Adapter>::print()
 
   for (size_t i = 0; i < nLocalVertices_; i++) {
     *os << me << " " << i << " GID " << vGids_[i] << ": ";
-    for (lno_t j = eOffsets_[i]; j < eOffsets_[i+1]; j++)
+    for (offset_t j = eOffsets_[i]; j < eOffsets_[i+1]; j++)
       *os << eGids_[j] << " " ;
     *os << std::endl;
   }
@@ -927,7 +928,7 @@ void GraphModel<Adapter>::print()
   if (nWeightsPerEdge_) {
     for (size_t i = 0; i < nLocalVertices_; i++) {
       *os << me << " " << i << " EWGTS " << vGids_[i] << ": ";
-      for (lno_t j = eOffsets_[i]; j < eOffsets_[i+1]; j++) {
+      for (offset_t j = eOffsets_[i]; j < eOffsets_[i+1]; j++) {
         *os << eGids_[j] << " (";
         for (int w = 0; w < nWeightsPerEdge_; w++)
           *os << eWeights_[w][j] << " ";

--- a/packages/zoltan2/src/models/Zoltan2_ModelHelpers.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_ModelHelpers.hpp
@@ -68,6 +68,7 @@ get2ndAdjsMatFromAdjs(const Teuchos::RCP<const MeshAdapter<User> > &ia,
   typedef typename MeshAdapter<User>::gno_t gno_t;
   typedef typename MeshAdapter<User>::lno_t lno_t;
   typedef typename MeshAdapter<User>::node_t node_t;
+  typedef typename MeshAdapter<User>::offset_t offset_t;
 
   typedef int nonzero_t;  // adjacency matrix doesn't need scalar_t
   typedef Tpetra::CrsMatrix<nonzero_t,lno_t,gno_t,node_t>   sparse_matrix_type;
@@ -85,7 +86,7 @@ get2ndAdjsMatFromAdjs(const Teuchos::RCP<const MeshAdapter<User> > &ia,
 
     // Get node-element connectivity
 
-    const lno_t *offsets=NULL;
+    const offset_t *offsets=NULL;
     const gno_t *adjacencyIds=NULL;
     ia->getAdjsView(sourcetarget, through, offsets, adjacencyIds);
 
@@ -196,11 +197,12 @@ void get2ndAdjsViewFromAdjs(
     const RCP<const Comm<int> > comm,
     Zoltan2::MeshEntityType sourcetarget,
     Zoltan2::MeshEntityType through,
-    Teuchos::ArrayRCP<typename MeshAdapter<User>::lno_t> &offsets,
+    Teuchos::ArrayRCP<typename MeshAdapter<User>::offset_t> &offsets,
     Teuchos::ArrayRCP<typename MeshAdapter<User>::gno_t> &adjacencyIds)
 {
   typedef typename MeshAdapter<User>::gno_t gno_t;
   typedef typename MeshAdapter<User>::lno_t lno_t;
+  typedef typename MeshAdapter<User>::offset_t offset_t;
   typedef typename MeshAdapter<User>::node_t node_t;
 
   typedef int nonzero_t;  // adjacency matrix doesn't need scalar_t
@@ -248,7 +250,7 @@ void get2ndAdjsViewFromAdjs(
       adj_[i] = adj[i];
     }
 
-    offsets = arcp<lno_t>(start, 0, LocalNumIDs+1, true);
+    offsets = arcp<offset_t>(start, 0, LocalNumIDs+1, true);
     adjacencyIds = arcp<gno_t>(adj_, 0, nadj, true);
   }
   else {
@@ -256,7 +258,7 @@ void get2ndAdjsViewFromAdjs(
     for (size_t i = 0; i <= LocalNumIDs; i++)
       start[i] = 0;
 
-    offsets = arcp<lno_t>(start, 0, LocalNumIDs+1, true);
+    offsets = arcp<offset_t>(start, 0, LocalNumIDs+1, true);
     adjacencyIds = Teuchos::null;
   }
 

--- a/packages/zoltan2/src/util/Zoltan2_EvaluateOrdering.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_EvaluateOrdering.hpp
@@ -64,6 +64,7 @@ class EvaluateOrdering : public EvaluateBaseClass<Adapter> {
 private:
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::part_t part_t;
   typedef typename Adapter::scalar_t scalar_t;
   typedef typename Adapter::base_adapter_t base_adapter_t;
@@ -183,7 +184,7 @@ public:
     ArrayView<const gno_t> Ids;
     ArrayView<input_t> vwgts;
     ArrayView<const gno_t> edgeIds;
-    ArrayView<const lno_t> offsets;
+    ArrayView<const offset_t> offsets;
     ArrayView<input_t> wgts;
     ArrayView<input_t> vtx;
     graph->getEdgeList(edgeIds, offsets, wgts);
@@ -218,7 +219,7 @@ public:
           std::cout << std::endl;
           // write 1's to old matrix (original form) and new matrix (using solution)
           for (lno_t y = 0; y < numVertex; y++) {
-            for (lno_t n = offsets[y]; n < offsets[y+1]; ++n) {
+            for (offset_t n = offsets[y]; n < offsets[y+1]; ++n) {
               lno_t x = static_cast<lno_t>(edgeIds[n]); // to resolve
               if (x < numVertex && y < numVertex) { // to develop - for MPI this may not be local
                 oldMatrix[x + y*numVertex] = 1;
@@ -259,7 +260,7 @@ public:
 
     for (lno_t j = 0; j < numVertex; j++) {
       lno_t y = Ids[j];
-      for (auto n = offsets[j]; n < offsets[j+1]; ++n) {
+      for (offset_t n = offsets[j]; n < offsets[j+1]; ++n) {
         lno_t x = static_cast<lno_t>(edgeIds[n]); // to resolve
         if(x < numVertex) {
           lno_t x2 = perm[x];

--- a/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
@@ -76,6 +76,7 @@ void globalWeightedCutsMessagesHopsByPart(
 
   typedef typename Adapter::lno_t t_lno_t;
   typedef typename Adapter::gno_t t_gno_t;
+  typedef typename Adapter::offset_t t_offset_t;
   typedef typename Adapter::scalar_t t_scalar_t;
   typedef typename Adapter::part_t part_t;
   typedef typename Adapter::node_t t_node_t;
@@ -94,7 +95,7 @@ void globalWeightedCutsMessagesHopsByPart(
 
   //get the edge ids, and weights
   ArrayView<const t_gno_t> edgeIds;
-  ArrayView<const t_lno_t> offsets;
+  ArrayView<const t_offset_t> offsets;
   ArrayView<t_input_t> e_wgts;
   graph->getEdgeList(edgeIds, offsets, e_wgts);
 
@@ -211,7 +212,7 @@ void globalWeightedCutsMessagesHopsByPart(
         //get part i, and first vertex in this part v.
         while (v != -1){
           //now get the neightbors of v.
-          for (t_lno_t j = offsets[v]; j < offsets[v+1]; ++j){
+          for (t_offset_t j = offsets[v]; j < offsets[v+1]; ++j){
             //get the part of the second vertex.
             part_t ep = e_parts[j];
 
@@ -391,6 +392,7 @@ void globalWeightedCutsMessagesByPart(
 
   typedef typename Adapter::lno_t t_lno_t;
   typedef typename Adapter::gno_t t_gno_t;
+  typedef typename Adapter::offset_t t_offset_t;
   typedef typename Adapter::scalar_t t_scalar_t;
   typedef typename Adapter::part_t part_t;
   typedef typename Adapter::node_t t_node_t;
@@ -409,7 +411,7 @@ void globalWeightedCutsMessagesByPart(
 
   //get the edge ids, and weights
   ArrayView<const t_gno_t> edgeIds;
-  ArrayView<const t_lno_t> offsets;
+  ArrayView<const t_offset_t> offsets;
   ArrayView<t_input_t> e_wgts;
   graph->getEdgeList(edgeIds, offsets, e_wgts);
 
@@ -525,7 +527,7 @@ void globalWeightedCutsMessagesByPart(
         //get part i, and first vertex in this part v.
         while (v != -1){
           //now get the neightbors of v.
-          for (t_lno_t j = offsets[v]; j < offsets[v+1]; ++j){
+          for (t_offset_t j = offsets[v]; j < offsets[v+1]; ++j){
             //get the part of the second vertex.
             part_t ep = e_parts[j];
 
@@ -685,6 +687,7 @@ template <typename Adapter>
   typedef typename Adapter::scalar_t scalar_t;
   typedef typename Adapter::gno_t gno_t;
   typedef typename Adapter::lno_t lno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::node_t node_t;
   typedef typename Adapter::part_t part_t;
   typedef StridedData<lno_t, scalar_t> input_t;
@@ -747,7 +750,7 @@ template <typename Adapter>
   graph->getVertexList(Ids, vwgts);
 
   ArrayView<const gno_t> edgeIds;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   ArrayView<input_t> wgts;
   //size_t numLocalEdges =
   graph->getEdgeList(edgeIds, offsets, wgts);
@@ -762,7 +765,7 @@ template <typename Adapter>
   size_t maxcols = 0;
   for (lno_t i = 0; i < localNumObj; ++i) {
     if (Ids[i] < min) min = Ids[i];
-    size_t ncols = offsets[i+1] - offsets[i];
+    offset_t ncols = offsets[i+1] - offsets[i];
     if (ncols > maxcols) maxcols = ncols;
   }
 
@@ -787,7 +790,7 @@ template <typename Adapter>
 
   for (lno_t localElement=0; localElement<localNumObj; ++localElement){
     // Insert all columns for global row Ids[localElement]
-    size_t ncols = offsets[localElement+1] - offsets[localElement];
+    offset_t ncols = offsets[localElement+1] - offsets[localElement];
     adjsMatrix->insertGlobalValues(Ids[localElement],
                                    edgeIds(offsets[localElement], ncols),
                                    justOneA(0, ncols));

--- a/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
@@ -762,7 +762,7 @@ template <typename Adapter>
 
   // Build a list of the global vertex ids...
   gno_t min = std::numeric_limits<gno_t>::max();
-  size_t maxcols = 0;
+  offset_t maxcols = 0;
   for (lno_t i = 0; i < localNumObj; ++i) {
     if (Ids[i] < min) min = Ids[i];
     offset_t ncols = offsets[i+1] - offsets[i];

--- a/packages/zoltan2/src/util/Zoltan2_componentMetrics.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_componentMetrics.hpp
@@ -162,7 +162,7 @@ perProcessorComponentMetrics<Adapter>::perProcessorComponentMetrics(
       q.pop();
 
       // Add neighbors of vtx to queue.
-      for (lno_t j = offset[vtx]; j < offset[vtx+1]; j++) {
+      for (offset_t j = offset[vtx]; j < offset[vtx+1]; j++) {
         if (!mark[adj[j]]) {
           markAndEnqueue(q, mark, nUnmarkedVtx, cSize, adj[j]);
         }

--- a/packages/zoltan2/src/util/Zoltan2_componentMetrics.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_componentMetrics.hpp
@@ -67,6 +67,7 @@ class perProcessorComponentMetrics{
 public:
   typedef typename Adapter::lno_t lno_t;
   typedef typename Adapter::gno_t gno_t;
+  typedef typename Adapter::offset_t offset_t;
   typedef typename Adapter::scalar_t scalar_t;
 
   perProcessorComponentMetrics(const Adapter &ia,
@@ -132,7 +133,7 @@ perProcessorComponentMetrics<Adapter>::perProcessorComponentMetrics(
   // get graph from model
   const size_t nVtx = graph.getLocalNumVertices();
   ArrayView<const gno_t> adj;
-  ArrayView<const lno_t> offset;
+  ArrayView<const offset_t> offset;
   ArrayView<StridedData<lno_t, scalar_t> > wgts;  // unused
   graph.getEdgeList(adj, offset, wgts);
 

--- a/packages/zoltan2/test/driver/test_driver.cpp
+++ b/packages/zoltan2/test/driver/test_driver.cpp
@@ -357,7 +357,7 @@ bool run(const UserInputForTests &uinput,
     lno_t localNumObj = xscrsGraphAdapter->getLocalNumVertices();
     const gno_t *vertexIds;
     xscrsGraphAdapter->getVertexIDsView(vertexIds);
-    const lno_t *offsets;
+    const offset_t *offsets;
     const gno_t *adjIds;
     xscrsGraphAdapter->getEdgesView(offsets, adjIds);
     for (int edim = 0; edim < ewgtDim; edim++) {
@@ -365,7 +365,7 @@ bool run(const UserInputForTests &uinput,
       int stride=0;
       xscrsGraphAdapter->getEdgeWeightsView(weights, stride, edim);
       for (lno_t i=0; i < localNumObj; i++)
-        for (lno_t j=offsets[i]; j < offsets[i+1]; j++)
+        for (offset_t j=offsets[i]; j < offsets[i+1]; j++)
           std::cout << edim << " " << vertexIds[i] << " " 
                     << adjIds[j] << " " << weights[stride*j] << std::endl;
     }

--- a/packages/zoltan2/test/helpers/Zoltan2_TestHelpers.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_TestHelpers.hpp
@@ -105,7 +105,6 @@ typedef Tpetra::Map<>::node_type znode_t;
 
 #ifdef HAVE_TPETRA_EXPLICIT_INSTANTIATION
 
-  typedef size_t zoffset_t;
 # ifdef HAVE_TPETRA_DOUBLE
     typedef double zscalar_t;
 #   define HAVE_EPETRA_SCALAR_TYPE

--- a/packages/zoltan2/test/helpers/Zoltan2_TestHelpers.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_TestHelpers.hpp
@@ -105,6 +105,7 @@ typedef Tpetra::Map<>::node_type znode_t;
 
 #ifdef HAVE_TPETRA_EXPLICIT_INSTANTIATION
 
+  typedef size_t zoffset_t;
 # ifdef HAVE_TPETRA_DOUBLE
     typedef double zscalar_t;
 #   define HAVE_EPETRA_SCALAR_TYPE

--- a/packages/zoltan2/test/helpers/Zoltan2_Typedefs.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_Typedefs.hpp
@@ -189,11 +189,11 @@ namespace Zoltan2_TestingFramework {
   typedef Zoltan2::BasicVectorAdapter<tMVector_t>         basic_vector_adapter;
 
 #ifdef HAVE_ZOLTAN2_PAMGEN
-  typedef Zoltan2::PamgenMeshAdapter<tMVector_t>          pamgen_adapter_t;
+  typedef Zoltan2::PamgenMeshAdapter<userTypes_t>          pamgen_adapter_t;
 #else
   // This typedef exists only to satisfy the compiler.
   // PamgenMeshAdapter cannot be used when Trilinos is not built with Pamgen
-  typedef Zoltan2::BasicVectorAdapter<tMVector_t>         pamgen_adapter_t;
+  typedef Zoltan2::BasicVectorAdapter<userTypes_t>         pamgen_adapter_t;
 #endif
 
 // when test objects are created they set an enum to define the adapter type

--- a/packages/zoltan2/test/partition/APFMeshAdapterTest.cpp
+++ b/packages/zoltan2/test/partition/APFMeshAdapterTest.cpp
@@ -99,6 +99,7 @@ void PrintGhostMetrics(Zoltan2::HyperGraphModel<Adapter>& mdl) {
   typedef typename Adapter::gno_t       gno_t;
   typedef typename Adapter::lno_t       lno_t;
   typedef typename Adapter::scalar_t       scalar_t;
+  typedef typename Adapter::offset_t       offset_t;
   typedef Zoltan2::StridedData<lno_t, scalar_t>  input_t;
 
   ArrayView<const gno_t> Ids;
@@ -108,7 +109,7 @@ void PrintGhostMetrics(Zoltan2::HyperGraphModel<Adapter>& mdl) {
   mdl.getOwnedList(isOwner);
   size_t numOwned = mdl.getLocalNumOwnedVertices();
   ArrayView<const gno_t> pins;
-  ArrayView<const lno_t> offsets;
+  ArrayView<const offset_t> offsets;
   mdl.getPinList(pins,offsets,wgts);
   
   std::set<gno_t> gids;

--- a/packages/zoltan2/test/partition/pamgenMeshAdapterTest.cpp
+++ b/packages/zoltan2/test/partition/pamgenMeshAdapterTest.cpp
@@ -79,7 +79,7 @@ using Teuchos::ArrayRCP;
 /*********************************************************/
 //Tpetra typedefs
 typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-typedef Tpetra::MultiVector<double>                  tMVector_t;
+typedef Zoltan2::BasicUserTypes<double>          basic_user_t;
 
 
 
@@ -188,7 +188,7 @@ int main(int narg, char *arg[]) {
   // Creating mesh adapter
   if (me == 0) cout << "Creating mesh adapter ... \n\n";
 
-  typedef Zoltan2::PamgenMeshAdapter<tMVector_t> inputAdapter_t;
+  typedef Zoltan2::PamgenMeshAdapter<basic_user_t> inputAdapter_t;
   typedef Zoltan2::EvaluatePartition<inputAdapter_t> quality_t;
 
   inputAdapter_t *ia = new inputAdapter_t(*CommT, "region");

--- a/packages/zoltan2/test/unit/input/APFMeshInput.cpp
+++ b/packages/zoltan2/test/unit/input/APFMeshInput.cpp
@@ -118,6 +118,7 @@ int main(int narg, char *arg[]) {
   typedef Adapter::lno_t lno_t;
   typedef Adapter::gno_t gno_t;
   typedef Adapter::scalar_t scalar_t;
+  typedef Adapter::offset_t offset_t;
 
   std::string pri = "face";
   std::string adj = "vertex";
@@ -174,7 +175,7 @@ int main(int narg, char *arg[]) {
     int x_stride;
     int y_stride;
     int z_stride;
-    const lno_t** offsets = new const lno_t*[dim];
+    const offset_t** offsets = new const offset_t*[dim];
     const gno_t** adj_gids = new const gno_t*[dim];
 
     ia.getIDsViewOf(ents[i],gids);
@@ -251,7 +252,7 @@ int main(int narg, char *arg[]) {
         }
         apf::Adjacent adjs;
         m->getAdjacent(ent,k,adjs);
-        lno_t ind = offsets[k][j];
+        offset_t ind = offsets[k][j];
         for (unsigned int l=0;l<adjs.getSize();l++) {
           if (apf::getNumber(gnums[k],apf::Node(adjs[l],0))!=adj_gids[k][ind]) {
             std::cerr<<"First adjacency does not match in dimension " <<i<<" to dimension "<<k

--- a/packages/zoltan2/test/unit/input/PamgenMeshInput.cpp
+++ b/packages/zoltan2/test/unit/input/PamgenMeshInput.cpp
@@ -141,7 +141,7 @@ int main(int narg, char *arg[]) {
   inputAdapter_t ia(*CommT, "region");
   inputAdapter_t ia2(*CommT, "vertex");
   inputAdapter_t::gno_t const *adjacencyIds=NULL;
-  inputAdapter_t::lno_t const *offsets=NULL;
+  inputAdapter_t::offset_t const *offsets=NULL;
   ia.print(me);
 
   // Exercise the componentMetrics on the input; make sure the adapter works
@@ -225,7 +225,7 @@ int main(int narg, char *arg[]) {
 	for (int j = 0; j < num_nodes_per_elem[b]; j++) {
 	  ssize_t in_list = -1;
 
-	  for(inputAdapter_t::lno_t k=offsets[telct];k<offsets[telct+1];k++) {
+	  for(inputAdapter_t::offset_t k=offsets[telct];k<offsets[telct+1];k++) {
 	    if(adjacencyIds[k] ==
 	       node_num_map[connect[b][i*num_nodes_per_elem[b]+j]-1]) {
 	      in_list = k;

--- a/packages/zoltan2/test/unit/input/PamgenMeshInput.cpp
+++ b/packages/zoltan2/test/unit/input/PamgenMeshInput.cpp
@@ -62,7 +62,7 @@ using Teuchos::RCP;
 /*********************************************************/
 //Tpetra typedefs
 typedef Tpetra::DefaultPlatform::DefaultPlatformType            Platform;
-typedef Tpetra::MultiVector<double, int, int>     tMVector_t;
+typedef Zoltan2::BasicUserTypes<double, int, int>           basic_user_t;
 
 
 
@@ -136,7 +136,7 @@ int main(int narg, char *arg[]) {
   // Creating mesh adapter
   if (me == 0) cout << "Creating mesh adapter ... \n\n";
 
-  typedef Zoltan2::PamgenMeshAdapter<tMVector_t> inputAdapter_t;
+  typedef Zoltan2::PamgenMeshAdapter<basic_user_t> inputAdapter_t;
 
   inputAdapter_t ia(*CommT, "region");
   inputAdapter_t ia2(*CommT, "vertex");

--- a/packages/zoltan2/test/unit/input/TpetraRowGraphInput.cpp
+++ b/packages/zoltan2/test/unit/input/TpetraRowGraphInput.cpp
@@ -72,8 +72,9 @@ using Teuchos::DefaultComm;
 typedef Tpetra::CrsGraph<zlno_t, zgno_t, znode_t> ztcrsgraph_t;
 typedef Tpetra::RowGraph<zlno_t, zgno_t, znode_t> ztrowgraph_t;
 
+template<typename offset_t>
 void printGraph(RCP<const Comm<int> > &comm, zlno_t nvtx,
-    const zgno_t *vtxIds, const zlno_t *offsets, const zgno_t *edgeIds)
+    const zgno_t *vtxIds, const offset_t *offsets, const zgno_t *edgeIds)
 {
   int rank = comm->getRank();
   int nprocs = comm->getSize();
@@ -83,7 +84,7 @@ void printGraph(RCP<const Comm<int> > &comm, zlno_t nvtx,
       std::cout << rank << ":" << std::endl;
       for (zlno_t i=0; i < nvtx; i++){
         std::cout << " vertex " << vtxIds[i] << ": ";
-        for (zlno_t j=offsets[i]; j < offsets[i+1]; j++){
+        for (offset_t j=offsets[i]; j < offsets[i+1]; j++){
           std::cout << edgeIds[j] << " ";
         }
         std::cout << std::endl;
@@ -99,6 +100,8 @@ template <typename User>
 int verifyInputAdapter(
   Zoltan2::TpetraRowGraphAdapter<User> &ia, ztrowgraph_t &graph)
 {
+  typedef typename Zoltan2::InputTraits<User>::offset_t offset_t;
+
   RCP<const Comm<int> > comm = graph.getComm();
   int fail = 0, gfail=0;
 
@@ -113,7 +116,7 @@ int verifyInputAdapter(
   gfail = globalFail(comm, fail);
 
   const zgno_t *vtxIds=NULL, *edgeIds=NULL;
-  const zlno_t *offsets=NULL;
+  const offset_t *offsets=NULL;
   size_t nvtx=0;
 
   if (!gfail){
@@ -128,7 +131,7 @@ int verifyInputAdapter(
     gfail = globalFail(comm, fail);
 
     if (gfail == 0){
-      printGraph(comm, nvtx, vtxIds, offsets, edgeIds);
+      printGraph<offset_t>(comm, nvtx, vtxIds, offsets, edgeIds);
     }
     else{
       if (!fail) fail = 10;

--- a/packages/zoltan2/test/unit/input/TpetraRowMatrixInput.cpp
+++ b/packages/zoltan2/test/unit/input/TpetraRowMatrixInput.cpp
@@ -75,8 +75,9 @@ typedef Tpetra::RowMatrix<zscalar_t, zlno_t, zgno_t, znode_t> ztrowmatrix_t;
 
 //////////////////////////////////////////////////////////////////////////
 
+template<typename offset_t>
 void printMatrix(RCP<const Comm<int> > &comm, zlno_t nrows,
-    const zgno_t *rowIds, const zlno_t *offsets, const zgno_t *colIds)
+    const zgno_t *rowIds, const offset_t *offsets, const zgno_t *colIds)
 {
   int rank = comm->getRank();
   int nprocs = comm->getSize();
@@ -86,7 +87,7 @@ void printMatrix(RCP<const Comm<int> > &comm, zlno_t nrows,
       std::cout << rank << ":" << std::endl;
       for (zlno_t i=0; i < nrows; i++){
         std::cout << " row " << rowIds[i] << ": ";
-        for (zlno_t j=offsets[i]; j < offsets[i+1]; j++){
+        for (offset_t j=offsets[i]; j < offsets[i+1]; j++){
           std::cout << colIds[j] << " ";
         }
         std::cout << std::endl;
@@ -104,6 +105,8 @@ template <typename User>
 int verifyInputAdapter(
   Zoltan2::TpetraRowMatrixAdapter<User> &ia, ztrowmatrix_t &M)
 {
+  typedef typename Zoltan2::InputTraits<User>::offset_t offset_t;
+
   RCP<const Comm<int> > comm = M.getComm();
   int fail = 0, gfail=0;
 
@@ -118,7 +121,7 @@ int verifyInputAdapter(
   gfail = globalFail(comm, fail);
 
   const zgno_t *rowIds=NULL, *colIds=NULL;
-  const zlno_t *offsets=NULL;
+  const offset_t *offsets=NULL;
   size_t nrows=0;
 
   if (!gfail){
@@ -133,7 +136,7 @@ int verifyInputAdapter(
     gfail = globalFail(comm, fail);
 
     if (gfail == 0){
-      printMatrix(comm, nrows, rowIds, offsets, colIds);
+      printMatrix<offset_t>(comm, nrows, rowIds, offsets, colIds);
     }
     else{
       if (!fail) fail = 10;

--- a/packages/zoltan2/test/unit/input/XpetraCrsGraphInput.cpp
+++ b/packages/zoltan2/test/unit/input/XpetraCrsGraphInput.cpp
@@ -73,8 +73,9 @@ using Teuchos::ArrayView;
 typedef Tpetra::CrsGraph<zlno_t, zgno_t, znode_t> tgraph_t;
 typedef Xpetra::CrsGraph<zlno_t, zgno_t, znode_t> xgraph_t;
 
+template<typename offset_t>
 void printGraph(RCP<const Comm<int> > &comm, zlno_t nvtx,
-    const zgno_t *vtxIds, const zlno_t *offsets, const zgno_t *edgeIds)
+    const zgno_t *vtxIds, const offset_t *offsets, const zgno_t *edgeIds)
 {
   int rank = comm->getRank();
   int nprocs = comm->getSize();
@@ -84,7 +85,7 @@ void printGraph(RCP<const Comm<int> > &comm, zlno_t nvtx,
       std::cout << rank << ":" << std::endl;
       for (zlno_t i=0; i < nvtx; i++){
         std::cout << " vertex " << vtxIds[i] << ": ";
-        for (zlno_t j=offsets[i]; j < offsets[i+1]; j++){
+        for (offset_t j=offsets[i]; j < offsets[i+1]; j++){
           std::cout << edgeIds[j] << " ";
         }
         std::cout << std::endl;
@@ -102,6 +103,8 @@ int verifyInputAdapter(
   tgraph_t &graph
 )
 {
+  typedef typename Zoltan2::InputTraits<User>::offset_t offset_t;
+
   RCP<const Comm<int> > comm = graph.getComm();
   int fail = 0, gfail=0;
 
@@ -116,7 +119,7 @@ int verifyInputAdapter(
   gfail = globalFail(comm, fail);
 
   const zgno_t *vtxIds=NULL, *edgeIds=NULL;
-  const zlno_t *offsets=NULL;
+  const offset_t *offsets=NULL;
   size_t nvtx=0;
 
   if (!gfail){
@@ -131,7 +134,7 @@ int verifyInputAdapter(
     gfail = globalFail(comm, fail);
 
     if (gfail == 0){
-      printGraph(comm, nvtx, vtxIds, offsets, edgeIds);
+      printGraph<offset_t>(comm, nvtx, vtxIds, offsets, edgeIds);
     }
     else{
       if (!fail) fail = 10;

--- a/packages/zoltan2/test/unit/input/XpetraCrsMatrixInput.cpp
+++ b/packages/zoltan2/test/unit/input/XpetraCrsMatrixInput.cpp
@@ -73,7 +73,7 @@ typedef Tpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t> tmatrix_t;
 typedef Xpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t> xmatrix_t;
 
 void printMatrix(RCP<const Comm<int> > &comm, zlno_t nrows,
-    const zgno_t *rowIds, const zlno_t *offsets, const zgno_t *colIds)
+    const zgno_t *rowIds, const zoffset_t *offsets, const zgno_t *colIds)
 {
   int rank = comm->getRank();
   int nprocs = comm->getSize();
@@ -113,7 +113,7 @@ int verifyInputAdapter(
   gfail = globalFail(comm, fail);
 
   const zgno_t *rowIds=NULL, *colIds=NULL;
-  const zlno_t *offsets=NULL;
+  const zoffset_t *offsets=NULL;
   size_t nrows=0;
 
   if (!gfail){

--- a/packages/zoltan2/test/unit/input/XpetraCrsMatrixInput.cpp
+++ b/packages/zoltan2/test/unit/input/XpetraCrsMatrixInput.cpp
@@ -72,8 +72,9 @@ using Teuchos::DefaultComm;
 typedef Tpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t> tmatrix_t;
 typedef Xpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t> xmatrix_t;
 
+template<typename offset_t>
 void printMatrix(RCP<const Comm<int> > &comm, zlno_t nrows,
-    const zgno_t *rowIds, const zoffset_t *offsets, const zgno_t *colIds)
+    const zgno_t *rowIds, const offset_t *offsets, const zgno_t *colIds)
 {
   int rank = comm->getRank();
   int nprocs = comm->getSize();
@@ -83,7 +84,7 @@ void printMatrix(RCP<const Comm<int> > &comm, zlno_t nrows,
       std::cout << rank << ":" << std::endl;
       for (zlno_t i=0; i < nrows; i++){
         std::cout << " row " << rowIds[i] << ": ";
-        for (zlno_t j=offsets[i]; j < offsets[i+1]; j++){
+        for (offset_t j=offsets[i]; j < offsets[i+1]; j++){
           std::cout << colIds[j] << " ";
         }
         std::cout << std::endl;
@@ -99,6 +100,8 @@ template <typename User>
 int verifyInputAdapter(
   Zoltan2::XpetraCrsMatrixAdapter<User> &ia, tmatrix_t &M)
 {
+  typedef typename Zoltan2::InputTraits<User>::offset_t offset_t;
+
   RCP<const Comm<int> > comm = M.getComm();
   int fail = 0, gfail=0;
 
@@ -113,7 +116,7 @@ int verifyInputAdapter(
   gfail = globalFail(comm, fail);
 
   const zgno_t *rowIds=NULL, *colIds=NULL;
-  const zoffset_t *offsets=NULL;
+  const offset_t *offsets=NULL;
   size_t nrows=0;
 
   if (!gfail){
@@ -128,7 +131,7 @@ int verifyInputAdapter(
     gfail = globalFail(comm, fail);
 
     if (gfail == 0){
-      printMatrix(comm, nrows, rowIds, offsets, colIds);
+      printMatrix<offset_t>(comm, nrows, rowIds, offsets, colIds);
     }
     else{
       if (!fail) fail = 10;

--- a/packages/zoltan2/test/unit/models/GraphModel.cpp
+++ b/packages/zoltan2/test/unit/models/GraphModel.cpp
@@ -81,7 +81,7 @@ using Teuchos::ArrayView;
 
 typedef Zoltan2::BasicUserTypes<zscalar_t, zlno_t, zgno_t> simpleUser_t;
 
-typedef Tpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t>      tcrsMatrix_t;
+typedef Tpetra::CrsMatrix<zscalar_t, zlno_t, zgno_t, znode_t>     tcrsMatrix_t;
 typedef Tpetra::CrsGraph<zlno_t, zgno_t, znode_t>                 tcrsGraph_t;
 typedef Tpetra::Map<zlno_t, zgno_t, znode_t>                      tmap_t;
 
@@ -97,9 +97,10 @@ using std::string;
 using std::vector;
 
 /////////////////////////////////////////////////////////////////////////////
+template<typename offset_t>
 void printGraph(zlno_t nrows, const zgno_t *v,
     const zgno_t *elid, const zgno_t *egid,
-    const zlno_t *idx,
+    const offset_t *idx,
     const RCP<const Comm<int> > &comm)
 {
   int rank = comm->getRank();
@@ -137,6 +138,8 @@ void testAdapter(
     bool consecutiveIdsRequested, bool removeSelfEdges, bool buildLocalGraph)
 {
   typedef Zoltan2::StridedData<zlno_t, zscalar_t> input_t;
+  typedef typename
+    Zoltan2::InputTraits<typename BaseAdapter::user_t>::offset_t offset_t;
 
   int fail=0;
   int rank = comm->getRank();
@@ -423,7 +426,7 @@ void testAdapter(
 
   if (!buildLocalGraph) {
     ArrayView<const zgno_t> edgeGids;
-    ArrayView<const zlno_t> offsets;
+    ArrayView<const offset_t> offsets;
     size_t numEdges=0;
 
     try{
@@ -438,8 +441,9 @@ void testAdapter(
     TEST_FAIL_AND_EXIT(*comm, wgts.size() == 0, "edge weights present", 1)
 
     size_t num = 0;
-    for (ArrayView<const zlno_t>::size_type i=0; i < offsets.size()-1; i++){
-      size_t edgeListSize = offsets[i+1] - offsets[i];
+    for (typename ArrayView<const offset_t>::size_type i=0;
+      i < offsets.size()-1; i++){
+      offset_t edgeListSize = offsets[i+1] - offsets[i];
       num += edgeListSize;
       size_t val = numNbors[i];
       if (removeSelfEdges && haveDiag[i])
@@ -454,7 +458,7 @@ void testAdapter(
     if (nGlobalRows < SMALL_NUMBER_OF_ROWS){
       if (rank == 0)
         std::cout << "Printing graph now " << nGlobalRows << std::endl;
-      printGraph(nLocalRows, vertexGids.getRawPtr(), NULL,
+      printGraph<offset_t>(nLocalRows, vertexGids.getRawPtr(), NULL,
         edgeGids.getRawPtr(), offsets.getRawPtr(), comm);
     }
     else{
@@ -468,7 +472,7 @@ void testAdapter(
 
     if (rank == 0) std::cout << "        Checking local edges" << std::endl;
     ArrayView<const zgno_t> localEdges;
-    ArrayView<const zlno_t> localOffsets;
+    ArrayView<const offset_t> localOffsets;
     size_t numLocalNeighbors=0;
 
     try{
@@ -485,7 +489,7 @@ void testAdapter(
 
     size_t num = 0;
     for (zlno_t i=0; i < nLocalRows; i++){
-      size_t edgeListSize = localOffsets[i+1] - localOffsets[i];
+      offset_t edgeListSize = localOffsets[i+1] - localOffsets[i];
       num += edgeListSize;
       size_t val = numLocalNbors[i];
       if (removeSelfEdges && haveDiag[i])
@@ -515,7 +519,7 @@ void testAdapter(
         std::cout << "  Graph of local edges is empty" << std::endl; 
       }
       else{
-        printGraph(nLocalRows, vertexGids.getRawPtr(), 
+        printGraph<offset_t>(nLocalRows, vertexGids.getRawPtr(),
           localEdges.getRawPtr(), NULL, localOffsets.getRawPtr(), comm);
       }
     }

--- a/packages/zoltan2/test/unit/models/GraphModel.cpp
+++ b/packages/zoltan2/test/unit/models/GraphModel.cpp
@@ -113,10 +113,10 @@ void printGraph(zlno_t nrows, const zgno_t *v,
       for (zlno_t i=0; i < nrows; i++){
         std::cout << "  Vtx " << i << ": ";
         if (elid)
-          for (zlno_t j=idx[i]; j < idx[i+1]; j++)
+          for (offset_t j=idx[i]; j < idx[i+1]; j++)
             std::cout << *elid++ << " ";
         else
-          for (zlno_t j=idx[i]; j < idx[i+1]; j++)
+          for (offset_t j=idx[i]; j < idx[i+1]; j++)
             std::cout << *egid++ << " ";
         std::cout << std::endl;
       }

--- a/packages/zoltan2/test/unit/models/GraphModel2ndAdjsFromAdjs.cpp
+++ b/packages/zoltan2/test/unit/models/GraphModel2ndAdjsFromAdjs.cpp
@@ -143,8 +143,8 @@ int main(int narg, char *arg[]) {
   inputAdapter_t ia(*CommT, "region");
   inputAdapter_t ia2(*CommT, "vertex");
   inputAdapter_t::gno_t const *adjacencyIds=NULL;
-  inputAdapter_t::lno_t const *offsets=NULL;
-  Teuchos::ArrayRCP<inputAdapter_t::lno_t> moffsets;
+  inputAdapter_t::offset_t const *offsets=NULL;
+  Teuchos::ArrayRCP<inputAdapter_t::offset_t> moffsets;
   Teuchos::ArrayRCP<inputAdapter_t::gno_t> madjacencyIds;
   ia.print(me);
 
@@ -188,10 +188,10 @@ int main(int narg, char *arg[]) {
         return 3;
       }
 
-      for (inputAdapter_t::lno_t j=moffsets[telct]; j<moffsets[telct+1]; j++) {
+      for (inputAdapter_t::offset_t j=moffsets[telct]; j<moffsets[telct+1]; j++) {
         ssize_t in_list = -1;
 
-        for (inputAdapter_t::lno_t k=offsets[telct]; k<offsets[telct+1]; k++) {
+        for (inputAdapter_t::offset_t k=offsets[telct]; k<offsets[telct+1]; k++) {
           if (adjacencyIds[k] == madjacencyIds[j]) {
             in_list = k;
             break;
@@ -247,10 +247,10 @@ int main(int narg, char *arg[]) {
         return 3;
       }
 
-      for (inputAdapter_t::lno_t j=moffsets[tnoct]; j<moffsets[tnoct+1]; j++) {
+      for (inputAdapter_t::offset_t j=moffsets[tnoct]; j<moffsets[tnoct+1]; j++) {
         ssize_t in_list = -1;
 
-        for (inputAdapter_t::lno_t k=offsets[tnoct]; k<offsets[tnoct+1]; k++) {
+        for (inputAdapter_t::offset_t k=offsets[tnoct]; k<offsets[tnoct+1]; k++) {
           if (adjacencyIds[k] == madjacencyIds[j]) {
             in_list = k;
             break;

--- a/packages/zoltan2/test/unit/models/GraphModel2ndAdjsFromAdjs.cpp
+++ b/packages/zoltan2/test/unit/models/GraphModel2ndAdjsFromAdjs.cpp
@@ -63,7 +63,7 @@ using Teuchos::RCP;
 /*********************************************************/
 //Tpetra typedefs
 typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-typedef Tpetra::MultiVector<double>                  tMVector_t;
+typedef Zoltan2::BasicUserTypes<double>          basic_user_t;
 
 
 
@@ -137,7 +137,7 @@ int main(int narg, char *arg[]) {
   // Creating mesh adapter
   if (me == 0) cout << "Creating mesh adapter ... \n\n";
 
-  typedef Zoltan2::PamgenMeshAdapter<tMVector_t> inputAdapter_t;
+  typedef Zoltan2::PamgenMeshAdapter<basic_user_t> inputAdapter_t;
   typedef inputAdapter_t::base_adapter_t base_adapter_t;
 
   inputAdapter_t ia(*CommT, "region");


### PR DESCRIPTION
@kddevin @trilinos/zoltan2
The proposed changes in this PR use the Xpetra CRS matrix getAllValues method to obtain pointers to row, columns and values. This removes the need to perform a deep copy of the values from the matrix and reduces the memory footprint of the adapter. In addition, the column id's and offsets are obtained directly from this call; reducing some computation (but see below). Tests run locally with clang pass.

There are a couple of considerations that could further reduce the footprint beyond what is done here:

1) Offsets can be obtained directly from the row pointer; however the offset in the Zoltan2 adapter is type def'd to lno_t, rather than size_t (provided by the getAllValues method). We would need to refactor the adapter to use the different type in order to avoid a copy of the data in the row pointer.

2) Local column id's are provided by getAllValues; the adapter utilizes global column ids'. Again, we would need to refactor the adapter to use the pointer provided by the Xpetra Crs matrix.
