### PR TITLE
@trilinos/tpetra: Generalize Tpetra::Map tests that depend on particu…

### DIFF
--- a/packages/tpetra/core/test/Map/CMakeLists.txt
+++ b/packages/tpetra/core/test/Map/CMakeLists.txt
@@ -10,7 +10,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 ENDIF()
 
-IF (Tpetra_INST_INT_LONG)
+# tjf 20 Oct 2016 modified to use default LO, GO types
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Map_Bug5378
   SOURCES
@@ -20,7 +20,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT
   )
-ENDIF()
 
 IF (Tpetra_INST_INT_LONG_LONG OR Tpetra_INST_INT_LONG)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -78,17 +77,16 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 # mfh 26 Sep 2015: Not sure if this one needs GO = int.
 # It might be OK just to use the default GO type.
-IF (TPETRA_INST_INT_INT)
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    Map_OneToOne
-    SOURCES
+# tjf 20 Oct 2016 modified to use default LO, GO, NT types
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Map_OneToOne
+  SOURCES
     Map_OneToOne
     ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    COMM serial mpi
-    STANDARD_PASS_OUTPUT
-    NUM_MPI_PROCS 2
-    )
-ENDIF()
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  NUM_MPI_PROCS 2
+  )
 
 IF (Tpetra_INST_INT_LONG_LONG OR Tpetra_INST_INT_LONG)
   # Tpetra bug 5822, first test.
@@ -137,29 +135,27 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
-IF (Tpetra_INST_INT_LONG)
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+# tjf 20 Oct 2016 modified to use default LO, GO, NT types
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Map_removeEmptyProcesses
+  SOURCES
     Map_removeEmptyProcesses
-    SOURCES
-      Map_removeEmptyProcesses
-      ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    COMM mpi
-    NUM_MPI_PROCS 1-10
-    STANDARD_PASS_OUTPUT
-    )
-ENDIF()
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM mpi
+  NUM_MPI_PROCS 1-10
+  STANDARD_PASS_OUTPUT
+)
 
-IF (Tpetra_INST_INT_INT)
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    Map_isOneToOne
-    SOURCES
-      isOneToOne
-      ${TEUCHOS_STD_UNIT_TEST_MAIN}
-    COMM serial mpi
-    NUM_MPI_PROCS 1-10
-    STANDARD_PASS_OUTPUT
-    )
-ENDIF()
+# tjf 20 Oct 2016 modified to use default LO, GO types
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Map_isOneToOne
+  SOURCES
+    isOneToOne
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+  NUM_MPI_PROCS 1-10
+  STANDARD_PASS_OUTPUT
+  )
 
 # FIXME (mfh 20 Oct 2015) My recent commit
 # 0abee4e8fffdc0975f329bde3b3671db916388bb reverts the fix for Bug

--- a/packages/tpetra/core/test/Map/Map_Bug5378.cpp
+++ b/packages/tpetra/core/test/Map/Map_Bug5378.cpp
@@ -41,6 +41,7 @@
 // @HEADER
 */
 
+#include <Tpetra_TestingUtilities.hpp>
 #include <Tpetra_ConfigDefs.hpp>
 
 #include <Teuchos_UnitTestHarness.hpp>
@@ -49,12 +50,15 @@
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Tpetra_Map.hpp>
 
+namespace { // (anonymous)
+
 using Teuchos::RCP;
 using Teuchos::Array;
 using Teuchos::tuple;
 
+
 ////
-TEUCHOS_UNIT_TEST( Map, Bug5378_GoodGIDs )
+TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, Bug5378_GoodGIDs, LO, GO)
 {
   RCP<const Teuchos::Comm<int> > comm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
   /**********************************************************************************/
@@ -64,12 +68,12 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_GoodGIDs )
   //
   // Lookup of any valid global ID should identify with proc 0
   //
-  RCP<const Tpetra::Map<int,long> > map = Tpetra::createContigMap<int,long>(10,10,comm);
-  Array<long> lookup_gids(  tuple<long>(1,3,5) );
-  Array<int> expected_ids(  tuple<int>( 0,0,0) );
-  Array<int> expected_lids( tuple<int>( 1,3,5) );
-  Array<int> nodeIDs( lookup_gids.size() ),
-             nodeLIDs( lookup_gids.size() );
+  RCP<const Tpetra::Map<LO,GO> > map = Tpetra::createContigMap<LO,GO>(10,10,comm);
+  Array<GO> lookup_gids(  tuple<GO>(1,3,5) );
+  Array<LO> expected_ids(  tuple<LO>( 0,0,0) );
+  Array<LO> expected_lids( tuple<LO>( 1,3,5) );
+  Array<LO> nodeIDs( lookup_gids.size() ),
+            nodeLIDs( lookup_gids.size() );
   Tpetra::LookupStatus lookup = map->getRemoteIndexList( lookup_gids(), nodeIDs(), nodeLIDs() );
   TEST_EQUALITY_CONST( lookup, Tpetra::AllIDsPresent )
   TEST_COMPARE_ARRAYS( nodeIDs(), expected_ids() );
@@ -82,7 +86,7 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_GoodGIDs )
 }
 
 ////
-TEUCHOS_UNIT_TEST( Map, Bug5378_BadGIDs )
+TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, Bug5378_BadGIDs, LO, GO)
 {
   RCP<const Teuchos::Comm<int> > comm = Teuchos::createMpiComm<int>(Teuchos::opaqueWrapper<MPI_Comm> (MPI_COMM_WORLD));
   /**********************************************************************************/
@@ -92,12 +96,12 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_BadGIDs )
   //
   // Lookup of any valid global ID should identify with proc 0
   //
-  RCP<const Tpetra::Map<int,long> > map = Tpetra::createContigMap<int,long>(10,10,comm);
-  Array<long> lookup_gids(  tuple<long>(1,10,5) );
-  Array<int> expected_ids(  tuple<int>( 0,-1,0) );
-  Array<int> expected_lids( tuple<int>( 1,-1,5) );
-  Array<int> nodeIDs( lookup_gids.size() ),
-             nodeLIDs( lookup_gids.size() );
+  RCP<const Tpetra::Map<LO,GO> > map = Tpetra::createContigMap<LO,GO>(10,10,comm);
+  Array<GO> lookup_gids(  tuple<GO>(1,10,5) );
+  Array<LO> expected_ids(  tuple<LO>( 0,-1,0) );
+  Array<LO> expected_lids( tuple<LO>( 1,-1,5) );
+  Array<LO> nodeIDs( lookup_gids.size() ),
+            nodeLIDs( lookup_gids.size() );
   Tpetra::LookupStatus lookup = map->getRemoteIndexList( lookup_gids(), nodeIDs(), nodeLIDs() );
   TEST_EQUALITY_CONST( lookup, Tpetra::IDNotPresent )
   TEST_COMPARE_ARRAYS( nodeIDs(), expected_ids() );
@@ -110,7 +114,7 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_BadGIDs )
 }
 
 ////
-TEUCHOS_UNIT_TEST( Map, Bug5378_GoodGIDsNoLIDs )
+TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, Bug5378_GoodGIDsNoLIDs, LO, GO)
 {
   RCP<const Teuchos::Comm<int> > comm = Teuchos::createMpiComm<int>(Teuchos::opaqueWrapper<MPI_Comm> (MPI_COMM_WORLD));
   /**********************************************************************************/
@@ -120,10 +124,10 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_GoodGIDsNoLIDs )
   //
   // Lookup of any valid global ID should identify with proc 0
   //
