### PR TITLE
Zoltan: add error checking in Matrix_Mark_Diag

### DIFF
--- a/packages/zoltan/src/matrix/matrix_operations.c
+++ b/packages/zoltan/src/matrix/matrix_operations.c
@@ -442,10 +442,13 @@ Zoltan_Matrix_Mark_Diag(ZZ* zz, const Zoltan_matrix* const m,
   (*n_nnz) = 0;
   for (y = 0 ; y < m->nY ; ++y) {
     int pin;
+    int found_diag = 0;
     for (pin = m->ystart[y] ; pin < m->yend[y] ; ++pin) {
       if (m->pinGNO[pin] == m->yGNO[y]) {
-	(*nnz)[(*n_nnz)] = pin;
-	(*n_nnz)++;
+        if (found_diag) FATAL_ERROR("Diagonal term declared twice");
+        (*nnz)[(*n_nnz)] = pin;
+        (*n_nnz)++;
+        found_diag = 1;
       }
     }
   }


### PR DESCRIPTION
This additional code just checks for the
precondition described in the comment of
the function.
If users declared diagonal terms twice,
this function used to segfault.
This change should produce a more helpful
error message so users know what they've
done wrong.

@trilinos/zoltan