### PR TITLE
Tpetra: Refactor CrsMatrix pack/unpack procedures to use PackTraits

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -56,6 +56,7 @@
 #include "Tpetra_DistObject.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_Vector.hpp"
+#include "Tpetra_Details_PackTraits.hpp"
 
 // localMultiply is templated on DomainScalar and RangeScalar, so we
 // have to include this header file here, rather than in the _def
@@ -3698,12 +3699,13 @@ namespace Tpetra {
     /// build).
     ///
     /// \return \c true if the method succeeded, else \c false.
-    bool
-    packRow (char* const numEntOut,
-             char* const valOut,
-             char* const indOut,
+    size_t
+    packRow (const typename Tpetra::Details::PackTraits<LocalOrdinal, typename Kokkos::View<int*, device_type>::HostMirror::execution_space>::output_buffer_type& exports,
+             const size_t offset,
              const size_t numEnt,
-             const LocalOrdinal lclRow) const;
+             const typename Tpetra::Details::PackTraits<GlobalOrdinal, typename Kokkos::View<int*, device_type>::HostMirror::execution_space>::input_array_type& gidsIn,
+             const typename Tpetra::Details::PackTraits<impl_scalar_type, typename Kokkos::View<int*, device_type>::HostMirror::execution_space>::input_array_type& valsIn,
+             const size_t numBytesPerValue) const;
 
     /// \brief Pack data for the current row to send, if the matrix's
     ///   graph is known to be static (and therefore fill complete,
@@ -3757,15 +3759,14 @@ namespace Tpetra {
     ///   the same row with the same column index).
     ///
     /// \return \c true if the method succeeded, else \c false.
-    bool
-    unpackRow (impl_scalar_type* const valInTmp,
-               GlobalOrdinal* const indInTmp,
-               const size_t tmpNumEnt,
-               const char* const valIn,
-               const char* const indIn,
+    size_t
+    unpackRow (const typename Tpetra::Details::PackTraits<GlobalOrdinal, typename Kokkos::View<int*, device_type>::HostMirror::execution_space>::output_array_type& gidsOut,
+               const typename Tpetra::Details::PackTraits<impl_scalar_type, typename Kokkos::View<int*, device_type>::HostMirror::execution_space>::output_array_type& valsOut,
+               const typename Tpetra::Details::PackTraits<int, typename Kokkos::View<int*, device_type>::HostMirror::execution_space>::input_buffer_type& imports,
+               const size_t offset,
+               const size_t numBytes,
                const size_t numEnt,
-               const LocalOrdinal lclRow,
-               const Tpetra::CombineMode combineMode);
+               const size_t numBytesPerValue);
 
     /// \brief Allocate space for pack() to pack entries to send.
     ///

--- a/packages/tpetra/core/src/Tpetra_Details_get1DConstView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_get1DConstView.hpp
@@ -1,0 +1,116 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_GET1DCONSTVIEW_HPP
+#define TPETRA_DETAILS_GET1DCONSTVIEW_HPP
+
+///
+/// \file Tpetra_Details_get1DConstView.hpp
+/// \brief Create a Kokkos::View from a raw host array.
+///
+
+#include "Tpetra_ConfigDefs.hpp"
+#include "Tpetra_Util.hpp"
+#include "Kokkos_DualView.hpp"
+#include <Teuchos_Array.hpp>
+#include <utility>
+
+namespace Tpetra {
+namespace Details {
+
+// mfh 28 Apr 2016: Sometimes we have a raw host array, and we need
+// to make a Kokkos::View out of it that lives in a certain memory
+// space.  We don't want to make a deep copy of the input array if
+// we don't need to, but if the memory spaces are different, we need
+// to.  The following code does that.  The struct is an
+// implementation detail, and the "free" function
+// get1DConstViewOfUnmanagedArray is the interface to call.
+
+template<class ST, class DT,
+         const bool outputIsHostMemory =
+           std::is_same<typename DT::memory_space, Kokkos::HostSpace>::value>
+struct Get1DConstViewOfUnmanagedHostArray {};
+
+template<class ST, class DT>
+struct Get1DConstViewOfUnmanagedHostArray<ST, DT, true> {
+  typedef Kokkos::View<const ST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> output_view_type;
+
+  static output_view_type
+    getView (const char /* label */ [], const ST* x_raw, const size_t x_len)
+    {
+      // We can return the input array, wrapped as an unmanaged View.
+      // Ignore the label, since unmanaged Views don't have labels.
+      return output_view_type (x_raw, x_len);
+    }
+};
+
+template<class ST, class DT>
+struct Get1DConstViewOfUnmanagedHostArray<ST, DT, false> {
+  typedef Kokkos::View<const ST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> input_view_type;
+  typedef Kokkos::View<const ST*, DT> output_view_type;
+
+  static output_view_type
+    getView (const char label[], const ST* x_raw, const size_t x_len)
+    {
+      input_view_type x_in (x_raw, x_len);
+      // The memory spaces are different, so we have to create a new
+      // View which is a deep copy of the input array.
+      //
+      // FIXME (mfh 28 Apr 2016) This needs to be converted to
+      // std::string, else the compiler can't figure out what
+      // constructor we're calling.
+      Kokkos::View<ST*, DT> x_out (std::string (label), x_len);
+      Kokkos::deep_copy (x_out, x_in);
+      return x_out;
+    }
+};
+
+template<class ST, class DT>
+  typename Get1DConstViewOfUnmanagedHostArray<ST, DT>::output_view_type
+get1DConstViewOfUnmanagedHostArray (const char label[], const ST* x_raw, const size_t x_len)
+{
+  return Get1DConstViewOfUnmanagedHostArray<ST, DT>::getView (label, x_raw, x_len);
+}
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_GET1DCONSTVIEW_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix.hpp
@@ -45,8 +45,8 @@
 #include "TpetraCore_config.h"
 #include "Teuchos_Array.hpp"
 #include "Teuchos_ArrayView.hpp"
+#include "Tpetra_Details_PackTraits.hpp"
 #include "Tpetra_Details_OrdinalTraits.hpp"
-#include "Tpetra_Details_computeOffsets.hpp"
 #include "Tpetra_Details_createMirrorView.hpp"
 #include "Kokkos_Core.hpp"
 #include <memory>
@@ -60,6 +60,19 @@
 /// \warning This file, and its contents, are implementation details
 ///   of Tpetra.  The file itself or its contents may disappear or
 ///   change at any time.
+///
+/// Data (bytes) describing the row of the CRS matrix are "packed"
+/// (concatenated) in to a (view of) char* object in the following order:
+///
+///   1. number of entries (LocalOrdinal)
+///   2. global column indices (GlobalOrdinal)
+///   3. proces IDs (optional, int)
+///   4. row values (Scalar)
+///
+/// The functions in this file are companions to
+/// Tpetra_Details_unpackCrsMatrix.hpp, i.e., Tpetra_Details_unpackCrsMatrix.hpp
+/// implements the reverse of the packing order described above to ensure proper
+/// unpacking.
 
 namespace Tpetra {
 
@@ -73,10 +86,18 @@ class Distributor;
 //
 namespace Details {
 
+/// \brief Compute the number of packets and offsets for the pack procedure
+///
+/// \tparam OutputOffsetsViewType the type of the output offsets view
+/// \tparam CountsViewType the type of the counts view
+/// \tparam InputOffsetsViewType the type of the input offsets view
+/// \tparam InputLocalRowIndicesViewType the type of the local row indices view
+/// \tparam InputLocalRowPidsViewType the type of the local process IDs view
 template<class OutputOffsetsViewType,
          class CountsViewType,
          class InputOffsetsViewType,
          class InputLocalRowIndicesViewType,
+         class InputLocalRowPidsViewType,
          const bool debug =
 #ifdef HAVE_TPETRA_DEBUG
          true
@@ -90,6 +111,7 @@ public:
   typedef typename CountsViewType::non_const_value_type count_type;
   typedef typename InputOffsetsViewType::non_const_value_type input_offset_type;
   typedef typename InputLocalRowIndicesViewType::non_const_value_type local_row_index_type;
+  typedef typename InputLocalRowPidsViewType::non_const_value_type local_row_pid_type;
   // output Views drive where execution happens.
   typedef typename OutputOffsetsViewType::device_type device_type;
   static_assert (std::is_same<typename CountsViewType::device_type::execution_space,
@@ -120,16 +142,20 @@ public:
                                const CountsViewType& counts,
                                const InputOffsetsViewType& rowOffsets,
                                const InputLocalRowIndicesViewType& lclRowInds,
+                               const InputLocalRowPidsViewType& lclRowPids,
                                const count_type sizeOfLclCount,
-                               const count_type sizeOfValue,
-                               const count_type sizeOfGblColInd) :
+                               const count_type sizeOfGblColInd,
+                               const count_type sizeOfPid,
+                               const count_type sizeOfValue) :
     outputOffsets_ (outputOffsets),
     counts_ (counts),
     rowOffsets_ (rowOffsets),
     lclRowInds_ (lclRowInds),
+    lclRowPids_ (lclRowPids),
     sizeOfLclCount_ (sizeOfLclCount),
-    sizeOfValue_ (sizeOfValue),
     sizeOfGblColInd_ (sizeOfGblColInd),
+    sizeOfPid_ (sizeOfPid),
+    sizeOfValue_ (sizeOfValue),
     error_ ("error") // don't forget this, or you'll get segfaults!
   {
     if (debug) {
@@ -140,14 +166,14 @@ public:
         os << "lclRowInds.dimension_0() = " << numRowsToPack
            << " != counts.dimension_0() = " << counts_.dimension_0 ()
            << ".";
-        throw std::invalid_argument (os.str ());
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
       }
       if (static_cast<size_t> (numRowsToPack + 1) != static_cast<size_t> (outputOffsets_.dimension_0 ())) {
         std::ostringstream os;
         os << "lclRowInds.dimension_0() + 1 = " << (numRowsToPack + 1)
            << " != outputOffsets.dimension_0() = " << outputOffsets_.dimension_0 ()
            << ".";
-        throw std::invalid_argument (os.str ());
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
       }
     }
   }
@@ -189,11 +215,14 @@ public:
         static_cast<count_type> (rowOffsets_(lclRow+1) - rowOffsets_(lclRow));
 
       // We pack first the number of entries in the row, then that many
-      // global column indices, then that many values.  However, if the
-      // number of entries in the row is zero, we pack nothing.
+      // global column indices, then that many pids (if any), then that many
+      // values.  However, if the number of entries in the row is zero, we pack
+      // nothing.
       const count_type numBytes = (count == 0) ?
         static_cast<count_type> (0) :
-        sizeOfLclCount_ + count * (sizeOfGblColInd_ + sizeOfValue_);
+        sizeOfLclCount_ + count * (sizeOfGblColInd_ +
+                                   (lclRowPids_.size() > 0 ? sizeOfPid_ : 0) +
+                                   sizeOfValue_);
 
       if (final) {
         counts_(curInd) = numBytes;
@@ -218,29 +247,43 @@ private:
   CountsViewType counts_;
   typename InputOffsetsViewType::const_type rowOffsets_;
   typename InputLocalRowIndicesViewType::const_type lclRowInds_;
+  typename InputLocalRowPidsViewType::const_type lclRowPids_;
   count_type sizeOfLclCount_;
-  count_type sizeOfValue_;
   count_type sizeOfGblColInd_;
+  count_type sizeOfPid_;
+  count_type sizeOfValue_;
   Kokkos::View<int, device_type> error_;
 };
 
+/// \brief Compute the number of packets and offsets for the pack procedure
+///
+/// \tparam OutputOffsetsViewType the type of the output offsets view
+/// \tparam CountsViewType the type of the counts view
+/// \tparam InputOffsetsViewType the type of the input offsets view
+/// \tparam InputLocalRowIndicesViewType the type of the local row indices view
+/// \tparam InputLocalRowPidsViewType the type of the local process IDs view
+///
+/// This is the high level interface to the NumPacketsAndOffsetsFunctor functor
 template<class OutputOffsetsViewType,
          class CountsViewType,
          class InputOffsetsViewType,
-         class InputLocalRowIndicesViewType>
-std::pair<typename CountsViewType::non_const_value_type, bool>
-computeNumPacketsAndOffsets (std::unique_ptr<std::ostringstream>& errStr,
-                             const OutputOffsetsViewType& outputOffsets,
+         class InputLocalRowIndicesViewType,
+         class InputLocalRowPidsViewType>
+typename CountsViewType::non_const_value_type
+computeNumPacketsAndOffsets (const OutputOffsetsViewType& outputOffsets,
                              const CountsViewType& counts,
                              const InputOffsetsViewType& rowOffsets,
                              const InputLocalRowIndicesViewType& lclRowInds,
+                             const InputLocalRowPidsViewType& lclRowPids,
                              const typename CountsViewType::non_const_value_type sizeOfLclCount,
-                             const typename CountsViewType::non_const_value_type sizeOfValue,
-                             const typename CountsViewType::non_const_value_type sizeOfGblColInd)
+                             const typename CountsViewType::non_const_value_type sizeOfGblColInd,
+                             const typename CountsViewType::non_const_value_type sizeOfPid,
+                             const typename CountsViewType::non_const_value_type sizeOfValue)
 {
   typedef NumPacketsAndOffsetsFunctor<OutputOffsetsViewType,
     CountsViewType, typename InputOffsetsViewType::const_type,
-    typename InputLocalRowIndicesViewType::const_type> functor_type;
+    typename InputLocalRowIndicesViewType::const_type,
+    typename InputLocalRowPidsViewType::const_type> functor_type;
   typedef typename CountsViewType::non_const_value_type count_type;
   typedef typename OutputOffsetsViewType::size_type size_type;
   typedef typename OutputOffsetsViewType::execution_space execution_space;
@@ -248,39 +291,33 @@ computeNumPacketsAndOffsets (std::unique_ptr<std::ostringstream>& errStr,
   typedef Kokkos::RangePolicy<execution_space, LO> range_type;
   const char prefix[] = "computeNumPacketsAndOffsets: ";
 
+
+  count_type count = 0;
   const count_type numRowsToPack = lclRowInds.dimension_0 ();
+
   if (numRowsToPack == 0) {
-    return {static_cast<count_type> (0), true}; // nothing to pack, but no error
+    return count;
   }
   else {
-    if (rowOffsets.dimension_0 () <= static_cast<size_type> (1)) {
-      if (errStr.get () == NULL) {
-        errStr = std::unique_ptr<std::ostringstream> (new std::ostringstream ());
-      }
-      std::ostringstream& os = *errStr;
-      os << prefix
-         << "There is at least one row to pack, but the matrix has no rows.  "
-        "lclRowInds.dimension_0() = " << numRowsToPack << ", but "
-        "rowOffsets.dimension_0() = " << rowOffsets.dimension_0 () << " <= 1."
-         << std::endl;
-      return {static_cast<count_type> (0), false};
-    }
-    if (outputOffsets.dimension_0 () != static_cast<size_type> (numRowsToPack + 1)) {
-      if (errStr.get () == NULL) {
-        errStr = std::unique_ptr<std::ostringstream> (new std::ostringstream ());
-      }
-      std::ostringstream& os = *errStr;
-      os << prefix
-         << "Output dimension does not match number of rows to pack.  "
-         << "outputOffsets.dimension_0() = " << outputOffsets.dimension_0 ()
-         << " != lclRowInds.dimension_0() + 1 = "
-         << static_cast<size_type> (numRowsToPack + 1) << "." << std::endl;
-      return {static_cast<count_type> (0), false};
-    }
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+        rowOffsets.dimension_0() <= static_cast<size_type>(1),
+        std::invalid_argument,
+        prefix << "There is at least one row to pack, but the matrix has no rows.  "
+        << "lclRowInds.dimension_0() = " << numRowsToPack << ", but "
+        << "rowOffsets.dimension_0() = " << rowOffsets.dimension_0 () << " <= 1.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+        outputOffsets.dimension_0() != static_cast<size_type> (numRowsToPack + 1),
+        std::invalid_argument,
+        prefix << "Output dimension does not match number of rows to pack.  "
+        << "outputOffsets.dimension_0() = " << outputOffsets.dimension_0 ()
+        << " != lclRowInds.dimension_0() + 1 = "
+        << static_cast<size_type> (numRowsToPack + 1) << ".");
 
     functor_type f (outputOffsets, counts, rowOffsets,
-                    lclRowInds, sizeOfLclCount,
-                    sizeOfValue, sizeOfGblColInd);
+                    lclRowInds, lclRowPids, sizeOfLclCount,
+                    sizeOfGblColInd, sizeOfPid, sizeOfValue);
 #ifdef HAVE_TPETRA_DEBUG
     TEUCHOS_TEST_FOR_EXCEPT(static_cast<size_t> (outputOffsets.dimension_0 ()) !=
                             static_cast<size_t> (numRowsToPack + 1));
@@ -294,16 +331,9 @@ computeNumPacketsAndOffsets (std::unique_ptr<std::ostringstream>& errStr,
 
     // At least in debug mode, this functor checks for errors.
     const int errCode = f.getError ();
-    if (errCode != 0) {
-      if (errStr.get () == NULL) {
-        errStr = std::unique_ptr<std::ostringstream> (new std::ostringstream ());
-      }
-      std::ostringstream& os = *errStr;
-      os << prefix
-         << "NumPacketsAndOffsetsFunctor reported error code " << errCode
-         << " != 0." << std::endl;
-      return {0, false};
-    }
+    TEUCHOS_TEST_FOR_EXCEPTION(errCode != 0, std::runtime_error,
+        prefix << "NumPacketsAndOffsetsFunctor reported error code " << errCode
+        << " != 0.");
 
 #if 0
     size_t total = 0;
@@ -344,7 +374,8 @@ computeNumPacketsAndOffsets (std::unique_ptr<std::ostringstream>& errStr,
              << outputOffsets(numRowsToPack-1) << "." << std::endl;
         }
       }
-      return {outputOffsets(numRowsToPack), false};
+      count = outputOffsets(numRowsToPack);
+      return {false, errStr};
     }
 #endif // HAVE_TPETRA_DEBUG
 
@@ -352,122 +383,194 @@ computeNumPacketsAndOffsets (std::unique_ptr<std::ostringstream>& errStr,
     // of counts.  Don't assume UVM.
     auto outputOffsets_last = Kokkos::subview (outputOffsets, numRowsToPack);
     auto outputOffsets_last_h = Kokkos::create_mirror_view (outputOffsets_last);
-    return {static_cast<count_type> (outputOffsets_last_h ()), true};
+
+    return static_cast<count_type>(outputOffsets_last_h());
   }
 }
 
-/// \brief Reduction result for PackCrsMatrixFunctor below.
+/// \brief Packs a single row of the CrsMatrix.
 ///
-/// The reduction result finds the offset and number of bytes associated with
-/// the first out of bounds error or packing error occurs.
-template<class LO>
-struct PackCrsMatrixError {
+/// \tparam ST The type of the numerical entries of the matrix.
+///   (You can use real-valued or complex-valued types here, unlike
+///   in Epetra, where the scalar type is always \c double.)
+/// \tparam ColumnMap the type of the local column map
+///
+/// Data (bytes) describing the row of the CRS matrix are "packed"
+/// (concatenated) in to a single (view of) char* in the following order:
+///
+///   1. LO number of entries
+///   2. GO column indices
+///   3. int proces IDs
+///   4. SC values
+///
+template<class ST, class ColumnMap>
+KOKKOS_FUNCTION
+Kokkos::pair<int, size_t>
+packCrsMatrixRow(const ColumnMap& col_map,
+                 const typename PackTraits<typename ColumnMap::local_ordinal_type, typename ColumnMap::device_type>::output_buffer_type& exports,
+                 const typename PackTraits<typename ColumnMap::local_ordinal_type, typename ColumnMap::device_type>::input_array_type& lids_in,
+                 const typename PackTraits<int, typename ColumnMap::device_type>::input_array_type& pids_in,
+                 const typename PackTraits<ST, typename ColumnMap::device_type>::input_array_type& vals_in,
+                 const size_t offset,
+                 const size_t num_ent,
+                 const size_t num_bytes_per_value)
+{
+    using Kokkos::subview;
+    typedef typename ColumnMap::local_ordinal_type LO;
+    typedef typename ColumnMap::global_ordinal_type GO;
+    typedef typename ColumnMap::device_type DT;
+    typedef Kokkos::pair<int, size_t> return_type;
 
-  LO bad_index; // only valid if outOfBounds == true.
-  size_t bad_offset;   // only valid if outOfBounds == true.
-  size_t bad_num_bytes; // only valid if outOfBounds == true.
-  bool out_of_bounds_error;
-  bool packing_error;
+    // NOTE (mfh 02 Feb 2015) This assumes that output_buffer_type is
+    // the same, no matter what type we're packing.  It's a reasonable
+    // assumption, given that we go through the trouble of PackTraits
+    // just so that we can pack data of different types in the same
+    // buffer.
+    typedef typename PackTraits<LO, DT>::output_buffer_type output_buffer_type;
+    typedef typename output_buffer_type::size_type size_type;
+    typedef typename Kokkos::pair<size_type, size_type> pair_type;
 
-  KOKKOS_INLINE_FUNCTION PackCrsMatrixError () :
-    bad_index (Tpetra::Details::OrdinalTraits<LO>::invalid ()),
-    bad_offset (0),
-    bad_num_bytes (0),
-    out_of_bounds_error (false),
-    packing_error (false)
-  {}
+    if (num_ent == 0) {
+      // Empty rows always take zero bytes, to ensure sparsity.
+      return return_type(0, 0);
+    }
 
-  bool success() const
-  {
-    // Any possible error would result in bad_index being changed from
-    // `invalid` to the index associated with the error.
-    return bad_index == Tpetra::Details::OrdinalTraits<LO>::invalid();
-  }
+    const LO num_ent_LO = static_cast<LO>(num_ent); // packValueCount wants this
+    const size_t num_ent_beg = offset;
+    const size_t num_ent_len = PackTraits<LO, DT>::packValueCount(num_ent_LO);
 
-  std::string summary() const
-  {
-    std::ostringstream os;
-    os << "First bad index: " << bad_index
-       << ", first bad offset: " << bad_offset
-       << ", first bad number of bytes: " << bad_num_bytes
-       << ", out of bounds error?: " << (out_of_bounds_error ? "true" : "false");
-    return os.str();
-  }
-};
+    const GO gid = 0; // packValueCount wants this
+    const size_t gids_beg = num_ent_beg + num_ent_len;
+    const size_t gids_len = num_ent * PackTraits<GO, DT>::packValueCount(gid);
 
-template<class NumPacketsPerLidViewType,
-         class OffsetsViewType,
-         class ExportsViewType,
-         class ExportLidsViewType,
-         class LocalMatrixType,
-         class LocalMapType>
+    const bool pack_pids = pids_in.size() > 0;
+    const int pid = 0; // packValueCount wants this
+    const size_t pids_beg = gids_beg + gids_len;
+    const size_t pids_len = (pack_pids) ? num_ent * PackTraits<int, DT>::packValueCount(pid) : 0;
+
+    const size_t vals_beg = gids_beg + gids_len + pids_len;
+    const size_t vals_len = num_ent * num_bytes_per_value;
+
+    output_buffer_type num_ent_out =
+      subview(exports, pair_type(num_ent_beg, num_ent_beg + num_ent_len));
+    output_buffer_type gids_out =
+      subview(exports, pair_type(gids_beg, gids_beg + gids_len));
+    output_buffer_type pids_out;
+    if (pack_pids) {
+      pids_out = subview(exports, pair_type(pids_beg, pids_beg + pids_len));
+    }
+    output_buffer_type vals_out =
+      subview(exports, pair_type(vals_beg, vals_beg + vals_len));
+
+    size_t num_bytes_out = 0;
+    int error_code = 0;
+    num_bytes_out += PackTraits<LO, DT>::packValue(num_ent_out, num_ent_LO);
+
+    {
+      // Copy column indices one at a time, so that we don't need
+      // temporary storage.
+      for (size_t k=0; k<num_ent; k++) {
+        GO gid = col_map.getGlobalElement(lids_in[k]);
+        num_bytes_out += PackTraits<GO,DT>::packValue(gids_out, k, gid);
+      }
+
+      // Copy PIDs one at a time, so that we don't need temporary storage.
+      if (pack_pids) {
+        for (size_t k=0; k<num_ent; k++) {
+          int pid = pids_in[lids_in[k]];
+          num_bytes_out += PackTraits<int,DT>::packValue(pids_out, k, pid);
+        }
+      }
+
+      // Copy the values
+      auto p = PackTraits<ST, DT>::packArray(vals_out, vals_in, num_ent);
+      error_code += p.first;
+      num_bytes_out += p.second;
+    }
+
+    if (error_code != 0) {
+      return return_type(10, num_bytes_out);
+    }
+
+    const size_t expected_num_bytes = num_ent_len + gids_len + pids_len + vals_len;
+    if (num_bytes_out != expected_num_bytes) {
+      return return_type(11, num_bytes_out);
+    }
+    return return_type(0, num_bytes_out);
+}
+
+template<class LocalMatrix, class LocalMap>
 struct PackCrsMatrixFunctor {
-  typedef NumPacketsPerLidViewType num_packets_per_lid_view_type;
-  typedef OffsetsViewType offsets_view_type;
-  typedef ExportsViewType exports_view_type;
-  typedef ExportLidsViewType export_lids_view_type;
+  typedef LocalMatrix local_matrix_type;
+  typedef LocalMap local_map_type;
+  typedef typename local_matrix_type::value_type ST;
+  typedef typename local_map_type::local_ordinal_type LO;
+  typedef typename local_map_type::global_ordinal_type GO;
+  typedef typename local_matrix_type::device_type DT;
+
+  typedef typename PackTraits<size_t,DT>::input_array_type num_packets_per_lid_view_type;
+  typedef typename PackTraits<size_t,DT>::input_array_type offsets_view_type;
+  typedef typename PackTraits<size_t,DT>::output_buffer_type exports_view_type;
+  typedef typename PackTraits<LO,DT>::input_array_type export_lids_view_type;
+  typedef typename PackTraits<int,DT>::input_array_type source_pids_view_type;
 
   typedef typename num_packets_per_lid_view_type::non_const_value_type count_type;
   typedef typename offsets_view_type::non_const_value_type offset_type;
-  typedef typename LocalMatrixType::value_type IST;
-  typedef typename LocalMatrixType::ordinal_type LO;
-  typedef typename LocalMapType::global_ordinal_type GO;
-  typedef PackCrsMatrixError<LO> value_type;
 
-  static_assert (std::is_same<LO, typename LocalMatrixType::ordinal_type>::value,
-                 "LocalMapType::local_ordinal_type and "
-                 "LocalMatrixType::ordinal_type must be the same.");
+  typedef Kokkos::pair<int, LO> value_type;
 
-  num_packets_per_lid_view_type num_packets_per_lid_;
-  offsets_view_type offsets_;
-  exports_view_type exports_;
-  export_lids_view_type export_lids_;
-  LocalMatrixType local_matrix_;
-  LocalMapType local_col_map_;
+  static_assert (std::is_same<LO, typename local_matrix_type::ordinal_type>::value,
+                 "local_map_type::local_ordinal_type and "
+                 "local_matrix_type::ordinal_type must be the same.");
 
-  PackCrsMatrixFunctor (const num_packets_per_lid_view_type& num_packets_per_lid,
-                        const offsets_view_type& offsets,
-                        const exports_view_type& exports,
-                        const export_lids_view_type& export_lids,
-                        const LocalMatrixType& local_matrix,
-                        const LocalMapType& local_col_map) :
-    num_packets_per_lid_ (num_packets_per_lid),
-    offsets_ (offsets),
-    exports_ (exports),
-    export_lids_ (export_lids),
-    local_matrix_ (local_matrix),
-    local_col_map_ (local_col_map)
+  LO InvalidIndex = OrdinalTraits<LO>::invalid();
+
+  local_matrix_type local_matrix;
+  local_map_type local_col_map;
+  exports_view_type exports;
+  num_packets_per_lid_view_type num_packets_per_lid;
+  export_lids_view_type export_lids;
+  source_pids_view_type source_pids;
+  offsets_view_type offsets;
+  size_t num_bytes_per_value;
+
+  PackCrsMatrixFunctor (const local_matrix_type& local_matrix_in,
+                        const local_map_type& local_col_map_in,
+                        const exports_view_type& exports_in,
+                        const num_packets_per_lid_view_type& num_packets_per_lid_in,
+                        const export_lids_view_type& export_lids_in,
+                        const source_pids_view_type& source_pids_in,
+                        const offsets_view_type& offsets_in, 
+                        const size_t num_bytes_per_value_in) :
+    local_matrix (local_matrix_in),
+    local_col_map (local_col_map_in),
+    exports (exports_in),
+    num_packets_per_lid (num_packets_per_lid_in),
+    export_lids (export_lids_in),
+    source_pids (source_pids_in),
+    offsets (offsets_in),
+    num_bytes_per_value (num_bytes_per_value_in)
   {}
 
   KOKKOS_INLINE_FUNCTION void init(value_type& dst) const
   {
-    dst.bad_index = Tpetra::Details::OrdinalTraits<LO>::invalid();
-    dst.bad_offset = 0;
-    dst.bad_num_bytes = 0;
-    dst.out_of_bounds_error = false;
-    dst.packing_error = false;
+    dst = Kokkos::make_pair(0, InvalidIndex);
   }
 
   KOKKOS_INLINE_FUNCTION void
   join (volatile value_type& dst, const volatile value_type& src) const
   {
-    // The dst object should reflect the first (least) bad index and
+    // `dst` should reflect the first (least) bad index and
     // all other associated error codes and data.  Thus, we need only
-    // check if the src object shows an error and if its associated
-    // `bad_index` is less than the dst.bad_index (if dst shows
-    // errors).
-    LO invalid = Tpetra::Details::OrdinalTraits<LO>::invalid();
-    if (src.bad_index != invalid) {
+    // check if the `src` object shows an error and if its associated
+    // bad index is less than `dst`'s bad index.
+    if (src.second != InvalidIndex) {
       // An error in the src; check if
-      //   1. The dst shows errors
-      //   2. If dst does show errors, if src bad_index is less than
-      //      its bad index
-      if (dst.bad_index == invalid || src.bad_index < dst.bad_index) {
-        dst.bad_index = src.bad_index;
-        dst.bad_offset = src.bad_offset;
-        dst.bad_num_bytes = src.bad_num_bytes;
-        dst.out_of_bounds_error = src.out_of_bounds_error;
-        dst.packing_error = src.packing_error;
+      //   1. `dst` shows errors
+      //   2. If `dst` does show errors, if src's bad index is less than
+      //      *this' bad index
+      if (dst.second == InvalidIndex || src.second < dst.second) {
+        dst = src;
       }
     }
   }
@@ -475,144 +578,274 @@ struct PackCrsMatrixFunctor {
   KOKKOS_INLINE_FUNCTION
   void operator() (const LO i, value_type& dst) const
   {
-    const LO export_lid = export_lids_[i];
-    const size_t buf_size = exports_.size();
+    using Kokkos::View;
+    typedef typename PackTraits<LO,DT>::output_buffer_type output_buffer_type;
+    typedef typename output_buffer_type::size_type size_type;
+    typedef typename Kokkos::pair<size_type, size_type> pair_type;
+
+    const size_t offset = offsets(i);
+    const LO export_lid = export_lids[i];
+    const size_t buf_size = exports.size();
+    const size_t num_bytes = num_packets_per_lid(i);
     const size_t num_ent =
-      static_cast<size_t> (local_matrix_.graph.row_map[export_lid+1]
-                           - local_matrix_.graph.row_map[export_lid]);
+      static_cast<size_t> (local_matrix.graph.row_map[export_lid+1]
+                         - local_matrix.graph.row_map[export_lid]);
 
     // Only pack this row's data if it has a nonzero number of
     // entries.  We can do this because receiving processes get the
     // number of packets, and will know that zero packets means zero
     // entries.
-    if (num_ent != 0) {
-      char* const num_ent_beg = exports_.ptr_on_device() + offsets_(i);
-      char* const num_ent_end = num_ent_beg + sizeof (LO);
-      char* const val_beg = num_ent_end;
-      char* const val_end = val_beg + num_ent * sizeof (IST);
-      char* const ind_beg = val_end;
-      const size_t num_bytes = num_packets_per_lid_(i);
+    if (num_ent == 0) {
+      return;
+    }
 
-      if ((offsets_(i) > buf_size || offsets_(i) + num_bytes > buf_size)) {
-        dst.out_of_bounds_error = true;
-      }
-      else {
-        dst.packing_error = ! packCrsMatrixRow(local_matrix_, local_col_map_,
-            num_ent_beg, val_beg, ind_beg, num_ent, export_lid);
-      }
-      if (dst.out_of_bounds_error || dst.packing_error) {
-        dst.bad_index = i;
-        dst.bad_offset = offsets_(i);
-        dst.bad_num_bytes = num_bytes;
-      }
+#ifdef HAVE_TPETRA_DEBUG
+    if (export_lid >= local_matrix.numRows() ||
+        (static_cast<size_t>(export_lid + 1) >=
+         static_cast<size_t>(local_matrix.graph.row_map.dimension_0())))
+#else // NOT HAVE_TPETRA_DEBUG
+    if (export_lid >= local_matrix.numRows ())
+#endif // HAVE_TPETRA_DEBUG
+    {
+      // Invalid row
+      dst = Kokkos::make_pair(1, i);
+      return;
+    }
+
+    if ((offset > buf_size || offset + num_bytes > buf_size)) {
+      // Out of bounds
+      dst = Kokkos::make_pair(2, i);
+      return;
+    }
+
+    // We can now pack this row
+
+    // Since the matrix is locally indexed on the calling process, we
+    // have to use its column Map (which it _must_ have in this case)
+    // to convert to global indices.
+    const size_type row_beg = local_matrix.graph.row_map[export_lid];
+    const size_type row_end = local_matrix.graph.row_map[export_lid + 1];
+
+    auto vals_in = subview(local_matrix.values, pair_type(row_beg, row_end));
+    auto lids_in = subview(local_matrix.graph.entries, pair_type(row_beg, row_end));
+
+    auto p = packCrsMatrixRow<ST,local_map_type>(local_col_map, exports,
+        lids_in, source_pids, vals_in, offset, num_ent, num_bytes_per_value);
+
+    int error_code_this_row = p.first;
+    size_t num_bytes_packed_this_row = p.second;
+    if (error_code_this_row != 0) {
+      // Bad pack
+      dst = Kokkos::make_pair(error_code_this_row, i);
+    } else if (num_bytes_packed_this_row != num_bytes) {
+      dst = Kokkos::make_pair(3, i);
     }
   }
 };
 
-/// \brief Packs a single row of the CrsMatrix.
+/// \brief Perform the pack operation for the matrix
 ///
-/// Data (bytes) describing the row of the CRS matrix are "packed"
-/// (concatenated) in to a single char* as
-///
-///   LO number of entries  |
-///   GO column indices      > -- number of entries | column indices | values --
-///   SC values             |
-///
-/// \tparam LocalMatrixType the specialization of the KokkosSparse::CrsMatrix
+/// \tparam LocalMatrix the specialization of the KokkosSparse::CrsMatrix
 ///   local matrix
-/// \tparam LocalMapType the type of the local column map
-template<class LocalMatrixType, class LocalMapType>
-KOKKOS_FUNCTION bool
-packCrsMatrixRow (const LocalMatrixType& lclMatrix,
-                  const LocalMapType& lclColMap,
-                  char* const numEntOut,
-                  char* const valOut,
-                  char* const indOut,
-                  const size_t numEnt, // number of entries in row
-                  const typename LocalMatrixType::ordinal_type lclRow)
+/// \tparam LocalMap the type of the local column map
+///
+/// This is a higher level interface to the PackCrsMatrixFunctor
+template<class LocalMatrix, class LocalMap>
+void
+do_pack(const LocalMatrix& local_matrix,
+        const LocalMap& local_map,
+        const typename PackTraits<size_t,typename LocalMatrix::device_type>::output_buffer_type& exports,
+        const typename PackTraits<size_t,typename LocalMatrix::device_type>::input_array_type& num_packets_per_lid,
+        const typename PackTraits<typename LocalMap::local_ordinal_type,typename LocalMatrix::device_type>::input_array_type& export_lids,
+        const typename PackTraits<int,typename LocalMatrix::device_type>::input_array_type& source_pids,
+        const typename PackTraits<size_t,typename LocalMatrix::device_type>::input_array_type& offsets,
+        const size_t num_bytes_per_value)
 {
-  using Kokkos::subview;
-  typedef LocalMatrixType local_matrix_type;
-  typedef LocalMapType local_map_type;
-  typedef typename local_matrix_type::value_type IST;
-  typedef typename local_matrix_type::ordinal_type LO;
-  typedef typename local_matrix_type::size_type offset_type;
-  typedef typename local_map_type::global_ordinal_type GO;
-  typedef Kokkos::pair<offset_type, offset_type> pair_type;
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename LocalMatrix::device_type DT;
+  typedef Kokkos::RangePolicy<typename DT::execution_space, LO> range_type;
 
-  const LO numEntLO = static_cast<LO> (numEnt);
-  // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
-  // function.  It does what one would expect.
-  memcpy (numEntOut, &numEntLO, sizeof (LO));
+  const char prefix[] = "Tpetra::Details::do_pack: ";
 
-  if (numEnt == 0) {
-    return true; // nothing more to pack
-  }
+  // Now do the actual pack!
+  typedef PackCrsMatrixFunctor<LocalMatrix, LocalMap> pack_functor_type;
+  pack_functor_type f(local_matrix, local_map, exports, num_packets_per_lid,
+      export_lids, source_pids, offsets, num_bytes_per_value);
 
-#ifdef HAVE_TPETRA_DEBUG
-  if (lclRow >= lclMatrix.numRows () ||
-      (static_cast<size_t> (lclRow + 1) >=
-       static_cast<size_t> (lclMatrix.graph.row_map.dimension_0 ()))) {
-#else // NOT HAVE_TPETRA_DEBUG
-  if (lclRow >= lclMatrix.numRows ()) {
-#endif // HAVE_TPETRA_DEBUG
-    // It's bad if this is not a valid local row index.  One thing
-    // we can do is just pack the flag invalid value for the column
-    // indices.  That makes sure that the receiving process knows
-    // something went wrong.
-    const GO flagInd = Tpetra::Details::OrdinalTraits<GO>::invalid ();
-    for (size_t k = 0; k < numEnt; ++k) {
-      // As of CUDA 6, it's totally fine to use memcpy in a CUDA
-      // device function.  It does what one would expect.
-      memcpy (indOut + k * sizeof (GO), &flagInd, sizeof (GO));
-    }
-    // The values don't actually matter, but we might as well pack
-    // something here.
-    const IST zero = Kokkos::ArithTraits<IST>::zero ();
-    for (size_t k = 0; k < numEnt; ++k) {
-      // As of CUDA 6, it's totally fine to use memcpy in a CUDA
-      // device function.  It does what one would expect.
-      memcpy (valOut + k * sizeof (IST), &zero, sizeof (IST));
-    }
-    return false;
-  }
+  typename pack_functor_type::value_type x;
+  Kokkos::parallel_reduce(range_type(0, num_packets_per_lid.dimension_0()), f, x);
+  auto x_h = x.to_std_pair();
+  TEUCHOS_TEST_FOR_EXCEPTION(x_h.first != 0, std::runtime_error,
+      prefix << "PackCrsMatrixFunctor reported error code "
+             << x_h.first << " for the first bad row " << x.second);
 
-  // Since the matrix is locally indexed on the calling process, we
-  // have to use its column Map (which it _must_ have in this case)
-  // to convert to global indices.
-  const offset_type rowBeg = lclMatrix.graph.row_map[lclRow];
-  const offset_type rowEnd = lclMatrix.graph.row_map[lclRow + 1];
-
-  auto indIn = subview (lclMatrix.graph.entries, pair_type (rowBeg, rowEnd));
-  auto valIn = subview (lclMatrix.values, pair_type (rowBeg, rowEnd));
-
-  // Copy column indices one at a time, so that we don't need
-  // temporary storage.
-  for (size_t k = 0; k < numEnt; ++k) {
-    const GO gblIndIn = lclColMap.getGlobalElement (indIn[k]);
-    // As of CUDA 6, it's totally fine to use memcpy in a CUDA
-    // device function.  It does what one would expect.
-    memcpy (indOut + k * sizeof (GO), &gblIndIn, sizeof (GO));
-  }
-  // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
-  // function.  It does what one would expect.
-  memcpy (valOut, valIn.ptr_on_device (), numEnt * sizeof (IST));
-  return true;
+  return;
 }
-
-
-
 
 /// \brief Pack specified entries of the given local sparse matrix for
 ///   communication.
 ///
+/// \tparam ST The type of the numerical entries of the matrix.
+///   (You can use real-valued or complex-valued types here, unlike
+///   in Epetra, where the scalar type is always \c double.)
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
 /// \warning This is an implementation detail of Tpetra::CrsMatrix.
 ///
-/// \param errStr [in/out] If an error occurs on any participating
-///   process, allocate this if it is null, then fill the string with
-///   local error reporting.  This is purely local to the process that
-///   reports the error.  The caller is responsible for synchronizing
-///   across processes.
+/// \param sourceMatrix [in] the CrsMatrix source
+///
+/// \param exports [in/out] Output pack buffer; resized if needed.
+///
+/// \param num_packets_per_lid [out] Entry k gives the number of bytes
+///   packed for row export_lids[k] of the local matrix.
+///
+/// \param export_lids [in] Local indices of the rows to pack.
+///
+/// \param export_pids [in] Process IDs for each row
+///
+/// \param constant_num_packets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+template<typename ST, typename LO, typename GO, typename NT>
+void
+packCrsMatrixImpl(const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
+                  Kokkos::DualView<char*, typename NT::device_type>& exports,
+                  const Kokkos::View<size_t*, typename NT::device_type>& num_packets_per_lid,
+                  const Kokkos::View<const LO*, typename NT::device_type>& export_lids,
+                  const Kokkos::View<const int*, typename NT::device_type>& export_pids,
+                  size_t& constant_num_packets,
+                  Distributor& /* dist */)
+{
+
+  using Kokkos::View;
+
+  typedef typename NT::device_type DT;
+  typedef typename DT::execution_space execution_space;
+  typedef typename Kokkos::DualView<char*, DT> exports_view_type;
+  typedef typename exports_view_type::t_dev::memory_space dev_memory_space;
+
+  const char prefix[] = "Tpetra::Details::packCrsMatrixImpl: ";
+
+  auto local_matrix = sourceMatrix.getLocalMatrix();
+  auto local_col_map = sourceMatrix.getColMap()->getLocalMap();
+
+  // Setting this to zero tells the caller to expect a possibly
+  // different ("nonconstant") number of packets per local index
+  // (i.e., a possibly different number of entries per row).
+  constant_num_packets = 0;
+
+  const size_t num_export_lids = static_cast<size_t>(export_lids.dimension_0());
+  if (num_export_lids != static_cast<size_t>(num_packets_per_lid.dimension_0())) {
+    std::ostringstream os;
+    TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        prefix << "num_export_lids.dimension_0() = " << num_export_lids
+               << " != num_packets_per_lid.dimension_0() = " << num_packets_per_lid.dimension_0()
+               << ".");
+  }
+
+  if (num_export_lids != 0 && num_packets_per_lid.ptr_on_device() == NULL) {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        prefix << "num_export_lids = " << num_export_lids << " != 0, but "
+               << "num_packets_per_lid.ptr_on_device() = " << num_packets_per_lid.ptr_on_device()
+               << " != NULL.");
+  }
+
+  LO lid = 0;
+  const size_t num_bytes_per_lid = PackTraits<LO,DT>::packValueCount(lid);
+
+  GO gid = 0;
+  const size_t num_bytes_per_gid = PackTraits<GO,DT>::packValueCount(gid);
+
+  int pid = 0;
+  const size_t num_bytes_per_pid = PackTraits<int,DT>::packValueCount(pid);
+
+  size_t num_bytes_per_value = 0;
+  if (PackTraits<ST,DT>::compileTimeSize) {
+    ST val; // assume that ST is default constructible
+    num_bytes_per_value = PackTraits<ST,DT>::packValueCount(val);
+  }
+  else {
+    // Since the packed data come from the source matrix, we can use the source
+    // matrix to get the number of bytes per Scalar value stored in the matrix.
+    // This assumes that all Scalar values in the source matrix require the same
+    // number of bytes.  If the source matrix has no entries on the calling
+    // process, then we hope that some process does have some idea how big
+    // a Scalar value is.  Of course, if no processes have any entries, then no
+    // values should be packed (though this does assume that in our packing
+    // scheme, rows with zero entries take zero bytes).
+    size_t num_bytes_per_value_l = 0;
+    if (local_matrix.values.dimension_0() > 0) {
+      const ST& val = local_matrix.values(0);
+      num_bytes_per_value_l = PackTraits<ST,DT>::packValueCount(val);
+    }
+    Teuchos::reduceAll<int, size_t>(*(sourceMatrix.getComm()),
+                                    Teuchos::REDUCE_MAX,
+                                    num_bytes_per_value_l,
+                                    Teuchos::outArg(num_bytes_per_value));
+  }
+
+  if (num_export_lids == 0) {
+    // FIXME (26 Apr 2016) Fences around (UVM) allocations only
+    // temporarily needed for #227 debugging.  Should be able to
+    // remove them after that's fixed.
+    execution_space::fence ();
+    exports = Kokkos::DualView<char*, DT>("exports", 0);
+    execution_space::fence ();
+    return;
+  }
+
+  // Array of offsets into the pack buffer.
+  Kokkos::View<size_t*, DT> offsets("offsets", num_export_lids + 1);
+
+  // Compute number of packets per LID (row to send), as well as
+  // corresponding offsets (the prefix sum of the packet counts).
+  size_t count =
+    computeNumPacketsAndOffsets (offsets, num_packets_per_lid,
+                                 local_matrix.graph.row_map, export_lids, export_pids,
+                                 num_bytes_per_lid, num_bytes_per_gid,
+                                 num_bytes_per_pid, num_bytes_per_value);
+
+  // Resize the output pack buffer if needed.
+  if (count > static_cast<size_t>(exports.dimension_0())) {
+    // FIXME (26 Apr 2016) Fences around (UVM) allocations only
+    // temporarily needed for #227 debugging.  Should be able to
+    // remove them after that's fixed.
+    execution_space::fence ();
+    exports = Kokkos::DualView<char*, DT>("exports", count);
+    execution_space::fence ();
+  }
+
+  exports.template modify<dev_memory_space>();
+
+  do_pack(local_matrix, local_col_map,
+          exports.template view<dev_memory_space>(), num_packets_per_lid,
+          export_lids, export_pids, offsets, num_bytes_per_value);
+
+  // If we got this far, we succeeded. Copy pack result back to host, if needed.
+  exports.template sync<Kokkos::HostSpace>();
+
+  return;
+}
+
+/// \brief Pack specified entries of the given local sparse matrix for
+///   communication.
+///
+/// \tparam ST The type of the numerical entries of the matrix.
+///   (You can use real-valued or complex-valued types here, unlike
+///   in Epetra, where the scalar type is always \c double.)
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceMatrix [in] the CrsMatrix source
 ///
 /// \param exports [in/out] Output pack buffer; resized if needed.
 ///
@@ -621,169 +854,155 @@ packCrsMatrixRow (const LocalMatrixType& lclMatrix,
 ///
 /// \param exportLIDs [in] Local indices of the rows to pack.
 ///
-/// \param lclMatrix [in] The local sparse matrix to pack.
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
 ///
-/// \return true if no errors occurred on the calling process, else
-///   false.  This is purely local to the process that discovered the
-///   error.  The caller is responsible for synchronizing across
-///   processes.
-template<class LocalMatrixType, class LocalMapType>
-bool
-packCrsMatrix (const LocalMatrixType& lclMatrix,
-               const LocalMapType& lclColMap,
-               std::unique_ptr<std::string>& errStr,
+/// \param distor [in] The distributor (not used)
+///
+/// This is the public interface to the pack machinery
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsMatrix migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<typename ST, typename LO, typename GO, typename NT>
+void
+packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                Teuchos::Array<char>& exports,
                const Teuchos::ArrayView<size_t>& numPacketsPerLID,
+               const Teuchos::ArrayView<const LO>& exportLIDs,
                size_t& constantNumPackets,
-               const Teuchos::ArrayView<const typename LocalMatrixType::ordinal_type>& exportLIDs,
-               const int myRank,
-               Distributor& /* dist */)
+               Distributor& distor)
 {
-  using Kokkos::View;
-  using Kokkos::HostSpace;
-  using Kokkos::MemoryUnmanaged;
-  using ::Tpetra::Details::computeOffsetsFromCounts;
-  typedef typename LocalMapType::local_ordinal_type LO;
-  typedef typename LocalMapType::global_ordinal_type GO;
-  typedef typename LocalMatrixType::value_type IST;
-  typedef typename LocalMatrixType::device_type device_type;
-  typedef typename device_type::execution_space execution_space;
-  typedef typename Kokkos::RangePolicy<execution_space, LO> range_type;
-  const char prefix[] = "Tpetra::Details::packCrsMatrix: ";
+  typedef typename CrsMatrix<ST,LO,GO,NT>::local_matrix_type local_matrix_type;
+  typedef typename local_matrix_type::device_type device_type;
+  typename local_matrix_type::device_type outputDevice;
 
-  static_assert (std::is_same<LO, typename LocalMatrixType::ordinal_type>::value,
-                 "LocalMapType::local_ordinal_type and "
-                 "LocalMatrixType::ordinal_type must be the same.");
-  // Setting this to zero tells the caller to expect a possibly
-  // different ("nonconstant") number of packets per local index
-  // (i.e., a possibly different number of entries per row).
-  constantNumPackets = 0;
+  // Convert all Teuchos::Array to Kokkos::View
 
-  const size_t numExportLIDs = static_cast<size_t> (exportLIDs.size ());
-  if (numExportLIDs != static_cast<size_t> (numPacketsPerLID.size ())) {
-    std::ostringstream os;
-    os << prefix << "exportLIDs.size() = " << numExportLIDs
-       << " != numPacketsPerLID.size() = " << numPacketsPerLID.size ()
-       << "." << std::endl;
-    if (errStr.get () == NULL) {
-      errStr = std::unique_ptr<std::string> (new std::string (os.str ()));
-    }
-    else {
-      *errStr = *errStr + os.str ();
-    }
-    return false;
-  }
-  if (numExportLIDs != 0 && numPacketsPerLID.getRawPtr () == NULL) {
-    std::ostringstream os;
-    os << prefix << "numExportLIDs = " << numExportLIDs << " != 0, but "
-       << "numPacketsPerLID.getRawPtr() = " << numPacketsPerLID.getRawPtr ()
-       << " != NULL." << std::endl;
-    if (errStr.get () == NULL) {
-      errStr = std::unique_ptr<std::string> (new std::string (os.str ()));
-    }
-    else {
-      *errStr = *errStr + os.str ();
-    }
-    return false;
-  }
-
-  if (numExportLIDs == 0) {
-    exports.resize (0);
-    return true; // nothing to pack
-  }
-
-  typename LocalMatrixType::device_type outputDevice;
-  using Tpetra::Details::create_mirror_view_from_raw_host_array;
   // This is an output array, so we don't have to copy to device here.
   // However, we'll have to remember to copy back to host when done.
-  auto numPktPerLid_d =
-    create_mirror_view_from_raw_host_array (outputDevice,
-                                            numPacketsPerLID.getRawPtr (),
-                                            numPacketsPerLID.size (),
-                                            false,
-                                            "numPktPerLid");
+  auto num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array(outputDevice, numPacketsPerLID.getRawPtr(),
+                                           numPacketsPerLID.size(), false,
+                                           "num_packets_per_lid");
+
   // This is an input array, so we have to copy to device here.
   // However, we never need to copy it back to host.
-  auto packLids_d =
-    create_mirror_view_from_raw_host_array (outputDevice,
-                                            exportLIDs.getRawPtr (),
-                                            exportLIDs.size (),
-                                            true,
-                                            "packLids");
-  // Array of offsets into the pack buffer.
-  Kokkos::View<size_t*, device_type> packOffsets_d ("packOffsets",
-                                                    numExportLIDs + 1);
-  // Compute number of packets per LID (row to send), as well as
-  // corresponding offsets (the prefix sum of the packet counts).
-  std::unique_ptr<std::ostringstream> errStrm;
-  std::pair<size_t, bool> countResult =
-    computeNumPacketsAndOffsets (errStrm,
-                                 packOffsets_d,
-                                 numPktPerLid_d,
-                                 lclMatrix.graph.row_map,
-                                 packLids_d,
-                                 sizeof (LO),
-                                 sizeof (IST),
-                                 sizeof (GO));
+  auto export_lids_d =
+    create_mirror_view_from_raw_host_array(outputDevice, exportLIDs.getRawPtr(),
+                                           exportLIDs.size(), true,
+                                           "export_lids");
 
-  if (! countResult.second) {
-    if (errStr.get () == NULL) {
-      errStr = std::unique_ptr<std::string> (new std::string (errStrm->str ()));
-    }
-    else {
-      *errStr = *errStr + errStrm->str ();
-    }
-    return false;
-  }
+  // Create an empty array of PIDs
+  Kokkos::View<int*, device_type> export_pids_d("export_pids", 0);
 
-  // The counts were an output of computeNumPacketsAndOffsets, so we
+  // Dual view of Exports
+  typedef typename Kokkos::DualView<char*, device_type> exports_view_type;
+  typedef typename exports_view_type::t_dev::memory_space dev_memory_space;
+  Kokkos::DualView<char*, device_type> exports_dv("exports", 0);
+
+  packCrsMatrixImpl<ST,LO,GO,NT>(sourceMatrix, exports_dv,
+                                 num_packets_per_lid_d,
+                                 export_lids_d, export_pids_d,
+                                 constantNumPackets, distor);
+
+  // The counts are an output of packCrsMatrixImpl, so we
   // have to copy them back to host.
-  typename decltype (numPktPerLid_d)::HostMirror numPktPerLid_h (numPacketsPerLID.getRawPtr (),
-                                                                 numPacketsPerLID.size ());
-  Kokkos::deep_copy (numPktPerLid_h, numPktPerLid_d);
+  typename decltype(num_packets_per_lid_d)::HostMirror num_packets_per_lid_h(
+      numPacketsPerLID.getRawPtr(), numPacketsPerLID.size());
+  Kokkos::deep_copy(num_packets_per_lid_h, num_packets_per_lid_d);
 
-  // Resize the output pack buffer if needed.
-  if (countResult.first > static_cast<size_t> (exports.size ())) {
-    exports.resize (countResult.first);
-  }
-  // Make device version of output pack buffer.  This is an output
-  // array, so we don't have to copy to device here.
-  auto packBuf_d =
-    create_mirror_view_from_raw_host_array (outputDevice,
-                                            exports.getRawPtr (),
-                                            countResult.first,
-                                            false,
-                                            "packBuf");
-  // Now do the actual pack!
-  typedef PackCrsMatrixFunctor<
-    decltype (numPktPerLid_d),
-    decltype (packOffsets_d),
-    decltype (packBuf_d),
-    decltype (packLids_d),
-    LocalMatrixType,
-    LocalMapType> pack_functor_type;
-  pack_functor_type packer (numPktPerLid_d, packOffsets_d, packBuf_d,
-                            packLids_d, lclMatrix, lclColMap);
-  typename pack_functor_type::value_type result;
-  Kokkos::parallel_reduce (range_type (0, numExportLIDs), packer, result);
+  // The exports are an output of packCrsMatrixImpl, so we
+  // have to copy them back to host.
+  auto exports_d = exports_dv.template view<dev_memory_space>();
+  exports.resize(exports_d.dimension_0());
+  typename decltype(exports_d)::HostMirror exports_h(
+      exports.getRawPtr(), exports.size());
+  Kokkos::deep_copy(exports_h, exports_d);
 
-  if (! result.success ()) {
-    std::ostringstream os;
-    os << "Proc " << myRank << ": packCrsMatrix failed.  "
-       << result.summary()
-       << std::endl;
-    if (errStr.get () != NULL) {
-      errStr = std::unique_ptr<std::string> (new std::string ());
-      *errStr = os.str ();
-    }
-    return false;
-  }
+}
 
-  // Copy pack result back to host, if needed.
-  typename decltype (packBuf_d)::HostMirror packBuf_h (exports.getRawPtr (),
-                                                       countResult.first);
-  Kokkos::deep_copy (packBuf_h, packBuf_d);
-  return true; // if we got this far, we succeeded
+/// \brief Pack specified entries of the given local sparse matrix for
+///   communication.
+///
+/// \tparam ST The type of the numerical entries of the matrix.
+///   (You can use real-valued or complex-valued types here, unlike
+///   in Epetra, where the scalar type is always \c double.)
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceMatrix [in] the CrsMatrix source
+///
+/// \param exports [in/out] Output pack buffer; resized if needed.
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local matrix.
+///
+/// \param exportLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// This is the public interface to the pack machinery
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsMatrix migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<typename ST, typename LO, typename GO, typename NT>
+void
+packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
+                             Kokkos::DualView<char*, typename NT::device_type>& exports_dv,
+                             const Teuchos::ArrayView<size_t>& numPacketsPerLID,
+                             const Teuchos::ArrayView<const LO>& exportLIDs,
+                             const Teuchos::ArrayView<const int>& sourcePIDs,
+                             size_t& constantNumPackets,
+                             Distributor &distor)
+{
+  typedef typename CrsMatrix<ST,LO,GO,NT>::local_matrix_type local_matrix_type;
+  typename local_matrix_type::device_type outputDevice;
+
+  // Convert all Teuchos::Array to Kokkos::View
+
+  // This is an output array, so we don't have to copy to device here.
+  // However, we'll have to remember to copy back to host when done.
+  auto num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array(outputDevice, numPacketsPerLID.getRawPtr(),
+                                           numPacketsPerLID.size(), false,
+                                           "num_packets_per_lid");
+
+  // This is an input array, so we have to copy to device here.
+  // However, we never need to copy it back to host.
+  auto export_lids_d =
+    create_mirror_view_from_raw_host_array(outputDevice, exportLIDs.getRawPtr(),
+                                           exportLIDs.size(), true,
+                                           "export_lids");
+
+  // This is an input array, so we have to copy to device here.
+  // However, we never need to copy it back to host.
+  auto export_pids_d =
+    create_mirror_view_from_raw_host_array(outputDevice, sourcePIDs.getRawPtr(),
+                                           sourcePIDs.size(), true,
+                                           "export_pids");
+
+  packCrsMatrixImpl<ST,LO,GO,NT>(sourceMatrix, exports_dv,
+                                 num_packets_per_lid_d,
+                                 export_lids_d, export_pids_d,
+                                 constantNumPackets, distor);
+
+  // The counts are an output of packCrsMatrixImpl, so we
+  // have to copy them back to host.
+  typename decltype(num_packets_per_lid_d)::HostMirror num_packets_per_lid_h(
+      numPacketsPerLID.getRawPtr(), numPacketsPerLID.size());
+  Kokkos::deep_copy(num_packets_per_lid_h, num_packets_per_lid_d);
+
 }
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrix.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrix.hpp
@@ -45,6 +45,7 @@
 #include "TpetraCore_config.h"
 #include "Teuchos_Array.hpp"
 #include "Teuchos_ArrayView.hpp"
+#include "Tpetra_Details_PackTraits.hpp"
 #include "Tpetra_Details_OrdinalTraits.hpp"
 #include "Tpetra_Details_computeOffsets.hpp"
 #include "Kokkos_Core.hpp"
@@ -59,6 +60,18 @@
 /// \warning This file, and its contents, are implementation details
 ///   of Tpetra.  The file itself or its contents may disappear or
 ///   change at any time.
+///
+/// Data (bytes) describing the row of the CRS matrix are "packed"
+/// (concatenated) in to a (view of) char* object in the following order:
+///
+///   1. number of entries (LocalOrdinal)
+///   2. global column indices (GlobalOrdinal)
+///   3. proces IDs (optional, int)
+///   4. row values (Scalar)
+///
+/// The functions in this file are companions to
+/// Tpetra_Details_packCrsMatrix.hpp, i.e., Tpetra_Details_packCrsMatrix.hpp
+/// implements the packing order described above to ensure proper unpacking.
 
 namespace Tpetra {
 
@@ -72,176 +85,207 @@ class Distributor;
 //
 namespace Details {
 
-/// \brief Reduction result for UnpackCrsMatrixAndCombineFunctor below.
+/// \brief Unpack a single row of a CrsMatrix
 ///
-/// The reduction result finds the offset and number of bytes associated with
-/// the first out of bounds error or unpacking error occurs.
-template<class LO>
-struct UnpackCrsMatrixError {
+/// \tparam ST The type of the numerical entries of the matrix.
+///   (You can use real-valued or complex-valued types here, unlike
+///   in Epetra, where the scalar type is always \c double.)
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Device The Kokkos Device type.  See the documentation of Map
+///   for requirements.
+template<class ST, class LO, class GO, class Device>
+KOKKOS_FUNCTION int
+unpack_crs_matrix_row(typename PackTraits<GO, Device>::output_array_type& gids_out,
+                      typename PackTraits<int, Device>::output_array_type& pids_out,
+                      typename PackTraits<ST, Device>::output_array_type& vals_out,
+                      const typename PackTraits<LO, Device>::input_buffer_type& imports,
+                      const size_t offset, const size_t num_bytes, const size_t num_ent,
+                      size_t num_bytes_per_value=0)
+{
+  using Kokkos::subview;
 
-  LO bad_index; // only valid if outOfBounds == true.
-  size_t num_ent;
-  size_t offset;   // only valid if outOfBounds == true.
-  size_t expected_num_bytes;
-  size_t num_bytes; // only valid if outOfBounds == true.
-  size_t buf_size;
-  bool wrong_num_bytes_error;
-  bool out_of_bounds_error;
-  bool invalid_combine_mode_error;
+  // NOTE (mfh 02 Feb 2015) This assumes that output_buffer_type is
+  // the same, no matter what type we're packing.  It's a reasonable
+  // assumption, given that we go through the trouble of PackTraits
+  // just so that we can pack data of different types in the same
+  // buffer.
+  typedef typename PackTraits<LO, Device>::input_buffer_type input_buffer_type;
+  typedef typename input_buffer_type::size_type size_type;
+  typedef typename Kokkos::pair<size_type, size_type> slice;
 
-  KOKKOS_INLINE_FUNCTION UnpackCrsMatrixError():
-    bad_index(Tpetra::Details::OrdinalTraits<LO>::invalid()),
-    num_ent(0),
-    offset(0),
-    expected_num_bytes(0),
-    num_bytes(0),
-    buf_size(0),
-    wrong_num_bytes_error(false),
-    out_of_bounds_error(false),
-    invalid_combine_mode_error(false) {}
+  if (num_ent == 0) {
+    // Empty rows always take zero bytes, to ensure sparsity.
+    return 0;
+  }
+  bool unpack_pids = pids_out.size() > 0;
 
-  bool success() const
-  {
-    // Any possible error would result in bad_index being changed from
-    // `invalid` to the index associated with the error.
-    return bad_index == Tpetra::Details::OrdinalTraits<LO>::invalid();
+  const LO num_ent_LO = static_cast<LO>(num_ent); // packValueCount wants this
+  const size_t num_ent_beg = offset;
+  const size_t num_ent_len = PackTraits<LO, Device>::packValueCount(num_ent_LO);
+
+  const GO gid = 0; // packValueCount wants this
+  const size_t gids_beg = num_ent_beg + num_ent_len;
+  const size_t gids_len = num_ent * PackTraits<GO, Device>::packValueCount(gid);
+
+  const int pid = 0; // packValueCount wants this
+  const size_t pids_beg = gids_beg + gids_len;
+  const size_t pids_len = (unpack_pids) ? num_ent * PackTraits<int, Device>::packValueCount(pid) : 0;
+
+  if (num_bytes_per_value == 0) {
+    ST val; // packValueCount wants this
+    num_bytes_per_value = PackTraits<ST, Device>::packValueCount(val);
+  }
+  const size_t vals_beg = gids_beg + gids_len + pids_len;
+  const size_t vals_len = num_ent * num_bytes_per_value;
+
+  input_buffer_type num_ent_in =
+    subview(imports, slice(num_ent_beg, num_ent_beg + num_ent_len));
+  input_buffer_type gids_in =
+    subview(imports, slice(gids_beg, gids_beg + gids_len));
+  input_buffer_type pids_in;
+  if (unpack_pids) {
+    pids_in = subview(imports, slice(pids_beg, pids_beg + pids_len));
+  }
+  input_buffer_type vals_in =
+    subview(imports, slice(vals_beg, vals_beg + vals_len));
+
+  size_t num_bytes_out = 0;
+
+  LO num_ent_out;
+  num_bytes_out += PackTraits<LO, Device>::unpackValue(num_ent_out, num_ent_in);
+
+  if (static_cast<size_t>(num_ent_out) != num_ent) {
+    return 20;
   }
 
-  std::string summary() const
   {
-    std::ostringstream os;
-    if (wrong_num_bytes_error ||
-        out_of_bounds_error ||
-        invalid_combine_mode_error) {
-      if (wrong_num_bytes_error) {
-        os << "At index i = " << bad_index
-           << ", expectedNumBytes > numBytes.";
-      }
-      else if (out_of_bounds_error) {
-        os << "First invalid offset into 'imports' "
-           << "unpack buffer at index i = " << bad_index << ".";
-      }
-      else if (invalid_combine_mode_error) {
-        os << "Invalid combine mode; code should never get "
-              "here!  Please report this bug to the Tpetra developers.";
-      }
-      os << "  importLIDs[i]: " << bad_index
-         << ", bufSize: " << buf_size
-         << ", offset: " << offset
-         << ", numBytes: " << num_bytes
-         << ", expectedNumBytes: " << expected_num_bytes
-         << ", numEnt: " << num_ent;
+    Kokkos::pair<int, size_t> p;
+    p = PackTraits<GO, Device>::unpackArray(gids_out, gids_in, num_ent);
+    if (p.first != 0) return 21;
+    num_bytes_out += p.second;
+
+    if (unpack_pids) {
+      p = PackTraits<int, Device>::unpackArray(pids_out, pids_in, num_ent);
+      if (p.first != 0) return 22;
+      num_bytes_out += p.second;
     }
-    return os.str();
-  }
-};
 
+    p = PackTraits<ST, Device>::unpackArray(vals_out, vals_in, num_ent);
+    if (p.first != 0) return 23;
+    num_bytes_out += p.second;
+  }
+
+  const size_t expected_num_bytes = num_ent_len + gids_len + pids_len + vals_len;
+
+  if (num_bytes_out != expected_num_bytes) return 24;
+
+  return 0;
+}
 
 /// \brief Unpacks and combines a single row of the CrsMatrix.
 ///
-/// Data (bytes) describing the row of the CRS matrix are "unpacked"
-/// from a single (concatenated) char* in to the row of the matrix
-///
-/// \tparam NumPacketsPerLIDType the specialization of the Kokkos::View of counts
-/// \tparam OffsetsType the specialization of the Kokkos::View of offsets
-/// \tparam ImportsType the specialization of the Kokkos::View of imports
-/// \tparam ImportLIDsType the specialization of the Kokkos::View of import
-//local IDs
-/// \tparam LocalMatrixType the specialization of the KokkosSparse::CrsMatrix
+/// \tparam LocalMatrix the specialization of the KokkosSparse::CrsMatrix
 ///   local matrix
-/// \tparam LocalMapType the type of the local column map
-template<class NumPacketsPerLIDType, class OffsetsType,
-  class ImportsType, class ImportLIDsType,
-  class LocalMatrixType, class LocalMapType>
+/// \tparam LocalMap the type of the local column map
+///
+/// Data (bytes) describing the row of the CRS matrix are "unpacked"
+/// from a single (concatenated) (view of) char* directly in to the row of the matrix
+template<class LocalMatrix, class LocalMap>
 struct UnpackCrsMatrixAndCombineFunctor {
 
-  typedef NumPacketsPerLIDType num_packets_per_lid_type;
-  typedef OffsetsType offsets_type;
-  typedef ImportsType imports_type;
-  typedef ImportLIDsType import_lids_type;
-  typedef LocalMatrixType local_matrix_type;
-  typedef LocalMapType local_map_type;
-  typedef typename local_matrix_type::value_type IST;
-  typedef typename local_matrix_type::ordinal_type LO;
+  typedef LocalMatrix local_matrix_type;
+  typedef LocalMap local_map_type;
+
+  typedef typename local_matrix_type::value_type ST;
+  typedef typename local_map_type::local_ordinal_type LO;
   typedef typename local_map_type::global_ordinal_type GO;
-  typedef UnpackCrsMatrixError<LO> value_type;
+  typedef typename local_map_type::device_type Device;
+  typedef typename Device::execution_space execution_space;
 
-  static_assert (Kokkos::Impl::is_view<NumPacketsPerLIDType>::value,
-                 "NumPacketsPerLIDType must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<OffsetsType>::value,
-                 "OffsetsType must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<ImportsType>::value,
-                 "ImportsType must be a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_view<ImportLIDsType>::value,
-                 "ImportLIDsType must be a Kokkos::View.");
-  static_assert (std::is_same<LO, typename LocalMatrixType::ordinal_type>::value,
-                 "LocalMapType::local_ordinal_type and "
-                 "LocalMatrixType::ordinal_type must be the same.");
+  typedef typename PackTraits<size_t,Device>::input_array_type num_packets_per_lid_type;
+  typedef typename PackTraits<size_t,Device>::input_array_type offsets_type;
+  typedef typename PackTraits<LO,Device>::input_buffer_type input_buffer_type;
+  typedef typename PackTraits<LO,Device>::input_array_type import_lids_type;
 
-  NumPacketsPerLIDType num_packets_per_lid_;
-  OffsetsType offsets_;
-  ImportsType imports_;
-  ImportLIDsType import_lids_;
-  LocalMatrixType local_matrix_;
-  LocalMapType local_col_map_;
-  Tpetra::CombineMode combine_mode_;
-  bool atomic_;
+  typedef Kokkos::View<LO*, Device> lids_scratch_type;
+  typedef Kokkos::View<GO*, Device> gids_scratch_type;
+  typedef Kokkos::View<int*,Device> pids_scratch_type;
+  typedef Kokkos::View<ST*, Device> vals_scratch_type;
+
+  typedef Kokkos::pair<int, LO> value_type;
+
+  static_assert (std::is_same<LO, typename local_matrix_type::ordinal_type>::value,
+                 "LocalMap::local_ordinal_type and "
+                 "LocalMatrix::ordinal_type must be the same.");
+
+  LO InvalidIndex = OrdinalTraits<LO>::invalid();
+
+  local_matrix_type local_matrix;
+  local_map_type local_col_map;
+  input_buffer_type imports;
+  num_packets_per_lid_type num_packets_per_lid;
+  import_lids_type import_lids;
+  offsets_type offsets;
+  Tpetra::CombineMode combine_mode;
+  size_t max_num_ent;
+  bool unpack_pids;
+  bool atomic;
+  Kokkos::Experimental::UniqueToken<execution_space , Kokkos::Experimental::UniqueTokenScope::Global> tokens;
+  lids_scratch_type lids_scratch;
+  gids_scratch_type gids_scratch;
+  pids_scratch_type pids_scratch;
+  vals_scratch_type vals_scratch;
 
   UnpackCrsMatrixAndCombineFunctor(
-      const num_packets_per_lid_type& num_packets_per_lid,
-      const offsets_type& offsets,
-      const imports_type& imports,
-      const import_lids_type& import_lids,
-      local_matrix_type& local_matrix,
-      const local_map_type& local_col_map,
-      const Tpetra::CombineMode combine_mode,
-      const bool atomic) :
-    num_packets_per_lid_(num_packets_per_lid),
-    offsets_(offsets),
-    imports_(imports),
-    import_lids_(import_lids),
-    local_matrix_(local_matrix),
-    local_col_map_(local_col_map),
-    combine_mode_(combine_mode),
-    atomic_(atomic)
+      const local_matrix_type& local_matrix_in,
+      const local_map_type& local_col_map_in,
+      const input_buffer_type& imports_in,
+      const num_packets_per_lid_type& num_packets_per_lid_in,
+      const import_lids_type& import_lids_in,
+      const offsets_type& offsets_in,
+      const Tpetra::CombineMode combine_mode_in,
+      const size_t max_num_ent_in,
+      const bool unpack_pids_in,
+      const bool atomic_in) :
+    local_matrix (local_matrix_in),
+    local_col_map (local_col_map_in),
+    imports (imports_in),
+    num_packets_per_lid (num_packets_per_lid_in),
+    import_lids (import_lids_in),
+    offsets (offsets_in),
+    combine_mode (combine_mode_in),
+    max_num_ent (max_num_ent_in),
+    unpack_pids (unpack_pids_in),
+    atomic (atomic_in),
+    tokens (execution_space()),
+    lids_scratch ("pids_scratch", tokens.size() * max_num_ent),
+    gids_scratch ("gids_scratch", tokens.size() * max_num_ent),
+    pids_scratch ("lids_scratch", tokens.size() * max_num_ent),
+    vals_scratch ("vals_scratch", tokens.size() * max_num_ent)
   {}
 
   KOKKOS_INLINE_FUNCTION void init(value_type& dst) const
   {
-    dst.bad_index = Tpetra::Details::OrdinalTraits<LO>::invalid();
-    dst.num_ent = 0;
-    dst.offset = 0;
-    dst.expected_num_bytes = 0;
-    dst.num_bytes = 0;
-    dst.buf_size = 0;
-    dst.wrong_num_bytes_error = false;
-    dst.out_of_bounds_error = false;
-    dst.invalid_combine_mode_error = false;
+    dst = Kokkos::make_pair(0, InvalidIndex);
   }
 
   KOKKOS_INLINE_FUNCTION void
   join (volatile value_type& dst, const volatile value_type& src) const
   {
-    // The dst object should reflect the first bad index and all other
-    // associated error codes and data.  Thus, we need only check if the src
-    // object shows an error and if its associated `bad_index` is less than the
-    // dst.bad_index (if dst shows errors).
-    LO invalid = Tpetra::Details::OrdinalTraits<LO>::invalid();
-    if (src.bad_index != invalid) {
-      // An error in the src, check if whether:
-      //   1. The dst shows errors
-      //   2. If dst does show errors, if src bad_index is less than its bad
-      //      index
-      if (dst.bad_index == invalid || src.bad_index < dst.bad_index) {
-        dst.bad_index = src.bad_index;
-        dst.num_ent = src.num_ent;
-        dst.offset = src.offset;
-        dst.expected_num_bytes = src.expected_num_bytes;
-        dst.num_bytes = src.num_bytes;
-        dst.buf_size = src.buf_size;
-        dst.wrong_num_bytes_error = src.wrong_num_bytes_error;
-        dst.out_of_bounds_error = src.out_of_bounds_error;
-        dst.invalid_combine_mode_error = src.invalid_combine_mode_error;
+    // `dst` should reflect the first (least) bad index and
+    // all other associated error codes and data.  Thus, we need only
+    // check if the `src` object shows an error and if its associated
+    // bad index is less than `dst`'s bad index.
+    if (src.second != InvalidIndex) {
+      // An error in the src; check if
+      //   1. `dst` shows errors
+      //   2. If `dst` does show errors, if src's bad index is less than
+      //      *this' bad index
+      if (dst.second == InvalidIndex || src.second < dst.second) {
+        dst = src;
       }
     }
   }
@@ -249,210 +293,363 @@ struct UnpackCrsMatrixAndCombineFunctor {
   KOKKOS_INLINE_FUNCTION
   void operator()(const LO i, value_type& dst) const
   {
-    const LO local_row = import_lids_[i];
-    const size_t num_bytes = num_packets_per_lid_(i);
+    using Kokkos::View;
+    using Kokkos::subview;
+    using Kokkos::MemoryUnmanaged;
+    typedef typename PackTraits<LO,Device>::input_buffer_type input_buffer_type;
+    typedef typename execution_space::size_type size_type;
+    typedef typename Kokkos::pair<size_type, size_type> slice;
 
-    if (num_bytes > 0) { // there is actually something in the row
+    typedef View<LO*, Device, MemoryUnmanaged> lids_out_type;
+    typedef View<int*,Device, MemoryUnmanaged> pids_out_type;
+    typedef View<GO*, Device, MemoryUnmanaged> gids_out_type;
+    typedef View<ST*, Device, MemoryUnmanaged> vals_out_type;
 
-      const size_t buf_size = imports_.size();
-      const char* const num_ent_beg = imports_.ptr_on_device() + offsets_(i);
-      const char* const num_ent_end = num_ent_beg + sizeof(LO);
+    const size_t num_bytes = num_packets_per_lid(i);
 
-      // Now we know how many entries to expect in the received data
-      // for this row.
-      LO num_ent = 0;
-      memcpy(&num_ent, num_ent_beg, sizeof(LO));
-
-      const char* const val_beg = num_ent_end;
-      const char* const val_end = val_beg + static_cast<size_t>(num_ent) * sizeof(IST);
-      const char* const ind_beg = val_end;
-      const size_t expected_num_bytes = sizeof(LO) +
-        static_cast<size_t>(num_ent) * (sizeof(IST) + sizeof(GO));
-
-      if (expected_num_bytes > num_bytes) {
-        dst.wrong_num_bytes_error = true;
-      }
-      else if (offsets_(i) > buf_size || offsets_(i) + num_bytes > buf_size) {
-        dst.out_of_bounds_error = true;
-      }
-      else {
-
-        // FIXME (mfh 23 Mar 2017) CrsMatrix_NonlocalSumInto_Ignore test
-        // expects this method to ignore incoming entries that do not
-        // exist on the process that owns those rows.  We would like to
-        // distinguish between "errors" resulting from ignored entries,
-        // vs. actual errors.
-
-        // Combine a single column/value at a time to avoid temporary storage
-        LO num_modified = 0;
-        if (combine_mode_ == ADD) {
-          for (size_t k = 0; k < static_cast<size_t>(num_ent); ++k) {
-            IST val = 0;
-            GO col = 0;
-            memcpy(&val, val_beg + k * sizeof(IST), sizeof(IST));
-            memcpy(&col, ind_beg + k * sizeof(GO), sizeof(GO));
-            LO local_col_idx = local_col_map_.getLocalElement(col);
-            num_modified += local_matrix_.sumIntoValues(local_row,
-                &local_col_idx, 1, &val, false, atomic_);
-          }
-        }
-        else if (combine_mode_ == REPLACE) {
-          for (size_t k = 0; k < static_cast<size_t>(num_ent); ++k) {
-            IST val = 0;
-            GO col = 0;
-            memcpy(&val, val_beg + k * sizeof(IST), sizeof(IST));
-            memcpy(&col, ind_beg + k * sizeof(GO), sizeof(GO));
-            LO local_col_idx = local_col_map_.getLocalElement(col);
-            num_modified += local_matrix_.replaceValues(local_row,
-                &local_col_idx, 1, &val, false, atomic_);
-          }
-        }
-        else {
-          dst.invalid_combine_mode_error = true;
-        }
-      }
-
-      if (dst.wrong_num_bytes_error ||
-          dst.out_of_bounds_error ||
-          dst.invalid_combine_mode_error) {
-        dst.bad_index = i;
-        dst.num_ent = num_ent;
-        dst.offset = offsets_(i);
-        dst.expected_num_bytes = expected_num_bytes;
-        dst.num_bytes = num_bytes;
-        dst.buf_size = buf_size;
-      }
+    // Only unpack data if there is a nonzero number of bytes.
+    if (num_bytes == 0) {
+      return;
     }
+
+    // there is actually something in the row
+    const LO import_lid = import_lids[i];
+    const size_t buf_size = imports.size();
+    const size_t offset = offsets(i);
+
+    // Get the number of entries to expect in the received data for this row.
+    LO num_ent_LO = 0;
+    const size_t num_ent_len = PackTraits<LO,Device>::packValueCount(num_ent_LO);
+    input_buffer_type in_buf = subview(imports, slice(offset, offset+num_ent_len));
+    (void) PackTraits<LO,Device>::unpackValue(num_ent_LO, in_buf);
+    const size_t num_ent = static_cast<size_t>(num_ent_LO);
+
+    // Count the number of bytes expected to unpack
+    size_t expected_num_bytes = 0;
+    {
+      LO lid = 0; // packValueCount wants these
+      expected_num_bytes += PackTraits<LO,Device>::packValueCount(lid);
+
+      GO gid = 0; // packValueCount wants these
+      expected_num_bytes += num_ent * PackTraits<GO,Device>::packValueCount(gid);
+
+      if (unpack_pids) {
+        int pid = 0;
+        expected_num_bytes += num_ent * PackTraits<int,Device>::packValueCount(pid);
+      }
+
+      ST val; // packValueCount wants these
+      expected_num_bytes += num_ent * PackTraits<ST,Device>::packValueCount(val);
+    }
+
+    if (expected_num_bytes > num_bytes) {
+      // Wrong number of bytes
+      dst = Kokkos::make_pair(1, i);
+      return;
+    }
+
+    if (offset > buf_size || offset + num_bytes > buf_size) {
+      // Out of bounds
+      dst = Kokkos::make_pair(2, i);
+      return;
+    }
+
+    // Get subviews in to the scratch arrays.  The token returned from acquire
+    // is an integer in [0, tokens.size()).  It is used to grab a unique (to
+    // this thread) subview of the scratch arrays.
+    const size_type token = tokens.acquire();
+    const size_t a = static_cast<size_t>(token) * max_num_ent;
+    const size_t b = a + num_ent;
+    lids_out_type lids_out = subview(lids_scratch, slice(a, b));
+    gids_out_type gids_out = subview(gids_scratch, slice(a, b));
+    pids_out_type pids_out = subview(pids_scratch, slice(a, (unpack_pids ? b : a)));
+    vals_out_type vals_out = subview(vals_scratch, slice(a, b));
+
+    // Unpack this row!
+    int unpack_err = unpack_crs_matrix_row<ST,LO,GO,Device>(gids_out, pids_out, vals_out,
+        imports, offset, num_bytes, num_ent);
+
+    if (unpack_err != 0) {
+      // Unpack error
+      dst = Kokkos::make_pair(unpack_err, i);
+      tokens.release(token);
+      return;
+    }
+
+    // Column indices come in as global indices, in case the
+    // source object's column Map differs from the target object's
+    // (this's) column Map, and must be converted local index values
+    for (size_t k = 0; k < num_ent; ++k) {
+      lids_out(k) = local_col_map.getLocalElement(gids_out(k));
+    }
+
+    // Combine the values according to the combine_mode
+    const LO* const lids_raw = const_cast<const LO*> (lids_out.data());
+    const ST* const vals_raw = const_cast<const ST*> (vals_out.data());
+    LO num_modified = 0;
+    if (combine_mode == ADD) {
+      num_modified += local_matrix.sumIntoValues(import_lid,
+          lids_raw, num_ent, vals_raw, false, atomic);
+    }
+    else if (combine_mode == REPLACE) {
+      num_modified += local_matrix.replaceValues(import_lid,
+          lids_raw, num_ent, vals_raw, false, atomic);
+    }
+    else {
+      // Invalid combine mode
+      dst = Kokkos::make_pair(4, i);
+      tokens.release(token);
+      return;
+    }
+
+    tokens.release(token);
+
+    // Unpack successful.
   }
 
 };
 
-/// \brief Unpack the imported column indices and values, and combine into matrix.
+/// \brief Functor to determine the maximum number of entries in any row of the
+///   matrix using Kokkos::parallel_reduce
 ///
-/// \warning The allowed \c combineMode are:
-///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
-template<class LocalMatrixType, class LocalMapType>
-bool
-unpackCrsMatrixAndCombine(
-    LocalMatrixType& lclMatrix,
-    const LocalMapType& lclColMap,
-    std::unique_ptr<std::string>& errStr,
-    const Teuchos::ArrayView<const typename LocalMatrixType::ordinal_type>& importLIDs,
-    const Teuchos::ArrayView<const char>& imports,
-    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
-    size_t constantNumPackets,
-    const int myRank,
-    Distributor & /* distor */,
-    CombineMode combineMode,
-    const bool atomic)
-{
-  using Kokkos::View;
-  using ::Tpetra::Details::computeOffsetsFromCounts;
-  using Tpetra::Details::create_mirror_view_from_raw_host_array;
-  typedef LocalMatrixType local_matrix_type;
-  typedef LocalMapType local_map_type;
-  typedef typename LocalMapType::local_ordinal_type LO;
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Device The Kokkos Device type.  See the documentation of Map
+///   for requirements.
+///
+/// The maximum number of entries is required for allocated device scratch space
+template<class LO, class Device>
+struct MaxNumEntriesFunctor {
+  typedef size_t value_type;
+  typedef typename PackTraits<LO,Device>::input_buffer_type input_buffer_type;
+  typedef typename PackTraits<size_t,Device>::input_array_type offsets_type;
+  typedef typename PackTraits<size_t,Device>::input_array_type num_packets_per_lid_type;
+  typedef Kokkos::pair<size_t,size_t> slice;
+  num_packets_per_lid_type num_packets_per_lid;
+  offsets_type offsets;
+  input_buffer_type imports;
+  MaxNumEntriesFunctor(const num_packets_per_lid_type num_packets_per_lid_in,
+                       const offsets_type& offsets_in,
+                       const input_buffer_type& imports_in) :
+    num_packets_per_lid(num_packets_per_lid_in),
+    offsets(offsets_in),
+    imports(imports_in)
+  {}
 
-  static_assert (std::is_same<LO, typename LocalMatrixType::ordinal_type>::value,
-                 "LocalMapType::local_ordinal_type and "
-                 "LocalMatrixType::ordinal_type must be the same.");
-
-  typedef typename LocalMatrixType::device_type device_type;
-  typedef typename device_type::execution_space execution_space;
-  typedef Kokkos::RangePolicy<execution_space, LO> range_type;
-
-  const size_t numImportLIDs = static_cast<size_t>(importLIDs.size());
-
-  {
-    // Check for correct input
-    int qa_errors = 0;
-    std::ostringstream os;
-    if (combineMode == ABSMAX) {
-      qa_errors += 1;
-      os << "ABSMAX combine mode is not yet implemented for a matrix that has a "
-         << "static graph (i.e., was constructed with the CrsMatrix constructor "
-         << "that takes a const CrsGraph pointer).\n";
-    }
-    else if (combineMode == INSERT) {
-      qa_errors += 1;
-      os << "INSERT combine mode is not allowed if the matrix has a static graph "
-         << "(i.e., was constructed with the CrsMatrix constructor that takes a "
-         << "const CrsGraph pointer).\n";
-    }
-    else if (!(combineMode == ADD || combineMode == REPLACE)) {
-      qa_errors += 1;
-      // Unknown combine mode!
-      os << "Invalid combine mode; should never get "
-         << "here!  Please report this bug to the Tpetra developers.\n";
-    }
-
-    // Check that sizes of input objects are consistent.
-    if (numImportLIDs != static_cast<size_t>(numPacketsPerLID.size())) {
-      qa_errors += 1;
-      os << "importLIDs.size() (" << numImportLIDs << ") != "
-         << "numPacketsPerLID.size() (" << numPacketsPerLID.size() << ").";
-    }
-
-    if (qa_errors) {
-      if (errStr.get() == NULL) {
-        errStr = std::unique_ptr<std::string>(new std::string());
-      }
-      *errStr = os.str();
-      return false;
-    }
-  } // end QA error checking
-
-  // numPacketsPerLID, importLIDs, and imports are input, so we have to copy
-  // them to device.  Since unpacking is done directly in to the local matrix
-  // (lclMatrix), not copying needs to be performed after unpacking.
-  typename LocalMatrixType::device_type outputDevice;
-  auto num_packets_per_lid_d =
-    create_mirror_view_from_raw_host_array(outputDevice,
-        numPacketsPerLID.getRawPtr(), numPacketsPerLID.size(),
-        true, "num_packets_per_lid_d");
-
-  auto import_lids_d =
-    create_mirror_view_from_raw_host_array(outputDevice,
-        importLIDs.getRawPtr(), importLIDs.size(),
-        true, "import_lids_d");
-
-  auto imports_d =
-    create_mirror_view_from_raw_host_array(outputDevice,
-        imports.getRawPtr(), imports.size(),
-        true, "imports_d");
-
-  // Get the offsets
-  View<size_t*, device_type>
-    offsets_d("offsets_d", numImportLIDs+1);
-  computeOffsetsFromCounts(offsets_d, num_packets_per_lid_d);
-
-  // Now do the actual unpack!
-  typedef UnpackCrsMatrixAndCombineFunctor<
-    decltype(num_packets_per_lid_d),
-    decltype(offsets_d),
-    decltype(imports_d),
-    decltype(import_lids_d),
-    local_matrix_type,
-    local_map_type> unpack_functor_type;
-  unpack_functor_type unpack_functor(num_packets_per_lid_d, offsets_d,
-      imports_d, import_lids_d, lclMatrix, lclColMap, combineMode, atomic);
-
-  typename unpack_functor_type::value_type result;
-  Kokkos::parallel_reduce(range_type(0, numImportLIDs), unpack_functor, result);
-
-  if (!result.success()) {
-    std::ostringstream os;
-    os << "Proc " << myRank << ": packCrsMatrix failed.  "
-       << result.summary()
-       << std::endl;
-    if (errStr.get () != NULL) {
-      errStr = std::unique_ptr<std::string> (new std::string ());
-      *errStr = os.str ();
+  KOKKOS_INLINE_FUNCTION void
+  operator() (const LO i, value_type& update) const {
+    // Get how many entries to expect in the received data for this row.
+    const size_t num_bytes = num_packets_per_lid(i);
+    if (num_bytes > 0) {
+      LO num_ent_LO = 0;
+      const size_t offset = offsets(i);
+      const size_t num_ent_len = PackTraits<LO,Device>::packValueCount(num_ent_LO);
+      input_buffer_type in_buf = subview(imports, slice(offset, offset+num_ent_len));
+      (void) PackTraits<LO,Device>::unpackValue(num_ent_LO, in_buf);
+      size_t num_ent = static_cast<size_t>(num_ent_LO);
+      if (update < num_ent) update = num_ent;
     }
   }
 
-  return result.success();
+  KOKKOS_INLINE_FUNCTION void
+  join (volatile value_type& dst, const volatile value_type& src) const
+  {if (dst < src) dst = src; }
+};
 
+/// \brief Functor to determine the maximum number of entries in any row of the
+///   matrix using Kokkos::parallel_reduce
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Device The Kokkos Device type.  See the documentation of Map
+///   for requirements.
+///
+/// This procedure is a high level interface to MaxNumEntriesFunctor
+template<class LO, class Device>
+size_t compute_maximum_num_entries(
+    const typename PackTraits<size_t,Device>::input_array_type num_packets_per_lid,
+    const typename PackTraits<size_t,Device>::input_array_type offsets,
+    const typename PackTraits<LO,Device>::input_buffer_type imports)
+{
+  typedef typename Device::execution_space execution_space;
+  typedef Kokkos::RangePolicy<execution_space, LO> range_type;
+  size_t n = 0;
+  MaxNumEntriesFunctor<LO,Device> functor(num_packets_per_lid, offsets, imports);
+  Kokkos::parallel_reduce(range_type(0, num_packets_per_lid.dimension_0()), functor, n);
+  return n;
+}
+
+/// \brief Perform the unpack operation for the matrix
+///
+/// \tparam LocalMatrix the specialization of the KokkosSparse::CrsMatrix
+///   local matrix
+/// \tparam LocalMap the type of the local column map
+///
+/// This is a higher level interface to the UnpackCrsMatrixAndCombineFunctor
+template<class LocalMatrix, class LocalMap>
+void
+do_unpack_and_combine(const LocalMatrix& local_matrix,
+                      const LocalMap& local_map,
+                      const typename PackTraits<typename LocalMap::local_ordinal_type, typename LocalMap::device_type>::input_buffer_type imports,
+                      const typename PackTraits<size_t, typename LocalMap::device_type>::input_array_type num_packets_per_lid,
+                      const typename PackTraits<typename LocalMap::local_ordinal_type, typename LocalMap::device_type>::input_array_type import_lids,
+                      const Tpetra::CombineMode combine_mode,
+                      const bool unpack_pids,
+                      const bool atomic)
+{
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename LocalMap::device_type Device;
+  typedef typename Device::execution_space execution_space;
+  typedef Kokkos::RangePolicy<execution_space, LO> range_type;
+  typedef UnpackCrsMatrixAndCombineFunctor<LocalMatrix, LocalMap> unpack_functor_type;
+
+  const char prefix[] = "Tpetra::Details::do_unpack_and_combine: ";
+
+  const size_t num_import_lids = static_cast<size_t>(import_lids.dimension_0());
+  if (num_import_lids == 0) {
+    // Nothing to unpack
+    return;
+  }
+
+  {
+    // Check for correct input
+    TEUCHOS_TEST_FOR_EXCEPTION(combine_mode == ABSMAX,
+        std::invalid_argument,
+        prefix << "ABSMAX combine mode is not yet implemented for a matrix that has a "
+        "static graph (i.e., was constructed with the CrsMatrix constructor "
+        "that takes a const CrsGraph pointer).");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(combine_mode == INSERT,
+        std::invalid_argument,
+        prefix << "INSERT combine mode is not allowed if the matrix has a static graph "
+        "(i.e., was constructed with the CrsMatrix constructor that takes a "
+        "const CrsGraph pointer).");
+
+    // Unknown combine mode!
+    TEUCHOS_TEST_FOR_EXCEPTION(!(combine_mode == ADD || combine_mode == REPLACE),
+        std::invalid_argument,
+        prefix << "Invalid combine mode; should never get "
+        "here!  Please report this bug to the Tpetra developers.");
+
+    // Check that sizes of input objects are consistent.
+    bool bad_num_import_lids =
+      num_import_lids != static_cast<size_t>(num_packets_per_lid.dimension_0());
+    TEUCHOS_TEST_FOR_EXCEPTION(bad_num_import_lids,
+        std::invalid_argument,
+        prefix << "importLIDs.size() (" << num_import_lids << ") != "
+        "numPacketsPerLID.size() (" << num_packets_per_lid.dimension_0() << ").");
+  } // end QA error checking
+
+  // Get the offsets
+  Kokkos::View<size_t*, Device> offsets("offsets_d", num_import_lids+1);
+  computeOffsetsFromCounts(offsets, num_packets_per_lid);
+
+  // Determine the maximum number of entries in any row in the matrix.  The
+  // maximum number of entries is needed to allocate unpack buffers on the
+  // device.
+  size_t max_num_ent = compute_maximum_num_entries<LO,Device>(
+      num_packets_per_lid, offsets, imports);
+
+  // Now do the actual unpack!
+  unpack_functor_type f(local_matrix, local_map,
+      imports, num_packets_per_lid, import_lids, offsets, combine_mode,
+      max_num_ent, unpack_pids, atomic);
+
+  typename unpack_functor_type::value_type x;
+  Kokkos::parallel_reduce(range_type(0, num_import_lids), f, x);
+  auto x_h = x.to_std_pair();
+  TEUCHOS_TEST_FOR_EXCEPTION(x_h.first != 0, std::runtime_error,
+      prefix << "UnpackCrsMatrixAndCombineFunctor reported error code "
+             << x_h.first << " for the first bad row " << x_h.second);
+
+  return;
+}
+
+/// \brief Unpack the imported column indices and values, and combine into matrix.
+///
+/// \tparam ST The type of the numerical entries of the matrix.
+///   (You can use real-valued or complex-valued types here, unlike
+///   in Epetra, where the scalar type is always \c double.)
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Node The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceMatrix [in] the CrsMatrix source
+///
+/// \param ixports [in/out] Output pack buffer; resized if needed.
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local matrix.
+///
+/// \param ixportLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// \param combineMode [in] the mode to use for combining values
+///
+/// \param atomic [in] whether or not do atomic adds/replaces in to the matrix
+///
+/// \warning The allowed \c combineMode are:
+///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
+///
+/// This is the public interface to the unpack and combine machinery and
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsMatrix migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<typename ST, typename LO, typename GO, typename Node>
+void
+unpackCrsMatrixAndCombine(const CrsMatrix<ST, LO, GO, Node>& sourceMatrix,
+                          const Teuchos::ArrayView<const char>& imports,
+                          const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+                          const Teuchos::ArrayView<const LO>& importLIDs,
+                          size_t constantNumPackets,
+                          Distributor & distor,
+                          CombineMode combineMode,
+                          const bool atomic)
+{
+  using Kokkos::View;
+  typedef typename Node::device_type device_type;
+  typedef typename CrsMatrix<ST,LO,GO,Node>::local_matrix_type local_matrix_type;
+  static_assert (std::is_same<device_type, typename local_matrix_type::device_type>::value,
+                 "Node::device_type and LocalMatrix::device_type must be the same.");
+
+  // Execution space.
+  typedef typename device_type::execution_space execution_space;
+
+  // Convert all Teuchos::Array to Kokkos::View.
+  typename execution_space::device_type outputDevice;
+
+  // numPacketsPerLID, importLIDs, and imports are input, so we have to copy
+  // them to device.  Since unpacking is done directly in to the local matrix
+  // (lclMatrix), no copying needs to be performed after unpacking.
+  auto num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array(outputDevice, numPacketsPerLID.getRawPtr(),
+        numPacketsPerLID.size(), true, "num_packets_per_lid");
+
+  auto import_lids_d =
+    create_mirror_view_from_raw_host_array(outputDevice, importLIDs.getRawPtr(),
+        importLIDs.size(), true, "import_lids");
+
+  auto imports_d =
+    create_mirror_view_from_raw_host_array(outputDevice, imports.getRawPtr(),
+        imports.size(), true, "imports");
+
+  auto local_matrix = sourceMatrix.getLocalMatrix();
+  auto local_col_map = sourceMatrix.getColMap()->getLocalMap();
+
+  // Now do the actual unpack!
+  do_unpack_and_combine(local_matrix, local_col_map, imports_d,
+      num_packets_per_lid_d, import_lids_d, combineMode, false, atomic);
+
+  return;
 }
 
 } // namespace Details

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -59,6 +59,7 @@
 #include "Tpetra_Import.hpp"
 #include "Tpetra_Import_Util.hpp"
 #include "Tpetra_Import_Util2.hpp"
+#include "Tpetra_Details_packCrsMatrix.hpp"
 #include "Tpetra_Export.hpp"
 #include "Tpetra_RowMatrixTransposer.hpp"
 #include "TpetraExt_MatrixMatrix.hpp"
@@ -1856,7 +1857,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util, PackAndPrepareWithOwningPIDs, LO
     Tpetra::Import_Util::getPids<LO, GO, Node>(*Importer,pids,false);
     constantNumPackets2=0;
     numPackets2.resize(Importer->getExportLIDs().size());
-    Tpetra::Import_Util::packAndPrepareWithOwningPIDs<double, LO, GO, Node>(*A,Importer->getExportLIDs(),exports2,numPackets2(),constantNumPackets2,Importer->getDistributor(),pids());
+    Tpetra::Details::packCrsMatrixWithOwningPIDs<double, LO, GO, Node>(
+        *A, exports2, InumPackets2(), Importer->getExportLIDs(), pids(),
+        constantNumPackets2, Importer->getExportLIDs());
 
     // This test reads exports2 on the host, so sync there.
     exports2.template sync<Kokkos::HostSpace> ();
@@ -1953,7 +1956,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
     numExportPackets.resize(Importer->getExportLIDs().size());
     numImportPackets.resize(Importer->getRemoteLIDs().size());
 
-    Tpetra::Import_Util::packAndPrepareWithOwningPIDs<Scalar, LO, GO, Node>(*A,Importer->getExportLIDs(),exports,numExportPackets(),constantNumPackets,distor,SourcePids());
+    Tpetra::Details::packCrsMatrixWithOwningPIDs<Scalar, LO, GO, Node>(
+        *A, exports, numExportPackets(), Importer->getExportLIDs(),
+        SourcePids(), constantNumPackets, distor);
 
     // This test reads exports on the host, so sync there.
     exports.template sync<Kokkos::HostSpace> ();


### PR DESCRIPTION
@trilinos/tpetra, @mhoemmen

Comments
--------
This commit is a combination of several commits that address a several
issues: #797, #798, #800, #802

A summary of changes are as follows:

- Refactor CrsMatrix pack/unpack procedures to use PackTraits (for both static
  and dynamic profile matrices)
- Refactor packCrsMatrix to pack (optional) PIDs
- Remove exists packAndPrepareWithOwningPIDs and instead use the aforementioned
  packCrsMatrix procedure.
- Modify PackTraits run on threads by removing calls to TEUCHOS_TEST_FOR_EXCEPTION
  and decorating device code with KOKKOS_INLINE_FUNCTION
- Ditto for Stokhos' specialization of PackTraits

Build/Test Cases Summary
Enabled Packages: TpetraCore
Disabled Packages: PyTrilinos,Claps,TriKota
Enabled all Forward Packages
0) MPI_RELEASE_DEBUG_SHARED_PT => passed:
passed=1483,notpassed=0 (79.62 min)