### PR TITLE
@trilinos/tpetra Query environment variables with Tpetra

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Environment.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Environment.cpp
@@ -1,0 +1,93 @@
+#include <cstdlib>
+#include <string>
+#include <iostream>
+#include <algorithm>
+
+#include "Tpetra_Details_Environment.hpp"
+
+using Tpetra::Details::Environment;
+
+void Environment::cacheVariable(const std::string& variableName,
+                                const char* variableValue) {
+  // Cache the environment variable
+  environCache_[variableName] = variableValue;
+}
+
+bool Environment::variableExists(const std::string& variableName) {
+  // Check if variable is in the cache
+  if (environCache_.find(variableName) != environCache_.end()) {
+    // variableName is cached
+    return environCache_[variableName] != NULL;
+  } else {
+    // Variable has not been cached
+    const char* variableValue = std::getenv(variableName.c_str());
+    cacheVariable(variableName, variableValue);
+    return variableValue != NULL;
+  }
+}
+
+bool Environment::variableIsCached(const std::string& variableName) {
+  // Check if variable is in the cache
+  if (environCache_.find(variableName) != environCache_.end()) {
+    return true;
+  } else {
+    // Variable has not been cached
+    return false;
+  }
+}
+
+bool Environment::getBooleanValue(const std::string& variableName,
+                                  const std::string& defaultValue) {
+  // Get the value of the environment variable variableName.
+  std::string variableValue(getValue(variableName, defaultValue));
+  std::transform(variableValue.begin(), variableValue.end(),
+                 variableValue.begin(), ::toupper);
+
+  if (variableValue.empty() ||
+      variableValue == "0"  ||
+      variableValue == "NO" ||
+      variableValue == "FALSE") {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+std::string Environment::getValue(const std::string& variableName,
+                                  const std::string& defaultValue) {
+  // Get the value of the environment variable variableName.
+  const char* tmpValue;
+  if (variableExists(variableName)) {
+    tmpValue = environCache_[variableName];
+  } else {
+    // First time encountering this variable, get it from the system and cache
+    // it
+    tmpValue = std::getenv(variableName.c_str());
+    cacheVariable(variableName, tmpValue);
+  }
+
+  std::string variableValue;
+  if (tmpValue != NULL) {
+    variableValue = std::string(tmpValue);
+  } else {
+    // Initialize variableValue to the default
+    variableValue = defaultValue;
+  }
+  return variableValue;
+}
+
+// void Environment::setValue(const std::string& variableName,
+//                            const std::string& variableValue,
+//                            const int overwrite) {
+//   // Set the environment variable
+//   bool exists = variableExists(variableName);
+//   if ((exists && overwrite) || (!exists)) {
+//     const char* tmpValue(variableValue.c_str());
+//     environCache_[variableName] = tmpValue;
+//     setenv(variableName.c_str(), variableValue.c_str(), 1);
+//   }
+// }
+
+void Environment::clearCache() {
+  environCache_.clear();
+}

--- a/packages/tpetra/core/src/Tpetra_Details_Environment.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Environment.hpp
@@ -1,0 +1,132 @@
+#include <map>
+#include <string>
+#include <list>
+
+#ifndef _TPETRA_DETAILS_ENVIRONMENT_HPP_
+#define _TPETRA_DETAILS_ENVIRONMENT_HPP_
+
+namespace Tpetra {
+namespace Details {
+
+class DefaultEnvironmentVariables {
+  /*
+   * This class merely provides a list of variables that should be cached on
+   * instantiation of the singleton Environment().  This can be moved and made
+   * more general to include default variables for other packages.
+   *
+   */
+ public:
+  static const std::list<std::string> getDefaults() {
+    const std::list<std::string> defaultVariables {"TPETRA_DEBUG",
+      "TPETRA_USE_BLAS"};
+    return defaultVariables;
+  }
+};
+
+
+class Environment {
+ public:
+  // Get singleton instance
+  static Environment& getInstance() {
+    // The following construction guarantees that theInstance_ will be
+    // destroyed and is instantiated only on first use.
+    static Environment theInstance_;
+    return theInstance_;
+  }
+
+ private:
+  Environment() {
+    // Initialize the instance
+    std::string variableValue;
+    std::list<std::string>::iterator variableName;
+    std::list<std::string> std_vars(DefaultEnvironmentVariables::getDefaults());
+    for (variableName = std_vars.begin();
+         variableName != std_vars.end();
+         ++variableName) {
+      // By getting the value, it will be cached
+      variableValue = getValue(*variableName);
+    }
+  }
+  std::map<std::string, const char *> environCache_;
+  void cacheVariable(const std::string& variableName,
+                     const char* variableValue);
+
+ public:
+  /* Don't allow any copies of the singleton to appear... (requires CXX11)
+   * Note: Scott Meyers mentions in his Effective Modern
+   *       C++ book, that deleted functions should generally
+   *       be public as it results in better error messages
+   *       due to the compilers behavior to check accessibility
+           before deleted status
+  */
+  Environment(Environment const&)    = delete;
+  void operator=(Environment const&) = delete;
+
+  /** @brief Checks if the environment variable variableName is cached
+   *
+   *  @param variableName the name of the environment variable
+   *  @return whether variableName is cached
+   */
+  bool variableIsCached(const std::string& variableName);
+
+  /** @brief Checks for existence of the environment variable variableName
+   *
+   *  This is nonconst because the implementation reserves the right to cache
+   *  results.
+   *
+   *  @param variableName the name of the environment variable
+   *  @return whether variableName exists
+  */
+  bool variableExists(const std::string& variableName);
+
+  /** @brief Gets value of the given environment variable.
+   *
+   *  This is nonconst because the implementation reserves the right to
+   *  cache the results.
+   *
+   *  @param variableName the name of the environment variable
+   *  @param defaultValue [optional, ""] the default value to return in the case
+   *         that the environment variable variableName does not exist
+   *
+   *  @return false if the variable does not exist, is one of [0, NO, FALSE],
+   *          else true
+   *
+   */
+  bool getBooleanValue(const std::string& variableName,
+                       const std::string& defaultValue="");
+
+  /** @brief Gets value of the given environment variable.
+   *
+   *  This is nonconst because the implementation reserves the right to
+   *  cache the results.
+   *
+   *  @param variableName the name of the environment variable
+   *  @param defaultValue [optional, ""] the default value to return in the case
+   *         that the environment variable variableName does not exist
+   *
+   *  @return the value of the environment variable (or default if it does not
+   *          exist)
+   *
+   */
+  std::string getValue(const std::string& variableName,
+                       const std::string& defaultValue="");
+
+  // /* @brief Sets value of the given environment variable.
+  //  *
+  //  *  @param variableName the name of the environment variable
+  //  *  @param variableValue the value of the environment variable
+  //  *  @param overwrite [optional, 1] overwrite the variable if it already exists
+  //  *
+  //  *  @return void
+  //  *
+  //  */
+  // void setValue(const std::string& variableName,
+  //               const std::string& variableValue,
+  //               const int overwrite=1);
+
+
+  void clearCache();
+};
+}  // namespace Details
+}  // namespace Tpetra
+#endif  // _TPETRA_DETAILS_ENVIRONMENT_HPP_

--- a/packages/tpetra/core/test/CMakeLists.txt
+++ b/packages/tpetra/core/test/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_SUBDIRECTORIES(
   CrsMatrix
   Directory
   Distributor
+  Environment
   HashTable
   ImportExport
   ImportExport2

--- a/packages/tpetra/core/test/Environment/CMakeLists.txt
+++ b/packages/tpetra/core/test/Environment/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Environment_UnitTests
+  SOURCES
+    Environment_UnitTests
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/Environment/Environment_UnitTests.cpp
+++ b/packages/tpetra/core/test/Environment/Environment_UnitTests.cpp
@@ -1,0 +1,171 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+#include <iostream>
+#include <string>
+#include <cstdlib>
+#include <Tpetra_ConfigDefs.hpp>
+#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_TestingUtilities.hpp>
+#include <Tpetra_Details_Environment.hpp>
+
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_CommHelpers.hpp>
+
+
+namespace {
+
+  using Tpetra::Details::Environment;
+  using std::endl;
+
+  // Constants
+  std::string TEST_VAR_SET = "TPETRA_ENVIRONMENT_TEST_HELPER_VAR_SET";
+  std::string TEST_VAR_NOT_SET = "TPETRA_ENVIRONMENT_TEST_HELPER_VAR_NOT_SET";
+
+  TEUCHOS_STATIC_SETUP()
+  {
+    setenv(TEST_VAR_SET.c_str(), TEST_VAR_SET.c_str(), 1);
+  }
+
+  //
+  // UNIT TESTS
+  //
+  TEUCHOS_UNIT_TEST(Environment, Check_variableExists_1) {
+    out << "Check existence of variable that *should* exist" << endl;
+    bool env_exists = Environment::getInstance().variableExists(TEST_VAR_SET);
+    TEUCHOS_TEST_ASSERT(env_exists, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_variableExists_2) {
+    out << "Check existence of variable that *should not* exist" << endl;
+    bool env_does_not_exist =
+      ! Environment::getInstance().variableExists(TEST_VAR_NOT_SET);
+    TEUCHOS_TEST_ASSERT(env_does_not_exist, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_getValue_1) {
+    out << "Check variable value that *should* exist" << endl;
+    std::string envar = Environment::getInstance().getValue(TEST_VAR_SET);
+    bool envar_is_correct = envar == TEST_VAR_SET;
+    TEUCHOS_TEST_ASSERT(envar_is_correct, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_getValue_withCacheCheck) {
+    out << "Check that nonexistent variable returns an empty string" << endl;
+    std::string name = "__AN_OBVIOSULY_FAKE_NAME__";
+    std::string envar = Environment::getInstance().getValue(name);
+    bool envar_is_empty = envar.empty();
+    TEUCHOS_TEST_ASSERT(envar_is_empty, out, success);
+    out << "Check that variable is cached (even though it does not exist)";
+    bool envar_is_cached = Environment::getInstance().variableIsCached(name);
+    TEUCHOS_TEST_ASSERT(envar_is_cached, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_getValue_WithDefault) {
+    out << "Check that nonexistent variable returns requested default" << endl;
+    std::string envar = Environment::getInstance().getValue(TEST_VAR_NOT_SET,
+                                                            TEST_VAR_NOT_SET);
+    bool env_used_requested_default = envar == TEST_VAR_NOT_SET;
+    TEUCHOS_TEST_ASSERT(env_used_requested_default, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_variableIsCached) {
+    out << "Check that environment variable cached";
+    std::string name = "TPETRA_DEBUG";
+    bool envar_is_cached = Environment::getInstance().variableIsCached(name);
+    TEUCHOS_TEST_ASSERT(envar_is_cached, out, success);
+    name = "TPETRA_USE_BLAS";
+    envar_is_cached = Environment::getInstance().variableIsCached(name);
+    TEUCHOS_TEST_ASSERT(envar_is_cached, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_getBooleanValue_1) {
+    out << "Check existing variable returns true" << endl;
+    bool envar_is_true = Environment::getInstance().getBooleanValue(TEST_VAR_SET);
+    TEUCHOS_TEST_ASSERT(envar_is_true, out, success);
+  }
+
+  TEUCHOS_UNIT_TEST(Environment, Check_getBooleanValue_2) {
+    out << "Check nonexistent variable returns false" << endl;
+    bool envar_is_false =
+      Environment::getInstance().getBooleanValue(TEST_VAR_NOT_SET);
+    TEUCHOS_TEST_ASSERT(!envar_is_false, out, success);
+  }
+
+  // TEUCHOS_UNIT_TEST(Environment, Check_setValue) {
+  //   out << "Check variable setting" << endl;
+  //   std::string envar;
+  //   std::string value1 = "X1";
+  //   std::string value2 = "X2";
+
+  //   out << "Make sure nonexistent envar does not exist" << endl;
+  //   bool env_does_not_exist =
+  //     ! Environment::getInstance().variableExists(TEST_VAR_NOT_SET);
+  //   TEUCHOS_TEST_ASSERT(env_does_not_exist, out, success);
+
+  //   out << "Now set the value" << endl;
+  //   // setValue overwrites by default
+  //   Environment::getInstance().setValue(TEST_VAR_NOT_SET, value1);
+
+  //   out << "Check that the value was set correctly" << endl;
+  //   envar = Environment::getInstance().getValue(TEST_VAR_NOT_SET);
+  //   bool envar_set_correctly = envar == value1;
+  //   TEUCHOS_TEST_ASSERT(envar_set_correctly, out, success);
+
+  //   out << "Try to set the value again, but with overwrite=0" << endl;
+  //   int overwrite = 0;
+  //   Environment::getInstance().setValue(TEST_VAR_NOT_SET, value2, overwrite);
+
+  //   out << "Check that the value was NOT set" << endl;
+  //   envar = Environment::getInstance().getValue(TEST_VAR_NOT_SET);
+  //   bool envar_not_set = envar != value2;
+  //   TEUCHOS_TEST_ASSERT(envar_not_set, out, success);
+
+  //   out << "Check that the value is still correct" << endl;
+  //   bool envar_still_correct = envar == value1;
+  //   TEUCHOS_TEST_ASSERT(envar_still_correct, out, success);
+
+  //   // Unset the environment variable
+  //   unsetenv(TEST_VAR_NOT_SET.c_str());
+  // }
+
+} // namespace (anonymous)


### PR DESCRIPTION
Adds Tpetra::Details::Environment singleton class:
- query system for environment variables
- cache retrieved environment variables
- cache default variables on instantiation (TPETRA_DEBUG,
  TPETRA_USE_BLAS)
- setting environment variables capability is disabled

Commit also provides an updated method of loading configuration files
with the checkin-test.py script, allowing configuration files to have
extensions different than '.py'

Addresses: #654, #684, #688

Build/Test Cases Summary
Enabled Packages: TpetraCore, Ifpack2, Belos, Amesos2, Zoltan2, Xpetra, MueLu, Stokhos, Sacado
Disabled Packages: SEACAS,STK,Shards,FEI,ROL,Moertel,Panzer,ThreadPool,OptiPack,Rythmos,Intrepid,PyTrilinos
0) MPI_DEBUG => passed: passed=515,notpassed=0 (11.04 min)