### PR TITLE
Framework: Updating parameterized cdash track

### DIFF
--- a/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic.cmake
+++ b/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic.cmake
@@ -71,7 +71,16 @@ IF(COMM_TYPE STREQUAL MPI)
 ENDIF()
 SET(BUILD_DIR_NAME ${COMM_TYPE}_${BUILD_TYPE}_${COMPILER_DIR}_${COMM_DIR}_DEV)
 SET(CTEST_PARALLEL_LEVEL 16)
-SET(CTEST_TEST_TYPE $ENV{JENKINS_JOB_TYPE})
+
+# Note: CTEST_TEST_TYPE drives some side-effects in Tribits that should be 
+#       taken into account.  If CTEST_TEST_TYPE is Experimental, Tribits will
+#       override Trilinos_TRACK and *always* assign results to the Experimental
+#       track on CDash.  Also, Tribits does different things based on CTEST_TEST_TYPE
+#       being one of the 3 blessed types (Nightly, Continuous, Experimental), so it's
+#       best to keep CTEST_TEST_TYPE one of these values.  
+SET(CTEST_TEST_TYPE Nightly)
+SET(Trilinos_TRACK  $ENV{JENKINS_JOB_TYPE})
+
 SET(CTEST_TEST_TIMEOUT 900)
 
 


### PR DESCRIPTION
The parameterized build needs to set the cdash track via the Trilinos_TRACK
property to be able to set the cdash track to something other than the three
blessed values ("Nightly", "Experimental", "Continuous").

Tribits can also change things based on the value of CTEST_TEST_TYPE.
- if CTEST_TEST_TYPE is Experimental, Tribits will override Trilinos_TRACK and set it to Experimental.
- if CTEST_TEST_TYPE is Nightly, Tribits pulls in other stuff

Since it's best to keep CTEST_TEST_TYPE to one of the three blessed values, we'll hard-wire it to
use Nightly for now.  In the future, we may need to update this to something more generic.

This relates to issues #1294, #1298 

Additional relevant information can be found in [Tribits issue 189](https://github.com/TriBITSPub/TriBITS/issues/189)