### PR TITLE
Zoltan: Fix incorrect windows macro.

### DIFF
--- a/packages/zoltan/src/include/zoltan_types.h
+++ b/packages/zoltan/src/include/zoltan_types.h
@@ -49,7 +49,7 @@
 
 #include <mpi.h>
 #include <stddef.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #include <limits.h>


### PR DESCRIPTION
@zoltan 

Replaced "WIN32" in zoltan_types.h with the correct version "_WIN32". See [Visual Studio Predefined Macros](https://msdn.microsoft.com/en-us/library/b0084kay.aspx) for more information. This is also consistent with what is used elsewhere in zoltan (like src/zz/zz_util.c and src/Utilities/Timer/timer.h).