### PR TITLE
Move certain Kokkos symbols out of Experimental

### DIFF
--- a/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
+++ b/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
@@ -286,7 +286,7 @@ void IntrepidGetP1NodeInHi(const Teuchos::RCP<Intrepid2::Basis<typename KokkosDe
     throw std::runtime_error("IntrepidPCoarsenFactory: Unknown element type");
 
   // Get coordinates of the hi_basis dof's
-  Kokkos::Experimental::resize(hi_DofCoords,hi_basis->getCardinality(),hi_basis->getBaseCellTopology().getDimension());
+  Kokkos::resize(hi_DofCoords,hi_basis->getCardinality(),hi_basis->getBaseCellTopology().getDimension());
   hi_basis->getDofCoords(hi_DofCoords);
 }
 #else
@@ -338,7 +338,7 @@ void GenerateLoNodeInHiViaGIDs(const std::vector<std::vector<size_t> > & candida
 
    size_t numElem     = hi_elemToNode.dimension(0);
    size_t lo_nperel   = candidates.size();
-   Kokkos::Experimental::resize(lo_elemToHiRepresentativeNode,numElem, lo_nperel);
+   Kokkos::resize(lo_elemToHiRepresentativeNode,numElem, lo_nperel);
 
 
    for(size_t i=0; i<numElem; i++)
@@ -384,7 +384,7 @@ void BuildLoElemToNodeViaRepresentatives(const LOFieldContainer & hi_elemToNode,
   size_t numElem     = hi_elemToNode.dimension(0);
   size_t hi_numNodes = hi_nodeIsOwned.size();
   size_t lo_nperel = lo_elemToHiRepresentativeNode.dimension(1);
-  Kokkos::Experimental::resize(lo_elemToNode,numElem, lo_nperel);
+  Kokkos::resize(lo_elemToNode,numElem, lo_nperel);
 
   // Start by flagginc the representative nodes
   std::vector<bool> is_low_order(hi_numNodes,false);
@@ -461,7 +461,7 @@ void BuildLoElemToNode(const LOFieldContainer & hi_elemToNode,
   size_t hi_numNodes = hi_nodeIsOwned.size();
 
   size_t lo_nperel = lo_node_in_hi.size();
-  Kokkos::Experimental::resize(lo_elemToNode,numElem, lo_nperel);
+  Kokkos::resize(lo_elemToNode,numElem, lo_nperel);
 
   // Build lo_elemToNode (in the hi local index ordering) and flag owned ones
   std::vector<bool> is_low_order(hi_numNodes,false);
@@ -917,7 +917,7 @@ void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Generat
         double threshold = 1e-10;
         std::vector<std::vector<size_t> > candidates;
 #ifdef HAVE_MUELU_INTREPID2_REFACTOR
-        Kokkos::Experimental::resize(hi_DofCoords,hi_basis->getCardinality(),hi_basis->getBaseCellTopology().getDimension());
+        Kokkos::resize(hi_DofCoords,hi_basis->getCardinality(),hi_basis->getBaseCellTopology().getDimension());
         hi_basis->getDofCoords(hi_DofCoords);
 #else
         // NTS: This might not work

--- a/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
+++ b/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
@@ -1989,7 +1989,7 @@ bool test_representative_basis(Teuchos::FancyOStream &out, const std::string & n
       FC hi_DofCoords, lo_DofCoords;
 #ifdef HAVE_MUELU_INTREPID2_REFACTOR
       RCP<Basis> hi = rcp(new Basis(highPolyDegree,ptype));
-      Kokkos::Experimental::resize(hi_DofCoords,hi->getCardinality(),hi->getBaseCellTopology().getDimension());
+      Kokkos::resize(hi_DofCoords,hi->getCardinality(),hi->getBaseCellTopology().getDimension());
       hi->getDofCoords(hi_DofCoords);
 #else
       RCP<Basis> hi = rcp(new Basis(highPolyDegree,ptype));
@@ -2037,7 +2037,7 @@ bool test_representative_basis(Teuchos::FancyOStream &out, const std::string & n
         out << "Testing with high order " << highPolyDegree << ", low order " << lowPolyDegree << endl;
 #ifdef HAVE_MUELU_INTREPID2_REFACTOR
         RCP<Basis> lo = rcp(new Basis(lowPolyDegree,ptype));
-        Kokkos::Experimental::resize(lo_DofCoords,lo->getCardinality(),lo->getBaseCellTopology().getDimension());
+        Kokkos::resize(lo_DofCoords,lo->getCardinality(),lo->getBaseCellTopology().getDimension());
         lo->getDofCoords(lo_DofCoords);
 #else
         RCP<Basis> lo = rcp(new Basis(lowPolyDegree,ptype));
@@ -2181,8 +2181,8 @@ bool test_representative_basis(Teuchos::FancyOStream &out, const std::string & n
             // get the mapped dof coords for lo and high bases:
             FC lo_physDofCoords, hi_physDofCoords;
 #ifdef HAVE_MUELU_INTREPID2_REFACTOR
-            Kokkos::Experimental::resize(lo_physDofCoords, numCells, lo->getCardinality(), cellTopo.getDimension());
-            Kokkos::Experimental::resize(hi_physDofCoords, numCells, hi->getCardinality(), cellTopo.getDimension());
+            Kokkos::resize(lo_physDofCoords, numCells, lo->getCardinality(), cellTopo.getDimension());
+            Kokkos::resize(hi_physDofCoords, numCells, hi->getCardinality(), cellTopo.getDimension());
 #else
             lo_physDofCoords.resize(numCells,lo->getCardinality(),cellTopo.getDimension());
             hi_physDofCoords.resize(numCells,hi->getCardinality(),cellTopo.getDimension());

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers_HO.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers_HO.hpp
@@ -216,7 +216,7 @@ namespace MueLuTests {
       // Fill elem_to_node using Kirby-style ordering
       // Ownership rule: I own the element if I own the left node in said element
 #     ifdef HAVE_MUELU_INTREPID2_REFACTOR
-      Kokkos::Experimental::resize(elem_to_node,local_num_elements,degree+1);
+      Kokkos::resize(elem_to_node,local_num_elements,degree+1);
 #     else
       elem_to_node.resize(local_num_elements,degree+1);
 #     endif

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -71,14 +71,13 @@ dimension_scalar_aligned(const view_type& view) {
 #if defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)
 
 #include "Sacado_Traits.hpp"
-#include "impl/KokkosExp_ViewMapping.hpp"
+#include "impl/Kokkos_ViewMapping.hpp"
 #include "Kokkos_LayoutContiguous.hpp"
 #include "Kokkos_LayoutNatural.hpp"
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 struct ViewSpecializeSacadoFad {};
@@ -98,7 +97,6 @@ struct is_ViewSpecializeSacadoFad< Kokkos::View<D,P...> , Args... > {
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 namespace Kokkos {
@@ -108,9 +106,9 @@ struct is_view_fad< View<T,P...> > {
   typedef View<T,P...> view_type;
   static const bool value =
     std::is_same< typename view_type::specialize,
-                  Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+                  Impl::ViewSpecializeSacadoFad >::value ||
     std::is_same< typename view_type::specialize,
-                  Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value;
+                  Impl::ViewSpecializeSacadoFadContiguous >::value;
 };
 
 template <typename T, typename ... P>
@@ -118,7 +116,7 @@ struct is_view_fad_contiguous< View<T,P...> > {
   typedef View<T,P...> view_type;
   static const bool value =
     std::is_same< typename view_type::specialize,
-                  Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value;
+                  Impl::ViewSpecializeSacadoFadContiguous >::value;
 };
 
 template <typename T, typename ... P>
@@ -163,9 +161,9 @@ void deep_copy(
   const typename Sacado::ScalarType< typename View<DT,DP...>::value_type >::type & value
   , typename std::enable_if<(
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+              , Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value
+              , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
   )>::type * = 0 )
 {
   static_assert(
@@ -183,9 +181,9 @@ void deep_copy(
   const typename View<DT,DP...>::value_type & value
   , typename std::enable_if<(
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+              , Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value
+              , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
   )>::type * = 0 )
 {
   static_assert(
@@ -203,16 +201,16 @@ void deep_copy( const View<DT,DP...> & dst ,
                 const View<ST,SP...> & src
   , typename std::enable_if<(
   ( std::is_same< typename ViewTraits<DT,DP...>::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value
+                , Kokkos::Impl::ViewSpecializeSacadoFad >::value
     ||
     std::is_same< typename ViewTraits<DT,DP...>::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value )
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value )
   &&
   ( std::is_same< typename ViewTraits<ST,SP...>::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value
+                , Kokkos::Impl::ViewSpecializeSacadoFad >::value
     ||
     std::is_same< typename ViewTraits<ST,SP...>::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value )
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value )
   )>::type * = 0 )
 {
   static_assert(
@@ -237,7 +235,6 @@ void deep_copy( const View<DT,DP...> & dst ,
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 template< class DataType , class ArrayLayout , class ScalarType , unsigned DimFad >
@@ -401,7 +398,6 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
@@ -424,7 +420,6 @@ namespace ELRCacheFad { template< typename , int > class SLFad ; }
 }
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 #define KOKKOS_VIEW_DATA_ANALYSIS_SACADO_FAD( NS ) \
@@ -461,13 +456,11 @@ KOKKOS_VIEW_DATA_ANALYSIS_SACADO_FAD( ELRCacheFad )
 #undef KOKKOS_VIEW_DATA_ANALYSIS_SACADO_FAD
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 template< class Traits >
@@ -821,13 +814,11 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 /**\brief  Assign compatible Sacado FAD view mappings.
@@ -935,13 +926,11 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 // Subview mapping
@@ -1074,7 +1063,6 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -173,7 +173,7 @@ void deep_copy(
                   typename ViewTraits<DT,DP...>::non_const_value_type >::value
     , "Can only deep copy into non-const type" );
 
-  Kokkos::Experimental::Impl::ViewFill< View<DT,DP...> >( view , value );
+  Kokkos::Impl::ViewFill< View<DT,DP...> >( view , value );
 }
 
 // Overload of deep_copy for Fad views intializing to a constant Fad
@@ -193,7 +193,7 @@ void deep_copy(
                   typename ViewTraits<DT,DP...>::non_const_value_type >::value
     , "Can only deep copy into non-const type" );
 
-  Kokkos::Experimental::Impl::ViewFill< View<DT,DP...> >( view , value );
+  Kokkos::Impl::ViewFill< View<DT,DP...> >( view , value );
 }
 
 /* Specialize for deep copy of FAD */
@@ -490,7 +490,7 @@ class ViewMapping< Traits , /* View internal mapping */
 private:
 
   template< class , class ... > friend class ViewMapping ;
-  template< class , class ... > friend class Kokkos::Experimental::View ;
+  template< class , class ... > friend class Kokkos::View ;
 
   typedef typename Traits::value_type  fad_type ;
   typedef typename Sacado::ValueType< fad_type >::type fad_value_type ;
@@ -858,7 +858,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 
@@ -1031,13 +1031,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -47,9 +47,9 @@ struct ThreadLocalScalarType {
 template <typename ViewType>
 struct ViewScalarStride {
   static const unsigned stride =
-    Experimental::Impl::LayoutScalarStride< typename ViewType::array_layout>::stride;
+    Impl::LayoutScalarStride< typename ViewType::array_layout>::stride;
   static const bool is_unit_stride =
-    Experimental::Impl::LayoutScalarStride< typename ViewType::array_layout>::is_unit_stride;
+    Impl::LayoutScalarStride< typename ViewType::array_layout>::is_unit_stride;
 };
 
 } // namespace Kokkos
@@ -134,7 +134,7 @@ namespace Sacado {
 
 #include "Sacado_Traits.hpp"
 #include "Kokkos_Core.hpp"
-#include "impl/KokkosExp_ViewMapping.hpp"
+#include "impl/Kokkos_ViewMapping.hpp"
 
 //----------------------------------------------------------------------------
 
@@ -210,7 +210,7 @@ struct ThreadLocalScalarType<
   ViewType,
   typename std::enable_if< is_view_fad_contiguous<ViewType>::value >::type > {
   typedef typename ViewType::traits TraitsType;
-  typedef Experimental::Impl::ViewMapping<TraitsType, void> MappingType;
+  typedef Impl::ViewMapping<TraitsType, void> MappingType;
   typedef typename MappingType::thread_local_scalar_type type;
 };
 
@@ -289,7 +289,6 @@ struct ViewFill<
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 template< class ... Args >
@@ -306,13 +305,11 @@ struct is_ViewSpecializeSacadoFadContiguous< Kokkos::View<D,P...> , Args... > {
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 // Compute a partitioned fad size given a stride.  Return 0 if the stride
@@ -996,13 +993,11 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 /**\brief  Assign compatible Sacado FAD view mappings.
@@ -1181,13 +1176,11 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 // Subview mapping
@@ -1337,13 +1330,11 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 //---------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 // Partition mapping
@@ -1398,7 +1389,6 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
 #endif // defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -194,13 +194,13 @@ namespace Kokkos {
 
 template< unsigned Stride, typename D, typename ... P  >
 KOKKOS_INLINE_FUNCTION
-typename Kokkos::Experimental::Impl::ViewMapping< void, typename Kokkos::Experimental::ViewTraits<D,P...>, Sacado::Fad::Partition<Stride> >::type
-partition( const Kokkos::Experimental::View<D,P...> & src ,
+typename Kokkos::Impl::ViewMapping< void, typename Kokkos::ViewTraits<D,P...>, Sacado::Fad::Partition<Stride> >::type
+partition( const Kokkos::View<D,P...> & src ,
            const unsigned offset ,
            const unsigned stride )
 {
-  typedef Kokkos::Experimental::ViewTraits<D,P...> traits;
-  typedef typename Kokkos::Experimental::Impl::ViewMapping< void, traits, Sacado::Fad::Partition<Stride> >::type DstViewType;
+  typedef Kokkos::ViewTraits<D,P...> traits;
+  typedef typename Kokkos::Impl::ViewMapping< void, traits, Sacado::Fad::Partition<Stride> >::type DstViewType;
   const Sacado::Fad::Partition<Stride> part( offset , stride );
   return DstViewType(src, part);
 }
@@ -404,7 +404,7 @@ class ViewMapping< Traits , /* View internal mapping */
 private:
 
   template< class , class ... > friend class ViewMapping ;
-  template< class , class ... > friend class Kokkos::Experimental::View ;
+  template< class , class ... > friend class Kokkos::View ;
 
   typedef typename Traits::value_type  fad_type ;
   typedef typename Sacado::ValueType< fad_type >::type fad_value_type ;
@@ -1028,7 +1028,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 
@@ -1119,7 +1119,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 
@@ -1270,13 +1270,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -415,13 +415,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type
@@ -433,13 +433,13 @@ public:
 
     static_assert( Kokkos::Impl::is_memory_traits< MemoryTraits >::value , "" );
 
-    typedef Kokkos::Experimental::ViewTraits
+    typedef Kokkos::ViewTraits
       < data_type
       , array_layout
       , typename SrcTraits::device_type
       , MemoryTraits > traits_type ;
 
-    typedef Kokkos::Experimental::View
+    typedef Kokkos::View
       < data_type
       , array_layout
       , typename SrcTraits::device_type
@@ -693,7 +693,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 
@@ -984,7 +984,7 @@ void deep_copy
 
 } //end Experimental
 
-using Kokkos::Experimental::deep_copy;
+using Kokkos::deep_copy;
 
 }
 

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -48,7 +48,7 @@ namespace Experimental {
 namespace Impl {
 
 template <>
-struct DynRankDimTraits<ViewSpecializeSacadoFad> {
+struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFad> {
 
   enum : size_t{unspecified = ~size_t(0)};
 
@@ -171,6 +171,11 @@ struct DynRankDimTraits<ViewSpecializeSacadoFad> {
   }
 
 };
+
+}}} // namespace Kokkos::Experimental::Impl
+
+namespace Kokkos {
+namespace Impl {
 
 template <unsigned> struct AssignDim7 {
   template <typename Dst>
@@ -377,7 +382,7 @@ template< class SrcTraits , class ... Args >
 struct ViewMapping
   < typename std::enable_if<(
       std::is_same< typename SrcTraits::specialize ,
-                    ViewSpecializeSacadoFad >::value
+                    Kokkos::Impl::ViewSpecializeSacadoFad >::value
       &&
       (
         std::is_same< typename SrcTraits::array_layout
@@ -387,7 +392,7 @@ struct ViewMapping
         std::is_same< typename SrcTraits::array_layout
                     , Kokkos::LayoutStride >::value
       ) 
-    ), DynRankSubviewTag >::type
+    ), Kokkos::Experimental::Impl::DynRankSubviewTag >::type
   , SrcTraits
   , Args ... >
 {
@@ -687,7 +692,7 @@ class ViewMapping< DstTraits , SrcTraits ,
     // Source view has FAD only
     std::is_same< typename SrcTraits::specialize
                 , ViewSpecializeSacadoFad >::value
-  ), ViewToDynRankViewTag >::type >
+  ), Kokkos::Experimental::Impl::ViewToDynRankViewTag >::type >
 {
 public:
 
@@ -760,9 +765,9 @@ public:
     }
 };
 
-} //end Impl
+}} //end Kokkos::Impl
 
-} //end Experimental
+namespace Kokkos {
 
 template <typename view_type>
 struct is_dynrankview_fad { static const bool value = false; };
@@ -775,9 +780,9 @@ struct is_dynrankview_fad< DynRankView<T,P...> > {
   typedef DynRankView<T,P...> view_type;
   static const bool value =
     std::is_same< typename view_type::specialize,
-                  Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+                  Impl::ViewSpecializeSacadoFad >::value ||
     std::is_same< typename view_type::specialize,
-                  Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value;
+                  Impl::ViewSpecializeSacadoFadContiguous >::value;
 };
 
 template <typename T, typename ... P>
@@ -785,7 +790,7 @@ struct is_dynrankview_fad_contiguous< DynRankView<T,P...> > {
   typedef DynRankView<T,P...> view_type;
   static const bool value =
     std::is_same< typename view_type::specialize,
-                  Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value;
+                  Impl::ViewSpecializeSacadoFadContiguous >::value;
 };
 
 template <typename T, typename ... P>
@@ -805,9 +810,9 @@ void deep_copy(
   const typename Sacado::ScalarType< typename DynRankView<DT,DP...>::value_type >::type & value
   , typename std::enable_if<(
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+              , Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value
+              , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
   )>::type * = 0 )
 {
   static_assert(
@@ -825,9 +830,9 @@ void deep_copy(
   const typename DynRankView<DT,DP...>::value_type & value
   , typename std::enable_if<(
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+              , Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
   std::is_same< typename ViewTraits<DT,DP...>::specialize
-              , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value
+              , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
   )>::type * = 0 )
 {
   static_assert(
@@ -845,14 +850,14 @@ void deep_copy
   , const SrcType & src
   , typename std::enable_if<(
   ( std::is_same< typename DstType::traits::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+                , Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
     std::is_same< typename DstType::traits::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value )
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value )
   &&
   ( std::is_same< typename SrcType::traits::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFad >::value ||
+                , Kokkos::Impl::ViewSpecializeSacadoFad >::value ||
     std::is_same< typename SrcType::traits::specialize
-                , Kokkos::Experimental::Impl::ViewSpecializeSacadoFadContiguous >::value )
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value )
   &&
   ( Kokkos::Experimental::is_dyn_rank_view<DstType>::value || Kokkos::Experimental::is_dyn_rank_view<SrcType
 >::value )
@@ -986,7 +991,7 @@ void deep_copy
 
 using Kokkos::deep_copy;
 
-}
+} // end Kokkos
 
 #endif //defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)
 

--- a/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
@@ -214,13 +214,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type
@@ -232,13 +232,13 @@ public:
 
     static_assert( Kokkos::Impl::is_memory_traits< MemoryTraits >::value , "" );
 
-    typedef Kokkos::Experimental::ViewTraits
+    typedef Kokkos::ViewTraits
       < data_type
       , array_layout
       , typename SrcTraits::device_type
       , MemoryTraits > traits_type ;
 
-    typedef Kokkos::Experimental::View
+    typedef Kokkos::View
       < data_type
       , array_layout
       , typename SrcTraits::device_type
@@ -406,13 +406,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type
@@ -424,13 +424,13 @@ public:
 
     static_assert( Kokkos::Impl::is_memory_traits< MemoryTraits >::value , "" );
 
-    typedef Kokkos::Experimental::ViewTraits
+    typedef Kokkos::ViewTraits
       < data_type
       , array_layout
       , typename SrcTraits::device_type
       , MemoryTraits > traits_type ;
 
-    typedef Kokkos::Experimental::View
+    typedef Kokkos::View
       < data_type
       , array_layout
       , typename SrcTraits::device_type
@@ -598,7 +598,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 
@@ -680,7 +680,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 

--- a/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
@@ -48,7 +48,7 @@ namespace Experimental {
 namespace Impl {
 
 template <>
-struct DynRankDimTraits<ViewSpecializeSacadoFadContiguous> {
+struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFadContiguous> {
 
   enum : size_t{unspecified = ~size_t(0)};
 
@@ -172,13 +172,18 @@ struct DynRankDimTraits<ViewSpecializeSacadoFadContiguous> {
 
 };
 
+}}} // end Kokkos::Experimental::Impl
+
+namespace Kokkos {
+namespace Impl {
+
 // Specializations for subdynrankview
 
 template< class SrcTraits , class ... Args >
 struct ViewMapping
   < typename std::enable_if<(
       std::is_same< typename SrcTraits::specialize ,
-                    ViewSpecializeSacadoFadContiguous >::value
+                    Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
       &&
       (
         std::is_same< typename SrcTraits::array_layout
@@ -186,7 +191,7 @@ struct ViewMapping
         std::is_same< typename SrcTraits::array_layout
                     , Kokkos::LayoutStride >::value
       )
-    ), DynRankSubviewTag >::type
+    ), Kokkos::Experimental::Impl::DynRankSubviewTag >::type
   , SrcTraits
   , Args ... >
 {
@@ -374,11 +379,11 @@ template< class SrcTraits , class ... Args >
 struct ViewMapping
   < typename std::enable_if<(
       std::is_same< typename SrcTraits::specialize ,
-                    ViewSpecializeSacadoFadContiguous >::value
+                    Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
       &&
       std::is_same< typename SrcTraits::array_layout
                    , Kokkos::LayoutLeft >::value
-    ), DynRankSubviewTag >::type
+    ), Kokkos::Experimental::Impl::DynRankSubviewTag >::type
   , SrcTraits
   , Args ... >
 {
@@ -587,12 +592,12 @@ class ViewMapping< DstTraits , SrcTraits ,
     &&
     // Destination view has FAD only
     std::is_same< typename DstTraits::specialize
-                , ViewSpecializeSacadoFadContiguous >::value
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
     &&
     // Source view has FAD only
     std::is_same< typename SrcTraits::specialize
-                , ViewSpecializeSacadoFadContiguous >::value
-  ), ViewToDynRankViewTag >::type >
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
+  ), Kokkos::Experimental::Impl::ViewToDynRankViewTag >::type >
 {
 public:
 
@@ -673,8 +678,8 @@ class ViewMapping< DstTraits , SrcTraits ,
     &&
     // Source view has FAD only
     std::is_same< typename SrcTraits::specialize
-                , ViewSpecializeSacadoFadContiguous >::value
-  ), ViewToDynRankViewTag >::type >
+                , Kokkos::Impl::ViewSpecializeSacadoFadContiguous >::value
+  ), Kokkos::Experimental::Impl::ViewToDynRankViewTag >::type >
 {
 public:
 
@@ -724,11 +729,7 @@ public:
     }
 };
 
-} //end Impl
-
-} //end Experimental
-
-}
+}} //end Kokkos::Impl
 
 #endif //defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)
 

--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -27,8 +27,8 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef KOKKOS_EXPERIMENTAL_LAYOUT_CONTIGUOUS_HPP
-#define KOKKOS_EXPERIMENTAL_LAYOUT_CONTIGUOUS_HPP
+#ifndef KOKKOS_LAYOUT_CONTIGUOUS_HPP
+#define KOKKOS_LAYOUT_CONTIGUOUS_HPP
 
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Macros.hpp"
@@ -80,10 +80,9 @@ namespace std {
 
 }
 
-#include "impl/KokkosExp_ViewMapping.hpp"
+#include "impl/Kokkos_ViewMapping.hpp"
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 // Implement ViewOffset for LayoutContiguous
@@ -125,7 +124,6 @@ struct LayoutScalarStride< LayoutContiguous<Layout,Stride> > {
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
-#endif // #ifndef KOKKOS_EXPERIMENTAL_LAYOUT_CONTIGUOUS_HPP
+#endif // #ifndef KOKKOS_LAYOUT_CONTIGUOUS_HPP

--- a/packages/sacado/src/Kokkos_LayoutNatural.hpp
+++ b/packages/sacado/src/Kokkos_LayoutNatural.hpp
@@ -27,8 +27,8 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef KOKKOS_EXPERIMENTAL_LAYOUT_NATURAL_HPP
-#define KOKKOS_EXPERIMENTAL_LAYOUT_NATURAL_HPP
+#ifndef KOKKOS_LAYOUT_NATURAL_HPP
+#define KOKKOS_LAYOUT_NATURAL_HPP
 
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Macros.hpp"
@@ -73,10 +73,9 @@ namespace std {
 
 }
 
-#include "impl/KokkosExp_ViewMapping.hpp"
+#include "impl/Kokkos_ViewMapping.hpp"
 
 namespace Kokkos {
-namespace Experimental {
 namespace Impl {
 
 // Implement ViewOffset for LayoutNatural
@@ -106,7 +105,6 @@ public:
 };
 
 } // namespace Impl
-} // namespace Experimental
 } // namespace Kokkos
 
-#endif // #ifndef KOKKOS_EXPERIMENTAL_LAYOUT_NATURAL_HPP
+#endif // #ifndef KOKKOS_LAYOUT_NATURAL_HPP

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda.cpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests_Cuda.cpp
@@ -50,7 +50,7 @@ TEUCHOS_UNIT_TEST(Kokkos_View_Fad, SFadCudaAligned)
   typedef Kokkos::View<FadType*,Layout,Device> ViewType;
 
   typedef typename ViewType::traits TraitsType;
-  typedef Kokkos::Experimental::Impl::ViewMapping< TraitsType , void > MappingType;
+  typedef Kokkos::Impl::ViewMapping< TraitsType , void > MappingType;
   const int view_static_dim = MappingType::FadStaticDimension;
   TEUCHOS_TEST_EQUALITY(view_static_dim, StaticDim, out, success);
 
@@ -79,7 +79,7 @@ TEUCHOS_UNIT_TEST(Kokkos_View_Fad, SFadCudaNotAligned)
   typedef Kokkos::View<FadType*,Layout,Device> ViewType;
 
   typedef typename ViewType::traits TraitsType;
-  typedef Kokkos::Experimental::Impl::ViewMapping< TraitsType , void > MappingType;
+  typedef Kokkos::Impl::ViewMapping< TraitsType , void > MappingType;
   const int view_static_dim = MappingType::FadStaticDimension;
   TEUCHOS_TEST_EQUALITY(view_static_dim, StaticDim, out, success);
 

--- a/packages/sacado/test/UnitTests/ViewFactoryTests.cpp
+++ b/packages/sacado/test/UnitTests/ViewFactoryTests.cpp
@@ -43,8 +43,8 @@ TEUCHOS_UNIT_TEST(view_factory, dyn_rank_views)
   using Kokkos::createDynRankViewWithType;
   using Kokkos::createViewWithType;
   using Kokkos::dimension_scalar;
-  using Kokkos::Experimental::view_alloc;
-  using Kokkos::Experimental::WithoutInitializing;
+  using Kokkos::view_alloc;
+  using Kokkos::WithoutInitializing;
   const unsigned derivative_dim_plus_one = 7;
 
   // Test a DynRankView from a DynRankView

--- a/packages/shylu/tacho/core/src/TachoExp_CrsMatrixBase.hpp
+++ b/packages/shylu/tacho/core/src/TachoExp_CrsMatrixBase.hpp
@@ -49,17 +49,17 @@ namespace Tacho {
         if (static_cast<ordinal_type>(_ap.dimension_0()) < (m+1)) 
           _ap = size_type_array("CrsMatrixBase::RowPtrArray", m+1);
         else 
-          Kokkos::Experimental::Impl::ViewFill<size_type_array>(_ap, size_type());
+          Kokkos::Impl::ViewFill<size_type_array>(_ap, size_type());
 
         if (static_cast<size_type>(_aj.dimension_0()) < nnz) 
           _aj = ordinal_type_array("CrsMatrixBase::ColsArray", nnz);
         else 
-          Kokkos::Experimental::Impl::ViewFill<ordinal_type_array>(_aj, ordinal_type());
+          Kokkos::Impl::ViewFill<ordinal_type_array>(_aj, ordinal_type());
 
         if (static_cast<size_type>(_ax.dimension_0()) < nnz) 
           _ax = value_type_array("CrsMatrixBase::ValuesArray", nnz);
         else 
-          Kokkos::Experimental::Impl::ViewFill<value_type_array>(_ax, value_type());
+          Kokkos::Impl::ViewFill<value_type_array>(_ax, value_type());
       }
     
     public:

--- a/packages/shylu/tacho/core/src/Tacho_CrsMatrixBase.hpp
+++ b/packages/shylu/tacho/core/src/Tacho_CrsMatrixBase.hpp
@@ -71,28 +71,28 @@ namespace Tacho {
         _ap_begin = size_type_array("CrsMatrixBase::RowPtrBeginArray", m);
       } else {
         // otherwise initialize it
-        Kokkos::Experimental::Impl::ViewFill<size_type_array>(_ap_begin, size_type());
+        Kokkos::Impl::ViewFill<size_type_array>(_ap_begin, size_type());
       }
 
       if (static_cast<ordinal_type>(_ap_end.dimension_0()) < m) {
         _ap_end = size_type_array("CrsMatrixBase::RowPtrEndArray", m);
       } else {
         // otherwise initialize it
-        Kokkos::Experimental::Impl::ViewFill<size_type_array>(_ap_end, size_type());
+        Kokkos::Impl::ViewFill<size_type_array>(_ap_end, size_type());
       }
 
       if (static_cast<size_type>(_aj.dimension_0()) < nnz) {
         _aj = ordinal_type_array("CrsMatrixBase::ColsArray", nnz);
       } else {
         // otherwise initialize it
-        Kokkos::Experimental::Impl::ViewFill<ordinal_type_array>(_aj, ordinal_type());
+        Kokkos::Impl::ViewFill<ordinal_type_array>(_aj, ordinal_type());
       }
 
       if (static_cast<size_type>(_ax.dimension_0()) < nnz) {
         _ax = value_type_array("CrsMatrixBase::ValuesArray", nnz);
       } else {
         // otherwise initialize it
-        Kokkos::Experimental::Impl::ViewFill<value_type_array>(_ax, value_type());
+        Kokkos::Impl::ViewFill<value_type_array>(_ax, value_type());
       }
     }
     

--- a/packages/shylu/tacho/core/src/Tacho_DenseMatrixBase.hpp
+++ b/packages/shylu/tacho/core/src/Tacho_DenseMatrixBase.hpp
@@ -85,7 +85,7 @@ namespace Tacho {
         _a = value_type_array("DenseMatrixBase::ValueArray", size);
       } else {
         // otherwise initialize it
-        Kokkos::Experimental::Impl::ViewFill<value_type_array>(_a, value_type());
+        Kokkos::Impl::ViewFill<value_type_array>(_a, value_type());
       }
     }
 

--- a/packages/shylu/tacho/refactor/src/TachoExp_CrsMatrixBase.hpp
+++ b/packages/shylu/tacho/refactor/src/TachoExp_CrsMatrixBase.hpp
@@ -49,17 +49,17 @@ namespace Tacho {
         if (static_cast<ordinal_type>(_ap.dimension_0()) < (m+1)) 
           _ap = size_type_array("CrsMatrixBase::RowPtrArray", m+1);
         else 
-          Kokkos::Experimental::Impl::ViewFill<size_type_array>(_ap, size_type());
+          Kokkos::Impl::ViewFill<size_type_array>(_ap, size_type());
 
         if (static_cast<size_type>(_aj.dimension_0()) < nnz) 
           _aj = ordinal_type_array("CrsMatrixBase::ColsArray", nnz);
         else 
-          Kokkos::Experimental::Impl::ViewFill<ordinal_type_array>(_aj, ordinal_type());
+          Kokkos::Impl::ViewFill<ordinal_type_array>(_aj, ordinal_type());
 
         if (static_cast<size_type>(_ax.dimension_0()) < nnz) 
           _ax = value_type_array("CrsMatrixBase::ValuesArray", nnz);
         else 
-          Kokkos::Experimental::Impl::ViewFill<value_type_array>(_ax, value_type());
+          Kokkos::Impl::ViewFill<value_type_array>(_ax, value_type());
       }
     
     public:

--- a/packages/stk/stk_simd/stk_simd_view/simd_layout.hpp
+++ b/packages/stk/stk_simd/stk_simd_view/simd_layout.hpp
@@ -261,7 +261,7 @@ struct ViewOffset< Dimension , stk::simd::LayoutRight<RealType> , void>
       static_assert( DimRHS::rank == 1 && dimension_type::rank == 1 && dimension_type::rank_dynamic == 1
                    , "ViewOffset LayoutRight and LayoutStride are only compatible when rank == 1" );
       if ( rhs.m_stride.S0 != 1 ) {
-        Kokkos::abort("Kokkos::Experimental::ViewOffset assignment of LayoutRight from LayoutStride  requires stride == 1" );
+        Kokkos::abort("Kokkos::ViewOffset assignment of LayoutRight from LayoutStride  requires stride == 1" );
       }
     }
 
@@ -414,7 +414,7 @@ struct ViewOffset< Dimension , stk::simd::LayoutLeft<RealType> , void>
       static_assert( DimRHS::rank == 1 && dimension_type::rank == 1 && dimension_type::rank_dynamic == 1
                    , "ViewOffset LayoutLeft and LayoutStride are only compatible when rank == 1" );
       if ( rhs.m_stride.S0 != 1 ) {
-        Kokkos::abort("Kokkos::Experimental::ViewOffset assignment of LayoutLeft from LayoutStride  requires stride == 1" );
+        Kokkos::abort("Kokkos::ViewOffset assignment of LayoutLeft from LayoutStride  requires stride == 1" );
       }
     }
   

--- a/packages/stk/stk_simd/stk_simd_view/simd_view.hpp
+++ b/packages/stk/stk_simd/stk_simd_view/simd_view.hpp
@@ -150,8 +150,8 @@ class View
   typedef typename ViewTraits<DataType,Prop...>::ExecutionSpace execution_space;
   typedef typename ViewTraits<DataType,Prop...>::MemoryTraits memory_traits;
 
-  typedef typename Kokkos::Experimental::View< DataType, array_layout, execution_space, memory_traits >::traits traits;
-  typedef typename Kokkos::Experimental::View< DataType, array_layout, execution_space, memory_traits >::reference_type reference_type;
+  typedef typename Kokkos::View< DataType, array_layout, execution_space, memory_traits >::traits traits;
+  typedef typename Kokkos::View< DataType, array_layout, execution_space, memory_traits >::reference_type reference_type;
 
   typedef typename stk::SimdT<reference_type>::type simd_reference_type;
 

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -99,9 +99,9 @@ void deep_copy(
   typedef typename view_type::array_type::value_type scalar_type;
   typedef typename FlatArrayType<view_type>::type flat_array_type;
   if (value == scalar_type(0))
-    Kokkos::Experimental::Impl::ViewFill< flat_array_type >( view , value );
+    Kokkos::Impl::ViewFill< flat_array_type >( view , value );
   else
-    Kokkos::Experimental::Impl::ViewFill< view_type>( view , value );
+    Kokkos::Impl::ViewFill< view_type>( view , value );
 }
 
 // Overload of deep_copy for UQ::PCE views intializing to a constant UQ::PCE
@@ -119,7 +119,7 @@ void deep_copy(
                   typename ViewTraits<DT,DP...>::non_const_value_type >::value
     , "Can only deep copy into non-const type" );
 
-  Kokkos::Experimental::Impl::ViewFill< View<DT,DP...> >( view , value );
+  Kokkos::Impl::ViewFill< View<DT,DP...> >( view , value );
 }
 
 namespace Experimental {
@@ -747,7 +747,7 @@ class ViewMapping< Traits , /* View internal mapping */
 private:
 
   template< class , class ... > friend class ViewMapping ;
-  template< class , class ... > friend class Kokkos::Experimental::View ;
+  template< class , class ... > friend class Kokkos::View ;
 
 public:
   typedef typename Traits::value_type  sacado_uq_pce_type ;
@@ -1130,7 +1130,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcType ;
 
@@ -1214,7 +1214,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcType ;
 
@@ -1322,7 +1322,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcType ;
 
@@ -1418,24 +1418,24 @@ template< class DataType, class ... P , class Arg0, class ... Args >
 struct ViewMapping
   < typename std::enable_if<(
       // Source view has UQ::PCE only
-      std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::specialize
+      std::is_same< typename Kokkos::ViewTraits<DataType,P...>::specialize
                   , ViewPCEContiguous >::value
       &&
       (
-        std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::array_layout
+        std::is_same< typename Kokkos::ViewTraits<DataType,P...>::array_layout
                     , Kokkos::LayoutLeft >::value ||
-        std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::array_layout
+        std::is_same< typename Kokkos::ViewTraits<DataType,P...>::array_layout
                     , Kokkos::LayoutRight >::value ||
-        std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::array_layout
+        std::is_same< typename Kokkos::ViewTraits<DataType,P...>::array_layout
                     , Kokkos::LayoutStride >::value
       )
     )>::type
-  , Kokkos::Experimental::ViewTraits<DataType,P...>
+  , Kokkos::ViewTraits<DataType,P...>
   , Arg0, Args ... >
 {
 private:
 
-  typedef Kokkos::Experimental::ViewTraits<DataType,P...> SrcTraits;
+  typedef Kokkos::ViewTraits<DataType,P...> SrcTraits;
 
   //static_assert( SrcTraits::rank == sizeof...(Args) , "" );
 
@@ -1493,13 +1493,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -121,7 +121,7 @@ void deep_copy(
     , "Can only deep copy into non-const type" );
 
   typedef typename FlatArrayType< View<DT,DP...> >::type flat_array_type;
-  Kokkos::Experimental::Impl::ViewFill< flat_array_type >( view , value );
+  Kokkos::Impl::ViewFill< flat_array_type >( view , value );
 }
 
 // Overload of deep_copy for MP::Vector views intializing to a constant MP::Vector
@@ -146,7 +146,7 @@ void deep_copy(
   //               , Kokkos::HostSpace >::value
   //   , "Deep copy from a FAD type must be statically sized or host space" );
 
-  Kokkos::Experimental::Impl::ViewFill< View<DT,DP...> >( view , value );
+  Kokkos::Impl::ViewFill< View<DT,DP...> >( view , value );
 }
 
 /* Specialize for deep copy of MP::Vector */
@@ -529,7 +529,7 @@ class ViewMapping< Traits , /* View internal mapping */
 private:
 
   template< class , class ... > friend class ViewMapping ;
-  template< class , class ... > friend class Kokkos::Experimental::View ;
+  template< class , class ... > friend class Kokkos::View ;
 
   typedef typename Traits::value_type  sacado_mp_vector_type ;
   typedef typename sacado_mp_vector_type::storage_type stokhos_storage_type ;
@@ -906,7 +906,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcType ;
 
@@ -989,7 +989,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcType ;
 
@@ -1098,7 +1098,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcType ;
 
@@ -1195,25 +1195,25 @@ template< class DataType, class ... P , class Arg0, class ... Args >
 struct ViewMapping
   < typename std::enable_if<(
       // Source view has MP::Vector only
-      std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::specialize
+      std::is_same< typename Kokkos::ViewTraits<DataType,P...>::specialize
                   , ViewMPVectorContiguous >::value
       &&
       (
-        std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::array_layout
+        std::is_same< typename Kokkos::ViewTraits<DataType,P...>::array_layout
                     , Kokkos::LayoutLeft >::value ||
-        std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::array_layout
+        std::is_same< typename Kokkos::ViewTraits<DataType,P...>::array_layout
                     , Kokkos::LayoutRight >::value ||
-        std::is_same< typename Kokkos::Experimental::ViewTraits<DataType,P...>::array_layout
+        std::is_same< typename Kokkos::ViewTraits<DataType,P...>::array_layout
                     , Kokkos::LayoutStride >::value
       )
       && !Sacado::MP::is_vector_partition<Arg0>::value
     )>::type
-  , Kokkos::Experimental::ViewTraits<DataType,P...>
+  , Kokkos::ViewTraits<DataType,P...>
   , Arg0, Args ... >
 {
 private:
 
-  typedef Kokkos::Experimental::ViewTraits<DataType,P...> SrcTraits;
+  typedef Kokkos::ViewTraits<DataType,P...> SrcTraits;
 
   //static_assert( SrcTraits::rank == sizeof...(Args) , "" );
 
@@ -1271,13 +1271,13 @@ private:
 
 public:
 
-  typedef Kokkos::Experimental::ViewTraits
+  typedef Kokkos::ViewTraits
     < data_type
     , array_layout
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > traits_type ;
 
-  typedef Kokkos::Experimental::View
+  typedef Kokkos::View
     < data_type
     , array_layout
     , typename SrcTraits::device_type
@@ -1391,12 +1391,12 @@ public:
 
 template< unsigned Size, typename D, typename ... P  >
 KOKKOS_INLINE_FUNCTION
-typename Kokkos::Experimental::Impl::ViewMapping< void, typename Kokkos::Experimental::ViewTraits<D,P...>, Sacado::MP::VectorPartition<Size> >::type
-partition( const Kokkos::Experimental::View<D,P...> & src ,
+typename Kokkos::Impl::ViewMapping< void, typename Kokkos::ViewTraits<D,P...>, Sacado::MP::VectorPartition<Size> >::type
+partition( const Kokkos::View<D,P...> & src ,
            const unsigned beg )
 {
-  typedef Kokkos::Experimental::ViewTraits<D,P...> traits;
-  typedef typename Kokkos::Experimental::Impl::ViewMapping< void, traits, Sacado::MP::VectorPartition<Size> >::type DstViewType;
+  typedef Kokkos::ViewTraits<D,P...> traits;
+  typedef typename Kokkos::Impl::ViewMapping< void, traits, Sacado::MP::VectorPartition<Size> >::type DstViewType;
   const Sacado::MP::VectorPartition<Size> part( beg , beg+Size );
   return DstViewType(src, part);
 }
@@ -1526,7 +1526,7 @@ public:
 
   enum { is_assignable = true };
 
-  typedef Kokkos::Experimental::Impl::SharedAllocationTracker  TrackType ;
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Utils.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Utils.hpp
@@ -60,7 +60,7 @@ struct LocalMPVectorView<ViewType, LocalSize, false> {
 
 template <typename D, typename ... P, unsigned LocalSize>
 struct LocalMPVectorView< View<D,P...>, LocalSize, true > {
-  typedef typename Kokkos::Experimental::Impl::ViewMapping< void, typename Kokkos::Experimental::ViewTraits<D,P...>, Sacado::MP::VectorPartition<LocalSize> >::type type;
+  typedef typename Kokkos::Impl::ViewMapping< void, typename Kokkos::ViewTraits<D,P...>, Sacado::MP::VectorPartition<LocalSize> >::type type;
 };
 
 namespace Impl {

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -258,12 +258,7 @@ namespace { // (anonymous)
   template<class DualViewType>
   DualViewType
   takeSubview (const DualViewType& X,
-//We will move the ALL_t to the Kokkos namespace eventually, this is a workaround for testing the new View implementation
-#ifdef KOKKOS_USING_EXPERIMENTAL_VIEW
-               const Kokkos::Experimental::Impl::ALL_t&,
-#else
-               const Kokkos::ALL&,
-#endif
+               const Kokkos::Impl::ALL_t&,
                const std::pair<size_t, size_t>& colRng)
   {
     if (X.dimension_0 () == 0 && X.dimension_1 () != 0) {

--- a/packages/trilinoscouplings/examples/scaling/example_Poisson2D_pn_tpetra.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Poisson2D_pn_tpetra.cpp
@@ -365,7 +365,7 @@ void evaluateExactSolutionGrad(ArrayOut &       exactSolutionGradValues,
 template<class FC1, class FC2>
 void CopyFieldContainer2D(const FC1 & c1, FC2 & c2) {
 #ifdef HAVE_TRILINOSCOUPLINGS_INTREPID2_REFACTOR
-  Kokkos::Experimental::resize(c2,c1.dimension(0),c1.dimension(1));
+  Kokkos::resize(c2,c1.dimension(0),c1.dimension(1));
 #else
   c2.resize(c1.dimension(0),c1.dimension(1));
 #endif


### PR DESCRIPTION
Satisfies most of #1426

These symbols have matured and are no longer just Experimental (they are in both right now). They may be removed from Experimental in the near future. Therefore, the way forward is to use them outside the Experimental namespace.

@trilinos/muelu @trilinos/sacado @trilinos/shylu @trilinos/stokhos 

Also, does anyone know who should be mentioned w.r.t. TrilinosCouplings?