### PR TITLE
Stratimikos: allow compilation without Epetra

### DIFF
--- a/packages/stratimikos/cmake/Dependencies.cmake
+++ b/packages/stratimikos/cmake/Dependencies.cmake
@@ -2,9 +2,15 @@
 # adapters will get enabled by default.  Note that Belos and ML do *not* have
 # a required dependence on Epetra but the Stratimikos Belos and ML adapters
 # need the Thyra/Epetra adapters.
-SET(LIB_REQUIRED_DEP_PACKAGES ThyraEpetraAdapters)
-SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt)
-SET(TEST_REQUIRED_DEP_PACKAGES)
+IF (Stratimikos_MAKE_EPETRA_OPTIONAL)
+  SET(LIB_REQUIRED_DEP_PACKAGES)
+  SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt ThyraEpetraAdapters)
+  SET(TEST_REQUIRED_DEP_PACKAGES ThyraEpetraAdapters)
+ELSE()
+  SET(LIB_REQUIRED_DEP_PACKAGES ThyraEpetraAdapters)
+  SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt)
+  SET(TEST_REQUIRED_DEP_PACKAGES)
+ENDIF()
 SET(TEST_OPTIONAL_DEP_PACKAGES Triutils Ifpack2 ThyraTpetraAdapters)
 SET(LIB_REQUIRED_DEP_TPLS)
 SET(LIB_OPTIONAL_DEP_TPLS)

--- a/packages/stratimikos/cmake/Dependencies.cmake
+++ b/packages/stratimikos/cmake/Dependencies.cmake
@@ -2,15 +2,9 @@
 # adapters will get enabled by default.  Note that Belos and ML do *not* have
 # a required dependence on Epetra but the Stratimikos Belos and ML adapters
 # need the Thyra/Epetra adapters.
-IF (Stratimikos_MAKE_EPETRA_OPTIONAL)
-  SET(LIB_REQUIRED_DEP_PACKAGES)
-  SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt ThyraEpetraAdapters)
-  SET(TEST_REQUIRED_DEP_PACKAGES ThyraEpetraAdapters)
-ELSE()
-  SET(LIB_REQUIRED_DEP_PACKAGES ThyraEpetraAdapters)
-  SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt)
-  SET(TEST_REQUIRED_DEP_PACKAGES)
-ENDIF()
+SET(LIB_REQUIRED_DEP_PACKAGES)
+SET(LIB_OPTIONAL_DEP_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt ThyraEpetraAdapters)
+SET(TEST_REQUIRED_DEP_PACKAGES ThyraEpetraAdapters)
 SET(TEST_OPTIONAL_DEP_PACKAGES Triutils Ifpack2 ThyraTpetraAdapters)
 SET(LIB_REQUIRED_DEP_TPLS)
 SET(LIB_OPTIONAL_DEP_TPLS)

--- a/packages/stratimikos/src/Stratimikos_Config.h.in
+++ b/packages/stratimikos/src/Stratimikos_Config.h.in
@@ -36,14 +36,14 @@
 /* Define if want to build stratimikos-tests */
 #undef HAVE_STRATIMIKOS_TESTS
 
-/* Define if want to build with thyra enabled */
-#undef HAVE_STRATIMIKOS_THYRA_EPETRA
+/* Define if want to build with epetra enabled */
+#undef HAVE_STRATIMIKOS_THYRAEPETRAADAPTERS
 
 /* Define if want to build with thyra enabled */
 #undef HAVE_STRATIMIKOS_THYRA_EPETRAEXT
 
-/* Define if want to build with thyra enabled */
-#undef HAVE_STRATIMIKOS_THYRA_TPETRA
+/* Define if want to build with tpetra enabled */
+#undef HAVE_STRATIMIKOS_THYRATPETRAADAPTERS
 
 /* Define if want to build with stratimikos enabled */
 #undef HAVE_STRATIMIKOS_TRIUTILS

--- a/packages/stratimikos/src/Stratimikos_DefaultLinearSolverBuilder.hpp
+++ b/packages/stratimikos/src/Stratimikos_DefaultLinearSolverBuilder.hpp
@@ -49,8 +49,10 @@
 #include "Teuchos_StandardParameterEntryValidators.hpp"
 
 // Include these to make all of the helpful decls appear
+#ifdef HAVE_STRATIMIKOS_THYRAEPETRAADAPTERS
 #include "Thyra_EpetraThyraWrappers.hpp"
 #include "Thyra_EpetraLinearOp.hpp"
+#endif
 #include "Thyra_LinearOpWithSolveFactoryHelpers.hpp"
 #include "Thyra_LinearOpWithSolveBase.hpp"
 #include "Thyra_PreconditionerFactoryHelpers.hpp"


### PR DESCRIPTION
This is a modernized version of stale PR #314,
which should address the concerns of @bartlettroscoe ,
and resolve #313 if merged.

@trilinos/stratimikos 

allow an optional, not required, dependency
on Epetra. it seems only the builder header
needs #ifdef guards.
since this changes the dependency graph,
it is protected by

Stratimikos_MAKE_EPETRA_OPTIONAL:BOOL

which must explicitly be set to true
for the changes in dependency status
to change.
this flag should remain until the next
backwards-compatibility-breaking
release of Trilinos.