### PR TITLE
Phalanx: Issue 1610

### DIFF
--- a/packages/phalanx/example/FiniteElementAssembly/FiniteElementAssembly.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly/FiniteElementAssembly.cpp
@@ -115,10 +115,10 @@ int main(int argc, char *argv[])
     constexpr int num_dofs = (nx+1)*(ny+1)*(nz+1)*num_equations;
     constexpr int max_deriv_entries_per_row = 8 * 8 * num_equations;
         
-    RCP<const PHX::DataLayout> qp_layout = rcp(new MDALayout<CELL,QP>("qp",workset_size,8));
-    RCP<const PHX::DataLayout> grad_qp_layout = rcp(new MDALayout<CELL,QP,DIM>("grad_qp",workset_size,8,3));
-    RCP<const PHX::DataLayout> basis_layout = rcp(new MDALayout<CELL,BASIS>("basis",workset_size,8));
-    RCP<const PHX::DataLayout> scatter_layout = rcp(new MDALayout<CELL>("scatter",0));
+    RCP<PHX::DataLayout> qp_layout = rcp(new MDALayout<CELL,QP>("qp",workset_size,8));
+    RCP<PHX::DataLayout> grad_qp_layout = rcp(new MDALayout<CELL,QP,DIM>("grad_qp",workset_size,8,3));
+    RCP<PHX::DataLayout> basis_layout = rcp(new MDALayout<CELL,BASIS>("basis",workset_size,8));
+    RCP<PHX::DataLayout> scatter_layout = rcp(new MDALayout<CELL>("scatter",0));
     
     PHX::FieldManager<MyTraits> fm;
     {

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/Constant.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/Constant.hpp
@@ -61,7 +61,7 @@ class Constant : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   Constant(const std::string& field_name,
-           const Teuchos::RCP<const PHX::DataLayout>& layout,
+           const Teuchos::RCP<PHX::DataLayout>& layout,
            const double& value);
   void postRegistrationSetup(typename Traits::SetupData d,
                              PHX::FieldManager<Traits>& fm) override;

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/Constant_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/Constant_Def.hpp
@@ -46,7 +46,7 @@
 template<typename EvalT, typename Traits>
 Constant<EvalT,Traits>::
 Constant(const std::string& field_name,
-         const Teuchos::RCP<const PHX::DataLayout>& layout,
+         const Teuchos::RCP<PHX::DataLayout>& layout,
          const double& val) :
   value(val),
   constant(field_name,layout)

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/GatherSolution.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/GatherSolution.hpp
@@ -85,7 +85,7 @@ class GatherSolution<PHX::MyTraits::Residual,Traits>
 
 public:
   GatherSolution(const std::string& field_name,
-                 const Teuchos::RCP<const PHX::DataLayout>& layout,
+                 const Teuchos::RCP<PHX::DataLayout>& layout,
                  const int& in_num_equations,
                  const int& in_field_index,
                  const Kokkos::View<double*,PHX::Device>& x);
@@ -112,7 +112,7 @@ class GatherSolution<PHX::MyTraits::Jacobian,Traits>
   
 public:
   GatherSolution(const std::string& field_name,
-                 const Teuchos::RCP<const PHX::DataLayout>& layout,
+                 const Teuchos::RCP<PHX::DataLayout>& layout,
                  const int& in_num_equations,
                  const int& in_field_index,
                  const Kokkos::View<double*,PHX::Device>& x);

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/GatherSolution_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/GatherSolution_Def.hpp
@@ -52,7 +52,7 @@
 template<typename Traits>
 GatherSolution<PHX::MyTraits::Residual, Traits>::
 GatherSolution(const std::string& field_name,
-               const Teuchos::RCP<const PHX::DataLayout>& layout,
+               const Teuchos::RCP<PHX::DataLayout>& layout,
                const int& in_num_equations,
                const int& in_field_index,
                const Kokkos::View<double*,PHX::Device>& in_x) :
@@ -93,7 +93,7 @@ operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
 template<typename Traits>
 GatherSolution<PHX::MyTraits::Jacobian, Traits>::
 GatherSolution(const std::string& field_name,
-               const Teuchos::RCP<const PHX::DataLayout>& layout,
+               const Teuchos::RCP<PHX::DataLayout>& layout,
                const int& in_num_equations,
                const int& in_field_index,
                const Kokkos::View<double*,PHX::Device>& in_x) :

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateDiffusionTerm.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateDiffusionTerm.hpp
@@ -62,9 +62,9 @@ class IntegrateDiffusionTerm : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   IntegrateDiffusionTerm(const std::string& flux_name,
-                         const Teuchos::RCP<const PHX::DataLayout>& flux_layout,
+                         const Teuchos::RCP<PHX::DataLayout>& flux_layout,
                          const std::string& residual_name,
-                         const Teuchos::RCP<const PHX::DataLayout>& residual_layout);
+                         const Teuchos::RCP<PHX::DataLayout>& residual_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateDiffusionTerm_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateDiffusionTerm_Def.hpp
@@ -46,9 +46,9 @@
 template<typename EvalT, typename Traits>
 IntegrateDiffusionTerm<EvalT,Traits>::
 IntegrateDiffusionTerm(const std::string& flux_name,
-                       const Teuchos::RCP<const PHX::DataLayout>& flux_layout,
+                       const Teuchos::RCP<PHX::DataLayout>& flux_layout,
                        const std::string& residual_name,
-                       const Teuchos::RCP<const PHX::DataLayout>& residual_layout) :
+                       const Teuchos::RCP<PHX::DataLayout>& residual_layout) :
   flux(flux_name,flux_layout),
   residual(residual_name,residual_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateSourceTerm.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateSourceTerm.hpp
@@ -62,9 +62,9 @@ class IntegrateSourceTerm : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   IntegrateSourceTerm(const std::string& source_name,
-                      const Teuchos::RCP<const PHX::DataLayout>& source_layout,
+                      const Teuchos::RCP<PHX::DataLayout>& source_layout,
                       const std::string& residual_name,
-                      const Teuchos::RCP<const PHX::DataLayout>& residual_layout);
+                      const Teuchos::RCP<PHX::DataLayout>& residual_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateSourceTerm_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/IntegrateSourceTerm_Def.hpp
@@ -46,9 +46,9 @@
 template<typename EvalT, typename Traits>
 IntegrateSourceTerm<EvalT,Traits>::
 IntegrateSourceTerm(const std::string& source_name,
-                    const Teuchos::RCP<const PHX::DataLayout>& source_layout,
+                    const Teuchos::RCP<PHX::DataLayout>& source_layout,
                     const std::string& residual_name,
-                    const Teuchos::RCP<const PHX::DataLayout>& residual_layout) :
+                    const Teuchos::RCP<PHX::DataLayout>& residual_layout) :
   source(source_name,source_layout),
   residual(residual_name,residual_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectGradientToQP.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectGradientToQP.hpp
@@ -61,8 +61,8 @@ class ProjectGradientToQP : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   ProjectGradientToQP(const std::string& field_name,
-                      const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                      const Teuchos::RCP<const PHX::DataLayout>& grad_qp_layout);
+                      const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                      const Teuchos::RCP<PHX::DataLayout>& grad_qp_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectGradientToQP_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectGradientToQP_Def.hpp
@@ -46,8 +46,8 @@
 template<typename EvalT, typename Traits>
 ProjectGradientToQP<EvalT,Traits>::
 ProjectGradientToQP(const std::string& field_name,
-                    const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                    const Teuchos::RCP<const PHX::DataLayout>& grad_qp_layout) :
+                    const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                    const Teuchos::RCP<PHX::DataLayout>& grad_qp_layout) :
   field_at_basis(field_name,basis_layout),
   grad_field_at_qp(field_name,grad_qp_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectValueToQP.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectValueToQP.hpp
@@ -61,8 +61,8 @@ class ProjectValueToQP : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   ProjectValueToQP(const std::string& field_name,
-                   const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                   const Teuchos::RCP<const PHX::DataLayout>& qp_layout);
+                   const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                   const Teuchos::RCP<PHX::DataLayout>& qp_layout);
   void evaluateFields(typename Traits::EvalData d) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectValueToQP_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ProjectValueToQP_Def.hpp
@@ -46,8 +46,8 @@
 template<typename EvalT, typename Traits>
 ProjectValueToQP<EvalT,Traits>::
 ProjectValueToQP(const std::string& field_name,
-                 const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                 const Teuchos::RCP<const PHX::DataLayout>& qp_layout) :
+                 const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                 const Teuchos::RCP<PHX::DataLayout>& qp_layout) :
   field_at_basis(field_name,basis_layout),
   field_at_qp(field_name,qp_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ScatterResidual.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ScatterResidual.hpp
@@ -88,7 +88,7 @@ public:
   
   ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& scatter_tag,
                   const std::string& residual_name,
-                  const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                  const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                   const int& in_euqation_index,
                   const int& in_num_equations,
                   const Kokkos::View<double*,PHX::Device>& global_residual);  
@@ -119,7 +119,7 @@ class ScatterResidual<PHX::MyTraits::Jacobian,Traits>
 public:  
   ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& scatter_tag,
                   const std::string& residual_name,
-                  const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                  const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                   const int& in_euqation_index,
                   const int& in_num_equations,
                   const Kokkos::View<double*,PHX::Device>& global_residual,

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ScatterResidual_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ScatterResidual_Def.hpp
@@ -54,7 +54,7 @@ template<typename Traits>
 ScatterResidual<PHX::MyTraits::Residual, Traits>::
 ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& in_scatter_tag,
                 const std::string& residual_name,
-                const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                 const int& in_equation_index,
                 const int& in_num_equations,
                 const Kokkos::View<double*,PHX::Device>& in_global_residual) :
