### PR TITLE
Tpetra: parallel kernels for CRS matrix addition (#1367)

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1599,7 +1599,7 @@ addUnsortedGlobalCols(
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("computing unsorted unmerged sum"))));
 #endif
-  UnmergedSumFunctor<scalar_type, ordinal_type, values_array, row_ptrs_array, col_ind_type>
+  UnmergedSumFunctor<impl_scalar_type, ordinal_type, values_array, row_ptrs_array, col_ind_type>
     unmergedSum(Avals, Arowptrs, Acolinds, scalarA, Bvals, Browptrs, Bcolinds, scalarB, CvalsOver, CrowptrTemp, CcolindOver);
   Kokkos::parallel_for(range_type(0, nrows), unmergedSum);
   {

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -49,6 +49,8 @@
 #include "Tpetra_CrsMatrix.hpp"
 #include "TpetraExt_MMHelpers_def.hpp"
 #include "Tpetra_RowMatrixTransposer.hpp"
+#include "Tpetra_Details_computeOffsets.hpp"
+#include "Tpetra_Details_radixSort.hpp"
 #include "Tpetra_ConfigDefs.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Export.hpp"
@@ -478,6 +480,77 @@ void Add(
   }
 }
 
+namespace ColMapFunctors
+{
+  template<typename ByteView, typename GView>
+  struct UnionEntries
+  {
+    UnionEntries(ByteView entryUnion_, const GView gids_) : entryUnion(entryUnion_), gids(gids_) {}
+    KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+    {
+      entryUnion(gids(i)) = 1;
+    }
+    ByteView entryUnion;
+    const GView gids;
+  };
+
+  template<typename LView, typename GView>
+  struct ConvertGlobalToLocal
+  {
+    ConvertGlobalToLocal(const LView gtol_, const GView gids_, LView lids_) : gtol(gtol_), gids(gids_), lids(lids_) {}
+    KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+    {
+      lids(i) = gtol(gids(i));
+    }
+    const LView gtol;
+    const GView gids;
+    LView lids;
+  };
+}
+
+//Build the minimal (sorted) column map for the given set of global columns
+//Then convert gids and store them in lids (gids is not modified)
+template<typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Teuchos::RCP<Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> Details::AddKernels<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+makeColMapAndConvertGids(GlobalOrdinal ncols,
+                   const typename Details::AddKernels<Scalar, LocalOrdinal, GlobalOrdinal, Node>::global_col_inds_array& gids,
+                   typename Details::AddKernels<Scalar, LocalOrdinal, GlobalOrdinal, Node>::col_inds_array& lids,
+                   const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
+{
+  using namespace ColMapFunctors;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  typedef Kokkos::View<char*, device_type> ByteView;
+  typedef typename Details::AddKernels<Scalar, LocalOrdinal, GlobalOrdinal, Node>::global_col_inds_array GView;
+  typedef typename Details::AddKernels<Scalar, LocalOrdinal, GlobalOrdinal, Node>::col_inds_array LView;
+  //Functors (explained in the procedural code below)
+  auto nentries = gids.dimension_0();
+  //each entry of entryUnion is 0 unless there is a local entry in that column (then it is 1)
+  ByteView entryUnion("entry union", ncols);
+  UnionEntries<ByteView, GView> ue(entryUnion, gids);
+  Kokkos::parallel_for(range_type(0, nentries), ue);
+  //turn entryUnion into prefix sum gtol (where gtol(i) gives the new local col for global col i)
+  LView gtol("global col -> local col", ncols + 1);
+  Tpetra::Details::computeOffsetsFromCounts<decltype(gtol), decltype(entryUnion)>(gtol, entryUnion);
+  //convert gids to local ids and put them in lids (implicitly sorted as long as input gids is sorted per row)
+  ConvertGlobalToLocal<LView, GView> cgtl(gtol, gids, lids);
+  Kokkos::parallel_for(range_type(0, gids.dimension_0()), cgtl);
+  //build local set of GIDs for constructing column map - the last entry in gtol is the total number of local cols
+  execution_space::fence();
+  GView colmap("column map", gtol(ncols));
+  size_t localIter = 0;
+  execution_space::fence();
+  for(size_t i = 0; i < entryUnion.dimension_0(); i++)
+  {
+    if(entryUnion(i) != 0)
+    {
+      colmap(localIter++) = i;
+    }
+  }
+  execution_space::fence();
+  //finally, construct Tpetra map
+  return rcp(new map_type(Teuchos::OrdinalTraits<GlobalOrdinal>::invalid(), colmap, 0, comm));
+}
 
 template <class Scalar,
           class LocalOrdinal,
@@ -495,84 +568,189 @@ add (const Scalar& alpha,
      const Teuchos::RCP<Teuchos::ParameterList>& params)
 {
   using Teuchos::RCP;
+  using Teuchos::rcp;
   using Teuchos::rcpFromRef;
   using Teuchos::rcp_implicit_cast;
   using Teuchos::rcp_dynamic_cast;
-
+  using Teuchos::TimeMonitor;
   typedef Scalar                            SC;
   typedef LocalOrdinal                      LO;
   typedef GlobalOrdinal                     GO;
   typedef Node                              NO;
-  typedef RowMatrix<SC,LO,GO,NO>            row_matrix_type;
   typedef CrsMatrix<SC,LO,GO,NO>            crs_matrix_type;
+  typedef Map<LO,GO,NO>                     map_type;
   typedef RowMatrixTransposer<SC,LO,GO,NO>  transposer_type;
-
-  const std::string prefix = "TpetraExt::MatrixMatrix::add(): ";
-
+  typedef Import<LO,GO,NO>                  import_type;
+  typedef Export<LO,GO,NO>                  export_type;
+  typedef Details::AddKernels<SC,LO,GO,NO>           AddKern;
+  const char* prefix_mmm = "TpetraExt::MatrixMatrix::add(): ";
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  RCP<Teuchos::TimeMonitor> MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("transpose"))));
+#endif
   TEUCHOS_TEST_FOR_EXCEPTION(!A.isFillComplete () || !B.isFillComplete (), std::invalid_argument,
-    prefix << "A and B must both be fill complete.");
-
+    prefix_mmm << "A and B must both be fill complete.");
 #ifdef HAVE_TPETRA_DEBUG
   // The matrices don't have domain or range Maps unless they are fill complete.
   if (A.isFillComplete () && B.isFillComplete ()) {
     const bool domainMapsSame =
-      (!transposeA && !transposeB && !A.getDomainMap()->isSameAs (*B.getDomainMap ())) ||
+      (!transposeA && !transposeB && !A.getDomainMap()->locallySameAs (*B.getDomainMap ())) ||
       (!transposeA &&  transposeB && !A.getDomainMap()->isSameAs (*B.getRangeMap  ())) ||
       ( transposeA && !transposeB && !A.getRangeMap ()->isSameAs (*B.getDomainMap ()));
     TEUCHOS_TEST_FOR_EXCEPTION(domainMapsSame, std::invalid_argument,
-      prefix << "The domain Maps of Op(A) and Op(B) are not the same.");
+      prefix_mmm << "The domain Maps of Op(A) and Op(B) are not the same.");
 
     const bool rangeMapsSame =
       (!transposeA && !transposeB && !A.getRangeMap ()->isSameAs (*B.getRangeMap ())) ||
       (!transposeA &&  transposeB && !A.getRangeMap ()->isSameAs (*B.getDomainMap())) ||
       ( transposeA && !transposeB && !A.getDomainMap()->isSameAs (*B.getRangeMap ()));
     TEUCHOS_TEST_FOR_EXCEPTION(rangeMapsSame, std::invalid_argument,
-      prefix << "The range Maps of Op(A) and Op(B) are not the same.");
+      prefix_mmm << "The range Maps of Op(A) and Op(B) are not the same.");
   }
 #endif // HAVE_TPETRA_DEBUG
-
+  auto comm = A.getComm();
   // Form the explicit transpose of A if necessary.
-  RCP<const crs_matrix_type> Aprime;
+  RCP<const crs_matrix_type> Aprime = rcpFromRef(A);
   if (transposeA) {
-    transposer_type transposer (rcpFromRef (A));
+    transposer_type transposer(Aprime);
     Aprime = transposer.createTranspose ();
-
-  } else {
-    Aprime = rcpFromRef (A);
   }
-
 #ifdef HAVE_TPETRA_DEBUG
   TEUCHOS_TEST_FOR_EXCEPTION(Aprime.is_null (), std::logic_error,
-    prefix << "Failed to compute Op(A). Please report this bug to the Tpetra developers.");
+    prefix_mmm << "Failed to compute Op(A). Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
-
   // Form the explicit transpose of B if necessary.
-  RCP<const crs_matrix_type> Bprime;
+  RCP<const crs_matrix_type> Bprime = rcpFromRef(B);
   if (transposeB) {
-    transposer_type transposer (rcpFromRef (B));
+    transposer_type transposer(Bprime);
     Bprime = transposer.createTranspose ();
-
-  } else {
-    Bprime = rcpFromRef (B);
   }
