### PR TITLE
Amesos2: Functional changes to deal with noncontig GIDs

### DIFF
--- a/packages/amesos2/example/CMakeLists.txt
+++ b/packages/amesos2/example/CMakeLists.txt
@@ -1,11 +1,18 @@
 
-# TRIBITS_ADD_EXECUTABLE_AND_TEST(
-#   SimpleSolveExample
-#   SOURCES SimpleSolve
-#   ARGS
-#   COMM serial mpi
-# )
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  SimpleSolveExampleNonContigMap
+  SOURCES SimpleSolveNonContigMap
+  ARGS
+  COMM serial mpi
+  NUM_MPI_PROCS 2
+)
 
+
+TRIBITS_ADD_EXECUTABLE(
+  SimpleSolveExample
+  SOURCES SimpleSolve
+  COMM serial mpi
+  )
 
 # TRIBITS_ADD_EXECUTABLE_AND_TEST(
 #   MultipleSolvesFileExample
@@ -47,6 +54,7 @@ IF (Tpetra_INST_INT_INT)
   SOURCES SimpleSolve_File
  )
 ENDIF ()
+
 
 IF (Tpetra_INST_INT_INT)
 IF (${PACKAGE_NAME}_ENABLE_EpetraExt)

--- a/packages/amesos2/example/SimpleSolveNonContigMap.cpp
+++ b/packages/amesos2/example/SimpleSolveNonContigMap.cpp
@@ -1,0 +1,255 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//           Amesos2: Templated Direct Sparse Solver Package
+//                  Copyright 2011 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+
+/**
+   \file   SimpleSolveNonContigMap.cpp
+   \author Eric Bavier <etbavie@sandia.gov>
+   \author Nathan Ellingwood <ndellin@sandia.gov>
+   \date   Wed Apr 26 10:08:39 2017
+
+   \brief  Simple example of Amesos2 usage with a map with non-contiguous GIDs.
+
+   This example solves a simple sparse system of linear equations using the
+   Amesos2 interface
+
+   The example is hard-coded for 2 MPI processes
+*/
+
+#include <Teuchos_ScalarTraits.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_oblackholestream.hpp>
+#include <Teuchos_Tuple.hpp>
+#include <Teuchos_VerboseObject.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+
+
+#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Map.hpp>
+#include <Tpetra_MultiVector.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+#include "Amesos2.hpp"
+#include "Amesos2_Version.hpp"
+
+
+int main(int argc, char *argv[]) {
+  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+
+  std::string solver_name = "Basker";
+  Teuchos::CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("solver", &solver_name, "Which TPL solver library to use.");
+  if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+
+  // Before we do anything, check that the solver is enabled
+  if( !Amesos2::query(solver_name) ){
+    std::cerr << solver_name << " not enabled.  Exiting..." << std::endl;
+    return EXIT_SUCCESS;	// Otherwise CTest will pick it up as
+				// failure, which it isn't really
+  }
+
+
+  typedef double Scalar;
+  typedef int LO;
+  typedef int GO;
+
+  typedef Tpetra::CrsMatrix<Scalar,LO,GO> MAT;
+  typedef Tpetra::MultiVector<Scalar,LO,GO> MV;
+
+  using Tpetra::global_size_t;
+  using Teuchos::tuple;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  Teuchos::RCP<const Teuchos::Comm<int> > comm
+    = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+
+  size_t myRank = comm->getRank();
+
+  std::ostream &out = std::cout;
+
+  out << Amesos2::version() << std::endl << std::endl;
+
+  const size_t numVectors = 1;
+
+  const global_size_t numProcs = comm->getSize();
+
+  global_size_t nrows = 6;
+
+  if( numProcs != 2 ){
+    std::cerr << "Example should be run with number of processes \
+      equal to 2 (hard-coded example).  Exiting..." << std::endl;
+    return EXIT_SUCCESS;	// Otherwise CTest will pick it up as
+				// failure, which it isn't really
+  }
+
+  const GO numGlobalEntries = nrows;
+  const LO numLocalEntries = nrows / numProcs;
+
+  // Create non-contiguous Map
+  // This example: np 2 leads to GIDS: proc0 - 0,2,4  proc 1 - 1,3,5
+  Teuchos::Array<GO> elementList(numLocalEntries);
+  for ( LO k = 0; k < numLocalEntries; ++k ) {
+        elementList[k] = myRank + k*numProcs + 4*myRank;
+  }
+
+  typedef Tpetra::Map<LO,GO>  map_type;
+  RCP< const map_type > map = rcp( new map_type(numGlobalEntries, elementList, 0, comm) );
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    comm->getSize () > 1 && map->isContiguous (),
+    std::logic_error,
+    "The non-contiguous map claims to be contiguous.");
+
+
+  //RCP<MAT> A = rcp( new MAT(map,3) ); // max of three entries in a row
+  RCP<MAT> A = rcp( new MAT(map,0) );
+
+  /*
+   * We will solve a system with a known solution, for which we will be using
+   * the following matrix:
+   *
+   *  GID  0   2   4   5   7   9
+   * [ 0 [ 7,  0, -3,  0, -1,  0 ]
+   *   2 [ 2,  8,  0,  0,  0,  0 ]
+   *   4 [ 0,  0,  1,  0,  0,  0 ]
+   *   5 [-3,  0,  0,  5,  0,  0 ]
+   *   7 [ 0, -1,  0,  0,  4,  0 ]
+   *   9 [ 0,  0,  0, -2,  0,  6 ] ]
+   *
+   */
+
+  // Construct matrix
+    if( myRank == 0 ){
+      A->insertGlobalValues(0,tuple<GO>(0,4,7),tuple<Scalar>(7,-3,-1));
+      A->insertGlobalValues(2,tuple<GO>(0,2),tuple<Scalar>(2,8));
+      A->insertGlobalValues(4,tuple<GO>(4),tuple<Scalar>(1));
+      A->insertGlobalValues(5,tuple<GO>(0,5),tuple<Scalar>(-3,5));
+      A->insertGlobalValues(7,tuple<GO>(2,7),tuple<Scalar>(-1,4));
+      A->insertGlobalValues(9,tuple<GO>(5,9),tuple<Scalar>(-2,6));
+    }
+
+  A->fillComplete();
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    comm->getSize () > 1 && A->getMap()->isContiguous (),
+    std::logic_error,
+    "The non-contiguous map of A claims to be contiguous.");
+
+
+  // Create random X
+  RCP<MV> X = rcp(new MV(map,numVectors));
+  X->randomize();
+
+  /* Create B, use same GIDs
+   *
+   * Use RHS:
+   *
+   *  [[-7]
+   *   [18]
+   *   [ 3]
+   *   [17]
+   *   [18]
+   *   [28]]
+   */
+  RCP<MV> B = rcp(new MV(map,numVectors));
+  int rowids[6] = {0,2,4,5,7,9};
+  int data[6] = {-7,18,3,17,18,28};
+  for( int i = 0; i < 6; ++i ){
+    if( B->getMap()->isNodeGlobalElement(rowids[i]) ){
+      B->replaceGlobalValue(rowids[i],0,data[i]);
+    }
+  }
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    comm->getSize () > 1 && X->getMap()->isContiguous () && B->getMap()->isContiguous (),
+    std::logic_error,
+    "The non-contiguous maps of X or B claims to be contiguous.");
+
+
+  // Create solver interface with Amesos2 factory method
+  RCP<Amesos2::Solver<MAT,MV> > solver = Amesos2::create<MAT,MV>(solver_name, A, X, B);
+
+  if( Amesos2::query(solver_name) ) {
+  
+    // Create a Teuchos::ParameterList to hold solver parameters
+    Teuchos::ParameterList amesos2_params("Amesos2");
+    amesos2_params.sublist(solver_name).set("IsContiguous", false, "Are GIDs Contiguous");
+
+//    Teuchos::ParameterList & sublist_params = amesos2_params.sublist(solver_name);
+//     sublist_params.set("IsContiguous", false, "Are GIDs Contiguous");
+#ifdef SHYLUBASKER
+    if ( solver_name == "Basker" ) {
+      amesos2_params.sublist(solver_name).set("num_threads", 1, "Number of threads");
+//      sublist_params.set("num_threads", 1, "Number of threads");
+    }
+#endif
+
+    solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+  }
+
+  solver->symbolicFactorization().numericFactorization().solve();
+
+
+  /* Print the solution
+   *
+   * Should be:
+   *
+   *  [[1]
+   *   [2]
+   *   [3]
+   *   [4]
+   *   [5]
+   *   [6]]
+   */
+  RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(out));
+
+  *fos << "\nSolution :" << std::endl;
+  X->describe(*fos,Teuchos::VERB_EXTREME);
+  *fos << std::endl;
+
+  // We are done.
+  return 0;
+}

