### PR TITLE
Stratimikos: state dependency on ThyraCore

### DIFF
--- a/packages/stratimikos/cmake/Dependencies.cmake
+++ b/packages/stratimikos/cmake/Dependencies.cmake
@@ -3,6 +3,7 @@
 # a required dependence on Epetra but the Stratimikos Belos and ML adapters
 # need the Thyra/Epetra adapters.
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
+  LIB_REQUIRED_PACKAGES ThyraCore
   LIB_OPTIONAL_PACKAGES Amesos AztecOO Belos Ifpack ML EpetraExt ThyraEpetraAdapters
   TEST_REQUIRED_PACKAGES ThyraEpetraAdapters
   TEST_OPTIONAL_PACKAGES Triutils Ifpack2 ThyraTpetraAdapters


### PR DESCRIPTION
Stratimikos depends on ThyraCore, but until
recently that was implicitly taken care of
by a required dependency on ThyraEpetraAdapters.
Now that ThyraEpetraAdapters is optional,
we need to explicitly state the dependency on
ThyraCore.

This should resolve #1054

@bartlettroscoe  sorry for the never-ending string of fixes !