-
 #ifdef HAVE_TPETRA_DEBUG
   TEUCHOS_TEST_FOR_EXCEPTION(Bprime.is_null (), std::logic_error,
-    prefix << "Failed to compute Op(B). Please report this bug to the Tpetra developers.");
-
+    prefix_mmm << "Failed to compute Op(B). Please report this bug to the Tpetra developers.");
   TEUCHOS_TEST_FOR_EXCEPTION(
     !Aprime->isFillComplete () || !Bprime->isFillComplete (), std::invalid_argument,
-    prefix << "Aprime and Bprime must both be fill complete.  "
+    prefix_mmm << "Aprime and Bprime must both be fill complete.  "
     "Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
-
-  RCP<row_matrix_type> C =
-    Bprime->add (alpha, *rcp_implicit_cast<const row_matrix_type> (Aprime),
-                 beta, domainMap, rangeMap, params);
-
-  return rcp_dynamic_cast<crs_matrix_type> (C);
+  RCP<const map_type> CDomainMap = domainMap;
+  RCP<const map_type> CRangeMap = rangeMap;
+  if(CDomainMap.is_null())
+  {
+    CDomainMap = Bprime->getDomainMap();
+  }
+  if(CRangeMap.is_null())
+  {
+    CRangeMap = Bprime->getRangeMap();
+  }
+  assert(!(CDomainMap.is_null()));
+  assert(!(CRangeMap.is_null()));
+  typedef typename AddKern::values_array values_array;
+  typedef typename AddKern::row_ptrs_array row_ptrs_array;
+  typedef typename AddKern::col_inds_array col_inds_array;
+  bool AGraphSorted = Aprime->getCrsGraph()->isSorted();
+  bool BGraphSorted = Bprime->getCrsGraph()->isSorted();
+  values_array vals;
+  row_ptrs_array rowptrs;
+  col_inds_array colinds;
+  auto acolmap = Aprime->getColMap()->getMyGlobalIndices();
+  auto bcolmap = Bprime->getColMap()->getMyGlobalIndices();
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("rowmap check/import"))));
+#endif
+  if(!(Aprime->getRowMap()->isSameAs(*(Bprime->getRowMap()))))
+  {
+    //import Aprime into Bprime's row map so the local matrices have same # of rows
+    auto import = rcp(new import_type(Aprime->getRowMap(), Bprime->getRowMap()));
+    Aprime = importAndFillCompleteCrsMatrix<crs_matrix_type>(Aprime, *import, Bprime->getDomainMap(), Bprime->getRangeMap());
+  }
+  bool matchingColMaps = Aprime->getColMap()->isSameAs(*(Bprime->getColMap()));
+  bool sorted = AGraphSorted && BGraphSorted;
+  RCP<crs_matrix_type> C;
+  RCP<const map_type> CrowMap;
+  RCP<const map_type> CcolMap;
+  RCP<const import_type> Cimport = Teuchos::null;
+  RCP<export_type> Cexport = Teuchos::null;
+  //The unsorted KCRS addition kernel uses std::sort(), which can't run on CUDA
+  if(!matchingColMaps && !(CDomainMap->isContiguous()))
+  {
+    //can't do with current set of kernels, so fall back to original (slow) version
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("fallback to CrsMatrix::add"))));
+#endif
+    return Teuchos::rcp_static_cast<crs_matrix_type>(Bprime->add(alpha, *Aprime, beta, CDomainMap, CRangeMap, params));
+  }
+  else if(!matchingColMaps)
+  {
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("mismatched col map full kernel"))));
+#endif
+    //use kernel that converts col indices in both A and B to common domain map before adding
+    auto Acolmap = Aprime->getColMap()->getMyGlobalIndices();
+    auto Bcolmap = Bprime->getColMap()->getMyGlobalIndices();
+    typename AddKern::global_col_inds_array globalColinds("", 0);
+    AddKern::convertToGlobalAndAdd(
+      Aprime->getLocalMatrix(), alpha, Bprime->getLocalMatrix(), beta, Acolmap, Bcolmap,
+      CRangeMap->getMinGlobalIndex(), Aprime->getGlobalNumCols(), vals, rowptrs, globalColinds);
+    colinds = col_inds_array("C colinds", globalColinds.dimension_0());
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("building optimized column map"))));
+#endif
+    CrowMap = Bprime->getRowMap();
+    //OLD: CcolMap = AddKern::makeColMapAndConvertGids(Aprime->getGlobalNumCols(), globalColinds, colinds, comm);
+    //Get C's column map as the union of Aprime and Bprime col maps
+    auto Aimport = Aprime->getCrsGraph()->getImporter();
+    auto Bimport = Bprime->getCrsGraph()->getImporter();
+    Cimport = Aimport->setUnion(*Bimport);
+    CcolMap = Cimport->getTargetMap();
+  }
+  else
+  {
+    auto localA = Aprime->getLocalMatrix();
+    auto localB = Bprime->getLocalMatrix();
+    auto Avals = localA.values;
+    auto Bvals = localB.values;
+    auto Arowptrs = localA.graph.row_map;
+    auto Browptrs = localB.graph.row_map;
+    auto Acolinds = localA.graph.entries;
+    auto Bcolinds = localB.graph.entries;
+    if(sorted)
+    {
+      //use sorted kernel
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("sorted entries full kernel"))));
+#endif
+      AddKern::addSorted(Avals, Arowptrs, Acolinds, alpha, Bvals, Browptrs, Bcolinds, beta, vals, rowptrs, colinds);
+    }
+    else
+    {
+      //use unsorted kernel
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("mm add unsorted entries full kernel"))));
+#endif
+      AddKern::addUnsorted(Avals, Arowptrs, Acolinds, alpha, Bvals, Browptrs, Bcolinds, beta, Aprime->getGlobalNumCols(), vals, rowptrs, colinds);
+    }
+    CrowMap = Bprime->getRowMap();
+    CcolMap = Bprime->getColMap();
+    if(!CDomainMap->isSameAs(*CcolMap))
+    {
+      Cimport = rcp(new import_type(CDomainMap, CcolMap));
+    }
+    //note: Cexport created below (if it's needed)
+  }
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("Tpetra::Crs constructor"))));
+#endif
+      C = rcp(new crs_matrix_type(CrowMap, CcolMap, rowptrs, colinds, vals, params));
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("Tpetra::Crs expertStaticFillComplete"))));
+#endif
+  if(!CrowMap->isSameAs(*CRangeMap))
+  {
+    Cexport = rcp(new export_type(CrowMap, CRangeMap));
+  }
+  C->expertStaticFillComplete(CDomainMap, CRangeMap, Cimport, Cexport, params);
+  return C;
 }
-
 
 template <class Scalar,
           class LocalOrdinal,
@@ -894,6 +1072,565 @@ void Add(
   }
 }
 