-  RCP<const Tpetra::Map<int,long> > map = Tpetra::createContigMap<int,long>(10,10,comm);
-  Array<long> lookup_gids(  tuple<long>(1,3,5) );
-  Array<int> expected_ids(  tuple<int>( 0,0,0) );
-  Array<int> nodeIDs( lookup_gids.size() );
+  RCP<const Tpetra::Map<LO,GO> > map = Tpetra::createContigMap<LO,GO>(10,10,comm);
+  Array<GO> lookup_gids(  tuple<GO>(1,3,5) );
+  Array<LO> expected_ids(  tuple<LO>( 0,0,0) );
+  Array<LO> nodeIDs( lookup_gids.size() );
   Tpetra::LookupStatus lookup = map->getRemoteIndexList( lookup_gids(), nodeIDs() );
   TEST_EQUALITY_CONST( lookup, Tpetra::AllIDsPresent )
   TEST_COMPARE_ARRAYS( nodeIDs(), expected_ids() );
@@ -135,7 +139,7 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_GoodGIDsNoLIDs )
 }
 
 ////
-TEUCHOS_UNIT_TEST( Map, Bug5378_BadGIDsNoLIDs )
+TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, Bug5378_BadGIDsNoLIDs, LO, GO)
 {
   RCP<const Teuchos::Comm<int> > comm = Teuchos::createMpiComm<int>(Teuchos::opaqueWrapper<MPI_Comm> (MPI_COMM_WORLD));
   /**********************************************************************************/
@@ -145,10 +149,10 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_BadGIDsNoLIDs )
   //
   // Lookup of any valid global ID should identify with proc 0
   //
-  RCP<const Tpetra::Map<int,long> > map = Tpetra::createContigMap<int,long>(10,10,comm);
-  Array<long> lookup_gids(  tuple<long>(1,10,5) );
-  Array<int> expected_ids(  tuple<int>( 0,-1,0) );
-  Array<int> nodeIDs( lookup_gids.size() );
+  RCP<const Tpetra::Map<LO,GO> > map = Tpetra::createContigMap<LO,GO>(10,10,comm);
+  Array<GO> lookup_gids(  tuple<GO>(1,10,5) );
+  Array<LO> expected_ids(  tuple<LO>( 0,-1,0) );
+  Array<LO> nodeIDs( lookup_gids.size() );
   Tpetra::LookupStatus lookup = map->getRemoteIndexList( lookup_gids(), nodeIDs() );
   TEST_EQUALITY_CONST( lookup, Tpetra::IDNotPresent )
   TEST_COMPARE_ARRAYS( nodeIDs(), expected_ids() );
@@ -159,4 +163,14 @@ TEUCHOS_UNIT_TEST( Map, Bug5378_BadGIDsNoLIDs )
   comm->barrier ();
 }
 
+#define UNIT_TEST_GROUP(LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, Bug5378_GoodGIDs, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, Bug5378_BadGIDs, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, Bug5378_GoodGIDsNoLIDs, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, Bug5378_BadGIDsNoLIDs, LO, GO)
 
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_LG(UNIT_TEST_GROUP)
+
+} // namespace (anonymous)

--- a/packages/tpetra/core/test/Map/Map_Bug5822.cpp
+++ b/packages/tpetra/core/test/Map/Map_Bug5822.cpp
@@ -48,6 +48,7 @@
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 
+namespace { // (anonymous)
 using Tpetra::global_size_t;
 using Teuchos::Array;
 using Teuchos::ArrayView;
@@ -58,9 +59,7 @@ using Teuchos::RCP;
 using Teuchos::tuple;
 using std::endl;
 
-// This test works (and exercises the interesting case) in serial mode
-// or for 1 MPI process, but it was originally written for 2 MPI
-// processes.
+// Test requires exactly 2 MPI processes
 TEUCHOS_UNIT_TEST( Map, Bug5822_StartWith3Billion )
 {
   RCP<const Comm<int> > comm = Teuchos::DefaultComm<int>::getComm ();
@@ -158,5 +157,4 @@ TEUCHOS_UNIT_TEST( Map, Bug5822_StartWith3Billion )
     TEST_COMPARE_ARRAYS( remoteLids (), expectedRemoteLids () );
   }
 }
-
-
+} // (anonymous)

--- a/packages/tpetra/core/test/Map/Map_Bug5822_2.cpp
+++ b/packages/tpetra/core/test/Map/Map_Bug5822_2.cpp
@@ -49,6 +49,7 @@
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 
+namespace { // (anonymous)
 using Tpetra::global_size_t;
 using Teuchos::Array;
 using Teuchos::ArrayView;
@@ -263,5 +264,4 @@ TEUCHOS_UNIT_TEST( Map, Bug5822_StartWithZeroThenSkipTo3Billion )
   cout << endl; // make TimeMonitor output neat on test line
   Teuchos::TimeMonitor::summarize();
 }
-
-
+} // (anonymous)

--- a/packages/tpetra/core/test/Map/Map_ExportTest_Bug5882.cpp
+++ b/packages/tpetra/core/test/Map/Map_ExportTest_Bug5882.cpp
@@ -89,5 +89,3 @@ int main(int argc, char *argv[]) {
 
   return EXIT_SUCCESS;
 }
-
-

--- a/packages/tpetra/core/test/Map/Map_OneToOne.cpp
+++ b/packages/tpetra/core/test/Map/Map_OneToOne.cpp
@@ -41,6 +41,7 @@
 // @HEADER
 */
 
+#include <Tpetra_TestingUtilities.hpp>
 #include <Tpetra_ConfigDefs.hpp>
 
 #include "Teuchos_UnitTestHarness.hpp"
@@ -51,18 +52,14 @@
 
 #define NUM_GLOBAL_ELEMENTS 100
 
-using Teuchos::RCP;
-using Teuchos::Array;
-using Teuchos::ArrayView;
-typedef int LO;
-typedef int GO;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-typedef Tpetra::Map<LO, GO, Node> Map;
-typedef Tpetra::Directory<LO, GO, Node> Directory;
+namespace { // (anonymous)
 
 
-namespace {
+  using Teuchos::RCP;
+  using Teuchos::Array;
+  using Teuchos::ArrayView;
+
+  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
 
   template <typename LO,typename GO>
   class GotoLowTieBreak : public Tpetra::Details::TieBreak<LO,GO> {
@@ -76,22 +73,22 @@ namespace {
           index = i;
         }
       }
-
       return index;
     }
   };
 
   // Create a contiguous Map that is already one-to-one, and test
   // whether createOneToOne returns a Map that is the same.
-  TEUCHOS_UNIT_TEST( OneToOne, AlreadyOneToOneContig)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne, AlreadyOneToOneContig, LO, GO, NT)
   {
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-    RCP<Node> node = platform.getNode();
+    RCP<NT> node = platform.getNode();
 
-    RCP<const Map> map = Tpetra::createUniformContigMapWithNode<LO, GO, Node> (NUM_GLOBAL_ELEMENTS, comm, node);
+    RCP<const Map> map = Tpetra::createUniformContigMapWithNode<LO, GO, NT> (NUM_GLOBAL_ELEMENTS, comm, node);
 
-    RCP<const Map> new_map = Tpetra::createOneToOne<LO, GO, Node> (map);
+    RCP<const Map> new_map = Tpetra::createOneToOne<LO, GO, NT> (map);
 
     TEST_ASSERT(map->isSameAs(*new_map));
   }
