### PR TITLE
Teuchos: ensure YAML scalar types are preserved

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -49,6 +49,8 @@
 
 #include <iostream>
 #include <iomanip>
+#include <ios>
+#include <sstream>
 
 #include "Teuchos_YamlParser_decl.hpp"
 #include "Teuchos_XMLParameterListCoreHelpers.hpp"
@@ -704,9 +706,24 @@ void generalWriteDouble(double d, std::ostream& yaml)
   yaml << d;
 }
 
-bool stringNeedsQuotes(const std::string& str)
+template <typename T>
+static bool canBeParsedAs(std::string const& s) {
+  std::istringstream iss(s);
+  T val;
+  iss >> std::noskipws >> val;
+  return iss.eof() && !iss.fail();
+}
+
+static bool containsSpecialCharacters(std::string const& s) {
+  char const* const control_chars = ":{}[],&*#?|-<>=!%@\\";
+  return s.find_first_of(control_chars) != std::string::npos;
+}
+
+bool stringNeedsQuotes(const std::string& s)
 {
-  return strpbrk(str.c_str(), ":{}[],&*#?|-<>=!%@\\");
+  return containsSpecialCharacters(s) ||
+         canBeParsedAs<int>(s) ||
+         canBeParsedAs<double>(s);
 }
 
 } //namespace YAMLParameterList

--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -72,7 +72,7 @@ namespace Teuchos
    the Tag workaround suggested in the issue linked above. */
 
 template <typename T>
