### PR TITLE
TeuchosRemainder: LinearSolverFactory virtual dtor

### DIFF
--- a/packages/teuchos/remainder/src/Trilinos_Details_LinearSolverFactory.hpp
+++ b/packages/teuchos/remainder/src/Trilinos_Details_LinearSolverFactory.hpp
@@ -234,6 +234,7 @@ getLinearSolver (const std::string& packageName, const std::string& solverName);
 template<class MV, class OP, class NormType>
 class LinearSolverFactory {
 public:
+  virtual ~LinearSolverFactory() {}
   /// \brief Get an instance of a solver from a particular package.
   ///
   /// \param solverName [in] The solver's name.  Names are case


### PR DESCRIPTION
This class has a pure virtual method, so it needs
a virtual destructor as well.
There were compiler warnings indicating that
LinearSolverFactory pointers were being deleted
in one of the Teuchos examples.

@trilinos/teuchos