### PR TITLE
Misleading indentation (whitespace-only)

### DIFF
--- a/packages/aztecoo/src/Epetra_MsrMatrix.cpp
+++ b/packages/aztecoo/src/Epetra_MsrMatrix.cpp
@@ -2,13 +2,13 @@
 /*
 //@HEADER
 // ***********************************************************************
-// 
-//        AztecOO: An Object-Oriented Aztec Linear Solver Package 
+//
+//        AztecOO: An Object-Oriented Aztec Linear Solver Package
 //                 Copyright (2002) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,8 +36,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ***********************************************************************
 //@HEADER
 */
@@ -73,7 +73,7 @@ Epetra_MsrMatrix::Epetra_MsrMatrix(int * proc_config, AZ_MATRIX * a_mat)
   Comm_ = new Epetra_MpiComm(*mpicomm);
 #else
   Comm_ = new Epetra_SerialComm();
-#endif  
+#endif
   if (a_mat->data_org[AZ_matrix_type]!=AZ_MSR_MATRIX)
     throw Comm_->ReportError("AZ_matrix_type must be AZ_MSR_MATRIX", -1);
   int * bindx = a_mat->bindx;
@@ -92,7 +92,7 @@ Epetra_MsrMatrix::Epetra_MsrMatrix(int * proc_config, AZ_MATRIX * a_mat)
 #endif
 
   int * MyGlobalElements = a_mat->update;
-  if (MyGlobalElements==0) 
+  if (MyGlobalElements==0)
     throw Comm_->ReportError("Aztec matrix has no update list: Check if AZ_Transform was called.", -2);
 
 #ifdef EPETRA_NO_32BIT_GLOBAL_INDICES
@@ -114,7 +114,7 @@ Epetra_MsrMatrix::Epetra_MsrMatrix(int * proc_config, AZ_MATRIX * a_mat)
 #endif
 
   Importer_ = new Epetra_Import(*ColMap_, *DomainMap_);
-  
+
   delete [] dbleColGIDs;
   delete [] ColGIDs;
 }
