### PR TITLE
Two potential fixes for issue 183, just for review purposes.

### DIFF
--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
@@ -149,41 +149,6 @@ class AlgAMD : public Algorithm<Adapter>
       // wgts are ignored in AMD
       model->getEdgeList(edgeIds, offsets, wgts);
 
-#if AMD_WITH_LNO_T
-    {
-
-      // SR: We will always call AMD with lno_t
-      AMDTraits<lno_t> AMDobj;
-      double Control[AMD_CONTROL];
-      double Info[AMD_INFO];
-
-      amd_defaults(Control);
-      amd_control(Control);
-
-      lno_t *perm;
-      perm = (lno_t *) (solution->getPermutationRCP().getRawPtr());
-
-      lno_t *amd_edgeIds;
-      // SR: This conversion might throw as we are going from gno_t to
-      // lno_t. Another option is to change local ordering to use gno_t
-      // everywhere and upgrade and use the AMD with gno_t.
-      TPL_Traits<lno_t, const gno_t>::ASSIGN_ARRAY(&amd_edgeIds, edgeIds);
-
-      lno_t amd_nVtx=0;
-      TPL_Traits<lno_t, size_t>::ASSIGN(amd_nVtx, nVtx);
-
-      lno_t result = AMDobj.order(amd_nVtx, offsets.getRawPtr(),
-                             amd_edgeIds, perm, Control, Info);
-
-      if (result != AMD_OK && result != AMD_OK_BUT_JUMBLED)
-          ierr = -1;
-
-      // Delete copies
-      TPL_Traits<lno_t, const gno_t>::DELETE_ARRAY(&amd_edgeIds);
-    }
-#else // AMD_WITH_GNO_T
-    {
-
       // We will always call AMD with SuiteSparse_long
       AMDTraits<SuiteSparse_long> AMDobj;
       double Control[AMD_CONTROL];
@@ -226,8 +191,6 @@ class AlgAMD : public Algorithm<Adapter>
       TPL_Traits<SuiteSparse_long, const lno_t>::DELETE_ARRAY(&amd_offsets);
       TPL_Traits<SuiteSparse_long, const gno_t>::DELETE_ARRAY(&amd_edgeIds);
       delete [] amd_perm;
-     }
-#endif
 
       solution->setHavePerm(true);
       return ierr;

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
@@ -164,7 +164,7 @@ class AlgAMD : public Algorithm<Adapter>
       SuiteSparse_long *amd_offsets, *amd_edgeIds;
       TPL_Traits<SuiteSparse_long, const lno_t>::ASSIGN_ARRAY(&amd_offsets,
              offsets);
-      // This might through depending on how SuiteSparse was compiled
+      // This might throw depending on how SuiteSparse was compiled
       // with long or long long and the size of both of them
       TPL_Traits<SuiteSparse_long, const gno_t>::ASSIGN_ARRAY(&amd_edgeIds,
              edgeIds);

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
@@ -53,6 +53,7 @@
 #include <Zoltan2_Algorithm.hpp>
 #include <Zoltan2_GraphModel.hpp>
 #include <Zoltan2_OrderingSolution.hpp>
+#include <Zoltan2_TPLTraits.hpp>
 
 
 #ifdef HAVE_ZOLTAN2_AMD
@@ -83,15 +84,17 @@ class AMDTraits<int>
 };
 
 template <>
-class AMDTraits<long>
+class AMDTraits<SuiteSparse_long>
 {
     public:
-    long order(long n, const long *Ap, const long *Ai, long *perm,
+    long order(SuiteSparse_long n, const SuiteSparse_long *Ap,
+                const SuiteSparse_long *Ai, SuiteSparse_long *perm,
                 double *control, double *info)
     {
         return (amd_l_order(n, Ap, Ai, perm, control, info));
     }
 };
+
 #endif
 
 }
@@ -146,6 +149,10 @@ class AlgAMD : public Algorithm<Adapter>
       // wgts are ignored in AMD
       model->getEdgeList(edgeIds, offsets, wgts);
 
