### PR TITLE
Tpetra: CrsGraph insertInd... tfecfFuncName

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1595,9 +1595,7 @@ namespace Tpetra {
                             const ELocalGlobal lg,
                             const ELocalGlobal I)
     {
-#ifdef HAVE_TPETRA_DEBUG
       const char tfecfFuncName[] = "insertIndicesAndValues: ";
-#endif // HAVE_TPETRA_DEBUG
 
       const size_t oldNumEnt = rowInfo.numEntries;
 


### PR DESCRIPTION
2feb2e75 removed HAVE_DEBUG protection from
a call to
TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
which means tfecfFuncName needs to be defined
in all cases now.

@trilinos/tpetra

addresses #1528