### PR TITLE
fixed white space error in doxygen markdown formatting.

### DIFF
--- a/packages/belos/src/BelosSolverFactory.hpp
+++ b/packages/belos/src/BelosSolverFactory.hpp
@@ -143,7 +143,7 @@ enum EBelosSolverType {
 /// is an alias for "Block GMRES", and also sets the "Flexible Gmres"
 /// parameter to true in the input parameter list.
 ///
-///      Solver name | Aliases | Solver Manager Class
+///  Solver name | Aliases | Solver Manager Class
 ///  ----------- | ------- | ----------
 ///  Pseudoblock GMRES |  GMRES, Pseudo Block GMRES, PseudoBlockGMRES, PseudoBlockGmres | \c PseudoBlockGmresSolMgr
 ///  Block GMRES | Flexible GMRES | \c BlockGmresSolMgr


### PR DESCRIPTION
An indent caused Doxygen to interpret a Markdown table as a code snippet, which caused incorrect html to be generated.  Fixed now.  