@@ -99,16 +96,19 @@ namespace {
   // Create a noncontiguous Map that is already one-to-one, and test
   // whether createOneToOne returns a Map that is the same.
   // Use index base 0.
-  TEUCHOS_UNIT_TEST( OneToOne, AlreadyOneToOneNonContigIndexBaseZero )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne,
+                                    AlreadyOneToOneNonContigIndexBaseZero,
+                                    LO, GO, NT)
   {
     using Teuchos::Array;
     using Teuchos::outArg;
     using Teuchos::REDUCE_SUM;
     using Teuchos::reduceAll;
 
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform ();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm ();
-    RCP<Node> node = platform.getNode ();
+    RCP<NT> node = platform.getNode ();
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
     const GO indexBase = 0;
@@ -136,7 +136,7 @@ namespace {
 
     RCP<const Map> inputMap =
       Teuchos::rcp (new Map (globalNumElts, myElts (), indexBase, comm, node));
-    RCP<const Map> outputMap = Tpetra::createOneToOne<LO, GO, Node> (inputMap);
+    RCP<const Map> outputMap = Tpetra::createOneToOne<LO, GO, NT> (inputMap);
 
     TEST_ASSERT(inputMap->isSameAs(*outputMap));
   }
@@ -145,16 +145,19 @@ namespace {
   // Create a noncontiguous Map that is already one-to-one, and test
   // whether createOneToOne returns a Map that is the same.
   // Use index base 1, just to make sure that it works.
-  TEUCHOS_UNIT_TEST( OneToOne, AlreadyOneToOneNonContigIndexBaseOne )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne,
+                                    AlreadyOneToOneNonContigIndexBaseOne,
+                                    LO, GO, NT)
   {
     using Teuchos::Array;
     using Teuchos::outArg;
     using Teuchos::REDUCE_SUM;
     using Teuchos::reduceAll;
 
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform ();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm ();
-    RCP<Node> node = platform.getNode ();
+    RCP<NT> node = platform.getNode ();
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
     const GO indexBase = 1;
@@ -188,18 +191,19 @@ namespace {
 
     RCP<const Map> inputMap =
       Teuchos::rcp (new Map (globalNumElts, myElts (), indexBase, comm, node));
-    RCP<const Map> outputMap = Tpetra::createOneToOne<LO, GO, Node> (inputMap);
+    RCP<const Map> outputMap = Tpetra::createOneToOne<LO, GO, NT> (inputMap);
 
     TEST_ASSERT(inputMap->isSameAs(*outputMap));
   }
 
 
-  TEUCHOS_UNIT_TEST(OneToOne, LargeOverlap)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne, LargeOverlap, LO, GO, NT)
   {
     //Creates a map with large overlaps
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-    RCP<Node> node = platform.getNode();
+    RCP<NT> node = platform.getNode();
     const int myRank = comm->getRank();
     const int numProc = comm->getSize();
 
@@ -234,7 +238,7 @@ namespace {
 
     RCP<const Map> map = Tpetra::createNonContigMapWithNode<LO,GO>(elementList,comm,node);
     //std::cout<<map->description();
-    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,Node>(map);
+    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,NT>(map);
     //std::cout<<new_map->description();
     //Now we need to test if we lost anything.
 
@@ -263,13 +267,14 @@ namespace {
     }
   }
 
-  TEUCHOS_UNIT_TEST(OneToOne, AllOnOneProc)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne, AllOnOneProc, LO, GO, NT)
   {
     //Will create a non-contig map with all of the elements on a single
     //processor. Nothing should change.
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-    RCP<Node> node = platform.getNode();
+    RCP<NT> node = platform.getNode();
     const int myRank = comm->getRank();
 
     Array<GO> elementList;
@@ -286,34 +291,36 @@ namespace {
       elementList = Array<GO>(0);
     }
     RCP<const Map> map = Tpetra::createNonContigMapWithNode<LO,GO>(elementList,comm,node);
-    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,Node>(map);
+    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,NT>(map);
     TEST_ASSERT(map->isSameAs(*new_map));
   }
 
-  TEUCHOS_UNIT_TEST(OneToOne, NoIDs)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne, NoIDs, LO, GO, NT)
   {
     //An empty map.
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-    RCP<Node> node = platform.getNode();
+    RCP<NT> node = platform.getNode();
 
     Array<GO> elementList (0);
 
     RCP<const Map> map = Tpetra::createNonContigMapWithNode<LO,GO>(elementList,comm,node);
-    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,Node>(map);
+    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,NT>(map);
     TEST_ASSERT(map->isSameAs(*new_map));
 
 
   }
 
-  TEUCHOS_UNIT_TEST(OneToOne, AllOwnEvery)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne, AllOwnEvery, LO, GO, NT)
   {
     //Every processor starts by owning all of them.
     //After one-to-one, only the last processor should own all of them.
 
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-    RCP<Node> node = platform.getNode();
+    RCP<NT> node = platform.getNode();
     const int myRank = comm->getRank();
     const int numProc = comm->getSize();
 
@@ -324,7 +331,7 @@ namespace {
       elementList[i]=i;
     }
     RCP<const Map> map = Tpetra::createNonContigMapWithNode<LO,GO>(elementList,comm,node);
-    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,Node>(map);
+    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,NT>(map);
 
     if(myRank<numProc-1)//I shouldn't have any elements.
     {
@@ -336,12 +343,13 @@ namespace {
     }
   }
 
-  TEUCHOS_UNIT_TEST(OneToOne, TieBreak)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(OneToOne, TieBreak, LO, GO, NT)
   {
     //Creates a map with large overlaps
+    typedef Tpetra::Map<LO, GO, NT> Map;
     Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
     RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-    RCP<Node> node = platform.getNode();
+    RCP<NT> node = platform.getNode();
     const int myRank = comm->getRank();
     const int numProc = comm->getSize();
 
@@ -376,7 +384,7 @@ namespace {
 
     GotoLowTieBreak<LO,GO> tie_break;
     RCP<const Map> map = Tpetra::createNonContigMapWithNode<LO,GO>(elementList,comm,node);
-    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,Node>(map,tie_break);
+    RCP<const Map> new_map = Tpetra::createOneToOne<LO,GO,NT>(map,tie_break);
     //Now we need to test if we lost anything.
 
     Array<int> nodeIDlist(num_loc_elems); //This is unimportant. It's only used in the following function.
@@ -401,6 +409,22 @@ namespace {
       }
     }
   }
-}
 
+  //
+  // Instantiations of tests
+  //
+#define UNIT_TEST_GROUP( LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, AlreadyOneToOneNonContigIndexBaseZero, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, AlreadyOneToOneContig, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, AlreadyOneToOneNonContigIndexBaseOne, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, LargeOverlap, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, AllOnOneProc, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, NoIDs, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, AllOwnEvery, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(OneToOne, TieBreak, LO, GO, NT)
 
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_LGN( UNIT_TEST_GROUP )
+
+} // namespace (anonymous)

--- a/packages/tpetra/core/test/Map/Map_removeEmptyProcesses.cpp
+++ b/packages/tpetra/core/test/Map/Map_removeEmptyProcesses.cpp
@@ -41,6 +41,7 @@
 // @HEADER
 */
 
+#include <Tpetra_TestingUtilities.hpp>
 #include <Tpetra_ConfigDefs.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 #include <Teuchos_Tuple.hpp>
@@ -54,7 +55,8 @@
 #include <Tpetra_Directory_def.hpp>
 #endif // HAVE_TPETRA_EXPLICIT_INSTANTIATION
 
