### PR TITLE
Teuchos: accept ostream precision for YAML values

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -662,11 +662,7 @@ void generalWriteString(const std::string& str, std::ostream& yaml)
 
 void generalWriteDouble(double d, std::ostream& yaml)
 {
-  std::ios saved_state(0);
-  saved_state.copyfmt(yaml);
-  yaml << std::noshowpoint << std::scientific << std::setprecision(15);
   yaml << d;
-  yaml.copyfmt(saved_state);
 }
 
 bool stringNeedsQuotes(const std::string& str)

--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -47,6 +47,9 @@
 #ifndef TEUCHOS_YAMLPARSER_DEF_H_
 #define TEUCHOS_YAMLPARSER_DEF_H_
 
+#include <iostream>
+#include <iomanip>
+
 #include "Teuchos_YamlParser_decl.hpp"
 #include "Teuchos_XMLParameterListCoreHelpers.hpp"
 #include "Teuchos_YamlParameterListCoreHelpers.hpp"
@@ -659,17 +662,11 @@ void generalWriteString(const std::string& str, std::ostream& yaml)
 
 void generalWriteDouble(double d, std::ostream& yaml)
 {
-  yaml << std::showpoint << std::setprecision(8);
-  if(d < 1e6 && d > 1e-5)
-  {
-    //use regular notation
-    yaml << d;
-  }
-  else
-  {
-    yaml << std::scientific << d;
-  }
-  yaml << std::fixed;
+  std::ios saved_state(0);
+  saved_state.copyfmt(yaml);
+  yaml << std::noshowpoint << std::scientific << std::setprecision(15);
+  yaml << d;
+  yaml.copyfmt(saved_state);
 }
 
 bool stringNeedsQuotes(const std::string& str)

--- a/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
+++ b/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
@@ -156,7 +156,7 @@ namespace TeuchosTests
       "  Problem: \n"
       "    Neumann BCs: \n"
       "      Time Dependent NBC on SS cyl_outside for DOF all set P: \n"
-      "        BC Values: [[0.000000000000000e+00], [1.000000000000000e+01], [2.000000000000000e+01]]\n"
+      "        BC Values: [[0], [10], [20]]\n"
       "  Discretization: \n"
       "    Node Set Associations: [[1, 2], [top, bottom]]\n"
       "...\n";

--- a/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
+++ b/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
@@ -156,7 +156,7 @@ namespace TeuchosTests
       "  Problem: \n"
       "    Neumann BCs: \n"
       "      Time Dependent NBC on SS cyl_outside for DOF all set P: \n"
-      "        BC Values: [[0.00000000e+00], [10.00000000], [20.00000000]]\n"
+      "        BC Values: [[0.000000000000000e+00], [1.000000000000000e+01], [2.000000000000000e+01]]\n"
       "  Discretization: \n"
       "    Node Set Associations: [[1, 2], [top, bottom]]\n"
       "...\n";


### PR DESCRIPTION
As seen in gahansen/Albany@5e8ded1, the previous
code was losing too much precision and caused
Albany regression tests to fail.
Increasing to always use scientific notation
with 15 decimal places.

@trilinos/teuchos 
this is part of the solution to gahansen/Albany#95