@@ -99,7 +99,7 @@ template<typename Traits>
 ScatterResidual<PHX::MyTraits::Jacobian, Traits>::
 ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& in_scatter_tag,
                 const std::string& residual_name,
-                const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                 const int& in_equation_index,
                 const int& in_num_equations,
                 const Kokkos::View<double*,PHX::Device>& in_global_residual,

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ZeroContributedField.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ZeroContributedField.hpp
@@ -60,7 +60,7 @@ class ZeroContributedField : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   ZeroContributedField(const std::string& field_name,
-                       const Teuchos::RCP<const PHX::DataLayout>& layout);
+                       const Teuchos::RCP<PHX::DataLayout>& layout);
   void evaluateFields(typename Traits::EvalData d) override;
 };
 

--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/ZeroContributedField_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/ZeroContributedField_Def.hpp
@@ -46,7 +46,7 @@
 template<typename EvalT, typename Traits>
 ZeroContributedField<EvalT,Traits>::
 ZeroContributedField(const std::string& field_name,
-                     const Teuchos::RCP<const PHX::DataLayout>& layout) :
+                     const Teuchos::RCP<PHX::DataLayout>& layout) :
   field(field_name,layout)
 {
   // "Evalauted" is always called before "Contributed" for the same field

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/FiniteElementAssembly.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/FiniteElementAssembly.cpp
@@ -115,10 +115,10 @@ int main(int argc, char *argv[])
     constexpr int max_deriv_entries_per_row = 8 * 8 * num_equations;
         
     // We will size the layouts later 
-    RCP<const PHX::DataLayout> qp_layout = rcp(new Layout("DL<CELL,QP>"));
-    RCP<const PHX::DataLayout> grad_qp_layout = rcp(new Layout("DL<CELL,QP,DIM>"));
-    RCP<const PHX::DataLayout> basis_layout = rcp(new Layout("DL<CELL,BASIS>"));
-    RCP<const PHX::DataLayout> scatter_layout = rcp(new Layout("DL<SCATTER>"));
+    RCP<PHX::DataLayout> qp_layout = rcp(new Layout("DL<CELL,QP>"));
+    RCP<PHX::DataLayout> grad_qp_layout = rcp(new Layout("DL<CELL,QP,DIM>"));
+    RCP<PHX::DataLayout> basis_layout = rcp(new Layout("DL<CELL,BASIS>"));
+    RCP<PHX::DataLayout> scatter_layout = rcp(new Layout("DL<SCATTER>"));
     
     PHX::FieldManager<MyTraits> fm;
     {
@@ -258,13 +258,13 @@ int main(int argc, char *argv[])
 
       for (auto& t : tags) {
         if (t->dataLayout().identifier() == "DL<CELL,QP>")
-          dynamic_cast<PHX::Layout&>(const_cast<PHX::DataLayout&>(t->dataLayout())).setExtents(workset_size,8);
+          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(workset_size,8);
         else if (t->dataLayout().identifier() == "DL<CELL,QP,DIM>")
-          dynamic_cast<PHX::Layout&>(const_cast<PHX::DataLayout&>(t->dataLayout())).setExtents(workset_size,8,3);
+          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(workset_size,8,3);
         else if (t->dataLayout().identifier() == "DL<CELL,BASIS>")
-          dynamic_cast<PHX::Layout&>(const_cast<PHX::DataLayout&>(t->dataLayout())).setExtents(workset_size,8);
+          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(workset_size,8);
         else if (t->dataLayout().identifier() == "DL<SCATTER>")
-          dynamic_cast<PHX::Layout&>(const_cast<PHX::DataLayout&>(t->dataLayout())).setExtents(0);
+          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(0);
         else
           TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                      "ERROR: unknown DataLayout identifier:" <<

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/FiniteElementAssembly.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/FiniteElementAssembly.cpp
@@ -258,13 +258,13 @@ int main(int argc, char *argv[])
 
       for (auto& t : tags) {
         if (t->dataLayout().identifier() == "DL<CELL,QP>")
-          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(workset_size,8);
+          t->nonConstDataLayout().setExtents(workset_size,8);
         else if (t->dataLayout().identifier() == "DL<CELL,QP,DIM>")
-          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(workset_size,8,3);
+          t->nonConstDataLayout().setExtents(workset_size,8,3);
         else if (t->dataLayout().identifier() == "DL<CELL,BASIS>")
-          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(workset_size,8);
+          t->nonConstDataLayout().setExtents(workset_size,8);
         else if (t->dataLayout().identifier() == "DL<SCATTER>")
-          dynamic_cast<PHX::Layout&>(t->nonConstDataLayout()).setExtents(0);
+          t->nonConstDataLayout().setExtents(0);
         else
           TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                      "ERROR: unknown DataLayout identifier:" <<

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/Constant.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/Constant.hpp
@@ -61,7 +61,7 @@ class Constant : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   Constant(const std::string& field_name,
-           const Teuchos::RCP<const PHX::DataLayout>& layout,
+           const Teuchos::RCP<PHX::DataLayout>& layout,
            const double& value);
   void postRegistrationSetup(typename Traits::SetupData d,
                              PHX::FieldManager<Traits>& fm) override;

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/Constant_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/Constant_Def.hpp
@@ -46,7 +46,7 @@
 template<typename EvalT, typename Traits>
 Constant<EvalT,Traits>::
 Constant(const std::string& field_name,
-         const Teuchos::RCP<const PHX::DataLayout>& layout,
+         const Teuchos::RCP<PHX::DataLayout>& layout,
          const double& val) :
   value(val),
   constant(field_name,layout)

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/GatherSolution.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/GatherSolution.hpp
@@ -85,7 +85,7 @@ class GatherSolution<PHX::MyTraits::Residual,Traits>
 
 public:
   GatherSolution(const std::string& field_name,
-                 const Teuchos::RCP<const PHX::DataLayout>& layout,
+                 const Teuchos::RCP<PHX::DataLayout>& layout,
                  const int& in_num_equations,
                  const int& in_field_index,
                  const Kokkos::View<double*,PHX::Device>& x);
@@ -112,7 +112,7 @@ class GatherSolution<PHX::MyTraits::Jacobian,Traits>
   
 public:
   GatherSolution(const std::string& field_name,
-                 const Teuchos::RCP<const PHX::DataLayout>& layout,
+                 const Teuchos::RCP<PHX::DataLayout>& layout,
                  const int& in_num_equations,
                  const int& in_field_index,
                  const Kokkos::View<double*,PHX::Device>& x);

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/GatherSolution_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/GatherSolution_Def.hpp
@@ -52,7 +52,7 @@
 template<typename Traits>
 GatherSolution<PHX::MyTraits::Residual, Traits>::
 GatherSolution(const std::string& field_name,
-               const Teuchos::RCP<const PHX::DataLayout>& layout,
+               const Teuchos::RCP<PHX::DataLayout>& layout,
                const int& in_num_equations,
                const int& in_field_index,
                const Kokkos::View<double*,PHX::Device>& in_x) :
@@ -93,7 +93,7 @@ operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
 template<typename Traits>
 GatherSolution<PHX::MyTraits::Jacobian, Traits>::
 GatherSolution(const std::string& field_name,
-               const Teuchos::RCP<const PHX::DataLayout>& layout,
+               const Teuchos::RCP<PHX::DataLayout>& layout,
                const int& in_num_equations,
                const int& in_field_index,
                const Kokkos::View<double*,PHX::Device>& in_x) :

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateDiffusionTerm.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateDiffusionTerm.hpp
@@ -62,9 +62,9 @@ class IntegrateDiffusionTerm : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   IntegrateDiffusionTerm(const std::string& flux_name,
-                         const Teuchos::RCP<const PHX::DataLayout>& flux_layout,
+                         const Teuchos::RCP<PHX::DataLayout>& flux_layout,
                          const std::string& residual_name,
-                         const Teuchos::RCP<const PHX::DataLayout>& residual_layout);
+                         const Teuchos::RCP<PHX::DataLayout>& residual_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateDiffusionTerm_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateDiffusionTerm_Def.hpp
@@ -46,9 +46,9 @@
 template<typename EvalT, typename Traits>
 IntegrateDiffusionTerm<EvalT,Traits>::
 IntegrateDiffusionTerm(const std::string& flux_name,
-                       const Teuchos::RCP<const PHX::DataLayout>& flux_layout,
+                       const Teuchos::RCP<PHX::DataLayout>& flux_layout,
                        const std::string& residual_name,
-                       const Teuchos::RCP<const PHX::DataLayout>& residual_layout) :
+                       const Teuchos::RCP<PHX::DataLayout>& residual_layout) :
   flux(flux_name,flux_layout),
   residual(residual_name,residual_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateSourceTerm.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateSourceTerm.hpp
@@ -61,9 +61,9 @@ class IntegrateSourceTerm : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   IntegrateSourceTerm(const std::string& source_name,
-                      const Teuchos::RCP<const PHX::DataLayout>& source_layout,
+                      const Teuchos::RCP<PHX::DataLayout>& source_layout,
                       const std::string& residual_name,
-                      const Teuchos::RCP<const PHX::DataLayout>& residual_layout);
+                      const Teuchos::RCP<PHX::DataLayout>& residual_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateSourceTerm_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/IntegrateSourceTerm_Def.hpp
@@ -47,9 +47,9 @@
 template<typename EvalT, typename Traits>
 IntegrateSourceTerm<EvalT,Traits>::
 IntegrateSourceTerm(const std::string& source_name,
-                    const Teuchos::RCP<const PHX::DataLayout>& source_layout,
+                    const Teuchos::RCP<PHX::DataLayout>& source_layout,
                     const std::string& residual_name,
-                    const Teuchos::RCP<const PHX::DataLayout>& residual_layout)
+                    const Teuchos::RCP<PHX::DataLayout>& residual_layout)
 {
   PHX::Tag<ScalarT> ft_source(source_name,source_layout);
   PHX::Tag<ScalarT> ft_residual(residual_name,residual_layout);

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectGradientToQP.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectGradientToQP.hpp
@@ -60,8 +60,8 @@ class ProjectGradientToQP : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   ProjectGradientToQP(const std::string& field_name,
-                      const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                      const Teuchos::RCP<const PHX::DataLayout>& grad_qp_layout);
+                      const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                      const Teuchos::RCP<PHX::DataLayout>& grad_qp_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectGradientToQP_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectGradientToQP_Def.hpp
@@ -46,8 +46,8 @@
 template<typename EvalT, typename Traits>
 ProjectGradientToQP<EvalT,Traits>::
 ProjectGradientToQP(const std::string& field_name,
-                    const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                    const Teuchos::RCP<const PHX::DataLayout>& grad_qp_layout) :
+                    const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                    const Teuchos::RCP<PHX::DataLayout>& grad_qp_layout) :
   field_at_basis(field_name,basis_layout),
   grad_field_at_qp(field_name,grad_qp_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectValueToQP.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectValueToQP.hpp
@@ -61,8 +61,8 @@ class ProjectValueToQP : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   ProjectValueToQP(const std::string& field_name,
-                   const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                   const Teuchos::RCP<const PHX::DataLayout>& qp_layout);
+                   const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                   const Teuchos::RCP<PHX::DataLayout>& qp_layout);
   void evaluateFields(typename Traits::EvalData d) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectValueToQP_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ProjectValueToQP_Def.hpp
@@ -46,8 +46,8 @@
 template<typename EvalT, typename Traits>
 ProjectValueToQP<EvalT,Traits>::
 ProjectValueToQP(const std::string& field_name,
-                 const Teuchos::RCP<const PHX::DataLayout>& basis_layout,
-                 const Teuchos::RCP<const PHX::DataLayout>& qp_layout) :
+                 const Teuchos::RCP<PHX::DataLayout>& basis_layout,
+                 const Teuchos::RCP<PHX::DataLayout>& qp_layout) :
   field_at_basis(field_name,basis_layout),
   field_at_qp(field_name,qp_layout)
 {

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ScatterResidual.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ScatterResidual.hpp
@@ -88,7 +88,7 @@ public:
   
   ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& scatter_tag,
                   const std::string& residual_name,
-                  const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                  const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                   const int& in_euqation_index,
                   const int& in_num_equations,
                   const Kokkos::View<double*,PHX::Device>& global_residual);  
@@ -119,7 +119,7 @@ class ScatterResidual<PHX::MyTraits::Jacobian,Traits>
 public:  
   ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& scatter_tag,
                   const std::string& residual_name,
-                  const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                  const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                   const int& in_euqation_index,
                   const int& in_num_equations,
                   const Kokkos::View<double*,PHX::Device>& global_residual,

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ScatterResidual_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ScatterResidual_Def.hpp
@@ -54,7 +54,7 @@ template<typename Traits>
 ScatterResidual<PHX::MyTraits::Residual, Traits>::
 ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& in_scatter_tag,
                 const std::string& residual_name,
-                const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                 const int& in_equation_index,
                 const int& in_num_equations,
                 const Kokkos::View<double*,PHX::Device>& in_global_residual) :
@@ -99,7 +99,7 @@ template<typename Traits>
 ScatterResidual<PHX::MyTraits::Jacobian, Traits>::
 ScatterResidual(const Teuchos::RCP<PHX::FieldTag>& in_scatter_tag,
                 const std::string& residual_name,
-                const Teuchos::RCP<const PHX::DataLayout>& residual_layout,
+                const Teuchos::RCP<PHX::DataLayout>& residual_layout,
                 const int& in_equation_index,
                 const int& in_num_equations,
                 const Kokkos::View<double*,PHX::Device>& in_global_residual,

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ZeroContributedField.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ZeroContributedField.hpp
@@ -60,7 +60,7 @@ class ZeroContributedField : public PHX::EvaluatorWithBaseImpl<Traits>,
   
 public:
   ZeroContributedField(const std::string& field_name,
-                       const Teuchos::RCP<const PHX::DataLayout>& layout);
+                       const Teuchos::RCP<PHX::DataLayout>& layout);
   void evaluateFields(typename Traits::EvalData d) override;
 };
 

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ZeroContributedField_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/ZeroContributedField_Def.hpp
@@ -46,7 +46,7 @@
 template<typename EvalT, typename Traits>
 ZeroContributedField<EvalT,Traits>::
 ZeroContributedField(const std::string& field_name,
-                     const Teuchos::RCP<const PHX::DataLayout>& layout) :
+                     const Teuchos::RCP<PHX::DataLayout>& layout) :
   field(field_name,layout)
 {
   // "Evalauted" is always called before "Contributed" for the same field

--- a/packages/phalanx/src/Phalanx_DataLayout.hpp
+++ b/packages/phalanx/src/Phalanx_DataLayout.hpp
@@ -52,18 +52,44 @@
 
 namespace PHX{
 
+  template<typename... extent_pack>
+  struct SetExtentsImpl;
 
-  /*! \brief A pure virtual class to distinguish a unique data layout in a cell.
+  //! Used to set the extents from a parameter pack. Can't use a simple initializer list due to narrowing from in size_type.
+  template<typename T, typename... extent_pack>
+  struct SetExtentsImpl<T,extent_pack...> {
+    static void setExtents(PHX::Device::size_type index,
+                           std::vector<PHX::Device::size_type>& extents,
+                           T val,
+                           extent_pack... pack)
+    {
+      extents[index] = val;
+      PHX::SetExtentsImpl<extent_pack...>::setExtents(index+1,extents,pack...);
+    }
+  };
 
-      The DataLayout class is used to (1) specify the array size of a
-      an algebraic type in a single cell, and (2) to differentiate
-      FieldTags that have the same name, but have different
-      DataLayouts in the FieldManager.  For example suppose we want to
-      store density at both the nodes and the quadrature points in a
-      cell.  If we use the same string name for the FieldTag, the
-      DataLayout will differentiate the objects.  We could probably
-      just use an enumerated type here, but the DataLayout class
-      allows users to derive and pass in auxiliary data via the tag.
+  //! Used to set the extents from a parameter pack. this implementation ends the recursion.
+  template<>
+  struct SetExtentsImpl<> {
+    static void setExtents(PHX::Device::size_type ,
+                           std::vector<PHX::Device::size_type>& )
+    {}
+  };
+
+  // ******************************************************************
+  /*! \brief A pure virtual class to provide size and rank information
+      and a unique identifier for a fields.
+
+      The DataLayout class is used to (1) specify the rank and extents
+      of fields, and (2) to provide a unique identifier that can be
+      used to differentiate fields.  For example suppose we want to
+      store density at both the basis points and the quadrature points
+      in a cell.  If we use the same string name for the field in the
+      FieldTag, the DataLayout could be used to differentiate the objects.
+
+      NOTE: We could probably just use an enumerated type here, but
+      the DataLayout class allows users to derive and pass in
+      auxiliary data via the tag.
   */
   class DataLayout {
 
@@ -102,6 +128,23 @@ namespace PHX{
     virtual std::string identifier() const = 0;
 
     virtual void print(std::ostream& os, int indent = 0) const = 0;
+
+    template<typename... extent_pack>
+    void setExtents(extent_pack... extents)
+    {
+      static_assert(sizeof...(extents) > 0,
+                    "Error - PHX::Layout - rank must be greater than zero!");
+      static_assert(sizeof...(extents) < 9,
+                    "Error - PHX::Layout - rank must be less than 9!");
+
+      std::vector<PHX::Device::size_type> extents_vec(sizeof...(extents));
+      PHX::SetExtentsImpl<extent_pack...>::setExtents(0,extents_vec,extents...);
+      this->setExtentsOnDerivedClass(extents_vec);
+    }
+
+  protected:
+
+    virtual void setExtentsOnDerivedClass(const std::vector<PHX::Device::size_type>& extents) = 0;
 
   };
 

--- a/packages/phalanx/src/Phalanx_DataLayout_DynamicLayout.cpp
+++ b/packages/phalanx/src/Phalanx_DataLayout_DynamicLayout.cpp
@@ -149,6 +149,14 @@ void PHX::Layout::print(std::ostream& os, int offset) const
 }
 
 //**********************************************************************
+void
+PHX::Layout::
+setExtentsOnDerivedClass(const std::vector<PHX::Device::size_type>& extents)
+{
+  m_extents = std::move(extents);
+}
+
+//**********************************************************************
 std::ostream& PHX::operator<<(std::ostream& os, const PHX::Layout& v)
 {
   v.print(os,0);

--- a/packages/phalanx/src/Phalanx_DataLayout_DynamicLayout.hpp
+++ b/packages/phalanx/src/Phalanx_DataLayout_DynamicLayout.hpp
@@ -52,30 +52,6 @@
 
 namespace PHX {
 
-  template<typename... extent_pack>
-  struct SetExtentsImpl;
-
-  //! Used to set the extents from a parameter pack. Can't use a simple initializer list due to narrowing from in size_type.
-  template<typename T, typename... extent_pack>
-  struct SetExtentsImpl<T,extent_pack...> {
-    static void setExtents(PHX::Device::size_type index,
-                           std::vector<PHX::Device::size_type>& extents,
-                           T val,
-                           extent_pack... pack)
-    {
-      extents[index] = val;
-      PHX::SetExtentsImpl<extent_pack...>::setExtents(index+1,extents,pack...);
-    }
-  };
-
-  //! Used to set the extents from a parameter pack. this implementation ends the recursion.
-  template<>
-  struct SetExtentsImpl<> {
-    static void setExtents(PHX::Device::size_type ,
-                           std::vector<PHX::Device::size_type>& )
-    {}
-  };
-
   //! Default DataLayout implementation that allows for runtime sizing.
   class Layout : public DataLayout {
 
@@ -128,11 +104,16 @@ namespace PHX {
 
     virtual std::string name(size_type ordinal) const override;
 
-    virtual void names(std::vector<std::string>& names) const override; 
+    virtual void names(std::vector<std::string>& names) const override;
 
     virtual std::string identifier() const override;
 
     virtual void print(std::ostream& os, int offset) const override;
+
+  protected:
+
+    virtual void
+    setExtentsOnDerivedClass(const std::vector<PHX::Device::size_type>& extents) override;
 
   private:
 

--- a/packages/phalanx/src/Phalanx_DataLayout_MDALayout.hpp
+++ b/packages/phalanx/src/Phalanx_DataLayout_MDALayout.hpp
@@ -176,6 +176,11 @@ namespace PHX {
     typename std::enable_if<std::is_unsigned<IndexType>::value>::type
     checkForValidRank(const IndexType& ordinal) const;
 
+  protected:
+
+    virtual void 
+    setExtentsOnDerivedClass(const std::vector<PHX::Device::size_type>& extents) override;
+
   private:
 
     std::vector<const char*> m_dim_name;

--- a/packages/phalanx/src/Phalanx_DataLayout_MDALayout_Def.hpp
+++ b/packages/phalanx/src/Phalanx_DataLayout_MDALayout_Def.hpp
@@ -660,6 +660,22 @@ createIdentifier(const std::string& prefix)
 //**********************************************************************
 template<typename Tag0, typename Tag1, typename Tag2, typename Tag3,
 	 typename Tag4, typename Tag5, typename Tag6, typename Tag7>
+void
+PHX::MDALayout<Tag0,Tag1,Tag2,Tag3,Tag4,Tag5,Tag6,Tag7>::
+setExtentsOnDerivedClass(const std::vector<PHX::Device::size_type>& extents)
+{
+#ifdef PHX_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPTION(extents.size() != Rank, std::runtime_error,
+                             "ERROR - MDALayout::setExtentsOnDerivedClass()"
+                             << " - Rank mismatch while setting extents!");
+#endif
+  for (std::size_t i=0; i < extents.size(); ++i)
+    m_dim_size[i] = extents[i];
+}
+
+//**********************************************************************
+template<typename Tag0, typename Tag1, typename Tag2, typename Tag3,
+	 typename Tag4, typename Tag5, typename Tag6, typename Tag7>
 template<typename IndexType>
 typename std::enable_if<std::is_signed<IndexType>::value>::type
 PHX::MDALayout<Tag0,Tag1,Tag2,Tag3,Tag4,Tag5,Tag6,Tag7>::

--- a/packages/phalanx/src/Phalanx_Field.hpp
+++ b/packages/phalanx/src/Phalanx_Field.hpp
@@ -115,7 +115,7 @@ namespace PHX {
     typedef typename PHX::Device::size_type size_type;
     typedef typename array_type::execution_space execution_space;
 
-    Field(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& t);
+    Field(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& t);
 
     Field(const PHX::Tag<DataT>& v);
 

--- a/packages/phalanx/src/Phalanx_FieldTag.hpp
+++ b/packages/phalanx/src/Phalanx_FieldTag.hpp
@@ -74,6 +74,8 @@ namespace PHX {
 
     virtual const PHX::DataLayout& dataLayout() const = 0;
 
+    virtual PHX::DataLayout& nonConstDataLayout() = 0;
+
     virtual const std::type_info& dataTypeInfo() const = 0;
     
     //! Unique name identifier that can be used for strict weak ordering in stl std::map keys.

--- a/packages/phalanx/src/Phalanx_FieldTag_Tag.hpp
+++ b/packages/phalanx/src/Phalanx_FieldTag_Tag.hpp
@@ -70,7 +70,7 @@ namespace PHX {
 
     typedef DataT value_type;
 
-    Tag(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& dl);
+    Tag(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& dl);
 
     // Use SFINAE to remove this ctor if the data types are not the
     // same (excluding const differences). This works but the error
@@ -101,6 +101,8 @@ namespace PHX {
 
     const PHX::DataLayout& dataLayout() const override;
 
+    PHX::DataLayout& nonConstDataLayout() override;
+
     const std::type_info& dataTypeInfo() const override;
 
     const std::string identifier() const override;
@@ -113,7 +115,7 @@ namespace PHX {
 
     std::string m_name;
     
-    Teuchos::RCP<const PHX::DataLayout> m_data_layout;
+    Teuchos::RCP<PHX::DataLayout> m_data_layout;
 
   };
 

--- a/packages/phalanx/src/Phalanx_FieldTag_Tag_Def.hpp
+++ b/packages/phalanx/src/Phalanx_FieldTag_Tag_Def.hpp
@@ -53,7 +53,7 @@
 //**********************************************************************
 template<typename DataT>
 PHX::Tag<DataT>::Tag(const std::string& name,
-		     const Teuchos::RCP<const PHX::DataLayout>& dl) :
+		     const Teuchos::RCP<PHX::DataLayout>& dl) :
   m_name(name),
   m_data_layout(dl)
 { }
@@ -97,6 +97,11 @@ const std::string& PHX::Tag<DataT>::name() const
 //**********************************************************************
 template<typename DataT>
 const PHX::DataLayout& PHX::Tag<DataT>::dataLayout() const
+{ return *m_data_layout; }
+
+//**********************************************************************
+template<typename DataT>
+PHX::DataLayout& PHX::Tag<DataT>::nonConstDataLayout()
 { return *m_data_layout; }
 
 //**********************************************************************

--- a/packages/phalanx/src/Phalanx_Field_Def.hpp
+++ b/packages/phalanx/src/Phalanx_Field_Def.hpp
@@ -66,7 +66,7 @@ const std::string PHX::Field<DataT,Rank>::m_field_data_error_msg =
 // **********************************************************************
 template<typename DataT,int Rank>
 PHX::Field<DataT,Rank>::
-Field(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& t) :
+Field(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& t) :
   m_tag(name,t)
 #ifdef PHX_DEBUG
   , m_tag_set(true),

--- a/packages/phalanx/src/Phalanx_MDField.hpp
+++ b/packages/phalanx/src/Phalanx_MDField.hpp
@@ -152,7 +152,7 @@ namespace PHX {
     typedef typename PHX::Device::size_type size_type;
     typedef typename array_type::execution_space execution_space;
  
-    MDField(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& t);
+    MDField(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& t);
     
     MDField(const PHX::Tag<DataT>& v);
 

--- a/packages/phalanx/src/Phalanx_MDField_Def.hpp
+++ b/packages/phalanx/src/Phalanx_MDField_Def.hpp
@@ -81,7 +81,7 @@ template<typename DataT,
 	 typename Tag0,typename Tag1, typename Tag2, typename Tag3,
 	 typename Tag4,typename Tag5, typename Tag6, typename Tag7>
 PHX::MDField<DataT,Tag0,Tag1,Tag2,Tag3,Tag4,Tag5,Tag6,Tag7>::
-MDField(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& t) :
+MDField(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& t) :
   m_tag(name,t)
 #ifdef PHX_DEBUG
   , m_tag_set(true),

--- a/packages/phalanx/src/Phalanx_MDField_DynRank.hpp
+++ b/packages/phalanx/src/Phalanx_MDField_DynRank.hpp
@@ -84,7 +84,7 @@ namespace PHX {
 
     typedef typename array_type::execution_space execution_space;
 
-    MDField(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& t);
+    MDField(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& t);
     
     MDField(const PHX::Tag<DataT>& v);
     

--- a/packages/phalanx/src/Phalanx_MDField_DynRank_Def.hpp
+++ b/packages/phalanx/src/Phalanx_MDField_DynRank_Def.hpp
@@ -64,7 +64,7 @@
 //**********************************************************************
 template<typename DataT>
 PHX::MDField<DataT,void,void,void,void,void,void,void,void>::
-MDField(const std::string& name, const Teuchos::RCP<const PHX::DataLayout>& t) :
+MDField(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& t) :
   m_tag(name,t)
 #ifdef PHX_DEBUG
   , m_tag_set(true),

--- a/packages/phalanx/test/DagManager/DagManagerTest.cpp
+++ b/packages/phalanx/test/DagManager/DagManagerTest.cpp
@@ -659,9 +659,13 @@ TEUCHOS_UNIT_TEST(dag, contrib_only_B)
     const auto& order_new = dag.getEvaluatorInternalOrdering();
     //const std::vector<PHX::DagNode<MyTraits>>& nodes = dag.getDagNodes();
     TEST_EQUALITY(order_new[0],2);
-    TEST_EQUALITY(order_new[1],1);
-    TEST_EQUALITY(order_new[2],3);
-    TEST_EQUALITY(order_new[3],4);
+    // Node 2 is first, nodes 1, 3, 4 can happen in any order, then node 0 last.
+    TEST_ASSERT( (order_new[1] == 1) || (order_new[1] == 3) || (order_new[1] == 4) );
+    TEST_ASSERT( (order_new[2] == 1) || (order_new[2] == 3) || (order_new[2] == 4) );
+    TEST_ASSERT( (order_new[3] == 1) || (order_new[3] == 3) || (order_new[3] == 4) );
+    TEST_INEQUALITY(order_new[1],order_new[3]);
+    TEST_INEQUALITY(order_new[1],order_new[4]);
+    TEST_INEQUALITY(order_new[3],order_new[4]);
     TEST_EQUALITY(order_new[4],0);
   }
 

--- a/packages/phalanx/test/DataLayout/DynamicLayout.cpp
+++ b/packages/phalanx/test/DataLayout/DynamicLayout.cpp
@@ -162,7 +162,7 @@ TEUCHOS_UNIT_TEST(DynamicLayout, basic)
     Layout b("a",50,4,2); // matches a, but different object
     Layout c("c",50,4,2); // different identifier than a
     Layout d("a",50,4);   // different rank than a
-    Layout e("e",50,4,3); // different extent than a
+    Layout e("a",50,4,3); // different extent than a
 
     // Returns true if identifier rank and extents match
 
@@ -453,6 +453,70 @@ TEUCHOS_UNIT_TEST(DynamicLayout, basic)
     TEST_EQUALITY(e8.extent_int(5),6);
     TEST_EQUALITY(e8.extent_int(6),7);
     TEST_EQUALITY(e8.extent_int(7),8);
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // setExtents() from base class implementation
+  {
+    DataLayout& b1 = e1;
+    b1.setExtents(10);
+    TEST_EQUALITY(b1.extent(0),10);
+
+    DataLayout& b2 = e2;
+    b2.setExtents(10,20);
+    TEST_EQUALITY(b2.extent(0),10);
+    TEST_EQUALITY(b2.extent(1),20);
+
+    DataLayout& b3 = e3;
+    b3.setExtents(10,20,30);
+    TEST_EQUALITY(b3.extent(0),10);
+    TEST_EQUALITY(b3.extent(1),20);
+    TEST_EQUALITY(b3.extent(2),30);
+
+    DataLayout& b4 = e4;
+    b4.setExtents(10,20,30,40);
+    TEST_EQUALITY(b4.extent(0),10);
+    TEST_EQUALITY(b4.extent(1),20);
+    TEST_EQUALITY(b4.extent(2),30);
+    TEST_EQUALITY(b4.extent(3),40);
+
+    DataLayout& b5 = e5;
+    b5.setExtents(10,20,30,40,50);
+    TEST_EQUALITY(b5.extent(0),10);
+    TEST_EQUALITY(b5.extent(1),20);
+    TEST_EQUALITY(b5.extent(2),30);
+    TEST_EQUALITY(b5.extent(3),40);
+    TEST_EQUALITY(b5.extent(4),50);
+
+    DataLayout& b6 = e6;
+    b6.setExtents(10,20,30,40,50,60);
+    TEST_EQUALITY(b6.extent(0),10);
+    TEST_EQUALITY(b6.extent(1),20);
+    TEST_EQUALITY(b6.extent(2),30);
+    TEST_EQUALITY(b6.extent(3),40);
+    TEST_EQUALITY(b6.extent(4),50);
+    TEST_EQUALITY(b6.extent(5),60);
+
+    DataLayout& b7 = e7;
+    b7.setExtents(10,20,30,40,50,60,70);
+    TEST_EQUALITY(b7.extent(0),10);
+    TEST_EQUALITY(b7.extent(1),20);
+    TEST_EQUALITY(b7.extent(2),30);
+    TEST_EQUALITY(b7.extent(3),40);
+    TEST_EQUALITY(b7.extent(4),50);
+    TEST_EQUALITY(b7.extent(5),60);
+    TEST_EQUALITY(b7.extent(6),70);
+
+    DataLayout& b8 = e8;
+    b8.setExtents(10,20,30,40,50,60,70,80);
+    TEST_EQUALITY(b8.extent(0),10);
+    TEST_EQUALITY(b8.extent(1),20);
+    TEST_EQUALITY(b8.extent(2),30);
+    TEST_EQUALITY(b8.extent(3),40);
+    TEST_EQUALITY(b8.extent(4),50);
+    TEST_EQUALITY(b8.extent(5),60);
+    TEST_EQUALITY(b8.extent(6),70);
+    TEST_EQUALITY(b8.extent(7),80);
   }
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packages/phalanx/test/DataLayout/MDALayout.cpp
+++ b/packages/phalanx/test/DataLayout/MDALayout.cpp
@@ -1,7 +1,7 @@
 // @HEADER
 // ************************************************************************
 //
-//        Phalanx: A Partial Differential Equation Field Evaluation 
+//        Phalanx: A Partial Differential Equation Field Evaluation
 //       Kernel for Flexible Management of Complex Dependency Chains
 //                    Copyright 2008 Sandia Corporation
 //
@@ -125,64 +125,64 @@ struct Ordinal8 : public PHX::DimTag {
   static const Ordinal8 & tag();
 };
 
-const char * Spatial::name() const 
+const char * Spatial::name() const
 { static const char n[] = "Spatial" ; return n ; }
-const Spatial & Spatial::tag() 
+const Spatial & Spatial::tag()
 { static const Spatial myself ; return myself ; }
 
-const char * Quadrature::name() const 
+const char * Quadrature::name() const
 { static const char n[] = "Quadrature" ; return n ; }
-const Quadrature & Quadrature::tag() 
+const Quadrature & Quadrature::tag()
 { static const Quadrature myself ; return myself ; }
 
-const char * Node::name() const 
+const char * Node::name() const
 { static const char n[] = "Node" ; return n ; }
-const Node & Node::tag() 
+const Node & Node::tag()
 { static const Node myself ; return myself ; }
 
-const char * Cell::name() const 
+const char * Cell::name() const
 { static const char n[] = "Cell" ; return n ; }
-const Cell & Cell::tag() 
+const Cell & Cell::tag()
 { static const Cell myself ; return myself ; }
 
-const char * Ordinal1::name() const 
+const char * Ordinal1::name() const
 { static const char n[] = "Ordinal1" ; return n ; }
-const Ordinal1 & Ordinal1::tag() 
+const Ordinal1 & Ordinal1::tag()
 { static const Ordinal1 myself ; return myself ; }
 
-const char * Ordinal2::name() const 
+const char * Ordinal2::name() const
 { static const char n[] = "Ordinal2" ; return n ; }
-const Ordinal2 & Ordinal2::tag() 
+const Ordinal2 & Ordinal2::tag()
 { static const Ordinal2 myself ; return myself ; }
 
-const char * Ordinal3::name() const 
+const char * Ordinal3::name() const
 { static const char n[] = "Ordinal3" ; return n ; }
-const Ordinal3 & Ordinal3::tag() 
+const Ordinal3 & Ordinal3::tag()
 { static const Ordinal3 myself ; return myself ; }
 
-const char * Ordinal4::name() const 
+const char * Ordinal4::name() const
 { static const char n[] = "Ordinal4" ; return n ; }
-const Ordinal4 & Ordinal4::tag() 
+const Ordinal4 & Ordinal4::tag()
 { static const Ordinal4 myself ; return myself ; }
 
-const char * Ordinal5::name() const 
+const char * Ordinal5::name() const
 { static const char n[] = "Ordinal5" ; return n ; }
-const Ordinal5 & Ordinal5::tag() 
+const Ordinal5 & Ordinal5::tag()
 { static const Ordinal5 myself ; return myself ; }
 
-const char * Ordinal6::name() const 
+const char * Ordinal6::name() const
 { static const char n[] = "Ordinal6" ; return n ; }
-const Ordinal6 & Ordinal6::tag() 
+const Ordinal6 & Ordinal6::tag()
 { static const Ordinal6 myself ; return myself ; }
 
-const char * Ordinal7::name() const 
+const char * Ordinal7::name() const
 { static const char n[] = "Ordinal7" ; return n ; }
-const Ordinal7 & Ordinal7::tag() 
+const Ordinal7 & Ordinal7::tag()
 { static const Ordinal7 myself ; return myself ; }
 
-const char * Ordinal8::name() const 
+const char * Ordinal8::name() const
 { static const char n[] = "Ordinal8" ; return n ; }
-const Ordinal8 & Ordinal8::tag() 
+const Ordinal8 & Ordinal8::tag()
 { static const Ordinal8 myself ; return myself ; }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -195,7 +195,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // ctor
-  cout << "\nTesting constructor...";    
+  cout << "\nTesting constructor...";
   MDALayout<Ordinal1,Ordinal2,Ordinal3,Ordinal4,Ordinal5,Ordinal6,Ordinal7,Ordinal8> rank8(1,2,3,4,5,6,7,8);
   MDALayout<Ordinal1,Ordinal2,Ordinal3,Ordinal4,Ordinal5,Ordinal6,Ordinal7> rank7(1,2,3,4,5,6,7);
   MDALayout<Ordinal1,Ordinal2,Ordinal3,Ordinal4,Ordinal5,Ordinal6> rank6(1,2,3,4,5,6);
@@ -214,7 +214,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
   MDALayout<Ordinal1> prank1("DL1",1);
   MDALayout<Cell,Node,Spatial,Spatial> n_mat(100,4,2,2);
   cout << "passed!" << endl;
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // identifier()
   TEST_EQUALITY(rank8.identifier(),"<Ordinal1,Ordinal2,Ordinal3,Ordinal4,Ordinal5,Ordinal6,Ordinal7,Ordinal8>(1,2,3,4,5,6,7,8)");
@@ -234,7 +234,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
   TEST_EQUALITY(prank2.identifier(),"DL2<Ordinal1,Ordinal2>(1,2)");
   TEST_EQUALITY(prank1.identifier(),"DL1<Ordinal1>(1)");
   TEST_EQUALITY(n_mat.identifier(),"<Cell,Node,Spatial,Spatial>(100,4,2,2)");
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // rank()
   TEST_EQUALITY(rank8.rank(),8);
@@ -254,7 +254,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
   TEST_EQUALITY(prank2.rank(),2);
   TEST_EQUALITY(prank1.rank(),1);
   TEST_EQUALITY(n_mat.rank(),4);
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // dimensions()
   {
@@ -265,7 +265,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(dims[2],2);
     TEST_EQUALITY(dims[3],2);
   }
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // names()
   {
@@ -276,11 +276,11 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(names[2],"Spatial");
     TEST_EQUALITY(names[3],"Spatial");
   }
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // size()
   TEST_EQUALITY(n_mat.size(),1600);
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // operator==()
   {
@@ -289,50 +289,50 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     MDALayout<Cell,Node,Spatial> n_vec_c(50,4,2);
     MDALayout<Cell,Quadrature,Spatial> qp_vec(100,4,2);
     MDALayout<Cell,Quadrature,Spatial,Spatial> qp_mat(100,4,2,2);
-    
+
     // Same data layout, different objects
     TEST_EQUALITY(n_vec_b,n_vec_c);
-    
+
     // Same ordinal types, different dim sizes
     TEST_INEQUALITY(n_vec_a,n_vec_c);
-    
+
     // Different ordinal types, same rank, same dim sizes
     TEST_INEQUALITY(n_vec_a,qp_vec);
-    
+
     // Different ordianl types, different dim sizes
     TEST_INEQUALITY(n_vec_a,qp_mat);
   }
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // dimension()
   {
     TEST_EQUALITY(rank1.dimension(0),1);
-    
+
     TEST_EQUALITY(rank2.dimension(0),1);
     TEST_EQUALITY(rank2.dimension(1),2);
-    
+
     TEST_EQUALITY(rank3.dimension(0),1);
     TEST_EQUALITY(rank3.dimension(1),2);
     TEST_EQUALITY(rank3.dimension(2),3);
-    
+
     TEST_EQUALITY(rank4.dimension(0),1);
     TEST_EQUALITY(rank4.dimension(1),2);
     TEST_EQUALITY(rank4.dimension(2),3);
     TEST_EQUALITY(rank4.dimension(3),4);
-    
+
     TEST_EQUALITY(rank5.dimension(0),1);
     TEST_EQUALITY(rank5.dimension(1),2);
     TEST_EQUALITY(rank5.dimension(2),3);
     TEST_EQUALITY(rank5.dimension(3),4);
     TEST_EQUALITY(rank5.dimension(4),5);
-    
+
     TEST_EQUALITY(rank6.dimension(0),1);
     TEST_EQUALITY(rank6.dimension(1),2);
     TEST_EQUALITY(rank6.dimension(2),3);
     TEST_EQUALITY(rank6.dimension(3),4);
     TEST_EQUALITY(rank6.dimension(4),5);
     TEST_EQUALITY(rank6.dimension(5),6);
-    
+
     TEST_EQUALITY(rank7.dimension(0),1);
     TEST_EQUALITY(rank7.dimension(1),2);
     TEST_EQUALITY(rank7.dimension(2),3);
@@ -340,7 +340,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank7.dimension(4),5);
     TEST_EQUALITY(rank7.dimension(5),6);
     TEST_EQUALITY(rank7.dimension(6),7);
-    
+
     TEST_EQUALITY(rank8.dimension(0),1);
     TEST_EQUALITY(rank8.dimension(1),2);
     TEST_EQUALITY(rank8.dimension(2),3);
@@ -351,32 +351,32 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank8.dimension(7),8);
 
     TEST_EQUALITY(prank1.dimension(0),1);
-    
+
     TEST_EQUALITY(prank2.dimension(0),1);
     TEST_EQUALITY(prank2.dimension(1),2);
-    
+
     TEST_EQUALITY(prank3.dimension(0),1);
     TEST_EQUALITY(prank3.dimension(1),2);
     TEST_EQUALITY(prank3.dimension(2),3);
-    
+
     TEST_EQUALITY(prank4.dimension(0),1);
     TEST_EQUALITY(prank4.dimension(1),2);
     TEST_EQUALITY(prank4.dimension(2),3);
     TEST_EQUALITY(prank4.dimension(3),4);
-    
+
     TEST_EQUALITY(prank5.dimension(0),1);
     TEST_EQUALITY(prank5.dimension(1),2);
     TEST_EQUALITY(prank5.dimension(2),3);
     TEST_EQUALITY(prank5.dimension(3),4);
     TEST_EQUALITY(prank5.dimension(4),5);
-    
+
     TEST_EQUALITY(prank6.dimension(0),1);
     TEST_EQUALITY(prank6.dimension(1),2);
     TEST_EQUALITY(prank6.dimension(2),3);
     TEST_EQUALITY(prank6.dimension(3),4);
     TEST_EQUALITY(prank6.dimension(4),5);
     TEST_EQUALITY(prank6.dimension(5),6);
-    
+
     TEST_EQUALITY(prank7.dimension(0),1);
     TEST_EQUALITY(prank7.dimension(1),2);
     TEST_EQUALITY(prank7.dimension(2),3);
@@ -384,7 +384,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank7.dimension(4),5);
     TEST_EQUALITY(prank7.dimension(5),6);
     TEST_EQUALITY(prank7.dimension(6),7);
-    
+
     TEST_EQUALITY(prank8.dimension(0),1);
     TEST_EQUALITY(prank8.dimension(1),2);
     TEST_EQUALITY(prank8.dimension(2),3);
@@ -395,37 +395,37 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank8.dimension(7),8);
 
   }
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // extent()
   {
     TEST_EQUALITY(rank1.extent(0),1);
-    
+
     TEST_EQUALITY(rank2.extent(0),1);
     TEST_EQUALITY(rank2.extent(1),2);
-    
+
     TEST_EQUALITY(rank3.extent(0),1);
     TEST_EQUALITY(rank3.extent(1),2);
     TEST_EQUALITY(rank3.extent(2),3);
-    
+
     TEST_EQUALITY(rank4.extent(0),1);
     TEST_EQUALITY(rank4.extent(1),2);
     TEST_EQUALITY(rank4.extent(2),3);
     TEST_EQUALITY(rank4.extent(3),4);
-    
+
     TEST_EQUALITY(rank5.extent(0),1);
     TEST_EQUALITY(rank5.extent(1),2);
     TEST_EQUALITY(rank5.extent(2),3);
     TEST_EQUALITY(rank5.extent(3),4);
     TEST_EQUALITY(rank5.extent(4),5);
-    
+
     TEST_EQUALITY(rank6.extent(0),1);
     TEST_EQUALITY(rank6.extent(1),2);
     TEST_EQUALITY(rank6.extent(2),3);
     TEST_EQUALITY(rank6.extent(3),4);
     TEST_EQUALITY(rank6.extent(4),5);
     TEST_EQUALITY(rank6.extent(5),6);
-    
+
     TEST_EQUALITY(rank7.extent(0),1);
     TEST_EQUALITY(rank7.extent(1),2);
     TEST_EQUALITY(rank7.extent(2),3);
@@ -433,7 +433,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank7.extent(4),5);
     TEST_EQUALITY(rank7.extent(5),6);
     TEST_EQUALITY(rank7.extent(6),7);
-    
+
     TEST_EQUALITY(rank8.extent(0),1);
     TEST_EQUALITY(rank8.extent(1),2);
     TEST_EQUALITY(rank8.extent(2),3);
@@ -444,32 +444,32 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank8.extent(7),8);
 
     TEST_EQUALITY(prank1.extent(0),1);
-    
+
     TEST_EQUALITY(prank2.extent(0),1);
     TEST_EQUALITY(prank2.extent(1),2);
-    
+
     TEST_EQUALITY(prank3.extent(0),1);
     TEST_EQUALITY(prank3.extent(1),2);
     TEST_EQUALITY(prank3.extent(2),3);
-    
+
     TEST_EQUALITY(prank4.extent(0),1);
     TEST_EQUALITY(prank4.extent(1),2);
     TEST_EQUALITY(prank4.extent(2),3);
     TEST_EQUALITY(prank4.extent(3),4);
-    
+
     TEST_EQUALITY(prank5.extent(0),1);
     TEST_EQUALITY(prank5.extent(1),2);
     TEST_EQUALITY(prank5.extent(2),3);
     TEST_EQUALITY(prank5.extent(3),4);
     TEST_EQUALITY(prank5.extent(4),5);
-    
+
     TEST_EQUALITY(prank6.extent(0),1);
     TEST_EQUALITY(prank6.extent(1),2);
     TEST_EQUALITY(prank6.extent(2),3);
     TEST_EQUALITY(prank6.extent(3),4);
     TEST_EQUALITY(prank6.extent(4),5);
     TEST_EQUALITY(prank6.extent(5),6);
-    
+
     TEST_EQUALITY(prank7.extent(0),1);
     TEST_EQUALITY(prank7.extent(1),2);
     TEST_EQUALITY(prank7.extent(2),3);
@@ -477,7 +477,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank7.extent(4),5);
     TEST_EQUALITY(prank7.extent(5),6);
     TEST_EQUALITY(prank7.extent(6),7);
-    
+
     TEST_EQUALITY(prank8.extent(0),1);
     TEST_EQUALITY(prank8.extent(1),2);
     TEST_EQUALITY(prank8.extent(2),3);
@@ -488,37 +488,37 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank8.extent(7),8);
 
   }
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // extent_int()
   {
     TEST_EQUALITY(rank1.extent_int(0),1);
-    
+
     TEST_EQUALITY(rank2.extent_int(0),1);
     TEST_EQUALITY(rank2.extent_int(1),2);
-    
+
     TEST_EQUALITY(rank3.extent_int(0),1);
     TEST_EQUALITY(rank3.extent_int(1),2);
     TEST_EQUALITY(rank3.extent_int(2),3);
-    
+
     TEST_EQUALITY(rank4.extent_int(0),1);
     TEST_EQUALITY(rank4.extent_int(1),2);
     TEST_EQUALITY(rank4.extent_int(2),3);
     TEST_EQUALITY(rank4.extent_int(3),4);
-    
+
     TEST_EQUALITY(rank5.extent_int(0),1);
     TEST_EQUALITY(rank5.extent_int(1),2);
     TEST_EQUALITY(rank5.extent_int(2),3);
     TEST_EQUALITY(rank5.extent_int(3),4);
     TEST_EQUALITY(rank5.extent_int(4),5);
-    
+
     TEST_EQUALITY(rank6.extent_int(0),1);
     TEST_EQUALITY(rank6.extent_int(1),2);
     TEST_EQUALITY(rank6.extent_int(2),3);
     TEST_EQUALITY(rank6.extent_int(3),4);
     TEST_EQUALITY(rank6.extent_int(4),5);
     TEST_EQUALITY(rank6.extent_int(5),6);
-    
+
     TEST_EQUALITY(rank7.extent_int(0),1);
     TEST_EQUALITY(rank7.extent_int(1),2);
     TEST_EQUALITY(rank7.extent_int(2),3);
@@ -526,7 +526,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank7.extent_int(4),5);
     TEST_EQUALITY(rank7.extent_int(5),6);
     TEST_EQUALITY(rank7.extent_int(6),7);
-    
+
     TEST_EQUALITY(rank8.extent_int(0),1);
     TEST_EQUALITY(rank8.extent_int(1),2);
     TEST_EQUALITY(rank8.extent_int(2),3);
@@ -537,32 +537,32 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank8.extent_int(7),8);
 
     TEST_EQUALITY(prank1.extent_int(0),1);
-    
+
     TEST_EQUALITY(prank2.extent_int(0),1);
     TEST_EQUALITY(prank2.extent_int(1),2);
-    
+
     TEST_EQUALITY(prank3.extent_int(0),1);
     TEST_EQUALITY(prank3.extent_int(1),2);
     TEST_EQUALITY(prank3.extent_int(2),3);
-    
+
     TEST_EQUALITY(prank4.extent_int(0),1);
     TEST_EQUALITY(prank4.extent_int(1),2);
     TEST_EQUALITY(prank4.extent_int(2),3);
     TEST_EQUALITY(prank4.extent_int(3),4);
-    
+
     TEST_EQUALITY(prank5.extent_int(0),1);
     TEST_EQUALITY(prank5.extent_int(1),2);
     TEST_EQUALITY(prank5.extent_int(2),3);
     TEST_EQUALITY(prank5.extent_int(3),4);
     TEST_EQUALITY(prank5.extent_int(4),5);
-    
+
     TEST_EQUALITY(prank6.extent_int(0),1);
     TEST_EQUALITY(prank6.extent_int(1),2);
     TEST_EQUALITY(prank6.extent_int(2),3);
     TEST_EQUALITY(prank6.extent_int(3),4);
     TEST_EQUALITY(prank6.extent_int(4),5);
     TEST_EQUALITY(prank6.extent_int(5),6);
-    
+
     TEST_EQUALITY(prank7.extent_int(0),1);
     TEST_EQUALITY(prank7.extent_int(1),2);
     TEST_EQUALITY(prank7.extent_int(2),3);
@@ -570,7 +570,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank7.extent_int(4),5);
     TEST_EQUALITY(prank7.extent_int(5),6);
     TEST_EQUALITY(prank7.extent_int(6),7);