--- a/packages/amesos2/example/quick_solve.cpp
+++ b/packages/amesos2/example/quick_solve.cpp
@@ -165,6 +165,14 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
+  #ifdef SHYLUBASKER
+  if( Amesos2::query("Basker") ) {
+    Teuchos::ParameterList amesos2_params("Amesos2");
+      amesos2_params.sublist(solver_name).set("num_threads", 1, "Number of threads");
+    solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+  }
+  #endif
+
   solver->numericFactorization();
 
   if( printLUStats && myRank == 0 ){

--- a/packages/amesos2/example/quick_solve_epetra.cpp
+++ b/packages/amesos2/example/quick_solve_epetra.cpp
@@ -159,6 +159,14 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
+  #ifdef SHYLUBASKER
+  if( Amesos2::query("Basker") ) {
+    Teuchos::ParameterList amesos2_params("Amesos2");
+      amesos2_params.sublist(solver_name).set("num_threads", 1, "Number of threads");
+    solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+  }
+  #endif
+
   solver->solve();
 
   if( printSolution ){

--- a/packages/amesos2/src/Amesos2_Basker_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_decl.hpp
@@ -185,6 +185,9 @@ private:
   /// Stores the row indices of the nonzero entries
   Teuchos::Array<local_ordinal_type> colptr_;
 
+  bool is_contiguous_;
+
+
   /// Persisting 1D store for X
   mutable Teuchos::Array<slu_type> xvals_;  local_ordinal_type ldx_;
   /// Persisting 1D store for B

--- a/packages/amesos2/src/Amesos2_Basker_def.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_def.hpp
@@ -72,6 +72,7 @@ Basker<Matrix,Vector>::Basker(
   , nzvals_()                   // initialize to empty arrays
   , rowind_()
   , colptr_()
+  , is_contiguous_(true)
 {
 
   //Nothing
@@ -144,7 +145,6 @@ template <class Matrix, class Vector>
 int
 Basker<Matrix,Vector>::symbolicFactorization_impl()
 {
-  
 #ifdef SHYLUBASKER
 
   if(this->root_)
@@ -168,7 +168,7 @@ Basker<Matrix,Vector>::symbolicFactorization_impl()
       // in this special case we pass the CRS raw pointers directly to ShyLUBasker which copies+transposes+sorts the data for CCS format
       //   loadA_impl is essentially an empty function in this case, as the raw pointers are handled here and similarly in Symbolic
 
-      bool case_check = ( (this->matrixA_->getComm()->getRank() == 0) && (this->matrixA_->getComm()->getSize() == 1) ) ;
+      bool case_check = ( (this->matrixA_->getComm()->getRank() == 0) && (this->matrixA_->getComm()->getSize() == 1) && is_contiguous_ ) ;
       if ( case_check ) {
 
         // this needs to be checked during loadA_impl...
@@ -200,7 +200,6 @@ Basker<Matrix,Vector>::symbolicFactorization_impl()
                                 rowind_.getRawPtr(),
                                 nzvals_.getRawPtr());
       }
-      //std::cout << "Symbolic Factorization Done" << std::endl; 
       TEUCHOS_TEST_FOR_EXCEPTION(info != 0,
         std::runtime_error, "Error in Basker Symbolic");
  
@@ -239,7 +238,7 @@ Basker<Matrix,Vector>::numericFactorization_impl()
       // in this special case we pass the CRS raw pointers directly to ShyLUBasker which copies+transposes+sorts the data for CCS format
       //   loadA_impl is essentially an empty function in this case, as the raw pointers are handled here and similarly in Symbolic
 
-      bool case_check = ( (this->matrixA_->getComm()->getRank() == 0) && (this->matrixA_->getComm()->getSize() == 1) ) ;
+      bool case_check = ( (this->matrixA_->getComm()->getRank() == 0) && (this->matrixA_->getComm()->getSize() == 1) && is_contiguous_ ) ;
       if ( case_check ) {
 
         auto sp_rowptr = this->matrixA_->returnRowPtr();
@@ -340,9 +339,15 @@ Basker<Matrix,Vector>::solve_impl(
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
-    Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
-      slu_type>::do_get(B, bvals_(),as<size_t>(ld_rhs),
-                                               ROOTED);
+
+    if ( is_contiguous_ == true ) {
+      Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
+        slu_type>::do_get(B, bvals_(), as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+    }
+    else {
+      Util::get_1d_copy_helper<MultiVecAdapter<Vector>,
+        slu_type>::do_get(B, bvals_(), as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
+    }
   }
 
   int ierr = 0; // returned error code
@@ -378,10 +383,18 @@ Basker<Matrix,Vector>::solve_impl(
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
 
-    Util::put_1d_data_helper<
-    MultiVecAdapter<Vector>,slu_type>::do_put(X, xvals_(),
-                                         as<size_t>(ld_rhs),
-                                         ROOTED);
+    if ( is_contiguous_ == true ) {
+      Util::put_1d_data_helper<
+        MultiVecAdapter<Vector>,slu_type>::do_put(X, xvals_(),
+            as<size_t>(ld_rhs),
+            ROOTED);
+    }
+    else {
+      Util::put_1d_data_helper<
+        MultiVecAdapter<Vector>,slu_type>::do_put(X, xvals_(),
+            as<size_t>(ld_rhs),
+            CONTIGUOUS_AND_ROOTED);
+    }
   }
 
   return(ierr);
@@ -406,6 +419,11 @@ Basker<Matrix,Vector>::setParameters_impl(const Teuchos::RCP<Teuchos::ParameterL
   using Teuchos::ParameterEntryValidator;
 
   RCP<const Teuchos::ParameterList> valid_params = getValidParameters_impl();
+
+  if(parameterList->isParameter("IsContiguous"))
+    {
+      is_contiguous_ = parameterList->get<bool>("IsContiguous");
+    }
 
 #ifdef SHYLUBASKER
   if(parameterList->isParameter("num_threads"))
@@ -443,7 +461,7 @@ Basker<Matrix,Vector>::setParameters_impl(const Teuchos::RCP<Teuchos::ParameterL
   if(parameterList->isParameter("matching_type"))
     {
       basker->Options.matching_type =
-	(local_ordinal_type) parameterList->get<int>("matching_type");
+        (local_ordinal_type) parameterList->get<int>("matching_type");
     }
   if(parameterList->isParameter("btf"))
     {
@@ -478,6 +496,8 @@ Basker<Matrix,Vector>::getValidParameters_impl() const
   if( is_null(valid_params) )
     {
       Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+      pl->set("IsContiguous", true, 
+	      "Are GIDs contiguous");
       pl->set("num_threads", 1, 
 	      "Number of threads");
       pl->set("pivot", false,
@@ -511,6 +531,7 @@ Basker<Matrix,Vector>::getValidParameters_impl() const
   if( is_null(valid_params) ){
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
+    pl->set("IsContiguous", true, "Are GIDs contiguous");
     pl->set("alnnz",  2, "Approx number of nonzeros in L, default is 2*nnz(A)");
     pl->set("aunnx",  2, "Approx number of nonzeros in I, default is 2*nnz(U)");
     valid_params = pl;
@@ -525,17 +546,17 @@ bool
 Basker<Matrix,Vector>::loadA_impl(EPhase current_phase)
 {
   using Teuchos::as;
-
   if(current_phase == SOLVE) return (false);
 
   #ifdef HAVE_AMESOS2_TIMERS
   Teuchos::TimeMonitor convTimer(this->timers_.mtxConvTime_);
   #endif
 
+
 #ifdef SHYLUBASKER
   // NDE: Can clean up duplicated code with the #ifdef guards
 
-  bool case_check = ( (this->root_) && (this->matrixA_->getComm()->getRank() == 0) && (this->matrixA_->getComm()->getSize() == 1) ) ;
+  bool case_check = ( (this->root_) && (this->matrixA_->getComm()->getRank() == 0) && (this->matrixA_->getComm()->getSize() == 1) && is_contiguous_ ) ;
 
   if ( case_check ) {
   // NDE: Nothing is done in this special case - CRS raw pointers are passed to SHYLUBASKER and transpose of copies handled there
@@ -547,7 +568,7 @@ Basker<Matrix,Vector>::loadA_impl(EPhase current_phase)
     if( this->root_ ){
       nzvals_.resize(this->globalNumNonZeros_);
       rowind_.resize(this->globalNumNonZeros_);
-      colptr_.resize(this->globalNumCols_ + 1);
+      colptr_.resize(this->globalNumCols_ + 1); //this will be wrong for case of gapped col ids, e.g. 0,2,4,9; num_cols = 10 ([0,10)) but num GIDs = 4...
     }
 
     local_ordinal_type nnz_ret = 0;
@@ -555,16 +576,25 @@ Basker<Matrix,Vector>::loadA_impl(EPhase current_phase)
     #ifdef HAVE_AMESOS2_TIMERS
       Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
     #endif
-      Util::get_ccs_helper<
-        MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
-        ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
-            nnz_ret, ROOTED, ARBITRARY); // copies from matrixA_ to Basker ConcreteSolver cp, ri, nzval members
+
+      if ( is_contiguous_ == true ) {
+        Util::get_ccs_helper<
+          MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
+          ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
+              nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_); // copies from matrixA_ to Basker ConcreteSolver cp, ri, nzval members
+      }
+      else {
+        Util::get_ccs_helper<
+          MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
+          ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
+              nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_); // copies from matrixA_ to Basker ConcreteSolver cp, ri, nzval members
+      }
     }
 
     if( this->root_ ){
       TEUCHOS_TEST_FOR_EXCEPTION( nnz_ret != as<local_ordinal_type>(this->globalNumNonZeros_),
           std::runtime_error,
-          "Did not get the expected number of non-zero vals");
+          "Amesos2_Basker loadA_impl: Did not get the expected number of non-zero vals");
     }
 
   } //end alternative path 
@@ -582,16 +612,25 @@ Basker<Matrix,Vector>::loadA_impl(EPhase current_phase)
   #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor mtxRedistTimer( this->timers_.mtxRedistTime_ );
   #endif
-    Util::get_ccs_helper<
-    MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
-    ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
-             nnz_ret, ROOTED, ARBITRARY);
+
+    if ( is_contiguous_ == true ) {
+      Util::get_ccs_helper<
+        MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
+        ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
+            nnz_ret, ROOTED, ARBITRARY, this->rowIndexBase_);
+    }
+    else {
+      Util::get_ccs_helper<
+        MatrixAdapter<Matrix>,slu_type,local_ordinal_type,local_ordinal_type>
+        ::do_get(this->matrixA_.ptr(), nzvals_(), rowind_(), colptr_(),
+            nnz_ret, CONTIGUOUS_AND_ROOTED, ARBITRARY, this->rowIndexBase_);
+    }
   }
 
   if( this->root_ ){
     TEUCHOS_TEST_FOR_EXCEPTION( nnz_ret != as<local_ordinal_type>(this->globalNumNonZeros_),
                         std::runtime_error,
-                        "Did not get the expected number of non-zero vals");
+                        "Amesos2_Basker loadA_impl: Did not get the expected number of non-zero vals");
   }
 #endif //SHYLUBASKER
   return true;

--- a/packages/amesos2/src/Amesos2_Cholmod_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Cholmod_decl.hpp
@@ -248,6 +248,7 @@ private:
 
   Teuchos::RCP<const Tpetra::Map<local_ordinal_type,global_ordinal_type,node_type> > map;
 
+  bool is_contiguous_;
 };                              // End class Cholmod
 
 

--- a/packages/amesos2/src/Amesos2_EpetraCrsMatrix_MatrixAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraCrsMatrix_MatrixAdapter_decl.hpp
@@ -102,7 +102,7 @@ namespace Amesos2 {
     
     ConcreteMatrixAdapter(RCP<matrix_t> m);
     
-    RCP<const MatrixAdapter<matrix_t> > get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const;
+    RCP<const MatrixAdapter<matrix_t> > get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution = ROOTED) const;
     
   };
 

--- a/packages/amesos2/src/Amesos2_EpetraCrsMatrix_MatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraCrsMatrix_MatrixAdapter_def.hpp
@@ -60,7 +60,7 @@ namespace Amesos2 {
     {}
 
   Teuchos::RCP<const MatrixAdapter<Epetra_CrsMatrix> >
-  ConcreteMatrixAdapter<Epetra_CrsMatrix>::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const
+  ConcreteMatrixAdapter<Epetra_CrsMatrix>::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution) const
     {
       using Teuchos::as;
       using Teuchos::rcp;

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
@@ -179,7 +179,8 @@ namespace Amesos2 {
 		    Teuchos::Ptr<
 		    const Tpetra::Map<local_ordinal_t,
 		    global_ordinal_t,
-		    node_t> > distribution_map ) const;
+		    node_t> > distribution_map,
+        EDistribution distribution) const;
 
 
     /**
@@ -217,7 +218,8 @@ namespace Amesos2 {
 		    Teuchos::Ptr<
 		    const Tpetra::Map<local_ordinal_t,
 		    global_ordinal_t,
-		    node_t> > source_map );
+		    node_t> > source_map,
+        EDistribution distribution );
 
 
 

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
@@ -204,7 +204,8 @@ void MultiVecAdapter<Epetra_MultiVector>::get1dCopy(
   Teuchos::Ptr<
     const Tpetra::Map<MultiVecAdapter<Epetra_MultiVector>::local_ordinal_t,
                       MultiVecAdapter<Epetra_MultiVector>::global_ordinal_t,
-                      MultiVecAdapter<Epetra_MultiVector>::node_t> > distribution_map ) const
+                      MultiVecAdapter<Epetra_MultiVector>::node_t> > distribution_map,
+                      EDistribution distribution) const
 {
   using Teuchos::rcpFromPtr;
   using Teuchos::as;
@@ -307,7 +308,8 @@ MultiVecAdapter<Epetra_MultiVector>::put1dData(
   Teuchos::Ptr<
     const Tpetra::Map<MultiVecAdapter<Epetra_MultiVector>::local_ordinal_t,
                       MultiVecAdapter<Epetra_MultiVector>::global_ordinal_t,
-                      MultiVecAdapter<Epetra_MultiVector>::node_t> > source_map)
+                      MultiVecAdapter<Epetra_MultiVector>::node_t> > source_map,
+                      EDistribution distribution )
 {
   using Teuchos::rcpFromPtr;
   using Teuchos::as;

--- a/packages/amesos2/src/Amesos2_EpetraRowMatrix_AbstractMatrixAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraRowMatrix_AbstractMatrixAdapter_decl.hpp
@@ -151,6 +151,11 @@ namespace Amesos2 {
     const RCP<const Tpetra::Map<local_ordinal_t,
 				global_ordinal_t,
 				node_t> >
+    getMap_impl() const;
+
+    const RCP<const Tpetra::Map<local_ordinal_t,
+				global_ordinal_t,
+				node_t> >
     getRowMap_impl() const;
 
     const RCP<const Tpetra::Map<local_ordinal_t,
@@ -167,7 +172,7 @@ namespace Amesos2 {
     // Because instantiation of the subclasses could be wildly
     // different (cf subclasses of Epetra_RowMatrix), this method
     // hands off implementation to the adapter for the subclass
-    RCP<const super_t> get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const;
+    RCP<const super_t> get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution = ROOTED) const;
 
     typename super_t::spmtx_ptr_t  getSparseRowPtr() const;
 

--- a/packages/amesos2/src/Amesos2_EpetraRowMatrix_AbstractMatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraRowMatrix_AbstractMatrixAdapter_def.hpp
@@ -246,6 +246,18 @@ namespace Amesos2 {
   const RCP<const Tpetra::Map<MatrixTraits<Epetra_RowMatrix>::local_ordinal_t,
                               MatrixTraits<Epetra_RowMatrix>::global_ordinal_t,
                               MatrixTraits<Epetra_RowMatrix>::node_t> >
+  AbstractConcreteMatrixAdapter<Epetra_RowMatrix, DerivedMat>::getMap_impl() const
+  {
+    // Should Map() be used (returns Epetra_BlockMap)
+    printf("Amesos2_EpetraRowMatrix_AbstractMatrixAdapter: Epetra does not support a 'getMap()' method. Returning rcp(Teuchos::null). \
+        If your map contains non-contiguous GIDs please use Tpetra instead of Epetra. \n");
+    return( Teuchos::null );
+  }
+
+  template <class DerivedMat>
+  const RCP<const Tpetra::Map<MatrixTraits<Epetra_RowMatrix>::local_ordinal_t,
+                              MatrixTraits<Epetra_RowMatrix>::global_ordinal_t,
+                              MatrixTraits<Epetra_RowMatrix>::node_t> >
   AbstractConcreteMatrixAdapter<Epetra_RowMatrix, DerivedMat>::getRowMap_impl() const
   {
     // Must transform to a Tpetra::Map
@@ -285,16 +297,17 @@ namespace Amesos2 {
     return this->mat_->IndicesAreGlobal();
   }
 
+
   template <class DerivedMat>
   RCP<const MatrixAdapter<DerivedMat> >
-  AbstractConcreteMatrixAdapter<Epetra_RowMatrix, DerivedMat>::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const
+  AbstractConcreteMatrixAdapter<Epetra_RowMatrix, DerivedMat>::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution) const
   {
     // Delegate implementation to subclass
 #ifdef __CUDACC__
     // NVCC doesn't seem to like the static_cast, even though it is valid
-    return dynamic_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map);
+    return dynamic_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map, distribution);
 #else
-    return static_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map);
+    return static_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map, distribution);
 #endif
   }
 

--- a/packages/amesos2/src/Amesos2_KLU2_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_decl.hpp
@@ -241,6 +241,8 @@ private:
   /// Transpose flag
   /// 0: Non-transpose, 1: Transpose, 2: Conjugate-transpose
   int transFlag_;
+
+  bool is_contiguous_;
 };                              // End class KLU2
 
 

--- a/packages/amesos2/src/Amesos2_Lapack_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Lapack_decl.hpp
@@ -217,6 +217,8 @@ namespace Amesos2 {
     // Teuchos::SerialDenseSolver<global_ordinal_type,scalar_type> solver_;
     mutable Teuchos::SerialDenseSolver<int,scalar_type> solver_;
 
+    bool is_contiguous_;
+
   };                              // End class Lapack
 
   

--- a/packages/amesos2/src/Amesos2_MUMPS_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_decl.hpp
@@ -340,6 +340,7 @@ private:
   MPI_Comm MUMPSComm;
 #endif
 
+    bool is_contiguous_;
 
 };
 

--- a/packages/amesos2/src/Amesos2_MatrixAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MatrixAdapter_decl.hpp
@@ -119,6 +119,8 @@ namespace Amesos2 {
      * \param [in]  rowmap A Tpetra::Map describing the desired distribution of
      *              the rows of the CRS representation on the calling processors.
      * \param [in]  ordering
+     * \param [in]  distribution (optional: default = ROOTED 
+     *              - only CONTIGUOUS_AND_ROOTED has an effect behavior)
      *
      * \exception std::length_error Thrown if \c nzval or \c colind is not
      * large enough to hold the global number of nonzero values.
@@ -134,7 +136,8 @@ namespace Amesos2 {
 		const Teuchos::ArrayView<global_size_t> rowptr,
 		global_size_t& nnz,
 		const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
-		EStorage_Ordering ordering=ARBITRARY) const;
+		EStorage_Ordering ordering=ARBITRARY,
+		EDistribution distribution=ROOTED) const; // This was placed as last argument to preserve API
 
     /**
      * Convenience overload for the getCrs function that uses an enum
@@ -164,6 +167,8 @@ namespace Amesos2 {
      * \param [in]  colmap A Tpetra::Map describing the desired distribution of
      *              the columns of the CCS representation on the calling processors.
      * \param [in]  ordering
+     * \param [in]  distribution (optional: default = ROOTED 
+     *              - only CONTIGUOUS_AND_ROOTED has an effect behavior)
      *
      * \exception std::length_error Thrown if \c nzval or \c rowind is not
      * large enough to hold the global number of nonzero values.
@@ -179,7 +184,8 @@ namespace Amesos2 {
 		const Teuchos::ArrayView<global_size_t> colptr,
 		global_size_t& nnz,
 		const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
-		EStorage_Ordering ordering=ARBITRARY) const;
+		EStorage_Ordering ordering=ARBITRARY,
+		EDistribution distribution=ROOTED) const; // This was placed as last argument to preserve API
 
     /**
      * Convenience overload for the getCcs function that uses an enum
@@ -225,6 +231,11 @@ namespace Amesos2 {
     size_t getLocalNNZ() const;
 
     Teuchos::RCP<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> >
+    getMap() const {
+      return static_cast<const adapter_t*>(this)->getMap_impl();
+    }
+
+    Teuchos::RCP<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> >
     getRowMap() const {
       return row_map_;
     }
@@ -234,7 +245,7 @@ namespace Amesos2 {
       return col_map_;
     }
 
-    Teuchos::RCP<const type> get(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const;
+    Teuchos::RCP<const type> get(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution = ROOTED) const;
 
     /// Returns a short description of this Solver
     std::string description() const;
@@ -259,6 +270,7 @@ namespace Amesos2 {
 		     const Teuchos::ArrayView<global_size_t> rowptr,
 		     global_size_t& nnz,
 		     const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
+		     EDistribution distribution,
 		     EStorage_Ordering ordering,
 		     has_special_impl hsi) const;
 
@@ -267,30 +279,34 @@ namespace Amesos2 {
 		     const Teuchos::ArrayView<global_size_t> rowptr,
 		     global_size_t& nnz,
 		     const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
+		     EDistribution distribution,
 		     EStorage_Ordering ordering,
 		     no_special_impl nsi) const;
 
     void do_getCrs(const Teuchos::ArrayView<scalar_t> nzval,
-		   const Teuchos::ArrayView<global_ordinal_t> colind,
-		   const Teuchos::ArrayView<global_size_t> rowptr,
-		   global_size_t& nnz,
-		   const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
-		   EStorage_Ordering ordering,
-		   row_access ra) const;
+        const Teuchos::ArrayView<global_ordinal_t> colind,
+        const Teuchos::ArrayView<global_size_t> rowptr,
+        global_size_t& nnz,
+        const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
+        EDistribution distribution,
+        EStorage_Ordering ordering,
+        row_access ra) const;
 
     void do_getCrs(const Teuchos::ArrayView<scalar_t> nzval,
-		   const Teuchos::ArrayView<global_ordinal_t> colind,
-		   const Teuchos::ArrayView<global_size_t> rowptr,
-		   global_size_t& nnz,
-		   const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
-		   EStorage_Ordering ordering,
-		   col_access ca) const;
+        const Teuchos::ArrayView<global_ordinal_t> colind,
+        const Teuchos::ArrayView<global_size_t> rowptr,
+        global_size_t& nnz,
+        const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > rowmap,
+        EDistribution distribution,
+        EStorage_Ordering ordering,
+        col_access ca) const;
 
     void help_getCcs(const Teuchos::ArrayView<scalar_t> nzval,
 		     const Teuchos::ArrayView<global_ordinal_t> rowind,
 		     const Teuchos::ArrayView<global_size_t> colptr,
 		     global_size_t& nnz,
 		     const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
+		     EDistribution distribution,
 		     EStorage_Ordering ordering,
 		     has_special_impl hsi) const;
 
@@ -299,24 +315,27 @@ namespace Amesos2 {
 		     const Teuchos::ArrayView<global_size_t> colptr,
 		     global_size_t& nnz,
 		     const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
+		     EDistribution distribution,
 		     EStorage_Ordering ordering,
 		     no_special_impl nsi) const;
 
     void do_getCcs(const Teuchos::ArrayView<scalar_t> nzval,
-		   const Teuchos::ArrayView<global_ordinal_t> rowind,
-		   const Teuchos::ArrayView<global_size_t> colptr,
-		   global_size_t& nnz,
-		   const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
-		   EStorage_Ordering ordering,
-		   row_access ra) const;
+        const Teuchos::ArrayView<global_ordinal_t> rowind,
+        const Teuchos::ArrayView<global_size_t> colptr,
+        global_size_t& nnz,
+        const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
+        EDistribution distribution,
+        EStorage_Ordering ordering,
+        row_access ra) const;
 
     void do_getCcs(const Teuchos::ArrayView<scalar_t> nzval,
-		   const Teuchos::ArrayView<global_ordinal_t> rowind,
-		   const Teuchos::ArrayView<global_size_t> colptr,
-		   global_size_t& nnz,
-		   const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
-		   EStorage_Ordering ordering,
-		   col_access ca) const;
+        const Teuchos::ArrayView<global_ordinal_t> rowind,
+        const Teuchos::ArrayView<global_size_t> colptr,
+        global_size_t& nnz,
+        const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > colmap,
+        EDistribution distribution,
+        EStorage_Ordering ordering,
+        col_access ca) const;
 
   protected:
     // These methods will link to concrete implementations, and may
@@ -363,14 +382,11 @@ namespace Amesos2 {
   protected:
     const Teuchos::RCP<const Matrix> mat_;
 
-    // only need to be mutable for the initial assignment, is there
-    // another way to do this?
     mutable Teuchos::RCP<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > row_map_;
 
     mutable Teuchos::RCP<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > col_map_;
 
     mutable Teuchos::RCP<const Teuchos::Comm<int> > comm_;
-
   };				// end class MatrixAdapter
 
 

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
@@ -216,7 +216,8 @@ namespace Amesos2 {
       static void apply(const Teuchos::Ptr<const MV>& mv,
                         const Teuchos::ArrayView<typename MV::scalar_t>& v,
                         const size_t ldx,
-                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map );
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution );
     };
 
     /*
@@ -230,7 +231,8 @@ namespace Amesos2 {
       static void apply(const Teuchos::Ptr<const MV>& mv,
                         const Teuchos::ArrayView<S>& v,
                         const size_t& ldx,
-                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map );
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution );
     };
 
     /** \internal
@@ -245,7 +247,8 @@ namespace Amesos2 {
       do_get (const Teuchos::Ptr<const MV>& mv,
               const Teuchos::ArrayView<S>& vals,
               const size_t ldx,
-              Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map );
+              Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+              EDistribution distribution = ROOTED);
 
       static void
       do_get (const Teuchos::Ptr<const MV>& mv,
@@ -269,7 +272,8 @@ namespace Amesos2 {
       static void apply(const Teuchos::Ptr<MV>& mv,
                         const Teuchos::ArrayView<typename MV::scalar_t>& data,
                         const size_t ldx,
-                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map );
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution );
     };
 
     /*
@@ -283,7 +287,8 @@ namespace Amesos2 {
       static void apply(const Teuchos::Ptr<MV>& mv,
                         const Teuchos::ArrayView<S>& data,
                         const size_t& ldx,
-                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map );
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution );
     };
 
     /** \internal
@@ -297,7 +302,8 @@ namespace Amesos2 {
       static void do_put(const Teuchos::Ptr<MV>& mv,
                          const Teuchos::ArrayView<S>& data,
                          const size_t ldx,
-                         Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map );
+                         Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                         EDistribution distribution = ROOTED);
 
       static void do_put(const Teuchos::Ptr<MV>& mv,
                          const Teuchos::ArrayView<S>& data,

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
@@ -66,9 +66,10 @@ namespace Amesos2{
     void same_type_get_copy<MV>::apply(const Teuchos::Ptr<const MV>& mv,
                                        const Teuchos::ArrayView<typename MV::scalar_t>& v,
                                        const size_t ldx,
-                                       Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map )
+                                       Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                                       EDistribution distribution )
     {
-      mv->get1dCopy (v, ldx, distribution_map);
+      mv->get1dCopy (v, ldx, distribution_map, distribution);
     }
 
     /*
@@ -82,7 +83,8 @@ namespace Amesos2{
     apply (const Teuchos::Ptr<const MV>& mv,
            const Teuchos::ArrayView<S>& v,
            const size_t& ldx,
-           Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map)
+           Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+           EDistribution distribution )
     {
       typedef typename MV::scalar_t mv_scalar_t;
       typedef typename Teuchos::Array<mv_scalar_t>::size_type size_type;
@@ -97,7 +99,7 @@ namespace Amesos2{
       const size_type vals_length = v.size ();
       Teuchos::Array<mv_scalar_t> vals_tmp (vals_length);
 
-      mv->get1dCopy (vals_tmp (), ldx, distribution_map);
+      mv->get1dCopy (vals_tmp (), ldx, distribution_map, distribution);
       for (size_type i = 0; i < vals_length; ++i) {
         v[i] = Teuchos::as<S> (vals_tmp[i]);
       }
@@ -114,12 +116,13 @@ namespace Amesos2{
     do_get (const Teuchos::Ptr<const MV>& mv,
             const Teuchos::ArrayView<S>& vals,
             const size_t ldx,
-            Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map)
+            Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+            EDistribution distribution)
     {
       // Dispatch to the copy function appropriate for the type
       if_then_else<is_same<typename MV::scalar_t,S>::value,
         same_type_get_copy<MV>,
-        diff_type_get_copy<MV,S> >::type::apply (mv, vals, ldx, distribution_map);
+        diff_type_get_copy<MV,S> >::type::apply (mv, vals, ldx, distribution_map, distribution);
     }
 
     template <class MV, typename S>
@@ -142,8 +145,11 @@ namespace Amesos2{
       Teuchos::RCP<const Tpetra::Map<lo_t,go_t,node_t> > map
         = Amesos2::Util::getDistributionMap<lo_t,go_t,gs_t,node_t> (distribution,
                                                                     mv->getGlobalLength (),
-                                                                    mv->getComm (), indexBase);
-      do_get (mv, vals, ldx, Teuchos::ptrInArg (*map));
+                                                                    mv->getComm (),
+                                                                    indexBase,
+                                                                    mv->getMap());
+
+      do_get (mv, vals, ldx, Teuchos::ptrInArg (*map), distribution);
     }
 
     template <class MV, typename S>
@@ -163,7 +169,8 @@ namespace Amesos2{
         map.is_null (), std::invalid_argument,
         "Amesos2::get_1d_copy_helper::do_get(3 args): mv->getMap() is null.");
 
-      do_get (mv, vals, ldx, Teuchos::ptrInArg (*map));
+
+      do_get (mv, vals, ldx, Teuchos::ptrInArg (*map), ROOTED); // ROOTED the default here for now
     }
 
 
@@ -175,9 +182,10 @@ namespace Amesos2{
     void same_type_data_put<MV>::apply(const Teuchos::Ptr<MV>& mv,
                                        const Teuchos::ArrayView<typename MV::scalar_t>& data,
                                        const size_t ldx,
-                                       Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map )
+                                       Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                                       EDistribution distribution )
     {
-      mv->put1dData (data, ldx, distribution_map);
+      mv->put1dData (data, ldx, distribution_map, distribution);
     }
 
     /*
@@ -190,7 +198,8 @@ namespace Amesos2{
     void diff_type_data_put<MV,S>::apply(const Teuchos::Ptr<MV>& mv,
                                          const Teuchos::ArrayView<S>& data,
                                          const size_t& ldx,
-                                         Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map )
+                                         Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                                         EDistribution distribution )
     {
       typedef typename MV::scalar_t mv_scalar_t;
       typedef typename Teuchos::Array<mv_scalar_t>::size_type size_type;
@@ -206,7 +215,7 @@ namespace Amesos2{
         data_tmp[i] = Teuchos::as<mv_scalar_t> (data[i]);
       }
 
-      mv->put1dData (data_tmp (), ldx, distribution_map);
+      mv->put1dData (data_tmp (), ldx, distribution_map, distribution);
     }
 
 
@@ -220,12 +229,13 @@ namespace Amesos2{
     void put_1d_data_helper<MV,S>::do_put(const Teuchos::Ptr<MV>& mv,
                                           const Teuchos::ArrayView<S>& data,
                                           const size_t ldx,
-                                          Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map )
+                                          Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                                          EDistribution distribution )
     {
       // Dispatch to the copy function appropriate for the type
       if_then_else<is_same<typename MV::scalar_t,S>::value,
         same_type_data_put<MV>,
-        diff_type_data_put<MV,S> >::type::apply(mv, data, ldx, distribution_map);
+        diff_type_data_put<MV,S> >::type::apply(mv, data, ldx, distribution_map, distribution);
     }
 
     template <class MV, typename S>
@@ -242,8 +252,11 @@ namespace Amesos2{
       const Teuchos::RCP<const Tpetra::Map<lo_t,go_t,node_t> > map
         = Amesos2::Util::getDistributionMap<lo_t,go_t,gs_t,node_t>(distribution,
                                                                    mv->getGlobalLength(),
-                                                                   mv->getComm(), indexBase);
-      do_put(mv, data, ldx, Teuchos::ptrInArg(*map));
+                                                                   mv->getComm(), 
+                                                                   indexBase,
+                                                                   mv->getMap());
+
+      do_put(mv, data, ldx, Teuchos::ptrInArg(*map), distribution);
     }
 
     template <class MV, typename S>
@@ -255,7 +268,7 @@ namespace Amesos2{
         typename MV::global_ordinal_t,
         typename MV::node_t> > map
         = mv->getMap();
-      do_put (mv, data, ldx, Teuchos::ptrInArg (*map));
+      do_put (mv, data, ldx, Teuchos::ptrInArg (*map), ROOTED); // Default as ROOTED for now
     }
 
   } // end namespace Util

--- a/packages/amesos2/src/Amesos2_PardisoMKL_decl.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_decl.hpp
@@ -308,6 +308,8 @@ namespace Amesos2 {
     = Meta::or_<Meta::is_same<solver_scalar_type, PMKL::_MKL_Complex8>::value,
                 Meta::is_same<solver_scalar_type, PMKL::_DOUBLE_COMPLEX_t>::value>::value;
 
+    bool is_contiguous_;
+
 };                              // End class PardisoMKL
 
 

--- a/packages/amesos2/src/Amesos2_Superlu_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superlu_decl.hpp
@@ -297,6 +297,7 @@ private:
   bool same_symbolic_;
   bool ILU_Flag_;
 
+  bool is_contiguous_;
 };                              // End class Superlu
 
 

--- a/packages/amesos2/src/Amesos2_Superludist_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_decl.hpp
@@ -326,6 +326,8 @@ private:
                                  global_ordinal_type,
                                  node_type> > superlu_rowmap_;
 
+  bool is_contiguous_;
+
 };                              // End class Superludist
 
 

--- a/packages/amesos2/src/Amesos2_Superludist_def.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_def.hpp
@@ -75,6 +75,7 @@ namespace Amesos2 {
     , bvals_()
     , xvals_()
     , in_grid_(false)
+    , is_contiguous_(true)
   {
     using Teuchos::Comm;
     // It's OK to depend on MpiComm explicitly here, because
@@ -669,6 +670,10 @@ namespace Amesos2 {
 
     bool replace_tiny = parameterList->get<bool>("ReplaceTinyPivot", true);
     data_.options.ReplaceTinyPivot = replace_tiny ? SLUD::YES : SLUD::NO;
+
+    if( parameterList->isParameter("IsContiguous") ){
+      is_contiguous_ = parameterList->get<bool>("IsContiguous");
+    }
   }
 
 
@@ -732,6 +737,8 @@ namespace Amesos2 {
                                                     tuple<SLUD::colperm_t>(SLUD::NATURAL,
                                                                            SLUD::PARMETIS),
                                                     pl.getRawPtr());
+
+      pl->set("IsContiguous", true, "Whether GIDs contiguous");
 
       valid_params = pl;
     }

--- a/packages/amesos2/src/Amesos2_Superlumt_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Superlumt_decl.hpp
@@ -284,6 +284,8 @@ private:
    * *compressed-row* format because that is the format Amesos used.
    */
 
+  bool is_contiguous_;
+
 };                              // End class Superlumt
 
 

--- a/packages/amesos2/src/Amesos2_TpetraCrsMatrix_MatrixAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraCrsMatrix_MatrixAdapter_decl.hpp
@@ -120,7 +120,7 @@ namespace Amesos2 {
 
     ConcreteMatrixAdapter(RCP<matrix_t> m);
 
-    RCP<const MatrixAdapter<matrix_t> > get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const;
+    RCP<const MatrixAdapter<matrix_t> > get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution = ROOTED) const;
 
   };
 

--- a/packages/amesos2/src/Amesos2_TpetraCrsMatrix_MatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraCrsMatrix_MatrixAdapter_def.hpp
@@ -78,7 +78,7 @@ namespace Amesos2 {
   Teuchos::RCP<const MatrixAdapter<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > >
   ConcreteMatrixAdapter<
     Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>
-    >::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const
+    >::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution) const
     {
       using Teuchos::RCP;
       using Teuchos::rcp;
@@ -94,6 +94,29 @@ namespace Amesos2 {
       // mfh 27 Mar 2012: INSERT is correct in this case, because
       // we're Importing into an empty matrix with a dynamic graph.
       t_mat->doImport (*(this->mat_), *importer, Tpetra::INSERT);
+
+      // Case for non-contiguous GIDs
+      if ( distribution == CONTIGUOUS_AND_ROOTED ) {
+        t_mat->fillComplete(); // if not used std::bad_alloc thrown...
+        auto myRank = map->getComm()->getRank();
+
+        auto local_matrix = t_mat->getLocalMatrix();
+        const size_t global_num_contiguous_entries = t_mat->getGlobalNumRows();
+        const size_t local_num_contiguous_entries = (myRank == 0) ? t_mat->getGlobalNumRows() : 0;
+
+        //create maps
+        typedef Tpetra::Map< local_ordinal_t, global_ordinal_t, node_t>  contiguous_map_type;
+        RCP<const contiguous_map_type> contiguousRowMap = rcp( new contiguous_map_type(global_num_contiguous_entries, local_num_contiguous_entries, 0, (t_mat->getComm() ) ) );
+        RCP<const contiguous_map_type> contiguousColMap = rcp( new contiguous_map_type(global_num_contiguous_entries, local_num_contiguous_entries, 0, (t_mat->getComm() ) ) );
+        RCP<const contiguous_map_type> contiguousDomainMap = rcp( new contiguous_map_type(global_num_contiguous_entries, local_num_contiguous_entries, 0, (t_mat->getComm() ) ) );
+        RCP<const contiguous_map_type> contiguousRangeMap = rcp( new contiguous_map_type(global_num_contiguous_entries, local_num_contiguous_entries, 0, (t_mat->getComm() ) ) );
+
+        RCP<matrix_t> contiguous_t_mat = rcp( new matrix_t(contiguousRowMap, contiguousColMap, local_matrix) );
+        contiguous_t_mat->resumeFill();
+        contiguous_t_mat->expertStaticFillComplete(contiguousDomainMap, contiguousRangeMap);
+
+        return rcp (new ConcreteMatrixAdapter<matrix_t> (contiguous_t_mat));
+      } //end if not contiguous
 
       return rcp (new ConcreteMatrixAdapter<matrix_t> (t_mat));
     }

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
@@ -96,7 +96,7 @@ namespace Amesos2 {
 
   protected:
     // Do not allow direct construction of MultiVecAdapter's.  Only
-    // allow construction throw the non-member friend functions.
+    // allow construction through the non-member friend functions.
 
     /// Copy constructor
     MultiVecAdapter( const MultiVecAdapter<multivec_t>& adapter );
@@ -224,6 +224,8 @@ namespace Amesos2 {
      *                     describes where the 'rows' of the multivector
      *                     will end up.
      *
+     *  \param [in] distribution
+     *
      *  \throw std::runtime_error Thrown if the space available in \c A
      *  is not large enough given \c lda , the value of \c global_copy ,
      *  and the number of vectors in \c this.
@@ -233,7 +235,8 @@ namespace Amesos2 {
                size_t lda,
                Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,
                                               global_ordinal_t,
-                                              node_t> > distribution_map) const;
+                                              node_t> > distribution_map,
+                                              EDistribution distribution) const;
 
     /**
      * \brief Extracts a 1 dimensional view of this MultiVector's data
@@ -257,13 +260,15 @@ namespace Amesos2 {
      * \param source_map describes how the input array data is distributed
      *                 accross processors.  This data will be redistributed
      *                 to match the map of the adapted multivector.
+     *  \param [in] distribution
      */
     void
     put1dData (const Teuchos::ArrayView<const scalar_t>& new_data,
                size_t lda,
                Teuchos::Ptr< const Tpetra::Map<local_ordinal_t,
                                         global_ordinal_t,
-                                        node_t> > source_map );
+                                        node_t> > source_map,
+                                        EDistribution distribution );
 
     //! Get a short description of this adapter class
     std::string description () const;

--- a/packages/amesos2/src/Amesos2_TpetraRowMatrix_AbstractMatrixAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraRowMatrix_AbstractMatrixAdapter_decl.hpp
@@ -151,6 +151,11 @@ namespace Amesos2 {
     const RCP<const Tpetra::Map<local_ordinal_t,
                                          global_ordinal_t,
                                          node_t> >
+    getMap_impl() const;
+
+    const RCP<const Tpetra::Map<local_ordinal_t,
+                                         global_ordinal_t,
+                                         node_t> >
     getRowMap_impl() const;
 
     const RCP<const Tpetra::Map<local_ordinal_t,
@@ -167,7 +172,7 @@ namespace Amesos2 {
     // Because instantiation of the subclasses could be wildly
     // different (cf subclasses of Tpetra::CrsMatrix), this method
     // hands off implementation to the adapter for the subclass
-    RCP<const super_t> get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const;
+    RCP<const super_t> get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution = ROOTED) const;
 
     typename super_t::spmtx_ptr_t  getSparseRowPtr() const;
 

--- a/packages/amesos2/src/Amesos2_TpetraRowMatrix_AbstractMatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraRowMatrix_AbstractMatrixAdapter_def.hpp
@@ -348,6 +348,22 @@ namespace Amesos2 {
                       LocalOrdinal,
                       GlobalOrdinal,
                       Node>,
+    DerivedMat>:: getMap_impl() const
+  {
+    return this->mat_->getMap();
+  }
+
+  template <typename Scalar,
+            typename LocalOrdinal,
+            typename GlobalOrdinal,
+            typename Node,
+            class DerivedMat>
+  const RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
+  AbstractConcreteMatrixAdapter<
+    Tpetra::RowMatrix<Scalar,
+                      LocalOrdinal,
+                      GlobalOrdinal,
+                      Node>,
     DerivedMat>:: getRowMap_impl() const
   {
     return this->mat_->getRowMap();
@@ -417,17 +433,18 @@ namespace Amesos2 {
     return this->mat_->isGloballyIndexed();
   }
 
+
   template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node, class DerivedMat>
   RCP<const MatrixAdapter<DerivedMat> >
   AbstractConcreteMatrixAdapter<
     Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, DerivedMat
-    >::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map) const
+    >::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution) const
   {
 #ifdef __CUDACC__
     // NVCC doesn't seem to like the static_cast, even though it is valid
-    return dynamic_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map);
+    return dynamic_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map, distribution);
 #else
-    return static_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map);
+    return static_cast<ConcreteMatrixAdapter<DerivedMat>*>(this)->get_impl(map, distribution);
 #endif
   }
 

