### PR TITLE
MiniTensor: include Teuchos_ScalarTraits.hpp

### DIFF
--- a/packages/minitensor/src/MiniTensor_Utilities.h
+++ b/packages/minitensor/src/MiniTensor_Utilities.h
@@ -44,6 +44,7 @@
 
 #include "MiniTensor_config.h"
 #include "Sacado.hpp"
+#include "Teuchos_ScalarTraits.hpp"
 
 namespace minitensor {
 


### PR DESCRIPTION
@lxmota I think this include is needed to properly compile a code that only includes `MiniTensor.h` and nothing else.