+namespace AddSortedFunctors
+{
+
+template<typename Ordinal, typename RowPtrs, typename ColInds>
+struct EntryCountingFunctor
+{
+  EntryCountingFunctor(const typename RowPtrs::const_type Arowptrs_, const ColInds Acolinds_, const typename RowPtrs::const_type Browptrs_, const ColInds Bcolinds_, RowPtrs Crowcounts_) :
+    Arowptrs(Arowptrs_), Acolinds(Acolinds_),
+    Browptrs(Browptrs_), Bcolinds(Bcolinds_),
+    Crowcounts(Crowcounts_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    //count the union of nonzeros in Arow and Brow
+    Ordinal numEntries = 0;
+    Ordinal ai = 0;
+    Ordinal bi = 0;
+    auto Arowstart = Arowptrs(i);
+    auto Arowlen = Arowptrs(i + 1) - Arowstart;
+    auto Browstart = Browptrs(i);
+    auto Browlen = Browptrs(i + 1) - Browstart;
+    while(ai < Arowlen && bi < Browlen)
+    {
+      //have an entry in C's row
+      numEntries++;
+      auto Acol = Acolinds(Arowstart + ai);
+      auto Bcol = Bcolinds(Browstart + bi);
+      if(Acol <= Bcol)
+        ai++;
+      if(Acol >= Bcol)
+        bi++;
+    }
+    numEntries += Arowlen - ai;
+    numEntries += Browlen - bi;
+    Crowcounts(i) = numEntries;
+  }
+  const typename RowPtrs::const_type Arowptrs;
+  const ColInds Acolinds;
+  const typename RowPtrs::const_type Browptrs;
+  const ColInds Bcolinds;
+  RowPtrs Crowcounts;
+};
+
+template<typename Scalar, typename Ordinal, typename Values, typename RowPtrs, typename ColInds>
+struct SumFunctor
+{
+  SumFunctor(const Values Avals_, const typename RowPtrs::const_type Arowptrs_, const ColInds Acolinds_, const Scalar scalarA_,
+           const Values Bvals_, const typename RowPtrs::const_type Browptrs_, const ColInds Bcolinds_, const Scalar scalarB_,
+           Values Cvals_, const RowPtrs Crowptrs_, ColInds Ccolinds_) :
+    Avals(Avals_), Arowptrs(Arowptrs_), Acolinds(Acolinds_), scalarA(scalarA_),
+    Bvals(Bvals_), Browptrs(Browptrs_), Bcolinds(Bcolinds_), scalarB(scalarB_),
+    Cvals(Cvals_), Crowptrs(Crowptrs_), Ccolinds(Ccolinds_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    //get views of row i in A and B
+    auto Arowstart = Arowptrs(i);
+    auto Arowlen = Arowptrs(i + 1) - Arowstart;
+    auto Browstart = Browptrs(i);
+    auto Browlen = Browptrs(i + 1) - Browstart;
+    Ordinal CrowStart = Crowptrs(i);
+    Ordinal ai = 0;
+    Ordinal bi = 0;
+    Ordinal numInserted = 0;
+    while(ai < Arowlen && bi < Browlen)
+    {
+      Ordinal Acol = Acolinds(Arowstart + ai);
+      Ordinal Bcol = Bcolinds(Browstart + bi);
+      //next col in C is minimum of two next cols in A and B
+      Ordinal Ccol = Acol < Bcol ? Acol : Bcol;
+      Scalar val = 0;
+      if(Acol == Ccol)
+      {
+        val += scalarA * Avals(Arowstart + ai);
+        ai++;
+      }
+      if(Bcol == Ccol)
+      {
+        val += scalarB * Bvals(Browstart + bi);
+        bi++;
+      }
+      Cvals(CrowStart + numInserted) = val;
+      Ccolinds(CrowStart + numInserted) = Ccol;
+      numInserted++;
+    }
+    for(; ai < Arowlen; ai++)
+    {
+      Cvals(CrowStart + numInserted) = scalarA * Avals(Arowstart + ai);
+      Ccolinds(CrowStart + numInserted) = Acolinds(Arowstart + ai);
+      numInserted++;
+    }
+    for(; bi < Browlen; bi++)
+    {
+      Cvals(CrowStart + numInserted) = scalarB * Bvals(Browstart + bi);
+      Ccolinds(CrowStart + numInserted) = Bcolinds(Browstart + bi);
+      numInserted++;
+    }
+  }
+  const Values Avals;
+  const typename RowPtrs::const_type Arowptrs;
+  const ColInds Acolinds;
+  const Scalar scalarA;
+  const Values Bvals;
+  const typename RowPtrs::const_type Browptrs;
+  const ColInds Bcolinds;
+  const Scalar scalarB;
+  Values Cvals;
+  const RowPtrs Crowptrs;
+  ColInds Ccolinds;
+};
+}
+
+template<typename SC, typename LO, typename GO, typename NO>
+void Details::AddKernels<SC, LO, GO, NO>::
+addSorted(
+  const typename Details::AddKernels<SC, LO, GO, NO>::values_array& Avals,
+  const typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array_const& Arowptrs,
+  const typename Details::AddKernels<SC, LO, GO, NO>::col_inds_array& Acolinds, 
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarA,
+  const typename Details::AddKernels<SC, LO, GO, NO>::values_array& Bvals,
+  const typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array_const& Browptrs,
+  const typename Details::AddKernels<SC, LO, GO, NO>::col_inds_array& Bcolinds, 
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarB,
+  typename Details::AddKernels<SC, LO, GO, NO>::values_array& Cvals,
+  typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array& Crowptrs,
+  typename Details::AddKernels<SC, LO, GO, NO>::col_inds_array& Ccolinds)
+{
+  using namespace AddSortedFunctors;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::TimeMonitor;
+  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.dimension_0() != Browptrs.dimension_0(), std::runtime_error, "Can't add matrices with different numbers of rows.");
+  auto nrows = Arowptrs.dimension_0() - 1;
+  Crowptrs = row_ptrs_array("C row ptrs", nrows + 1);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  auto MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() sorted kernel: " + std::string("entry counting and rowptr prefix sum"))));
+#endif
+  {
+    row_ptrs_array Crowcounts("C row counts", nrows);
+    EntryCountingFunctor<LO, row_ptrs_array, col_inds_array> entCount(Arowptrs, Acolinds, Browptrs, Bcolinds, Crowcounts);
+    Kokkos::parallel_for(range_type(0, nrows), entCount);
+    //Count C nonzeros in each row in parallel
+    Tpetra::Details::computeOffsetsFromCounts<row_ptrs_array, row_ptrs_array>(Crowptrs, Crowcounts);
+  }
+  execution_space::fence();
+  auto nnz = Crowptrs(nrows);
+  Cvals = values_array("C values", nnz);
+  Ccolinds = col_inds_array("C colinds", nnz);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() sorted kernel: " + std::string("get sum values/indices"))));
+#endif
+  SumFunctor<impl_scalar_type, LO, values_array, row_ptrs_array, col_inds_array>
+    sumFunct(Avals, Arowptrs, Acolinds, scalarA, Bvals, Browptrs, Bcolinds, scalarB, Cvals, Crowptrs, Ccolinds);
+  Kokkos::parallel_for(range_type(0, nrows), sumFunct);
+}
+
+template<typename GO, typename LocalIndicesType, typename GlobalIndicesType, typename ColMapType>
+struct ConvertColIndsFunctor
+{
+  ConvertColIndsFunctor(GO minGlobal_, const LocalIndicesType& colindsOrig_, GlobalIndicesType& colindsConverted_, const ColMapType& colmap_) : minGlobal(minGlobal_), colindsOrig(colindsOrig_), colindsConverted(colindsConverted_), colmap(colmap_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    colindsConverted[i] = colmap[colindsOrig[i]];
+  }
+  GO minGlobal;
+  const LocalIndicesType& colindsOrig;
+  GlobalIndicesType& colindsConverted;
+  const ColMapType& colmap;
+};
+
+template<typename SC, typename LO, typename GO, typename NO>
+void Details::AddKernels<SC, LO, GO, NO>::
+convertToGlobalAndAdd(
+  const typename Details::AddKernels<SC, LO, GO, NO>::KCRS& A,
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarA,
+  const typename Details::AddKernels<SC, LO, GO, NO>::KCRS& B,
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarB,
+  const typename Details::AddKernels<SC, LO, GO, NO>::local_map_type& AcolMap,
+  const typename Details::AddKernels<SC, LO, GO, NO>::local_map_type& BcolMap,
+  GO minGlobalCol,
+  GO numGlobalCols,
+  typename Details::AddKernels<SC, LO, GO, NO>::values_array& Cvals,
+  typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array& Crowptrs,
+  typename Details::AddKernels<SC, LO, GO, NO>::global_col_inds_array& Ccolinds)
+{
+  using namespace AddSortedFunctors;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::TimeMonitor;
+  const values_array& Avals = A.values;
+  const values_array& Bvals = B.values;
+  const col_inds_array& Ainds = A.graph.entries;
+  const col_inds_array& Binds = B.graph.entries;
+  auto Arowptrs = A.graph.row_map;
+  auto Browptrs = B.graph.row_map;
+  global_col_inds_array AindsConverted("A colinds (converted)", Ainds.dimension_0());
+  global_col_inds_array BindsConverted("B colinds (converted)", Binds.dimension_0());
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  auto MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() diff col map kernel: " + std::string("column map conversion"))));
+#endif
+  ConvertColIndsFunctor<GO, col_inds_array, global_col_inds_array, local_map_type> convertA(minGlobalCol, Ainds, AindsConverted, AcolMap);
+  Kokkos::parallel_for(range_type(0, Ainds.dimension_0()), convertA);
+  ConvertColIndsFunctor<GO, col_inds_array, global_col_inds_array, local_map_type> convertB(minGlobalCol, Binds, BindsConverted, BcolMap);
+  Kokkos::parallel_for(range_type(0, Binds.dimension_0()), convertB);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() diff col map kernel: " + std::string("unsorted addition"))));
+#endif
+  addUnsortedGlobalCols(
+     Avals, Arowptrs, AindsConverted, scalarA,
+     Bvals, Browptrs, BindsConverted, scalarB,
+     numGlobalCols, Cvals, Crowptrs, Ccolinds);
+}
+
+namespace AddUnsortedFunctors
+{
+//Non-ideal for peak memory usage but works and is completely parallel over rows (except for allocations and a few minor intermediate steps)
+//4 Functors:
+//  <Allocate CrowptrTemp>
+//1: compute C entries per row upper bound (A entries + B entries)
+//  <Make CrowptrTemp into prefix sum array>
+//  <Allocate oversized Cvals and Ccolind>
+//2: just copy scaled a,b values into oversized C values/colind (filling it completely)
+//  Note: these values aren't condensed or sorted yet (so, may be duplicate colinds, but that's expected)
+//  <Allocate Crowptr>
+//3: Sort each row's colinds (permuting values at same time), then count unique colinds (write that to Crowptr(i))
+//  <Make Crowptr into prefix sum array>
+//  <Allocate correctly sized Cvals and Ccolind>
+//4: Condense values from oversized Cvals/Ccolind to correctly sized
+//  <done: have everything needed to build final C>
+
+template<typename Ordinal, typename Values, typename RowPtrs, typename ColInds>
+struct EntryUpperBoundFunctor
+{
+  EntryUpperBoundFunctor(const Values Avals_, const typename RowPtrs::const_type Arowptrs_, const ColInds Acolinds_, const Values Bvals_, const typename RowPtrs::const_type Browptrs_, const ColInds Bcolinds_, RowPtrs CrowcountsTemp_) :
+  Avals(Avals_), Arowptrs(Arowptrs_), Acolinds(Acolinds_),
+  Bvals(Bvals_), Browptrs(Browptrs_), Bcolinds(Bcolinds_),
+  CrowcountsTemp(CrowcountsTemp_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    CrowcountsTemp(i) = (Arowptrs(i + 1) - Arowptrs(i)) + (Browptrs(i + 1) - Browptrs(i));
+  }
+  const Values Avals;
+  const typename RowPtrs::const_type Arowptrs;
+  const ColInds Acolinds;
+  const Values Bvals;
+  const typename RowPtrs::const_type Browptrs;
+  const ColInds Bcolinds;
+  RowPtrs CrowcountsTemp;
+};
+
+template<typename Scalar, typename Ordinal, typename Values, typename RowPtrs, typename ColInds>
+struct UnmergedSumFunctor
+{
+  UnmergedSumFunctor(const Values Avals_, const typename RowPtrs::const_type Arowptrs_, const ColInds Acolinds_, const Scalar scalarA_,
+           const Values Bvals_, const typename RowPtrs::const_type Browptrs_, const ColInds Bcolinds_, const Scalar scalarB_,
+           Values CvalsOver_, const RowPtrs CrowptrsTemp_, ColInds CcolindsOver_) :
+    Avals(Avals_), Arowptrs(Arowptrs_), Acolinds(Acolinds_), scalarA(scalarA_),
+    Bvals(Bvals_), Browptrs(Browptrs_), Bcolinds(Bcolinds_), scalarB(scalarB_),
+    CvalsOver(CvalsOver_), CrowptrsTemp(CrowptrsTemp_), CcolindsOver(CcolindsOver_)
+  {}
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    Ordinal inserted = 0;
+    auto rowStart = CrowptrsTemp(i);
+    auto arowstart = Arowptrs(i);
+    auto arowlen = Arowptrs(i + 1) - arowstart;
+    auto browstart = Browptrs(i);
+    auto browlen = Browptrs(i + 1) - browstart;
+    for(Ordinal j = 0; j < arowlen; j++)
+    {
+      CvalsOver(rowStart + inserted) = scalarA * Avals(arowstart + j);
+      CcolindsOver(rowStart + inserted) = Acolinds(arowstart + j);
+      inserted++;
+    }
+    for(Ordinal j = 0; j < browlen; j++)
+    {
+      CvalsOver(rowStart + inserted) = scalarB * Bvals(browstart + j);
+      CcolindsOver(rowStart + inserted) = Bcolinds(browstart + j);
+      inserted++;
+    }
+  }
+  const Values Avals;
+  const typename RowPtrs::const_type Arowptrs;
+  const ColInds Acolinds;
+  const Scalar scalarA;
+  const Values Bvals;
+  const typename RowPtrs::const_type Browptrs;
+  const ColInds Bcolinds;
+  const Scalar scalarB;
+  Values CvalsOver;
+  const RowPtrs CrowptrsTemp;
+  ColInds CcolindsOver;
+};
+
+template<typename Ordinal, typename Scalar, typename Values, typename RowPtrs, typename ColInds>
+struct SortAndMergeFunctor
+{
+  SortAndMergeFunctor(const RowPtrs CrowptrTemp_, RowPtrs Crowcounts_, ColInds CcolindOver_, Values CvalsOver_, ColInds CcolindAux_, Values CvalsAux_, Ordinal ncols_) :
+    CrowptrTemp(CrowptrTemp_),
+    Crowcounts(Crowcounts_),
+    CcolindOver(CcolindOver_),
+    CvalsOver(CvalsOver_),
+    CcolindAux(CcolindAux_),
+    CvalsAux(CvalsAux_),
+    ncols(ncols_)
+  {}
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    //3: Sort each row's colinds (permuting values at same time), then count unique colinds (write that to Crowptr(i))
+    //CrowptrTemp tells how many entries in each oversized row
+    Ordinal rowStart = CrowptrTemp(i);
+    Ordinal rowEnd = CrowptrTemp(i + 1);
+    Ordinal rowNum = rowEnd - rowStart;
+    Tpetra::Details::radixSortKeysAndValues(CcolindOver.ptr_on_device() + rowStart, CcolindAux.ptr_on_device() + rowStart, CvalsOver.ptr_on_device() + rowStart, CvalsAux.ptr_on_device() + rowStart, (size_t) rowNum, (size_t) ncols);
+    //now that they are sorted, can sweep through and gather together values in same column
+    Ordinal finalPos = 0;
+    Ordinal overPos = 0;
+    while(overPos < rowNum)
+    {
+      //check if the two entries at overPos are the same col
+      if(CcolindOver(rowStart + overPos) == CcolindOver(rowStart + overPos + 1) && (overPos + 1 < rowNum))
+      {
+        //they are the same col, so combine the two entries at finalPos
+        //Then increment overPos an extra time since just processed two entries
+        CcolindOver(rowStart + finalPos) = CcolindOver(rowStart + overPos);
+        CvalsOver(rowStart + finalPos) = CvalsOver(rowStart + overPos) + CvalsOver(rowStart + overPos + 1);
+        overPos++;
+      }
+      else
+      {
+        //they are not the same col, so just copy the one entry at overPos to finalPos
+        CcolindOver(rowStart + finalPos) = CcolindOver(rowStart + overPos);
+        CvalsOver(rowStart + finalPos) = CvalsOver(rowStart + overPos);
+      }
+      overPos++;
+      finalPos++;
+    }
+    Crowcounts(i) = finalPos;
+  }
+  const RowPtrs CrowptrTemp;
+  RowPtrs Crowcounts;
+  ColInds CcolindOver;
+  Values CvalsOver;
+  //Two scratch arrays, used for sorting (with same size as CcolindOver and CvalsOver)
+  ColInds CcolindAux;
+  Values CvalsAux;
+  Ordinal ncols;
+};
+
+template<typename Ordinal, typename Values, typename RowPtrs, typename ColInds>
+struct CondenseArraysFunctor
+{
+  CondenseArraysFunctor(const RowPtrs& Crowptr_, const RowPtrs& CrowptrTemp_, const ColInds& CcolindOver_, ColInds& Ccolind_, const Values& CvalsOver_, Values& Cvals_) :
+    Crowptr(Crowptr_),
+    CrowptrTemp(CrowptrTemp_),
+    CcolindOver(CcolindOver_),
+    Ccolind(Ccolind_),
+    CvalsOver(CvalsOver_),
+    Cvals(Cvals_)
+  {}
+  //4: Copy values from oversized Cvals/Ccolind to correctly sized
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const
+  {
+    Ordinal rowNum = Crowptr(i + 1) - Crowptr(i);
+    for(Ordinal j = 0; j < rowNum; j++)
+    {
+      Ccolind(Crowptr(i) + j) = CcolindOver(CrowptrTemp(i) + j);
+      Cvals(Crowptr(i) + j) = CvalsOver(CrowptrTemp(i) + j);
+    }
+  }
+  const RowPtrs& Crowptr;
+  const RowPtrs& CrowptrTemp;
+  const ColInds& CcolindOver;
+  ColInds& Ccolind;
+  const Values& CvalsOver;
+  Values& Cvals;
+};
+}
+
+template<typename SC, typename LO, typename GO, typename NO>
+void Details::AddKernels<SC, LO, GO, NO>::
+addUnsorted(
+  const typename Details::AddKernels<SC, LO, GO, NO>::values_array& Avals,
+  const typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array_const& Arowptrs,
+  const typename Details::AddKernels<SC, LO, GO, NO>::col_inds_array& Acolinds, 
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarA,
+  const typename Details::AddKernels<SC, LO, GO, NO>::values_array& Bvals,
+  const typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array_const& Browptrs,
+  const typename Details::AddKernels<SC, LO, GO, NO>::col_inds_array& Bcolinds, 
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarB,
+  GO numGlobalCols,
+  typename Details::AddKernels<SC, LO, GO, NO>::values_array& Cvals,
+  typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array& Crowptrs,
+  typename Details::AddKernels<SC, LO, GO, NO>::col_inds_array& Ccolinds)
+{
+  using namespace AddUnsortedFunctors;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::TimeMonitor;
+  typedef col_inds_array col_ind_type;
+//  <Allocate CrowptrTemp>
+//1: compute C entries per row upper bound (A entries + B entries)
+//  <Make CrowptrTemp into prefix sum array>
+//  <Allocate oversized Cvals and Ccolind>
+//2: just copy scaled a,b values into oversized C values/colind (filling it completely)
+//  Note: these values aren't condensed or sorted yet (so, may be duplicate colinds, but that's expected)
+//  <Allocate Crowptr>
+//3: Sort each row's colinds (permuting values at same time), then count unique colinds (write that to Crowptr(i))
+//  <Make Crowptr into prefix sum array>
+//  <Allocate correctly sized Cvals and Ccolind>
+//4: Condense values from oversized Cvals/Ccolind to correctly sized
+//  <done: have everything needed to build final C>
+  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.dimension_0() != Browptrs.dimension_0(), std::runtime_error, "Can't add matrices with different numbers of rows.");
+  LO nrows = Arowptrs.dimension_0() - 1;
+  row_ptrs_array CrowptrTemp("C row pointers (upper bound)", nrows + 1);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  auto MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("nnz upper bound"))));
+#endif
+  {
+    row_ptrs_array rowCounts("Row counts", nrows);
+    AddUnsortedFunctors::EntryUpperBoundFunctor<LO, values_array, row_ptrs_array, col_ind_type> funct1(Avals, Arowptrs, Acolinds, Bvals, Browptrs, Bcolinds, rowCounts);
+    //Count C nonzeros in each row in parallel
+    Kokkos::parallel_for(range_type(0, nrows), funct1);
+    //Make C rowptr cumulative (and also fill in last row with total nnz)
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("nnz upper bound"))));
+#endif
+    Tpetra::Details::computeOffsetsFromCounts<row_ptrs_array, row_ptrs_array>(CrowptrTemp, rowCounts);
+  }
+  auto nnz = CrowptrTemp(nrows);
+  col_ind_type CcolindOver("C indices", nnz + 1);
+  values_array CvalsOver("C values", nnz + 1);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("computing unsorted unmerged sum"))));
+#endif
+  UnmergedSumFunctor<impl_scalar_type, LO, values_array, row_ptrs_array, col_ind_type>
+    unmergedSum(Avals, Arowptrs, Acolinds, scalarA, Bvals, Browptrs, Bcolinds, scalarB, CvalsOver, CrowptrTemp, CcolindOver);
+  Kokkos::parallel_for(range_type(0, nrows), unmergedSum);
+  {
+    col_ind_type CcolindAux("C indices sorting buffer", nnz);
+    values_array CvalsAux("C values sorting buffer", nnz);
+    row_ptrs_array Crowcounts("C row counts", nrows);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("sorting and merging sum"))));
+#endif
+    SortAndMergeFunctor<LO, impl_scalar_type, values_array, row_ptrs_array, col_ind_type>
+      sortAndMerge(CrowptrTemp, Crowcounts, CcolindOver, CvalsOver, CcolindAux, CvalsAux, numGlobalCols);
+    Kokkos::parallel_for(range_type(0, nrows), sortAndMerge);
+    //convert Crowcounts into prefix sum Crowptrs
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("getting rowptr prefix sum"))));
+#endif
+    Crowptrs = row_ptrs_array("C row pointers", nrows + 1);
+    Tpetra::Details::computeOffsetsFromCounts<row_ptrs_array, row_ptrs_array>(Crowptrs, Crowcounts);
+  }
+  execution_space::fence();
+  nnz = Crowptrs(nrows);
+  //Turn Crowptrs into a prefix sum
+  Cvals = values_array("C values", nnz);
+  Ccolinds = col_ind_type("C col indices", nnz);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("copying sum into condensed arrays"))));
+#endif
+  CondenseArraysFunctor<LO, values_array, row_ptrs_array, col_ind_type>
+    condense(Crowptrs, CrowptrTemp, CcolindOver, Ccolinds, CvalsOver, Cvals);
+  Kokkos::parallel_for(range_type(0, nrows), condense);
+} 
+
+template<typename SC, typename LO, typename GO, typename NO>
+void Details::AddKernels<SC, LO, GO, NO>::
+addUnsortedGlobalCols(
+  const typename Details::AddKernels<SC, LO, GO, NO>::values_array& Avals,
+  const typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array_const& Arowptrs,
+  const typename Details::AddKernels<SC, LO, GO, NO>::global_col_inds_array& Acolinds, 
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarA,
+  const typename Details::AddKernels<SC, LO, GO, NO>::values_array& Bvals,
+  const typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array_const& Browptrs,
+  const typename Details::AddKernels<SC, LO, GO, NO>::global_col_inds_array& Bcolinds, 
+  const typename Details::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarB,
+  GO numGlobalCols,
+  typename Details::AddKernels<SC, LO, GO, NO>::values_array& Cvals,
+  typename Details::AddKernels<SC, LO, GO, NO>::row_ptrs_array& Crowptrs,
+  typename Details::AddKernels<SC, LO, GO, NO>::global_col_inds_array& Ccolinds)
+{
+  using namespace AddUnsortedFunctors;
+  typedef global_col_inds_array col_ind_type;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::TimeMonitor;
+  typedef typename NO::device_type::execution_space execution_space;
+  typedef SC scalar_type;
+  typedef LO ordinal_type;
+  typedef Kokkos::RangePolicy<execution_space, size_t> range_type;
+//  <Allocate CrowptrTemp>
+//1: compute C entries per row upper bound (A entries + B entries)
+//  <Make CrowptrTemp into prefix sum array>
+//  <Allocate oversized Cvals and Ccolind>
+//2: just copy scaled a,b values into oversized C values/colind (filling it completely)
+//  Note: these values aren't condensed or sorted yet (so, may be duplicate colinds, but that's expected)
+//  <Allocate Crowptr>
+//3: Sort each row's colinds (permuting values at same time), then count unique colinds (write that to Crowptr(i))
+//  <Make Crowptr into prefix sum array>
+//  <Allocate correctly sized Cvals and Ccolind>
+//4: Condense values from oversized Cvals/Ccolind to correctly sized
+//  <done: have everything needed to build final C>
+  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.dimension_0() != Browptrs.dimension_0(), std::runtime_error, "Can't add matrices with different numbers of rows.");
+  ordinal_type nrows = Arowptrs.dimension_0() - 1;
+  row_ptrs_array CrowptrTemp("C row pointers (upper bound)", nrows + 1);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  auto MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("nnz upper bound"))));
+#endif
+  {
+    row_ptrs_array rowCounts("Row counts", nrows);
+    AddUnsortedFunctors::EntryUpperBoundFunctor<ordinal_type, values_array, row_ptrs_array, col_ind_type>
+      funct1(Avals, Arowptrs, Acolinds, Bvals, Browptrs, Bcolinds, rowCounts);
+    //Count C nonzeros in each row in parallel
+    Kokkos::parallel_for(range_type(0, nrows), funct1);
+    //Make C rowptr cumulative (and also fill in last row with total nnz)
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("nnz upper bound"))));
+#endif
+    Tpetra::Details::computeOffsetsFromCounts<row_ptrs_array, row_ptrs_array>(CrowptrTemp, rowCounts);
+  }
+  auto nnz = CrowptrTemp(nrows);
+  col_ind_type CcolindOver("C indices", nnz + 1);
+  values_array CvalsOver("C values", nnz + 1);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("computing unsorted unmerged sum"))));
+#endif
+  UnmergedSumFunctor<scalar_type, ordinal_type, values_array, row_ptrs_array, col_ind_type>
+    unmergedSum(Avals, Arowptrs, Acolinds, scalarA, Bvals, Browptrs, Bcolinds, scalarB, CvalsOver, CrowptrTemp, CcolindOver);
+  Kokkos::parallel_for(range_type(0, nrows), unmergedSum);
+  {
+    col_ind_type CcolindAux("C indices sorting buffer", nnz);
+    values_array CvalsAux("C values sorting buffer", nnz);
+    row_ptrs_array Crowcounts("C row counts", nrows);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("sorting and merging sum"))));
+#endif
+    SortAndMergeFunctor<ordinal_type, impl_scalar_type, values_array, row_ptrs_array, col_ind_type>
+      sortAndMerge(CrowptrTemp, Crowcounts, CcolindOver, CvalsOver, CcolindAux, CvalsAux, numGlobalCols);
+    Kokkos::parallel_for(range_type(0, nrows), sortAndMerge);
+    //convert Crowcounts into prefix sum Crowptrs
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("getting rowptr prefix sum"))));
+#endif
+    Crowptrs = row_ptrs_array("C row pointers", nrows + 1);
+    Tpetra::Details::computeOffsetsFromCounts<row_ptrs_array, row_ptrs_array>(Crowptrs, Crowcounts);
+  }
+  execution_space::fence();
+  nnz = Crowptrs(nrows);
+  //Turn Crowptrs into a prefix sum
+  Cvals = values_array("", nnz);
+  Ccolinds = col_ind_type("", nnz);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() unsorted kernel: " + std::string("copying sum into condensed arrays"))));
+#endif
+  CondenseArraysFunctor<ordinal_type, values_array, row_ptrs_array, col_ind_type>
+    condense(Crowptrs, CrowptrTemp, CcolindOver, Ccolinds, CvalsOver, Cvals);
+  Kokkos::parallel_for(range_type(0, nrows), condense);
+}
 
 } //End namespace MatrixMatrix
 