--- a/packages/amesos2/src/Amesos2_TypeDecl.hpp
+++ b/packages/amesos2/src/Amesos2_TypeDecl.hpp
@@ -124,7 +124,8 @@ namespace Amesos2 {
     DISTRIBUTED,                /**< no processor has a view of the entire matrix, only local pieces */
     DISTRIBUTED_NO_OVERLAP,     /**< no row or column may be present on more than one processor */
     GLOBALLY_REPLICATED,        /**< each processor has a view of the entire matrix */
-    ROOTED                      /**< only \c rank=0 has a full view, all others have nothing. */
+    ROOTED,                     /**< only \c rank=0 has a full view, all others have nothing. */
+    CONTIGUOUS_AND_ROOTED       /**< the global GIDs of the map are not contiguous */
   } EDistribution;
 
   /** \internal

--- a/packages/amesos2/test/adapters/CrsMatrix_Adapter_Consistency_Tests.cpp
+++ b/packages/amesos2/test/adapters/CrsMatrix_Adapter_Consistency_Tests.cpp
@@ -362,8 +362,8 @@ namespace {
     }
     const Tpetra::Map<int,int> half_map(g_num_rows, my_num_rows, 0, tcomm);
 
-    tadapter->getCrs(tnzvals, tcolind, trowptr, tnnz, Teuchos::ptrInArg(half_map), SORTED_INDICES);
-    eadapter->getCrs(enzvals, ecolind, erowptr, ennz, Teuchos::ptrInArg(half_map), SORTED_INDICES);
+    tadapter->getCrs(tnzvals, tcolind, trowptr, tnnz, Teuchos::ptrInArg(half_map), SORTED_INDICES, Amesos2::DISTRIBUTED); // ROOTED = default distribution
+    eadapter->getCrs(enzvals, ecolind, erowptr, ennz, Teuchos::ptrInArg(half_map), SORTED_INDICES, Amesos2::DISTRIBUTED);
 
     /*
      * Check that you got the entries you'd expect

--- a/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
@@ -586,7 +586,7 @@ namespace {
     const Tpetra::Map<int,int> half_map(6, my_num_rows, 0,
 					to_teuchos_comm(comm));
 
-    adapter->getCrs(nzvals,colind,rowptr,nnz, Teuchos::ptrInArg(half_map), Amesos2::SORTED_INDICES);
+    adapter->getCrs(nzvals,colind,rowptr,nnz, Teuchos::ptrInArg(half_map), Amesos2::SORTED_INDICES, Amesos2::DISTRIBUTED); // ROOTED = default distribution
 
     /*
      * Check that you got the entries you'd expect

--- a/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
@@ -461,7 +461,7 @@ namespace {
     }
     const Map<LO,GO,Node> half_map(6, my_num_rows, 0, comm);
 
-    adapter->getCrs(nzvals,colind,rowptr,nnz, Teuchos::ptrInArg(half_map), Amesos2::SORTED_INDICES);
+    adapter->getCrs(nzvals,colind,rowptr,nnz, Teuchos::ptrInArg(half_map), Amesos2::SORTED_INDICES, Amesos2::DISTRIBUTED); // ROOTED = default distribution
 
     /*
      * Check that you got the entries you'd expect

--- a/packages/amesos2/test/solvers/Basker_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/Basker_UnitTests.cpp
@@ -435,6 +435,171 @@ namespace {
    * Unit Tests for Complex data types
    */
 
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Basker, NonContgGID, SCALAR, LO, GO )
+  {
+    typedef CrsMatrix<SCALAR,LO,GO,Node> MAT;
+    typedef ScalarTraits<SCALAR> ST;
+    typedef MultiVector<SCALAR,LO,GO,Node> MV;
+    typedef typename ST::magnitudeType Mag;
+
+    using Tpetra::global_size_t;
+    using Teuchos::tuple;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Scalar = SCALAR;
+
+    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
+    RCP<const Comm<int> > comm = platform.getComm();
+    RCP<Node>             node = platform.getNode();
+
+    size_t myRank = comm->getRank();
+    const global_size_t numProcs = comm->getSize();
+
+    // Unit test created for 2 processes
+    if ( numProcs == 2 ) {
+
+      const global_size_t numVectors = 1;
+      const global_size_t nrows = 6;
+
+      const GO numGlobalEntries = nrows;
+      const LO numLocalEntries = nrows / numProcs;
+
+      // Create non-contiguous Map
+      // This example: np 2 leads to GIDS: proc0 - 0,2,4  proc 1 - 1,3,5
+      Teuchos::Array<GO> elementList(numLocalEntries);
+      for ( LO k = 0; k < numLocalEntries; ++k ) {
+        elementList[k] = myRank + k*numProcs + 4*myRank;
+      }
+
+      typedef Tpetra::Map<LO,GO>  map_type;
+      RCP< const map_type > map = rcp( new map_type(numGlobalEntries, elementList, 0, comm) );
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && map->isContiguous (),
+          std::logic_error,
+          "Basker NonContigGID Test: The non-contiguous map claims to be contiguous.");
+
+      //RCP<MAT> A = rcp( new MAT(map,3) ); // max of three entries in a row
+      RCP<MAT> A = rcp( new MAT(map,0) );
+      A->setObjectLabel("A");
+
+      /*
+       * We will solve a system with a known solution, for which we will be using
+       * the following matrix:
+       *
+       *  GID  0   2   4   5   7   9
+       * [ 0 [ 7,  0, -3,  0, -1,  0 ]
+       *   2 [ 2,  8,  0,  0,  0,  0 ]
+       *   4 [ 0,  0,  1,  0,  0,  0 ]
+       *   5 [-3,  0,  0,  5,  0,  0 ]
+       *   7 [ 0, -1,  0,  0,  4,  0 ]
+       *   9 [ 0,  0,  0, -2,  0,  6 ] ]
+       *
+       */
+
+      // Construct matrix
+      if( myRank == 0 ){
+        A->insertGlobalValues(0,tuple<GO>(0,4,7),tuple<Scalar>(7,-3,-1));
+        A->insertGlobalValues(2,tuple<GO>(0,2),tuple<Scalar>(2,8));
+        A->insertGlobalValues(4,tuple<GO>(4),tuple<Scalar>(1));
+        A->insertGlobalValues(5,tuple<GO>(0,5),tuple<Scalar>(-3,5));
+        A->insertGlobalValues(7,tuple<GO>(2,7),tuple<Scalar>(-1,4));
+        A->insertGlobalValues(9,tuple<GO>(5,9),tuple<Scalar>(-2,6));
+      }
+
+      A->fillComplete();
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && A->getMap()->isContiguous (),
+          std::logic_error,
+          "Basker NonContigGID Test: The non-contiguous map of A claims to be contiguous.");
+
+
+      // Create X with random values
+      RCP<MV> X = rcp(new MV(map,numVectors));
+      X->setObjectLabel("X");
+      X->randomize();
+
+      /* Create B, use same GIDs
+       *
+       * Use RHS:
+       *
+       *  [[-7]
+       *   [18]
+       *   [ 3]
+       *   [17]
+       *   [18]
+       *   [28]]
+       */
+      RCP<MV> B = rcp(new MV(map,numVectors));
+      B->setObjectLabel("B");
+      GO rowids[nrows] = {0,2,4,5,7,9};
+      Scalar data[nrows] = {-7,18,3,17,18,28};
+      for( global_size_t i = 0; i < nrows; ++i ){
+        if( B->getMap()->isNodeGlobalElement(rowids[i]) ){
+          B->replaceGlobalValue(rowids[i],0,data[i]);
+        }
+      }
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && X->getMap()->isContiguous () && B->getMap()->isContiguous (),
+          std::logic_error,
+          "Basker NonContigGID Test: The non-contiguous maps of X or B claims to be contiguous.");
+
+
+      // Create solver interface with Amesos2 factory method
+      RCP<Amesos2::Solver<MAT,MV> > solver = Amesos2::create<MAT,MV>("Basker", A, X, B);
+
+      // Create a Teuchos::ParameterList to hold solver parameters
+      Teuchos::ParameterList amesos2_params("Amesos2");
+      amesos2_params.sublist("Basker").set("IsContiguous", false, "Are GIDs Contiguous");
+
+      solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+
+      solver->symbolicFactorization().numericFactorization().solve();
+
+
+      /* Check the solution
+       *
+       * Should be:
+       *
+       *  [[1]
+       *   [2]
+       *   [3]
+       *   [4]
+       *   [5]
+       *   [6]]
+       */
+      // Solution Vector for later comparison
+      RCP<MV> Xhat = rcp(new MV(map,numVectors));
+      Xhat->setObjectLabel("Xhat");
+      GO rowids_soln[nrows] = {0,2,4,5,7,9};
+      Scalar data_soln[nrows] = {1,2,3,4,5,6};
+      for( global_size_t i = 0; i < nrows; ++i ){
+        if( Xhat->getMap()->isNodeGlobalElement(rowids_soln[i]) ){
+          Xhat->replaceGlobalValue(rowids_soln[i],0,data_soln[i]);
+        }
+      }
+
+      A->describe(out, Teuchos::VERB_EXTREME);
+      B->describe(out, Teuchos::VERB_EXTREME);
+      Xhat->describe(out, Teuchos::VERB_EXTREME);
+      X->describe(out, Teuchos::VERB_EXTREME);
+
+      //A->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+
+      // Check result of solve
+      Array<Mag> xhatnorms(numVectors), xnorms(numVectors);
+      Xhat->norm2(xhatnorms());
+      X->norm2(xnorms());
+      TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
+    } // end if numProcs = 2
+  }
+
+
   TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Basker, ComplexSolve, SCALAR, LO, GO )
   {
     typedef std::complex<SCALAR> cmplx;
@@ -682,7 +847,8 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Basker, Initialization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Basker, SymbolicFactorization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Basker, NumericFactorization, SCALAR, LO, GO ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Basker, Solve, SCALAR, LO, GO )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Basker, Solve, SCALAR, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Basker, NonContgGID, SCALAR, LO, GO )
 
 #endif
 