@@ -131,7 +131,7 @@ Epetra_MsrMatrix::~Epetra_MsrMatrix(){
 }
 //==========================================================================
 int Epetra_MsrMatrix::ExtractMyRowCopy(int Row, int Length, int & NumEntries, double * Values,
-					 int * Indices) const 
+					 int * Indices) const
 {
   int tmpNumEntries;
   int err = AZ_MSR_getrow(Indices, Values, &tmpNumEntries, Amat_, 1, &Row, Length);
@@ -139,7 +139,7 @@ int Epetra_MsrMatrix::ExtractMyRowCopy(int Row, int Length, int & NumEntries, do
   return(err-1);
 }
 //==========================================================================
-int Epetra_MsrMatrix::NumMyRowEntries(int Row, int & NumEntries) const 
+int Epetra_MsrMatrix::NumMyRowEntries(int Row, int & NumEntries) const
 {
 
   if (RowMatrixRowMap().MyLID(Row)) NumEntries = Amat_->bindx[Row+1] - Amat_->bindx[Row] + 1;
@@ -150,7 +150,7 @@ int Epetra_MsrMatrix::NumMyRowEntries(int Row, int & NumEntries) const
 }
 //==============================================================================
 int Epetra_MsrMatrix::ExtractDiagonalCopy(Epetra_Vector & Diagonal) const {
-	
+
   int iend = NumMyDiagonals();
   for (int i=0; i<iend; i++) Diagonal[i] = Amat_->val[i];
   return(0);
@@ -178,7 +178,7 @@ int Epetra_MsrMatrix::Multiply(bool TransA,
   }
   for (int i=0; i<NumVectors; i++)
     Amat_->matvec(xptrs[i], yptrs[i], Amat_, proc_config_);
-  
+
   double flops = (double) NumGlobalNonzeros64();
   flops *= 2.0;
   flops *= (double) NumVectors;
@@ -187,7 +187,7 @@ int Epetra_MsrMatrix::Multiply(bool TransA,
 }
 
 //=============================================================================
-int Epetra_MsrMatrix::Solve(bool Upper, bool Trans, bool UnitDiagonal, 
+int Epetra_MsrMatrix::Solve(bool Upper, bool Trans, bool UnitDiagonal,
                             const Epetra_MultiVector& X,
                             Epetra_MultiVector& Y) const
 {
@@ -225,7 +225,7 @@ int Epetra_MsrMatrix::GetRow(int Row) const {
     if (Indices_==0) Indices_ = new int[maxNumEntries];
   }
   Epetra_MsrMatrix::ExtractMyRowCopy(Row, maxNumEntries, NumEntries, Values_, Indices_);
-  
+
   return(NumEntries);
 }
 
@@ -265,11 +265,11 @@ int Epetra_MsrMatrix::InvColSums(Epetra_Vector& x) const {
 
   if (!Filled()) EPETRA_CHK_ERR(-1); // Matrix must be filled.
   if (!OperatorDomainMap().SameAs(x.Map())) EPETRA_CHK_ERR(-2); // x must have the same distribution as the domain of A
-  
+
 
   Epetra_Vector * xp = 0;
   Epetra_Vector * x_tmp = 0;
-  
+
 
   // If we have a non-trivial importer, we must export elements that are permuted or belong to other processors
   if (RowMatrixImporter()!=0) {
@@ -323,7 +323,7 @@ int Epetra_MsrMatrix::LeftScale(const Epetra_Vector& x) {
 
 
   for (i=0; i < NumMyRows_; i++) {
-    
+
     int NumEntries = bindx[i+1] - bindx[i];
     double scale = x[i];
     val[i] *= scale;
@@ -386,7 +386,7 @@ double Epetra_MsrMatrix::NormInf() const {
     int NumEntries = GetRow(i);
     double sum = 0.0;
     for (int j=0; j < NumEntries; j++) sum += fabs(Values_[j]);
-    
+
     Local_NormInf = EPETRA_MAX(Local_NormInf, sum);
   }
   Comm().MaxAll(&Local_NormInf, &NormInf_, 1);
@@ -401,10 +401,10 @@ double Epetra_MsrMatrix::NormOne() const {
   if (!Filled()) EPETRA_CHK_ERR(-1); // Matrix must be filled.
 
   Epetra_Vector * x = new Epetra_Vector(RowMatrixRowMap()); // Need temp vector for column sums
-  
+
   Epetra_Vector * xp = 0;
   Epetra_Vector * x_tmp = 0;
-  
+
 
   // If we have a non-trivial importer, we must export elements that are permuted or belong to other processors
   if (RowMatrixImporter()!=0) {
@@ -437,12 +437,16 @@ void Epetra_MsrMatrix::Print(std::ostream& os) const {
       const Epetra_fmtflags oldf = os.setf(ios::scientific,ios::floatfield);
       const int             oldp = os.precision(12); */
       if (MyPID==0) {
-	os <<  "\nNumber of Global Rows        = "; os << NumGlobalRows64(); os << std::endl;
-	os <<    "Number of Global Cols        = "; os << NumGlobalCols64(); os << std::endl;
-	os <<    "Number of Global Diagonals   = "; os << NumGlobalDiagonals64(); os << std::endl;
-	os <<    "Number of Global Nonzeros    = "; os << NumGlobalNonzeros64(); os << std::endl;
-	if (LowerTriangular()) os <<    " ** Matrix is Lower Triangular **"; os << std::endl;
-	if (UpperTriangular()) os <<    " ** Matrix is Upper Triangular **"; os << std::endl;
+        os <<  "\nNumber of Global Rows        = "; os << NumGlobalRows64(); os << std::endl;
+        os <<    "Number of Global Cols        = "; os << NumGlobalCols64(); os << std::endl;
+        os <<    "Number of Global Diagonals   = "; os << NumGlobalDiagonals64(); os << std::endl;
+        os <<    "Number of Global Nonzeros    = "; os << NumGlobalNonzeros64(); os << std::endl;
+        if (LowerTriangular()) {
+          os <<    " ** Matrix is Lower Triangular **"; os << std::endl;
+        }
+        if (UpperTriangular()) {
+          os <<    " ** Matrix is Upper Triangular **"; os << std::endl;
+        }
       }
 
       os <<  "\nNumber of My Rows        = "; os << NumMyRows(); os << std::endl;
@@ -451,9 +455,9 @@ void Epetra_MsrMatrix::Print(std::ostream& os) const {
       os <<    "Number of My Nonzeros    = "; os << NumMyNonzeros(); os << std::endl; os << std::endl;
 
       os << std::flush;
-      
+
       // Reset os flags
-      
+
 /*      os.setf(olda,ios::adjustfield);
       os.setf(oldf,ios::floatfield);
       os.precision(oldp); */
@@ -469,36 +473,33 @@ void Epetra_MsrMatrix::Print(std::ostream& os) const {
       int i, j;
 
       if (MyPID==0) {
-	os.width(8);
-	os <<  "   Processor ";
-	os.width(10);
-	os <<  "   Row Index ";
-	os.width(10);
-	os <<  "   Col Index ";
-	os.width(20);
-	os <<  "   Value     ";
-	os << std::endl;
+        os.width(8);
+        os <<  "   Processor ";
+        os.width(10);
+        os <<  "   Row Index ";
+        os.width(10);
+        os <<  "   Col Index ";
+        os.width(20);
+        os <<  "   Value     ";
+        os << std::endl;
       }
       for (i=0; i<NumMyRows_; i++) {
-	long long Row = RowMatrixRowMap().GID64(i); // Get global row number
-	int NumEntries = GetRow(i); // ith row is now in Values_ and Indices_
-	
-	for (j = 0; j < NumEntries ; j++) {   
-	  os.width(8);
-	  os <<  MyPID ; os << "    ";	
-	  os.width(10);
-	  os <<  Row ; os << "    ";	
-	  os.width(10);
-	  os <<  RowMatrixColMap().GID64(Indices_[j]); os << "    ";
-	  os.width(20);
-	  os <<  Values_[j]; os << "    ";
-	  os << std::endl;
-	}
-      }
+        long long Row = RowMatrixRowMap().GID64(i); // Get global row number
+        int NumEntries = GetRow(i); // ith row is now in Values_ and Indices_
 
-      
+        for (j = 0; j < NumEntries ; j++) {
+          os.width(8);
+          os <<  MyPID ; os << "    ";
+          os.width(10);
+          os <<  Row ; os << "    ";
+          os.width(10);
+          os <<  RowMatrixColMap().GID64(Indices_[j]); os << "    ";
+          os.width(20);
+          os <<  Values_[j]; os << "    ";
+          os << std::endl;
+        }
+      }
       os << std::flush;
-      
     }
     // Do a few global ops to give I/O a chance to complete
     RowMatrixRowMap().Comm().Barrier();

--- a/packages/aztecoo/src/az_precond.c
+++ b/packages/aztecoo/src/az_precond.c
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ***********************************************************************
-// 
-//        AztecOO: An Object-Oriented Aztec Linear Solver Package 
+//
+//        AztecOO: An Object-Oriented Aztec Linear Solver Package
 //                 Copyright (2002) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ***********************************************************************
 //@HEADER
 */
@@ -88,7 +88,7 @@ extern int az_iterate_id;
 /******************************************************************************/
 
 void AZ_precondition(double x[], int input_options[], int proc_config[],
-                     double input_params[], AZ_MATRIX *Amat, 
+                     double input_params[], AZ_MATRIX *Amat,
 		     AZ_PRECOND *input_precond)
 
 
@@ -137,7 +137,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
         jacobi                 -- point Jacobi method.
         AZ_polynomial_expansion-- Polynomial expansion; Neumann series and
                                   least squares.
-        domain decomposition   -- Block solvers (LU , ILU or ILUT) used on 
+        domain decomposition   -- Block solvers (LU , ILU or ILUT) used on
                                   each processor. The blocks are either
                                   non-overlapping or overlapping.
         icc                    -- incomplete sparse Choleski (symmetric
@@ -188,7 +188,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
 
   precond = input_precond;
 
-  sprintf(suffix," in precond%d",input_options[AZ_recursion_level]);  
+  sprintf(suffix," in precond%d",input_options[AZ_recursion_level]);
                                               /* set string that will be used */
                                               /* for manage_memory label      */
 
@@ -199,10 +199,10 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
   m    = data_org[AZ_N_int_blk] + data_org[AZ_N_bord_blk];
   N    = data_org[AZ_N_internal] + data_org[AZ_N_border];
   max_externals = Amat->data_org[AZ_N_external];
-  if (max_externals < data_org[AZ_N_external]) 
+  if (max_externals < data_org[AZ_N_external])
      max_externals = data_org[AZ_N_external];
 
-  current_rhs = x; 
+  current_rhs = x;
   if (options[AZ_precond] == AZ_multilevel) {
 
      /* make extra vectors to hold rhs and residual */
@@ -228,7 +228,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
      indx     = precond->Pmat->indx;
      rpntr    = precond->Pmat->rpntr;
      bpntr    = precond->Pmat->bpntr;
-     if (max_externals < data_org[AZ_N_external]) 
+     if (max_externals < data_org[AZ_N_external])
         max_externals = data_org[AZ_N_external];
 
      switch (options[AZ_precond]) {
@@ -258,9 +258,9 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
            if (options[AZ_pre_calc] < AZ_sys_reuse) {
               sprintf(tag,"d2_inv %s",precond->context->tag);
               d2_inv   = (double *) AZ_manage_memory(N*sizeof(double),AZ_ALLOC,
-						data_org[AZ_name],tag,&i);
+                  data_org[AZ_name],tag,&i);
               Pmat = precond->Pmat;
-              if ( (Pmat->N_nz < 0) || (Pmat->max_per_row < 0)) 
+              if ( (Pmat->N_nz < 0) || (Pmat->max_per_row < 0))
                  AZ_matfree_Nnzs(Pmat);
 
               if ( (Pmat->getrow == NULL) && (N != 0) ) {
@@ -276,10 +276,10 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
               itemp = (int    *) AZ_manage_memory(Pmat->max_per_row*
 				                sizeof(int   ),AZ_ALLOC,
 						data_org[AZ_name],tag,&i);
-  
+
 	      for (i = 0; i < N; i++) {
                  Pmat->getrow(itemp,dtemp,&length,Pmat,1,&i,Pmat->max_per_row);
-                 for (k =0; k < length; k++) 
+                 for (k =0; k < length; k++)
                     if (itemp[k] == i) break;
 
                  if (k == length) d2_inv[i] = 0.0; /* no diagonal */
@@ -306,53 +306,65 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
         else if (data_org[AZ_matrix_type] == AZ_VBR_MATRIX) {
            /* block Jacobi preconditioning */
 
-           if (options[AZ_pre_calc] < AZ_sys_reuse) {
-              /* First, compute block-diagonal inverse */
-              /* (only if not already computed)        */
+          if (options[AZ_pre_calc] < AZ_sys_reuse) {
+            /* First, compute block-diagonal inverse */
+            /* (only if not already computed)        */
 
-              tsize = 0;
-              for (i = 0; i < m; i++)
-                 tsize += (rpntr[i+1] - rpntr[i]) * (cpntr[i+1] - cpntr[i]);
+            tsize = 0;
+            for (i = 0; i < m; i++)
+              tsize += (rpntr[i+1] - rpntr[i]) * (cpntr[i+1] - cpntr[i]);
 
-                 sprintf(tag,"d2_indx %s",precond->context->tag);
-                 d2_indx  = (int *) AZ_manage_memory((m+1)*sizeof(int),AZ_ALLOC,
-                                            data_org[AZ_name], tag, &i);
-                 sprintf(tag,"d2_bindx %s",precond->context->tag);
-                 d2_bindx = (int *) AZ_manage_memory(m*sizeof(int), AZ_ALLOC,
-                                            data_org[AZ_name], tag, &i);
-                 sprintf(tag,"d2_rpntr %s",precond->context->tag);
-                 d2_rpntr = (int *) AZ_manage_memory((m+1)*sizeof(int),AZ_ALLOC,
-                                            data_org[AZ_name], tag, &i);
-                 sprintf(tag,"d2_bpntr %s",precond->context->tag);
-                 d2_bpntr = (int *) AZ_manage_memory((m+1)*sizeof(int),AZ_ALLOC,
-                                            data_org[AZ_name], tag, &i);
-                 sprintf(tag,"d2_inv %s",precond->context->tag);
-                 d2_inv   = (double *) AZ_manage_memory(tsize*sizeof(double),
-                                            AZ_ALLOC, data_org[AZ_name],tag,&i);
-                 d2_bpntr[0] = 0;
-                 sprintf(tag,"dmat_calk_binv %s",precond->context->tag);
-                 Dmat     = (AZ_MATRIX *) AZ_manage_memory(sizeof(AZ_MATRIX), 
-                                            AZ_ALLOC,data_org[AZ_name],tag,&i);
+            sprintf(tag,"d2_indx %s",precond->context->tag);
+            d2_indx  = (int *) AZ_manage_memory(
+                (m+1)*sizeof(int),AZ_ALLOC,
+                data_org[AZ_name], tag, &i
+                );
+            sprintf(tag,"d2_bindx %s",precond->context->tag);
+            d2_bindx = (int *) AZ_manage_memory(
+                m*sizeof(int), AZ_ALLOC,
+                data_org[AZ_name], tag, &i
+                );
+            sprintf(tag,"d2_rpntr %s",precond->context->tag);
+            d2_rpntr = (int *) AZ_manage_memory(
+                (m+1)*sizeof(int),AZ_ALLOC,
+                data_org[AZ_name], tag, &i
+                );
+            sprintf(tag,"d2_bpntr %s",precond->context->tag);
+            d2_bpntr = (int *) AZ_manage_memory(
+                (m+1)*sizeof(int),AZ_ALLOC,
+                data_org[AZ_name], tag, &i
+                );
+            sprintf(tag,"d2_inv %s",precond->context->tag);
+            d2_inv   = (double *) AZ_manage_memory(
+                tsize*sizeof(double),
+                AZ_ALLOC, data_org[AZ_name],tag,&i
+                );
+            d2_bpntr[0] = 0;
+            sprintf(tag,"dmat_calk_binv %s",precond->context->tag);
+            Dmat     = (AZ_MATRIX *) AZ_manage_memory(
+                sizeof(AZ_MATRIX),
+                AZ_ALLOC,data_org[AZ_name],tag,&i
+                );
 
-                 Dmat->rpntr         = d2_rpntr;   Dmat->cpntr    = d2_rpntr;
-                 Dmat->bpntr         = d2_bpntr;   Dmat->bindx    = d2_bindx;
-                 Dmat->indx          = d2_indx;    Dmat->val      = d2_inv;
-                 Dmat->data_org      = data_org;
-                 Dmat->matvec        = precond->Pmat->matvec;
-                 Dmat->matrix_type   = precond->Pmat->matrix_type;
+            Dmat->rpntr         = d2_rpntr;   Dmat->cpntr    = d2_rpntr;
+            Dmat->bpntr         = d2_bpntr;   Dmat->bindx    = d2_bindx;
+            Dmat->indx          = d2_indx;    Dmat->val      = d2_inv;
+            Dmat->data_org      = data_org;
+            Dmat->matvec        = precond->Pmat->matvec;
+            Dmat->matrix_type   = precond->Pmat->matrix_type;
 
-                 if (options[AZ_pre_calc] != AZ_reuse) {
-                    AZ_calc_blk_diag_inv(val, indx, bindx, rpntr, cpntr, bpntr,
-                                         d2_inv, d2_indx, d2_bindx, d2_rpntr, 
-                                         d2_bpntr, data_org);
-                 }
-                 else if (i == AZ_NEW_ADDRESS) {
-                   AZ_printf_err( "Error: options[AZ_pre_calc]==AZ_reuse and"
-                         "previous factors\n       not found. Check"
-                         "data_org[AZ_name].\n");
-                   exit(-1);
-                 }
-           }
+            if (options[AZ_pre_calc] != AZ_reuse) {
+              AZ_calc_blk_diag_inv(val, indx, bindx, rpntr, cpntr, bpntr,
+                  d2_inv, d2_indx, d2_bindx, d2_rpntr,
+                  d2_bpntr, data_org);
+            }
+            else if (i == AZ_NEW_ADDRESS) {
+              AZ_printf_err( "Error: options[AZ_pre_calc]==AZ_reuse and"
+                  "previous factors\n       not found. Check"
+                  "data_org[AZ_name].\n");
+              exit(-1);
+            }
+          }
            else if (previous_factors != data_org[AZ_name]) {
               AZ_printf_err( "Warning: Using a previous factorization as a"
                        "preconditioner\neven though matrix"
@@ -407,7 +419,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
 
      case AZ_dom_decomp:
      case AZ_rilu:
-        AZ_domain_decomp(current_rhs, precond->Pmat, options, proc_config, 
+        AZ_domain_decomp(current_rhs, precond->Pmat, options, proc_config,
                          params, precond->context);
      break;
 
@@ -418,7 +430,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
      break;
 
      case AZ_user_precond:
-        precond->prec_function(current_rhs, options, proc_config, 
+        precond->prec_function(current_rhs, options, proc_config,
                                params, Amat, precond);
      break;
      case AZ_smoother:
@@ -428,7 +440,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
         for (i = 0 ; i < AZ_STATUS_SIZE ; i++ ) istatus[i] = 0.0;
 
         sprintf(label,"y %s",precond->context->tag);
-        y = AZ_manage_memory((N+max_externals)*sizeof(double), AZ_ALLOC, 
+        y = AZ_manage_memory((N+max_externals)*sizeof(double), AZ_ALLOC,
 			     AZ_SYS+az_iterate_id, label, &i);
         sprintf(label,"tttemp %s",precond->context->tag);
         tttemp = AZ_manage_memory((N+max_externals)*sizeof(double),AZ_ALLOC,
@@ -453,8 +465,8 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
                   (options[AZ_output] != AZ_summary) &&
                   (options[AZ_output] != AZ_warnings))
                   AZ_printf_out("   %d  %e\n",j, norm1);
-              else if ((j==options[AZ_poly_ord]-1) && 
-		  (options[AZ_output] != AZ_none) && 
+              else if ((j==options[AZ_poly_ord]-1) &&
+		  (options[AZ_output] != AZ_none) &&
                   (options[AZ_output] != AZ_warnings))
                   AZ_printf_out("   %d  %e\n",j, norm1);
               else if ((options[AZ_output] > 0) && (j%options[AZ_output] == 0))
@@ -478,7 +490,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
         options[AZ_aux_vec] = AZ_rand;
 
         options[AZ_recursion_level]++;
-        AZ_oldsolve(current_rhs, y,options, params, istatus, proc_config, 
+        AZ_oldsolve(current_rhs, y,options, params, istatus, proc_config,
                     Amat, precond, NULL);
         options[AZ_recursion_level]--;
         options[AZ_output]  = opt_save1;
@@ -499,9 +511,9 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
 
            ioptions[AZ_recursion_level] = options[AZ_recursion_level] + 1;
            if ((options[AZ_pre_calc] == AZ_sys_reuse) &&
-               (ioptions[AZ_keep_info] == 1)) 
+               (ioptions[AZ_keep_info] == 1))
               ioptions[AZ_pre_calc] = AZ_reuse;
-           AZ_oldsolve(current_rhs, y,ioptions,iparams, istatus, proc_config, 
+           AZ_oldsolve(current_rhs, y,ioptions,iparams, istatus, proc_config,
                        Aptr, Pptr, Sptr);
         }
         else {
@@ -522,7 +534,7 @@ void AZ_precondition(double x[], int input_options[], int proc_config[],
         }
         else {
            for (i = 0; i < N; i++) x_precond[i] += current_rhs[i];
-           AZ_compute_residual(orig_rhs, x_precond, current_rhs, 
+           AZ_compute_residual(orig_rhs, x_precond, current_rhs,
                                proc_config, Amat);
            precond = precond->next_prec;
            options = precond->options;
@@ -1079,36 +1091,39 @@ void AZ_do_Jacobi(double val[], int indx[], int bindx[], int rpntr[],
                      double temp[], int options[], int data_org[],
                      int proc_config[], double params[], int flag)
 {
-double *v;
-int i,step;
-int N;
- 
-  N    = data_org[AZ_N_internal] + data_org[AZ_N_border];
- 
-    if (data_org[AZ_matrix_type] == AZ_MSR_MATRIX) {
- 
-      if ( (options[AZ_poly_ord] != 0) && (flag == 1) )
-         for (i = data_org[AZ_N_internal]; i < N; i++) x[i] = b[i]/val[i];
- 
-      if (options[AZ_poly_ord] > flag) {
-        v = AZ_manage_memory((N+data_org[AZ_N_external])*sizeof(double),
-                             AZ_ALLOC, AZ_SYS+az_iterate_id, "v in do_jacobi", &i);
- 
-        for (i = 0; i < N; i++) v[i] = x[i];
- 
-        for (step = flag; step < options[AZ_poly_ord]; step++) {
-          Amat->matvec(v, temp, Amat, proc_config);
+  double *v;
+  int i,step;
+  int N;
 
-          for(i = 0; i < N; i++) v[i] += (b[i] - temp[i]) / val[i];
-        }
-        for (i = 0; i < N; i++) x[i] = v[i];
+  N = data_org[AZ_N_internal] + data_org[AZ_N_border];
+
+  if (data_org[AZ_matrix_type] == AZ_MSR_MATRIX) {
+    if ( (options[AZ_poly_ord] != 0) && (flag == 1) )
+      for (i = data_org[AZ_N_internal]; i < N; i++)
+        x[i] = b[i]/val[i];
+
+    if (options[AZ_poly_ord] > flag) {
+      v = AZ_manage_memory(
+          (N+data_org[AZ_N_external])*sizeof(double),
+          AZ_ALLOC, AZ_SYS+az_iterate_id, "v in do_jacobi", &i
+          );
+
+      for (i = 0; i < N; i++)
+        v[i] = x[i];
+      for (step = flag; step < options[AZ_poly_ord]; step++) {
+        Amat->matvec(v, temp, Amat, proc_config);
+        for(i = 0; i < N; i++)
+          v[i] += (b[i] - temp[i]) / val[i];
       }
+      for (i = 0; i < N; i++)
+        x[i] = v[i];
     }
-    else {
-       (void) AZ_printf_err("AZ_slu with option[AZ_poly_ord] > 0 only \n");
-       (void) AZ_printf_err("implemented for MSR matrices.\n");
-       exit(-1);
-    }
+  }
+  else {
+    (void) AZ_printf_err("AZ_slu with option[AZ_poly_ord] > 0 only \n");
+    (void) AZ_printf_err("implemented for MSR matrices.\n");
+    exit(-1);
+  }
 
 }
 #endif

--- a/packages/epetra/src/Epetra_BlockMap.cpp
+++ b/packages/epetra/src/Epetra_BlockMap.cpp
@@ -1447,8 +1447,9 @@ void Epetra_BlockMap::Print(std::ostream & os) const
   os <<    "Maximum of all GIDs        = "; os << MaxAllGID64(); os << std::endl;
   os <<    "Minimum of all GIDs        = "; os << MinAllGID64(); os << std::endl;
   os <<    "Index Base                 = "; os << IndexBase64(); os << std::endl;
-  if (ConstantElementSize())
+  if (ConstantElementSize()) {
     os <<  "Constant Element Size      = "; os << ElementSize(); os << std::endl;
+  }
       }
       os << std::endl;
 

--- a/packages/epetra/src/Epetra_CrsGraph.cpp
+++ b/packages/epetra/src/Epetra_CrsGraph.cpp
@@ -1061,20 +1061,20 @@ int Epetra_CrsGraph::ComputeGlobalConstants()
     int* ColElementSizeList = RowElementSizeList;
     if(Importer() != 0)
       ColElementSizeList = ColMap().ElementSizeList();
-      const Epetra_CrsGraphData::IndexData<int>& intData = CrsGraphData_->Data<int>();
+    const Epetra_CrsGraphData::IndexData<int>& intData = CrsGraphData_->Data<int>();
     for(int i = 0; i < numMyBlockRows; i++){
       int NumEntries = CrsGraphData_->NumIndicesPerRow_[i];
       int* indices = intData.Indices_[i];
       if(NumEntries > 0) {
-  int CurNumNonzeros = 0;
-  int RowDim = RowElementSizeList[i];
-  for(int j = 0; j < NumEntries; j++) {
-    int ColDim = ColElementSizeList[indices[j]];
-    CurNumNonzeros += RowDim*ColDim;
-    CrsGraphData_->MaxColDim_ = EPETRA_MAX(CrsGraphData_->MaxColDim_, ColDim);
-  }
-  CrsGraphData_->MaxNumNonzeros_ = EPETRA_MAX(CrsGraphData_->MaxNumNonzeros_, CurNumNonzeros);
-  CrsGraphData_->NumMyNonzeros_ += CurNumNonzeros;
+        int CurNumNonzeros = 0;
+        int RowDim = RowElementSizeList[i];
+        for(int j = 0; j < NumEntries; j++) {
+          int ColDim = ColElementSizeList[indices[j]];
+          CurNumNonzeros += RowDim*ColDim;
+          CrsGraphData_->MaxColDim_ = EPETRA_MAX(CrsGraphData_->MaxColDim_, ColDim);
+        }
+        CrsGraphData_->MaxNumNonzeros_ = EPETRA_MAX(CrsGraphData_->MaxNumNonzeros_, CurNumNonzeros);
+        CrsGraphData_->NumMyNonzeros_ += CurNumNonzeros;
       }
     }
 

--- a/packages/epetra/src/Epetra_CrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_CrsMatrix.cpp
@@ -495,7 +495,7 @@ int Epetra_CrsMatrix::PutScalar(double ScalarConstant)
       int NumEntries = Graph().NumMyIndices(i);
       double * targValues = Values(i);
       for(int j=0; j< NumEntries; j++)
-  targValues[j] = ScalarConstant;
+        targValues[j] = ScalarConstant;
     }
   }
   return(0);
@@ -512,7 +512,7 @@ int Epetra_CrsMatrix::Scale(double ScalarConstant)
       int NumEntries = Graph().NumMyIndices(i);
       double * targValues = Values(i);
       for(int j=0; j< NumEntries; j++)
-  targValues[j] *= ScalarConstant;
+        targValues[j] *= ScalarConstant;
     }
   }
   return(0);
@@ -804,9 +804,9 @@ int Epetra_CrsMatrix::InsertValues(int Row, int NumEntries,
            long long* Indices)
 {
   if(RowMap().GlobalIndicesLongLong())
-  return InsertValues<long long>(Row, NumEntries, values, Indices);
+    return InsertValues<long long>(Row, NumEntries, values, Indices);
   else
-  throw ReportError("Epetra_CrsMatrix::InsertValues long long version called for a matrix that is not long long.", -1);
+    throw ReportError("Epetra_CrsMatrix::InsertValues long long version called for a matrix that is not long long.", -1);
 }
 #endif
 
@@ -851,9 +851,9 @@ int Epetra_CrsMatrix::TReplaceGlobalValues(int_type Row, int NumEntries, const d
 #ifndef EPETRA_NO_32BIT_GLOBAL_INDICES
 int Epetra_CrsMatrix::ReplaceGlobalValues(int Row, int NumEntries, const double * srcValues, const int *Indices) {
   if(RowMap().GlobalIndicesInt())
-  return TReplaceGlobalValues<int>(Row, NumEntries, srcValues, Indices);
+    return TReplaceGlobalValues<int>(Row, NumEntries, srcValues, Indices);
   else
-  throw ReportError("Epetra_CrsMatrix::ReplaceGlobalValues int version called for a matrix that is not int.", -1);
+    throw ReportError("Epetra_CrsMatrix::ReplaceGlobalValues int version called for a matrix that is not int.", -1);
 }
 #endif
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
@@ -1031,9 +1031,9 @@ int Epetra_CrsMatrix::SumIntoGlobalValues(int Row,
             const int *Indices)
 {
   if(RowMap().GlobalIndicesInt())
-  return TSumIntoGlobalValues<int>(Row, NumEntries, srcValues, Indices);
+    return TSumIntoGlobalValues<int>(Row, NumEntries, srcValues, Indices);
   else
-  throw ReportError("Epetra_CrsMatrix::SumIntoGlobalValues int version called for a matrix that is not int.", -1);
+    throw ReportError("Epetra_CrsMatrix::SumIntoGlobalValues int version called for a matrix that is not int.", -1);
 }
 #endif
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
@@ -1043,9 +1043,9 @@ int Epetra_CrsMatrix::SumIntoGlobalValues(long long Row,
             const long long *Indices)
 {
   if(RowMap().GlobalIndicesLongLong())
-  return TSumIntoGlobalValues<long long>(Row, NumEntries, srcValues, Indices);
+    return TSumIntoGlobalValues<long long>(Row, NumEntries, srcValues, Indices);
   else
-  throw ReportError("Epetra_CrsMatrix::SumIntoGlobalValues long long version called for a matrix that is not long long.", -1);
+    throw ReportError("Epetra_CrsMatrix::SumIntoGlobalValues long long version called for a matrix that is not long long.", -1);
 }
 #endif
 
@@ -1219,16 +1219,16 @@ int Epetra_CrsMatrix::SortEntries() {
     while(m > 0) {
       int max = n - m;
       for(int j = 0; j < max; j++) {
-  for(int k = j; k >= 0; k-=m) {
-    if(locIndices[k+m] >= locIndices[k])
-      break;
-    double dtemp = locValues[k+m];
-    locValues[k+m] = locValues[k];
-    locValues[k] = dtemp;
-    int itemp = locIndices[k+m];
-    locIndices[k+m] = locIndices[k];
-    locIndices[k] = itemp;
-  }
+        for(int k = j; k >= 0; k-=m) {
+          if(locIndices[k+m] >= locIndices[k])
+            break;
+          double dtemp = locValues[k+m];
+          locValues[k+m] = locValues[k];
+          locValues[k] = dtemp;
+          int itemp = locIndices[k+m];
+          locIndices[k+m] = locIndices[k];
+          locIndices[k] = itemp;
+        }
       }
       m = m/2;
     }
@@ -1259,15 +1259,14 @@ int Epetra_CrsMatrix::MergeRedundantEntries() {
       int curEntry =0;
       double curValue = locValues[0];
       for(int k = 1; k < NumEntries; k++) {
-  if(locIndices[k] == locIndices[k-1])
-    curValue += locValues[k];
-  else {
-    locValues[curEntry++] = curValue;
-    curValue = locValues[k];
-  }
+        if(locIndices[k] == locIndices[k-1])
+          curValue += locValues[k];
+        else {
+          locValues[curEntry++] = curValue;
+          curValue = locValues[k];
+        }
       }
       locValues[curEntry] = curValue;
-
     }
   }
 
@@ -2903,9 +2902,15 @@ void Epetra_CrsMatrix::Print(std::ostream& os) const {
   os <<    "Number of Global Diagonals   = "; os << NumGlobalDiagonals64(); os << std::endl;
   os <<    "Number of Global Nonzeros    = "; os << NumGlobalNonzeros64(); os << std::endl;
   os <<    "Global Maximum Num Entries   = "; os << GlobalMaxNumEntries(); os << std::endl;
-  if (LowerTriangular()) os <<    " ** Matrix is Lower Triangular **"; os << std::endl;
-  if (UpperTriangular()) os <<    " ** Matrix is Upper Triangular **"; os << std::endl;
-  if (NoDiagonal())      os <<    " ** Matrix has no diagonal     **"; os << std::endl; os << std::endl;
+  if (LowerTriangular()) {
+    os <<    " ** Matrix is Lower Triangular **"; os << std::endl;
+  }
+  if (UpperTriangular()) {
+    os <<    " ** Matrix is Upper Triangular **"; os << std::endl;
+  }
+  if (NoDiagonal()) {
+    os <<    " ** Matrix has no diagonal     **"; os << std::endl; os << std::endl;
+  }
       }
 
       os <<  "\nNumber of My Rows        = "; os << NumMyRows(); os << std::endl;
@@ -3897,50 +3902,50 @@ void Epetra_CrsMatrix::GeneralSM(bool Upper, bool Trans, bool UnitDiagonal, doub
 
     else {
       for(k = 0; k < NumVectors; k++)
-  if(Yp[k] != Xp[k])
-    for(i = 0; i < NumMyRows_; i++)
-      Yp[k][i] = Xp[k][i]; // Initialize y for transpose multiply
+        if(Yp[k] != Xp[k])
+          for(i = 0; i < NumMyRows_; i++)
+            Yp[k][i] = Xp[k][i]; // Initialize y for transpose multiply
 
       if(Upper) {
-  j0 = 1;
-  if(NoDiagonal())
-    j0--; // Include first term if no diagonal
+        j0 = 1;
+        if(NoDiagonal())
+          j0--; // Include first term if no diagonal
 
-  for(i = 0; i < NumMyRows_; i++) {
-    int Offset = IndexOffset[i];
-    int      NumEntries = IndexOffset[i+1]-Offset;
-    int *    RowIndices = Indices+Offset;
-    double * RowValues  = values+Offset;
-    if(!UnitDiagonal)
-      diag = 1.0/RowValues[0]; // Take inverse of diagonal once for later use
-    for(k = 0; k < NumVectors; k++) {
-      if(!UnitDiagonal)
-        Yp[k][i] = Yp[k][i]*diag;
-      double ytmp = Yp[k][i];
-      for(j = j0; j < NumEntries; j++)
-        Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
-    }
-  }
+        for(i = 0; i < NumMyRows_; i++) {
+          int Offset = IndexOffset[i];
+          int      NumEntries = IndexOffset[i+1]-Offset;
+          int *    RowIndices = Indices+Offset;
+          double * RowValues  = values+Offset;
+          if(!UnitDiagonal)
+            diag = 1.0/RowValues[0]; // Take inverse of diagonal once for later use
+          for(k = 0; k < NumVectors; k++) {
+            if(!UnitDiagonal)
+              Yp[k][i] = Yp[k][i]*diag;
+            double ytmp = Yp[k][i];
+            for(j = j0; j < NumEntries; j++)
+              Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
+          }
+        }
       }
       else {
-  j0 = 1;
-  if(NoDiagonal())
-    j0--; // Include first term if no diagonal
-  for(i = NumMyRows_ - 1; i >= 0; i--) {
-    int Offset = IndexOffset[i];
-    int      NumEntries = IndexOffset[i+1]-Offset - j0;
-    int *    RowIndices = Indices+Offset;
-    double * RowValues  = values+Offset;
-    if(!UnitDiagonal)
-      diag = 1.0/RowValues[NumEntries]; // Take inverse of diagonal once for later use
-    for(k = 0; k < NumVectors; k++) {
-      if(!UnitDiagonal)
-        Yp[k][i] = Yp[k][i]*diag;
-      double ytmp = Yp[k][i];
-      for(j = 0; j < NumEntries; j++)
-        Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
-    }
-  }
+        j0 = 1;
+        if(NoDiagonal())
+          j0--; // Include first term if no diagonal
+        for(i = NumMyRows_ - 1; i >= 0; i--) {
+          int Offset = IndexOffset[i];
+          int      NumEntries = IndexOffset[i+1]-Offset - j0;
+          int *    RowIndices = Indices+Offset;
+          double * RowValues  = values+Offset;
+          if(!UnitDiagonal)
+            diag = 1.0/RowValues[NumEntries]; // Take inverse of diagonal once for later use
+          for(k = 0; k < NumVectors; k++) {
+            if(!UnitDiagonal)
+              Yp[k][i] = Yp[k][i]*diag;
+            double ytmp = Yp[k][i];
+            for(j = 0; j < NumEntries; j++)
+              Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
+          }
+        }
       }
     }
   }
@@ -3998,48 +4003,48 @@ void Epetra_CrsMatrix::GeneralSM(bool Upper, bool Trans, bool UnitDiagonal, doub
 
     else {
       for(k = 0; k < NumVectors; k++)
-  if(Yp[k] != Xp[k])
-    for(i = 0; i < NumMyRows_; i++)
-      Yp[k][i] = Xp[k][i]; // Initialize y for transpose multiply
+        if(Yp[k] != Xp[k])
+          for(i = 0; i < NumMyRows_; i++)
+            Yp[k][i] = Xp[k][i]; // Initialize y for transpose multiply
 
       if(Upper) {
-  j0 = 1;
-  if(NoDiagonal())
-    j0--; // Include first term if no diagonal
+        j0 = 1;
+        if(NoDiagonal())
+          j0--; // Include first term if no diagonal
 
-  for(i = 0; i < NumMyRows_; i++) {
-    int     NumEntries = NumMyEntries(i);
-    int*    RowIndices = Graph().Indices(i);
-    double* RowValues  = Values(i);
-    if(!UnitDiagonal)
-      diag = 1.0/RowValues[0]; // Take inverse of diagonal once for later use
-    for(k = 0; k < NumVectors; k++) {
-      if(!UnitDiagonal)
-        Yp[k][i] = Yp[k][i]*diag;
-      double ytmp = Yp[k][i];
-      for(j = j0; j < NumEntries; j++)
-        Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
-    }
-  }
+        for(i = 0; i < NumMyRows_; i++) {
+          int     NumEntries = NumMyEntries(i);
+          int*    RowIndices = Graph().Indices(i);
+          double* RowValues  = Values(i);
+          if(!UnitDiagonal)
+            diag = 1.0/RowValues[0]; // Take inverse of diagonal once for later use
+          for(k = 0; k < NumVectors; k++) {
+            if(!UnitDiagonal)
+              Yp[k][i] = Yp[k][i]*diag;
+            double ytmp = Yp[k][i];
+            for(j = j0; j < NumEntries; j++)
+              Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
+          }
+        }
       }
       else {
-  j0 = 1;
-  if(NoDiagonal())
-    j0--; // Include first term if no diagonal
-  for(i = NumMyRows_ - 1; i >= 0; i--) {
-    int     NumEntries = NumMyEntries(i) - j0;
-    int*    RowIndices = Graph().Indices(i);
-    double* RowValues  = Values(i);
-    if(!UnitDiagonal)
-      diag = 1.0/RowValues[NumEntries]; // Take inverse of diagonal once for later use
-    for(k = 0; k < NumVectors; k++) {
-      if(!UnitDiagonal)
-        Yp[k][i] = Yp[k][i]*diag;
-      double ytmp = Yp[k][i];
-      for(j = 0; j < NumEntries; j++)
-        Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
-    }
-  }
+        j0 = 1;
+        if(NoDiagonal())
+          j0--; // Include first term if no diagonal
+        for(i = NumMyRows_ - 1; i >= 0; i--) {
+          int     NumEntries = NumMyEntries(i) - j0;
+          int*    RowIndices = Graph().Indices(i);
+          double* RowValues  = Values(i);
+          if(!UnitDiagonal)
+            diag = 1.0/RowValues[NumEntries]; // Take inverse of diagonal once for later use
+          for(k = 0; k < NumVectors; k++) {
+            if(!UnitDiagonal)
+              Yp[k][i] = Yp[k][i]*diag;
+            double ytmp = Yp[k][i];
+            for(j = 0; j < NumEntries; j++)
+              Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
+          }
+        }
       }
     }
   }
@@ -4534,45 +4539,45 @@ int Epetra_CrsMatrix::Solve1(bool Upper, bool Trans, bool UnitDiagonal, const Ep
   else {
     for(k = 0; k < NumVectors; k++)
       if(Yp[k] != Xp[k])
-  for(i = 0; i < NumMyRows_; i++)
-    Yp[k][i] = Xp[k][i]; // Initialize y for transpose multiply
+        for(i = 0; i < NumMyRows_; i++)
+          Yp[k][i] = Xp[k][i]; // Initialize y for transpose multiply
 
     if(Upper) {
       j0 = 1;
       if(NoDiagonal())
-  j0--; // Include first term if no diagonal
+        j0--; // Include first term if no diagonal
 
       for(i = 0; i < NumMyRows_; i++) {
-  int     NumEntries = *NumEntriesPerRow++;
-  int*    RowIndices = *Indices++;
-  double* RowValues  = *Vals++;
-  if(!UnitDiagonal)
-    diag = 1.0/RowValues[0]; // Take inverse of diagonal once for later use
-  for(k = 0; k < NumVectors; k++) {
-    if(!UnitDiagonal)
-      Yp[k][i] = Yp[k][i]*diag;
-       double ytmp = Yp[k][i];
-    for(j = j0; j < NumEntries; j++)
-      Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
-  }
+        int     NumEntries = *NumEntriesPerRow++;
+        int*    RowIndices = *Indices++;
+        double* RowValues  = *Vals++;
+        if(!UnitDiagonal)
+          diag = 1.0/RowValues[0]; // Take inverse of diagonal once for later use
+        for(k = 0; k < NumVectors; k++) {
+          if(!UnitDiagonal)
+            Yp[k][i] = Yp[k][i]*diag;
+          double ytmp = Yp[k][i];
+          for(j = j0; j < NumEntries; j++)
+            Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
+        }
       }
     }
     else {
       j0 = 1;
       if(NoDiagonal())
-  j0--; // Include first term if no diagonal
+        j0--; // Include first term if no diagonal
       for(i = NumMyRows_ - 1; i >= 0; i--) {
-  int     NumEntries = *NumEntriesPerRow-- - j0;
-  int*    RowIndices = *Indices--;
-  double* RowValues  = *Vals--;
-     if (!UnitDiagonal)
-       diag = 1.0/RowValues[NumEntries]; // Take inverse of diagonal once for later use
-  for(k = 0; k < NumVectors; k++) {
-    if(!UnitDiagonal)
-      Yp[k][i] = Yp[k][i]*diag;
-       double ytmp = Yp[k][i];
-    for(j = 0; j < NumEntries; j++)
-      Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
+        int     NumEntries = *NumEntriesPerRow-- - j0;
+        int*    RowIndices = *Indices--;
+        double* RowValues  = *Vals--;
+        if (!UnitDiagonal)
+          diag = 1.0/RowValues[NumEntries]; // Take inverse of diagonal once for later use
+        for(k = 0; k < NumVectors; k++) {
+          if(!UnitDiagonal)
+            Yp[k][i] = Yp[k][i]*diag;
+          double ytmp = Yp[k][i];
+          for(j = 0; j < NumEntries; j++)
+            Yp[k][RowIndices[j]] -= RowValues[j] * ytmp;
         }
       }
     }

--- a/packages/epetra/src/Epetra_VbrMatrix.cpp
+++ b/packages/epetra/src/Epetra_VbrMatrix.cpp
@@ -416,9 +416,7 @@ void Epetra_VbrMatrix::DeleteMemory()
 
   for (i=0; i<NumMyBlockRows_; i++) {
     int NumAllocatedBlockEntries = NumAllocatedBlockEntriesPerRow_[i];
-
     if (NumAllocatedBlockEntries >0) {
-
       for (int j=0; j < NumAllocatedBlockEntries; j++) {
         if (Entries_[i][j]!=0) {
           delete Entries_[i][j];
@@ -485,9 +483,9 @@ int Epetra_VbrMatrix::PutScalar(double ScalarConstant)
       int LDA = Entries_[i][j]->LDA();
       int ColDim = Entries_[i][j]->N();
       for (int col=0; col < ColDim; col++) {
-  double * Entries = Entries_[i][j]->A()+col*LDA;
-  for (int row=0; row < RowDim; row++)
-    *Entries++ = ScalarConstant;
+        double * Entries = Entries_[i][j]->A()+col*LDA;
+        for (int row=0; row < RowDim; row++)
+          *Entries++ = ScalarConstant;
       }
     }
   }
@@ -507,9 +505,9 @@ int Epetra_VbrMatrix::Scale(double ScalarConstant)
       int LDA = Entries_[i][j]->LDA();
       int ColDim = Entries_[i][j]->N();
       for (int col=0; col < ColDim; col++) {
-  double * Entries = Entries_[i][j]->A()+col*LDA;
-  for (int row=0; row < RowDim; row++)
-    *Entries++ *= ScalarConstant;
+        double * Entries = Entries_[i][j]->A()+col*LDA;
+        for (int row=0; row < RowDim; row++)
+          *Entries++ *= ScalarConstant;
       }
     }
   }
@@ -949,20 +947,20 @@ int Epetra_VbrMatrix::SortEntries() {
     while (m > 0) {
       int max = n - m;
       for (int j=0; j<max; j++)
+      {
+        for (int k=j; k>=0; k-=m)
         {
-    for (int k=j; k>=0; k-=m)
-            {
-        if (Indices[k+m] >= Indices[k])
-    break;
-        Epetra_SerialDenseMatrix *dtemp = Entries[k+m];
-        Entries[k+m] = Entries[k];
-        Entries[k] = dtemp;
+          if (Indices[k+m] >= Indices[k])
+            break;
+          Epetra_SerialDenseMatrix *dtemp = Entries[k+m];
+          Entries[k+m] = Entries[k];
+          Entries[k] = dtemp;
 
-        int itemp = Indices[k+m];
-        Indices[k+m] = Indices[k];
-        Indices[k] = itemp;
-            }
+          int itemp = Indices[k+m];
+          Indices[k+m] = Indices[k];
+          Indices[k] = itemp;
         }
+      }
       m = m/2;
     }
   }
@@ -1669,13 +1667,13 @@ int Epetra_VbrMatrix::Multiply1(bool TransA, const Epetra_Vector& x, Epetra_Vect
       double * cury = yp + *FirstPointInElement++;
       int      RowDim = *ElementSize++;
       for (j=0; j < NumEntries; j++) {
-  //sum += BlockRowValues[j] * xp[BlockRowIndices[j]];
-  double * A = BlockRowValues[j]->A();
-  int LDA = BlockRowValues[j]->LDA();
-  int Index = BlockRowIndices[j];
-  double * curx = xp + ColFirstPointInElementList[Index];
-  int ColDim = ColElementSizeList[Index];
-  GEMV('N', RowDim, ColDim, 1.0, A, LDA, curx, 1.0, cury);
+        //sum += BlockRowValues[j] * xp[BlockRowIndices[j]];
+        double * A = BlockRowValues[j]->A();
+        int LDA = BlockRowValues[j]->LDA();
+        int Index = BlockRowIndices[j];
+        double * curx = xp + ColFirstPointInElementList[Index];
+        int ColDim = ColElementSizeList[Index];
+        GEMV('N', RowDim, ColDim, 1.0, A, LDA, curx, 1.0, cury);
       }
     }
     if (Exporter()!=0) {
@@ -1693,9 +1691,13 @@ int Epetra_VbrMatrix::Multiply1(bool TransA, const Epetra_Vector& x, Epetra_Vect
 
     if (Exporter()!=0) {
       if (ExportVector_!=0) {
-  if (ExportVector_->NumVectors()!=1) { delete ExportVector_; ExportVector_= 0;}
+        if (ExportVector_->NumVectors()!=1) {
+          delete ExportVector_;
+          ExportVector_= 0;
+        }
       }
-      if (ExportVector_==0) ExportVector_ = new Epetra_MultiVector(RowMap(),1); // Create Export vector if needed
+      if (ExportVector_==0)
+        ExportVector_ = new Epetra_MultiVector(RowMap(),1); // Create Export vector if needed
       EPETRA_CHK_ERR(ExportVector_->Import(x, *Exporter(), Insert));
       xp = (double*)ExportVector_->Values();
     }
@@ -1703,9 +1705,13 @@ int Epetra_VbrMatrix::Multiply1(bool TransA, const Epetra_Vector& x, Epetra_Vect
     // If we have a non-trivial importer, we must export elements that are permuted or belong to other processors
     if (Importer()!=0) {
       if (ImportVector_!=0) {
-  if (ImportVector_->NumVectors()!=1) { delete ImportVector_; ImportVector_= 0;}
+        if (ImportVector_->NumVectors()!=1) {
+          delete ImportVector_;
+          ImportVector_= 0;
+        }
       }
-      if (ImportVector_==0) ImportVector_ = new Epetra_MultiVector(ColMap(),1); // Create import vector if needed
+      if (ImportVector_==0)
+        ImportVector_ = new Epetra_MultiVector(ColMap(),1); // Create import vector if needed
       yp = (double*)ImportVector_->Values();
       ColElementSizeList = ColMap().ElementSizeList(); // The Import map will always have an existing ElementSizeList
       ColFirstPointInElementList = ColMap().FirstPointInElementList(); // Import map will always have an existing ...
@@ -1722,13 +1728,13 @@ int Epetra_VbrMatrix::Multiply1(bool TransA, const Epetra_Vector& x, Epetra_Vect
       double * curx = xp + *FirstPointInElement++;
       int      RowDim = *ElementSize++;
       for (j=0; j < NumEntries; j++) {
-  //yp[BlockRowIndices[j]] += BlockRowValues[j] * xp[i];
-  double * A = BlockRowValues[j]->A();
-  int LDA = BlockRowValues[j]->LDA();
-  int Index = BlockRowIndices[j];
-  double * cury = yp + ColFirstPointInElementList[Index];
-  int ColDim = ColElementSizeList[Index];
-  GEMV('T', RowDim, ColDim, 1.0, A, LDA, curx, 1.0, cury);
+        //yp[BlockRowIndices[j]] += BlockRowValues[j] * xp[i];
+        double * A = BlockRowValues[j]->A();
+        int LDA = BlockRowValues[j]->LDA();
+        int Index = BlockRowIndices[j];
+        double * cury = yp + ColFirstPointInElementList[Index];
+        int ColDim = ColElementSizeList[Index];
+        GEMV('T', RowDim, ColDim, 1.0, A, LDA, curx, 1.0, cury);
 
       }
     }
@@ -1791,7 +1797,10 @@ int Epetra_VbrMatrix::DoMultiply(bool TransA, const Epetra_MultiVector& X, Epetr
     // If we have a non-trivial importer, we must import elements that are permuted or are on other processors
     if (Importer()!=0) {
       if (ImportVector_!=0) {
-  if (ImportVector_->NumVectors()!=NumVectors) { delete ImportVector_; ImportVector_= 0;}
+        if (ImportVector_->NumVectors()!=NumVectors) {
+          delete ImportVector_;
+          ImportVector_= 0;
+        }
       }
       // Create import vector if needed
       if (ImportVector_==0) ImportVector_ = new Epetra_MultiVector(ColMap(),NumVectors);
@@ -1805,7 +1814,10 @@ int Epetra_VbrMatrix::DoMultiply(bool TransA, const Epetra_MultiVector& X, Epetr
     // If we have a non-trivial exporter, we must export elements that are permuted or belong to other processors
     if (Exporter()!=0) {
       if (ExportVector_!=0) {
-  if (ExportVector_->NumVectors()!=NumVectors) { delete ExportVector_; ExportVector_= 0;}
+        if (ExportVector_->NumVectors()!=NumVectors) {
+          delete ExportVector_;
+          ExportVector_= 0;
+        }
       }
       // Create Export vector if needed
       if (ExportVector_==0) ExportVector_ = new Epetra_MultiVector(RowMap(),NumVectors);
@@ -1822,172 +1834,173 @@ int Epetra_VbrMatrix::DoMultiply(bool TransA, const Epetra_MultiVector& X, Epetr
     // Do actual computation
     if ( All_Values_ != 0 ) { // Contiguous Storage
       if ( ! TransA && *RowElementSizeList <= 4 ) {
+        int RowDim = *RowElementSizeList ;
 
-  int RowDim = *RowElementSizeList ;
+        Epetra_SerialDenseMatrix* Asub = **Entries;
+        double *A = Asub->A_ ;
 
-  Epetra_SerialDenseMatrix* Asub = **Entries;
-  double *A = Asub->A_ ;
+        if ( NumVectors == 1 ) {
 
-  if ( NumVectors == 1 ) {
+          for (i=0; i < NumMyBlockRows_; i++) {
+            int      NumEntries = *NumBlockEntriesPerRow++;
+            int *    BlockRowIndices = *Indices++;
 
-    for (i=0; i < NumMyBlockRows_; i++) {
-      int      NumEntries = *NumBlockEntriesPerRow++;
-      int *    BlockRowIndices = *Indices++;
+            double * xptr = Xp[0];
+            double y0 = 0.0;
+            double y1 = 0.0;
+            double y2 = 0.0;
+            double y3 = 0.0;
+            switch(RowDim) {
+              case 1:
+                for (int j=0; j < NumEntries; ++j) {
+                  int xoff = ColFirstPointInElementList[*BlockRowIndices++];
 
-      double * xptr = Xp[0];
-      double y0 = 0.0;
-      double y1 = 0.0;
-      double y2 = 0.0;
-      double y3 = 0.0;
-      switch(RowDim) {
-      case 1:
-        for (int j=0; j < NumEntries; ++j) {
-    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                  y0 += A[0]*xptr[xoff];
+                  A += 1;
+                }
+                break;
 
-    y0 += A[0]*xptr[xoff];
-    A += 1;
-        }
-        break;
+              case 2:
+                for (int j=0; j < NumEntries; ++j) {
+                  int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                  y0 += A[0]*xptr[xoff] + A[2]*xptr[xoff+1];
+                  y1 += A[1]*xptr[xoff] + A[3]*xptr[xoff+1];
+                  A += 4 ;
+                }
+                break;
 
-      case 2:
-        for (int j=0; j < NumEntries; ++j) {
-    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
-    y0 += A[0]*xptr[xoff] + A[2]*xptr[xoff+1];
-    y1 += A[1]*xptr[xoff] + A[3]*xptr[xoff+1];
-    A += 4 ;
-        }
-        break;
+              case 3:
+                for (int j=0; j < NumEntries; ++j) {
+                  int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                  y0 += A[0]*xptr[xoff+0] + A[3]*xptr[xoff+1] + A[6]*xptr[xoff+2];
+                  y1 += A[1]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[7]*xptr[xoff+2];
+                  y2 += A[2]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[8]*xptr[xoff+2];
+                  A += 9 ;
+                }
+                break;
 
-      case 3:
-        for (int j=0; j < NumEntries; ++j) {
-    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
-    y0 += A[0]*xptr[xoff+0] + A[3]*xptr[xoff+1] + A[6]*xptr[xoff+2];
-    y1 += A[1]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[7]*xptr[xoff+2];
-    y2 += A[2]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[8]*xptr[xoff+2];
-    A += 9 ;
-        }
-        break;
+              case 4:
+                for (int j=0; j < NumEntries; ++j) {
+                  int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                  y0 += A[0]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[8]*xptr[xoff+2] +A[12]*xptr[xoff+3];
+                  y1 += A[1]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[9]*xptr[xoff+2] +A[13]*xptr[xoff+3];
+                  y2 += A[2]*xptr[xoff+0] + A[6]*xptr[xoff+1] + A[10]*xptr[xoff+2] +A[14]*xptr[xoff+3];
+                  y3 += A[3]*xptr[xoff+0] + A[7]*xptr[xoff+1] + A[11]*xptr[xoff+2] +A[15]*xptr[xoff+3];
+                  A += 16 ;
+                }
+                break;
+              default:
+                assert(false);
+            }
+            int  yoff = *RowFirstPointInElementList++;
+            switch(RowDim) {
+              case 4:
+                *(Yp[0]+yoff+3) = y3;
+              case 3:
+                *(Yp[0]+yoff+2) = y2;
+              case 2:
+                *(Yp[0]+yoff+1) = y1;
+              case 1:
+                *(Yp[0]+yoff) = y0;
+            }
+          }
+        } else { // NumVectors != 1
+          double *OrigA = A ;
+          for (i=0; i < NumMyBlockRows_; i++) {
+            int      NumEntries = *NumBlockEntriesPerRow++;
+            int  yoff = *RowFirstPointInElementList++;
+            int *    BRI = *Indices++;
 
-      case 4:
-        for (int j=0; j < NumEntries; ++j) {
-    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
-    y0 += A[0]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[8]*xptr[xoff+2] +A[12]*xptr[xoff+3];
-    y1 += A[1]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[9]*xptr[xoff+2] +A[13]*xptr[xoff+3];
-    y2 += A[2]*xptr[xoff+0] + A[6]*xptr[xoff+1] + A[10]*xptr[xoff+2] +A[14]*xptr[xoff+3];
-    y3 += A[3]*xptr[xoff+0] + A[7]*xptr[xoff+1] + A[11]*xptr[xoff+2] +A[15]*xptr[xoff+3];
-    A += 16 ;
-        }
-        break;
-      default:
-        assert(false);
-      }
-      int  yoff = *RowFirstPointInElementList++;
-      switch(RowDim) {
-      case 4:
-        *(Yp[0]+yoff+3) = y3;
-      case 3:
-        *(Yp[0]+yoff+2) = y2;
-      case 2:
-        *(Yp[0]+yoff+1) = y1;
-      case 1:
-        *(Yp[0]+yoff) = y0;
-      }
-    }
-  } else { // NumVectors != 1
-    double *OrigA = A ;
-    for (i=0; i < NumMyBlockRows_; i++) {
-      int      NumEntries = *NumBlockEntriesPerRow++;
-      int  yoff = *RowFirstPointInElementList++;
-      int *    BRI = *Indices++;
+            for (int k=0; k<NumVectors; k++) {
+              int *    BlockRowIndices = BRI;
+              A = OrigA ;
+              double * xptr = Xp[k];
+              double y0 = 0.0;
+              double y1 = 0.0;
+              double y2 = 0.0;
+              double y3 = 0.0;
+              switch(RowDim) {
+                case 1:
+                  for (int j=0; j < NumEntries; ++j) {
+                    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
 
-      for (int k=0; k<NumVectors; k++) {
-        int *    BlockRowIndices = BRI;
-        A = OrigA ;
-        double * xptr = Xp[k];
-        double y0 = 0.0;
-        double y1 = 0.0;
-        double y2 = 0.0;
-        double y3 = 0.0;
-        switch(RowDim) {
-        case 1:
-    for (int j=0; j < NumEntries; ++j) {
-      int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                    y0 += A[0]*xptr[xoff];
+                    A += 1;
+                  }
+                  break;
 
-      y0 += A[0]*xptr[xoff];
-      A += 1;
-    }
-    break;
+                case 2:
+                  for (int j=0; j < NumEntries; ++j) {
+                    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                    y0 += A[0]*xptr[xoff] + A[2]*xptr[xoff+1];
+                    y1 += A[1]*xptr[xoff] + A[3]*xptr[xoff+1];
+                    A += 4 ;
+                  }
+                  break;
 
-        case 2:
-    for (int j=0; j < NumEntries; ++j) {
-      int xoff = ColFirstPointInElementList[*BlockRowIndices++];
-      y0 += A[0]*xptr[xoff] + A[2]*xptr[xoff+1];
-      y1 += A[1]*xptr[xoff] + A[3]*xptr[xoff+1];
-      A += 4 ;
-    }
-    break;
-
-        case 3:
-    for (int j=0; j < NumEntries; ++j) {
-      int xoff = ColFirstPointInElementList[*BlockRowIndices++];
-      y0 += A[0]*xptr[xoff+0] + A[3]*xptr[xoff+1] + A[6]*xptr[xoff+2];
-      y1 += A[1]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[7]*xptr[xoff+2];
-      y2 += A[2]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[8]*xptr[xoff+2];
-      A += 9 ;
-    }
-    break;
-      case 4:
-        for (int j=0; j < NumEntries; ++j) {
-    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
-    y0 += A[0]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[8]*xptr[xoff+2] +A[12]*xptr[xoff+3];
-    y1 += A[1]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[9]*xptr[xoff+2] +A[13]*xptr[xoff+3];
-    y2 += A[2]*xptr[xoff+0] + A[6]*xptr[xoff+1] + A[10]*xptr[xoff+2] +A[14]*xptr[xoff+3];
-    y3 += A[3]*xptr[xoff+0] + A[7]*xptr[xoff+1] + A[11]*xptr[xoff+2] +A[15]*xptr[xoff+3];
-    A += 16 ;
-        }
-        break;
-        default:
-    assert(false);
-        }
-        switch(RowDim) {
-        case 4:
-    *(Yp[k]+yoff+3) = y3;
-        case 3:
-    *(Yp[k]+yoff+2) = y2;
-        case 2:
-    *(Yp[k]+yoff+1) = y1;
-        case 1:
-    *(Yp[k]+yoff) = y0;
-        }
-      }
-      OrigA = A ;
-    }
-  } // end else NumVectors != 1
+                case 3:
+                  for (int j=0; j < NumEntries; ++j) {
+                    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                    y0 += A[0]*xptr[xoff+0] + A[3]*xptr[xoff+1] + A[6]*xptr[xoff+2];
+                    y1 += A[1]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[7]*xptr[xoff+2];
+                    y2 += A[2]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[8]*xptr[xoff+2];
+                    A += 9 ;
+                  }
+                  break;
+                case 4:
+                  for (int j=0; j < NumEntries; ++j) {
+                    int xoff = ColFirstPointInElementList[*BlockRowIndices++];
+                    y0 += A[0]*xptr[xoff+0] + A[4]*xptr[xoff+1] + A[8]*xptr[xoff+2] +A[12]*xptr[xoff+3];
+                    y1 += A[1]*xptr[xoff+0] + A[5]*xptr[xoff+1] + A[9]*xptr[xoff+2] +A[13]*xptr[xoff+3];
+                    y2 += A[2]*xptr[xoff+0] + A[6]*xptr[xoff+1] + A[10]*xptr[xoff+2] +A[14]*xptr[xoff+3];
+                    y3 += A[3]*xptr[xoff+0] + A[7]*xptr[xoff+1] + A[11]*xptr[xoff+2] +A[15]*xptr[xoff+3];
+                    A += 16 ;
+                  }
+                  break;
+                default:
+                  assert(false);
+              }
+              switch(RowDim) {
+                case 4:
+                  *(Yp[k]+yoff+3) = y3;
+                case 3:
+                  *(Yp[k]+yoff+2) = y2;
+                case 2:
+                  *(Yp[k]+yoff+1) = y1;
+                case 1:
+                  *(Yp[k]+yoff) = y0;
+              }
+            }
+            OrigA = A ;
+          }
+        } // end else NumVectors != 1
 
       } else {
 
-  for (i=0; i < NumMyBlockRows_; i++) {
-    int      NumEntries = *NumBlockEntriesPerRow++;
-    int *    BlockRowIndices = *Indices++;
-    Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
-    int  yoff = *RowFirstPointInElementList++;
-    int RowDim = *RowElementSizeList++;
+        for (i=0; i < NumMyBlockRows_; i++) {
+          int      NumEntries = *NumBlockEntriesPerRow++;
+          int *    BlockRowIndices = *Indices++;
+          Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
+          int  yoff = *RowFirstPointInElementList++;
+          int RowDim = *RowElementSizeList++;
 
-    FastBlockRowMultiply(TransA, RowDim, NumEntries, BlockRowIndices, yoff,
-             ColFirstPointInElementList, ColElementSizeList,
-             BlockRowValues, Xp, Yp, NumVectors);
-  }
+          FastBlockRowMultiply(TransA, RowDim, NumEntries, BlockRowIndices, yoff,
+              ColFirstPointInElementList, ColElementSizeList,
+              BlockRowValues, Xp, Yp, NumVectors);
+        }
       }
     } else {
       for (i=0; i < NumMyBlockRows_; i++) {
-  int      NumEntries = *NumBlockEntriesPerRow++;
-  int *    BlockRowIndices = *Indices++;
-  Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
-  int  yoff = *RowFirstPointInElementList++;
-  int RowDim = *RowElementSizeList++;
-  BlockRowMultiply(TransA, RowDim, NumEntries, BlockRowIndices, yoff,
-       ColFirstPointInElementList, ColElementSizeList,
-       BlockRowValues, Xp, Yp, NumVectors);
+        int      NumEntries = *NumBlockEntriesPerRow++;
+        int *    BlockRowIndices = *Indices++;
+        Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
+        int  yoff = *RowFirstPointInElementList++;
+        int RowDim = *RowElementSizeList++;
+        BlockRowMultiply(
+            TransA, RowDim, NumEntries, BlockRowIndices, yoff,
+            ColFirstPointInElementList, ColElementSizeList,
+            BlockRowValues, Xp, Yp, NumVectors
+            );
       }
     }
 
@@ -2019,7 +2032,7 @@ int Epetra_VbrMatrix::DoMultiply(bool TransA, const Epetra_MultiVector& X, Epetr
     // If we have a non-trivial importer, we must export elements that are permuted or belong to other processors
     if (Importer()!=0) {
       if (ImportVector_!=0) {
-  if (ImportVector_->NumVectors()!=NumVectors) { delete ImportVector_; ImportVector_= 0;}
+        if (ImportVector_->NumVectors()!=NumVectors) { delete ImportVector_; ImportVector_= 0;}
       }
       // Create import vector if needed
       if (ImportVector_==0) ImportVector_ = new Epetra_MultiVector(ColMap(),NumVectors);
@@ -2036,25 +2049,27 @@ int Epetra_VbrMatrix::DoMultiply(bool TransA, const Epetra_MultiVector& X, Epetr
 
     if ( All_Values_ != 0 ) { // Contiguous Storage
       for (i=0; i < NumMyBlockRows_; i++) {
-  int      NumEntries = *NumBlockEntriesPerRow++;
-  int *    BlockRowIndices = *Indices++;
-  Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
-  int  xoff = *RowFirstPointInElementList++;
-  int RowDim = *RowElementSizeList++;
-  FastBlockRowMultiply(TransA, RowDim, NumEntries, BlockRowIndices, xoff,
-       ColFirstPointInElementList, ColElementSizeList,
-       BlockRowValues, Xp, Yp, NumVectors);
+        int      NumEntries = *NumBlockEntriesPerRow++;
+        int *    BlockRowIndices = *Indices++;
+        Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
+        int  xoff = *RowFirstPointInElementList++;
+        int RowDim = *RowElementSizeList++;
+        FastBlockRowMultiply(
+            TransA, RowDim, NumEntries, BlockRowIndices, xoff,
+            ColFirstPointInElementList, ColElementSizeList,
+            BlockRowValues, Xp, Yp, NumVectors
+            );
       }
     } else {
       for (i=0; i < NumMyBlockRows_; i++) {
-  int      NumEntries = *NumBlockEntriesPerRow++;
-  int *    BlockRowIndices = *Indices++;
-  Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
-  int  xoff = *RowFirstPointInElementList++;
-  int RowDim = *RowElementSizeList++;
-  BlockRowMultiply(TransA, RowDim, NumEntries, BlockRowIndices, xoff,
-       ColFirstPointInElementList, ColElementSizeList,
-       BlockRowValues, Xp, Yp, NumVectors);
+        int      NumEntries = *NumBlockEntriesPerRow++;
+        int *    BlockRowIndices = *Indices++;
+        Epetra_SerialDenseMatrix** BlockRowValues  = *Entries++;
+        int  xoff = *RowFirstPointInElementList++;
+        int RowDim = *RowElementSizeList++;
+        BlockRowMultiply(TransA, RowDim, NumEntries, BlockRowIndices, xoff,
+            ColFirstPointInElementList, ColElementSizeList,
+            BlockRowValues, Xp, Yp, NumVectors);
       }
     }
 
@@ -2076,19 +2091,21 @@ int Epetra_VbrMatrix::DoMultiply(bool TransA, const Epetra_MultiVector& X, Epetr
   return(0);
 }
 //=============================================================================
-void Epetra_VbrMatrix::BlockRowMultiply(bool TransA,
-          int RowDim,
-          int NumEntries,
-          int * BlockIndices,
-          int RowOff,
-          int * FirstPointInElementList,
-          int * ElementSizeList,
-          double Alpha,
-          Epetra_SerialDenseMatrix** As,
-          double ** X,
-          double Beta,
-          double ** Y,
-          int NumVectors) const
+void Epetra_VbrMatrix::BlockRowMultiply(
+    bool TransA,
+    int RowDim,
+    int NumEntries,
+    int * BlockIndices,
+    int RowOff,
+    int * FirstPointInElementList,
+    int * ElementSizeList,
+    double Alpha,
+    Epetra_SerialDenseMatrix** As,
+    double ** X,
+    double Beta,
+    double ** Y,
+    int NumVectors
+    ) const
 {
   //This overloading of BlockRowMultiply is the same as the one below, except
   //that this one accepts Alpha and Beta arguments. This BlockRowMultiply is
@@ -2104,14 +2121,13 @@ void Epetra_VbrMatrix::BlockRowMultiply(bool TransA,
       int ColDim = ElementSizeList[BlockIndex];
 
       for (k=0; k<NumVectors; k++) {
-  double * curx = X[k] + xoff;
-  double * cury = Y[k] + RowOff;
+        double * curx = X[k] + xoff;
+        double * cury = Y[k] + RowOff;
 
-  GEMV('N', RowDim, ColDim, Alpha, A, LDA, curx, Beta, cury);
+        GEMV('N', RowDim, ColDim, Alpha, A, LDA, curx, Beta, cury);
       }//end for (k
     }//end for (j
-  }
-  else { //TransA == true
+  } else { //TransA == true
     for (j=0; j < NumEntries; j++) {
       double * A = As[j]->A();
       int LDA = As[j]->LDA();
@@ -2119,9 +2135,9 @@ void Epetra_VbrMatrix::BlockRowMultiply(bool TransA,
       int yoff = FirstPointInElementList[BlockIndex];
       int ColDim = ElementSizeList[BlockIndex];
       for (k=0; k<NumVectors; k++) {
-  double * curx = X[k] + RowOff;
-  double * cury = Y[k] + yoff;
-  GEMV('T', RowDim, ColDim, Alpha, A, LDA, curx, Beta, cury);
+        double * curx = X[k] + RowOff;
+        double * cury = Y[k] + yoff;
+        GEMV('T', RowDim, ColDim, Alpha, A, LDA, curx, Beta, cury);
       }
     }
   }
@@ -3375,9 +3391,15 @@ void Epetra_VbrMatrix::Print(std::ostream& os) const {
   os <<    "Number of Global Diagonals   = "; os << NumGlobalDiagonals64(); os << std::endl;
   os <<    "Number of Global Nonzeros    = "; os << NumGlobalNonzeros64(); os << std::endl;
   os <<    "Global Maximum Num Entries   = "; os << GlobalMaxNumNonzeros(); os << std::endl;
-  if (LowerTriangular()) os <<    " ** Matrix is Lower Triangular **"; os << std::endl;
-  if (UpperTriangular()) os <<    " ** Matrix is Upper Triangular **"; os << std::endl;
-  if (NoDiagonal())      os <<    " ** Matrix has no diagonal     **"; os << std::endl; os << std::endl;
+  if (LowerTriangular()) {
+    os <<    " ** Matrix is Lower Triangular **"; os << std::endl;
+  }
+  if (UpperTriangular()) {
+    os <<    " ** Matrix is Upper Triangular **"; os << std::endl;
+  }
+  if (NoDiagonal()) {
+    os <<    " ** Matrix has no diagonal     **"; os << std::endl; os << std::endl;
+  }
       }
 
       os <<  "\nNumber of My Block Rows  = "; os << NumMyBlockRows(); os << std::endl;
@@ -3400,63 +3422,67 @@ void Epetra_VbrMatrix::Print(std::ostream& os) const {
     Comm().Barrier();
   }
 
-  {for (int iproc=0; iproc < NumProc; iproc++) {
-    if (MyPID==iproc) {
-      int NumBlockRows1 = NumMyBlockRows();
-      int MaxNumBlockEntries1 = MaxNumBlockEntries();
-      int * BlockIndices1  = new int[MaxNumBlockEntries1];
-      Epetra_SerialDenseMatrix ** Entries1;
-      int RowDim1, NumBlockEntries1;
-      int i, j;
+  {
+    for (int iproc=0; iproc < NumProc; iproc++) {
+      if (MyPID==iproc) {
+        int NumBlockRows1 = NumMyBlockRows();
+        int MaxNumBlockEntries1 = MaxNumBlockEntries();
+        int * BlockIndices1  = new int[MaxNumBlockEntries1];
+        Epetra_SerialDenseMatrix ** Entries1;
+        int RowDim1, NumBlockEntries1;
+        int i, j;
 
-      if (MyPID==0) {
-  os.width(8);
-  os <<  "   Processor ";
-  os.width(10);
-  os <<  "   Block Row Index ";
-  os.width(10);
-  os <<  "   Block Col Index \n";
-  os.width(20);
-  os <<  "   values     ";
-  os << std::endl;
-      }
-      for (i=0; i<NumBlockRows1; i++) {
-  int BlockRow1 = GRID64(i); // Get global row number// FIXME long long
-  ExtractGlobalBlockRowPointers(BlockRow1, MaxNumBlockEntries1, RowDim1,
+        if (MyPID==0) {
+          os.width(8);
+          os <<  "   Processor ";
+          os.width(10);
+          os <<  "   Block Row Index ";
+          os.width(10);
+          os <<  "   Block Col Index \n";
+          os.width(20);
+          os <<  "   values     ";
+          os << std::endl;
+        }
+        for (i=0; i<NumBlockRows1; i++) {
+          int BlockRow1 = GRID64(i); // Get global row number// FIXME long long
+          ExtractGlobalBlockRowPointers(
+              BlockRow1, MaxNumBlockEntries1, RowDim1,
               NumBlockEntries1, BlockIndices1,
-              Entries1);
+              Entries1
+              );
 
-  for (j = 0; j < NumBlockEntries1 ; j++) {
-    os.width(8);
-    os <<  MyPID ; os << "    ";
-    os.width(10);
-    os <<  BlockRow1 ; os << "    ";
-    os.width(10);
-    os <<  BlockIndices1[j]; os << "    " << std::endl;
-    os.width(20);
+          for (j = 0; j < NumBlockEntries1 ; j++) {
+            os.width(8);
+            os <<  MyPID ; os << "    ";
+            os.width(10);
+            os <<  BlockRow1 ; os << "    ";
+            os.width(10);
+            os <<  BlockIndices1[j]; os << "    " << std::endl;
+            os.width(20);
 
-          if (Entries1[j] == 0) {
-            os << "Block Entry == NULL"<< std::endl;
-            continue;
+            if (Entries1[j] == 0) {
+              os << "Block Entry == NULL"<< std::endl;
+              continue;
+            }
+
+            Epetra_SerialDenseMatrix entry_view(View, Entries1[j]->A(), Entries1[j]->LDA(),
+                RowDim1, Entries1[j]->N());
+            os << entry_view; os << "    ";
+            os << std::endl;
           }
+        }
 
-    Epetra_SerialDenseMatrix entry_view(View, Entries1[j]->A(), Entries1[j]->LDA(),
-           RowDim1, Entries1[j]->N());
-          os << entry_view; os << "    ";
-    os << std::endl;
-  }
+        delete [] BlockIndices1;
+
+        os << std::flush;
+
       }
-
-      delete [] BlockIndices1;
-
-      os << std::flush;
-
+      // Do a few global ops to give I/O a chance to complete
+      Comm().Barrier();
+      Comm().Barrier();
+      Comm().Barrier();
     }
-    // Do a few global ops to give I/O a chance to complete
-    Comm().Barrier();
-    Comm().Barrier();
-    Comm().Barrier();
-  }}
+  }
 
   return;
 }

--- a/packages/epetraext/src/transform/EpetraExt_Reindex_LinearProblem.cpp
+++ b/packages/epetraext/src/transform/EpetraExt_Reindex_LinearProblem.cpp
@@ -78,20 +78,20 @@ operator()( OriginalTypeRef orig )
     int NumMyElements = OldRowMap.NumMyElements();
 
 #ifndef EPETRA_NO_32BIT_GLOBAL_INDICES
-  if(OldRowMap.GlobalIndicesInt()) {
-    int NumGlobalElements = OldRowMap.NumGlobalElements();
-    NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0, OldRowMap.Comm() );
-  }
-  else
+    if(OldRowMap.GlobalIndicesInt()) {
+      int NumGlobalElements = OldRowMap.NumGlobalElements();
+      NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0, OldRowMap.Comm() );
+    }
+    else
 #endif
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
-  if(OldRowMap.GlobalIndicesLongLong()) {
-    long long NumGlobalElements = OldRowMap.NumGlobalElements64();
-    NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0LL, OldRowMap.Comm() );
-  }
-  else
+    if(OldRowMap.GlobalIndicesLongLong()) {
+      long long NumGlobalElements = OldRowMap.NumGlobalElements64();
+      NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0LL, OldRowMap.Comm() );
+    }
+    else
 #endif
-    throw "LinearProblem_Reindex::operator(): GlobalIndices type unknown for OldRowMap";
+      throw "LinearProblem_Reindex::operator(): GlobalIndices type unknown for OldRowMap";
 
     NewRowMapOwned_ = true;
   }

--- a/packages/epetraext/src/transform/EpetraExt_Reindex_LinearProblem2.cpp
+++ b/packages/epetraext/src/transform/EpetraExt_Reindex_LinearProblem2.cpp
@@ -81,20 +81,20 @@ operator()( OriginalTypeRef orig )
     int NumMyElements = OldRowMap.NumMyElements();
 
 #ifndef EPETRA_NO_32BIT_GLOBAL_INDICES
-  if(OldRowMap.GlobalIndicesInt()) {
-	int NumGlobalElements = OldRowMap.NumGlobalElements();
-    NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0, OldRowMap.Comm() );
-  }
-  else
+    if(OldRowMap.GlobalIndicesInt()) {
+      int NumGlobalElements = OldRowMap.NumGlobalElements();
+      NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0, OldRowMap.Comm() );
+    }
+    else
 #endif
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
-  if(OldRowMap.GlobalIndicesLongLong()) {
-	long long NumGlobalElements = OldRowMap.NumGlobalElements64();
-    NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0LL, OldRowMap.Comm() );
-  }
-  else
+    if(OldRowMap.GlobalIndicesLongLong()) {
+      long long NumGlobalElements = OldRowMap.NumGlobalElements64();
+      NewRowMap_ = new Epetra_Map( NumGlobalElements, NumMyElements, 0LL, OldRowMap.Comm() );
+    }
+    else
 #endif
-    throw "LinearProblem_Reindex2::operator(): GlobalIndices type unknown";
+      throw "LinearProblem_Reindex2::operator(): GlobalIndices type unknown";
 
     NewRowMapOwned_ = true;
   }

--- a/packages/isorropia/src/epetra/Isorropia_EpetraMatcher.cpp
+++ b/packages/isorropia/src/epetra/Isorropia_EpetraMatcher.cpp
@@ -409,29 +409,37 @@ Matcher::Matcher(Teuchos::RCP<const Epetra_CrsGraph> graphPtr,const Teuchos::Par
 
 Matcher::~Matcher()
 {
-    delete [] mateU_;
-    delete [] mateV_;
+  delete [] mateU_;
+  delete [] mateV_;
 
-    if(choice_==1 || choice_==2)
-    {
-        delete [] LU_;
-        delete [] LV_;
-        delete [] Queue_;
-    }
-    if(choice_==1 ||choice_==4)
-        delete [] lookahead_;
-    if(choice_==3 ||choice_==4)
-        delete [] unmatchedU_;
+  if(choice_==1 || choice_==2)
+  {
+    delete [] LU_;
+    delete [] LV_;
+    delete [] Queue_;
+  }
+  if(choice_==1 || choice_==4)
+    delete [] lookahead_;
+  if(choice_==3 || choice_==4)
+    delete [] unmatchedU_;
 
-    if (CRS_indices_) delete [] CRS_indices_; CRS_indices_ = NULL;
-    if (CRS_pointers_) delete [] CRS_pointers_; CRS_pointers_ = NULL;
-    if (parent_) delete [] parent_; parent_ = NULL;
+  if (CRS_indices_) {
+    delete [] CRS_indices_;
+    CRS_indices_ = NULL;
+  }
+  if (CRS_pointers_) {
+    delete [] CRS_pointers_;
+    CRS_pointers_ = NULL;
+  }
+  if (parent_) {
+    delete [] parent_;
+    parent_ = NULL;
+  }
 
 #ifdef ISORROPIA_HAVE_OMP
-    for(int i=0;i<V_;i++)
-        omp_destroy_lock(&scannedV_[i]);
+    for(int i=0; i < V_;i++)
+      omp_destroy_lock(&scannedV_[i]);
 #endif
-
 }
 
 void Matcher::getMatchedColumnsForRowsCopy(int len, int& size, int* array) const

--- a/packages/isorropia/utils/ispatest_lbeval_utils.cpp
+++ b/packages/isorropia/utils/ispatest_lbeval_utils.cpp
@@ -449,7 +449,7 @@ static int compute_hypergraph_metrics(const Epetra_BlockMap &rowmap,
   if ((totalHEWeights > 0) && (totalHEWeights <  numGlobalColumns)){
     if (myProc == 0)
       std::cerr << "Must supply either no h.e. weights or else supply at least one for each column" << std::endl;
-      return -1;
+    return -1;
   }
 
   std::map<int, float>::iterator heWgtIter;

--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
@@ -483,8 +483,8 @@ MultiLevelPreconditioner(const Epetra_RowMatrix & CurlCurlMatrix,
 }
 #ifdef NewStuff
 // ================================================ ====== ==== ==== == =
-/*! Constructor for multiphysics problems with variable dofs per node.  This version uses a 
- *  discrete laplacian and padding on coarse grids to make a hierarchy. It also allows for 
+/*! Constructor for multiphysics problems with variable dofs per node.  This version uses a
+ *  discrete laplacian and padding on coarse grids to make a hierarchy. It also allows for
  *  the removal of column nonzeros associated with Dirichlet points. To use this option
  *  the rhs and initial guess must be provided.
  */
@@ -508,7 +508,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
               dynamic_cast<Epetra_CrsMatrix *>(&RowMatrix);
 
   TEUCHOS_TEST_FOR_EXCEPT_MSG(Acrs == NULL,
-             ErrorMsg_ << "matrix must be crs to use this constructor\n"); 
+             ErrorMsg_ << "matrix must be crs to use this constructor\n");
 
   int nDofs = Acrs->NumMyRows();
   int *dofGlobals;
@@ -523,7 +523,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
   MLVec<bool> dofPresent(NotMLVecDofPresent,NotMLVecDofPresent+nNodes*maxDofPerNode);
 
   RowMatrix.Comm().SumAll(&itemp,&nGlobalNodes,1);
-  
+
   double *XXX = NULL, *YYY = NULL, *ZZZ = NULL;
 
   XXX = List_.get("x-coordinates",(double *) 0);
@@ -531,7 +531,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
   ZZZ = List_.get("z-coordinates",(double *) 0);
 
   TEUCHOS_TEST_FOR_EXCEPT_MSG( (XXX == NULL) && (nDofs != 0),
-             ErrorMsg_ << "Must supply coordinates to use multiphysics variable dof constructor\n"); 
+             ErrorMsg_ << "Must supply coordinates to use multiphysics variable dof constructor\n");
 
   struct wrappedCommStruct epetraFramework;
 
@@ -567,8 +567,8 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
   MLextractDiag(rowPtr,   cols, vals, theDiag, epetraFramework);
   MLfindDirichlets(rowPtr,cols, vals, theDiag, dirDropTol, dirOrNot, epetraFramework);
 
-  // if the rhs and solution are provided, remove column entries 
-  // associated with Dirichlet rows. Here, we overwrite the original 
+  // if the rhs and solution are provided, remove column entries
+  // associated with Dirichlet rows. Here, we overwrite the original
   // matrix arrays to reflect removal.
 
   if (rhsAndsolProvided) {
@@ -612,8 +612,8 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
    MLrmDifferentDofsCrossings(dofPresent,maxDofPerNode,amalgRowPtr,amalgCols,nDofs+nGhost, epetraFramework, myLocalNodeIds);
 
    int iiii = amalgColMap.size();
-   
-   MLVec<double> ghostedXXX(iiii); 
+
+   MLVec<double> ghostedXXX(iiii);
    if (YYY == NULL) iiii = 0;
    MLVec<double> ghostedYYY(iiii);
    if (ZZZ == NULL) iiii = 0;
@@ -680,9 +680,9 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
 // the code is hidden behind an ifdef in ML_agg_MIS.c. You can use run in parallel
 // turning on ML_AGGR_OUTAGGR. This will output a bunch of files (one per proc per
 // level). You need to cat together files associated with each level (e.g.,
-// cat agg*_0 > agg_0 ; cat agg*_1 > agg_1 ; ....). Then, recompile with 
+// cat agg*_0 > agg_0 ; cat agg*_1 > agg_1 ; ....). Then, recompile with
 // ML_AGGR_OUTAGGR undefined but ML_AGGR_INAGGR defined. Not run in serial.
-// If the smoother is jacobi, and the max eigenvalue is fixed independent of the 
+// If the smoother is jacobi, and the max eigenvalue is fixed independent of the
 // number of procs (e.g., hacking in return 2.0; inside ML_Krylov_Get_MaxEigenvalue()),
 // then the output should be the same as the parallel run
 
@@ -693,11 +693,11 @@ extern_index = (int *) ML_allocate(sizeof(int)*(nDofs+nGhost));
 for (int i = 0; i < nNodes; i++) update_index[i] = i;
 for (int i = 0; i < nGhost; i++) extern_index[i] = i+nNodes;
 external = &(update[nNodes]);
-#endif 
+#endif
 
   RowMatrix_ = LapMat;
-  AllocatedRowMatrix_ = false;  
-                                
+  AllocatedRowMatrix_ = false;
+
   ML_CHK_ERRV(Initialize());
 
   DontSetSmoothers_ = true;   // don't make smoothers based on Laplacian
@@ -715,14 +715,14 @@ Comm_ = &(RowMatrix.Comm());
 DomainMap_ = &(RowMatrix.OperatorDomainMap());
 RangeMap_ = &(RowMatrix.OperatorRangeMap());
 
-  
+
   int levelIndex, levelIncr = -1;
 
   levelIndex = ml_->ML_finest_level;
   if (levelIndex == 0) levelIncr = 1;
 
   // shove the real matrix into ML
-    
+
   int numMyRows = Acrs->NumMyRows();
   int N_ghost   = Acrs->NumMyCols() - numMyRows;
 
@@ -730,7 +730,7 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
   ML_Operator_Init(&(altml->Amat[levelIndex]), altml->comm);
   delete LapMat;
   delete epetAmalgColMap;
-  delete epetAmalgRowMap;  
+  delete epetAmalgRowMap;
   ML_Init_Amatrix(altml,levelIndex,numMyRows, numMyRows, (void *) Acrs);
   altml->Amat[levelIndex].type = ML_TYPE_CRS_MATRIX;
   ML_Set_Amatrix_Getrow(altml, levelIndex, ML_Epetra_CrsMatrix_getrow,
@@ -747,10 +747,10 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
     struct ML_CSR_MSRdata* ptr= (struct ML_CSR_MSRdata *) ml_->Pmat[levelIndex+levelIncr].data;
 
      // wrap crs stuff into std vectors
-    
+
     nNodesCoarse = ml_->Pmat[levelIndex+levelIncr].invec_leng;
 
-    MLVec<int>     PAmalgRowPtr(ptr->rowptr,ptr->rowptr+nNodesFine+1); 
+    MLVec<int>     PAmalgRowPtr(ptr->rowptr,ptr->rowptr+nNodesFine+1);
     MLVec<int>     PAmalgCols(ptr->columns,ptr->columns+(ptr->rowptr)[nNodesFine] );
     MLVec<double>  PAmalgVals(ptr->values,ptr->values + (ptr->rowptr)[nNodesFine] );
     MLVec<int>     newPRowPtr(nDofs+1);
@@ -775,7 +775,7 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
     mlFramework.myPid    = RowMatrix.Comm().MyPID();
     mlFramework.maxDofPerNode = maxDofPerNode;
     mlFramework.vecSize    = maxDofPerNode*(nGhostNew+ml_->Pmat[levelIndex+levelIncr].invec_leng);
-   
+
     MLShove(&(altml->Pmat[levelIndex+levelIncr]),newPRowPtr,newPCols,newPVals,
             ml_->Pmat[levelIndex+levelIncr].invec_leng*maxDofPerNode,
             dofCommUsingMlNodalMatrix, mlFramework, maxDofPerNode*nGhostNew);
@@ -785,7 +785,7 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
                            &(altml->SingleLevel[levelIndex]));
 
     // take the transpose and push in Rmat
-   
+
     ML_Operator_Clean(&(altml->Rmat[levelIndex]));
     ML_Operator_Init(&(altml->Rmat[levelIndex]), altml->comm);
     ML_Gen_Restrictor_TransP(altml, levelIndex, levelIndex+levelIncr, NULL);
@@ -798,36 +798,36 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
 
     int nCoarse = altml->Amat[levelIndex+levelIncr].outvec_leng;
 
-    // the coarse level matrix might have some empty rows due to the 
+    // the coarse level matrix might have some empty rows due to the
     // padding intended to force all coarse matrices to have the same
-    // number of dofs per node. For these empty rows, we want to 
+    // number of dofs per node. For these empty rows, we want to
     // stick in some Dirichlet points. It turns out that this would
-    // be real easy with ML's MSR matrices. We would just looks for 
+    // be real easy with ML's MSR matrices. We would just looks for
     // zeros on the diagonal and replace them by ones. However, I'd
     // like to prepare the code for MueLu and CRS matrices. So ...
     // I instead copy the MSR data to a buncy of CRS arrays. I then
     // invoke MLfindEmptyRows() & MLreplaceEmptyByDir() that are intended
     // for CRS matrices. Finally, I need to copy these back to the
     // MSR that ML wants.
-  
+
     // For a code like MueLu that works with CRS matrices, we could
     // perhaps just wrap the CRS vectors into MLVec's instead of copy as is
-    // done for ML. We'd have to be careful that there is actually 
+    // done for ML. We'd have to be careful that there is actually
     // enough storage for the new 1's entries.
     //
-    //  MLVec<int>    AcoarseRowPtr(newptr->rowptr, newptr->rowptr +  nCoarse+1); 
+    //  MLVec<int>    AcoarseRowPtr(newptr->rowptr, newptr->rowptr +  nCoarse+1);
     //  MLVec<int>    AcoarseCols(  newptr->columns,newptr->columns + (newptr->rowptr)[nCoarse] );
     //  MLVec<double> AcoarseVals(  newptr->values, newptr->values  + (newptr->rowptr)[nCoarse] );
-    // 
-    //    
+    //
+    //
 
     // count the number of nonzeros (for ML)
 
     int count = 0;
-    for (int i = 0; i < (newptr->columns)[nCoarse]; i++) 
+    for (int i = 0; i < (newptr->columns)[nCoarse]; i++)
       if (newptr->values[i] != 0.0) count++;
 
-    MLVec<int>      AcoarseRowPtr( nCoarse+1); 
+    MLVec<int>      AcoarseRowPtr( nCoarse+1);
     MLVec<int>     AcoarseCols(  count );
     MLVec<double>  AcoarseVals(  count );
 
@@ -865,13 +865,13 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
        }
        (newptr->columns)[i+1] =  count;
     }
-    AcoarseRowPtr.resize(0); AcoarseCols.resize(0); AcoarseVals.resize(0); 
-    
+    AcoarseRowPtr.resize(0); AcoarseCols.resize(0); AcoarseVals.resize(0);
+
     // compute the status array for the next level indicating whether dofs
-    // are padded or real. 
+    // are padded or real.
 
     MLVec<bool>   empty;
-    if (ii != ml_->ML_num_actual_levels - 2) 
+    if (ii != ml_->ML_num_actual_levels - 2)
       MLcoarseStatus(rowEmpty, empty , status);
 
     rowEmpty.resize(0);   // MLVec.resize(0) actually frees space
@@ -901,14 +901,14 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
  *  by simply duplicating the supernodes row of P for each of the individual
  *  vertices that contribute to the supernode. If share dofs are weakly
  *  connected (or not connected at all), nothing special is done (other than
- *  the ususal ignoring of weak connections). One last trick is employed, 
+ *  the ususal ignoring of weak connections). One last trick is employed,
  *  connections between supernodes and non-supernodes (i.e., regular nodes)
  *  are always assumed to be weak. Shared nodes are often used to capture
  *  interfaces or other features. By breaking these connections, the AMG
  *  can better maintain these features throughout the hierarchy. Finally, the
  *  constructor also allows for *  the removal of column nonzeros associated
  *  with Dirichlet points. To use this option the rhs and initial guess must be
- *  provided. Modification of the matrix, rhs, and initial guess must be 
+ *  provided. Modification of the matrix, rhs, and initial guess must be
  *  allowable to use this option.
  */
 ML_Epetra::MultiLevelPreconditioner::
@@ -932,7 +932,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
               dynamic_cast<Epetra_CrsMatrix *>(&RowMatrix);
 
   TEUCHOS_TEST_FOR_EXCEPT_MSG(Acrs == NULL,
-             ErrorMsg_ << "matrix must be crs to use this constructor\n"); 
+             ErrorMsg_ << "matrix must be crs to use this constructor\n");
 
   int nDofs = Acrs->NumMyRows();
   int *dofGlobals;
@@ -948,7 +948,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
   ZZZ = List_.get("z-coordinates",(double *) 0);
 
   TEUCHOS_TEST_FOR_EXCEPT_MSG(XXX == NULL,
-             ErrorMsg_ << "Must supply coordinates to use shaerd dof constructor\n"); 
+             ErrorMsg_ << "Must supply coordinates to use shaerd dof constructor\n");
 
   struct wrappedCommStruct epetraFramework;
 
@@ -982,8 +982,8 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
   MLextractDiag(rowPtr,   cols, vals, theDiag, epetraFramework);
   MLfindDirichlets(rowPtr,cols, vals, theDiag, dirDropTol, dirOrNot, epetraFramework);
 
-  // if the rhs and solution are provided, remove column entries 
-  // associated with Dirichlet rows. Here, we overwrite the original 
+  // if the rhs and solution are provided, remove column entries
+  // associated with Dirichlet rows. Here, we overwrite the original
   // matrix arrays to reflect removal.
 
   if (rhsAndsolProvided) {
@@ -1016,10 +1016,10 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
         epetraFramework, nLocalNodes, nLocalPlusGhostNodes);
 
     int iiii = Acrs->ColMap().NumMyElements();
-   
+
     MLVec<double> xx(iiii);   if (YYY == NULL) iiii = 0;
     MLVec<double> yy(iiii);   if (ZZZ == NULL) iiii = 0;
-    MLVec<double> zz(iiii); 
+    MLVec<double> zz(iiii);
 
     for (int i = 0; i < nDofs; i++) xx[i] = XXX[i];
     nodalComm(xx, myLocalNodeIds, epetraFramework);
@@ -1032,7 +1032,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
       for (int i = 0; i < nDofs; i++) zz[i] = ZZZ[i];
       nodalComm(zz, myLocalNodeIds, epetraFramework);
     }
-    
+
     MLVec<int> newGlobals(iiii);
 
     ZeroDist(xx,yy,zz,rowPtr,cols,vals,theDiag,tol,rowZeros,colZeros,distTol);
@@ -1052,7 +1052,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
     int        nNonShared;
 
     nNonShared = BuildNonSharedMap(newMap, groupHead, groupNext);
-    
+
     // fill the ghost part of newMap
     newMap.resize(nDofs+nGhost);
     nodalComm(groupHead, myLocalNodeIds, epetraFramework);
@@ -1078,7 +1078,7 @@ MultiLevelPreconditioner(Epetra_RowMatrix & RowMatrix,
     MLVec<int> newRowPtr(nNonShared+1);
     MLVec<int> newCols(cols.size());
 
-    buildCompressedA(rowPtr, cols, vals, theDiag, groupHead, groupNext, 
+    buildCompressedA(rowPtr, cols, vals, theDiag, groupHead, groupNext,
                      newRowPtr, newCols, newMap, nNonShared, tol);
 
     MLVec<double> newVals(newCols.size());
@@ -1126,8 +1126,8 @@ external = &(update[nNonShared]);
 #endif
 
   RowMatrix_ = LapMat;
-  AllocatedRowMatrix_ = false;  
-                                
+  AllocatedRowMatrix_ = false;
+
   ML_CHK_ERRV(Initialize());
 
   DontSetSmoothers_ = true;   // don't make smoothers based on Laplacian
@@ -1145,14 +1145,14 @@ Comm_ = &(RowMatrix.Comm());
 DomainMap_ = &(RowMatrix.OperatorDomainMap());
 RangeMap_ = &(RowMatrix.OperatorRangeMap());
 
-  
+
   int levelIndex, levelIncr = -1;
 
   levelIndex = ml_->ML_finest_level;
   if (levelIndex == 0) levelIncr = 1;
 
   // shove actual discretization matrix into ML
-    
+
   int numMyRows = Acrs->NumMyRows();
   int N_ghost   = Acrs->NumMyCols() - numMyRows;
 
@@ -1160,7 +1160,7 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
   ML_Operator_Init(&(altml->Amat[levelIndex]), altml->comm);
   delete LapMat;
   delete epetNewColMap;
-  delete epetNewRowMap;  
+  delete epetNewRowMap;
   ML_Init_Amatrix(altml,levelIndex,numMyRows, numMyRows, (void *) Acrs);
   altml->Amat[levelIndex].type = ML_TYPE_CRS_MATRIX;
   ML_Set_Amatrix_Getrow(altml, levelIndex, ML_Epetra_CrsMatrix_getrow,
@@ -1176,7 +1176,7 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
   int                  *Prowptr= ptr->rowptr;
 
   // count the number of nonzeros in uncompressed P
-    
+
   int nnz = 0;
   for (int i = 0; i < nDofs; i++) {
      int j = newMap[i];
@@ -1184,7 +1184,7 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
   }
 
   // allocated new CSR arrays and fill with uncompressed data
-  
+
   MLVec<int> newPRowPtr(nDofs+1);
   MLVec<int>     newPCols(nnz);
   MLVec<double>  newPVals(nnz);
@@ -1200,30 +1200,30 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
     newPRowPtr[i+1] = nnz;
   }
 
-  // stick new CSR arrays into the hierarchy 
- 
+  // stick new CSR arrays into the hierarchy
+
   struct ML_CSR_MSRdata* Newptr = (struct ML_CSR_MSRdata *) ML_allocate(sizeof(struct ML_CSR_MSRdata));
   if (Newptr == NULL) pr_error("no space for NewPtr\n");
 
   Newptr->rowptr  = newPRowPtr.getptr();     // getptr() + relinquishData
-  Newptr->columns = newPCols.getptr();       // effectively pulls data  
-  Newptr->values  = newPVals.getptr();       // out of a MLVec and empties 
+  Newptr->columns = newPCols.getptr();       // effectively pulls data
+  Newptr->values  = newPVals.getptr();       // out of a MLVec and empties
   newPRowPtr.relinquishData();               // MLVec's contents
-  newPCols.relinquishData();                
+  newPCols.relinquishData();
   newPVals.relinquishData();
 
 
   // old communication widget should still be good as uncompressed matrix has
   // the same ghost information. So, we'll take it out of the hierarchy, then
   // set it to null within the hierarchy so that ML_Operator_Clean() does not
-  // free it. Then later will manuall assign the save point to the new 
+  // free it. Then later will manuall assign the save point to the new
   // uncompressed matrix within the hierarchy
-  
+
   int insize  = ml_->Pmat[levelIndex+levelIncr].invec_leng;
   ML_CommInfoOP *newPrecComm = altml->Pmat[levelIndex+levelIncr].getrow->pre_comm;
   altml->Pmat[levelIndex+levelIncr].getrow->pre_comm = NULL;
   ML_Operator_Clean(&(altml->Pmat[levelIndex+levelIncr]));
-  ML_Operator_Init(&(altml->Pmat[levelIndex+levelIncr]), altml->comm); 
+  ML_Operator_Init(&(altml->Pmat[levelIndex+levelIncr]), altml->comm);
   ML_Operator_Set_ApplyFuncData(&(altml->Pmat[levelIndex+levelIncr]), insize,
                                 nDofs, Newptr, nDofs, NULL,0);
   ML_Operator_Set_Getrow(&(altml->Pmat[levelIndex+levelIncr]),nDofs,CSR_getrow);
@@ -1237,12 +1237,12 @@ RangeMap_ = &(RowMatrix.OperatorRangeMap());
                           &(altml->SingleLevel[levelIndex]));
 
   // take the transpose and push in Rmat
-   
+
   ML_Operator_Clean(&(altml->Rmat[levelIndex]));
   ML_Operator_Init(&(altml->Rmat[levelIndex]), altml->comm);
   ML_Gen_Restrictor_TransP(altml, levelIndex, levelIndex+levelIncr, NULL);
 
-  // re-do all RAPs with the real A (as opposesd to Laplacian) 
+  // re-do all RAPs with the real A (as opposesd to Laplacian)
   for (int ii = 0; ii < ml_->ML_num_actual_levels - 1 ; ii++) {
 
     ML_Operator_Clean(&(altml->Amat[levelIndex+levelIncr]));
@@ -2015,7 +2015,7 @@ ComputePreconditioner(const bool CheckPreconditioner)
     ml_nodes_->comm->ML_mypid  = Comm().MyPID();
     ml_nodes_->output_level = OutputLevel;
 #ifdef ML_MPI
-    ml_nodes_->comm->USR_comm = dynamic_cast<const Epetra_MpiComm*>(&Comm())->Comm(); 
+    ml_nodes_->comm->USR_comm = dynamic_cast<const Epetra_MpiComm*>(&Comm())->Comm();
 #endif
     ML_Set_Label(ml_nodes_, const_cast<char*>("nodes"));
 #ifdef HAVE_ML_EPETRAEXT
@@ -4348,13 +4348,13 @@ ResetTime()
 */
 
 #ifdef NewStuff
-// All of these functions are used by the multiphysics variable dof per node 
+// All of these functions are used by the multiphysics variable dof per node
 // precondiitoner. They should be made as private functions of this class.
 
 int MLcolGlobalIds(struct wrappedCommStruct& framework, MLVec<int>& myGids)
 {
    /***************************************************************************
-    Gets global column ids from an epetra matrx. 
+    Gets global column ids from an epetra matrx.
    ***************************************************************************/
 
    int nLocal;
@@ -4419,8 +4419,8 @@ int dofCommUsingMlNodalMatrix(double *data, void *widget)
 int MLnMyGhost(struct wrappedCommStruct& framework)
 {
    /***************************************************************************
-    Determine the number of ghost nodes based on either an ML matrix or an 
-    epetra matrix. 
+    Determine the number of ghost nodes based on either an ML matrix or an
+    epetra matrix.
    ***************************************************************************/
 
    if (framework.whichOne == mlType) {
@@ -4437,11 +4437,11 @@ int MLnMyGhost(struct wrappedCommStruct& framework)
    }
 }
 
-/*! 
-  @brief Take Crs std::vec's, make arrays and shove them into an ML Operator 
- 
+/*!
+  @brief Take Crs std::vec's, make arrays and shove them into an ML Operator
+
   This includes allocating double arrays and a widget to point to them and
-  calling all the appropriate ML functions to clean out what used to be in the 
+  calling all the appropriate ML functions to clean out what used to be in the
   operator before inserting the new matrix.
 
   @param[in] rowPtr,cols,vals    Crs matrix std:vectors
@@ -4449,37 +4449,39 @@ int MLnMyGhost(struct wrappedCommStruct& framework)
 */
 int MLShove(ML_Operator *Mat, MLVec<int>& rowPtr, MLVec<int>& cols, MLVec<double>& vals, int invec_leng, int (*commfunc  )(double *vec, void *data), struct wrappedCommStruct& framework, int nGhost)
 {
-    int outvec_leng = rowPtr.size() - 1;
+  int outvec_leng = rowPtr.size() - 1;
 
-    struct ML_CSR_MSRdata* ptr = (struct ML_CSR_MSRdata *) ML_allocate(sizeof(struct ML_CSR_MSRdata));
-    if (ptr == NULL) pr_error("ML_Operator_Add: no space for temp\n");
+  struct ML_CSR_MSRdata* ptr = (struct ML_CSR_MSRdata *) ML_allocate(sizeof(struct ML_CSR_MSRdata));
+  if (ptr == NULL) pr_error("ML_Operator_Add: no space for temp\n");
 
-    ptr->rowptr = rowPtr.getptr();         // getptr() + relinquishData
-    rowPtr.relinquishData();               // effectively pulls data 
-    ptr->columns = cols.getptr();          // out of a MLVec and empties 
-    cols.relinquishData();                 // MLVec's contents
-    ptr->values = vals.getptr();
-    vals.relinquishData();
+  ptr->rowptr = rowPtr.getptr();         // getptr() + relinquishData
+  rowPtr.relinquishData();               // effectively pulls data
+  ptr->columns = cols.getptr();          // out of a MLVec and empties
+  cols.relinquishData();                 // MLVec's contents
+  ptr->values = vals.getptr();
+  vals.relinquishData();
 
-    ML_Comm * temp_comm = Mat->comm;
+  ML_Comm * temp_comm = Mat->comm;
 
-    // Need to create new communication widget before cleaning out Mat
-    // as Mat may be used within commfunc.
+  // Need to create new communication widget before cleaning out Mat
+  // as Mat may be used within commfunc.
 
-    ML_CommInfoOP *newPrecComm = NULL;
-if (commfunc != NULL)
-    ML_CommInfoOP_Generate( &newPrecComm, commfunc, (void *) &framework, 
-                              Mat->comm, invec_leng, nGhost);
-    ML_Operator_Clean(Mat);
-    ML_Operator_Init(Mat, temp_comm);
-    ML_Operator_Set_ApplyFuncData(Mat, invec_leng, outvec_leng,
-                                  ptr, outvec_leng, NULL,0);
-    ML_Operator_Set_Getrow(Mat, outvec_leng, CSR_getrow);
-    ML_Operator_Set_ApplyFunc(Mat, CSR_matvec);
-    Mat->data_destroy = ML_CSR_MSRdata_Destroy;
-    Mat->N_nonzeros     = cols.size();
+  ML_CommInfoOP *newPrecComm = NULL;
+  if (commfunc != NULL)
+    ML_CommInfoOP_Generate(
+        &newPrecComm, commfunc, (void *) &framework,
+        Mat->comm, invec_leng, nGhost
+        );
+  ML_Operator_Clean(Mat);
+  ML_Operator_Init(Mat, temp_comm);
+  ML_Operator_Set_ApplyFuncData(Mat, invec_leng, outvec_leng,
+      ptr, outvec_leng, NULL,0);
+  ML_Operator_Set_Getrow(Mat, outvec_leng, CSR_getrow);
+  ML_Operator_Set_ApplyFunc(Mat, CSR_matvec);
+  Mat->data_destroy = ML_CSR_MSRdata_Destroy;
+  Mat->N_nonzeros     = cols.size();
 
-    Mat->getrow->pre_comm = newPrecComm;
+  Mat->getrow->pre_comm = newPrecComm;
 
   return(0);
 }
@@ -4488,7 +4490,7 @@ if (commfunc != NULL)
 int MLextractDiag(const MLVec<int>& rowPtr, const MLVec<int>& cols, const MLVec<double>& vals, MLVec<double>& diagonal, struct wrappedCommStruct &framework)
 {
 /******************************************************************************
- * extract matrix diagonal and store in diagonal. 
+ * extract matrix diagonal and store in diagonal.
  *****************************************************************************/
 
    for (int i = 0; i < (int) rowPtr.size()-1; i++) {
@@ -4504,11 +4506,11 @@ int MLextractDiag(const MLVec<int>& rowPtr, const MLVec<int>& cols, const MLVec<
 int MLfindDirichlets(const MLVec<int>& rowPtr, const MLVec<int>& cols, const MLVec<double>& vals, const MLVec<double>& diagonal, double tol, MLVec<bool>& dirOrNot, struct wrappedCommStruct &framework)
 {
 /******************************************************************************
- * Look at each matrix row and mark it as Dirichlet if there is only one 
- * "not small" nonzero on the diagonal. In determining whether a nonzero is 
+ * Look at each matrix row and mark it as Dirichlet if there is only one
+ * "not small" nonzero on the diagonal. In determining whether a nonzero is
  * "not small" use
- *           abs(A(i,j))/sqrt(abs(diag[i]*diag[j])) > tol 
- * 
+ *           abs(A(i,j))/sqrt(abs(diag[i]*diag[j])) > tol
+ *
  * On output,  dirOrNot is set to to true for Dirichlet rows, false for non-
  * Dirichlet rows
  *****************************************************************************/
@@ -4544,17 +4546,17 @@ int MLrmDirichletCols(MLVec<int>& rowPtr, MLVec<int>& cols, MLVec<double>& vals,
  *  When removing matrix entries, we can either set a zero in vals[k] or
  *  if squeeze == 1 we can actually really remove the entries and change
  *  rowPtr to reflect the removal.
- *  
+ *
  *  On output:  rowPtr, cols, vals, rhs, and possible solution
  *    are updated to reflect the removed entries.
- *  
+ *
  *  ******************************************************************************/
 
   if (!solution.empty()) {
     for (int i = 0; i < (int) rowPtr.size()-1; i++)
        if (dirOrNot[i]) solution[i] = rhs[i]/diagonal[i];
   }
-  MLVec<double> rhsCopy(dirOrNot.size()); 
+  MLVec<double> rhsCopy(dirOrNot.size());
   for (int i = 0; i < (int) rowPtr.size()-1; i++) rhsCopy[i] = rhs[i];
   dofComm(rhsCopy, framework);
 
@@ -4583,7 +4585,7 @@ int MLsqueezeOutNnzs(MLVec<int>& rowPtr, MLVec<int>& cols, MLVec<double>& vals, 
  * Get rid of nonzero entries that have 0's in them and properly change
  * rowPtr to reflect this removal (either vals == NULL & vals != NULL
  * or the contrary)
- * 
+ *
  *****************************************************************************/
   int count, newStart;
 
@@ -4624,9 +4626,9 @@ int MLbuildMap(const MLVec<bool>& dofPresent, MLVec<int>& map, int nDofs)
 {
 /******************************************************************************
  *  Compute map that maps dofs in a variable dof matrix to dofs in a padded
- *  matrix. Specifically, on input: 
+ *  matrix. Specifically, on input:
  *     dofPresent[ i*maxDofPerNode+j] indicates whether or not the jth dof
- *                                    at the ith node is present in the 
+ *                                    at the ith node is present in the
  *                                    variable dof matrix (e.g., the ith node
  *                                    has an air pressure dof). true means the
  *                                    dof is present while false means it is not
@@ -4634,13 +4636,13 @@ int MLbuildMap(const MLVec<bool>& dofPresent, MLVec<int>& map, int nDofs)
  *
  * On output:
  *    map[k]                          indicates that the kth dof in the variable
- *                                    dof matrix would correspond to the 
+ *                                    dof matrix would correspond to the
  *                                    map[k]th dof in a padded system. This
  *                                    padded system is not ever created but
  *                                    would be the associated matrix if every
  *                                    node had maxDofPerNode dofs.
  *
- *    nDofs                           length of map that should equal the 
+ *    nDofs                           length of map that should equal the
  *                                    dimension of the variable dof matrix.
  *                                    It is returned here to double check this.
  *  NOTE: in parallel we would want to do something so that map[j] also
@@ -4650,7 +4652,7 @@ int MLbuildMap(const MLVec<bool>& dofPresent, MLVec<int>& map, int nDofs)
 
    count = 0;
    for (int i = 0; i < (int) dofPresent.size(); i++) {
-     if (dofPresent[i]) map[count++] = i; 
+     if (dofPresent[i]) map[count++] = i;
    }
 
    TEUCHOS_TEST_FOR_EXCEPTION(nDofs != count,std::logic_error,
@@ -4666,36 +4668,36 @@ int MLassignGhostLocalNodeIds(MLVec<int> &myLocalNodeIds, int nLocalDofs, int nL
 /******************************************************************************
     Assign the ghost portion of myLocalNodeIds[], which will be the local
     amalgamated node id associated with the kth local non-amalgamated dof.
-    It is assumed that the non-ghost portion is properly set. 
+    It is assumed that the non-ghost portion is properly set.
 
-    For ghosts, we assign a "unique" number from nLocalNodes to 
+    For ghosts, we assign a "unique" number from nLocalNodes to
     nLocalNodes+nGhostNodes-1 (which is actually nLocalPlusGhostNodes-1
-    in the code). Here, nLocalNodes refers to the number of mesh nodes owned 
+    in the code). Here, nLocalNodes refers to the number of mesh nodes owned
     by the processor. nGhostNodes is the total number of ghost mesh nodes
-    associated with all of its ghost dofs. When I say "unique", I mean that 
-    I get to pick any local numbering of the ghost nodes so long as the 
+    associated with all of its ghost dofs. When I say "unique", I mean that
+    I get to pick any local numbering of the ghost nodes so long as the
     following is true:
        a) no two ghost dofs that are associated with different
-          mesh nodes have the same nodal id. 
+          mesh nodes have the same nodal id.
        b) all ghost nodes that are associated with a processor
           have consecutive numbering
-   
+
     This is done is as follows:
-   
+
        a) communicate so that for each ghost dof, a processor knows the local
           node id on the owning proc and knows the processor that owns it
-   
+
        b) for each owning proc ...
             i) copy the owning proc local node id into a new array, and record
                as well where this information came from. That is,
-   
+
                   tempId[  j] = myLocalNodeIds[i];
                   location[j] = i;
-   
+
             ii) sort tempId to make it easier to determine whether two ghosts
                 belong to the same node. Also shuffle location[] in the same
-                way as tempId[] so tempId[j] corresonds to myLocalNodeIds[ location[j] ]. 
-   
+                way as tempId[] so tempId[j] corresonds to myLocalNodeIds[ location[j] ].
+
        c) go through tempId[] and assign a unique ghost node id to tempId[k] if
           it has a different owning proc or a different local node id on the
           owning proc. That is, increment the number of ghost node ids when
@@ -4712,13 +4714,13 @@ int MLassignGhostLocalNodeIds(MLVec<int> &myLocalNodeIds, int nLocalDofs, int nL
    // local ids associated with the owning processor. We want to convert
    // these to local ids associated with the processor on which these are
    // ghosts. Thus, we have to re-number them. In doing this re-numbering
-   // we must make sure that we find all ghosts with the same id & proc 
+   // we must make sure that we find all ghosts with the same id & proc
    // and assign a unique local id to this group. To do this find, we sort
    // sort all ghost myLocalNodeIds that are owned by the same processor.
    // Then we can look for duplicates (i.e. several ghost entries
    // corresponding to dofs with the same node id) easily and make sure these
-   // are all assigned the same local id. To do the sorting  
-   // we'll make a temporary copy of the ghosts via tempId and tempProc and 
+   // are all assigned the same local id. To do the sorting
+   // we'll make a temporary copy of the ghosts via tempId and tempProc and
    // sort this multiple times for each group owned by the same processor
 
    int* location= (int *) ML_allocate(sizeof(int)*(nLocalPlusGhostDofs - nLocalDofs + 1));
@@ -4745,13 +4747,13 @@ int MLassignGhostLocalNodeIds(MLVec<int> &myLocalNodeIds, int nLocalDofs, int nL
         if ( myProc[i] == neighbor ) {
            location[tempIndex  ] = i;
            tempId[  tempIndex++] = myLocalNodeIds[i];
-           myProc[     i       ]= -1; // mark as visited 
+           myProc[     i       ]= -1; // mark as visited
         }
      }
      ML_az_sort(&(tempId[first]), tempIndex-first, &(location[first]), NULL);
 
      for (int i = first; i < tempIndex; i++) tempProc[i] = neighbor;
-     
+
      // find next notProcessed corresponding to first non-visited guy
 
      notProcessed++;
@@ -4759,15 +4761,15 @@ int MLassignGhostLocalNodeIds(MLVec<int> &myLocalNodeIds, int nLocalDofs, int nL
        notProcessed++;
    }
    TEUCHOS_TEST_FOR_EXCEPTION(tempIndex != nLocalPlusGhostDofs-nLocalDofs,std::logic_error,
-   "poo error, number of nonzero ghosts is not consistent\n"); 
-   
-     
+   "poo error, number of nonzero ghosts is not consistent\n");
+
+
    // now assign ids to all ghost nodes (giving the same id to those with
    // the same myProc[] and the same local id (on the proc
    // that actually owns the variable associated with the ghost)
 
    int lagged = -1;
-   nLocalNodes = 0; 
+   nLocalNodes = 0;
 
    if (nLocalDofs > 0) nLocalNodes = myLocalNodeIds[nLocalDofs-1] + 1;
    nLocalPlusGhostNodes = nLocalNodes;
@@ -4775,22 +4777,22 @@ int MLassignGhostLocalNodeIds(MLVec<int> &myLocalNodeIds, int nLocalDofs, int nL
    if (nLocalDofs < nLocalPlusGhostDofs) nLocalPlusGhostNodes++; // 1st ghost node is unique
                                                // (not already accounted for)
 
-   // check if two adjacent ghost dofs correspond to different nodes. To do 
-   // this, check if they are from different processors or whether they have 
+   // check if two adjacent ghost dofs correspond to different nodes. To do
+   // this, check if they are from different processors or whether they have
    // different local node ids
-   
+
    for (int i = nLocalDofs+1; i < nLocalPlusGhostDofs; i++) {
-   
+
       lagged = nLocalPlusGhostNodes-1;
 
       // i is a new unique ghost node (not already accounted for)
-      if ((tempId[i-nLocalDofs] != tempId[i-1-nLocalDofs]) || 
+      if ((tempId[i-nLocalDofs] != tempId[i-1-nLocalDofs]) ||
           (tempProc[i-nLocalDofs]         != tempProc[i-1-nLocalDofs]))
          nLocalPlusGhostNodes++;
 
       tempId[i-1-nLocalDofs] = lagged;
    }
-   if (nLocalPlusGhostDofs > nLocalDofs) 
+   if (nLocalPlusGhostDofs > nLocalDofs)
       tempId[nLocalPlusGhostDofs-1-nLocalDofs] = nLocalPlusGhostNodes-1;
 
 
@@ -4799,32 +4801,32 @@ int MLassignGhostLocalNodeIds(MLVec<int> &myLocalNodeIds, int nLocalDofs, int nL
    for (int i = nLocalDofs; i < nLocalPlusGhostDofs; i++)
       myLocalNodeIds[location[i-nLocalDofs]] = tempId[i-nLocalDofs];
 
-   ML_free(location); 
-   ML_free(tempProc); 
-   ML_free(tempId); 
+   ML_free(location);
+   ML_free(tempProc);
+   ML_free(tempId);
 
    return 0;
 }
 
 int MLfillNodalMaps(MLVec<int> &amalgRowMap, MLVec<int> &amalgColMap,
-        MLVec<int> &myLocalNodeIds, int nLocalDofs, 
+        MLVec<int> &myLocalNodeIds, int nLocalDofs,
         struct wrappedCommStruct &framework,
         int nLocalNodes, int nLocalPlusGhostNodes)
 {
 /*
     Fill amalgRowMap and amalgColMap.
 
-    amalgRowMap is easy. It corresponds to the global id of the 1st dof of each node 
+    amalgRowMap is easy. It corresponds to the global id of the 1st dof of each node
     (owned by this processor). It is easy because it doesn't involve communication.
 
-    amalgColMap is essentially the colmap version of amalgRowMap. We basically 
+    amalgColMap is essentially the colmap version of amalgRowMap. We basically
     assign the local portion of amalgColMap in the same way as amalgRowMap. To
     get the ghost part of amalgColMap, we use nodalComm(). This routine uses
     myLocalNodeIds[] in conjunction with a function to perform amalgamated dof
     communication.
 */
 
-   MLVec<int> myGids; 
+   MLVec<int> myGids;
 
    MLcolGlobalIds(framework, myGids);
 
@@ -4832,13 +4834,13 @@ int MLfillNodalMaps(MLVec<int> &amalgRowMap, MLVec<int> &amalgColMap,
    amalgColMap.resize(nLocalPlusGhostNodes);
 
    int count = 0;
-   if (nLocalDofs > 0) { 
+   if (nLocalDofs > 0) {
       amalgRowMap[count] = myGids[0];
       amalgColMap[count] = myGids[0];
       count++;
    }
    // dofs belonging to same node must be consecutive only for the local
-   // part of myLocalNodeIds[] 
+   // part of myLocalNodeIds[]
 
    for (int i = 1; i < nLocalDofs; i++) {
       if (myLocalNodeIds[i] != myLocalNodeIds[i-1]) {
@@ -4847,27 +4849,27 @@ int MLfillNodalMaps(MLVec<int> &amalgRowMap, MLVec<int> &amalgColMap,
          count++;
       }
    }
-   nodalComm(amalgColMap,  myLocalNodeIds, framework); 
+   nodalComm(amalgColMap,  myLocalNodeIds, framework);
 
    return 0;
 }
 
 /******************************************************************************
  *****************************************************************************/
-int MLvariableDofAmalg(int nCols, const MLVec<int>& rowPtr, 
-                     const MLVec<int>& cols, const MLVec<double>& vals, 
+int MLvariableDofAmalg(int nCols, const MLVec<int>& rowPtr,
+                     const MLVec<int>& cols, const MLVec<double>& vals,
                      int nNodes, int maxDofPerNode, const MLVec<int>& map,
-                     const MLVec<double>& diag, double tol, 
+                     const MLVec<double>& diag, double tol,
                      MLVec<int>& amalgRowPtr, MLVec<int>& amalgCols,
                      struct wrappedCommStruct &framework,
                      MLVec<int>& myLocalNodeIds)
 {
 /******************************************************************************
- *  Amalgmate crs matrix (rowPtr,cols,vals) and store result in 
+ *  Amalgmate crs matrix (rowPtr,cols,vals) and store result in
  *  amalgRowPtr, amalgCols.  Optionally, small vals in the non-amalgamated
- *  matrix can be dropped when performing this amalgamation  when 
+ *  matrix can be dropped when performing this amalgamation  when
  *
- *           abs(A(i,j))/sqrt(abs(diag[i]*diag[j])) < tol 
+ *           abs(A(i,j))/sqrt(abs(diag[i]*diag[j])) < tol
  *
  *  Here, the local non-amalgamated matrix is of size nRows x nCols and the
  *  resulting amalgamated matrix should have nNodes local rows.  On input,
@@ -4878,7 +4880,7 @@ int MLvariableDofAmalg(int nCols, const MLVec<int>& rowPtr,
  *****************************************************************************/
    int  blockRow = 0, blockColumn, newNzs, oldBlockRow;
    int  nNonZeros, doNotDrop;
-   int  nLocal = rowPtr.size()-1; 
+   int  nLocal = rowPtr.size()-1;
 
 
 
@@ -4893,7 +4895,7 @@ int MLvariableDofAmalg(int nCols, const MLVec<int>& rowPtr,
    newNzs = 0;
    amalgRowPtr[0] = newNzs;
 
-   doNotDrop = 0; 
+   doNotDrop = 0;
    if  (tol ==     0.0) doNotDrop = 1;
    if  (vals.empty())  doNotDrop = 1;
 
@@ -4909,7 +4911,7 @@ int MLvariableDofAmalg(int nCols, const MLVec<int>& rowPtr,
       }
 
       for (int j = rowPtr[i]; j < rowPtr[i+1]; j++) {
-        if (doNotDrop || 
+        if (doNotDrop ||
             ( fabs(vals[j]/sqrt(fabs(diag[i]*diag[cols[j]]))) >= tol)) {
            blockColumn = myLocalNodeIds[cols[j]];
            if  (isNonZero[blockColumn] == false) {
@@ -4937,16 +4939,16 @@ int MLrmDifferentDofsCrossings(const MLVec<bool>& dofPresent, int maxDofPerNode,
 {
 /******************************************************************************
  *  Remove matrix entries (i,j) where the ith node and the jth node
- *  have different dofs that are 'present'. 
+ *  have different dofs that are 'present'.
  *
- *  Specifically, on input: 
+ *  Specifically, on input:
  *    dofPresent[ i*maxDofPerNode+k] indicates whether or not the kth dof
- *                                   at the ith node is present in the 
+ *                                   at the ith node is present in the
  *                                   variable dof matrix (e.g., the ith node
  *                                   has an air pressure dof). true means the
  *                                   dof is present while false means it is not
- *                                     
- *  We create a unique id for the ith node (i.e. uniqueId[i]) via 
+ *
+ *  We create a unique id for the ith node (i.e. uniqueId[i]) via
  *      sum_{k=0 to maxDofPerNode-1} dofPresent[i*maxDofPerNode+k]*2^k
  *  and use this unique idea to remove entries (i,j) when
  *  uniqueId[i] != uniqueId[j]
@@ -4978,7 +4980,7 @@ int MLrmDifferentDofsCrossings(const MLVec<bool>& dofPresent, int maxDofPerNode,
    }
 
    MLVec<double>   empty;
-   MLsqueezeOutNnzs(rowPtr, cols, empty, keep); 
+   MLsqueezeOutNnzs(rowPtr, cols, empty, keep);
 
    return(0);
 }
@@ -4989,7 +4991,7 @@ int MLrmDifferentDofsCrossings(const MLVec<bool>& dofPresent, int maxDofPerNode,
 int MLbuildLaplacian(const MLVec<int>& rowPtr, const MLVec<int>& cols, MLVec<double>& vals, const MLVec<double>& x, const MLVec<double>& y, const MLVec<double>& z)
 {
 /******************************************************************************
- *  Given an inputMatrix (rowPtr,cols) Build a Laplacian matrix defined by 
+ *  Given an inputMatrix (rowPtr,cols) Build a Laplacian matrix defined by
  *
  *  L(i,j)  = 0                     if  inputMatrix(i,j) = 0
  *  L(i,j)  = 1/nodalDistance(i,j)  otherwise
@@ -5056,30 +5058,30 @@ int MLbuildLaplacian(const MLVec<int>& rowPtr, const MLVec<int>& cols, MLVec<dou
 
 /*! @brief Unamalgamate prolongator so that it is suitable for PDE systems
  *
- 
+
 Unamalgamate Pmat (represented as a CRS matrix via amalgRowPtr, amalgCols, amalgVals
 for two different situations:
   Case 1:  Fine level matrix is padded
            In this case, we basically replicate the unamalgamated
-           operator, except that padded dofs and Dirichlet points use 
+           operator, except that padded dofs and Dirichlet points use
            injection. Thus, PUnAmalg is equivalent to something like
                        (  Pmat      0       0  )
                        (    0     Pmat      0  )
                        (    0       0     Pmat )
            where entries associated with fine level padded dofs or Dir. BCs
-           are replaced by rows with a single nonzero (whose 
+           are replaced by rows with a single nonzero (whose
            value equals one) and the entire matrix is instead ordered
            so that dofs associated with nodes are consecutive.
- 
-  Case 2:  Fine level matrix is not padded. 
-           Thus, PUnAmalg is equivalent to 
+
+  Case 2:  Fine level matrix is not padded.
+           Thus, PUnAmalg is equivalent to
                        (  Pmat      0       0  )
                        (    0     Pmat      0  )
                        (    0       0     Pmat )
            where rows associated with dofs not present on finest level (e.g.,
            an air pressure dof within water region) are removed and rows
-           associated with Dir. BCs are replaced by rows with a single 
-           nonzero (whose value equals one) and the entire matrix is 
+           associated with Dir. BCs are replaced by rows with a single
+           nonzero (whose value equals one) and the entire matrix is
            instead ordered so dofs associated with nodes are consecutive.
 
 In both of the above cases, the coarse level discretization matrix is assumed to be padded.
@@ -5090,19 +5092,19 @@ In both of the above cases, the coarse level discretization matrix is assumed to
 @params amalgVals  CRS vals for amalgamted prolongator
 @params maxDofPerNode maximum number of degrees-of-freedom at any mesh node
 @params status    status[i*maxDofPerNode+j] refers to the jth dof at the ith node.  status()==s ==> standard element: present in fine operator and not a Dirichlet BC. status()==d ==> element corresponds to Dirichlet BC.  status()==p ==> element not present or is padded dof.
-@params fineIsPadded Indicates whether fine grid matrix includes padded dofs for those not really present in the PDE system 
+@params fineIsPadded Indicates whether fine grid matrix includes padded dofs for those not really present in the PDE system
 @params rowPtr   CRS local row pointer for resulting unamalgamated prolongator
 @params cols   CRS local cols for resulting unamalgamated prolongator
 @params vals   CRS vals for resulting unamalgamated prolongator
 */
 
-int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const MLVec<double>& amalgVals, 
+int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const MLVec<double>& amalgVals,
  int maxDofPerNode, const MLVec<char>& status, bool fineIsPadded, MLVec<int>& rowPtr, MLVec<int>& cols, MLVec<double>& vals)
 {
 
    int paddedNrows;
    int Cnt, rowLength, rowCount = 0;
- 
+
    paddedNrows = (amalgRowPtr.size()-1)*maxDofPerNode;
 
    if (fineIsPadded) {
@@ -5112,7 +5114,7 @@ int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const
       /* fine level Dirichlet points also use injection.                    */
 
       Cnt  = 0;
-      for (int i=0; i < (int) amalgRowPtr.size()-1; i++) { 
+      for (int i=0; i < (int) amalgRowPtr.size()-1; i++) {
        rowLength = amalgRowPtr[i+1] -  amalgRowPtr[i];
        for (int j = 0; j < maxDofPerNode; j++) {
           rowPtr[i*maxDofPerNode+j] = Cnt;
@@ -5127,7 +5129,7 @@ int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const
       }
       rowPtr[paddedNrows] = Cnt;
       rowCount = paddedNrows;
-   
+
    }
    else {
       /* Build Pmat for non-padded fine level matrices.  Need to map from   */
@@ -5135,7 +5137,7 @@ int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const
       /* skip padded dofs.                                                  */
 
      Cnt = 0;
-     for (int i=0; i < (int) amalgRowPtr.size()-1; i++) { 
+     for (int i=0; i < (int) amalgRowPtr.size()-1; i++) {
         rowLength = amalgRowPtr[i+1] -  amalgRowPtr[i];
 
         for (int j = 0; j < maxDofPerNode; j++) {
@@ -5148,7 +5150,7 @@ int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const
                 vals[Cnt++] = amalgVals[k+amalgRowPtr[i]];
              }
           }
-          if (status[i*maxDofPerNode+j] == 'd') 
+          if (status[i*maxDofPerNode+j] == 'd')
              rowPtr[rowCount++] = Cnt;
         }
      }
@@ -5158,25 +5160,25 @@ int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const
 
 
    return(rowCount);
-} 
+}
 
 int MLfindEmptyRows(const MLVec<int>& rowPtr, const MLVec<int>& cols, const MLVec<double>& vals, MLVec<bool>& rowEmpty)
 {
 /******************************************************************************
-  Find rows that have no nonzero entries. 
+  Find rows that have no nonzero entries.
 
   Padded matrices might give rise to empty rows (e.g., after RAP) that we want
   to replace with Dirichlet rows (where the Dirichlet point has no connections
   to the rest of the matrix).
- 
+
  *****************************************************************************/
-   
+
    rowEmpty.resize(rowPtr.size()-1);
 
    for (int i = 0; i < (int) rowPtr.size()-1; i++) {
       rowEmpty[i] = true;
       for (int j = rowPtr[i]; j < rowPtr[i+1]; j++) {
-         if (vals[j] != 0.0) { 
+         if (vals[j] != 0.0) {
             rowEmpty[i] = false;
             break;
          }
@@ -5193,7 +5195,7 @@ int MLreplaceEmptyByDirichlet(MLVec<int>& rowPtr, MLVec<int>& cols, MLVec<double
   Padded matrices might give rise to empty rows (e.g., after RAP) that we want
   to replace with Dirichlet rows (where the Dirichlet point has no connections
   to the rest of the matrix).
- 
+
  *****************************************************************************/
    int nEmpties, rowStart, rowEnd, lastMoved;
    int nRows = rowPtr.size()-1;
@@ -5241,9 +5243,9 @@ int MLfineStatus(const MLVec<bool>& dofPresent, const MLVec<int>& map, const MLV
 {
 /*****************************************************************************
   Fill the status array on the finest level based on the information in both
-  dofPresent and dirOrNot.  status[i*maxDofPerNode+j] refers to the jth dof 
+  dofPresent and dirOrNot.  status[i*maxDofPerNode+j] refers to the jth dof
   at the ith node.  status()==s ==> standard element: present in fine operator
-                                    and not a Dirichlet BC. 
+                                    and not a Dirichlet BC.
                     status()==d ==> element corresponds to Dirichlet BC.
                     status()==p ==> element not present (or on coarse levels
                                                          is padded)
@@ -5263,14 +5265,14 @@ int MLfineStatus(const MLVec<bool>& dofPresent, const MLVec<int>& map, const MLV
 int MLcoarseStatus(const MLVec<bool>& rowEmpty, const MLVec<bool>& dirOrNot, MLVec<char>& status)
 {
 /*****************************************************************************
-  Fill the status array on a coarse level based on the information in dirOrNot.  
-  status[i*maxDofPerNode+j] refers to the jth dof at the ith node.  
+  Fill the status array on a coarse level based on the information in dirOrNot.
+  status[i*maxDofPerNode+j] refers to the jth dof at the ith node.
 
                     status()==s ==> standard element: present in fine operator
-                                    and not a Dirichlet BC. 
+                                    and not a Dirichlet BC.
                     status()==p ==> element is padded dof.
 
-  The main difference with MLfineStatus() is that it is assumed that the 
+  The main difference with MLfineStatus() is that it is assumed that the
   dofsPerNode at all nodes is equal to maxDofsPerNode (that is padding
   has already been used so that this is true) and that no Dirichlet
   points remain.
@@ -5302,32 +5304,32 @@ int MLsortCols(const MLVec<int>& ARowPtr, MLVec<int>& ACols, MLVec<double>& AVal
 }
 
 /****************************************************************************/
-/* Given arrays denoting pairwise vertices that are shared, make a set of 
- * linked lists that groups all shared vertices together. For example, 
+/* Given arrays denoting pairwise vertices that are shared, make a set of
+ * linked lists that groups all shared vertices together. For example,
  * consider
  *     rowZeros[0] = i; colZeros[0] = j;  // indicates i and j are shared
  *     rowZeros[1] = j; colZeros[1] = k;  // indicates j and k are shared
  *     rowZeros[2] = k; colZeros[2] = m;  // indicates k and m are shared
  *
- * Create a linked list indicated that i,j,k, and m are all shared. More 
- * generally, we might have several linked lists indicating different 
+ * Create a linked list indicated that i,j,k, and m are all shared. More
+ * generally, we might have several linked lists indicating different
  * sets of shared vertices. On output groupHead[] and groupNext[] encode
  * all of the linked lists. groupHead[] and groupNext[] are described in
  * the comments to buildCompressedA().
  */
 /****************************************************************************/
-int MergeShared(MLVec<int>& cols, MLVec<int>& rowZeros, MLVec<int>& colZeros, 
+int MergeShared(MLVec<int>& cols, MLVec<int>& rowZeros, MLVec<int>& colZeros,
                 MLVec<int>& groupHead, MLVec<int>& groupNext)
 {
    int vertOne, vertTwo, vertOneHead;
    int secondGuy, currentListTwo;
    int prior;
 
-   for (int i = 0; i < groupHead.size(); i++) groupHead[i] = -1; 
-   for (int i = 0; i < groupNext.size(); i++) groupNext[i] = -1; 
+   for (int i = 0; i < groupHead.size(); i++) groupHead[i] = -1;
+   for (int i = 0; i < groupNext.size(); i++) groupNext[i] = -1;
 
 
-   for (int i = 0; i < rowZeros.size(); i++) { 
+   for (int i = 0; i < rowZeros.size(); i++) {
       vertOne = rowZeros[i];
       vertTwo = colZeros[i];
 
@@ -5358,11 +5360,11 @@ int MergeShared(MLVec<int>& cols, MLVec<int>& rowZeros, MLVec<int>& colZeros,
             // if these are the same shared group, then there is nothing
             // else to do. If they are different groups, we must merge
             // the two lists together into a single group.
-            
+
             if (groupHead[vertOne] != groupHead[vertTwo]) {
                // insert all of vertTwo's list just after the head of
                // vertOne's list
-              
+
                vertOneHead = groupHead[vertOne];
                secondGuy   = groupNext[vertOneHead];
                currentListTwo = groupHead[vertTwo];
@@ -5381,17 +5383,17 @@ int MergeShared(MLVec<int>& cols, MLVec<int>& rowZeros, MLVec<int>& colZeros,
    return 0;
 }
 /****************************************************************************/
-/* Look at the graph described by (rowPtr,cols,vals) and calculate the 
+/* Look at the graph described by (rowPtr,cols,vals) and calculate the
  * distance between any two adjacent vertices. If any of these distances
- * are less than a tol, then record these two vertices in 
+ * are less than a tol, then record these two vertices in
  * rowZeros and colZeros.
  *
  * Note: adjacent vertices that have small values are ignored. Specifically,
- * dropped entries correspond to 
- *           a(i,j) <= a(i,i)*a(j,j)*tol^2 
+ * dropped entries correspond to
+ *           a(i,j) <= a(i,i)*a(j,j)*tol^2
  */
 /****************************************************************************/
- 
+
 int ZeroDist(MLVec<double>& xxx, MLVec<double>& yyy, MLVec<double>& zzz,
              MLVec<int>& rowPtr, MLVec<int>& cols, MLVec<double>& vals,
              MLVec<double>& diagonal, double tol, MLVec<int>& rowZeros,  MLVec<int>& colZeros,
@@ -5423,14 +5425,14 @@ int ZeroDist(MLVec<double>& xxx, MLVec<double>& yyy, MLVec<double>& zzz,
    }
    rowZeros.resize(count);
    colZeros.resize(count);
-        
+
    return 0;
 }
 
 /****************************************************************************/
-/* Given a list of shared dofs (encoded within groupHead and groupNext), 
+/* Given a list of shared dofs (encoded within groupHead and groupNext),
  * compute an array that maps original rows to a compressed set of rows
- * where all shared dofs correspond to the same row in the compressed set. 
+ * where all shared dofs correspond to the same row in the compressed set.
  * The list of shared dofs is given by a strange linked list that is described
  * in the comments for buildCompressedA().
  */
@@ -5459,7 +5461,7 @@ int BuildNonSharedMap(MLVec<int>& newMap, MLVec<int>& groupHead, MLVec<int>& gro
        }
     }
     // restore groupHead
-    
+
     for (int i = 0; i < groupHead.size(); i++) {
        if (groupHead[i] < -1) groupHead[i] = -2 - groupHead[i];
     }
@@ -5469,12 +5471,12 @@ int BuildNonSharedMap(MLVec<int>& newMap, MLVec<int>& groupHead, MLVec<int>& gro
 /****************************************************************************/
 /*
 Given a set of shared dofs, build a compressed graph of the matrix. This
-compressed version is equivalent to taking any rows or columns that are 
-shared and merging them together into a single row or a single column 
+compressed version is equivalent to taking any rows or columns that are
+shared and merging them together into a single row or a single column
 within a compressed matrix. However, small entries in the original matrix
 are dropped when building the compressed graph. Specifically, dropped entries
-correspond to 
-             a(i,j) <= a(i,i)*a(j,j)*tol^2 
+correspond to
+             a(i,j) <= a(i,i)*a(j,j)*tol^2
 
 The list of shared dofs is given by a strange linked list. In particular,
 if groupHead[i] == -1, then i is not a shared dof. If groupHead[i] > -1,
@@ -5485,23 +5487,23 @@ the following when four nodes are shared (i,j,k,m):
     ______________      ______________     ______________     ______________
    | groupHead[i] |    | groupHead[j] |   | groupHead[k] |   | groupHead[m] |
    | groupNext[i]-|--->| groupNext[j]-|-->| groupNext[k]-|-->| groupNext[m] |
-    --------------      --------------     --------------      --------------   
+    --------------      --------------     --------------      --------------
 where
     groupHead[i] =    groupHead[j] =    groupHead[k] = groupHead[m]
-    groupNext[i] = j; groupNext[j] = k; groupNext[k] = m; 
-    groupNext[m] = -1; 
+    groupNext[i] = j; groupNext[j] = k; groupNext[k] = m;
+    groupNext[m] = -1;
 
 Additionally, it is assumed that map[] has already been computed such that
 map[ii] gives the row/col number in the compressed matrix corresponding to ii.
 Thus, in the above example  map[i]=map[j]=map[k]=map[m] as i,j,k,m all map
 to the same row. Such a map can be computed by invoking int BuildNonSharedMap()
-given groupHead[] and groupNext[].  Finally, newN is also given on input and 
+given groupHead[] and groupNext[].  Finally, newN is also given on input and
 it corresponds to the total number of rows in the compressed matrix.
 */
 /****************************************************************************/
 int buildCompressedA(MLVec<int>& inputRowPtr, MLVec<int>& inputCols,
                      MLVec<double>& inputVals, MLVec<double>& diagonal,
-                     MLVec<int>& groupHead, MLVec<int>& groupNext, 
+                     MLVec<int>& groupHead, MLVec<int>& groupNext,
                      MLVec<int>& outputRowPtr, MLVec<int>& outputCols,
                      MLVec<int>& map, int newN, double tol)
 {
@@ -5514,13 +5516,13 @@ int buildCompressedA(MLVec<int>& inputRowPtr, MLVec<int>& inputCols,
 
 
    for (int i=0; i < filled.size() ; i++) filled[i] = false;
-   
+
    outputRowPtr[0] = 0;
    for (int i=0; i < inputRowPtr.size()-1 ; i++) {
       nFilled = 0;
-      current = i; 
+      current = i;
       if (groupHead[i] > -1) current = groupHead[i];
-      if (groupHead[i] < -1) current = -1; 
+      if (groupHead[i] < -1) current = -1;
 
       while (current != -1) {
          newRow = map[current];
@@ -5541,21 +5543,21 @@ int buildCompressedA(MLVec<int>& inputRowPtr, MLVec<int>& inputCols,
                     outputCols[count] = newCol;
                     count++;
                  } // if filled(newCol) == 0,
-              }  
+              }
            }
          } // for (int j=inputRowPtr[current]; ...
 
          if (groupHead[current] > -1) groupHead[current]= -2 - groupHead[current]; // visited
          current = groupNext[current];
-      } // while (current != -1) 
-      for (int k=0; k < nFilled; k++)  filled[result[k]] = 0; 
+      } // while (current != -1)
+      for (int k=0; k < nFilled; k++)  filled[result[k]] = 0;
       nFilled = 0;
    }
    outputRowPtr[outputRowPtr.size()-1] = count;
 
    outputCols.resize(count);
    // restore groupHead
-    
+
    for (int i = 0; i < groupHead.size(); i++) {
       if (groupHead[i] < -1) groupHead[i] = -2 - groupHead[i];
    }

--- a/packages/pamgen/src/parse_routines.C
+++ b/packages/pamgen/src/parse_routines.C
@@ -19,7 +19,7 @@
 namespace PAMGEN_NEVADA {
 
 
-  enum ParamType { 
+  enum ParamType {
     P_STARTING_BLOCK_NUMBER = 0,
     P_OFFSET,
     P_GMIN,
@@ -1030,7 +1030,7 @@ namespace PAMGEN_NEVADA {
 
     //get function body
     Token token2 = token_stream->Shift();
-    if (!token2.Type() == TK_STRING){
+    if (!(token2.Type() == TK_STRING)){
       token_stream->Parse_Error("expected a quoted C-language function body");
     }
     std::string funcBody = token2.As_Stripped_String();
@@ -1071,7 +1071,7 @@ namespace PAMGEN_NEVADA {
 
     //get function body
     Token token2 = token_stream->Shift();
-    if (!token2.Type() == TK_STRING){
+    if (!(token2.Type() == TK_STRING)){
       token_stream->Parse_Error("expected a quoted C-language function body");
     }
     std::string funcBody = token2.As_Stripped_String();


### PR DESCRIPTION
@trilinos/framework Not sure who to tag/assign here.

Except for Pamgen: Whitespace-only PR.

Fixes GCC6 warnings about misleading indentation, e.g.,
```
./packages/aztecoo/src/Epetra_MsrMatrix.cpp:445:71: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
```