### PR TITLE
Amesos2: Fixed *Petra adapter unit tests

### DIFF
--- a/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
@@ -351,10 +351,13 @@ namespace {
     // getCrs does not guarantee the sorted-ness of the column
     // indices, so this test might fail
 
-    TEST_COMPARE_ARRAYS(nzvals, nzvals_test);
-    TEST_COMPARE_ARRAYS(colind, colind_test);
-    TEST_COMPARE_ARRAYS(rowptr, rowptr_test);
-    TEST_EQUALITY_CONST(nnz, 12);
+    if(rank == 0)
+    {
+      TEST_COMPARE_ARRAYS(nzvals, nzvals_test);
+      TEST_COMPARE_ARRAYS(colind, colind_test);
+      TEST_COMPARE_ARRAYS(rowptr, rowptr_test);
+      TEST_EQUALITY_CONST(nnz, 12);
+    }
 
     /////////////////////////////////////////////
     // Check now a rooted, sorted-indices repr //
@@ -595,16 +598,18 @@ namespace {
      * found in the top half of the rows, and the other half are found
      * in the bottom half of the rows.
      */
-    if ( rank == 0 ){
+    if(rank == 0) {
       TEST_COMPARE_ARRAYS(nzvals.view(0,6), nzvals_test.view(0,6));
       TEST_COMPARE_ARRAYS(colind.view(0,6), colind_test.view(0,6));
-      TEST_COMPARE_ARRAYS(rowptr.view(0,3), rowptr_test.view(0,3));
-      TEST_EQUALITY_CONST(rowptr[3], 6);
-    } else if ( rank == 1 ){
-      TEST_COMPARE_ARRAYS(nzvals.view(6,6), nzvals_test.view(6,6));
-      TEST_COMPARE_ARRAYS(colind.view(6,6), colind_test.view(6,6));
-      TEST_COMPARE_ARRAYS(rowptr.view(3,3), rowptr_test.view(3,3));
-      TEST_EQUALITY_CONST(rowptr[3], 6);
+      for(int i = 0; i < 4; i++) {
+        TEST_EQUALITY_CONST(rowptr[i], rowptr_test[i]);
+      }
+    } else if(rank == 1) {
+      TEST_COMPARE_ARRAYS(nzvals.view(0,6), nzvals_test.view(6,6));
+      TEST_COMPARE_ARRAYS(colind.view(0,6), colind_test.view(6,6));
+      for(int i = 0; i < 4; i++) {
+        TEST_EQUALITY_CONST(rowptr[i], rowptr_test[3 + i] - rowptr_test[3]);
+      }
     }
   }
 

--- a/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
@@ -470,16 +470,18 @@ namespace {
      * found in the top half of the rows, and the other half are found
      * in the bottom half of the rows.
      */
-    if ( rank == 0 ){
+    if(rank == 0) {
       TEST_COMPARE_ARRAYS(nzvals.view(0,6), nzvals_test.view(0,6));
       TEST_COMPARE_ARRAYS(colind.view(0,6), colind_test.view(0,6));
-      TEST_COMPARE_ARRAYS(rowptr.view(0,3), rowptr_test.view(0,3));
-      TEST_EQUALITY_CONST(rowptr[3], 6);
-    } else if ( rank == 1 ){
-      TEST_COMPARE_ARRAYS(nzvals.view(6,6), nzvals_test.view(6,6));
-      TEST_COMPARE_ARRAYS(colind.view(6,6), colind_test.view(6,6));
-      TEST_COMPARE_ARRAYS(rowptr.view(3,3), rowptr_test.view(3,3));
-      TEST_EQUALITY_CONST(rowptr[3], 6);
+      for(int i = 0; i < 4; i++) {
+        TEST_EQUALITY_CONST(rowptr[i], rowptr_test[i]);
+      }
+    } else if(rank == 1) {
+      TEST_COMPARE_ARRAYS(nzvals.view(0,6), nzvals_test.view(6,6));
+      TEST_COMPARE_ARRAYS(colind.view(0,6), colind_test.view(6,6));
+      for(int i = 0; i < 4; i++) {
+        TEST_EQUALITY_CONST(rowptr[i], rowptr_test[3 + i] - rowptr_test[3]);
+      }
     }
   }
 


### PR DESCRIPTION
In Amesos2, fixed adapter unit tests (#1495) (Tpetra_CrsMatrix, Epetra_RowMatrix and Epetra_MultiVector). In general, the failures were caused by the tests trying to compare global indices against local indices, when the matrices/vectors were distributed on two or more MPI ranks.

Normally I wouldn't make formatting changes, but I replaced some mixed tabs+spaces with just spaces (without changing indentation) to be consistent. I can revert that part if necessary.