--- a/packages/amesos2/test/solvers/CMakeLists.txt
+++ b/packages/amesos2/test/solvers/CMakeLists.txt
@@ -15,6 +15,7 @@ IF (${PACKAGE_NAME}_ENABLE_KLU2)
       KLU2_UnitTests
       ${TEUCHOS_STD_UNIT_TEST_MAIN}
     COMM serial mpi
+    NUM_MPI_PROCS 2
     CATEGORIES NIGHTLY
     STANDARD_PASS_OUTPUT
     )
@@ -47,6 +48,7 @@ IF (${PACKAGE_NAME}_ENABLE_SuperLU)
       Superlu_UnitTests
       ${TEUCHOS_STD_UNIT_TEST_MAIN}
     COMM serial mpi
+    NUM_MPI_PROCS 2
     CATEGORIES NIGHTLY
     STANDARD_PASS_OUTPUT
     )
@@ -140,6 +142,7 @@ IF (${PACKAGE_NAME}_ENABLE_Basker)
       Basker_UnitTests
       ${TEUCHOS_STD_UNIT_TEST_MAIN}
     COMM serial mpi
+    NUM_MPI_PROCS 2
     STANDARD_PASS_OUTPUT
     )
     

--- a/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
@@ -378,6 +378,169 @@ namespace {
     TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( KLU2, NonContgGID, SCALAR, LO, GO )
+  {
+    typedef CrsMatrix<SCALAR,LO,GO,Node> MAT;
+    typedef ScalarTraits<SCALAR> ST;
+    typedef MultiVector<SCALAR,LO,GO,Node> MV;
+    typedef typename ST::magnitudeType Mag;
+
+    using Tpetra::global_size_t;
+    using Teuchos::tuple;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Scalar = SCALAR;
+
+    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
+    RCP<const Comm<int> > comm = platform.getComm();
+    RCP<Node>             node = platform.getNode();
+
+    size_t myRank = comm->getRank();
+    const global_size_t numProcs = comm->getSize();
+
+    // Unit test created for 2 processes
+    if ( numProcs == 2 ) {
+
+      const global_size_t numVectors = 1;
+      const global_size_t nrows = 6;
+
+      const GO numGlobalEntries = nrows;
+      const LO numLocalEntries = nrows / numProcs;
+
+      // Create non-contiguous Map
+      // This example: np 2 leads to GIDS: proc0 - 0,2,4  proc 1 - 1,3,5
+      Teuchos::Array<GO> elementList(numLocalEntries);
+      for ( LO k = 0; k < numLocalEntries; ++k ) {
+        elementList[k] = myRank + k*numProcs + 4*myRank;
+      }
+
+      typedef Tpetra::Map<LO,GO>  map_type;
+      RCP< const map_type > map = rcp( new map_type(numGlobalEntries, elementList, 0, comm) );
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && map->isContiguous (),
+          std::logic_error,
+          "KLU2 NonContigGID Test: The non-contiguous map claims to be contiguous.");
+
+      //RCP<MAT> A = rcp( new MAT(map,3) ); // max of three entries in a row
+      RCP<MAT> A = rcp( new MAT(map,0) );
+      A->setObjectLabel("A");
+
+      /*
+       * We will solve a system with a known solution, for which we will be using
+       * the following matrix:
+       *
+       *  GID  0   2   4   5   7   9
+       * [ 0 [ 7,  0, -3,  0, -1,  0 ]
+       *   2 [ 2,  8,  0,  0,  0,  0 ]
+       *   4 [ 0,  0,  1,  0,  0,  0 ]
+       *   5 [-3,  0,  0,  5,  0,  0 ]
+       *   7 [ 0, -1,  0,  0,  4,  0 ]
+       *   9 [ 0,  0,  0, -2,  0,  6 ] ]
+       *
+       */
+
+      // Construct matrix
+      if( myRank == 0 ){
+        A->insertGlobalValues(0,tuple<GO>(0,4,7),tuple<Scalar>(7,-3,-1));
+        A->insertGlobalValues(2,tuple<GO>(0,2),tuple<Scalar>(2,8));
+        A->insertGlobalValues(4,tuple<GO>(4),tuple<Scalar>(1));
+        A->insertGlobalValues(5,tuple<GO>(0,5),tuple<Scalar>(-3,5));
+        A->insertGlobalValues(7,tuple<GO>(2,7),tuple<Scalar>(-1,4));
+        A->insertGlobalValues(9,tuple<GO>(5,9),tuple<Scalar>(-2,6));
+      }
+
+      A->fillComplete();
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && A->getMap()->isContiguous (),
+          std::logic_error,
+          "KLU2 NonContigGID Test: The non-contiguous map of A claims to be contiguous.");
+
+
+      // Create X with random values
+      RCP<MV> X = rcp(new MV(map,numVectors));
+      X->setObjectLabel("X");
+      X->randomize();
+
+      /* Create B, use same GIDs
+       *
+       * Use RHS:
+       *
+       *  [[-7]
+       *   [18]
+       *   [ 3]
+       *   [17]
+       *   [18]
+       *   [28]]
+       */
+      RCP<MV> B = rcp(new MV(map,numVectors));
+      B->setObjectLabel("B");
+      GO rowids[nrows] = {0,2,4,5,7,9};
+      Scalar data[nrows] = {-7,18,3,17,18,28};
+      for( global_size_t i = 0; i < nrows; ++i ){
+        if( B->getMap()->isNodeGlobalElement(rowids[i]) ){
+          B->replaceGlobalValue(rowids[i],0,data[i]);
+        }
+      }
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && X->getMap()->isContiguous () && B->getMap()->isContiguous (),
+          std::logic_error,
+          "KLU2 NonContigGID Test: The non-contiguous maps of X or B claims to be contiguous.");
+
+
+      // Create solver interface with Amesos2 factory method
+      RCP<Amesos2::Solver<MAT,MV> > solver = Amesos2::create<MAT,MV>("KLU2", A, X, B);
+
+      // Create a Teuchos::ParameterList to hold solver parameters
+      Teuchos::ParameterList amesos2_params("Amesos2");
+      amesos2_params.sublist("KLU2").set("IsContiguous", false, "Are GIDs Contiguous");
+
+      solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+
+      solver->symbolicFactorization().numericFactorization().solve();
+
+
+      /* Check the solution
+       *
+       * Should be:
+       *
+       *  [[1]
+       *   [2]
+       *   [3]
+       *   [4]
+       *   [5]
+       *   [6]]
+       */
+      // Solution Vector for later comparison
+      RCP<MV> Xhat = rcp(new MV(map,numVectors));
+      Xhat->setObjectLabel("Xhat");
+      GO rowids_soln[nrows] = {0,2,4,5,7,9};
+      Scalar data_soln[nrows] = {1,2,3,4,5,6};
+      for( global_size_t i = 0; i < nrows; ++i ){
+        if( Xhat->getMap()->isNodeGlobalElement(rowids_soln[i]) ){
+          Xhat->replaceGlobalValue(rowids_soln[i],0,data_soln[i]);
+        }
+      }
+
+      A->describe(out, Teuchos::VERB_EXTREME);
+      B->describe(out, Teuchos::VERB_EXTREME);
+      Xhat->describe(out, Teuchos::VERB_EXTREME);
+      X->describe(out, Teuchos::VERB_EXTREME);
+
+      //A->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+
+      // Check result of solve
+      Array<Mag> xhatnorms(numVectors), xnorms(numVectors);
+      Xhat->norm2(xhatnorms());
+      X->norm2(xnorms());
+      TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
+    } // end if numProcs = 2
+  }
+
   /*
    * Unit Tests for Complex data types
    */
