### PR TITLE
Storage reversal, alternative to #1513 

### DIFF
--- a/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
@@ -364,6 +364,8 @@ private:
   //! Copy constructor (declared private and undefined; may not be used)
   ILUT (const ILUT<MatrixType>& RHS);
 
+  void allocateSolvers ();
+
   //! operator= (declared private and undefined; may not be used)
   ILUT<MatrixType>& operator= (const ILUT<MatrixType>& RHS);
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
@@ -107,6 +107,9 @@ public:
   //! Specialization of Tpetra::RowMatrix used by this class.
   typedef Tpetra::RowMatrix<scalar_type, local_ordinal_type,
                             global_ordinal_type, node_type> row_matrix_type;
+  //! Specialization of Tpetra::CrsMatrix used by this class.
+  typedef Tpetra::CrsMatrix<scalar_type, local_ordinal_type,
+                            global_ordinal_type, node_type, false> crs_matrix_type;
 
   static_assert (std::is_same<MatrixType, row_matrix_type>::value,
                  "Ifpack2::LocalSparseTriangularSolver: The template parameter "
@@ -335,10 +338,7 @@ private:
   //! Debug output stream; may be null (not used in that case)
   Teuchos::RCP<Teuchos::FancyOStream> out_;
   //! The original input matrix, as a Tpetra::CrsMatrix.
-  Teuchos::RCP<const Tpetra::CrsMatrix<scalar_type,
-                                       local_ordinal_type,
-                                       global_ordinal_type,
-                                       node_type, false> > A_crs_;
+  Teuchos::RCP<const crs_matrix_type> A_crs_;
 
   typedef Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type> MV;
   mutable Teuchos::RCP<MV> X_colMap_;
@@ -346,6 +346,7 @@ private:
 
   bool isInitialized_;
   bool isComputed_;
+  bool isInternallyChanged_;
 
   mutable int numInitialize_;
   mutable int numCompute_;

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
@@ -183,6 +183,9 @@ public:
   ///
   /// \param plist [in] List of parameters.
   ///
+  /// - "trisolver: reverse U" (\c bool): reverse storage for upper triangular matrices
+  ///   to be more cache-efficient
+  ///
   /// If Trilinos_ENABLE_ShyLUHTS=TRUE, then these parameters are available:
   ///   - "trisolver: type" (\c string): One of {"Internal" (default), "HTS"}.
   ///   - "trisolver: block size" (\c int): The triangular matrix can usefully be
@@ -347,6 +350,7 @@ private:
   bool isInitialized_;
   bool isComputed_;
   bool isInternallyChanged_;
+  bool reverseStorage_;
 
   mutable int numInitialize_;
   mutable int numCompute_;

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -278,6 +278,7 @@ void LocalSparseTriangularSolver<MatrixType>::initializeState ()
 {
   isInitialized_ = false;
   isComputed_ = false;
+  reverseStorage_ = false;
   isInternallyChanged_ = false;
   numInitialize_ = 0;
   numCompute_ = 0;
@@ -321,6 +322,9 @@ setParameters (const Teuchos::ParameterList& pl)
     htsImpl_ = Teuchos::rcp (new HtsImpl ());
     htsImpl_->setParameters (pl);
   }
+
+  if (pl.isParameter("trisolver: reverse U"))
+    reverseStorage_ = pl.get<bool>("trisolver: reverse U");
 }
 
 template<class MatrixType>
@@ -359,7 +363,7 @@ initialize ()
     (! G->isFillComplete (), std::runtime_error, "If you call this method, "
      "the matrix's graph must be fill complete.  It is not.");
 