-    
+
     TEST_EQUALITY(prank8.extent_int(0),1);
     TEST_EQUALITY(prank8.extent_int(1),2);
     TEST_EQUALITY(prank8.extent_int(2),3);
@@ -581,26 +581,91 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank8.extent_int(7),8);
 
   }
-  
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // name() 
+  // setExtents() from base class and derived class
+  // NOTE: the derived class does not implement this method
+  {
+    DataLayout& b1 = rank1;
+    b1.setExtents(10);
+    TEST_EQUALITY(b1.extent(0),10);
+
+    DataLayout& b2 = rank2;
+    b2.setExtents(10,20);
+    TEST_EQUALITY(b2.extent(0),10);
+    TEST_EQUALITY(b2.extent(1),20);
+
+    DataLayout& b3 = rank3;
+    b3.setExtents(10,20,30);
+    TEST_EQUALITY(b3.extent(0),10);
+    TEST_EQUALITY(b3.extent(1),20);
+    TEST_EQUALITY(b3.extent(2),30);
+
+    DataLayout& b4 = rank4;
+    b4.setExtents(10,20,30,40);
+    TEST_EQUALITY(b4.extent(0),10);
+    TEST_EQUALITY(b4.extent(1),20);
+    TEST_EQUALITY(b4.extent(2),30);
+    TEST_EQUALITY(b4.extent(3),40);
+
+    DataLayout& b5 = rank5;
+    b5.setExtents(10,20,30,40,50);
+    TEST_EQUALITY(b5.extent(0),10);
+    TEST_EQUALITY(b5.extent(1),20);
+    TEST_EQUALITY(b5.extent(2),30);
+    TEST_EQUALITY(b5.extent(3),40);
+    TEST_EQUALITY(b5.extent(4),50);
+
+    DataLayout& b6 = rank6;
+    b6.setExtents(10,20,30,40,50,60);
+    TEST_EQUALITY(b6.extent(0),10);
+    TEST_EQUALITY(b6.extent(1),20);
+    TEST_EQUALITY(b6.extent(2),30);
+    TEST_EQUALITY(b6.extent(3),40);
+    TEST_EQUALITY(b6.extent(4),50);
+    TEST_EQUALITY(b6.extent(5),60);
+
+    DataLayout& b7 = rank7;
+    b7.setExtents(10,20,30,40,50,60,70);
+    TEST_EQUALITY(b7.extent(0),10);
+    TEST_EQUALITY(b7.extent(1),20);
+    TEST_EQUALITY(b7.extent(2),30);
+    TEST_EQUALITY(b7.extent(3),40);
+    TEST_EQUALITY(b7.extent(4),50);
+    TEST_EQUALITY(b7.extent(5),60);
+    TEST_EQUALITY(b7.extent(6),70);
+
+    DataLayout& b8 = rank8;
+    // Set on the derived class instead of base
+    rank8.setExtents(10,20,30,40,50,60,70,80);
+    TEST_EQUALITY(b8.extent(0),10);
+    TEST_EQUALITY(b8.extent(1),20);
+    TEST_EQUALITY(b8.extent(2),30);
+    TEST_EQUALITY(b8.extent(3),40);
+    TEST_EQUALITY(b8.extent(4),50);
+    TEST_EQUALITY(b8.extent(5),60);
+    TEST_EQUALITY(b8.extent(6),70);
+    TEST_EQUALITY(b8.extent(7),80);
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // name()
   {
     cout << "\n" << rank1.name(0) << std::endl;
-    
+
     TEST_EQUALITY(rank1.name(0),"Ordinal1");
-    
+
     TEST_EQUALITY(rank2.name(0),"Ordinal1");
     TEST_EQUALITY(rank2.name(1),"Ordinal2");
-    
+
     TEST_EQUALITY(rank3.name(0),"Ordinal1");
     TEST_EQUALITY(rank3.name(1),"Ordinal2");
     TEST_EQUALITY(rank3.name(2),"Ordinal3");
-    
+
     TEST_EQUALITY(rank4.name(0),"Ordinal1");
     TEST_EQUALITY(rank4.name(1),"Ordinal2");
     TEST_EQUALITY(rank4.name(2),"Ordinal3");
     TEST_EQUALITY(rank4.name(3),"Ordinal4");
-    
+
     TEST_EQUALITY(rank5.name(0),"Ordinal1");
     TEST_EQUALITY(rank5.name(1),"Ordinal2");
     TEST_EQUALITY(rank5.name(2),"Ordinal3");
@@ -613,7 +678,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank6.name(3),"Ordinal4");
     TEST_EQUALITY(rank6.name(4),"Ordinal5");
     TEST_EQUALITY(rank6.name(5),"Ordinal6");
-    
+
     TEST_EQUALITY(rank7.name(0),"Ordinal1");
     TEST_EQUALITY(rank7.name(1),"Ordinal2");
     TEST_EQUALITY(rank7.name(2),"Ordinal3");
@@ -621,7 +686,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank7.name(4),"Ordinal5");
     TEST_EQUALITY(rank7.name(5),"Ordinal6");
     TEST_EQUALITY(rank7.name(6),"Ordinal7");