@@ -2757,11 +3494,8 @@ void import_and_extract_views(
   }
 }
 
-
-
 } //End namepsace MMdetails
 
-} //End namespace Tpetra
 //
 // Explicit instantiation macro
 //
@@ -2769,7 +3503,6 @@ void import_and_extract_views(
 //
 
 #define TPETRA_MATRIXMATRIX_INSTANT(SCALAR,LO,GO,NODE) \
-  \
   template \
   void MatrixMatrix::Multiply( \
     const CrsMatrix< SCALAR , LO , GO , NODE >& A, \
@@ -2801,7 +3534,7 @@ template \
     bool transposeB, \
     SCALAR scalarB, \
     Teuchos::RCP<CrsMatrix< SCALAR , LO , GO , NODE > > C); \
-  \
+\
   template \
   void MatrixMatrix::Add( \
     const CrsMatrix<SCALAR, LO, GO, NODE>& A, \
@@ -2809,19 +3542,23 @@ template \
     SCALAR scalarA, \
     CrsMatrix<SCALAR, LO, GO, NODE>& B, \
     SCALAR scalarB ); \
-  \
+\
   template \
   Teuchos::RCP<CrsMatrix< SCALAR , LO , GO , NODE > > \
-  MatrixMatrix::add (const SCALAR & alpha, \
+  MatrixMatrix::add<SCALAR, LO, GO, NODE> \
+                    (const SCALAR & alpha, \
                      const bool transposeA, \
-                     const CrsMatrix< SCALAR , LO , GO , NODE >& A, \
+                     const CrsMatrix<SCALAR, LO, GO, NODE>& A, \
                      const SCALAR & beta, \
                      const bool transposeB, \
-                     const CrsMatrix< SCALAR , LO , GO , NODE >& B, \
-                     const Teuchos::RCP<const Map< LO , GO , NODE > >& domainMap, \
-                     const Teuchos::RCP<const Map< LO , GO , NODE > >& rangeMap, \
+                     const CrsMatrix<SCALAR, LO, GO, NODE>& B, \
+                     const Teuchos::RCP<const Map<LO, GO, NODE> >& domainMap, \
+                     const Teuchos::RCP<const Map<LO, GO, NODE> >& rangeMap, \
                      const Teuchos::RCP<Teuchos::ParameterList>& params); \
 \
+  template struct MatrixMatrix::Details::AddKernels<SCALAR, LO, GO, NODE>;
 
+} //End namespace Tpetra
 
 #endif // TPETRA_MATRIXMATRIX_DEF_HPP
+

--- a/packages/tpetra/core/src/Tpetra_Details_radixSort.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_radixSort.hpp
@@ -1,0 +1,150 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#ifndef TPETRA_DETAILS_RADIXSORT_HPP
+#define TPETRA_DETAILS_RADIXSORT_HPP
+
+#include "TpetraCore_config.h"
+#include "Kokkos_Macros.hpp"
+
+namespace Tpetra
+{
+namespace Details
+{
+
+/// \brief Radix sort the input array \c keys, and permute values identically to the keys.
+/// 
+/// Radix sort may be significantly faster (60%) than Details::shellsort but only works for integers
+///
+/// \pre KeyType is an integer (can be signed or unsigned)
+///
+/// \param keys [in/out] Input array of keys to sort.
+/// \param keysAux [in] Scratch space (double buffer) for keys (must be allocated to same size as keys)
+/// \param values [in/out] Input array of values to permute (must have same number of elements as keys)
+/// \param valuesAux [in] Scratch space (double buffer) for values (must be allocated to same size as values)
+/// \param n [in] Length of all 4 input arrays keys, keysAux, values and valuesAux.
+template<typename KeyType, typename ValueType, typename IndexType>
+KOKKOS_INLINE_FUNCTION void
+radixSortKeysAndValues(KeyType* keys, KeyType* keysAux, ValueType* values, ValueType* valuesAux, IndexType n, IndexType upperBound)
+{
+  if(n <= 1)
+    return;
+  KeyType mask = 0xF;
+  bool inAux = false;
+  //maskPos counts the low bit index of mask (0, 4, 8, ...)
+  IndexType maskPos = 0;
+  //Count number of bits required to sort (8 * sizeof(KeyType) - lzcnt(maxKey - minKey))
+  IndexType sortBits = 0;
+  while(upperBound)
+  {
+    upperBound >>= 1;
+    sortBits++;
+  }
+  for(IndexType s = 0; s < (sortBits + 3) / 4; s++)
+  {
+    //Count the number of elements in each bucket
+    IndexType count[16] = {0};
+    IndexType offset[17] = {0};
+    if(!inAux)
+    {
+      for(IndexType i = 0; i < n; i++)
+      {
+        count[(keys[i] & mask) >> maskPos]++;
+      }
+    }
+    else
+    {
+      for(IndexType i = 0; i < n; i++)
+      {
+        count[(keysAux[i] & mask) >> maskPos]++;
+      }
+    }
+    //get offset as the prefix sum for count
+    for(IndexType i = 0; i < 16; i++)
+    {
+      offset[i + 1] = offset[i] + count[i];
+    }
+    //now for each element in [lo, hi), move it to its offset in the other buffer
+    //this branch should be ok because whichBuf is the same on all threads
+    if(!inAux)
+    {
+      //copy from *Over to *Aux
+      for(IndexType i = 0; i < n; i++)
+      {
+        IndexType bucket = (keys[i] & mask) >> maskPos;
+        keysAux[offset[bucket + 1] - count[bucket]] = keys[i];
+        valuesAux[offset[bucket + 1] - count[bucket]] = values[i];
+        count[bucket]--;
+      }
+    }
+    else
+    {
+      //copy from *Aux to *Over
+      for(IndexType i = 0; i < n; i++)
+      {
+        IndexType bucket = (keysAux[i] & mask) >> maskPos;
+        keys[offset[bucket + 1] - count[bucket]] = keysAux[i];
+        values[offset[bucket + 1] - count[bucket]] = valuesAux[i];
+        count[bucket]--;
+      }
+    }
+    inAux = !inAux;
+    mask = mask << 4;
+    maskPos += 4;
+  }
+  if(inAux)
+  {
+    //need to deep copy from aux arrays to main
+    for(IndexType i = 0; i < n; i++)
+    {
+      keys[i] = keysAux[i];
+      values[i] = valuesAux[i];
+    }
+  }
+}
+
+} //namespace Details
+} //namespace Tpetra
+
+#endif  //include guard
+

--- a/packages/tpetra/core/test/MatrixMatrix/AddProfilingTest.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/AddProfilingTest.cpp
@@ -72,9 +72,9 @@ using Teuchos::RCP;
 using Teuchos::rcp;
 using Teuchos::Comm;
 
-#define NUM_ROWS 10000
+#define NUM_ROWS 1000
 #define NNZ_PER_ROW 100
-#define TRIALS 10
+#define TRIALS 5
 
 //Produce a random matrix with given nnz per global row
 template<typename SC, typename LO, typename GO, typename NT>

--- a/packages/tpetra/core/test/MatrixMatrix/AddProfilingTest.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/AddProfilingTest.cpp
@@ -1,0 +1,180 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+#include <Tpetra_ConfigDefs.hpp>
+#include <Tpetra_TestingUtilities.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include "TpetraExt_MatrixMatrix.hpp"
+#include "Tpetra_MatrixIO.hpp"
+#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Vector.hpp"
+#include "Tpetra_CrsMatrixMultiplyOp.hpp"
+#include "Tpetra_Import.hpp"
+#include "Tpetra_Export.hpp"
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "MatrixMarket_Tpetra.hpp"
+#include "Tpetra_RowMatrixTransposer.hpp"
+#include "impl/Kokkos_Timer.hpp"
+#include "TpetraExt_MatrixMatrix.hpp"
+
+#include <cmath>
+#include <unordered_set>
+
+namespace Tpetra
+{
+namespace AddProfiling
+{
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::Comm;
+
+#define NUM_ROWS 10000
+#define NNZ_PER_ROW 100
+#define TRIALS 10
+
+//Produce a random matrix with given nnz per global row
+template<typename SC, typename LO, typename GO, typename NT>
+RCP<Tpetra::CrsMatrix<SC, LO, GO, NT>> getTestMatrix(RCP<Tpetra::Map<LO, GO, NT>>& rowMap,
+    RCP<Tpetra::Map<LO, GO, NT>>& colMap, int seed, RCP<const Comm<int>>& comm)
+{
+  //create a non-overlapping distributed row map
+  auto mat = rcp(new Tpetra::CrsMatrix<SC, LO, GO, NT>(rowMap, colMap, NNZ_PER_ROW));
+  //get consistent results between trials
+  srand(comm->getRank() * 7 + 42 + seed);
+  auto myCols = colMap->getNodeElementList();
+  for(GO i = 0; i < NUM_ROWS; i++)
+  {
+    Teuchos::Array<SC> vals(NNZ_PER_ROW);
+    Teuchos::Array<GO> inds(NNZ_PER_ROW);
+    for(int j = 0; j < NNZ_PER_ROW; j++)
+    {
+      vals[j] = ((double) (rand() % RAND_MAX));
+      inds[j] = myCols[rand() % myCols.size()];
+    }
+    mat->insertGlobalValues(i, inds(), vals());
+  }
+  mat->fillComplete(rowMap, rowMap);
+  return mat;
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, sorted, SC, LO, GO, NT)
+{
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NT> crs_matrix_type;
+  typedef Tpetra::Map<LO, GO, NT> map_type;
+  RCP<const Comm<int> > comm = DefaultPlatform::getDefaultPlatform().getComm();
+  if(comm->getRank() == 0)
+    std::cout << "Running sorted add test on " << comm->getSize() << " MPI ranks.\n";
+  RCP<map_type> rowMap = rcp(new map_type(NUM_ROWS, 0, comm));
+  RCP<map_type> colMap = rcp(new map_type(NUM_ROWS, 0, comm));
+  RCP<crs_matrix_type> A = getTestMatrix<SC, LO, GO, NT>(rowMap, colMap, 1, comm);
+  RCP<crs_matrix_type> B = getTestMatrix<SC, LO, GO, NT>(rowMap, colMap, 2, comm);
+  Kokkos::Impl::Timer addTimer;
+  auto one = Teuchos::ScalarTraits<SC>::one();
+  for(int i = 0; i < TRIALS; i++)
+    RCP<crs_matrix_type> C = MatrixMatrix::add(one, false, *A, one, false, *B);
+  double tkernel = addTimer.seconds();
+  std::cout << "sorted (kernel): addition took on avg " << (tkernel / TRIALS) << "s.\n";
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, different_col_maps, SC, LO, GO, NT)
+{
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NT> crs_matrix_type;
+  typedef Tpetra::Map<LO, GO, NT> map_type;
+  RCP<const Comm<int> > comm = DefaultPlatform::getDefaultPlatform().getComm();
+  if(comm->getRank() == 0)
+    std::cout << "Running \"different col maps\" add test on " << comm->getSize() << " MPI ranks.\n";
+  RCP<map_type> rowMap = rcp(new map_type(NUM_ROWS, 0, comm));
+  //Number of random global columns to include in column map
+  GO colMapSize = NUM_ROWS / comm->getSize();
+  auto getRandColMap = [&] (int seed) -> Teuchos::Array<GO>
+  {
+    srand(seed);
+    std::unordered_set<GO> cols;
+    for(GO i = 0; i < colMapSize; i++)
+    {
+      GO col;
+      do
+      {
+        col = rand() % NUM_ROWS;
+      }
+      while(cols.find(col) != cols.end());
+      cols.insert(col);
+    }
+    Teuchos::Array<GO> colList(colMapSize);
+    {
+      int i = 0;
+      for(auto c : cols)
+      {
+        colList[i++] = c;
+      }
+    }
+    return colList;
+  };
+  Teuchos::Array<GO> colMapARaw = getRandColMap(comm->getRank() + 12342);
+  Teuchos::Array<GO> colMapBRaw = getRandColMap(comm->getRank() + 87345);
+  RCP<map_type> colMapA = rcp(new map_type(NUM_ROWS, colMapARaw(), 0, comm));
+  RCP<map_type> colMapB = rcp(new map_type(NUM_ROWS, colMapBRaw(), 0, comm));
+  RCP<crs_matrix_type> A = getTestMatrix<SC, LO, GO, NT>(rowMap, colMapA, 1, comm);
+  RCP<crs_matrix_type> B = getTestMatrix<SC, LO, GO, NT>(rowMap, colMapB, 2, comm);
+  Kokkos::Impl::Timer addTimer;
+  auto one = Teuchos::ScalarTraits<SC>::one();
+  for(int i = 0; i < TRIALS; i++)
+    RCP<crs_matrix_type> C = MatrixMatrix::add(one, false, *A, one, false, *B);
+  double tkernel = addTimer.seconds();
+  std::cout << "mismatched col maps (kernel): addition took on avg " << (tkernel / TRIALS) << "s.\n";
+}
+
+#define UNIT_TEST_GROUP_SC_LO_GO_NO( SC, LO, GO, NT )			\
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_AddProfiling, sorted, SC, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_AddProfiling, different_col_maps, SC, LO, GO, NT)
+
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( UNIT_TEST_GROUP_SC_LO_GO_NO )
+
+} //namespace AddProfiling
+} //namespace Tpetra
+

