### PR TITLE
Tpetra: fix another tfecfFuncName warning

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -3612,9 +3612,9 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node, classic>::
   resumeFill (const Teuchos::RCP<Teuchos::ParameterList>& params)
   {
+#ifdef HAVE_TPETRA_DEBUG
     const char tfecfFuncName[] = "resumeFill";
 
-#ifdef HAVE_TPETRA_DEBUG
     Teuchos::barrier( *rowMap_->getComm() );
 #endif // HAVE_TPETRA_DEBUG
     clearGlobalConstants();


### PR DESCRIPTION
In this case, the variable is only used
in debug mode, so it should only be
defined in debug mode

@trilinos/tpetra 