### PR TITLE
MueLu: add fine level statistics

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -61,6 +61,7 @@
 #include "MueLu_HierarchyFactory.hpp"
 #include "MueLu_Level.hpp"
 #include "MueLu_MasterList.hpp"
+#include "MueLu_PerfUtils.hpp"
 
 namespace MueLu {
 
@@ -149,6 +150,20 @@ namespace MueLu {
       VerboseObject::SetDefaultVerbLevel(verbosity_);
       if (graphOutputLevel_ >= 0)
         H.EnableGraphDumping("dep_graph.dot", graphOutputLevel_);
+
+      if (VerboseObject::IsPrint(Statistics2)) {
+        RCP<Matrix> Amat = rcp_dynamic_cast<Matrix>(Op);
+
+        if (!Amat.is_null()) {
+            RCP<ParameterList> params = rcp(new ParameterList());
+            params->set("printLoadBalancingInfo", true);
+            params->set("printCommInfo",          true);
+
+            VerboseObject::GetOStream(Statistics2) << PerfUtils::PrintMatrixInfo(*Amat, "A0", params);
+        } else {
+            VerboseObject::GetOStream(Warnings1) << "Fine level operator is not a matrix, statistics are not available" << std::endl;
+        }
+      }
 
       H.SetPRrebalance(doPRrebalance_);
       H.SetImplicitTranspose(implicitTranspose_);

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
@@ -70,6 +70,7 @@
 #include "MueLu_Level_fwd.hpp"
 #include "MueLu_MasterList.hpp"
 #include "MueLu_NoFactory.hpp"
+#include "MueLu_PerfUtils_fwd.hpp"
 #include "MueLu_PFactory_fwd.hpp"
 #include "MueLu_RFactory_fwd.hpp"
 #include "MueLu_SmootherBase_fwd.hpp"

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -66,6 +66,7 @@
 #include "MueLu_TopSmootherFactory.hpp"
 #include "MueLu_Level.hpp"
 #include "MueLu_Monitor.hpp"
+#include "MueLu_PerfUtils.hpp"
 #include "MueLu_PFactory.hpp"
 #include "MueLu_SmootherFactoryBase.hpp"
 #include "MueLu_SmootherFactory.hpp"
@@ -469,6 +470,20 @@ namespace MueLu {
 
     RCP<Operator> A = Levels_[startLevel]->template Get<RCP<Operator> >("A");
     lib_ = A->getDomainMap()->lib();
+
+    if (IsPrint(Statistics2)) {
+      RCP<Matrix> Amat = rcp_dynamic_cast<Matrix>(A);
+
+      if (!Amat.is_null()) {
+          RCP<ParameterList> params = rcp(new ParameterList());
+          params->set("printLoadBalancingInfo", true);
+          params->set("printCommInfo",          true);
+
+          GetOStream(Statistics2) << PerfUtils::PrintMatrixInfo(*Amat, "A0", params);
+      } else {
+          GetOStream(Warnings1) << "Fine level operator is not a matrix, statistics are not available" << std::endl;
+      }
+    }
 
     RCP<const FactoryManagerBase> rcpmanager = rcpFromRef(manager);
 

--- a/packages/muelu/src/Utils/MueLu_PerfUtils_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_PerfUtils_decl.hpp
@@ -54,7 +54,7 @@
 #include <Xpetra_Import_fwd.hpp>
 #include <Xpetra_Matrix_fwd.hpp>
 
-//#include "MueLu_Utilities_fwd.hpp"
+#include "MueLu_PerfUtils_fwd.hpp"
 
 namespace MueLu {
 // MPI helpers
@@ -77,6 +77,9 @@ namespace MueLu {
     static std::string PrintMatrixInfo(const Matrix& A, const std::string& msgTag, RCP<const Teuchos::ParameterList> params = Teuchos::null);
 
     static std::string CommPattern(const Matrix& A, const std::string& msgTag, RCP<const Teuchos::ParameterList> params = Teuchos::null);
+
+  private:
+    static bool CheckMatrix(const Matrix& A);
   };
 
 } //namespace MueLu

--- a/packages/muelu/src/Utils/MueLu_PerfUtils_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_PerfUtils_def.hpp
@@ -101,6 +101,9 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   std::string PerfUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::PrintMatrixInfo(const Matrix& A, const std::string& msgTag, RCP<const ParameterList> params) {
+    if (!CheckMatrix(A))
+      return "";
+
     typedef Xpetra::global_size_t global_size_t;
 
     std::ostringstream ss;
@@ -203,6 +206,9 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   std::string PerfUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::CommPattern(const Matrix& A, const std::string& msgTag, RCP<const ParameterList> params) {
+    if (!CheckMatrix(A))
+      return "";
+
     std::ostringstream out;
 
     RCP<const Teuchos::Comm<int> > comm = A.getRowMap()->getComm();
@@ -237,6 +243,24 @@ namespace MueLu {
     }
 
     return out.str();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool PerfUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::CheckMatrix(const Matrix& A) {
+    // We can only print statistics for matrices that have a crs graph. A
+    // potential issue is regarding Xpetra::TpetraBlockCrsMatrix which has no
+    // CrsGraph.  It is held as a private data member by Xpetra::CrsMatrix,
+    // which itself is an Xpetra::Matrix. So we check directly whether the
+    // request for the graph throws.
+    bool hasCrsGraph = true;
+    try {
+      A.getCrsGraph();
+
+    } catch (...) {
+      hasCrsGraph = false;
+    }
+
+    return hasCrsGraph;
   }
 
 } //namespace MueLu


### PR DESCRIPTION
- Do not throw when Operator is not a Matrix, instead produce a warning
- Fix #1059.
- Include the fwd header into PerfUtils_decl.hpp so that PerfUtils.hpp
  can be used in the standalone mode.

Fixes #1059.