### PR TITLE
Anasazi: add an early warning about small subspace dimensions

### DIFF
--- a/packages/anasazi/src/AnasaziGeneralizedDavidsonSolMgr.hpp
+++ b/packages/anasazi/src/AnasaziGeneralizedDavidsonSolMgr.hpp
@@ -298,6 +298,12 @@ GeneralizedDavidsonSolMgr<ScalarType,MV,OP>::GeneralizedDavidsonSolMgr(
     // Build solver
     d_outputMan->stream(Debug) << " >> Anasazi::GeneralizedDavidsonSolMgr: Building solver" << std::endl;
     d_solver = Teuchos::rcp( new GeneralizedDavidson<ScalarType,MV,OP>( problem, d_sortMan, d_outputMan, d_tester, d_orthoMan, pl ) );
+
+    TEUCHOS_TEST_FOR_EXCEPTION(d_solver->getMaxSubspaceDim() < d_restartDim, std::invalid_argument,
+        "The maximum size of the subspace dimension (" << d_solver->getMaxSubspaceDim() << ") must "
+        "not be smaller than the size of the restart space (" << d_restartDim << "). "
+        "Please adjust \"Restart Dimension\" and/or \"Maximum Subspace Dimension\" parameters.");
+
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
If a user specifies a "Maximum Subspace Dimension" to be too small, and
then during the solution the solver restarts, it will fails with a
"cryptic" message

    Throw test that evaluated to true: state.curDim <= d_restartDim

This does not actually tell a user what exactly is happening, and how to
address the problem. This patch tries to address it.