### PR TITLE
Xpetra blockcrs fix to remove build warning

### DIFF
--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
@@ -341,6 +341,11 @@ namespace Xpetra {
     void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {
       XPETRA_MONITOR("TpetraBlockCrsMatrix::getLocalDiagOffsets");
 
+      const size_t lclNumRows = mtx_->getGraph()->getNodeNumRows();
+      if (static_cast<size_t>(offsets.size()) < lclNumRows) {
+        offsets.resize(lclNumRows);
+      }
+
       // The input ArrayRCP must always be a host pointer.  Thus, if
       // device_type::memory_space is Kokkos::HostSpace, it's OK for us
       // to write to that allocation directly as a Kokkos::View.

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
@@ -340,7 +340,31 @@ namespace Xpetra {
     //! Get offsets of the diagonal entries in the matrix.
     void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {
       XPETRA_MONITOR("TpetraBlockCrsMatrix::getLocalDiagOffsets");
-      mtx_->getLocalDiagOffsets(offsets);
+
+      // The input ArrayRCP must always be a host pointer.  Thus, if
+      // device_type::memory_space is Kokkos::HostSpace, it's OK for us
+      // to write to that allocation directly as a Kokkos::View.
+      typedef typename Node::device_type device_type;
+      typedef typename device_type::memory_space memory_space;
+      if (std::is_same<memory_space, Kokkos::HostSpace>::value) {
+        // It is always syntactically correct to assign a raw host
+        // pointer to a device View, so this code will compile correctly
+        // even if this branch never runs.
+        typedef Kokkos::View<size_t*, device_type,
+                             Kokkos::MemoryUnmanaged> output_type;
+        output_type offsetsOut (offsets.getRawPtr(), offsets.size());
+        mtx_->getLocalDiagOffsets(offsetsOut);
+      }
+      else {
+        Kokkos::View<size_t*, device_type> offsetsTmp ("diagOffsets", offsets.size());
+        mtx_->getLocalDiagOffsets(offsetsTmp);
+        typedef Kokkos::View<size_t*, Kokkos::HostSpace,
+                             Kokkos::MemoryUnmanaged> output_type;
+        output_type offsetsOut(offsets.getRawPtr(), offsets.size());
+        Kokkos::deep_copy(offsetsOut, offsetsTmp);
+      }
+
+      // mtx_->getLocalDiagOffsets(offsets);
     }
 
     //! Get a copy of the diagonal entries owned by this node, with local row indices.

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
@@ -364,7 +364,6 @@ namespace Xpetra {
         Kokkos::deep_copy(offsetsOut, offsetsTmp);
       }
 
-      // mtx_->getLocalDiagOffsets(offsets);
     }
 
     //! Get a copy of the diagonal entries owned by this node, with local row indices.


### PR DESCRIPTION
As discussed previously, here is my little patch to remove the warnings stemming from the deprecated function call used in '''xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp'''
It follows what @mhoemmen did in Tpetra so I feel somewhat confident that it should be ok?

As it is my first attempt at using kokkos feel free to educate me : ) 