-  if (A_crs_->isUpperTriangular() && htsImpl_.is_null()) {
+  if (reverseStorage_ && A_crs_->isUpperTriangular() && htsImpl_.is_null()) {
     // Reverse the storage for an upper triangular matrix
     using local_matrix_type = typename crs_matrix_type::local_matrix_type;
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -374,6 +374,8 @@ initialize ()
     typename decltype(ind)::non_const_type  newind ("ind", ind.dimension_0 ());
     decltype(val)                           newval ("val", val.dimension_0 ());
 
+    // FIXME: The code below assumes UVM
+    crs_matrix_type::execution_space::fence();
     newptr(0) = 0;
     for (local_ordinal_type row = 0, rowStart = 0; row < numRows; ++row) {
       auto A_r = Alocal.row(numRows-1 - row);
@@ -386,6 +388,7 @@ initialize ()
       rowStart += numEnt;
       newptr(row+1) = rowStart;
     }
+    crs_matrix_type::execution_space::fence();
 
     // Reverse maps
     using map_type = typename crs_matrix_type::map_type;

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -278,6 +278,7 @@ void LocalSparseTriangularSolver<MatrixType>::initializeState ()
 {
   isInitialized_ = false;
   isComputed_ = false;
+  isInternallyChanged_ = false;
   numInitialize_ = 0;
   numCompute_ = 0;
   numApply_ = 0;
@@ -346,10 +347,10 @@ initialize ()
        "The input matrix A is not a Tpetra::CrsMatrix.");
     A_crs_ = A_crs;
   }
-  auto G = A_->getGraph ();
+  auto G = A_crs_->getGraph ();
   TEUCHOS_TEST_FOR_EXCEPTION
     (G.is_null (), std::logic_error, prefix << "A_ and A_crs_ are nonnull, "
-     "but A_'s RowGraph G is null.  "
+     "but A_crs_'s RowGraph G is null.  "
      "Please report this bug to the Ifpack2 developers.");
   // At this point, the graph MUST be fillComplete.  The "initialize"
   // (symbolic) part of setup only depends on the graph structure, so
@@ -358,8 +359,75 @@ initialize ()
     (! G->isFillComplete (), std::runtime_error, "If you call this method, "
      "the matrix's graph must be fill complete.  It is not.");
 
+  if (A_crs_->isUpperTriangular() && htsImpl_.is_null()) {
+    // Reverse the storage for an upper triangular matrix
+    using local_matrix_type = typename crs_matrix_type::local_matrix_type;
+
+    auto Alocal = A_crs_->getLocalMatrix();
+    auto ptr    = Alocal.graph.row_map;
+    auto ind    = Alocal.graph.entries;
+    auto val    = Alocal.values;
+
+    auto numRows = Alocal.numRows(), numCols = Alocal.numCols(), numNnz = Alocal.nnz();
+
+    typename decltype(ptr)::non_const_type  newptr ("ptr", ptr.dimension_0 ());
+    typename decltype(ind)::non_const_type  newind ("ind", ind.dimension_0 ());
+    decltype(val)                           newval ("val", val.dimension_0 ());
+
+    newptr(0) = 0;
+    for (local_ordinal_type row = 0, rowStart = 0; row < numRows; ++row) {
+      auto A_r = Alocal.row(numRows-1 - row);
+
+      auto numEnt = A_r.length;
+      for (local_ordinal_type k = 0; k < numEnt; ++k) {
+        newind(rowStart + k) = numCols-1 - A_r.colidx(numEnt-1 - k);
+        newval(rowStart + k) = A_r.value (numEnt-1 - k);
+      }
+      rowStart += numEnt;
+      newptr(row+1) = rowStart;
+    }
+
+    // Reverse maps
+    using map_type = typename crs_matrix_type::map_type;
+    Teuchos::RCP<map_type> newRowMap, newColMap;
+    {
+      // Reverse row map
+      auto rowMap = A_->getRowMap();
+      auto numElems = rowMap->getNodeNumElements();
+      auto rowElems = rowMap->getNodeElementList();
+
+      Teuchos::Array<global_ordinal_type> newRowElems(rowElems.size());
+      for (size_t i = 0; i < numElems; i++)
+        newRowElems[i] = rowElems[numElems-1 - i];
+
+      newRowMap = Teuchos::rcp(new map_type(rowMap->getGlobalNumElements(), newRowElems, rowMap->getIndexBase(), rowMap->getComm()));
+    }
+    {
+      // Reverse column map
+      auto colMap = A_->getColMap();
+      auto numElems = colMap->getNodeNumElements();
+      auto colElems = colMap->getNodeElementList();
+
+      Teuchos::Array<global_ordinal_type> newColElems(colElems.size());
+      for (size_t i = 0; i < numElems; i++)
+        newColElems[i] = colElems[numElems-1 - i];
+
+      newColMap = Teuchos::rcp(new map_type(colMap->getGlobalNumElements(), newColElems, colMap->getIndexBase(), colMap->getComm()));
+    }
+
+    // Construct new matrix
+    local_matrix_type newLocalMatrix("Upermuted", numRows, numCols, numNnz, newval, newptr, newind);
+
+    A_crs_ = Teuchos::rcp(new crs_matrix_type(newRowMap, newColMap, A_crs_->getDomainMap(), A_crs_->getRangeMap(), newLocalMatrix));
+
+    isInternallyChanged_ = true;
+  }
+
   if (Teuchos::nonnull (htsImpl_))
+  {
     htsImpl_->initialize (*A_crs_);
+    isInternallyChanged_ = true;
+  }
 
   isInitialized_ = true;
   ++numInitialize_;
@@ -424,8 +492,10 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type,
       *out_ << "A_crs_ is null!" << std::endl;
     }
     else {
-      const std::string uplo = A_crs_->isUpperTriangular () ? "U" :
-        (A_crs_->isLowerTriangular () ? "L" : "N");
+      Teuchos::RCP<const crs_matrix_type> A_crs =
+          Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_);
+      const std::string uplo = A_crs->isUpperTriangular () ? "U" :
+        (A_crs->isLowerTriangular () ? "L" : "N");
       const std::string trans = (mode == Teuchos::CONJ_TRANS) ? "C" :
         (mode == Teuchos::TRANS ? "T" : "N");
       const std::string diag =
