### PR TITLE
Amesos2 Basker: Add param list when testing shylubasker

### DIFF
--- a/packages/amesos2/test/solvers/SolverFactory.cpp
+++ b/packages/amesos2/test/solvers/SolverFactory.cpp
@@ -48,6 +48,9 @@
 #include "Amesos2_Factory.hpp"
 #include "Trilinos_Details_LinearSolver.hpp"
 #include "Trilinos_Details_LinearSolverFactory.hpp"
+
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_ParameterXMLFileReader.hpp>
 // Define typedefs and macros for testing over all Tpetra types.
 // They work whether or not ETI is enabled.
 #include "TpetraCore_ETIHelperMacros.h"
@@ -209,9 +212,50 @@ namespace {
     out << "Test solver \"" << solverName << "\" from Amesos2 package" << endl;
     Teuchos::OSTab tab1 (out);
 
+#ifdef SHYLUBASKER 
+    // NDE: Beginning changes towards passing parameter list to shylu basker
+    // for controlling various parameters per test, matrix, etc.
+
+    Teuchos::ParameterList amesos2_paramlist;
+    amesos2_paramlist.setName("Amesos2");
+    Teuchos::ParameterList & shylubasker_paramlist = amesos2_paramlist.sublist("Basker");
+
+      shylubasker_paramlist.set("num_threads", 1,
+        "Number of threads");
+      shylubasker_paramlist.set("pivot", false,
+        "Should not pivot");
+      shylubasker_paramlist.set("pivot_tol", .0001,
+        "Tolerance before pivot, currently not used");
+      shylubasker_paramlist.set("symmetric", false,
+        "Should Symbolic assume symmetric nonzero pattern");
+      shylubasker_paramlist.set("realloc" , false,
+        "Should realloc space if not enough");
+      shylubasker_paramlist.set("verbose", false,
+        "Information about factoring");
+      shylubasker_paramlist.set("verbose_matrix", false,
+        "Give Permuted Matrices");
+      shylubasker_paramlist.set("matching", true,
+        "Use WC matching (Not Supported)");
+      shylubasker_paramlist.set("matching_type", 0,
+        "Type of WC matching (Not Supported)");
+      shylubasker_paramlist.set("btf", true,
+        "Use BTF ordering");
+      shylubasker_paramlist.set("amd_btf", true,
+        "Use AMD on BTF blocks (Not Supported)");
+      shylubasker_paramlist.set("amd_dom", true,
+        "Use CAMD on ND blocks (Not Supported)");
+      shylubasker_paramlist.set("transpose", false,
+        "Solve the transpose A");
+#endif
+
     RCP<Trilinos::Details::LinearSolver<MV, OP, mag_type> > solver;
     try {
       solver = Trilinos::Details::getLinearSolver<MV, OP, mag_type> ("Amesos2", solverName);
+#ifdef SHYLUBASKER
+      solver->setParameters(Teuchos::rcpFromRef(amesos2_paramlist));
+#endif
+
+      //set parameter list here as well
     } catch (std::exception& e) {
       out << "*** FAILED: getLinearSolver threw an exception: " << e.what () << endl;
       success = false;
@@ -304,6 +348,44 @@ namespace {
         RCP<Amesos2::Solver<MAT, MV> > solver;
         try {
           solver = Amesos2::create<MAT, MV> (solverName, A, X, B);
+
+#ifdef SHYLUBASKER 
+          // NDE: Beginning changes towards passing parameter list to shylu basker
+          // for controlling various parameters per test, matrix, etc.
+
+          Teuchos::ParameterList amesos2_paramlist;
+          amesos2_paramlist.setName("Amesos2");
+          Teuchos::ParameterList & shylubasker_paramlist = amesos2_paramlist.sublist("Basker");
+
+          shylubasker_paramlist.set("num_threads", 1,
+              "Number of threads");
+          shylubasker_paramlist.set("pivot", false,
+              "Should not pivot");
+          shylubasker_paramlist.set("pivot_tol", .0001,
+              "Tolerance before pivot, currently not used");
+          shylubasker_paramlist.set("symmetric", false,
+              "Should Symbolic assume symmetric nonzero pattern");
+          shylubasker_paramlist.set("realloc" , false,
+              "Should realloc space if not enough");
+          shylubasker_paramlist.set("verbose", false,
+              "Information about factoring");
+          shylubasker_paramlist.set("verbose_matrix", false,
+              "Give Permuted Matrices");
+          shylubasker_paramlist.set("matching", true,
+              "Use WC matching (Not Supported)");
+          shylubasker_paramlist.set("matching_type", 0,
+              "Type of WC matching (Not Supported)");
+          shylubasker_paramlist.set("btf", true,
+              "Use BTF ordering");
+          shylubasker_paramlist.set("amd_btf", true,
+              "Use AMD on BTF blocks (Not Supported)");
+          shylubasker_paramlist.set("amd_dom", true,
+              "Use CAMD on ND blocks (Not Supported)");
+          shylubasker_paramlist.set("transpose", false,
+              "Solve the transpose A");
+
+          solver->setParameters(Teuchos::rcpFromRef(amesos2_paramlist));
+#endif
         }
         catch (...) {
           out << "Amesos2::create threw an exception for solverName = \"" <<

--- a/packages/shylu/basker/src/basker_order_scotch.hpp
+++ b/packages/shylu/basker/src/basker_order_scotch.hpp
@@ -590,7 +590,11 @@ namespace BaskerNS
             printf("ERROR: NOT ENOUGH DOMAINS FOR THREADS\n");
             printf("REDUCE THREAD COUNT AND TRY AGAIN\n");
           }
-      printf(" ShyLU Basker Error: num domains != ideal num domains\n");
+      printf(" ShyLU Basker Error: do_complete_tree routine \n");
+      printf("   num domains != ideal num domains\n");
+      printf("  This error occurs when the matrix to be solved is too small for given number of threads\n \
+            The number of threads must match the number of leaves in the tree\n \
+            To resolve this, rerun with fewer threads\n");
       // Make this throw exception instead
     	exit(EXIT_FAILURE);
       }

--- a/packages/shylu/basker/src/basker_order_scotch.hpp
+++ b/packages/shylu/basker/src/basker_order_scotch.hpp
@@ -10,19 +10,22 @@
 
 namespace BaskerNS
 {
+  template <typename iType>
   struct scotch_graph
   {
+    static_assert( std::is_same<iType,int32_t>::value || std::is_same<iType,int64_t>::value
+                 , "ShyLU Basker Error: scotch_graph members must be templated on type int32_t or int64_t only");
     scotch_graph()
     {};    
-    int m;
-    int nz;
-    int *Ap;
-    int *Ai;
-    int cblk;
-    int *permtab;
-    int *peritab;
-    int *rangtab;
-    int *treetab;
+    iType m;
+    iType nz;
+    iType *Ap;
+    iType *Ai;
+    iType cblk;
+    iType *permtab;
+    iType *peritab;
+    iType *rangtab;
+    iType *treetab;
   };
 
   //A+A'
@@ -137,14 +140,19 @@ namespace BaskerNS
     #endif
 
     //----------------------INIT Scotch Graph------------//
-    scotch_graph sg;
+  #if SHYLU_SCOTCH_64
+    using scotch_integral_type = int64_t; //NDE: make this depend on the scotch type
+  #else
+    using scotch_integral_type = int32_t; //NDE: make this depend on the scotch type
+  #endif
+    scotch_graph<scotch_integral_type> sg;
     sg.m = M.nrow;
-    sg.Ap = (int *)malloc((sg.m+1)     *sizeof(int));
-    sg.Ai = (int *)malloc((M.nnz)      *sizeof(int));
-    sg.permtab = (int *)malloc((sg.m)  *sizeof(int));
-    sg.peritab = (int *)malloc((sg.m)  *sizeof(int));
-    sg.rangtab = (int *)malloc((sg.m+1)*sizeof(int));
-    sg.treetab = (int *)malloc((sg.m)  *sizeof(int));
+    sg.Ap = (scotch_integral_type *)malloc((sg.m+1)     *sizeof(scotch_integral_type));
+    sg.Ai = (scotch_integral_type *)malloc((M.nnz)      *sizeof(scotch_integral_type));
+    sg.permtab = (scotch_integral_type *)malloc((sg.m)  *sizeof(scotch_integral_type));
+    sg.peritab = (scotch_integral_type *)malloc((sg.m)  *sizeof(scotch_integral_type));
+    sg.rangtab = (scotch_integral_type *)malloc((sg.m+1)*sizeof(scotch_integral_type));
+    sg.treetab = (scotch_integral_type *)malloc((sg.m)  *sizeof(scotch_integral_type));
     
     sg.Ap[0] = 0;
     Int sj;
@@ -197,7 +205,7 @@ namespace BaskerNS
     SCOTCH_Strat strdat;
     SCOTCH_Graph cgrafptr;
     int err;
-    int *vwgts; vwgts = NULL;
+    scotch_integral_type *vwgts; vwgts = NULL;
     
     if(SCOTCH_graphInit(&cgrafptr) != 0)
       {


### PR DESCRIPTION
This commit address Trilinos Github Issue #747

Added parameter list when testing shylubasker to set options,
      particularly for control of the thread count when testing a matrix
      that is too small for a given number of threads

This is prep to move towards using an xml file to test for multiple
matrices

 Changes to be committed:
	modified:   packages/amesos2/test/solvers/Basker_UnitTests.cpp
	modified:   packages/amesos2/test/solvers/SolverFactory.cpp
	modified:   packages/shylu/basker/src/basker_order_scotch.hpp