-    
+
     TEST_EQUALITY(rank8.name(0),"Ordinal1");
     TEST_EQUALITY(rank8.name(1),"Ordinal2");
     TEST_EQUALITY(rank8.name(2),"Ordinal3");
@@ -630,21 +695,21 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(rank8.name(5),"Ordinal6");
     TEST_EQUALITY(rank8.name(6),"Ordinal7");
     TEST_EQUALITY(rank8.name(7),"Ordinal8");
-    
+
     TEST_EQUALITY(prank1.name(0),"Ordinal1");
-    
+
     TEST_EQUALITY(prank2.name(0),"Ordinal1");
     TEST_EQUALITY(prank2.name(1),"Ordinal2");
-    
+
     TEST_EQUALITY(prank3.name(0),"Ordinal1");
     TEST_EQUALITY(prank3.name(1),"Ordinal2");
     TEST_EQUALITY(prank3.name(2),"Ordinal3");
-    
+
     TEST_EQUALITY(prank4.name(0),"Ordinal1");
     TEST_EQUALITY(prank4.name(1),"Ordinal2");
     TEST_EQUALITY(prank4.name(2),"Ordinal3");
     TEST_EQUALITY(prank4.name(3),"Ordinal4");
-    
+
     TEST_EQUALITY(prank5.name(0),"Ordinal1");
     TEST_EQUALITY(prank5.name(1),"Ordinal2");
     TEST_EQUALITY(prank5.name(2),"Ordinal3");