-struct SafeAs {
+struct QuotedAs {
   static T eval(YAML::Node const& node) {
     // this "!" tag apparently denotes that the value was quoted
     if (node.Tag() == "!") {
@@ -83,13 +83,13 @@ struct SafeAs {
 };
 
 template <>
-struct SafeAs<std::string> {
+struct QuotedAs<std::string> {
   // only a cast to string will succeed if quoted
   static std::string eval(YAML::Node const& node) { return node.as<std::string>(); }
 };
 
 template <typename T>
-static T quoted_as(YAML::Node const& node) { return SafeAs<T>::eval(node); }
+static T quoted_as(YAML::Node const& node) { return QuotedAs<T>::eval(node); }
 
 template<typename T> Teuchos::Array<T> getYamlArray(const YAML::Node& node)
 {

--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -58,12 +58,43 @@
 namespace Teuchos
 {
 
+/* see https://github.com/jbeder/yaml-cpp/issues/261
+   there are times when we want to insist that a parameter
+   value be interpreted as a string despite it being parseable
+   as a number.
+   the standard way to do this in YAML is to put the number in quotes,
+   i.e. '1e-3' instead of 1e-3.
+   however, the usual YAML::Node::as<T> system doesn't respect quoting
+   when trying to cast to numbers.
+   so, this is our own version of as<T>, called quoted_as<T>, using
+   the Tag workaround suggested in the issue linked above. */
+
+template <typename T>
+struct SafeAs {
+  static T eval(YAML::Node const& node) {
+    // this "!" tag apparently denotes that the value was quoted
+    if (node.Tag() == "!") {
+      throw YAML::TypedBadConversion<T>(node.Mark());
+    }
+    return node.as<T>();
+  }
+};
+
+template <>
+struct SafeAs<std::string> {
+  // only a cast to string will succeed if quoted
+  static std::string eval(YAML::Node const& node) { return node.as<std::string>(); }
+};
+
+template <typename T>
+static T quoted_as(YAML::Node const& node) { return SafeAs<T>::eval(node); }
+
 template<typename T> Teuchos::Array<T> getYamlArray(const YAML::Node& node)
 {
   Teuchos::Array<T> arr;
   for(YAML::const_iterator it = node.begin(); it != node.end(); it++)
   {
-    arr.push_back(it->as<T>());
+    arr.push_back(quoted_as<T>(*it));
   }
   return arr;
 }
@@ -91,7 +122,7 @@ template<typename T> Teuchos::TwoDArray<T> getYamlTwoDArray(const YAML::Node& no
     j = 0;
     for (YAML::const_iterator cit = rit->begin(); cit != rit->end(); ++cit)
     {
-      arr(i, j) = cit->as<T>();
+      arr(i, j) = quoted_as<T>(*cit);
       ++j;
     }
     ++i;
@@ -328,7 +359,7 @@ void processMapNode(const YAML::Node& node, Teuchos::ParameterList& parent, bool
         throw YamlKeyError("Keys must be plain strings");
       }
       //if this conversion fails and throws for any reason (shouldn't), let the caller handle it
-      const std::string key = i->first.as<std::string>();
+      const std::string key = quoted_as<std::string>(i->first);
       processKeyValueNode(key, i->second, parent, topLevel);
     }
   }
@@ -342,19 +373,19 @@ void processKeyValueNode(const std::string& key, const YAML::Node& node, Teuchos
   {
     try
     {
-      parent.set(key, node.as<int>());
+      parent.set(key, quoted_as<int>(node));
     }
     catch(...)
     {
       try
       {
-        parent.set(key, node.as<double>());
+        parent.set(key, quoted_as<double>(node));
       }
       catch(...)
       {
         try
         {
-          std::string rawString = node.as<std::string>();
+          std::string rawString = quoted_as<std::string>(node);
           if(rawString == "true")
           {
             parent.set<bool>(key, true);
@@ -391,23 +422,24 @@ void processKeyValueNode(const std::string& key, const YAML::Node& node, Teuchos
   {
     if (node.begin()->Type() == YAML::NodeType::Sequence) {
       checkYamlTwoDArray(node, key);
+      YAML::Node const& first_value = *(node.begin()->begin());
       try
       {
-        node.begin()->begin()->as<int>();
+        quoted_as<int>(first_value);
         parent.set(key, getYamlTwoDArray<int>(node));
       }
       catch(...)
       {
         try
         {
-          node.begin()->begin()->as<double>();
+          quoted_as<double>(first_value);
           parent.set(key, getYamlTwoDArray<double>(node));
         }
         catch(...)
         {
           try
           {
-            node.begin()->begin()->as<std::string>();
+            quoted_as<std::string>(first_value);
             parent.set(key, getYamlTwoDArray<std::string>(node));
           }
           catch(...)
@@ -417,24 +449,24 @@ void processKeyValueNode(const std::string& key, const YAML::Node& node, Teuchos
         }
       }
     } else {
-      //typeString is used to provide a useful error message if types inconsistent
+      YAML::Node const& first_value = *(node.begin());
       try
       {
-        node.begin()->as<int>();
+        quoted_as<int>(first_value);
         parent.set(key, getYamlArray<int>(node));
       }
       catch(...)
       {
         try
         {
-          node.begin()->as<double>();
+          quoted_as<double>(first_value);
           parent.set(key, getYamlArray<double>(node));
         }
         catch(...)
         {
           try
           {
-            node.begin()->as<std::string>();
+            quoted_as<std::string>(first_value);
             parent.set(key, getYamlArray<std::string>(node));
           }
           catch(...)
@@ -475,6 +507,13 @@ void writeYamlStream(std::ostream& yaml, const Teuchos::ParameterList& pl)
 void writeYamlFile(const std::string& yamlFile, const Teuchos::ParameterList& pl)
 {
   std::ofstream yaml(yamlFile);
+  /* set default floating-point style:
+     1. 17 decimal places to ensure the value remains the same
+     2. scientific: this prevents floating-point values that happen
+        to be integers from being printed as integers, because YAML
+        will then read that value back typed as an integer.
+   */
+  yaml << std::scientific << std::setprecision(17);
   writeYamlStream(yaml, pl);
 }
 

--- a/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
+++ b/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
@@ -158,7 +158,7 @@ namespace TeuchosTests
       "      Time Dependent NBC on SS cyl_outside for DOF all set P: \n"
       "        BC Values: [[0], [10], [20]]\n"
       "  Discretization: \n"
-      "    Node Set Associations: [[1, 2], [top, bottom]]\n"
+      "    Node Set Associations: [['1', '2'], [top, bottom]]\n"
       "...\n";
     TEST_EQUALITY(yamlString, expectedYamlString);
     std::stringstream yamlInStream(yamlString);


### PR DESCRIPTION
This commit solves two issues, both of which
fall into the category of "the type of a
parameter would change if written to YAML
and read back into Teuchos":
1. numbers with quotes around them would
   not be interpreted as strings
   (which is necessary to ensure strings
    remain string-typed even if they happen
    to just contain a number)
2. the API that takes only a filename
   would print integer-valued doubles
   in integer format (YAML has no other way
   of distinguishing double and int, so I
   added std::scientific to ensure all doubles
   get formatted differently from ints)
While fixing item (2), I added the precision
settings discussed in #1181.
There is no way for users to change those settings
from the API that takes only a file name, so
high precision seems like a good default.

@trilinos/teuchos

Issue (1) was originally pointed out to me by @ikalash, and at the time I was unsure it could be resolved, but this commit does resolve it (see the comment I put in the code for details on how). The reason I finally went in and fixed this is to switch Albany's ANISO project (coded by @bgranzow), which uses expression evaluation on string parameters, over to YAML.