-using Tpetra::global_size_t;
+namespace { // (anonymous)
+
 using Teuchos::Array;
 using Teuchos::ArrayView;
 using Teuchos::as;
@@ -71,143 +73,138 @@ using Teuchos::tuple;
 using std::cerr;
 using std::endl;
 
+typedef Tpetra::global_size_t GST;
+
 // This test is only meaningful in an MPI build.
-TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_MpiComm_noncontigMap )
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Map, removeEmptyProcesses_MpiComm_noncontigMap, LO, GO, NT)
 {
-  typedef int local_ordinal_type;
-  typedef long global_ordinal_type;
-  typedef Tpetra::Map<local_ordinal_type, global_ordinal_type> map_type;
-  typedef Array<global_ordinal_type>::size_type size_type;
+  typedef Tpetra::Map<LO, GO, NT> map_type;
+  typedef typename Array<GO>::size_type size_type;
 
-  RCP<const Comm<int> > origComm = rcp (new MpiComm<int> (MPI_COMM_WORLD));
-  const int numProcs = origComm->getSize ();
-  const int myRank = origComm->getRank ();
+  RCP<const Comm<int> > origComm = rcp(new MpiComm<int>(MPI_COMM_WORLD));
+  const int numProcs = origComm->getSize();
+  const int myRank = origComm->getRank();
 
-  // All processes but the last one (myRank == numProcs-1) contain a
+  // All processes but the last one(myRank == numProcs-1) contain a
   // nonzero number of elements.
-
   const size_type numGidsPerProc = 3; // not counting the last process
   const size_type myNumGids = (myRank == numProcs - 1) ? 0 : numGidsPerProc;
-  Array<global_ordinal_type> myGids (myNumGids);
+  Array<GO> myGids(myNumGids);
   if (myNumGids > 0) {
     for (size_type k = 0; k < myNumGids; ++k) {
-      myGids[k] = as<global_ordinal_type> (myRank) *
-        as<global_ordinal_type> (numGidsPerProc) +
-        as<global_ordinal_type> (k);
+      myGids[k] = as<GO>(myRank) * as<GO>(numGidsPerProc) + as<GO>(k);
     }
   }
 
-  const global_size_t globalNumElts = as<global_size_t> (numGidsPerProc) *
-    as<global_size_t> (numProcs - 1);
-  const global_ordinal_type indexBase = 0;
-  RCP<const map_type> origMap (new map_type (globalNumElts, myGids (),
-                                             indexBase, origComm));
-  RCP<const map_type> newMap = origMap->removeEmptyProcesses ();
+  const GST globalNumElts = as<GST>(numGidsPerProc) * as<GST>(numProcs - 1);
+  const GO indexBase = 0;
+  RCP<const map_type> origMap(new map_type(globalNumElts, myGids(),
+                                           indexBase, origComm));
+  RCP<const map_type> newMap = origMap->removeEmptyProcesses();
 
   // Test collectively for success, so the test doesn't hang on failure.
   int localSuccess = 1;
   std::ostringstream err;
   if (myRank == numProcs - 1) {
-    if (! newMap.is_null ()) {
+    if (! newMap.is_null()) {
       localSuccess = 0;
       err << "removeEmptyProcesses() should have returned null, but did not."
           << endl;
     }
   } else {
-    if (newMap.is_null ()) {
+    if (newMap.is_null()) {
       localSuccess = 0;
       err << "removeEmptyProcesses() should not have returned null, but did."
           << endl;
     } else {
-      RCP<const Comm<int> > newComm = newMap->getComm ();
-      if (newComm->getSize () != numProcs - 1) {
+      RCP<const Comm<int> > newComm = newMap->getComm();
+      if (newComm->getSize() != numProcs - 1) {
         localSuccess = 0;
         err << "New communicator should have " << (numProcs - 1)
-            << " processes, but has " << newComm->getSize ()
+            << " processes, but has " << newComm->getSize()
             << " processes instead." << endl;
       }
 
-      if (newMap->getGlobalNumElements () != origMap->getGlobalNumElements ()) {
+      if (newMap->getGlobalNumElements() != origMap->getGlobalNumElements()) {
         localSuccess = 0;
-        err << "New Map has " << newMap->getGlobalNumElements () << " global "
+        err << "New Map has " << newMap->getGlobalNumElements() << " global "
             << "elements, which differs from the original number "
-            << origMap->getGlobalNumElements () << "." << endl;
+            << origMap->getGlobalNumElements() << "." << endl;
       }
 
-      if (newMap->getNodeNumElements () != origMap->getNodeNumElements ()) {
+      if (newMap->getNodeNumElements() != origMap->getNodeNumElements()) {
         localSuccess = 0;
-        err << "New Map has " << newMap->getNodeNumElements () << " local "
+        err << "New Map has " << newMap->getNodeNumElements() << " local "
           "elements, which differs from the original number "
-          << origMap->getNodeNumElements () << "." << endl;
+          << origMap->getNodeNumElements() << "." << endl;
       }
 
-      if (newMap->getIndexBase () != origMap->getIndexBase ()) {
+      if (newMap->getIndexBase() != origMap->getIndexBase()) {
         localSuccess = 0;
-        err << "New Map has index base " << newMap->getIndexBase ()
+        err << "New Map has index base " << newMap->getIndexBase()
             << ", which differs from the original Map's index base "
-          << origMap->getIndexBase () << "." << endl;
+          << origMap->getIndexBase() << "." << endl;
       }
 
-      if (newMap->getMinLocalIndex () != origMap->getMinLocalIndex ()) {
+      if (newMap->getMinLocalIndex() != origMap->getMinLocalIndex()) {
         localSuccess = 0;
-        err << "New Map has min local index " << newMap->getMinLocalIndex ()
+        err << "New Map has min local index " << newMap->getMinLocalIndex()
             << ", which differs from the original Map's min local index "
-            << origMap->getMinLocalIndex () << "." << endl;
+            << origMap->getMinLocalIndex() << "." << endl;
       }
 
-      if (newMap->getMaxLocalIndex () != origMap->getMaxLocalIndex ()) {
+      if (newMap->getMaxLocalIndex() != origMap->getMaxLocalIndex()) {
         localSuccess = 0;
-        err << "New Map has max local index " << newMap->getMaxLocalIndex ()
+        err << "New Map has max local index " << newMap->getMaxLocalIndex()
             << ", which differs from the original Map's max local index "
-            << origMap->getMaxLocalIndex () << "." << endl;
+            << origMap->getMaxLocalIndex() << "." << endl;
       }
 
-      if (newMap->getMinGlobalIndex () != origMap->getMinGlobalIndex ()) {
+      if (newMap->getMinGlobalIndex() != origMap->getMinGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has local min global index "
-            << newMap->getMinGlobalIndex ()
+            << newMap->getMinGlobalIndex()
             << ", which differs from the original Map's local min global index "
-            << origMap->getMinGlobalIndex () << "." << endl;
+            << origMap->getMinGlobalIndex() << "." << endl;
       }
 
-      if (newMap->getMaxGlobalIndex () != origMap->getMaxGlobalIndex ()) {
+      if (newMap->getMaxGlobalIndex() != origMap->getMaxGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has local max global index "
-            << newMap->getMaxGlobalIndex ()
+            << newMap->getMaxGlobalIndex()
             << ", which differs from the original Map's local max global index "
-            << origMap->getMaxGlobalIndex () << "." << endl;
+            << origMap->getMaxGlobalIndex() << "." << endl;
       }
 
-      if (newMap->getMinAllGlobalIndex () != origMap->getMinAllGlobalIndex ()) {
+      if (newMap->getMinAllGlobalIndex() != origMap->getMinAllGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has global min global index "
-            << newMap->getMinAllGlobalIndex () << ", which differs from the "
+            << newMap->getMinAllGlobalIndex() << ", which differs from the "
             << "original Map's global min global index "
-            << origMap->getMinAllGlobalIndex () << "." << endl;
+            << origMap->getMinAllGlobalIndex() << "." << endl;
       }
 
-      if (newMap->getMaxAllGlobalIndex () != origMap->getMaxAllGlobalIndex ()) {
+      if (newMap->getMaxAllGlobalIndex() != origMap->getMaxAllGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has global max global index "
-            << newMap->getMaxAllGlobalIndex () << ", which differs from the "
+            << newMap->getMaxAllGlobalIndex() << ", which differs from the "
             << "original Map's global max global index "
-            << origMap->getMaxAllGlobalIndex () << "." << endl;
+            << origMap->getMaxAllGlobalIndex() << "." << endl;
       }
 
-      ArrayView<const global_ordinal_type> myNewGids =
-        newMap->getNodeElementList ();
-      if (myNewGids.size () != myGids.size () ||
-          ! std::equal (myNewGids.begin (), myNewGids.end (), myGids.begin ())) {
+      ArrayView<const GO> myNewGids = newMap->getNodeElementList();
+      if (myNewGids.size() != myGids.size() ||
+          ! std::equal(myNewGids.begin(), myNewGids.end(), myGids.begin())) {
         localSuccess = 0;
-        err << "New Map has local GID list " << toString (myNewGids) << ", but "
-            << "should have local GID list " << toString (myGids ()) << "."
+        err << "New Map has local GID list " << toString(myNewGids) << ", but "
+            << "should have local GID list " << toString(myGids()) << "."
             << endl;
       }
     }
   }
 
   int globalSuccess = 0;
-  reduceAll (*origComm, REDUCE_MIN, localSuccess, outArg (globalSuccess));
+  reduceAll(*origComm, REDUCE_MIN, localSuccess, outArg(globalSuccess));
   if (globalSuccess == 0) {
     if (myRank == 0) {
       cerr << "TEST FAILED" << endl
@@ -215,145 +212,147 @@ TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_MpiComm_noncontigMap )
     }
     for (int p = 0; p < numProcs; ++p) {
       if (myRank == p) {
-        cerr << "Process " << myRank << ": " << err.str () << endl;
+        cerr << "Process " << myRank << ": " << err.str() << endl;
       }
-      origComm->barrier (); // Give time for output to finish.
-      origComm->barrier ();
-      origComm->barrier ();
+      origComm->barrier(); // Give time for output to finish.
+      origComm->barrier();
+      origComm->barrier();
     }
   }
   TEST_EQUALITY(globalSuccess, 1);
+
+  if (globalSuccess != 1){
+    success = false;
+    return;
+  }
 }
 
-
 // This test is only meaningful in an MPI build.
-TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_MpiComm_contigMap )
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Map, removeEmptyProcesses_MpiComm_contigMap, LO, GO, NT)
 {
-  typedef int local_ordinal_type;
-  typedef long global_ordinal_type;
-  typedef Tpetra::Map<local_ordinal_type, global_ordinal_type> map_type;
+  typedef Tpetra::Map<LO, GO, NT> map_type;
 
-  RCP<const Comm<int> > origComm = rcp (new MpiComm<int> (MPI_COMM_WORLD));
-  const int numProcs = origComm->getSize ();
-  const int myRank = origComm->getRank ();
+  RCP<const Comm<int> > origComm = rcp(new MpiComm<int>(MPI_COMM_WORLD));
+  const int numProcs = origComm->getSize();
+  const int myRank = origComm->getRank();
 
   // Let Map compute the global number of elements.
-  const global_size_t globalNumElts = Teuchos::OrdinalTraits<global_size_t>::invalid ();
+  const GST globalNumElts = Teuchos::OrdinalTraits<GST>::invalid();
   // All processes but the last one (myRank == numProcs-1) contain a
   // nonzero number of elements.
   const size_t numEltsPerProc = 3; // on all but the last process
   const size_t myNumElts = (myRank == numProcs - 1) ? 0 : numEltsPerProc;
-  const global_ordinal_type indexBase = 0;
-  RCP<const map_type> origMap (new map_type (globalNumElts, myNumElts,
+  const GO indexBase = 0;
+  RCP<const map_type> origMap(new map_type(globalNumElts, myNumElts,
                                              indexBase, origComm));
-  RCP<const map_type> newMap = origMap->removeEmptyProcesses ();
+  RCP<const map_type> newMap = origMap->removeEmptyProcesses();
 
   // Test collectively for success, so the test doesn't hang on failure.
   int localSuccess = 1;
   std::ostringstream err;
   if (myRank == numProcs - 1) {
-    if (! newMap.is_null ()) {
+    if (! newMap.is_null()) {
       localSuccess = 0;
       err << "removeEmptyProcesses() should have returned null, but did not."
           << endl;
     }
   } else {
-    if (newMap.is_null ()) {
+    if (newMap.is_null()) {
       localSuccess = 0;
       err << "removeEmptyProcesses() should not have returned null, but did."
           << endl;
     } else {
-      RCP<const Comm<int> > newComm = newMap->getComm ();
-      if (newComm->getSize () != numProcs - 1) {
+      RCP<const Comm<int> > newComm = newMap->getComm();
+      if (newComm->getSize() != numProcs - 1) {
         localSuccess = 0;
         err << "New communicator should have " << (numProcs - 1)
-            << " processes, but has " << newComm->getSize ()
+            << " processes, but has " << newComm->getSize()
             << " processes instead." << endl;
       }
 
-      if (newMap->getGlobalNumElements () != origMap->getGlobalNumElements ()) {
+      if (newMap->getGlobalNumElements() != origMap->getGlobalNumElements()) {
         localSuccess = 0;
-        err << "New Map has " << newMap->getGlobalNumElements () << " global "
+        err << "New Map has " << newMap->getGlobalNumElements() << " global "
             << "elements, which differs from the original number "
-            << origMap->getGlobalNumElements () << "." << endl;
+            << origMap->getGlobalNumElements() << "." << endl;
       }
 
-      if (newMap->getNodeNumElements () != origMap->getNodeNumElements ()) {
+      if (newMap->getNodeNumElements() != origMap->getNodeNumElements()) {
         localSuccess = 0;
-        err << "New Map has " << newMap->getNodeNumElements () << " local "
+        err << "New Map has " << newMap->getNodeNumElements() << " local "
           "elements, which differs from the original number "
-          << origMap->getNodeNumElements () << "." << endl;
+          << origMap->getNodeNumElements() << "." << endl;
       }
 
-      if (newMap->getIndexBase () != origMap->getIndexBase ()) {
+      if (newMap->getIndexBase() != origMap->getIndexBase()) {
         localSuccess = 0;
-        err << "New Map has index base " << newMap->getIndexBase ()
+        err << "New Map has index base " << newMap->getIndexBase()
             << ", which differs from the original Map's index base "
-          << origMap->getIndexBase () << "." << endl;
+          << origMap->getIndexBase() << "." << endl;
       }
 
-      if (newMap->getMinLocalIndex () != origMap->getMinLocalIndex ()) {
+      if (newMap->getMinLocalIndex() != origMap->getMinLocalIndex()) {
         localSuccess = 0;
-        err << "New Map has min local index " << newMap->getMinLocalIndex ()
+        err << "New Map has min local index " << newMap->getMinLocalIndex()
             << ", which differs from the original Map's min local index "
-            << origMap->getMinLocalIndex () << "." << endl;
+            << origMap->getMinLocalIndex() << "." << endl;
       }
 
-      if (newMap->getMaxLocalIndex () != origMap->getMaxLocalIndex ()) {
+      if (newMap->getMaxLocalIndex() != origMap->getMaxLocalIndex()) {
         localSuccess = 0;
-        err << "New Map has max local index " << newMap->getMaxLocalIndex ()
+        err << "New Map has max local index " << newMap->getMaxLocalIndex()
             << ", which differs from the original Map's max local index "
-            << origMap->getMaxLocalIndex () << "." << endl;
+            << origMap->getMaxLocalIndex() << "." << endl;
       }
 
-      if (newMap->getMinGlobalIndex () != origMap->getMinGlobalIndex ()) {
+      if (newMap->getMinGlobalIndex() != origMap->getMinGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has local min global index "
-            << newMap->getMinGlobalIndex ()
+            << newMap->getMinGlobalIndex()
             << ", which differs from the original Map's local min global index "
-            << origMap->getMinGlobalIndex () << "." << endl;
+            << origMap->getMinGlobalIndex() << "." << endl;
       }
 
-      if (newMap->getMaxGlobalIndex () != origMap->getMaxGlobalIndex ()) {
+      if (newMap->getMaxGlobalIndex() != origMap->getMaxGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has local max global index "
-            << newMap->getMaxGlobalIndex ()
+            << newMap->getMaxGlobalIndex()
             << ", which differs from the original Map's local max global index "
-            << origMap->getMaxGlobalIndex () << "." << endl;
+            << origMap->getMaxGlobalIndex() << "." << endl;
       }
 
-      if (newMap->getMinAllGlobalIndex () != origMap->getMinAllGlobalIndex ()) {
+      if(newMap->getMinAllGlobalIndex() != origMap->getMinAllGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has global min global index "
-            << newMap->getMinAllGlobalIndex () << ", which differs from the "
+            << newMap->getMinAllGlobalIndex() << ", which differs from the "
             << "original Map's global min global index "
-            << origMap->getMinAllGlobalIndex () << "." << endl;
+            << origMap->getMinAllGlobalIndex() << "." << endl;
       }
 
-      if (newMap->getMaxAllGlobalIndex () != origMap->getMaxAllGlobalIndex ()) {
+      if (newMap->getMaxAllGlobalIndex() != origMap->getMaxAllGlobalIndex()) {
         localSuccess = 0;
         err << "New Map has global max global index "
-            << newMap->getMaxAllGlobalIndex () << ", which differs from the "
+            << newMap->getMaxAllGlobalIndex() << ", which differs from the "
             << "original Map's global max global index "
-            << origMap->getMaxAllGlobalIndex () << "." << endl;
+            << origMap->getMaxAllGlobalIndex() << "." << endl;
       }
 
-      ArrayView<const global_ordinal_type> myNewGids =
-        newMap->getNodeElementList ();
-      ArrayView<const global_ordinal_type> myGids =
-        origMap->getNodeElementList ();
-      if (myNewGids.size () != myGids.size () ||
-          ! std::equal (myNewGids.begin (), myNewGids.end (), myGids.begin ())) {
+      ArrayView<const GO> myNewGids =
+        newMap->getNodeElementList();
+      ArrayView<const GO> myGids =
+        origMap->getNodeElementList();
+      if (myNewGids.size() != myGids.size() ||
+          ! std::equal(myNewGids.begin(), myNewGids.end(), myGids.begin())) {
         localSuccess = 0;
-        err << "New Map has local GID list " << toString (myNewGids) << ", but "
-            << "should have local GID list " << toString (myGids ()) << "."
+        err << "New Map has local GID list " << toString(myNewGids) << ", but "
+            << "should have local GID list " << toString(myGids()) << "."
             << endl;
       }
     }
   }
 
   int globalSuccess = 0;
-  reduceAll (*origComm, REDUCE_MIN, localSuccess, outArg (globalSuccess));
+  reduceAll(*origComm, REDUCE_MIN, localSuccess, outArg(globalSuccess));
   if (globalSuccess == 0) {
     if (myRank == 0) {
       cerr << "TEST FAILED" << endl
@@ -361,144 +360,142 @@ TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_MpiComm_contigMap )
     }
     for (int p = 0; p < numProcs; ++p) {
       if (myRank == p) {
-        cerr << "Process " << myRank << ": " << err.str () << endl;
+        cerr << "Process " << myRank << ": " << err.str() << endl;
       }
-      origComm->barrier (); // Give time for output to finish.
-      origComm->barrier ();
-      origComm->barrier ();
+      origComm->barrier(); // Give time for output to finish.
+      origComm->barrier();
+      origComm->barrier();
     }
   }
   TEST_EQUALITY(globalSuccess, 1);
+
+  if (globalSuccess != 1){
+    success = false;
+    return;
+  }
 }
 
-
-
-TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_SerialComm1 )
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Map, removeEmptyProcesses_SerialComm1, LO, GO, NT )
 {
-  typedef int local_ordinal_type;
-  typedef long global_ordinal_type;
-  typedef Tpetra::Map<local_ordinal_type, global_ordinal_type> map_type;
-  typedef Array<global_ordinal_type>::size_type size_type;
+  typedef Tpetra::Map<LO, GO, NT> map_type;
+  typedef typename Array<GO>::size_type size_type;
 
-  RCP<const Comm<int> > origComm = rcp (new SerialComm<int>);
-  const int numProcs = origComm->getSize ();
-  const int myRank = origComm->getRank ();
+  RCP<const Comm<int> > origComm = rcp(new SerialComm<int>);
+  const int numProcs = origComm->getSize();
+  const int myRank = origComm->getRank();
 
   // The calling process (there is only one in the communicator) contains a nonzero number of elements.
   const size_type numGidsPerProc = 3;
   const size_type myNumGids = numGidsPerProc;
-  Array<global_ordinal_type> myGids (myNumGids);
+  Array<GO> myGids(myNumGids);
   for (size_type k = 0; k < myNumGids; ++k) {
-    myGids[k] = as<global_ordinal_type> (myRank) *
-      as<global_ordinal_type> (numGidsPerProc) +
-      as<global_ordinal_type> (k);
+    myGids[k] = as<GO>(myRank) * as<GO>(numGidsPerProc) + as<GO>(k);
   }
 
-  const global_size_t globalNumElts = as<global_size_t> (numGidsPerProc) *
-    as<global_size_t> (numProcs);
-  const global_ordinal_type indexBase = 0;
-  RCP<const map_type> origMap (new map_type (globalNumElts, myGids (),
+  const GST globalNumElts = as<GST>(numGidsPerProc) * as<GST>(numProcs);
+  const GO indexBase = 0;
+  RCP<const map_type> origMap(new map_type(globalNumElts, myGids(),
                                              indexBase, origComm));
-  RCP<const map_type> newMap = origMap->removeEmptyProcesses ();
+  RCP<const map_type> newMap = origMap->removeEmptyProcesses();
 
   // Test collectively for success, so the test doesn't hang on failure.
   int localSuccess = 1;
   std::ostringstream err;
 
-  if (newMap.is_null ()) {
+  if (newMap.is_null()) {
     localSuccess = 0;
     err << "removeEmptyProcesses() should not have returned null, but did."
         << endl;
   } else {
-    RCP<const Comm<int> > newComm = newMap->getComm ();
+    RCP<const Comm<int> > newComm = newMap->getComm();
     // No processes should be excluded in this case.
-    if (newComm->getSize () != numProcs) {
+    if (newComm->getSize() != numProcs) {
       localSuccess = 0;
       err << "New communicator should have " << numProcs
-          << " processes, but has " << newComm->getSize ()
+          << " processes, but has " << newComm->getSize()
           << " processes instead." << endl;
     }
 
-    if (newMap->getGlobalNumElements () != origMap->getGlobalNumElements ()) {
+    if (newMap->getGlobalNumElements() != origMap->getGlobalNumElements()) {
       localSuccess = 0;
-      err << "New Map has " << newMap->getGlobalNumElements () << " global "
+      err << "New Map has " << newMap->getGlobalNumElements() << " global "
           << "elements, which differs from the original number "
-          << origMap->getGlobalNumElements () << "." << endl;
+          << origMap->getGlobalNumElements() << "." << endl;
     }
 
-    if (newMap->getNodeNumElements () != origMap->getNodeNumElements ()) {
+    if (newMap->getNodeNumElements() != origMap->getNodeNumElements()) {
       localSuccess = 0;
-      err << "New Map has " << newMap->getNodeNumElements () << " local "
+      err << "New Map has " << newMap->getNodeNumElements() << " local "
         "elements, which differs from the original number "
-          << origMap->getNodeNumElements () << "." << endl;
+          << origMap->getNodeNumElements() << "." << endl;
     }
 
-    if (newMap->getIndexBase () != origMap->getIndexBase ()) {
+    if (newMap->getIndexBase() != origMap->getIndexBase()) {
       localSuccess = 0;
-      err << "New Map has index base " << newMap->getIndexBase ()
+      err << "New Map has index base " << newMap->getIndexBase()
           << ", which differs from the original Map's index base "
-          << origMap->getIndexBase () << "." << endl;
+          << origMap->getIndexBase() << "." << endl;
     }
 
-    if (newMap->getMinLocalIndex () != origMap->getMinLocalIndex ()) {
+    if (newMap->getMinLocalIndex() != origMap->getMinLocalIndex()) {
       localSuccess = 0;
-      err << "New Map has min local index " << newMap->getMinLocalIndex ()
+      err << "New Map has min local index " << newMap->getMinLocalIndex()
           << ", which differs from the original Map's min local index "
-          << origMap->getMinLocalIndex () << "." << endl;
+          << origMap->getMinLocalIndex() << "." << endl;
     }
 
-    if (newMap->getMaxLocalIndex () != origMap->getMaxLocalIndex ()) {
+    if (newMap->getMaxLocalIndex() != origMap->getMaxLocalIndex()) {
       localSuccess = 0;
-      err << "New Map has max local index " << newMap->getMaxLocalIndex ()
+      err << "New Map has max local index " << newMap->getMaxLocalIndex()
           << ", which differs from the original Map's max local index "
-          << origMap->getMaxLocalIndex () << "." << endl;
+          << origMap->getMaxLocalIndex() << "." << endl;
     }
 
-    if (newMap->getMinGlobalIndex () != origMap->getMinGlobalIndex ()) {
+    if (newMap->getMinGlobalIndex() != origMap->getMinGlobalIndex()) {
       localSuccess = 0;
       err << "New Map has local min global index "
-          << newMap->getMinGlobalIndex ()
+          << newMap->getMinGlobalIndex()
           << ", which differs from the original Map's local min global index "
-          << origMap->getMinGlobalIndex () << "." << endl;
+          << origMap->getMinGlobalIndex() << "." << endl;
     }
 
-    if (newMap->getMaxGlobalIndex () != origMap->getMaxGlobalIndex ()) {
+    if (newMap->getMaxGlobalIndex() != origMap->getMaxGlobalIndex()) {
       localSuccess = 0;
       err << "New Map has local max global index "
-          << newMap->getMaxGlobalIndex ()
+          << newMap->getMaxGlobalIndex()
           << ", which differs from the original Map's local max global index "
-          << origMap->getMaxGlobalIndex () << "." << endl;
+          << origMap->getMaxGlobalIndex() << "." << endl;
     }
 
-    if (newMap->getMinAllGlobalIndex () != origMap->getMinAllGlobalIndex ()) {
+    if (newMap->getMinAllGlobalIndex() != origMap->getMinAllGlobalIndex()) {
       localSuccess = 0;
       err << "New Map has global min global index "
-          << newMap->getMinAllGlobalIndex () << ", which differs from the "
+          << newMap->getMinAllGlobalIndex() << ", which differs from the "
           << "original Map's global min global index "
-          << origMap->getMinAllGlobalIndex () << "." << endl;
+          << origMap->getMinAllGlobalIndex() << "." << endl;
     }
 
-    if (newMap->getMaxAllGlobalIndex () != origMap->getMaxAllGlobalIndex ()) {
+    if (newMap->getMaxAllGlobalIndex() != origMap->getMaxAllGlobalIndex()) {
       localSuccess = 0;
       err << "New Map has global max global index "
-          << newMap->getMaxAllGlobalIndex () << ", which differs from the "
+          << newMap->getMaxAllGlobalIndex() << ", which differs from the "
           << "original Map's global max global index "
-          << origMap->getMaxAllGlobalIndex () << "." << endl;
+          << origMap->getMaxAllGlobalIndex() << "." << endl;
     }
 
-    ArrayView<const global_ordinal_type> myNewGids =
-      newMap->getNodeElementList ();
-    if (myNewGids.size () != myGids.size () ||
-        ! std::equal (myNewGids.begin (), myNewGids.end (), myGids.begin ())) {
+    ArrayView<const GO> myNewGids =
+      newMap->getNodeElementList();
+    if (myNewGids.size() != myGids.size() ||
+        ! std::equal(myNewGids.begin(), myNewGids.end(), myGids.begin())) {
       localSuccess = 0;
-      err << "New Map has local GID list " << toString (myNewGids) << ", but "
-          << "should have local GID list " << toString (myGids ()) << "."
+      err << "New Map has local GID list " << toString(myNewGids) << ", but "
+          << "should have local GID list " << toString(myGids()) << "."
           << endl;
     }
   }
 
   int globalSuccess = 0;
-  reduceAll (*origComm, REDUCE_MIN, localSuccess, outArg (globalSuccess));
+  reduceAll(*origComm, REDUCE_MIN, localSuccess, outArg(globalSuccess));
   if (globalSuccess == 0) {
     if (myRank == 0) {
       cerr << "TEST FAILED" << endl
@@ -506,53 +503,54 @@ TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_SerialComm1 )
     }
     for (int p = 0; p < numProcs; ++p) {
       if (myRank == p) {
-        cerr << "Process " << myRank << ": " << err.str () << endl;
+        cerr << "Process " << myRank << ": " << err.str() << endl;
       }
-      origComm->barrier (); // Give time for output to finish.
-      origComm->barrier ();
-      origComm->barrier ();
+      origComm->barrier(); // Give time for output to finish.
+      origComm->barrier();
+      origComm->barrier();
     }
   }
   TEST_EQUALITY(globalSuccess, 1);
+
+  if (globalSuccess != 1){
+    success = false;
+    return;
+  }
 }
 
-
-
-TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_SerialComm2 )
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Map, removeEmptyProcesses_SerialComm2, LO, GO, NT )
 {
-  typedef int local_ordinal_type;
-  typedef long global_ordinal_type;
-  typedef Tpetra::Map<local_ordinal_type, global_ordinal_type> map_type;
-  typedef Array<global_ordinal_type>::size_type size_type;
+  typedef Tpetra::Map<LO, GO, NT> map_type;
+  typedef typename Array<GO>::size_type size_type;
 
-  RCP<const Comm<int> > origComm = rcp (new SerialComm<int>);
-  const int numProcs = origComm->getSize ();
-  const int myRank = origComm->getRank ();
+  RCP<const Comm<int> > origComm = rcp(new SerialComm<int>);
+  const int numProcs = origComm->getSize();
+  const int myRank = origComm->getRank();
 
   // The calling process (there is only one in the communicator) contains zero elements.
   const size_type numGidsPerProc = 0;
   const size_type myNumGids = numGidsPerProc;
-  Array<global_ordinal_type> myGids (myNumGids);
+  Array<GO> myGids(myNumGids);
 
-  const global_size_t globalNumElts = as<global_size_t> (numGidsPerProc) *
-    as<global_size_t> (numProcs);
-  const global_ordinal_type indexBase = 0;
-  RCP<const map_type> origMap (new map_type (globalNumElts, myGids (),
+  const GST globalNumElts = as<GST>(numGidsPerProc) *
+    as<GST>(numProcs);
+  const GO indexBase = 0;
+  RCP<const map_type> origMap(new map_type(globalNumElts, myGids(),
                                              indexBase, origComm));
-  RCP<const map_type> newMap = origMap->removeEmptyProcesses ();
+  RCP<const map_type> newMap = origMap->removeEmptyProcesses();
 
   // Test collectively for success, so the test doesn't hang on failure.
   int localSuccess = 1;
   std::ostringstream err;
 
-  if (! newMap.is_null ()) {
+  if (! newMap.is_null()) {
     localSuccess = 0;
     err << "removeEmptyProcesses() should have returned null, but did not."
         << endl;
   }
 
   int globalSuccess = 0;
-  reduceAll (*origComm, REDUCE_MIN, localSuccess, outArg (globalSuccess));
+  reduceAll(*origComm, REDUCE_MIN, localSuccess, outArg(globalSuccess));
   if (globalSuccess == 0) {
     if (myRank == 0) {
       cerr << "TEST FAILED" << endl
@@ -560,15 +558,32 @@ TEUCHOS_UNIT_TEST( Map, removeEmptyProcesses_SerialComm2 )
     }
     for (int p = 0; p < numProcs; ++p) {
       if (myRank == p) {
-        cerr << "Process " << myRank << ": " << err.str () << endl;
+        cerr << "Process " << myRank << ": " << err.str() << endl;
       }
-      origComm->barrier (); // Give time for output to finish.
-      origComm->barrier ();
-      origComm->barrier ();
+      origComm->barrier(); // Give time for output to finish.
+      origComm->barrier();
+      origComm->barrier();
     }
   }
   TEST_EQUALITY(globalSuccess, 1);
+
+  if (globalSuccess != 1){
+    success = false;
+    return;
+  }
 }
 
+//
+// Instantiations of tests
+//
+#define UNIT_TEST_GROUP( LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Map, removeEmptyProcesses_MpiComm_noncontigMap, LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Map, removeEmptyProcesses_MpiComm_contigMap, LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Map, removeEmptyProcesses_SerialComm1, LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Map, removeEmptyProcesses_SerialComm2, LO, GO, NT )
 
+TPETRA_ETI_MANGLING_TYPEDEFS()
 
+TPETRA_INSTANTIATE_LGN( UNIT_TEST_GROUP )
+
+} // namespace (anonymous)

--- a/packages/tpetra/core/test/Map/isOneToOne.cpp
+++ b/packages/tpetra/core/test/Map/isOneToOne.cpp
@@ -41,6 +41,7 @@
 // @HEADER
 */
 
+#include <Tpetra_TestingUtilities.hpp>
 #include <Tpetra_ConfigDefs.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 #include <Tpetra_DefaultPlatform.hpp>
@@ -58,22 +59,16 @@ namespace {
   using std::endl;
 
   typedef Tpetra::global_size_t GST;
-  typedef int LO;
-  typedef int GO;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_type;
-  typedef Tpetra::Map<LO, GO, node_type> map_type;
   typedef Teuchos::Comm<int> comm_type;
-  typedef Teuchos::Array<GO>::size_type size_type;
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_contig_uniform_distributed )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_contig_uniform_distributed, LO, GO)
   {
     out << "Testing Map::isOneToOne with a contiguous uniform Map" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm =
       Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -90,7 +85,7 @@ namespace {
     const GO indexBase = 1;
     map_type map;
     try {
-      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::GloballyDistributed, node);
+      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::GloballyDistributed);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -128,14 +123,13 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_serial_contig_uniform_distributed )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_serial_contig_uniform_distributed, LO, GO)
   {
     out << "Testing Map::isOneToOne with a contiguous uniform Map over one process" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm = rcp (new Teuchos::SerialComm<int> ());
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -152,7 +146,7 @@ namespace {
     const GO indexBase = 1;
     map_type map;
     try {
-      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::GloballyDistributed, node);
+      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::GloballyDistributed);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -190,15 +184,14 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_contig_uniform_replicated )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_contig_uniform_replicated, LO, GO)
   {
     out << "Testing Map::isOneToOne with a contiguous uniform replicated Map" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm =
       Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -215,7 +208,7 @@ namespace {
     const GO indexBase = 1;
     map_type map;
     try {
-      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::LocallyReplicated, node);
+      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::LocallyReplicated);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -255,14 +248,13 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_serial_contig_uniform_replicated )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_serial_contig_uniform_replicated, LO, GO)
   {
     out << "Testing Map::isOneToOne with a contiguous uniform replicated Map over one process" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm = rcp (new Teuchos::SerialComm<int> ());
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -279,7 +271,7 @@ namespace {
     const GO indexBase = 1;
     map_type map;
     try {
-      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::LocallyReplicated, node);
+      map = map_type (numGlobalIndices, indexBase, comm, Tpetra::LocallyReplicated);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -321,15 +313,14 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_contig_nonuniform )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_contig_nonuniform, LO, GO)
   {
     out << "Testing Map::isOneToOne with a contiguous nonuniform Map" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm =
       Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -347,7 +338,7 @@ namespace {
     const GO indexBase = 1;
     map_type map;
     try {
-      map = map_type (numGlobalIndices, numLocalIndices, indexBase, comm, node);
+      map = map_type (numGlobalIndices, numLocalIndices, indexBase, comm);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -386,14 +377,13 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_serial_contig_nonuniform )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_serial_contig_nonuniform, LO, GO)
   {
     out << "Testing Map::isOneToOne with a contiguous nonuniform Map over one process" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm = rcp (new Teuchos::SerialComm<int> ());
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -411,7 +401,7 @@ namespace {
     const GO indexBase = 1;
     map_type map;
     try {
-      map = map_type (numGlobalIndices, numLocalIndices, indexBase, comm, node);
+      map = map_type (numGlobalIndices, numLocalIndices, indexBase, comm);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -450,15 +440,14 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_noncontig_oneToOne )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_noncontig_oneToOne, LO, GO)
   {
     out << "Testing Map::isOneToOne with a noncontiguous, one-to-one Map" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm =
       Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -485,7 +474,7 @@ namespace {
 
     map_type map;
     try {
-      map = map_type (numGlobalIndices, myGlobalIndices (), indexBase, comm, node);
+      map = map_type (numGlobalIndices, myGlobalIndices (), indexBase, comm);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -524,15 +513,14 @@ namespace {
   }
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_noncontig_replicated )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_noncontig_replicated, LO, GO)
   {
     out << "Testing Map::isOneToOne with a noncontiguous, replicated Map" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm =
       Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -557,7 +545,7 @@ namespace {
 
     map_type map;
     try {
-      map = map_type (numGlobalIndices, myGlobalIndices (), indexBase, comm, node);
+      map = map_type (numGlobalIndices, myGlobalIndices (), indexBase, comm);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -598,15 +586,14 @@ namespace {
 
 
 
-  TEUCHOS_UNIT_TEST( Map, isOneToOne_noncontig_notOneToOne )
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(Map, isOneToOne_noncontig_notOneToOne, LO, GO)
   {
     out << "Testing Map::isOneToOne with a noncontiguous, not one-to-one Map" << endl;
     Teuchos::OSTab tab0 (out);
+    typedef Tpetra::Map<LO, GO> map_type;
 
     RCP<const comm_type> comm =
       Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     const int numProcs = comm->getSize ();
     const int myRank = comm->getRank ();
@@ -634,7 +621,7 @@ namespace {
 
     map_type map;
     try {
-      map = map_type (numGlobalIndices, myGlobalIndices (), indexBase, comm, node);
+      map = map_type (numGlobalIndices, myGlobalIndices (), indexBase, comm);
       lclSuccess = 1;
     } catch (std::exception& e) {
       lclSuccess = 0;
@@ -673,6 +660,22 @@ namespace {
     TEST_EQUALITY_CONST(gblSuccess, 1);
   }
 
-}
+//
+// Instantiations of tests
+//
+#define UNIT_TEST_GROUP(LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_contig_uniform_distributed, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_serial_contig_uniform_distributed, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_contig_uniform_replicated, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_serial_contig_uniform_replicated, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_contig_nonuniform, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_serial_contig_nonuniform, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_noncontig_oneToOne, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_noncontig_replicated, LO, GO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_INSTANT(Map, isOneToOne_noncontig_notOneToOne, LO, GO)
 
+  TPETRA_ETI_MANGLING_TYPEDEFS()
 
+  TPETRA_INSTANTIATE_LG( UNIT_TEST_GROUP )
+
+} // (anonymous)


### PR DESCRIPTION
…lar GO

Tpetra::Map tests that depended unnecessarily on particular GlobalOrdinal (GO)
types were generalized (templatized)

- Tests modified to live in an anonymous namespace
- Several TEUCHOS_UNIT_TEST templates replaced with
  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL with associated test instantiations.

Addresses: #695