### PR TITLE
Teko: fix compile error introduced by e728fc0

### DIFF
--- a/packages/teko/src/Tpetra/Teko_InterlacedTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_InterlacedTpetra.cpp
@@ -122,6 +122,9 @@ void buildSubMaps(GO numGlobals,LO numMyElements,GO minMyGID,const std::vector<i
    for(varItr=vars.begin();varItr!=vars.end();++varItr) {
       LO numLocalVars = *varItr;
       GO numAllElmts = numLocalVars*numGlobals/numGlobalVars;
+#ifndef NDEBUG
+      LO numMyElmts = numLocalVars * numBlocks;
+#endif
 
       // create global arrays describing the as of yet uncreated maps
       std::vector<GO> subGlobals;


### PR DESCRIPTION
this variable does need to be defined if
the assert() call will be using it, so
it needs to be protected by the same
condition that controls assert(),
which is NDEBUG

@trilinos/teko 
Trilinos develop failed to compile in the Albany CDash:
http://my.cdash.org/viewBuildError.php?buildid=1158196