### PR TITLE
Issue #1178 (ROL build failure on Windows)

### DIFF
--- a/packages/rol/src/sol/function/ROL_Distribution.hpp
+++ b/packages/rol/src/sol/function/ROL_Distribution.hpp
@@ -44,13 +44,13 @@
 #ifndef ROL_DISTRIBUTION_HPP
 #define ROL_DISTRIBUTION_HPP
 
-#if defined(_MSC_VER) && !defined(M_PI)
-#define _USE_MATH_DEFINES
-#endif
-
 #include "ROL_Types.hpp"
 
-#include <cmath>
+#if defined(_MSC_VER)
+ #include "winmath.h"
+#else
+ #include <cmath>
+#endif
 #include <iostream>
 
 namespace ROL {

--- a/packages/rol/src/sol/function/ROL_Distribution.hpp
+++ b/packages/rol/src/sol/function/ROL_Distribution.hpp
@@ -44,6 +44,10 @@
 #ifndef ROL_DISTRIBUTION_HPP
 #define ROL_DISTRIBUTION_HPP
 
+#if defined(_MSC_VER) && !defined(M_PI)
+#define _USE_MATH_DEFINES
+#endif
+
 #include "ROL_Types.hpp"
 
 #include <cmath>

--- a/packages/rol/src/step/interiorpoint/ROL_InteriorPointPenalty.hpp
+++ b/packages/rol/src/step/interiorpoint/ROL_InteriorPointPenalty.hpp
@@ -134,7 +134,7 @@ private:
   public: 
     Mask( bool complement ) : complement_(complement) {}
     Real apply( const Real &x, const Real &y ) const {
-      return ( complement_ xor (y !=0) ) ? 0 : x;
+      return ( complement_ ^ (y !=0) ) ? 0 : x;
     } 
   }; // class Mask
 

--- a/packages/rol/src/utils/ROL_GaussChebyshev3Quadrature.hpp
+++ b/packages/rol/src/utils/ROL_GaussChebyshev3Quadrature.hpp
@@ -44,6 +44,10 @@
 #ifndef ROL_GAUSSCHEBYSHEV3QUADRATURE_HPP
 #define ROL_GAUSSCHEBYSHEV3QUADRATURE_HPP
 
+#if defined(_MSC_VER) && !defined(M_PI)
+#define _USE_MATH_DEFINES
+#endif
+
 #include "ROL_Quadrature1D.hpp"
 #include <cmath>
 

--- a/packages/rol/src/utils/ROL_GaussChebyshev3Quadrature.hpp
+++ b/packages/rol/src/utils/ROL_GaussChebyshev3Quadrature.hpp
@@ -44,12 +44,12 @@
 #ifndef ROL_GAUSSCHEBYSHEV3QUADRATURE_HPP
 #define ROL_GAUSSCHEBYSHEV3QUADRATURE_HPP
 
-#if defined(_MSC_VER) && !defined(M_PI)
-#define _USE_MATH_DEFINES
-#endif
-
 #include "ROL_Quadrature1D.hpp"
+#if defined(_MSC_VER)
+#include "winmath.h"
+#else
 #include <cmath>
+#endif
 
 namespace ROL {
 

--- a/packages/rol/src/zoo/ROL_HS5.hpp
+++ b/packages/rol/src/zoo/ROL_HS5.hpp
@@ -58,8 +58,8 @@
 #include "ROL_BoundConstraint.hpp"
 #include "ROL_Types.hpp"
 
-#if defined(_MSC_VER) && !defined(M_PI)
-#define M_PI 3.14159265358979323846
+#if defined(_MSC_VER)
+#include "winmath.h"
 #endif
 
 namespace ROL {

--- a/packages/rol/src/zoo/ROL_HS5.hpp
+++ b/packages/rol/src/zoo/ROL_HS5.hpp
@@ -58,6 +58,10 @@
 #include "ROL_BoundConstraint.hpp"
 #include "ROL_Types.hpp"
 
+#if defined(_MSC_VER) && !defined(M_PI)
+#define M_PI 3.14159265358979323846
+#endif
+
 namespace ROL {
 namespace ZOO {
 

--- a/packages/teuchos/core/src/Teuchos_ConfigDefs.hpp
+++ b/packages/teuchos/core/src/Teuchos_ConfigDefs.hpp
@@ -77,10 +77,6 @@
 #  define HAVE_COMPLEX
 #endif
 
-#if defined(_MSC_VER) && !defined(M_PI)
-#define _USE_MATH_DEFINES
-#endif
-
 #include <cstdio>
 #include <cstdarg>
 #include <cerrno>

--- a/packages/teuchos/core/src/Teuchos_ConfigDefs.hpp
+++ b/packages/teuchos/core/src/Teuchos_ConfigDefs.hpp
@@ -77,6 +77,10 @@
 #  define HAVE_COMPLEX
 #endif
 
+#if defined(_MSC_VER) && !defined(M_PI)
+#define _USE_MATH_DEFINES
+#endif
+
 #include <cstdio>
 #include <cstdarg>
 #include <cerrno>


### PR DESCRIPTION
@trilinos/rol 
@trilinos/teuchos 

Added some defines to enable using the M_PI constant.
Changed a gcc-specific 'xor' to standard c++ operator ^.