### PR TITLE
Amesos2: Expose getNnzLU in Basker and KLU

### DIFF
--- a/packages/amesos2/src/Amesos2_Basker_def.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_def.hpp
@@ -247,12 +247,12 @@ Basker<Matrix,Vector>::numericFactorization_impl()
       }
       else {
 
-      info = basker->Factor(this->globalNumRows_,
-                            this->globalNumCols_, 
-                            this->globalNumNonZeros_, 
-                            colptr_.getRawPtr(), 
-                            rowind_.getRawPtr(), 
-                            nzvals_.getRawPtr());
+        info = basker->Factor(this->globalNumRows_,
+            this->globalNumCols_, 
+            this->globalNumNonZeros_, 
+            colptr_.getRawPtr(), 
+            rowind_.getRawPtr(), 
+            nzvals_.getRawPtr());
       //We need to handle the realloc options
       }
 
@@ -262,8 +262,21 @@ Basker<Matrix,Vector>::numericFactorization_impl()
 				 std::runtime_error,
 				 "Error Basker Factor");
 
+      local_ordinal_type blnnz = local_ordinal_type(0); 
+      local_ordinal_type bunnz = local_ordinal_type(0); 
+      basker->GetLnnz(blnnz); // Add exception handling?
+      basker->GetUnnz(bunnz);
+
+      // This is set after numeric factorization complete as pivoting can be used;
+      // In this case, a discrepancy between symbolic and numeric nnz total can occur.
+      this->setNnzLU( as<size_t>( blnnz + bunnz ) );
+
 #else
-      info =basker.factor(this->globalNumRows_, this->globalNumCols_, this->globalNumNonZeros_, colptr_.getRawPtr(), rowind_.getRawPtr(), nzvals_.getRawPtr());
+      info = basker.factor(this->globalNumRows_, this->globalNumCols_, this->globalNumNonZeros_, colptr_.getRawPtr(), rowind_.getRawPtr(), nzvals_.getRawPtr());
+
+      // This is set after numeric factorization complete as pivoting can be used;
+      // In this case, a discrepancy between symbolic and numeric nnz total can occur.
+      this->setNnzLU( as<size_t>(basker.getNnzLU() ) ) ;
 #endif
 
     }
@@ -539,10 +552,6 @@ Basker<Matrix,Vector>::loadA_impl(EPhase current_phase)
 
   } //end alternative path 
 #else // Not ShyLUBasker
-
-  #ifdef HAVE_AMESOS2_TIMERS
-  Teuchos::TimeMonitor convTimer(this->timers_.mtxConvTime_);
-  #endif
 
   // Only the root image needs storage allocated
   if( this->root_ ){

--- a/packages/amesos2/src/Amesos2_Basker_def.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_def.hpp
@@ -276,7 +276,7 @@ Basker<Matrix,Vector>::numericFactorization_impl()
 
       // This is set after numeric factorization complete as pivoting can be used;
       // In this case, a discrepancy between symbolic and numeric nnz total can occur.
-      this->setNnzLU( as<size_t>(basker.getNnzLU() ) ) ;
+      this->setNnzLU( as<size_t>(basker.get_NnzLU() ) ) ;
 #endif
 
     }

--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -166,10 +166,13 @@ KLU2<Matrix,Vector>::numericFactorization_impl()
     if (data_.numeric_ != NULL)
       ::KLU2::klu_free_numeric<slu_type, local_ordinal_type>
                          (&(data_.numeric_), &(data_.common_)) ;
-    data_.numeric_ = ::KLU2::klu_factor<slu_type, local_ordinal_type>
-                (colptr_.getRawPtr(), rowind_.getRawPtr(), nzvals_.getRawPtr(),
-                data_.symbolic_, &(data_.common_)) ;
+      data_.numeric_ = ::KLU2::klu_factor<slu_type, local_ordinal_type>
+                  (colptr_.getRawPtr(), rowind_.getRawPtr(), nzvals_.getRawPtr(),
+                  data_.symbolic_, &(data_.common_)) ;
 
+      // This is set after numeric factorization complete as pivoting can be used;
+      // In this case, a discrepancy between symbolic and numeric nnz total can occur.
+      this->setNnzLU( as<size_t>((data_.numeric_)->lnz) + as<size_t>((data_.numeric_)->unz) );
     }
 
   }

