### PR TITLE
Teuchos: Fix LAPACK test typename for CXX11 off (#1208)

### DIFF
--- a/packages/teuchos/numerics/test/LAPACK/cxx_main.cpp
+++ b/packages/teuchos/numerics/test/LAPACK/cxx_main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
 
   typedef double ScalarType;
   typedef Teuchos::ScalarTraits<ScalarType> STS;
-  typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
+  typedef Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
 
   const int DIAG_SZ = 1031;
 


### PR DESCRIPTION
Fixes typename build error for CXX11 off in Teuchos LAPACK test.