### PR TITLE
Teuchos: fix the default values for help option for CommandLineProcessor

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -270,6 +270,17 @@ CommandLineProcessor::parse(
   const std::string  help_opt = "help";
   const std::string  pause_opt = "pause-for-debugging";
   int procRank = GlobalMPISession::getRank();
+
+  // check for help options before any others as we modify
+  // the values afterwards
+  for( int i = 1; i < argc; ++i ) {
+    bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
+    if( gov_return && opt_name == help_opt ) {
+      if(errout) printHelpMessage( argv[0], *errout );
+      return PARSE_HELP_PRINTED;
+    }
+  }
+  // check all other options
   for( int i = 1; i < argc; ++i ) {
     bool gov_return = get_opt_val( argv[i], &opt_name, &opt_val_str );
     if( !gov_return ) {
@@ -289,10 +300,6 @@ CommandLineProcessor::parse(
         *errout << "\n\n";
       }
       continue;
-    }
-    if( opt_name == help_opt ) {
-      if(errout) printHelpMessage( argv[0], *errout );
-      return PARSE_HELP_PRINTED;
     }
     if( opt_name == pause_opt ) {
       if(procRank == 0) {

--- a/packages/teuchos/core/test/CommandLineProcessor/cxx_main.cpp
+++ b/packages/teuchos/core/test/CommandLineProcessor/cxx_main.cpp
@@ -196,7 +196,67 @@ int main( int argc, char* argv[] )
   catch( ... ) {
     if(verbose)
       std::cout << "*** Caught UNEXPECTED unknown exception" << std::endl
-                << "Test 5:  CommandLineProcessor - Throw exceptions - Extra options not recognized: FAILED" << std::endl;
+                << "Test 6:  CommandLineProcessor - Throw exceptions - Extra options not recognized: FAILED" << std::endl;
+    parse_successful = false;  // No exceptions should be thrown for this command line processor.
+  }
+
+  // Next create tests for a command line processor that makes sure help output is the same independent of the arg position
+  try {
+    if (verbose)
+      std::cout << "Test 7 :  CommandLineProcessor - Help position" << std::endl;
+
+    CommandLineProcessor clp7(false, false);  // Recognize all options AND do not throw exceptions
+
+    int n = 10;
+    clp7.setOption("n", &n, "A parameter");
+
+    char arg_c[] = "command";
+    char arg_n[] = "--n=20";
+    char arg_h[] = "--help";
+
+    const int aux_argc = 3;
+    char *aux_argv[aux_argc];
+
+    std::stringbuf  buffer1, buffer2;;
+    std::streambuf* oldbuffer = NULL;
+
+    // help before args
+    aux_argv[0] = &arg_c[0];
+    aux_argv[1] = &arg_h[0];
+    aux_argv[2] = &arg_n[0];
+
+    oldbuffer = std::cerr.rdbuf(&buffer1);   // redirect output
+    clp7.parse(aux_argc, aux_argv);
+    std::cerr.rdbuf(oldbuffer);              // redirect output back
+
+    // help after args
+    aux_argv[0] = &arg_c[0];
+    aux_argv[1] = &arg_n[0];
+    aux_argv[2] = &arg_h[0];
+
+    oldbuffer = std::cerr.rdbuf(&buffer2);   // redirect output
+    clp7.parse(aux_argc, aux_argv);
+    std::cerr.rdbuf(oldbuffer);              // redirect output back
+
+    if (verbose)
+      std::cout << "Test 7 :  CommandLineProcessor - Help position: ";
+    if (buffer1.str() != buffer2.str())
+    {
+      parse_successful = false;
+      if (verbose) std::cout << "FAILED" << std::endl;
+    }
+    else
+      if (verbose) std::cout << "PASSED" << std::endl;
+  }
+  catch( CommandLineProcessor::UnrecognizedOption &excpt ) {
+    if(verbose)
+      std::cout << "*** Caught EXPECTED standard exception : " << excpt.what() << std::endl
+                << "Test 7:  CommandLineProcessor - Help position: PASSED" << std::endl;
+  }
+  catch( ... ) {
+    if(verbose)
+      std::cout << "*** Caught UNEXPECTED unknown exception" << std::endl
+                << "Test 7:  CommandLineProcessor - Help position: FAILED" << std::endl;
     parse_successful = false;  // No exceptions should be thrown for this command line processor.
   }
 


### PR DESCRIPTION
Depending on whether help option was before or after some arguments on
the command line, it could affect the output. Specifically, the provided
command line values of other parameters could appear as the default ones
in the help output.

This patch fixes (or works around) the problem by first searching
through the parameters to find if help option is present.

Fix #585.