### PR TITLE
MiniTensor: give protected access to bool failed

### DIFF
--- a/packages/minitensor/src/MiniTensor_Solvers.h
+++ b/packages/minitensor/src/MiniTensor_Solvers.h
@@ -115,7 +115,7 @@ public:
   char const * const
   get_failure_message();
 
-private:
+protected:
   ///
   /// Signal that something has gone horribly wrong.
   ///


### PR DESCRIPTION
There is code in the Albany CrystalPlasticity
model that directly accesses this boolean, and
got broken by f001af9.
This commit fixes the build.

@lxmota this fixes today's Albany CDash failures:

http://my.cdash.org/viewBuildError.php?buildid=1155248