@@ -657,7 +722,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank6.name(3),"Ordinal4");
     TEST_EQUALITY(prank6.name(4),"Ordinal5");
     TEST_EQUALITY(prank6.name(5),"Ordinal6");
-    
+
     TEST_EQUALITY(prank7.name(0),"Ordinal1");
     TEST_EQUALITY(prank7.name(1),"Ordinal2");
     TEST_EQUALITY(prank7.name(2),"Ordinal3");
@@ -665,7 +730,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank7.name(4),"Ordinal5");
     TEST_EQUALITY(prank7.name(5),"Ordinal6");
     TEST_EQUALITY(prank7.name(6),"Ordinal7");
-    
+
     TEST_EQUALITY(prank8.name(0),"Ordinal1");
     TEST_EQUALITY(prank8.name(1),"Ordinal2");
     TEST_EQUALITY(prank8.name(2),"Ordinal3");
@@ -675,7 +740,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     TEST_EQUALITY(prank8.name(6),"Ordinal7");
     TEST_EQUALITY(prank8.name(7),"Ordinal8");
   }
-  
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // ostream
   {
@@ -683,7 +748,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     ostringstream output;
     output << rank8 << endl;
     output << rank7 << endl;
-    output << rank6 << endl;   
+    output << rank6 << endl;
     output << rank5 << endl;
     output << rank4 << endl;
     output << rank3 << endl;
@@ -691,7 +756,7 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     output << rank1 << endl;
     output << prank8 << endl;
     output << prank7 << endl;
-    output << prank6 << endl;   
+    output << prank6 << endl;
     output << prank5 << endl;
     output << prank4 << endl;
     output << prank3 << endl;
@@ -700,5 +765,5 @@ TEUCHOS_UNIT_TEST(DataLayout, basic)
     output << n_mat << endl;
     cout << "...passed:\n" << output.str() << endl;
   }
