### PR TITLE
Intrepid2: ArrayToolsDefDot: fix for const ScalarT

### DIFF
--- a/packages/intrepid2/refactor/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
+++ b/packages/intrepid2/refactor/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
@@ -58,7 +58,7 @@ namespace Intrepid2 {
       leftInputViewType _leftInput;
       rightInputViewType _rightInput;
       const bool _hasField;
-      typedef typename leftInputViewType::value_type value_type;
+      typedef typename outputViewType::value_type value_type;
 
       KOKKOS_INLINE_FUNCTION
       F_dotMultiply(outputViewType output_,


### PR DESCRIPTION
value_type shouldn't be taken from one of the input
views because they may have `const ScalarT` as their
value_type. instead take it from the output view.

this is needed to resolve gahansen/Albany#34

@mperego @kyungjoo-kim 