### PR TITLE
Intrepid2: Fix issue #1572

### DIFF
--- a/packages/intrepid2/refactor/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
+++ b/packages/intrepid2/refactor/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
@@ -307,10 +307,12 @@ namespace Intrepid2 {
       numCells = cellWorkset.dimension(0),
       numPoints = points.dimension(1), 
       spaceDim = cellTopo.getDimension();
-    
+
+    using result_layout = typename DeduceLayout< decltype(points) >::result_layout;
+    using device_type = typename decltype(points)::device_type;
     auto vcprop = Kokkos::common_view_alloc_prop(points);
     using common_value_type = typename decltype(vcprop)::value_type;
-    Kokkos::DynRankView< common_value_type > refPoints ( Kokkos::view_alloc("CellTools::checkPointwiseInclusion::refPoints", vcprop), numCells, numPoints, spaceDim);
+    Kokkos::DynRankView< common_value_type, result_layout, device_type > refPoints ( Kokkos::view_alloc("CellTools::checkPointwiseInclusion::refPoints", vcprop), numCells, numPoints, spaceDim);
     
     // expect refPoints(CPD), points(CPD), cellWorkset(CND) 
     mapToReferenceFrame(refPoints, points, cellWorkset, cellTopo);

--- a/packages/intrepid2/refactor/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/refactor/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -135,7 +135,7 @@ namespace Intrepid2 {
     // the following does not work for RCP; its * operator returns reference not the object
     //typedef typename decltype(*basis)::output_value_type gradValueType;
     //typedef Kokkos::DynRankView<decltype(basis->getDummyOutputValue()),SpT> gradViewType;
-    
+
     auto vcprop = Kokkos::common_view_alloc_prop(points);
     typedef Kokkos::DynRankView<typename decltype(vcprop)::value_type,SpT> gradViewType;
 

--- a/packages/intrepid2/refactor/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/refactor/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -90,9 +90,11 @@ namespace Intrepid2 {
     const auto numPoints = physPoints.dimension(1);
     
     // init guess is created locally and non fad whatever refpoints type is 
+    using result_layout = typename DeduceLayout< decltype(refPoints) >::result_layout;
+    using device_type = typename decltype(refPoints)::device_type;
     auto vcprop = Kokkos::common_view_alloc_prop(refPoints);
     using common_value_type = typename decltype(vcprop)::value_type;
-    Kokkos::DynRankView< common_value_type > initGuess ( Kokkos::view_alloc("CellTools::mapToReferenceFrame::initGuess", vcprop), numCells, numPoints, spaceDim );
+    Kokkos::DynRankView< common_value_type, result_layout, device_type > initGuess ( Kokkos::view_alloc("CellTools::mapToReferenceFrame::initGuess", vcprop), numCells, numPoints, spaceDim );
     //refPointViewSpType initGuess("CellTools::mapToReferenceFrame::initGuess", numCells, numPoints, spaceDim);
     rst::clone(initGuess, cellCenter);
     
@@ -129,8 +131,10 @@ namespace Intrepid2 {
     typedef RealSpaceTools<SpT> rst;
     const auto tol = tolerence();
 
+    using result_layout = typename DeduceLayout< decltype(refPoints) >::result_layout;
+    using device_type = typename decltype(refPoints)::device_type;
     auto vcprop = Kokkos::common_view_alloc_prop(refPoints);
-    typedef Kokkos::DynRankView<typename decltype(vcprop)::value_type> viewType;
+    typedef Kokkos::DynRankView<typename decltype(vcprop)::value_type, result_layout, device_type > viewType;
 
     // Temp arrays for Newton iterates and Jacobians. Resize according to rank of ref. point array
     viewType xOld(Kokkos::view_alloc("CellTools::mapToReferenceFrameInitGuess::xOld", vcprop), numCells, numPoints, spaceDim);
@@ -141,7 +145,7 @@ namespace Intrepid2 {
 
     // jacobian should select fad dimension between xOld and worksetCell as they are input; no front interface yet
     auto vcpropJ = Kokkos::common_view_alloc_prop(refPoints, worksetCell);
-    typedef Kokkos::DynRankView<typename decltype(vcpropJ)::value_type> viewTypeJ;
+    typedef Kokkos::DynRankView<typename decltype(vcpropJ)::value_type, result_layout, device_type > viewTypeJ;
     viewTypeJ jacobian(Kokkos::view_alloc("CellTools::mapToReferenceFrameInitGuess::jacobian", vcpropJ), numCells, numPoints, spaceDim, spaceDim);
     viewTypeJ jacobianInv(Kokkos::view_alloc("CellTools::mapToReferenceFrameInitGuess::jacobianInv", vcpropJ), numCells, numPoints, spaceDim, spaceDim);
     

--- a/packages/intrepid2/refactor/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/refactor/src/Shared/Intrepid2_Utils.hpp
@@ -156,6 +156,23 @@ namespace Intrepid2 {
     typedef ViewSpaceType ExecSpaceType;
   };
 
+
+  ///
+  /// layout deduction (temporary meta-function)
+  ///
+
+  template <typename ViewType>
+  struct DeduceLayout {
+    using input_layout = typename ViewType::array_layout;
+    using default_layout = typename ViewType::device_type::execution_space::array_layout;
+    using result_layout  =
+      typename std::conditional<
+        std::is_same< input_layout, Kokkos::LayoutStride >::value,
+        default_layout,
+        input_layout >::type;
+  };
+
+
   ///
   /// utilities device compirable
   ///


### PR DESCRIPTION
Fix for usage pattern of Kokkos common_view_alloc_prop and view_alloc
routines for creating (DynRank)View's to replace Sacado's ViewFactory.

In the case when a DynRankView was auto constructed via assignment from a
DynRankView created using the new routines, the correct layout and
device type must also be provided as template arguments, like in the
ViewFactory. Failure to do results in compile-time errors when building
with Cuda and Serial execution spaces.

A temporary meta-function for deducing the appropriate layout was added
to Intrepid2_Utils.hpp.

Unit tests build and pass ctest with Cuda 7.5 + gcc 4.9.3 + OpenMPI
1.8.7, both with Sacado enabled and disabled.