-  
+
 }

--- a/packages/phalanx/test/EvaluatorUnitTester/AllRanksEvaluator.hpp
+++ b/packages/phalanx/test/EvaluatorUnitTester/AllRanksEvaluator.hpp
@@ -54,7 +54,7 @@
 */
 template<typename EvalT, typename Traits>
 class AllRanksEvaluator : public PHX::EvaluatorWithBaseImpl<Traits>,
-                        public PHX::EvaluatorDerived<EvalT, Traits>  {
+                          public PHX::EvaluatorDerived<EvalT, Traits>  {
 
   using ScalarT = typename EvalT::ScalarT;
   PHX::MDField<const ScalarT,R> f1;
@@ -71,12 +71,12 @@ class AllRanksEvaluator : public PHX::EvaluatorWithBaseImpl<Traits>,
   PHX::MDField<ScalarT,R,R,R,R,R,R> x6;
   
 public:
-  AllRanksEvaluator(const Teuchos::RCP<const PHX::DataLayout>& dl1,
-                    const Teuchos::RCP<const PHX::DataLayout>& dl2,
-                    const Teuchos::RCP<const PHX::DataLayout>& dl3,
-                    const Teuchos::RCP<const PHX::DataLayout>& dl4,
-                    const Teuchos::RCP<const PHX::DataLayout>& dl5,
-                    const Teuchos::RCP<const PHX::DataLayout>& dl6);
+  AllRanksEvaluator(const Teuchos::RCP<PHX::DataLayout>& dl1,
+                    const Teuchos::RCP<PHX::DataLayout>& dl2,
+                    const Teuchos::RCP<PHX::DataLayout>& dl3,
+                    const Teuchos::RCP<PHX::DataLayout>& dl4,
+                    const Teuchos::RCP<PHX::DataLayout>& dl5,
+                    const Teuchos::RCP<PHX::DataLayout>& dl6);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/test/EvaluatorUnitTester/AllRanksEvaluator_Def.hpp
+++ b/packages/phalanx/test/EvaluatorUnitTester/AllRanksEvaluator_Def.hpp
@@ -45,12 +45,12 @@
 //**********************************************************************
 template<typename EvalT, typename Traits>
 AllRanksEvaluator<EvalT,Traits>::
-AllRanksEvaluator(const Teuchos::RCP<const PHX::DataLayout>& dl1,
-                  const Teuchos::RCP<const PHX::DataLayout>& dl2,
-                  const Teuchos::RCP<const PHX::DataLayout>& dl3,
-                  const Teuchos::RCP<const PHX::DataLayout>& dl4,
-                  const Teuchos::RCP<const PHX::DataLayout>& dl5,
-                  const Teuchos::RCP<const PHX::DataLayout>& dl6) :
+AllRanksEvaluator(const Teuchos::RCP<PHX::DataLayout>& dl1,
+                  const Teuchos::RCP<PHX::DataLayout>& dl2,
+                  const Teuchos::RCP<PHX::DataLayout>& dl3,
+                  const Teuchos::RCP<PHX::DataLayout>& dl4,
+                  const Teuchos::RCP<PHX::DataLayout>& dl5,
+                  const Teuchos::RCP<PHX::DataLayout>& dl6) :
   f1("f1",dl1),
   f2("f2",dl2),
   f3("f3",dl3),

--- a/packages/phalanx/test/EvaluatorUnitTester/DuplicateFieldEvaluator.hpp
+++ b/packages/phalanx/test/EvaluatorUnitTester/DuplicateFieldEvaluator.hpp
@@ -64,7 +64,7 @@
     */
 template<typename EvalT, typename Traits>
 class DuplicateFieldEvaluator : public PHX::EvaluatorWithBaseImpl<Traits>,
-                        public PHX::EvaluatorDerived<EvalT, Traits>  {
+                                public PHX::EvaluatorDerived<EvalT, Traits>  {
 
   using ScalarT = typename EvalT::ScalarT;
   PHX::MDField<ScalarT,CELL,QP> a;
@@ -73,9 +73,9 @@ class DuplicateFieldEvaluator : public PHX::EvaluatorWithBaseImpl<Traits>,
   PHX::MDField<const ScalarT,CELL,QP,DIM> c;
   
 public:
-  DuplicateFieldEvaluator(const Teuchos::RCP<const PHX::DataLayout>& a_layout,
-                          const Teuchos::RCP<const PHX::DataLayout>& b_layout,
-                          const Teuchos::RCP<const PHX::DataLayout>& c_layout);
+  DuplicateFieldEvaluator(const Teuchos::RCP<PHX::DataLayout>& a_layout,
+                          const Teuchos::RCP<PHX::DataLayout>& b_layout,
+                          const Teuchos::RCP<PHX::DataLayout>& c_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/test/EvaluatorUnitTester/DuplicateFieldEvaluator_Def.hpp
+++ b/packages/phalanx/test/EvaluatorUnitTester/DuplicateFieldEvaluator_Def.hpp
@@ -45,9 +45,9 @@
 //**********************************************************************
 template<typename EvalT, typename Traits>
 DuplicateFieldEvaluator<EvalT,Traits>::
-DuplicateFieldEvaluator(const Teuchos::RCP<const PHX::DataLayout>& a_layout,
-                        const Teuchos::RCP<const PHX::DataLayout>& b_layout,
-                        const Teuchos::RCP<const PHX::DataLayout>& c_layout) :
+DuplicateFieldEvaluator(const Teuchos::RCP<PHX::DataLayout>& a_layout,
+                        const Teuchos::RCP<PHX::DataLayout>& b_layout,
+                        const Teuchos::RCP<PHX::DataLayout>& c_layout) :
   a("a",a_layout),
   b1("b",b_layout),
   b2("b",b_layout), // purposely duplicate b1 for corner case

--- a/packages/phalanx/test/EvaluatorUnitTester/SimpleEvaluator.hpp
+++ b/packages/phalanx/test/EvaluatorUnitTester/SimpleEvaluator.hpp
@@ -62,9 +62,9 @@ class SimpleEvaluator : public PHX::EvaluatorWithBaseImpl<Traits>,
   PHX::MDField<const ScalarT,CELL,QP,DIM> c;
   
 public:
-  SimpleEvaluator(const Teuchos::RCP<const PHX::DataLayout>& a_layout,
-                  const Teuchos::RCP<const PHX::DataLayout>& b_layout,
-                  const Teuchos::RCP<const PHX::DataLayout>& c_layout);
+  SimpleEvaluator(const Teuchos::RCP<PHX::DataLayout>& a_layout,
+                  const Teuchos::RCP<PHX::DataLayout>& b_layout,
+                  const Teuchos::RCP<PHX::DataLayout>& c_layout);
   void evaluateFields(typename Traits::EvalData workset) override;
   KOKKOS_INLINE_FUNCTION
   void operator () (const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;

--- a/packages/phalanx/test/EvaluatorUnitTester/SimpleEvaluator_Def.hpp
+++ b/packages/phalanx/test/EvaluatorUnitTester/SimpleEvaluator_Def.hpp
@@ -45,9 +45,9 @@
 //**********************************************************************
 template<typename EvalT, typename Traits>
 SimpleEvaluator<EvalT,Traits>::
-SimpleEvaluator(const Teuchos::RCP<const PHX::DataLayout>& a_layout,
-                const Teuchos::RCP<const PHX::DataLayout>& b_layout,
-                const Teuchos::RCP<const PHX::DataLayout>& c_layout) :
+SimpleEvaluator(const Teuchos::RCP<PHX::DataLayout>& a_layout,
+                const Teuchos::RCP<PHX::DataLayout>& b_layout,
+                const Teuchos::RCP<PHX::DataLayout>& c_layout) :
   a("a",a_layout),
   b("b",b_layout),
   c("c",c_layout)


### PR DESCRIPTION
PR for Issue #1610. Please do not merge until tests results for CUDA are complete.

@eric-c-cyr if you don't have the time, I can reassign to Sean. The addition of the non-virtual base class template function has resulted in an increase in compile times. The build of phalanx library/tests/examples jumped from 1m13s to 1m21s (mostly in the DataLayout unit tests). The FiniteElementAssembly is probably a more realistic assessment of the impact on applications, there the example jumped from 20.76s to 21.20 seconds. This capability is split into two commits for this reason. We can easily back out the interface change by reverting b62025f. This means the user would have to dynamic_cast to the derived DataLayout to set extents.
