### PR TITLE
Isorropia: fix indentation warning

### DIFF
--- a/packages/isorropia/src/epetra/Isorropia_EpetraMatcher.cpp
+++ b/packages/isorropia/src/epetra/Isorropia_EpetraMatcher.cpp
@@ -423,9 +423,9 @@ Matcher::~Matcher()
     if(choice_==3 ||choice_==4)
         delete [] unmatchedU_;
 
-    if (CRS_indices_) delete [] CRS_indices_; CRS_indices_ = NULL;
-    if (CRS_pointers_) delete [] CRS_pointers_; CRS_pointers_ = NULL;
-    if (parent_) delete [] parent_; parent_ = NULL;
+    if (CRS_indices_) { delete [] CRS_indices_; CRS_indices_ = NULL; }
+    if (CRS_pointers_) { delete [] CRS_pointers_; CRS_pointers_ = NULL; }
+    if (parent_) { delete [] parent_; parent_ = NULL; }
 
 #ifdef ISORROPIA_HAVE_OMP
     for(int i=0;i<V_;i++)


### PR DESCRIPTION
GCC 6.2.0 correctly points out that the
indentation here is misleading.
in this case the behavior is the same
either way, but for subtle reasons.
this commit should silence the warning.