### PR TITLE
Mod in Thyra_BelosLinearOpWithSolve: separating verbosity of BelosSol…

### DIFF
--- a/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_def.hpp
+++ b/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_def.hpp
@@ -635,15 +635,15 @@ BelosLinearOpWithSolve<Scalar>::solveImpl(
 
   Belos::ReturnType belosSolveStatus;
   {
-    // Write detailed convergence information if requested for levels >= VERB_LOW
-    RCP<std::ostream>
-      outUsed =
-      ( static_cast<int>(verbLevel) >= static_cast<int>(Teuchos::VERB_LOW)
-        ? out
-        : rcp(new FancyOStream(rcp(new Teuchos::oblackholestream())))
-        );
-    Teuchos::OSTab tab1(outUsed,1,"BELOS");
-    tmpPL->set("Output Stream", outUsed);
+    // LB: We no longer check this->getVerbLevel to decide whether the output stream
+    // of the iterative solver should be a blackhole or a valid ostream. Instead,
+    // we let the user decide that with the verbosity option in the solver's
+    // parameter list. This way we do not have to make this class verbose too, if
+    // we want the solver to be verbose. In other words, the verbosity of this class
+    // (which is set equal to that of its factory) should have nothing to do with
+    // the verbosity of the Belos solver (which is set via solver's parameter list
+    // by the user).
+    tmpPL->set("Output Stream", out);
     iterativeSolver_->setParameters(tmpPL);
     if (nonnull(generalSolveCriteriaBelosStatusTest)) {
       iterativeSolver_->setUserConvStatusTest(generalSolveCriteriaBelosStatusTest);

--- a/packages/stratimikos/example/belos_tpetra.xml
+++ b/packages/stratimikos/example/belos_tpetra.xml
@@ -1,0 +1,44 @@
+<ParameterList>
+  <ParameterList name="Stratimikos">
+    <Parameter name="Linear Solver Type"  type="string" value="Belos"/>
+    <Parameter name="Preconditioner Type" type="string" value="MueLu"/>
+
+    <ParameterList name="Linear Solver Types">
+      <ParameterList name="Belos">
+        <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+        <ParameterList name="Solver Types">
+          <ParameterList name="Block GMRES">
+            <Parameter name="Convergence Tolerance" type="double" value="1e-8"/>
+            <Parameter name="Output Frequency"      type="int"    value="1"/>
+            <Parameter name="Output Style"          type="int"    value="1"/>
+            <Parameter name="Verbosity"             type="int"    value="41"/>
+            <Parameter name="Maximum Iterations"    type="int"    value="20"/>
+            <Parameter name="Block Size"            type="int"    value="1"/>
+            <Parameter name="Num Blocks"            type="int"    value="4"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList> <!-- Linear Solver Types -->
+
+    <ParameterList name="Preconditioner Types">
+      <ParameterList name="Ifpack2">
+        <Parameter name="Overlap"                         type="int" value="0"/>
+        <Parameter name="Prec Type"                       type="string" value="ILUT"/>
+        <ParameterList name="Ifpack2 Settings">
+          <Parameter name="fact: level-of-fill"           type="int" value="0"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="MueLu">
+        <Parameter name="verbosity"                       type="string"   value="none"/>
+        <Parameter name="max levels"                      type="int"      value="10"/>
+        <Parameter name="multigrid algorithm"             type="string"   value="sa"/>
+        <Parameter name="smoother: type"                  type="string"   value="RELAXATION"/>
+        <ParameterList name="smoother: params">
+          <Parameter name="relaxation: type"              type="string"   value="Symmetric Gauss-Seidel"/>
+          <Parameter name="relaxation: sweeps"            type="int"      value="3"/>
+          <Parameter name="relaxation: damping factor"    type="double"   value="1"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList> <!-- Preconditioner Types -->
+</ParameterList>
+


### PR DESCRIPTION
…ver from that of Belos LOWS

The verbosity of Belos LOWS is set by the Belos LOWS factory to be the same
as that of the Belos LOWS factory.

Before this change, the ostream of the Belos solver was set to be a
oblackholestream if the LOWS verbosity was not at least equal to VERB_LOW,
in which case it would make the 'Verbosity' option in the Belos parameter
list completely ineffective. This, in turn, forced the user to give the
LOWS and the LOWS factory some degree of verbosity in order to allow the
Belos solver to print anything at all.

Since the user is not necessarily interested in the output of the LOWS and
LOWS factory, we modified this. Now the ostream passed to the Belos solver
is a valid ostream (not a blackhole) and the user can set the verbosity of
the Belos solver via parameter list independently of the verbosity of the
LOWS and LOWS factory.