### PR TITLE
TeuchosParser: add and test MathExpr language

### DIFF
--- a/packages/teuchos/parser/example/Calc.cpp
+++ b/packages/teuchos/parser/example/Calc.cpp
@@ -5,97 +5,32 @@
 
 #include <Teuchos_Language.hpp>
 #include <Teuchos_Reader.hpp>
+#include <Teuchos_MathExpr.hpp>
 
 namespace {
 
 using Teuchos::any;
 using Teuchos::any_cast;
 
-enum {
-  PROD_EXPR,
-  PROD_ADD_SUB_DECAY,
-  PROD_MUL_DIV_DECAY,
-  PROD_POW_DECAY,
-  PROD_NEG_DECAY,
-  PROD_ADD,
-  PROD_SUB,
-  PROD_MUL,
-  PROD_DIV,
-  PROD_POW,
-  PROD_UNARY_CALL,
-  PROD_BINARY_CALL,
-  PROD_PARENS,
-  PROD_CONST,
-  PROD_NEG,
-  PROD_NO_SPACES,
-  PROD_SPACES
+struct CallArgs {
+  double a0;
+  double a1;
+  int n;
 };
 
-enum { NPRODS = PROD_SPACES + 1 };
-
-enum {
-  TOK_SPACE,
-  TOK_NAME,
-  TOK_ADD,
-  TOK_SUB,
-  TOK_MUL,
-  TOK_DIV,
-  TOK_POW,
-  TOK_LPAREN,
-  TOK_RPAREN,
-  TOK_COMMA,
-  TOK_CONST
-};
-
-enum { NTOKS = TOK_CONST + 1 };
-
-Teuchos::Language make_language() {
-  Teuchos::Language out;
-  Teuchos::Language::Productions& prods = out.productions;
-  prods.resize(NPRODS);
-  prods[PROD_EXPR]("expr") >> "expr(+-)";
-  prods[PROD_ADD_SUB_DECAY]("expr(+-)") >> "expr(*/)";
-  prods[PROD_MUL_DIV_DECAY]("expr(*/)") >> "expr(^)";
-  prods[PROD_POW_DECAY]("expr(^)") >> "neg-expr";
-  prods[PROD_NEG_DECAY]("neg-expr") >> "scalar-expr";
-  prods[PROD_ADD]("expr(+-)") >> "expr(+-)", "+", "S?", "expr(*/)";
-  prods[PROD_SUB]("expr(+-)") >> "expr(+-)", "-", "S?", "expr(*/)";
-  prods[PROD_MUL]("expr(*/)") >> "expr(*/)", "*", "S?", "expr(^)";
-  prods[PROD_DIV]("expr(*/)") >> "expr(*/)", "/", "S?", "expr(^)";
-  prods[PROD_POW]("expr(^)") >> "expr(^)", "^", "S?", "neg-expr";
-  prods[PROD_NEG]("neg-expr") >> "-", "scalar-expr";
-  prods[PROD_UNARY_CALL]("scalar-expr") >> "name", "S?", "(", "S?", "expr(+-)", ")", "S?";
-  prods[PROD_BINARY_CALL]("scalar-expr") >> "name", "S?", "(", "S?", "expr(+-)", ",", "S?", "expr(+-)", ")", "S?";
-  prods[PROD_PARENS]("scalar-expr") >> "(", "S?", "expr(+-)", ")", "S?";
-  prods[PROD_CONST]("scalar-expr") >> "constant", "S?";
-  prods[PROD_NO_SPACES]("S?");
-  prods[PROD_SPACES]("S?") >> "spaces";
-  out.tokens.resize(NTOKS);
-  out.tokens[TOK_SPACE]("spaces", "[ \t\n\r]+");
-  out.tokens[TOK_NAME]("name", "[_a-zA-Z][_a-zA-Z0-9]*");
-  out.tokens[TOK_ADD]("+", "\\+");
-  out.tokens[TOK_SUB]("-", "\\-");
-  out.tokens[TOK_MUL]("*", "\\*");
-  out.tokens[TOK_DIV]("/", "\\/");
-  out.tokens[TOK_POW]("^", "\\^");
-  out.tokens[TOK_LPAREN]("(", "\\(");
-  out.tokens[TOK_RPAREN](")", "\\)");
-  out.tokens[TOK_COMMA](",", ",");
-  out.tokens[TOK_CONST]("constant", "(0|([1-9][0-9]*))(\\.[0-9]*)?([eE]\\-?[1-9][0-9]*)?");
-  return out;
+bool operator==(CallArgs const&, CallArgs const&) {
+  throw std::logic_error("CallArgs operator== is just to satisfy Teuchos");
+  return false;
 }
 
-Teuchos::ReaderTablesPtr ask_reader_tables() {
-  static Teuchos::ReaderTablesPtr ptr;
-  if (ptr.strong_count() == 0) {
-    ptr = Teuchos::make_reader_tables(make_language());
-  }
-  return ptr;
+std::ostream& operator<<(std::ostream& os, CallArgs const&) {
+  throw std::logic_error("CallArgs operator<< is just to satisfy Teuchos");
+  return os;
 }
 
 class Reader : public Teuchos::Reader {
  public:
-  Reader():Teuchos::Reader(ask_reader_tables()) {
+  Reader():Teuchos::Reader(Teuchos::MathExpr::ask_reader_tables()) {
     unary_map["sqrt"] = &std::sqrt;
     unary_map["sin"] = &std::sin;
     unary_map["cos"] = &std::cos;
@@ -113,12 +48,12 @@ class Reader : public Teuchos::Reader {
   virtual void at_shift(Teuchos::any& result_any, int token, std::string& text) {
     using std::swap;
     switch (token) {
-      case TOK_NAME: {
+      case Teuchos::MathExpr::TOK_NAME: {
         std::string& result = Teuchos::make_any_ref<std::string>(result_any);
         swap(result, text);
         return;
       }
-      case TOK_CONST: {
+      case Teuchos::MathExpr::TOK_CONST: {
         result_any = std::atof(text.c_str());
         return;
       }
@@ -127,55 +62,105 @@ class Reader : public Teuchos::Reader {
   virtual void at_reduce(Teuchos::any& result, int prod, std::vector<Teuchos::any>& rhs) {
     using std::swap;
     switch (prod) {
-      case PROD_EXPR:
-      case PROD_ADD_SUB_DECAY:
-      case PROD_MUL_DIV_DECAY:
-      case PROD_POW_DECAY:
-      case PROD_NEG_DECAY:
+      case Teuchos::MathExpr::PROD_EXPR:
+      case Teuchos::MathExpr::PROD_TERNARY_DECAY:
+      case Teuchos::MathExpr::PROD_OR_DECAY:
+      case Teuchos::MathExpr::PROD_AND_DECAY:
+      case Teuchos::MathExpr::PROD_ADD_SUB_DECAY:
+      case Teuchos::MathExpr::PROD_MUL_DIV_DECAY:
+      case Teuchos::MathExpr::PROD_POW_DECAY:
+      case Teuchos::MathExpr::PROD_NEG_DECAY:
+      case Teuchos::MathExpr::PROD_SOME_ARGS:
         swap(result, rhs.at(0));
         break;
-      case PROD_ADD:
+      case Teuchos::MathExpr::PROD_TERNARY:
+        result = any_cast<bool>(rhs.at(0)) ?
+                 any_cast<double>(rhs.at(3)) :
+                 any_cast<double>(rhs.at(6));
+        break;
+      case Teuchos::MathExpr::PROD_OR:
+        result = any_cast<bool>(rhs.at(0)) || any_cast<bool>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_AND:
+        result = any_cast<bool>(rhs.at(0)) && any_cast<bool>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_GT:
+        result = any_cast<double>(rhs.at(0)) > any_cast<double>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_LT:
+        result = any_cast<double>(rhs.at(0)) < any_cast<double>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_GEQ:
+        result = any_cast<double>(rhs.at(0)) >= any_cast<double>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_LEQ:
+        result = any_cast<double>(rhs.at(0)) <= any_cast<double>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_EQ:
+        result = any_cast<double>(rhs.at(0)) == any_cast<double>(rhs.at(3));
+        break;
+      case Teuchos::MathExpr::PROD_ADD:
         result = any_cast<double>(rhs.at(0)) + any_cast<double>(rhs.at(3));
         break;
-      case PROD_SUB:
+      case Teuchos::MathExpr::PROD_SUB:
         result = any_cast<double>(rhs.at(0)) - any_cast<double>(rhs.at(3));
         break;
-      case PROD_MUL:
+      case Teuchos::MathExpr::PROD_MUL:
         result = any_cast<double>(rhs.at(0)) * any_cast<double>(rhs.at(3));
         break;
-      case PROD_DIV:
+      case Teuchos::MathExpr::PROD_DIV:
         result = any_cast<double>(rhs.at(0)) / any_cast<double>(rhs.at(3));
         break;
-      case PROD_POW:
+      case Teuchos::MathExpr::PROD_POW:
         result = std::pow(any_cast<double>(rhs.at(0)), any_cast<double>(rhs.at(3)));
         break;
-      case PROD_NEG:
-        result = - any_cast<double>(rhs.at(1));
-        break;
-      case PROD_UNARY_CALL: {
+      case Teuchos::MathExpr::PROD_CALL: {
         std::string& name = Teuchos::any_ref_cast<std::string>(rhs.at(0));
-        double arg = any_cast<double>(rhs.at(4));
-        TEUCHOS_TEST_FOR_EXCEPTION(!unary_map.count(name), Teuchos::ParserFail,
-            "Unknown unary function name \"" << name << "\"\n");
-        Unary fptr = unary_map[name];
-        result = (*fptr)(arg);
+        CallArgs& args = Teuchos::any_ref_cast<CallArgs>(rhs.at(4));
+        TEUCHOS_TEST_FOR_EXCEPTION(args.n < 1 || args.n > 2, Teuchos::ParserFail,
+            "Only unary and binary functions supported!\n");
+        if (args.n == 1) {
+          TEUCHOS_TEST_FOR_EXCEPTION(!unary_map.count(name), Teuchos::ParserFail,
+              "Unknown unary function name \"" << name << "\"\n");
+          Unary fptr = unary_map[name];
+          result = (*fptr)(args.a0);
+        } else {
+          TEUCHOS_TEST_FOR_EXCEPTION(!binary_map.count(name), Teuchos::ParserFail,
+              "Unknown binary function name \"" << name << "\"\n");
+          Binary fptr = binary_map[name];
+          result = (*fptr)(args.a0, args.a1);
+        }
         break;
       }
-      case PROD_BINARY_CALL: {
-        std::string& name = Teuchos::any_ref_cast<std::string>(rhs.at(0));
-        double arg1 = any_cast<double>(rhs.at(4));
-        double arg2 = any_cast<double>(rhs.at(7));
-        TEUCHOS_TEST_FOR_EXCEPTION(!binary_map.count(name), Teuchos::ParserFail,
-            "Unknown binary function name \"" << name << "\"\n");
-        Binary fptr = binary_map[name];
-        result = (*fptr)(arg1, arg2);
+      case Teuchos::MathExpr::PROD_NO_ARGS: {
+        CallArgs& args = Teuchos::make_any_ref<CallArgs>(result);
+        args.n = 0;
         break;
       }
-      case PROD_PARENS:
+      case Teuchos::MathExpr::PROD_FIRST_ARG: {
+        CallArgs& args = Teuchos::make_any_ref<CallArgs>(result);
+        args.a0 = any_cast<double>(rhs.at(0));
+        args.n = 1;
+        break;
+      }
+      case Teuchos::MathExpr::PROD_NEXT_ARG: {
+        CallArgs& args = Teuchos::any_ref_cast<CallArgs>(rhs.at(0));
+        args.a1 = any_cast<double>(rhs.at(3));
+        args.n = 2;
+        swap(result, rhs.at(0));
+        break;
+      }
+      case Teuchos::MathExpr::PROD_NEG:
+        result = - any_cast<double>(rhs.at(2));
+        break;
+      case Teuchos::MathExpr::PROD_PARENS:
         result = any_cast<double>(rhs.at(2));
         break;
-      case PROD_CONST:
+      case Teuchos::MathExpr::PROD_CONST:
         result = any_cast<double>(rhs.at(0));
+        break;
+      case Teuchos::MathExpr::PROD_VAR:
+        throw Teuchos::ParserFail("Variables not supported!\n");
         break;
     }
   }

--- a/packages/teuchos/parser/src/CMakeLists.txt
+++ b/packages/teuchos/parser/src/CMakeLists.txt
@@ -18,7 +18,7 @@ SET(HEADERS
   "${DIR}/Teuchos_TableDecl.hpp"
   "${DIR}/Teuchos_XML.hpp"
   "${DIR}/Teuchos_YAML.hpp"
-  "${DIR}/Teuchos_Parser.hpp"
+  "${DIR}/Teuchos_MathExpr.hpp"
   )
 
 SET(SOURCES
@@ -33,6 +33,7 @@ SET(SOURCES
   "${DIR}/Teuchos_regex.cpp"
   "${DIR}/Teuchos_XML.cpp"
   "${DIR}/Teuchos_YAML.cpp"
+  "${DIR}/Teuchos_MathExpr.cpp"
   )
 
 #

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -9,7 +9,7 @@ Teuchos::Language make_language() {
   Teuchos::Language::Productions& prods = out.productions;
   prods.resize(NPRODS);
   prods[PROD_EXPR]("expr") >> "ternary";
-  prods[PROD_TERNARY_DECAY]("ternary") >> "add_mul";
+  prods[PROD_TERNARY_DECAY]("ternary") >> "add_sub";
   prods[PROD_OR_DECAY]("or") >> "and";
   prods[PROD_AND_DECAY]("and") >> "comp";
   prods[PROD_ADD_SUB_DECAY]("add_sub") >> "mul_div";
@@ -34,8 +34,8 @@ Teuchos::Language make_language() {
     >> "name", "S?", "(", "S?", "args?", ")", "S?";
   prods[PROD_NO_ARGS]("args?");
   prods[PROD_SOME_ARGS]("args?") >> "args";
-  prods[PROD_FIRST_ARG]("args") >> "arg";
-  prods[PROD_NEXT_ARG]("args") >> "args", ",", "S?", "arg";
+  prods[PROD_FIRST_ARG]("args") >> "ternary";
+  prods[PROD_NEXT_ARG]("args") >> "args", ",", "S?", "ternary";
   prods[PROD_NEG]("neg") >> "-", "S?", "scalar";
   prods[PROD_PARENS]("scalar") >> "(", "S?", "ternary", ")", "S?";
   prods[PROD_CONST]("scalar") >> "constant", "S?";

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -36,7 +36,7 @@ Teuchos::Language make_language() {
   prods[PROD_SOME_ARGS]("args?") >> "args";
   prods[PROD_FIRST_ARG]("args") >> "ternary";
   prods[PROD_NEXT_ARG]("args") >> "args", ",", "S?", "ternary";
-  prods[PROD_NEG]("neg") >> "-", "S?", "scalar";
+  prods[PROD_NEG]("neg") >> "-", "S?", "neg";
   prods[PROD_PARENS]("scalar") >> "(", "S?", "ternary", ")", "S?";
   prods[PROD_CONST]("scalar") >> "constant", "S?";
   prods[PROD_VAR]("scalar") >> "name", "S?";

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -1,0 +1,89 @@
+#include <Teuchos_MathExpr.hpp>
+
+namespace Teuchos {
+
+namespace MathExpr {
+
+Teuchos::Language make_language() {
+  Teuchos::Language out;
+  Teuchos::Language::Productions& prods = out.productions;
+  prods.resize(NPRODS);
+  prods[PROD_EXPR]("expr") >> "ternary";
+  prods[PROD_TERNARY_DECAY]("ternary") >> "add_mul";
+  prods[PROD_OR_DECAY]("or") >> "and";
+  prods[PROD_AND_DECAY]("and") >> "comp";
+  prods[PROD_ADD_SUB_DECAY]("add_sub") >> "mul_div";
+  prods[PROD_MUL_DIV_DECAY]("mul_div") >> "pow";
+  prods[PROD_POW_DECAY]("pow") >> "neg";
+  prods[PROD_NEG_DECAY]("neg") >> "scalar";
+  prods[PROD_TERNARY]("ternary")
+    >> "or", "?", "S?", "add_sub", ":", "S?", "add_sub";
+  prods[PROD_OR]("or") >> "or", "||", "S?", "and";
+  prods[PROD_AND]("and") >> "and", "&&", "S?", "comp";
+  prods[PROD_GT]("comp") >> "add_sub", ">", "S?", "add_sub";
+  prods[PROD_LT]("comp") >> "add_sub", "<", "S?", "add_sub";
+  prods[PROD_GEQ]("comp") >> "add_sub", ">=", "S?", "add_sub";
+  prods[PROD_LEQ]("comp") >> "add_sub", "<=", "S?", "add_sub";
+  prods[PROD_EQ]("comp") >> "add_sub", "==", "S?", "add_sub";
+  prods[PROD_ADD]("add_sub") >> "add_sub", "+", "S?", "mul_div";
+  prods[PROD_SUB]("add_sub") >> "add_sub", "-", "S?", "mul_div";
+  prods[PROD_MUL]("mul_div") >> "mul_div", "*", "S?", "pow";
+  prods[PROD_DIV]("mul_div") >> "mul_div", "/", "S?", "pow";
+  prods[PROD_POW]("pow") >> "pow", "^", "S?", "neg";
+  prods[PROD_CALL]("scalar")
+    >> "name", "S?", "(", "S?", "args?", ")", "S?";
+  prods[PROD_NO_ARGS]("args?");
+  prods[PROD_SOME_ARGS]("args?") >> "args";
+  prods[PROD_FIRST_ARG]("args") >> "arg";
+  prods[PROD_NEXT_ARG]("args") >> "args", ",", "S?", "arg";
+  prods[PROD_NEG]("neg") >> "-", "S?", "scalar";
+  prods[PROD_PARENS]("scalar") >> "(", "S?", "ternary", ")", "S?";
+  prods[PROD_CONST]("scalar") >> "constant", "S?";
+  prods[PROD_VAR]("scalar") >> "name", "S?";
+  prods[PROD_NO_SPACES]("S?");
+  prods[PROD_SPACES]("S?") >> "spaces";
+  out.tokens.resize(NTOKS);
+  out.tokens[TOK_SPACE]("spaces", "[ \t\n\r]+");
+  out.tokens[TOK_NAME]("name", "[_a-zA-Z][_a-zA-Z0-9]*");
+  out.tokens[TOK_ADD]("+", "\\+");
+  out.tokens[TOK_SUB]("-", "\\-");
+  out.tokens[TOK_MUL]("*", "\\*");
+  out.tokens[TOK_DIV]("/", "\\/");
+  out.tokens[TOK_POW]("^", "\\^");
+  out.tokens[TOK_LPAREN]("(", "\\(");
+  out.tokens[TOK_RPAREN](")", "\\)");
+  out.tokens[TOK_COMMA](",", ",");
+  out.tokens[TOK_CHECK]("?", "\\?");
+  out.tokens[TOK_CHOOSE](":", ":");
+  out.tokens[TOK_GT](">", ">");
+  out.tokens[TOK_LT]("<", "<");
+  out.tokens[TOK_GEQ](">=", ">=");
+  out.tokens[TOK_LEQ]("<=", "<=");
+  out.tokens[TOK_EQ]("==", "==");
+  out.tokens[TOK_AND]("&&", "&&");
+  out.tokens[TOK_OR]("||", "\\|\\|");
+  out.tokens[TOK_CONST]("constant",
+      "(0|([1-9][0-9]*))(\\.[0-9]*)?([eE]\\-?[1-9][0-9]*)?");
+  return out;
+}
+
+LanguagePtr ask_language() {
+  static LanguagePtr ptr;
+  if (ptr.strong_count() == 0) {
+    ptr.reset(new Language(make_language()));
+  }
+  return ptr;
+}
+
+Teuchos::ReaderTablesPtr ask_reader_tables() {
+  static Teuchos::ReaderTablesPtr ptr;
+  if (ptr.strong_count() == 0) {
+    LanguagePtr lang = ask_language();
+    ptr = Teuchos::make_reader_tables(*lang);
+  }
+  return ptr;
+}
+
+}  // end namespace MathExpr
+
+}  // end namespace Teuchos

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.hpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.hpp
@@ -1,0 +1,83 @@
+#ifndef TEUCHOS_MATHEXPR_HPP
+#define TEUCHOS_MATHEXPR_HPP
+
+#include <Teuchos_Language.hpp>
+#include <Teuchos_Reader.hpp>
+
+namespace Teuchos {
+
+namespace MathExpr {
+
+enum {
+  PROD_EXPR,
+  PROD_TERNARY_DECAY,
+  PROD_OR_DECAY,
+  PROD_AND_DECAY,
+  PROD_ADD_SUB_DECAY,
+  PROD_MUL_DIV_DECAY,
+  PROD_POW_DECAY,
+  PROD_NEG_DECAY,
+  PROD_TERNARY,
+  PROD_OR,
+  PROD_AND,
+  PROD_GT,
+  PROD_LT,
+  PROD_GEQ,
+  PROD_LEQ,
+  PROD_EQ,
+  PROD_ADD,
+  PROD_SUB,
+  PROD_MUL,
+  PROD_DIV,
+  PROD_POW,
+  PROD_CALL,
+  PROD_NO_ARGS,
+  PROD_SOME_ARGS,
+  PROD_FIRST_ARG,
+  PROD_NEXT_ARG,
+  PROD_NEG,
+  PROD_PARENS,
+  PROD_CONST,
+  PROD_VAR,
+  PROD_NO_SPACES,
+  PROD_SPACES
+};
+
+enum { NPRODS = PROD_SPACES + 1 };
+
+enum {
+  TOK_SPACE,
+  TOK_NAME,
+  TOK_ADD,
+  TOK_SUB,
+  TOK_MUL,
+  TOK_DIV,
+  TOK_POW,
+  TOK_LPAREN,
+  TOK_RPAREN,
+  TOK_COMMA,
+  TOK_CHECK,
+  TOK_CHOOSE,
+  TOK_GT,
+  TOK_LT,
+  TOK_GEQ,
+  TOK_LEQ,
+  TOK_EQ,
+  TOK_AND,
+  TOK_OR,
+  TOK_CONST
+};
+
+enum { NTOKS = TOK_CONST + 1 };
+
+Language make_language();
+
+LanguagePtr ask_language();
+
+ReaderTablesPtr ask_reader_tables();
+
+}  // end namespace MathExpr
+
+}  // end namespace Teuchos
+
+#endif

--- a/packages/teuchos/parser/test/unit_tests.cpp
+++ b/packages/teuchos/parser/test/unit_tests.cpp
@@ -293,6 +293,7 @@ TEUCHOS_UNIT_TEST( Parser, mathexpr_reader ) {
   test_mathexpr_reader("sqrt(x^2 + y^2) < 0.5 ? 1 : 0");
   test_mathexpr_reader("1.22+30.*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
   test_mathexpr_reader("1.23e5+8.07e10*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+  test_mathexpr_reader("---16");
 }
 
 } // anonymous namespace

--- a/packages/teuchos/parser/test/unit_tests.cpp
+++ b/packages/teuchos/parser/test/unit_tests.cpp
@@ -7,6 +7,7 @@
 #include <Teuchos_Reader.hpp>
 #include <Teuchos_XML.hpp>
 #include <Teuchos_YAML.hpp>
+#include <Teuchos_MathExpr.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 
 #include <iostream>
@@ -271,6 +272,12 @@ TEUCHOS_UNIT_TEST( Parser, yaml_reader ) {
   test_yaml_reader(
       "---\n#top comment\ntop entry: \n  sub-entry: twelve\n"
       "  # long comment\n  # about sub-entry2\n  sub-entry2: green\n...\n");
+}
+
+TEUCHOS_UNIT_TEST( Parser, mathexpr_language ) {
+  LanguagePtr lang = MathExpr::ask_language();
+  GrammarPtr grammar = make_grammar(*lang);
+  make_lalr1_parser(grammar);
 }
 
 } // anonymous namespace

--- a/packages/teuchos/parser/test/unit_tests.cpp
+++ b/packages/teuchos/parser/test/unit_tests.cpp
@@ -280,4 +280,19 @@ TEUCHOS_UNIT_TEST( Parser, mathexpr_language ) {
   make_lalr1_parser(grammar);
 }
 
+void test_mathexpr_reader(std::string const& str) {
+  Reader reader(MathExpr::ask_reader_tables());
+  any result;
+  reader.read_string(result, str, "test_mathexpr_reader");
+}
+
+TEUCHOS_UNIT_TEST( Parser, mathexpr_reader ) {
+  test_mathexpr_reader("1 + 1");
+  test_mathexpr_reader("concat(one, two, three)");
+  test_mathexpr_reader("x < 0.5 ? 1 : 0");
+  test_mathexpr_reader("sqrt(x^2 + y^2) < 0.5 ? 1 : 0");
+  test_mathexpr_reader("1.22+30.*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+  test_mathexpr_reader("1.23e5+8.07e10*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+}
+
 } // anonymous namespace


### PR DESCRIPTION
This PR is mostly for book-keeping and visibility purposes, as I think I can safely merge in changes that only affect TeuchosParser so long as it remains EX.

The "Calc" example was turned into a built-in language in TeuchosParser, by adding the ternary operator, boolean expressions for the ternary operator, and arbitrary numbers of function call arguments. The reason for this is that this language should be sufficient for cases like STKExprEval, and can form a common basis for codes that need to specify boundary and initial conditions. The language makes no requirements on the types of expressions or what code is used to evaluate them, and yet we can provide a common parser.