### PR TITLE
MueLu: silence warnings

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
@@ -150,7 +150,6 @@ namespace MueLu {
     typedef MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> Hierarchy;
     typedef MueLu::MLParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> MLParameterListInterpreter;
     typedef MueLu::ParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> ParameterListInterpreter;
-    typedef Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node> MultiVectorFactory;
 
     std::string timerName = "MueLu setup time";
     RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);

--- a/packages/muelu/src/MueCentral/MueLu_Level.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_Level.cpp
@@ -451,9 +451,9 @@ namespace MueLu {
         const container_type& requestedBy = it->second->Requests();
         std::ostringstream ss;
         for (container_type::const_iterator ct = requestedBy.begin(); ct != requestedBy.end(); ct++) {
-          if (ct != requestedBy.begin())    ss << ",";
-                                            ss << ct->first;
-          if (ct->second > 1)               ss << "(" << ct->second << ")";
+          if (ct != requestedBy.begin()) ss << ",";
+          ss << ct->first;
+          if (ct->second > 1) ss << "(" << ct->second << ")";
         }
         outputter.outputField(ss.str());
 

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_def.hpp
@@ -617,7 +617,6 @@ namespace MueLu {
      */
 
     using xdMV = Xpetra::MultiVector<double,LO,GO,NO>;
-    using STS  = Teuchos::ScalarTraits<SC>;
 
     LO lNumFineNodes    = lFineNodesPerDir[0]*lFineNodesPerDir[1]*lFineNodesPerDir[2];
     LO lNumCoarseNodes  = lCoarseNodesPerDir[0]*lCoarseNodesPerDir[1]*lCoarseNodesPerDir[2];


### PR DESCRIPTION
Two completely unused typedefs, and one
instance of "misleading indentation"
(GCC 6 and up detect this).

@trilinos/muelu 