### PR TITLE
Update Zoltan2_AlgPuLP.hpp

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -436,6 +436,7 @@ void AlgPuLP<Adapter>::partition(
 		vertex_weights = new int[num_verts*nVwgts];
 
 		//Used for debug purposes. Outputs local vertex weights by their vertices and components.
+    /*
 		std::cout << "Given input (not scaled/norm) weights within each process: " << std::endl;
 		for (int i = 0; i < nVwgts; ++i)
 		{
@@ -446,6 +447,7 @@ void AlgPuLP<Adapter>::partition(
 			}
 			std::cout << std::endl;
 		}
+    */
 
 		// global_wgt_sum and local_wgt_sum are arrays that stores the sum of the weights by component.
 		// Both have an additional element as flag for any weights being non-integer which triggers scaling.
@@ -573,7 +575,7 @@ void AlgPuLP<Adapter>::partition(
     !ierr, BASIC_ASSERTION, problemComm);
 #else
   //What does graph look like here?
-  ierr = xtrapulp_run(&g, &ppc, parts, num_parts, nVwgts, multiweight_option);
+  ierr = xtrapulp_run(&g, &ppc, parts, num_parts, multiweight_option);
   env->globalInputAssertion(__FILE__, __LINE__, "xtrapulp_run",
     !ierr, BASIC_ASSERTION, problemComm);//If any of the weights are not integers, extremely small (< INT_EPSILON), or extremely large (> MAX_NUM), then scale ALL the weights
 
@@ -625,7 +627,7 @@ void AlgPuLP<Adapter>::scale_weights(
 	int *iwgts
 )
 {
-    std::cout << "Single scale_weights called" << std::endl;
+  //std::cout << "Single scale_weights called" << std::endl;
 	const double INT_EPSILON = 1e-5;
 	const double MAX_NUM = 1e9;
 
@@ -704,7 +706,7 @@ void AlgPuLP<Adapter>::scale_weights(
     }
 
   /* Convert weights to positive integers using the computed scale factor */
-    std::cout << "Scaled weight component " << index << " with scale: " << scale << std::endl;
+  //std::cout << "Scaled weight component " << index << " with scale: " << scale << std::endl;
 	for (size_t i = 0; i < n; i++)
 	{
 		iwgts[i*weights_num + index] = (int)ceil(double(fwgts[i])*scale);
@@ -758,9 +760,3 @@ void AlgPuLP<Adapter>::aggregate_weights(
 
 
 #endif
-
-
-
-
-
-

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -1,5 +1,5 @@
 // @HEADER
-// Just a Test that this IDE works
+//
 // ***********************************************************************
 //
 //   Zoltan2: A package of combinatorial algorithms for scientific computing
@@ -426,7 +426,9 @@ void AlgPuLP<Adapter>::partition(
   int nVwgts = model->getNumWeightsPerVertex();
 
   int* vertex_weights = NULL;
-  long vertex_weights_sum = 0;
+  
+  // TODO: verify not used and delete; make compile says it doesn't
+  // long vertex_weights_sum = 0;
 
   if (nVwgts)
   {
@@ -473,10 +475,11 @@ void AlgPuLP<Adapter>::partition(
 		}
 
     //TODO: Is this necessary? 
-		if(nVwgts == 1)
+		/*if(nVwgts == 1)
         {
             vertex_weights_sum = global_wgt_sum[0];
         }
+        */
 	}
 
   // Get edge info
@@ -507,7 +510,7 @@ void AlgPuLP<Adapter>::partition(
 
   pulp_graph_t g = {num_verts, num_edges,
                     out_edges, out_offsets,
-                    vertex_weights, edge_weights, vertex_weights_sum};
+                    vertex_weights, edge_weights, global_wgt_sum[0]};
 
 #else
   // Create XtraPuLP's graph structure
@@ -705,9 +708,7 @@ void AlgPuLP<Adapter>::scale_weights(
 	for (size_t i = 0; i < n; i++)
 	{
 		iwgts[i*weights_num + index] = (int)ceil(double(fwgts[i])*scale);
-		std::cout << iwgts[i*weights_num + index] << " ";
 	}
-	std::cout << std::endl;
 }
 
 template <typename Adapter>
@@ -743,7 +744,6 @@ void AlgPuLP<Adapter>::aggregate_weights(
         }
     }
 
-    std::cout << "reduceAll called" << std::endl;
     Teuchos::reduceAll<int,double>(*problemComm, Teuchos::REDUCE_SUM, nVwgts + 1, local_wgt_sum, global_wgt_sum);
 
     //TODO: 07JUL17: Check nothing will break and remove after.
@@ -758,3 +758,9 @@ void AlgPuLP<Adapter>::aggregate_weights(
 
 
 #endif
+
+
+
+
+
+

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -472,6 +472,7 @@ void AlgPuLP<Adapter>::partition(
 			scale_weights(num_verts, vwgts[i], vertex_weights, nVwgts, i, scale_option, global_wgt_sum[i], global_max_wgt[i], global_wgt_sum[nVwgts]);
 		}
 
+    //TODO: Is this necessary? 
 		if(nVwgts == 1)
         {
             vertex_weights_sum = global_wgt_sum[0];
@@ -531,20 +532,10 @@ void AlgPuLP<Adapter>::partition(
 
   dist_graph_t g;
 
-	if (nVwgts == 1)
-	{
-	    create_xtrapulp_dist_graph(&g, num_verts_global, num_edges_global,
-			(unsigned long)num_verts, (unsigned long)num_edges,
-			out_edges, out_offsets, global_ids, verts_per_rank,
-			vertex_weights, edge_weights);
-	}
-	else
-	{
-		create_xtrapulp_dist_graph2(&g, num_verts_global, num_edges_global,
+	create_xtrapulp_dist_graph(&g, num_verts_global, num_edges_global,
 			(unsigned long)num_verts, (unsigned long)num_edges,
 			out_edges, out_offsets, global_ids, verts_per_rank,
 			vertex_weights, edge_weights, nVwgts, norm_option, multiweight_option);
-	}
 
 #endif
 
@@ -579,7 +570,7 @@ void AlgPuLP<Adapter>::partition(
     !ierr, BASIC_ASSERTION, problemComm);
 #else
   //What does graph look like here?
-  ierr = xtrapulp_run(&g, &ppc, parts, num_parts);
+  ierr = xtrapulp_run(&g, &ppc, parts, num_parts, nVwgts, multiweight_option);
   env->globalInputAssertion(__FILE__, __LINE__, "xtrapulp_run",
     !ierr, BASIC_ASSERTION, problemComm);//If any of the weights are not integers, extremely small (< INT_EPSILON), or extremely large (> MAX_NUM), then scale ALL the weights
 
@@ -719,7 +710,6 @@ void AlgPuLP<Adapter>::scale_weights(
 	std::cout << std::endl;
 }
 
-
 template <typename Adapter>
 void AlgPuLP<Adapter>::aggregate_weights(
   size_t nVtx,
@@ -760,10 +750,11 @@ void AlgPuLP<Adapter>::aggregate_weights(
     Teuchos::reduceAll<int,double>(*problemComm, Teuchos::REDUCE_MAX, nVwgts, local_max_wgt, global_max_wgt);
 }
 
-
-
 } // namespace Zoltan2
 
 #endif // HAVE_ZOLTAN2_PULP
+
 ////////////////////////////////////////////////////////////////////////
+
+
 #endif


### PR DESCRIPTION
+ Added test options: scaling, norm, and multi weight strategy; had to move up the parameter options
+ Accepts graphs with multiple vertex weights
+ Unrolls multiple vertex weights of 2-D structure into 1-D structure (aggregate_weights)
+ Added scaling method for multiple vertex weights (scale_weights); currently has one option (MAX_NUM/scale), if one component scales, then all other component scales. 
+ Reduced the number of reduceALL calls per processor (from # of weight components to 1)