### PR TITLE
Ifpack2: Fix #560 (bug in Amesos2Wrapper)

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
@@ -477,7 +477,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     //is never hit.
     //bmk 6-19-17: previously, the next line only set multipleProcs if A_ was distributed
     //  This doesn't work if A_ is local but X/Y are distributed, as in AdditiveSchwarz.
-    const bool multipleProcs = (A_->getRowMap ()->getComm ()->getSize () > 1) || X.getMap ()->getComm ()->getSize () > 1;
+    const bool multipleProcs = (A_->getRowMap ()->getComm ()->getSize () > 1) || (X.getMap ()->getComm ()->getSize () > 1);
     if (multipleProcs) {
       // Interpret X and Y as "local" multivectors, that is, in the
       // local filter's domain resp. range Maps.  "Interpret" means that

--- a/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
@@ -475,7 +475,9 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     RCP<MV> Y_local;
     //JJH 15-Apr-2016 I changed this from ">=" to ">".  Otherwise the else block
     //is never hit.
-    const bool multipleProcs = (A_->getRowMap ()->getComm ()->getSize () > 1);
+    //bmk 6-19-17: previously, the next line only set multipleProcs if A_ was distributed
+    //  This doesn't work if A_ is local but X/Y are distributed, as in AdditiveSchwarz.
+    const bool multipleProcs = (A_->getRowMap ()->getComm ()->getSize () > 1) || X.getMap ()->getComm ()->getSize () > 1;
     if (multipleProcs) {
       // Interpret X and Y as "local" multivectors, that is, in the
       // local filter's domain resp. range Maps.  "Interpret" means that

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -658,13 +658,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SparseDirectSolver, SC
 
   out << "Creating AdditiveSchwarz instance" << endl;
 
-  Ifpack2::AdditiveSchwarz<row_matrix_type> prec (A,1);
+  Ifpack2::AdditiveSchwarz<row_matrix_type> prec (A);
   ParameterList params, zlist;
 
   out << "Filling in ParameterList for AdditiveSchwarz" << endl;
 
-  params.set ("schwarz: overlap level", 0);  //FIXME Note that this test will fail for overlap>0.
-                                       //See github issue #460.
+  params.set ("schwarz: overlap level", 2);
+
 #if defined(HAVE_IFPACK2_XPETRA) && defined(HAVE_IFPACK2_ZOLTAN2)
   params.set ("schwarz: use reordering", true);
 #else
@@ -756,7 +756,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SparseDirectSolver, SC
   }
 
   out << "Generating input and output (multi)vectors" << endl;
-  MV x(rowmap,2), y(rowmap,2);
+  int numCols = 2;
+  MV x(rowmap, numCols), y(rowmap, numCols);
   x.randomize();
 
   if (gblSuccess == 1) {
@@ -780,8 +781,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SparseDirectSolver, SC
   prec.initialize();
   out << "Calling AdditiveSchwarz::compute()" << endl;
   prec.compute();
+  MV z(rowmap,numCols);
   out << "Calling AdditiveSchwarz::apply()" << endl;
-  MV z(rowmap,2);
+
   prec.apply (x, z);
 
   if (gblSuccess == 1) {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -756,7 +756,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SparseDirectSolver, SC
   }
 
   out << "Generating input and output (multi)vectors" << endl;
-  int numCols = 2;
+  const int numCols = 2;
   MV x(rowmap, numCols), y(rowmap, numCols);
   x.randomize();
 


### PR DESCRIPTION
Ifpack2's Amesos2Wrapper (_def, line 480) sometimes didn't detect the need to
create local versions of X and Y to pass to Amesos2. In
distributed AdditiveScwharz with overlap, this logic incorrectly
thought the problem was serial and did not create local views of X and Y.