### PR TITLE
ML: silence unused variable warnings

### DIFF
--- a/packages/ml/src/MLAPI/MLAPI_Eig.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Eig.cpp
@@ -129,10 +129,6 @@ void Eigs(const Operator& A, int NumEigenvalues,
   if (A.GetDomainSpace() != A.GetRangeSpace())
     ML_THROW("Input Operator is not square", -1);
 
-  double time;
-
-  time = GetClock();
-
   int length = NumEigenvalues;
   double tol = 1e-3;
   int restarts = 1;

--- a/packages/ml/src/MLAPI/MLAPI_LoadBalanceOperator.h
+++ b/packages/ml/src/MLAPI/MLAPI_LoadBalanceOperator.h
@@ -121,12 +121,6 @@ public:
     DomainSpace_       = DomainSpace;
 
     RCPOperatorBox_    = Teuchos::rcp(new ML_Operator_Box(Op,Ownership));
-    // NOTE: Should the code crash, change the following to `false'
-    bool cheap;
-    if (RangeSpace_ != DomainSpace_)
-      cheap = true;
-    else
-      cheap = false;
     RCPRowMatrix_      = Teuchos::rcp(new ML_Epetra::RowMatrix(Op,&(GetEpetra_Comm()),
                                                                false));
     RCPAuxOperatorBox_ = AuxOp;


### PR DESCRIPTION
Since there is no @trilinos/ml, mentioning @aprokop and @bmpersc based on this file's history.