### PR TITLE
Revert "Fix a link error in TrilinosSS for shared builds."

### DIFF
--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
@@ -67,6 +67,5 @@ TRIBITS_ADD_LIBRARY(
   SOURCES ${SOURCES}
   )
 
-target_link_libraries(trilinosss m)
 
 


### PR DESCRIPTION
Reverts trilinos/Trilinos#997. See discussion on #998.