### PR TITLE
add missing -lm to suitesparse link line

### DIFF
--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
@@ -65,6 +65,7 @@ TRIBITS_ADD_LIBRARY(
   trilinosss
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
+  IMPORTEDLIBS m  # for ceil, sqrt etc.
   )
 
 


### PR DESCRIPTION
Fixes link errors like
```
/trilinos_trilinosss.dir/AMD/Source/trilinos_amd_2.c.o: In function `trilinos_amd_2':
/<<PKGBUILDDIR>>/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_2.c:603: undefined reference to `sqrt'
```
(See [here](https://launchpadlibrarian.net/302188380/buildlog_ubuntu-xenial-amd64.trilinos_12.11~20170112121320-f79c84aa-1xenial1_BUILDING.txt.gz) for full details.)
Errors of this kind happen once in a while and are easily detected by adding `-Wl,--no-undefined` to the link commands, e.g., by adding
```cmake
  -DCMAKE_SHARED_LINKER_FLAGS:STRING="-Wl,--no-undefined"
```
to the configure line. @jwillenbring Could this be done for the nightly testing?