### PR TITLE
Teuchos: fix typing of TwoDArray::operator[]

### DIFF
--- a/packages/teuchos/core/src/Teuchos_TwoDArray.hpp
+++ b/packages/teuchos/core/src/Teuchos_TwoDArray.hpp
@@ -107,7 +107,7 @@ public:
   inline ArrayView<T> operator[](size_type i);
 
   /** \brief Returns a const ArrayView containing the contents of row i */
-  inline const ArrayView<T> operator[](size_type i) const;
+  inline ArrayView<const T> operator[](size_type i) const;
 
   /** \brief returns the number of rows in the TwoDArray. */
   inline size_type getNumRows() const{
@@ -266,7 +266,7 @@ ArrayView<T> TwoDArray<T>::operator[](size_type i){
 }
 
 template<class T> inline
-const ArrayView<T> TwoDArray<T>::operator[](size_type i) const{
+ArrayView<const T> TwoDArray<T>::operator[](size_type i) const{
   return _data.view(_numCols*i, _numCols);
 }
 

--- a/packages/teuchos/core/test/TwoDArray/TwoDArray_UnitTests.cpp
+++ b/packages/teuchos/core/test/TwoDArray/TwoDArray_UnitTests.cpp
@@ -67,12 +67,22 @@ TEUCHOS_UNIT_TEST(Teuchos_TwoDArrays, simpleTest){
   simpleArray[1][1] =4;
   simpleArray[2][0] =5;
   simpleArray[2][1] =6;
+
   TEST_EQUALITY_CONST(simpleArray[0][0],1)
   TEST_EQUALITY_CONST(simpleArray[0][1],2)
   TEST_EQUALITY_CONST(simpleArray[1][0],3)
   TEST_EQUALITY_CONST(simpleArray[1][1],4)
   TEST_EQUALITY_CONST(simpleArray[2][0],5)
   TEST_EQUALITY_CONST(simpleArray[2][1],6)
+
+  TwoDArray<int> const& simpleArrayConst = simpleArray;
+
+  TEST_EQUALITY_CONST(simpleArrayConst[0][0],1)
+  TEST_EQUALITY_CONST(simpleArrayConst[0][1],2)
+  TEST_EQUALITY_CONST(simpleArrayConst[1][0],3)
+  TEST_EQUALITY_CONST(simpleArrayConst[1][1],4)
+  TEST_EQUALITY_CONST(simpleArrayConst[2][0],5)
+  TEST_EQUALITY_CONST(simpleArrayConst[2][1],6)
 
   TEST_EQUALITY_CONST(simpleArray(0,0),1)
   TEST_EQUALITY_CONST(simpleArray(0,1),2)


### PR DESCRIPTION
This operator must be rarely used, because
the return type doesn't match the type of
the expression returned (it should be
`ArrayView<const T>`, not `const ArrayView<T>`).
I'm fixing this because I need this operator
to unit test some YAML functionality I'm
developing.
(I can't use the operator(i, j) because there can
be no commas in the argument to TEST_NOTHROW).

@trilinos/teuchos 

This is a precursor to an upcoming PR