--- a/packages/tpetra/core/test/MatrixMatrix/CMakeLists.txt
+++ b/packages/tpetra/core/test/MatrixMatrix/CMakeLists.txt
@@ -5,6 +5,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ${TEUCHOS_STD_UNIT_TEST_MAIN}
   ARGS "--matnames-file=\"matrixsystems.xml\" --v"
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  AddProfiling_UnitTests
+  SOURCES 
+  AddProfilingTest.cpp
+  ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  )
+
 IF (KokkosKernels_ENABLE_Experimental)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
 		MatrixMatrixKernels_UnitTests

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -57,6 +57,7 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 #include "Tpetra_RowMatrixTransposer.hpp"
+#include "TpetraExt_MatrixMatrix.hpp"
 #include <cmath>
 
 namespace {
@@ -544,7 +545,7 @@ mult_test_results jacobi_test(
 
   // Jacobi version
   RCP<Matrix_t> C = rcp(new Matrix_t(B->getRowMap(),0));
-  Tpetra::MatrixMatrix::Jacobi(omega,Dinv,*A,*B,*C);
+  Tpetra::MatrixMatrix::Jacobi<SC, LO, GO, NT>(omega,Dinv,*A,*B,*C);
 
   // Multiply + Add version
   Dinv.putScalar(omega);
@@ -1140,6 +1141,238 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO,
   }
   TEST_EQUALITY_CONST( gblSuccess, 1 );
 }
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, threaded_add_sorted, SC, LO, GO, NT)
+{
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = DefaultPlatform::getDefaultPlatform().getComm();
+  using Teuchos::RCP;
+  //First, make two local, random, sorted Kokkos sparse matrices
+  size_t nrows = 1000;
+  size_t nnzPerRow = 20;
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NT> crs_matrix_type;
+  typedef typename crs_matrix_type::local_matrix_type KCRS;
+  typedef typename crs_matrix_type::impl_scalar_type ISC;
+  typedef typename KCRS::values_type::non_const_type ValuesType;
+  typedef typename KCRS::row_map_type::non_const_type RowptrsType;
+  typedef typename KCRS::index_type::non_const_type ColindsType;
+  //The 3 views are for A, B and C
+  ValuesType valsCRS[3];
+  RowptrsType rowptrsCRS[3];
+  ColindsType colindsCRS[3];
+  //Populate A and B
+  {
+    ISC* vals[2] = {new ISC[nrows * nnzPerRow], new ISC[nrows * nnzPerRow]};
+    LO* rowptrs[2] = {new LO[nrows * nnzPerRow], new LO[nrows * nnzPerRow]};
+    LO* colinds[2] = {new LO[nrows * nnzPerRow], new LO[nrows * nnzPerRow]};
+    //want consistent test results
+    srand(12);
+    for(LO m = 0; m < 2; m++)
+    {
+      for(size_t row = 0; row < nrows; row++)
+      {
+        //rows are sorted, so come up with nnzPerRow vals and cols and then sort them
+        std::vector<ISC> rowVals(nnzPerRow);
+        std::vector<LO> rowInds(nnzPerRow);
+        for(size_t entry = 0; entry < nnzPerRow; entry++)
+        {
+          rowVals[entry] = ((double) rand()) / RAND_MAX;
+          //don't allow repeats in col inds
+          LO ind;
+          do
+          {
+            ind = rand() % nrows;
+          }
+          while(std::find(rowInds.begin(), rowInds.end(), ind) != rowInds.end());
+          rowInds[entry] = ind;
+        }
+        std::sort(rowInds.begin(), rowInds.end());
+        //now insert new coordinates in big arrays
+        for(size_t entry = 0; entry < nnzPerRow; entry++)
+        {
+          vals[m][nnzPerRow * row + entry] = rowVals[entry];
+          colinds[m][nnzPerRow * row + entry] = rowInds[entry];
+        }
+      }
+      //set rowptrs
+      for(size_t row = 0; row <= nrows; row++)
+      {
+        rowptrs[m][row] = row * nnzPerRow;
+      }
+      valsCRS[m] = ValuesType("Values", nrows * nnzPerRow);
+      rowptrsCRS[m] = RowptrsType("RowPtrs", nrows + 1);
+      colindsCRS[m] = ColindsType("ColInds", nrows * nnzPerRow);
+      for(size_t i = 0; i < nrows + 1; i++)
+      {
+        rowptrsCRS[m](i) = rowptrs[m][i];
+      }
+      for(size_t i = 0; i < nrows * nnzPerRow; i++)
+      {
+        valsCRS[m](i) = vals[m][i];
+        colindsCRS[m](i) = colinds[m][i];
+      }
+    }
+    for(int i = 0; i < 2; i++)
+    {
+      delete[] vals[i];
+      delete[] rowptrs[i];
+      delete[] colinds[i];
+    }
+  }
+  //now run the threaded addition on mats[0] and mats[1]
+  ISC zero(0);
+  ISC one(1);
+  Tpetra::MatrixMatrix::Details::AddKernels<SC, LO, GO, NT>::
+    addSorted(valsCRS[0], rowptrsCRS[0], colindsCRS[0], one, valsCRS[1], rowptrsCRS[1], colindsCRS[1], one, valsCRS[2], rowptrsCRS[2], colindsCRS[2]);
+  //now scan through C's rows and entries to check they are correct
+  TEUCHOS_TEST_FOR_EXCEPTION(rowptrsCRS[0].dimension_0() != rowptrsCRS[2].dimension_0(), std::logic_error,
+      "Threaded addition of sorted Kokkos::CrsMatrix returned a matrix with the wrong number of rows.");
+  for(size_t i = 0; i < nrows; i++)
+  {
+    //also compute what C's row should be (as dense values)
+    std::vector<ISC> correctVals(nrows, zero);
+    std::vector<bool> correctEntries(nrows, false);
+    for(size_t j = 0; j < nnzPerRow; j++)
+    {
+      int col1 = colindsCRS[0](i * nnzPerRow + j);
+      int col2 = colindsCRS[1](i * nnzPerRow + j);
+      correctVals[col1] += valsCRS[0](i * nnzPerRow + j);
+      correctEntries[col1] = true;
+      correctVals[col2] += valsCRS[1](i * nnzPerRow + j);
+      correctEntries[col2] = true;
+    }
+    size_t actualNNZ = 0;
+    for(size_t j = 0; j < nrows; j++)
+    {
+      if(correctEntries[j])
+        actualNNZ++;
+    }
+    size_t Crowstart = rowptrsCRS[2](i);
+    size_t Crowlen = rowptrsCRS[2](i + 1) - Crowstart;
+    TEUCHOS_TEST_FOR_EXCEPTION(Crowlen != actualNNZ, std::logic_error,
+        std::string("Threaded addition of sorted Kokkos::CrsMatrix produced row ") + std::to_string(i) + " with the wrong number of entries.");
+    for(size_t j = 0; j < Crowlen; j++)
+    {
+      TEUCHOS_TEST_FOR_EXCEPTION(valsCRS[2](Crowstart + j) != correctVals[colindsCRS[2](Crowstart + j)], std::logic_error,
+          "Threaded addition of sorted Kokkos::CrsMatrix produced an incorrect value.");
+    }
+  }
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, threaded_add_unsorted, SC, LO, GO, NT)
+{
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = DefaultPlatform::getDefaultPlatform().getComm();
+  using Teuchos::RCP;
+  //First, make two local, random, unsorted Kokkos sparse matrices
+  size_t nrows = 1000;
+  size_t nnzPerRow = 20;
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NT> crs_matrix_type;
+  typedef typename crs_matrix_type::local_matrix_type KCRS;
+  typedef typename crs_matrix_type::impl_scalar_type ISC;
+  typedef typename KCRS::values_type::non_const_type ValuesType;
+  typedef typename KCRS::row_map_type::non_const_type RowptrsType;
+  typedef typename KCRS::index_type::non_const_type ColindsType;
+  //The 3 views are for A, B and C
+  ValuesType valsCRS[3];
+  RowptrsType rowptrsCRS[3];
+  ColindsType colindsCRS[3];
+  //Populate A and B
+  {
+    ISC* vals[2] = {new ISC[nrows * nnzPerRow], new ISC[nrows * nnzPerRow]};
+    LO* rowptrs[2] = {new LO[nrows * nnzPerRow], new LO[nrows * nnzPerRow]};
+    LO* colinds[2] = {new LO[nrows * nnzPerRow], new LO[nrows * nnzPerRow]};
+    //want consistent test results
+    srand(12);
+    for(LO m = 0; m < 2; m++)
+    {
+      for(size_t row = 0; row < nrows; row++)
+      {
+        //rows are sorted, so come up with nnzPerRow vals and cols and then sort them
+        std::vector<ISC> rowVals(nnzPerRow);
+        std::vector<LO> rowInds(nnzPerRow);
+        for(size_t entry = 0; entry < nnzPerRow; entry++)
+        {
+          rowVals[entry] = ((double) rand()) / RAND_MAX;
+          //don't allow repeats in col inds
+          LO ind;
+          do
+          {
+            ind = rand() % nrows;
+          }
+          while(std::find(rowInds.begin(), rowInds.end(), ind) != rowInds.end());
+          rowInds[entry] = ind;
+        }
+        //now insert new coordinates in big arrays
+        for(size_t entry = 0; entry < nnzPerRow; entry++)
+        {
+          vals[m][nnzPerRow * row + entry] = rowVals[entry];
+          colinds[m][nnzPerRow * row + entry] = rowInds[entry];
+        }
+      }
+      //set rowptrs
+      for(size_t row = 0; row <= nrows; row++)
+      {
+        rowptrs[m][row] = row * nnzPerRow;
+      }
+      valsCRS[m] = ValuesType("Values", nrows * nnzPerRow);
+      rowptrsCRS[m] = RowptrsType("RowPtrs", nrows + 1);
+      colindsCRS[m] = ColindsType("ColInds", nrows * nnzPerRow);
+      for(size_t i = 0; i < nrows + 1; i++)
+      {
+        rowptrsCRS[m](i) = rowptrs[m][i];
+      }
+      for(size_t i = 0; i < nrows * nnzPerRow; i++)
+      {
+        valsCRS[m](i) = vals[m][i];
+        colindsCRS[m](i) = colinds[m][i];
+      }
+    }
+    for(int i = 0; i < 2; i++)
+    {
+      delete[] vals[i];
+      delete[] rowptrs[i];
+      delete[] colinds[i];
+    }
+  }
+  //now run the threaded addition on mats[0] and mats[1]
+  ISC zero(0);
+  ISC one(1);
+  Tpetra::MatrixMatrix::Details::AddKernels<SC, LO, GO, NT>::
+    addUnsorted(valsCRS[0], rowptrsCRS[0], colindsCRS[0], one, valsCRS[1], rowptrsCRS[1], colindsCRS[1], one, nrows, valsCRS[2], rowptrsCRS[2], colindsCRS[2]);
+  //now scan through C's rows and entries to check they are correct
+  TEUCHOS_TEST_FOR_EXCEPTION(rowptrsCRS[0].dimension_0() != rowptrsCRS[2].dimension_0(), std::logic_error,
+      "Threaded addition of sorted Kokkos::CrsMatrix returned a matrix with the wrong number of rows.");
+  for(size_t i = 0; i < nrows; i++)
+  {
+    //also compute what C's row should be (as dense values)
+    std::vector<ISC> correctVals(nrows, zero);
+    std::vector<bool> correctEntries(nrows, false);
+    for(size_t j = 0; j < nnzPerRow; j++)
+    {
+      int col1 = colindsCRS[0][i * nnzPerRow + j];
+      int col2 = colindsCRS[1][i * nnzPerRow + j];
+      correctVals[col1] += valsCRS[0](i * nnzPerRow + j);
+      correctEntries[col1] = true;
+      correctVals[col2] += valsCRS[1](i * nnzPerRow + j);
+      correctEntries[col2] = true;
+    }
+    size_t actualNNZ = 0;
+    for(size_t j = 0; j < nrows; j++)
+    {
+      if(correctEntries[j])
+        actualNNZ++;
+    }
+    size_t Crowstart = rowptrsCRS[2](i);
+    size_t Crowlen = rowptrsCRS[2](i + 1) - Crowstart;
+    TEUCHOS_TEST_FOR_EXCEPTION(Crowlen != actualNNZ, std::logic_error,
+        std::string("Threaded addition of unsorted Kokkos::CrsMatrix produced row ") + std::to_string(i) + " with the wrong number of entries (is " + std::to_string(Crowlen) + ", should be " + std::to_string(actualNNZ) + ")");
+    for(size_t j = 0; j < Crowlen; j++)
+    {
+      TEUCHOS_TEST_FOR_EXCEPTION(valsCRS[2](Crowstart + j) != correctVals[colindsCRS[2](Crowstart + j)], std::logic_error,
+          "Threaded addition of unsorted Kokkos::CrsMatrix produced an incorrect value.");
+    }
+  }
+}
+
 /*
  * This test was added at the request of Chris Siefert
  * Turns out it fails because the original algorithm in
@@ -1185,8 +1418,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO,
 #define UNIT_TEST_GROUP_SC_LO_GO_NO( SC, LO, GO, NT )			\
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, operations_test,SC, LO, GO, NT) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, range_row_test, SC, LO, GO, NT) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO, NT)
-
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, threaded_add_sorted, SC, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, threaded_add_unsorted, SC, LO, GO, NT)
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 

--- a/packages/tpetra/core/test/Sort/Sort.cpp
+++ b/packages/tpetra/core/test/Sort/Sort.cpp
@@ -47,6 +47,8 @@
 #include "Kokkos_ArithTraits.hpp"
 #include <iterator>
 #include <utility> // std::swap
+//numeric_limits<unsigned short> - not provided by Teuchos OrdinalTraits):
+#include <limits>
 
 namespace { // (anonymous)
 
@@ -253,7 +255,7 @@ test_fixedTypes_fixedArrayLength (bool& success,
   ValueType valuesCopy4Aux[arrayLength];
   copyArray (keysCopy4, keys, arrayLength);
   copyArray (valuesCopy4, values, arrayLength);
-  ::Tpetra::Details::radixSortKeysAndValues (keysCopy4, keysCopy4Aux, valuesCopy4, valuesCopy4Aux, arrayLength);
+  ::Tpetra::Details::radixSortKeysAndValues<KeyType, ValueType, size_t>(keysCopy4, keysCopy4Aux, valuesCopy4, valuesCopy4Aux, arrayLength, std::numeric_limits<KeyType>::max());
   const bool equalKeys4 = isEqual (keysCopy2, keysCopy4, arrayLength);
   TEST_ASSERT( equalKeys4 );
   const bool equalValues4 = isEqual (valuesCopy2, valuesCopy4, arrayLength);

--- a/packages/tpetra/core/test/Sort/Sort.cpp
+++ b/packages/tpetra/core/test/Sort/Sort.cpp
@@ -43,6 +43,7 @@
 
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Tpetra_Details_shortSort.hpp"
+#include "Tpetra_Details_radixSort.hpp"
 #include "Kokkos_ArithTraits.hpp"
 #include <iterator>
 #include <utility> // std::swap
@@ -243,6 +244,20 @@ test_fixedTypes_fixedArrayLength (bool& success,
     const bool equalValues3 = isEqual (valuesCopy2, valuesCopy3, arrayLength);
     TEST_ASSERT( equalValues3 );
   }
+
+  // Compare against Tpetra::Details::radixSortKeysAndValues.
+  // LSB-first radix sort is always stable and can always handle duplicate keys
+  KeyType keysCopy4[arrayLength];
+  KeyType keysCopy4Aux[arrayLength];
+  ValueType valuesCopy4[arrayLength];
+  ValueType valuesCopy4Aux[arrayLength];
+  copyArray (keysCopy4, keys, arrayLength);
+  copyArray (valuesCopy4, values, arrayLength);
+  ::Tpetra::Details::radixSortKeysAndValues (keysCopy4, keysCopy4Aux, valuesCopy4, valuesCopy4Aux, arrayLength);
+  const bool equalKeys4 = isEqual (keysCopy2, keysCopy4, arrayLength);
+  TEST_ASSERT( equalKeys4 );
+  const bool equalValues4 = isEqual (valuesCopy2, valuesCopy4, arrayLength);
+  TEST_ASSERT( equalValues4 );
 }
 
 // Fill the given array with distinct values.


### PR DESCRIPTION
-Makes TpetraExt::MatrixMatrix::add very thread scalable in most cases
-Kernels using Kokkos to locally add two Tpetra CrsMatrices
-One kernel for the sorted graph, matching col map case, and
 a more general one for unsorted graph and/or mismatched col map case
-Unit tests for both kernels