@@ -607,7 +770,8 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, SymbolicFactorization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, NumericFactorization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, Solve, SCALAR, LO, GO ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, SolveTrans, SCALAR, LO, GO )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, SolveTrans, SCALAR, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( KLU2, NonContgGID, SCALAR, LO, GO )
 
 #define UNIT_TEST_GROUP_ORDINAL( ORDINAL )              \
   UNIT_TEST_GROUP_ORDINAL_ORDINAL( ORDINAL, ORDINAL )

--- a/packages/amesos2/test/solvers/Superlu_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/Superlu_UnitTests.cpp
@@ -376,6 +376,170 @@ namespace {
     TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Superlu, NonContgGID, SCALAR, LO, GO )
+  {
+    typedef CrsMatrix<SCALAR,LO,GO,Node> MAT;
+    typedef ScalarTraits<SCALAR> ST;
+    typedef MultiVector<SCALAR,LO,GO,Node> MV;
+    typedef typename ST::magnitudeType Mag;
+
+    using Tpetra::global_size_t;
+    using Teuchos::tuple;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Scalar = SCALAR;
+
+    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
+    RCP<const Comm<int> > comm = platform.getComm();
+    RCP<Node>             node = platform.getNode();
+
+    size_t myRank = comm->getRank();
+    const global_size_t numProcs = comm->getSize();
+
+    // Unit test created for 2 processes
+    if ( numProcs == 2 ) {
+
+      const global_size_t numVectors = 1;
+      const global_size_t nrows = 6;
+
+      const GO numGlobalEntries = nrows;
+      const LO numLocalEntries = nrows / numProcs;
+
+      // Create non-contiguous Map
+      // This example: np 2 leads to GIDS: proc0 - 0,2,4  proc 1 - 1,3,5
+      Teuchos::Array<GO> elementList(numLocalEntries);
+      for ( LO k = 0; k < numLocalEntries; ++k ) {
+        elementList[k] = myRank + k*numProcs + 4*myRank;
+      }
+
+      typedef Tpetra::Map<LO,GO>  map_type;
+      RCP< const map_type > map = rcp( new map_type(numGlobalEntries, elementList, 0, comm) );
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && map->isContiguous (),
+          std::logic_error,
+          "SuperLU NonContigGID Test: The non-contiguous map claims to be contiguous.");
+
+      //RCP<MAT> A = rcp( new MAT(map,3) ); // max of three entries in a row
+      RCP<MAT> A = rcp( new MAT(map,0) );
+      A->setObjectLabel("A");
+
+      /*
+       * We will solve a system with a known solution, for which we will be using
+       * the following matrix:
+       *
+       *  GID  0   2   4   5   7   9
+       * [ 0 [ 7,  0, -3,  0, -1,  0 ]
+       *   2 [ 2,  8,  0,  0,  0,  0 ]
+       *   4 [ 0,  0,  1,  0,  0,  0 ]
+       *   5 [-3,  0,  0,  5,  0,  0 ]
+       *   7 [ 0, -1,  0,  0,  4,  0 ]
+       *   9 [ 0,  0,  0, -2,  0,  6 ] ]
+       *
+       */
+
+      // Construct matrix
+      if( myRank == 0 ){
+        A->insertGlobalValues(0,tuple<GO>(0,4,7),tuple<Scalar>(7,-3,-1));
+        A->insertGlobalValues(2,tuple<GO>(0,2),tuple<Scalar>(2,8));
+        A->insertGlobalValues(4,tuple<GO>(4),tuple<Scalar>(1));
+        A->insertGlobalValues(5,tuple<GO>(0,5),tuple<Scalar>(-3,5));
+        A->insertGlobalValues(7,tuple<GO>(2,7),tuple<Scalar>(-1,4));
+        A->insertGlobalValues(9,tuple<GO>(5,9),tuple<Scalar>(-2,6));
+      }
+
+      A->fillComplete();
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && A->getMap()->isContiguous (),
+          std::logic_error,
+          "SuperLU NonContigGID Test: The non-contiguous map of A claims to be contiguous.");
+
+
+      // Create X with random values
+      RCP<MV> X = rcp(new MV(map,numVectors));
+      X->setObjectLabel("X");
+      X->randomize();
+
+      /* Create B, use same GIDs
+       *
+       * Use RHS:
+       *
+       *  [[-7]
+       *   [18]
+       *   [ 3]
+       *   [17]
+       *   [18]
+       *   [28]]
+       */
+      RCP<MV> B = rcp(new MV(map,numVectors));
+      B->setObjectLabel("B");
+      GO rowids[nrows] = {0,2,4,5,7,9};
+      Scalar data[nrows] = {-7,18,3,17,18,28};
+      for( global_size_t i = 0; i < nrows; ++i ){
+        if( B->getMap()->isNodeGlobalElement(rowids[i]) ){
+          B->replaceGlobalValue(rowids[i],0,data[i]);
+        }
+      }
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          comm->getSize () > 1 && X->getMap()->isContiguous () && B->getMap()->isContiguous (),
+          std::logic_error,
+          "SuperLU NonContigGID Test: The non-contiguous maps of X or B claims to be contiguous.");
+
+
+      // Create solver interface with Amesos2 factory method
+      RCP<Amesos2::Solver<MAT,MV> > solver = Amesos2::create<MAT,MV>("SuperLU", A, X, B);
+
+      // Create a Teuchos::ParameterList to hold solver parameters
+      Teuchos::ParameterList amesos2_params("Amesos2");
+      amesos2_params.sublist("SuperLU").set("IsContiguous", false, "Are GIDs Contiguous");
+
+      solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+
+      solver->symbolicFactorization().numericFactorization().solve();
+
+
+      /* Check the solution
+       *
+       * Should be:
+       *
+       *  [[1]
+       *   [2]
+       *   [3]
+       *   [4]
+       *   [5]
+       *   [6]]
+       */
+      // Solution Vector for later comparison
+      RCP<MV> Xhat = rcp(new MV(map,numVectors));
+      Xhat->setObjectLabel("Xhat");
+      GO rowids_soln[nrows] = {0,2,4,5,7,9};
+      Scalar data_soln[nrows] = {1,2,3,4,5,6};
+      for( global_size_t i = 0; i < nrows; ++i ){
+        if( Xhat->getMap()->isNodeGlobalElement(rowids_soln[i]) ){
+          Xhat->replaceGlobalValue(rowids_soln[i],0,data_soln[i]);
+        }
+      }
+
+      A->describe(out, Teuchos::VERB_EXTREME);
+      B->describe(out, Teuchos::VERB_EXTREME);
+      Xhat->describe(out, Teuchos::VERB_EXTREME);
+      X->describe(out, Teuchos::VERB_EXTREME);
+
+      //A->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //B->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //Xhat->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+      //X->describe(*(getDefaultOStream()), Teuchos::VERB_EXTREME);
+
+      // Check result of solve
+      Array<Mag> xhatnorms(numVectors), xnorms(numVectors);
+      Xhat->norm2(xhatnorms());
+      X->norm2(xnorms());
+      TEST_COMPARE_FLOATING_ARRAYS( xhatnorms, xnorms, 0.005 );
+    } // end if numProcs = 2
+  }
+
+
   /*
    * Unit Tests for Complex data types
    */
@@ -601,7 +765,8 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Superlu, SymbolicFactorization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Superlu, NumericFactorization, SCALAR, LO, GO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Superlu, Solve, SCALAR, LO, GO ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Superlu, SolveTrans, SCALAR, LO, GO )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Superlu, SolveTrans, SCALAR, LO, GO ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Superlu, NonContgGID, SCALAR, LO, GO )
 
 
 #define UNIT_TEST_GROUP_ORDINAL( ORDINAL )              \


### PR DESCRIPTION
TODO:
More cleanup

Revise to call computeGatherMap one time per run; storing in
MatrixAdapter would require a 'setter' method, may harm encapsulation. A
different class appropriate for this, used only if parameter list option
for noncontiguous gids set to false?

Cleanup and add two unit tests / examples: 1. Modification of
quick_solve_epetra to accept RHS and check output (if no RHS provided);
2. example exercising the non-contiguous GID case; revise CMakeLists
file appropriately

Full testing via checkin script