### PR TITLE
Sacado_cmath.hpp: Refactor_preprocessor_ifdef

### DIFF
--- a/packages/sacado/src/Sacado_cmath.hpp
+++ b/packages/sacado/src/Sacado_cmath.hpp
@@ -34,8 +34,7 @@
 #include "Sacado_ConfigDefs.h"
 
 // Define some math functions that aren't usually in cmath
-#define HAS_GXX_CMATH_11 defined(_GLIBCXX_USE_C99_MATH_TR1) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-#if !( HAS_GXX_CMATH_11 || defined(HAVE_SACADO_CXX11) || defined(HAS_C99_TR1_CMATH) || defined(USER_DISABLE_SACADO_TR1_CMATH) )
+#if !( ( defined(_GLIBCXX_USE_C99_MATH_TR1) && defined(__GXX_EXPERIMENTAL_CXX0X__) ) || defined(HAVE_SACADO_CXX11) || defined(HAS_C99_TR1_CMATH) || defined(USER_DISABLE_SACADO_TR1_CMATH) )
 namespace std {
   inline float acosh(float x) {
     return std::log(x + std::sqrt(x*x - float(1.0))); }


### PR DESCRIPTION
Change to all one ifdef statement, as Windows
compiles complain about "defined" always being
false in a macro expansion.

Resubmitting to the 12.6 branch because that is what is currently built for Xyce.