### PR TITLE
ML Matlab interface:  in R2016a MX_API_VER does not exist anymore

### DIFF
--- a/packages/ml/matlab/mlmex.cpp
+++ b/packages/ml/matlab/mlmex.cpp
@@ -79,9 +79,8 @@ typedef enum {MODE_SETUP=0, MODE_SOLVE, MODE_CLEANUP, MODE_STATUS, MODE_AGGREGAT
 /* Debugging */
 //#define VERBOSE_OUTPUT
 
-/* Stuff for MATLAB R2006b vs. previous versions */
-#if(defined(MX_API_VER) && MX_API_VER >= 0x07030000)
-#else
+/* Compatibiliy with older version of MATLAB */
+#ifndef MWSIZE_MAX
 typedef int mwIndex;
 #endif
 


### PR DESCRIPTION
ML Matlab interface fix for > R2016a:
From R2016a on the macro MX_API_VER does not exist in matrix.h anymore.
This fix has been suggested on 
https://de.mathworks.com/matlabcentral/answers/274084-how-to-determine-mex-api-version
and works for me.