### PR TITLE
Ifpack2: ILUT: get rid of allocations in apply()

### DIFF
--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -816,88 +816,60 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::rcpFromRef;
-  typedef Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type> MV;
+  using STS = Teuchos::ScalarTraits<scalar_type>;
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    ! isComputed (), std::runtime_error,
+    "Ifpack2::ILUT::apply: You must call compute() to compute the incomplete "
+    "factorization, before calling apply().");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    X.getNumVectors() != Y.getNumVectors(), std::runtime_error,
+    "Ifpack2::ILUT::apply: X and Y must have the same number of columns.  "
+    "X has " << X.getNumVectors () << " columns, but Y has "
+    << Y.getNumVectors () << " columns.");
+
+  const scalar_type one = STS::one ();
+  const scalar_type zero = STS::zero ();
 
   Teuchos::Time timer ("ILUT::apply");
-  { // Timer scope for timing apply()
+  { // Start timing
     Teuchos::TimeMonitor timeMon (timer, true);
 
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      ! isComputed (), std::runtime_error,
-      "Ifpack2::ILUT::apply: You must call compute() to compute the incomplete "
-      "factorization, before calling apply().");
+    if (alpha == one && beta == zero) {
+      if (mode == Teuchos::NO_TRANS) { // Solve L (U Y) = X for Y.
+        // Start by solving L Y = X for Y.
+        L_solver_->apply (X, Y, mode);
 
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      X.getNumVectors() != Y.getNumVectors(), std::runtime_error,
-      "Ifpack2::ILUT::apply: X and Y must have the same number of columns.  "
-      "X has " << X.getNumVectors () << " columns, but Y has "
-      << Y.getNumVectors () << " columns.");
-
-    if (alpha == Teuchos::ScalarTraits<scalar_type>::zero ()) {
-      // alpha == 0, so we don't need to apply the operator.
-      //
-      // The special case for beta == 0 ensures that if Y contains Inf
-      // or NaN values, we replace them with 0 (following BLAS
-      // convention), rather than multiplying them by 0 to get NaN.
-      if (beta == Teuchos::ScalarTraits<scalar_type>::zero ()) {
-        Y.putScalar (beta);
-      } else {
-        Y.scale (beta);
+        // Solve U Y = Y.
+        U_solver_->apply (Y, Y, mode);
       }
-      return;
-    }
+      else { // Solve U^P (L^P Y)) = X for Y (where P is * or T).
 
-    // If beta != 0, create a temporary multivector Y_temp to hold the
-    // contents of alpha*M^{-1}*X.  Otherwise, alias Y_temp to Y.
-    RCP<MV> Y_temp;
-    if (beta == Teuchos::ScalarTraits<scalar_type>::zero ()) {
-      Y_temp = rcpFromRef (Y);
-    } else {
-      Y_temp = rcp (new MV (Y.getMap (), Y.getNumVectors ()));
-    }
+        // Start by solving U^P Y = X for Y.
+        U_solver_->apply (X, Y, mode);
 
-    // If X and Y are pointing to the same memory location, create an
-    // auxiliary vector, X_temp, so that we don't clobber the input
-    // when computing the output.  Otherwise, alias X_temp to X.
-    RCP<const MV> X_temp;
-    {
-      auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
-      auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-      if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
-        X_temp = rcp (new MV (X, Teuchos::Copy));
-      } else {
-        X_temp = rcpFromRef (X);
+        // Solve L^P Y = Y.
+        L_solver_->apply (Y, Y, mode);
       }
     }
-
-    // Create a temporary multivector Y_mid to hold the intermediate
-    // between the L and U (or U and L, for the transpose or conjugate
-    // transpose case) solves.
-    RCP<MV> Y_mid = rcp (new MV (Y.getMap (), Y.getNumVectors ()));
-
-    if (mode == Teuchos::NO_TRANS) { // Solve L U Y = X
-      L_solver_->apply (*X_temp, *Y_mid, mode);
-
-      // FIXME (mfh 20 Aug 2013) Is it OK to use Y_temp for both the
-      // input and the output?
-
-      U_solver_->apply (*Y_mid, *Y_temp, mode);
+    else { // alpha != 1 or beta != 0
+      if (alpha == zero) {
+        // The special case for beta == 0 ensures that if Y contains Inf
+        // or NaN values, we replace them with 0 (following BLAS
+        // convention), rather than multiplying them by 0 to get NaN.
+        if (beta == zero) {
+          Y.putScalar (zero);
+        } else {
+          Y.scale (beta);
+        }
+      } else { // alpha != zero
+        apply (X, Y, mode);
+        Y.update (alpha, Y, beta);
+      }
     }
-    else { // Solve U^* L^* Y = X
-      U_solver_->apply (*X_temp, *Y_mid, mode);
+  }//end timing
 
-      // FIXME (mfh 20 Aug 2013) Is it OK to use Y_temp for both the
-      // input and the output?
-
-      L_solver_->apply (*Y_mid, *Y_temp, mode);
-    }
-
-    if (beta == Teuchos::ScalarTraits<scalar_type>::zero ()) {
-      Y.scale (alpha);
-    } else { // beta != 0
-      Y.update (alpha, *Y_temp, beta);
-    }
-  }
   ++NumApply_;
   ApplyTime_ += timer.totalElapsedTime ();
 }

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -959,7 +959,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
 
         U_solver_->apply (Y, Y, mode); // Solve U Y = Y.
       }
-      else { // Solve U^P (D^P (U^P Y)) = X for Y (where P is * or T).
+      else { // Solve U^P (D^P (L^P Y)) = X for Y (where P is * or T).
 
         // Start by solving U^P Y = X for Y.
         U_solver_->apply (X, Y, mode);
@@ -976,6 +976,9 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
     }
     else { // alpha != 1 or beta != 0
       if (alpha == zero) {
+        // The special case for beta == 0 ensures that if Y contains Inf
+        // or NaN values, we replace them with 0 (following BLAS
+        // convention), rather than multiplying them by 0 to get NaN.
         if (beta == zero) {
           Y.putScalar (zero);
         } else {


### PR DESCRIPTION
From the @ambrad's comment in #1525:
```
I might be wrong, but if you're using ILUT in particular, it might be worth looking at the ILUT::apply() impl a bit, outside of just the LocalSparseTri apply() calls. I suspect there's at least one memory alloc every single apply() call, whereas IIRC we got RILUK::apply() down to none in the common case.
```
He was right 👍 
