### PR TITLE
@trilinos/teuchos: Provides resolution for Issue #892

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_MatrixMarket_split.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_MatrixMarket_split.cpp
@@ -111,7 +111,10 @@ namespace Teuchos {
           return make_pair (first, 1);
         else
           { // Next index of a delimiter character
-            const size_t next = str.find_first_of (delimiters, start+1);
+            // Search for the next delimiting token from "first" (instead of
+            // "start+1" as originally coded and commented out below.)
+            // const size_t next = str.find_first_of (delimiters, start+1);
+            const size_t next = str.find_first_of (delimiters, first);
             return make_pair (first, next - first);
           }
       }


### PR DESCRIPTION
Issue #892 demonstrates that the @trilinos/teuchos and @trilinos/tpetra MatrixMarket file reader will
fail to read MatrixMarket files with consecutive spaces in the banner.
This commit fixes that problem.

Issues: #892 

Tests Summary:
Comfiguration: MPI_RELEASE_DEBUG_SHARED_PT
Configure: Passed (4.37 min)
Build: Passed (92.82 min)
Test: FAILED (12.04 min)
99% tests passed, 2 tests failed out of 2256
The 2 failing tests are the same as those described in #910
