### PR TITLE
ctest_linux_nightly_generic_sierra.cmake: use path to BLAS if set

### DIFF
--- a/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
+++ b/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
@@ -116,6 +116,11 @@ SET(EXTRA_CONFIGURE_OPTIONS
   "-DCMAKE_Fortran_FLAGS=$ENV{JENKINS_Fortran_FLAGS}"
 )
 
+IF (DEFINED $ENV{JENKINS_BLAS_LIBRARY_DIRS})
+    SET(EXTRA_CONFIGURE_OPTIONS ${EXTRA_CONFIGURE_OPTIONS}
+        "-DBLAS_LIBRARY_DIRS=$ENV{JENKINS_BLAS_LIBRARY_DIRS}")
+ENDIF()
+
 #"-DMPI_EXEC_POST_NUMPROCS_FLAGS:STRING=-bind-to;socket;--map-by;socket"
 #
 # Set the rest of the system-specific options and run the dashboard build/test


### PR DESCRIPTION
Basically Ride does not store this in /usr/lib, but I don't
want to have to set it for all the platforms that do...