### PR TITLE
Replace `throw char*` with call to `TEUCHOS_TEST_FOR_EXCEPTION`

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -6348,9 +6348,7 @@ namespace Tpetra {
       bool locallyCorrect = unpackCrsMatrixAndCombine (
           this->lclMatrix_, lclColMap, errStr, importLIDs, imports,
           numPacketsPerLID, constantNumPackets, distor, combineMode, atomic);
-      if (!locallyCorrect) {
-        throw errStr->c_str();
-      }
+      TEUCHOS_TEST_FOR_EXCEPTION(!locallyCorrect, std::runtime_error, *errStr);
     }
     else {
       this->unpackAndCombineImplNonStatic (importLIDs, imports, numPacketsPerLID,


### PR DESCRIPTION
Package: @trilinos/tpetra

Review: @mhoemmen

Test Summary:

  100% tests passed, 0 tests failed out of 286

  Label Time Summary:
  Amesos2    =   2.67 sec (5 tests)
  Belos      =  33.89 sec (9 tests)
  Ifpack2    =  92.74 sec (32 tests)
  Stokhos    = 102.15 sec (28 tests)
  Tpetra     =  63.24 sec (125 tests)
  Zoltan2    =  55.90 sec (87 tests)

  Total Test time (real) =  95.06 sec