--- a/packages/amesos2/src/basker/basker_decl.hpp
+++ b/packages/amesos2/src/basker/basker_decl.hpp
@@ -48,6 +48,10 @@ namespace Basker{
     int returnP(Int **p);
     int solve( Entry* b, Entry* x);
     int solveMultiple(Int nrhs, Entry *b, Entry *x);
+
+    Int getNnzL();
+    Int getNnzU();
+    Int getNnzLU();
     //int solve();
 
   private:

--- a/packages/amesos2/src/basker/basker_decl.hpp
+++ b/packages/amesos2/src/basker/basker_decl.hpp
@@ -49,9 +49,9 @@ namespace Basker{
     int solve( Entry* b, Entry* x);
     int solveMultiple(Int nrhs, Entry *b, Entry *x);
 
-    Int getNnzL();
-    Int getNnzU();
-    Int getNnzLU();
+    Int get_NnzL();
+    Int get_NnzU();
+    Int get_NnzLU();
     //int solve();
 
   private:
@@ -81,6 +81,8 @@ namespace Basker{
     basker_matrix<Int, Entry> *U;
     Int *in_perm;
     Int *pinv;
+    Int actual_lnnz;
+    Int actual_unnz;
     bool been_fact;
     bool perm_flag;
 

--- a/packages/amesos2/src/basker/basker_def.hpp
+++ b/packages/amesos2/src/basker/basker_def.hpp
@@ -102,8 +102,6 @@ namespace Basker{
     delete L;
     //FREE(U);
     delete U;
-
-
   }
 
 
@@ -598,9 +596,29 @@ namespace Basker{
 
     //FREE(X);
     //FREE(tptr);
+
     been_fact = true;
     return 0;
   }//end factor
+
+
+  template <class Int, class Entry>
+  Int Basker<Int, Entry>::getNnzL()
+  {
+    return L->nnz;
+  }
+
+  template <class Int, class Entry>
+  Int Basker<Int, Entry>::getNnzU()
+  {
+    return U->nnz;
+  }
+
+  template <class Int, class Entry>
+  Int Basker<Int, Entry>::getNnzLU()
+  {
+    return (U->nnz + L->nnz);
+  }
 
   template <class Int, class Entry>
   int Basker<Int, Entry>::returnL(Int *dim, Int *nnz, Int **col_ptr, Int **row_idx, Entry **val)

--- a/packages/amesos2/src/basker/basker_def.hpp
+++ b/packages/amesos2/src/basker/basker_def.hpp
@@ -59,6 +59,9 @@ namespace Basker{
     U = new basker_matrix<Int,Entry>;
     U->nnz = 0;
 
+    actual_lnnz = Int(0);
+    actual_unnz = Int(0);
+
     been_fact = false;
     perm_flag = false;
   }
@@ -76,6 +79,9 @@ namespace Basker{
     //U = (basker_matrix<Int, Entry> *) malloc(sizeof(basker_matrix<Int,Entry>));
     U = new basker_matrix<Int, Entry>;
     U->nnz = nnzU;
+
+    actual_lnnz = Int(0);
+    actual_unnz = Int(0);
 
     been_fact = false;
     perm_flag = false;
@@ -597,27 +603,30 @@ namespace Basker{
     //FREE(X);
     //FREE(tptr);
 
+    actual_lnnz = lnnz;
+    actual_unnz = unnz;
+
     been_fact = true;
     return 0;
   }//end factor
 
 
   template <class Int, class Entry>
-  Int Basker<Int, Entry>::getNnzL()
+  Int Basker<Int, Entry>::get_NnzL()
   {
-    return L->nnz;
+    return actual_lnnz;
   }
 
   template <class Int, class Entry>
-  Int Basker<Int, Entry>::getNnzU()
+  Int Basker<Int, Entry>::get_NnzU()
   {
-    return U->nnz;
+    return actual_unnz;
   }
 
   template <class Int, class Entry>
-  Int Basker<Int, Entry>::getNnzLU()
+  Int Basker<Int, Entry>::get_NnzLU()
   {
-    return (U->nnz + L->nnz);
+    return (actual_lnnz + actual_unnz);
   }
 
   template <class Int, class Entry>

--- a/packages/amesos2/test/solvers/Basker_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/Basker_UnitTests.cpp
@@ -277,6 +277,8 @@ namespace {
 
     solver->symbolicFactorization().numericFactorization();
 
+    TEST_ASSERT( solver->getStatus().getNnzLU() != 0 );
+    TEST_ASSERT( solver->getStatus().getNnzLU() == numLocal*static_cast<const size_t>(2*comm->getSize()) );
     // Good way to check the factors L and U?  Probs not, since they are private members
   }
 

--- a/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
@@ -265,6 +265,8 @@ namespace {
 
     solver->symbolicFactorization().numericFactorization();
 
+    TEST_ASSERT( solver->getStatus().getNnzLU() != 0 );
+    TEST_ASSERT( solver->getStatus().getNnzLU() == numLocal*static_cast<const size_t>(2*comm->getSize()) );
     // Good way to check the factors L and U?  Probs not, since they are private members
   }
 


### PR DESCRIPTION
This address Github issue #1127
At the end of numericFactorization_impl, whether using Basker or KLU,
   the status_ lu_nnz_ variable is set via the setNnzLU( args ) method;
this is done at the end of numericFactorization as these solvers allow
for pivoting, which could cause a discrepency in the number of
non-zeros reported after symbolicFactorization compared to
numericFactorization.