+#if AMD_WITH_LNO_T
+    {
+
+      // SR: We will always call AMD with lno_t
       AMDTraits<lno_t> AMDobj;
       double Control[AMD_CONTROL];
       double Info[AMD_INFO];
@@ -156,11 +163,71 @@ class AlgAMD : public Algorithm<Adapter>
       lno_t *perm;
       perm = (lno_t *) (solution->getPermutationRCP().getRawPtr());
 
-      lno_t result = AMDobj.order(nVtx, offsets.getRawPtr(),
-                             edgeIds.getRawPtr(), perm, Control, Info);
+      lno_t *amd_edgeIds;
+      // SR: This conversion might throw as we are going from gno_t to
+      // lno_t. Another option is to change local ordering to use gno_t
+      // everywhere and upgrade and use the AMD with gno_t.
+      TPL_Traits<lno_t, const gno_t>::ASSIGN_ARRAY(&amd_edgeIds, edgeIds);
+
+      lno_t amd_nVtx=0;
+      TPL_Traits<lno_t, size_t>::ASSIGN(amd_nVtx, nVtx);
+
+      lno_t result = AMDobj.order(amd_nVtx, offsets.getRawPtr(),
+                             amd_edgeIds, perm, Control, Info);
 
       if (result != AMD_OK && result != AMD_OK_BUT_JUMBLED)
           ierr = -1;
+
+      // Delete copies
+      TPL_Traits<lno_t, const gno_t>::DELETE_ARRAY(&amd_edgeIds);
+    }
+#else // AMD_WITH_GNO_T
+    {
+
+      // We will always call AMD with SuiteSparse_long
+      AMDTraits<SuiteSparse_long> AMDobj;
+      double Control[AMD_CONTROL];
+      double Info[AMD_INFO];
+
+      amd_defaults(Control);
+      amd_control(Control);
+
+      // We will use the lno_t for local ordering
+      lno_t *perm;
+      perm = (lno_t *) (solution->getPermutationRCP().getRawPtr());
+
+      SuiteSparse_long *amd_offsets, *amd_edgeIds;
+      TPL_Traits<SuiteSparse_long, const lno_t>::ASSIGN_ARRAY(&amd_offsets,
+             offsets);
+      // This might through depending on how SuiteSparse was compiled
+      // with long or long long and the size of both of them
+      TPL_Traits<SuiteSparse_long, const gno_t>::ASSIGN_ARRAY(&amd_edgeIds,
+             edgeIds);
+
+      SuiteSparse_long amd_nVtx=0;
+      TPL_Traits<SuiteSparse_long, size_t>::ASSIGN(amd_nVtx, nVtx);
+
+      // Allocate a SuiteSparse_long perm
+      SuiteSparse_long *amd_perm = new SuiteSparse_long[amd_nVtx];
+
+      lno_t result = AMDobj.order(amd_nVtx, amd_offsets,
+                             amd_edgeIds, amd_perm, Control, Info);
+
+      if (result != AMD_OK && result != AMD_OK_BUT_JUMBLED)
+          ierr = -1;
+
+      // SR: This conversion might throw as we are going from SuiteSparse_long
+      // to lno_t. Another option is to change local ordering solution
+      // to use gno_t everywhere
+      for (size_t i = 0; i < nVtx; i++)
+          TPL_Traits<lno_t, SuiteSparse_long>::ASSIGN(perm[i], amd_perm[i]);
+
+      // Delete copies
+      TPL_Traits<SuiteSparse_long, const lno_t>::DELETE_ARRAY(&amd_offsets);
+      TPL_Traits<SuiteSparse_long, const gno_t>::DELETE_ARRAY(&amd_edgeIds);
+      delete [] amd_perm;
+     }
+#endif
 
       solution->setHavePerm(true);
       return ierr;


### PR DESCRIPTION
@kddevin : Can you look over these two potential fixes for issue 183 ? Both have pros and cons.

One use lno_t for calling AMD other uses SuiteSparse_long for AMD but has to downgrade the permutation as perm in OrderingSolution uses lno_t. Both will resolve #183 for now. There is an ifdef in the code that splits these two options. 