### PR TITLE
Stratimikos: use MPI in Amesos adapter test

### DIFF
--- a/packages/stratimikos/adapters/amesos/test/test_single_amesos_thyra_solver.cpp
+++ b/packages/stratimikos/adapters/amesos/test/test_single_amesos_thyra_solver.cpp
@@ -52,7 +52,11 @@
 #include "Thyra_LinearOpTester.hpp"
 #include "Thyra_LinearOpWithSolveTester.hpp"
 #include "EpetraExt_readEpetraLinearSystem.h"
+#ifdef EPETRA_MPI
+#include "Epetra_MpiComm.h"
+#else
 #include "Epetra_SerialComm.h"
+#endif
 
 #endif // SUN_CXX
 
@@ -105,7 +109,11 @@ bool Thyra::test_single_amesos_thyra_solver(
   
   if(out.get()) *out << "\nA) Reading in an epetra matrix A from the file \'"<<matrixFile<<"\' ...\n";
   
+#ifdef EPETRA_MPI
+  Epetra_MpiComm comm(MPI_COMM_WORLD);
+#else
   Epetra_SerialComm comm;
+#endif
   RCP<Epetra_CrsMatrix> epetra_A;
   EpetraExt::readEpetraLinearSystem( matrixFile, comm, &epetra_A );
 

--- a/packages/stratimikos/adapters/amesos/test/test_single_amesos_thyra_solver_driver.cpp
+++ b/packages/stratimikos/adapters/amesos/test/test_single_amesos_thyra_solver_driver.cpp
@@ -44,9 +44,17 @@
 #include "test_single_amesos_thyra_solver.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_VerboseObject.hpp"
+#include "Epetra_ConfigDefs.h"
+#ifdef EPETRA_MPI
+#include <mpi.h>
+#endif
 
 int main(int argc, char* argv[])
 {
+
+#ifdef EPETRA_MPI
+  MPI_Init(&argc, &argv);
+#endif
   
   using Teuchos::CommandLineProcessor;
 
@@ -129,6 +137,10 @@ int main(int argc, char* argv[])
     if(success)  *out << "\nCongratulations! All of the tests checked out!\n";
     else         *out << "\nOh no! At least one of the tests failed!\n";
   }
+
+#ifdef EPETRA_MPI
+  MPI_Finalize();
+#endif
 
   return ( success ? 0 : 1 );
 }


### PR DESCRIPTION
The Amesos interface to SuperLU_DIST needs to
give SuperLU_DIST and MPI_Comm, therefore it
needs to be given an Epetra_MpiComm, even on
a single rank.
Without this commit, Stratimikos+Amesos+SuperLU_DIST
testing will always fail with a bad_cast
from Epetra_SerialComm to Epetra_MpiComm.

This is leading up to more work I'm doing adding
Amesos2 to Stratimikos, will show up in a future PR.

@trilinos/stratimikos 