@@ -461,10 +531,10 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type,
      " apply().  You do NOT need to call setMatrix, as long as the matrix "
      "itself (that is, its address in memory) is the same.");
 
-  auto G = A_->getGraph ();
+  auto G = A_crs_->getGraph ();
   TEUCHOS_TEST_FOR_EXCEPTION
     (G.is_null (), std::logic_error, prefix << "A_ and A_crs_ are nonnull, "
-     "but A_'s RowGraph G is null.  "
+     "but A_crs_'s RowGraph G is null.  "
      "Please report this bug to the Ifpack2 developers.");
   auto importer = G->getImporter ();
   auto exporter = G->getExporter ();
@@ -697,7 +767,7 @@ setMatrix (const Teuchos::RCP<const row_matrix_type>& A)
   // because users are supposed to call this method with the same
   // object over all participating processes, and pointer identity
   // implies object identity.
-  if (A.getRawPtr () != A_.getRawPtr ()) {
+  if (A.getRawPtr () != A_.getRawPtr () || isInternallyChanged_) {
     // Check in serial or one-process mode if the matrix is square.
     TEUCHOS_TEST_FOR_EXCEPTION
       (! A.is_null () && A->getComm ()->getSize () == 1 &&

--- a/packages/ifpack2/src/Ifpack2_Parameters.cpp
+++ b/packages/ifpack2/src/Ifpack2_Parameters.cpp
@@ -95,6 +95,7 @@ void getValidParameters(Teuchos::ParameterList& params)
   // Ifpack2_LocalSparseTriangularSolver.cpp
   params.set("trisolver: type", "Internal");
   params.set("trisolver: block size", (int)1);
+  params.set("trisolver: reverse U", false);
 
   // Overlapping partitioner
   params.set("partitioner: local parts", (int)1);

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -600,7 +600,7 @@ void RILUK<MatrixType>::initialize ()
         checkOrderingConsistency (*A_local_);
         L_solver_->setMatrix (L_);
         L_solver_->initialize ();
-        U_solver_->setMatrix( U_);
+        U_solver_->setMatrix (U_);
         U_solver_->initialize ();
         // Do not call initAllValues. compute() always calls initAllValues to
         // fill L and U with possibly new numbers. initialize() is concerned
@@ -1043,7 +1043,10 @@ void RILUK<MatrixType>::compute ()
       ! U_->isUpperTriangular (), std::runtime_error,
       "Ifpack2::RILUK::compute: U isn't lower triangular.");
 
+    // If L_solver_ or U_solver store modified factors internally, we need to reset those
+    L_solver_->setMatrix (L_);
     L_solver_->compute ();
+    U_solver_->setMatrix (U_);
     U_solver_->compute ();
   }
   else {


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/tpetra @mhoemmen @sthomas61

Seems to work, but multiple improvements required:

- [x] See #1523 
  Could be bypassed if Tpetra provided a `CrsMatrix` constructor taking in all 4 maps and a Kokkos matrix. The only Kokkos matrix-based constructor takes in only row and column maps at this point.
- [x] Call `setMatrix` for `U_solver_` and `L_solver_` in RILUK's `compute()` so that the solver storage is updated
- [x] Remove pointer equal shortcut `LocalSparseTriangularSolver::setMatrix` so that the storage is updated (otherwise, if matrix values are updated but stored in the same matrix, these updates are ignored)
- [x] ~Need to move some stuff to parallel regions, if serial works out well~