### PR TITLE
Zoltan2: Fix non virtual destructor for PartitioningSolution (#1186)

### DIFF
--- a/packages/zoltan2/src/problems/Zoltan2_Solution.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_Solution.hpp
@@ -67,6 +67,8 @@ namespace Zoltan2 {
 
 class Solution
 {
+public:
+  virtual ~Solution() {}
 };
 
 }


### PR DESCRIPTION
Adds virtual destructor base class Zoltan2_Solution.hpp to avoid warnings for PartitioningSolution.