### PR TITLE
Allow orthoManagers to be configured using nested parameter list

### DIFF
--- a/packages/belos/src/BelosDGKSOrthoManager.hpp
+++ b/packages/belos/src/BelosDGKSOrthoManager.hpp
@@ -99,10 +99,16 @@ namespace Belos {
         sing_tol_( sing_tol ),
         label_( label )
     {
-#ifdef BELOS_TEUCHOS_TIME_MONITOR
-      std::string orthoLabel = label_ + ": Orthogonalization";
-      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter( orthoLabel );
-#endif
+
+      // if timers are enabled, then we must update their labels, as they track the ortho passes
+      #ifdef BELOS_TEUCHOS_TIME_MONITOR
+      {
+        std::stringstream ss;
+        ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+        std::string orthoLabel = ss.str () + ": Orthogonalization";
+        timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+      }
+      #endif
     }
 
     //! Constructor that takes a list of parameters.
@@ -118,10 +124,15 @@ namespace Belos {
     {
       setParameterList (plist);
 
-#ifdef BELOS_TEUCHOS_TIME_MONITOR
-      std::string orthoLabel = label_ + ": Orthogonalization";
-      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter( orthoLabel );
-#endif
+      // if timers are enabled, then we must update their labels, as they track the ortho passes
+      #ifdef BELOS_TEUCHOS_TIME_MONITOR
+      {
+        std::stringstream ss;
+        ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+        std::string orthoLabel = ss.str () + ": Orthogonalization";
+        timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+      }
+      #endif
     }
 
     //! Destructor
@@ -163,6 +174,16 @@ namespace Belos {
       dep_tol_ = depTol;
       sing_tol_ = singTol;
 
+      // if timers are enabled, then we must update their labels, as they track the ortho passes
+      #ifdef BELOS_TEUCHOS_TIME_MONITOR
+      {
+        std::stringstream ss;
+        ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+        std::string orthoLabel = ss.str () + ": Orthogonalization";
+        timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+      }
+      #endif
+
       setMyParamList (params);
     }
 
@@ -188,6 +209,9 @@ namespace Belos {
 
         const MagnitudeType defaultSingTol = as<MagnitudeType> (10) * eps;
 
+
+        //params->set ("Name", "DGKS", "Daniel, Gragg, Kaufman and Stewart (DGKS), orthgonalization");
+
         params->set ("maxNumOrthogPasses", defaultMaxNumOrthogPasses,
                      "Maximum number of orthogonalization passes (includes the "
                      "first).  Default is 2, since \"twice is enough\" for Krylov "
@@ -203,6 +227,45 @@ namespace Belos {
       return defaultParams_;
     }
 
+    static
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getDefaultParameters ()
+    {
+      using Teuchos::as;
+      using Teuchos::ParameterList;
+      using Teuchos::parameterList;
+      using Teuchos::RCP;
+
+      RCP<ParameterList> params = parameterList ("DGKS");
+      const MagnitudeType eps = MGT::eps ();
+
+      // Default parameter values for DGKS orthogonalization.
+      // Documentation will be embedded in the parameter list.
+      const int defaultMaxNumOrthogPasses = 2;
+      const MagnitudeType defaultBlkTol =
+        as<MagnitudeType> (10) * MGT::squareroot (eps);
+      const MagnitudeType defaultDepTol =
+        MGT::one() / MGT::squareroot (as<MagnitudeType> (2));
+
+      const MagnitudeType defaultSingTol = as<MagnitudeType> (10) * eps;
+
+
+      //params->set ("Name", "DGKS", "Daniel, Gragg, Kaufman and Stewart (DGKS), orthgonalization");
+
+      params->set ("maxNumOrthogPasses", defaultMaxNumOrthogPasses,
+                   "Maximum number of orthogonalization passes (includes the "
+                   "first).  Default is 2, since \"twice is enough\" for Krylov "
+                   "methods.");
+      params->set ("blkTol", defaultBlkTol, "Block reorthogonalization "
+                   "threshhold.");
+      params->set ("depTol", defaultDepTol,
+                   "(Non-block) reorthogonalization threshold.");
+      params->set ("singTol", defaultSingTol, "Singular block detection "
+                   "threshold.");
+
+      RCP<const ParameterList> params_const = params;
+      return params;
+    }
     //@}
 
     Teuchos::RCP<const Teuchos::ParameterList>
@@ -531,10 +594,16 @@ namespace Belos {
   {
     if (label != label_) {
       label_ = label;
-      std::string orthoLabel = label_ + ": Orthogonalization";
-#ifdef BELOS_TEUCHOS_TIME_MONITOR
-      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
-#endif
+
+      // if timers are enabled, then we must update their labels, as they track the ortho passes
+      #ifdef BELOS_TEUCHOS_TIME_MONITOR
+      {
+        std::stringstream ss;
+        ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+        std::string orthoLabel = ss.str () + ": Orthogonalization";
+        timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+      }
+      #endif
     }
   }
 

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -1270,10 +1270,9 @@ PseudoBlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
     //-----------------------------------------------------------------------
 
     // legacy parameters
-    Teuchos::RCP<Teuchos::ParameterList> orthoPl = Teuchos::sublist(pl, "Orthogonalziation");
-    orthoPl->set("Orthogonalization", orthoType_default_,
+    pl->set("Orthogonalization", orthoType_default_,
       "The type of orthogonalization to use: DGKS, ICGS, IMGS.");
-    orthoPl->set("Orthogonalization Constant",orthoKappa_default_,
+    pl->set("Orthogonalization Constant",orthoKappa_default_,
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
 

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -656,6 +656,8 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 {
   using Teuchos::ParameterList;
   using Teuchos::parameterList;
+  using Teuchos::sublist;
+  using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::rcp_dynamic_cast;
 
@@ -735,9 +737,28 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
     }
   }
 
+  // Optional sublist for OrthoManager parameters
+  RCP<ParameterList> orthoParams;
+  std::string tempOrthoType;
+  // the sublist for ortho options is new (2017).
+  // the intent is that the string parameter 'Orthogonalization'
+  // can optionally define a sublist.
+  const bool haveOrthoParamName = params->isParameter ("Orthogonalization");
+  if (haveOrthoParamName) {
+    tempOrthoType = params->get ("Orthogonalization", orthoType_default_);
+  } else {
+    tempOrthoType = orthoType_default_;
+  }
+
+  const bool haveOrthoSublist = params->isSublist (tempOrthoType);
+
+  if (haveOrthoSublist) {
+    orthoParams = sublist (params, tempOrthoType, true);
+  }
+
   // Check if the orthogonalization changed.
-  if (params->isParameter ("Orthogonalization")) {
-    std::string tempOrthoType = params->get ("Orthogonalization", orthoType_default_);
+  if (haveOrthoParamName || haveOrthoSublist) {
+
 #ifdef HAVE_BELOS_TSQR
     TEUCHOS_TEST_FOR_EXCEPTION(
       tempOrthoType != "DGKS" && tempOrthoType != "ICGS" &&
@@ -758,32 +779,52 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
     if (tempOrthoType != orthoType_) {
       orthoType_ = tempOrthoType;
+
       params_->set("Orthogonalization", orthoType_);
+
+      if (haveOrthoSublist) {
+        params_->set("OrthoManager", *orthoParams);
+      }
+
       // Create orthogonalization manager
       if (orthoType_ == "DGKS") {
         typedef DGKSOrthoManager<ScalarType, MV, OP> ortho_type;
         if (orthoKappa_ <= 0) {
-          ortho_ = rcp (new ortho_type (label_));
+          ortho_ = rcp (new ortho_type (orthoParams,label_));
         }
         else {
-          ortho_ = rcp (new ortho_type (label_));
+          ortho_ = rcp (new ortho_type (orthoParams,label_));
+          // TODO: jje 01 Feb 2017
+          //  1) deprecate constructor call that uses kappa
+          //  2) clean up this logic.
+          //
+          // this will enforce precedence of the constructor ortho parameter.
+          // This is not good. The constructor should remove the kappa option
+          // otherwise, it is unclear which to use if both are specified
+          //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
           rcp_dynamic_cast<ortho_type> (ortho_)->setDepTol (orthoKappa_);
         }
       }
       else if (orthoType_ == "ICGS") {
         typedef ICGSOrthoManager<ScalarType, MV, OP> ortho_type;
-        ortho_ = rcp (new ortho_type (label_));
+        ortho_ = rcp (new ortho_type (orthoParams,label_));
+        // configure the orthogonalizer using the parameter sublist
+        //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
       }
       else if (orthoType_ == "IMGS") {
         typedef IMGSOrthoManager<ScalarType, MV, OP> ortho_type;
-        ortho_ = rcp (new ortho_type (label_));
+        ortho_ = rcp (new ortho_type (orthoParams,label_));
+        // configure the orthogonalizer using the parameter sublist
+        //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
       }
-#ifdef HAVE_BELOS_TSQR
+      #ifdef HAVE_BELOS_TSQR
       else if (orthoType_ == "TSQR") {
         typedef TsqrMatOrthoManager<ScalarType, MV, OP> ortho_type;
-        ortho_ = rcp (new ortho_type (label_));
+        ortho_ = rcp (new ortho_type (orthoParams,label_));
+        // configure the orthogonalizer using the parameter sublist
+        //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
       }
-#endif // HAVE_BELOS_TSQR
+      #endif // HAVE_BELOS_TSQR
     }
   }
 
@@ -1041,29 +1082,44 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
   // Create orthogonalization manager if we need to.
   if (ortho_.is_null ()) {
+
     params_->set("Orthogonalization", orthoType_);
+    if (haveOrthoSublist) {
+      params_->set("OrthoManager", *orthoParams);
+    }
+
     if (orthoType_ == "DGKS") {
       typedef DGKSOrthoManager<ScalarType, MV, OP> ortho_type;
       if (orthoKappa_ <= 0) {
-        ortho_ = rcp (new ortho_type (label_));
+        ortho_ = rcp (new ortho_type (orthoParams,label_));
+        // configure the orthogonalizer using the parameter sublist
+        //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
       }
       else {
-        ortho_ = rcp (new ortho_type (label_));
+        ortho_ = rcp (new ortho_type (orthoParams,label_));
+        // configure the orthogonalizer using the parameter sublist
+        //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
         rcp_dynamic_cast<ortho_type> (ortho_)->setDepTol (orthoKappa_);
       }
     }
     else if (orthoType_ == "ICGS") {
       typedef ICGSOrthoManager<ScalarType, MV, OP> ortho_type;
-      ortho_ = rcp (new ortho_type (label_));
+      ortho_ = rcp (new ortho_type (orthoParams,label_));
+      // configure the orthogonalizer using the parameter sublist
+      //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
     }
     else if (orthoType_ == "IMGS") {
       typedef IMGSOrthoManager<ScalarType, MV, OP> ortho_type;
-      ortho_ = rcp (new ortho_type (label_));
+      ortho_ = rcp (new ortho_type (orthoParams,label_));
+      // configure the orthogonalizer using the parameter sublist
+      //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
     }
 #ifdef HAVE_BELOS_TSQR
     else if (orthoType_ == "TSQR") {
       typedef TsqrMatOrthoManager<ScalarType, MV, OP> ortho_type;
-      ortho_ = rcp (new ortho_type (label_));
+      ortho_ = rcp (new ortho_type (orthoParams,label_));
+      // configure the orthogonalizer using the parameter sublist
+      //rcp_dynamic_cast<ortho_type> (ortho_)->setParameterList (orthoParams);
     }
 #endif // HAVE_BELOS_TSQR
     else {
@@ -1124,11 +1180,17 @@ template<class ScalarType, class MV, class OP>
 Teuchos::RCP<const Teuchos::ParameterList>
 PseudoBlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
-  static Teuchos::RCP<const Teuchos::ParameterList> validPL;
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+  using Teuchos::sublist;
+  using Teuchos::parameterList;
+
+  static RCP<const ParameterList> validPL;
   if (is_null(validPL)) {
-    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+
+    RCP<ParameterList> pl = parameterList();
   // Set all the valid parameters and their default values.
-    pl= Teuchos::rcp( new Teuchos::ParameterList() );
+    pl= Teuchos::rcp( new ParameterList() );
     pl->set("Convergence Tolerance", convtol_default_,
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
@@ -1167,11 +1229,55 @@ PseudoBlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "The type of scaling used in the explicit residual convergence test.");
     pl->set("Timer Label", label_default_,
       "The string to use as a prefix for the timer labels.");
-    pl->set("Orthogonalization", orthoType_default_,
+
+    //-----------------------------------------------------------------------
+    // Gather the orthoManager's default parameters
+
+    // DGKS ortho parameter list
+    {
+      typedef DGKSOrthoManager<ScalarType, MV, OP> ortho_type;
+
+      RCP<ParameterList> orthoParams = sublist(pl, "DGKS");
+      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
+      // override the depTol using this class's defined value (legacy value)
+      orthoParams->set("depTol", orthoKappa_default_);
+    }
+    // ICGS
+    {
+      typedef ICGSOrthoManager<ScalarType, MV, OP> ortho_type;
+
+      RCP<ParameterList> orthoParams = sublist(pl, "ICGS");
+      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
+    }
+    // IMGS
+    {
+      typedef IMGSOrthoManager<ScalarType, MV, OP> ortho_type;
+
+      RCP<ParameterList> orthoParams = sublist(pl, "IMGS");
+
+      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
+    }
+    #ifdef HAVE_BELOS_TSQR
+    // TSQR
+    {
+      typedef TsqrMatOrthoManager<ScalarType, MV, OP> ortho_type;
+      RCP<ortho_type> ortho_tmp = rcp (new ortho_type ());
+
+      RCP<ParameterList> orthoParams = sublist(pl, "TSQR");
+      orthoParams->setParameters( *(ortho_tmp->getValidParameters()) );
+    }
+    #endif // HAVE_BELOS_TSQR
+    //-----------------------------------------------------------------------
+
+    // legacy parameters
+    Teuchos::RCP<Teuchos::ParameterList> orthoPl = Teuchos::sublist(pl, "Orthogonalziation");
+    orthoPl->set("Orthogonalization", orthoType_default_,
       "The type of orthogonalization to use: DGKS, ICGS, IMGS.");
-    pl->set("Orthogonalization Constant",orthoKappa_default_,
+    orthoPl->set("Orthogonalization Constant",orthoKappa_default_,
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
+
+
     pl->sublist("User Status Tests");
     pl->set("User Status Tests Combo Type", "SEQ",
         "Type of logical combination operation of user-defined\n"

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -783,7 +783,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
       params_->set("Orthogonalization", orthoType_);
 
       if (haveOrthoSublist) {
-        params_->set("OrthoManager", *orthoParams);
+        params_->set(orthoType_, *orthoParams);
       }
 
       // Create orthogonalization manager
@@ -1085,7 +1085,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
     params_->set("Orthogonalization", orthoType_);
     if (haveOrthoSublist) {
-      params_->set("OrthoManager", *orthoParams);
+      params_->set(orthoType_, *orthoParams);
     }
 
     if (orthoType_ == "DGKS") {
@@ -1232,46 +1232,50 @@ PseudoBlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
 
     //-----------------------------------------------------------------------
     // Gather the orthoManager's default parameters
-
-    // DGKS ortho parameter list
-    {
-      typedef DGKSOrthoManager<ScalarType, MV, OP> ortho_type;
-
-      RCP<ParameterList> orthoParams = sublist(pl, "DGKS");
-      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
-      // override the depTol using this class's defined value (legacy value)
-      orthoParams->set("depTol", orthoKappa_default_);
-    }
-    // ICGS
-    {
-      typedef ICGSOrthoManager<ScalarType, MV, OP> ortho_type;
-
-      RCP<ParameterList> orthoParams = sublist(pl, "ICGS");
-      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
-    }
-    // IMGS
-    {
-      typedef IMGSOrthoManager<ScalarType, MV, OP> ortho_type;
-
-      RCP<ParameterList> orthoParams = sublist(pl, "IMGS");
-
-      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
-    }
-    #ifdef HAVE_BELOS_TSQR
-    // TSQR
-    {
-      typedef TsqrMatOrthoManager<ScalarType, MV, OP> ortho_type;
-      RCP<ortho_type> ortho_tmp = rcp (new ortho_type ());
-
-      RCP<ParameterList> orthoParams = sublist(pl, "TSQR");
-      orthoParams->setParameters( *(ortho_tmp->getValidParameters()) );
-    }
-    #endif // HAVE_BELOS_TSQR
-    //-----------------------------------------------------------------------
+//
+//    // DGKS ortho parameter list
+//    {
+//      typedef DGKSOrthoManager<ScalarType, MV, OP> ortho_type;
+//
+//      RCP<ParameterList> orthoParams = sublist(pl, "DGKS");
+//      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
+//      // override the depTol using this class's defined value (legacy value)
+//      orthoParams->set("depTol", orthoKappa_default_);
+//    }
+//    // ICGS
+//    {
+//      typedef ICGSOrthoManager<ScalarType, MV, OP> ortho_type;
+//
+//      RCP<ParameterList> orthoParams = sublist(pl, "ICGS");
+//      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
+//    }
+//    // IMGS
+//    {
+//      typedef IMGSOrthoManager<ScalarType, MV, OP> ortho_type;
+//
+//      RCP<ParameterList> orthoParams = sublist(pl, "IMGS");
+//
+//      orthoParams->setParameters( *(ortho_type::getDefaultParameters()) );
+//    }
+//    #ifdef HAVE_BELOS_TSQR
+//    // TSQR
+//    {
+//      typedef TsqrMatOrthoManager<ScalarType, MV, OP> ortho_type;
+//      RCP<ortho_type> ortho_tmp = rcp (new ortho_type ());
+//
+//      RCP<ParameterList> orthoParams = sublist(pl, "TSQR");
+//      orthoParams->setParameters( *(ortho_tmp->getValidParameters()) );
+//    }
+//    #endif // HAVE_BELOS_TSQR
+//    //-----------------------------------------------------------------------
 
     // legacy parameters
     pl->set("Orthogonalization", orthoType_default_,
-      "The type of orthogonalization to use: DGKS, ICGS, IMGS.");
+      #ifdef HAVE_BELOS_TSQR
+        "The type of orthogonalization to use: DGKS, ICGS, IMGS, TSQR.");
+      #else
+        "The type of orthogonalization to use: DGKS, ICGS, IMGS.");
+      #endif
     pl->set("Orthogonalization Constant",orthoKappa_default_,
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");

--- a/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
+++ b/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
@@ -1450,6 +1450,8 @@ namespace Belos {
 
     if (defaultParams_.is_null()) {
       RCP<ParameterList> params = parameterList ("TsqrOrthoManagerImpl");
+
+      //params->set ("Name", "TSQR", "Tall Skinny QR");
       //
       // TSQR parameters (set as a sublist).
       //

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_IntrepidPoissonExample_SolveWithBelos.hpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_IntrepidPoissonExample_SolveWithBelos.hpp
@@ -147,8 +147,10 @@ solveWithBelos (bool& converged,
   belosParams->set ("Num Blocks", maxNumIters);
   belosParams->set ("Convergence Tolerance", tol);
   if (solverName == "GMRES") {
+    RCP<ParameterList> orthoParams = sublist (belosParams, "ICGS");
+    //orthoParams->set ("Name", "ICGS");
+    orthoParams->set ("maxNumOrthogPasses", 1);
     belosParams->set ("Orthogonalization", "ICGS");
-    belosParams->set ("maxNumOrthogPasses", 1);
   }
   belosParams->set ("Output Frequency", 10);
   belosParams->set ("Output Style", 1);


### PR DESCRIPTION
Update OrthOmanagers and Belos Pseudo Block GMRES to allow parameterlist configurations

API works as:
Solver Parameter List:
-- Orthogonalization : DGKS | ICGS | IMGS | TSQR
-- DGKS (sublist)
---- ...
-- ICGS (sublist)
---- ...

Ortho parameters are valid if they are acceptable as setParameters()
This allows a user to fully configure the orthogonalizer.

WARNING:
It is not clear how to handle the "Orthogonalization Constant" (kappa) that
is baked into GMRES. Currently, this constant's default is enforced at the GMRES
level.

Additions
1) allows the use of a sublist to control the orthomanager
   The solver takes a string parameter named "Orthogonalization"
   "Orthogonalization" accepts the same values it always has: DGKS, ICGS, IMGS, TSQR

   The solver constructs its default parameter list by calling the OrthoManager's new
   static function, getDefaultParameters. A sublist is added to the solver's paramater
   list named DGKS, ICGS, IMGS, and TSQR.

   An orthoManager is instantiated based off the Orthogonalization name, and
   the sublist if present, is passed to the constructor.

   This required the addition of:
   static template<const ParameterList> getDefaultParameters ()

   And the modification of:
   getValidParameters in the solver
   setParameters in the solver

   Note:
   The current implementations convolute getValidParameters with getDefaultParameters.
   A small change would be to have getValidParameters call getDefaultParameters.
   The former uses the defaults, and performs validation. The latter provides defaults
   without needed the class to be instantiated.

   The motivation for getDefaultParameters is that we can validate parameters without instantiating
   an orthoManager. E.g., we can query acceptable parameters without instantiation, and then
   validate against this list at the solver level.

   Orthogonalization sublists are validated. This will ensure that if a user provides a parameter,
   it will either be used or an error generated. This resolves the current problem, where apps
   and examples set the number of Ortho sweeps, but this does nothing.

2) Adjusted the labels used for Teuchos timers inside the orthoManagers.
   Labels now take the form: label_ + kernel_name + [ortho_passes] + detailed label
   E.g., Belos: ICGS[1]: Ortho (Inner Product)

   This addresses a performance concern, where users experience slow performance
   because the default ortho kernel is robust  numerically, but has slow performance relative
   to classical gram schmidt. This is a compromise between changing the default, and ignoring
   this user issue. This way, users are informed as best as possible, and performance

@mhoemmen @hkthorn 