### PR TITLE
Tweak ML Matlab build for macOS

### DIFF
--- a/packages/ml/matlab/CMakeLists.txt
+++ b/packages/ml/matlab/CMakeLists.txt
@@ -53,10 +53,14 @@ if(TPL_ENABLE_MATLAB)
 
   # Manually drop in options from the mex script (R2009b) on a linux platform.
   # g++ -O -pthread -shared -Wl,--version-script,/usr/local/matlab/7.9/extern/lib/glnxa64/mexFunction.map -Wl,--no-undefined -o  "mlmex.mexa64"   "mlmex-mlmex.o"  -lm -Wl,-rpath-link,/usr/local/matlab/7.9/bin/glnxa64 -L/usr/local/matlab/7.9/bin/glnxa64 -lmx -lmex -lmat -lm
-  SET(MLMEX_OPTS1 "-pthread;-shared;-Wl,--version-script,${MATLAB_ROOT}/extern/lib/${MATLAB_ARCH}/mexFunction.map;-Wl,--no-undefined")
-  
-  SET(MLMEX_OPTS2 "-Wl,-rpath-link,${MATLAB_ROOT}/bin/${MATLAB_ARCH} ${${PROJECT_NAME}_EXTRA_LINK_FLAGS}")
-    
+  if (NOT APPLE)
+    SET(MLMEX_OPTS1 "-pthread;-shared;-Wl,--version-script,${MATLAB_ROOT}/extern/lib/${MATLAB_ARCH}/mexFunction.map;-Wl,--no-undefined")
+    SET(MLMEX_OPTS2 "-Wl,-rpath-link,${MATLAB_ROOT}/bin/${MATLAB_ARCH}")
+  else()
+    SET(MLMEX_OPTS1 "-bundle -Wl,-exported_symbols_list,${MATLAB_ROOT}/extern/lib/${MATLAB_ARCH}/mexFunction.map")
+    SET(MLMEX_OPTS2 "")
+  endif()
+
   # Use TARGET_LINK_LIBRARIES and the C++ compiler to link the mlmex.cpp file to the rest of Trilinos & the mex libs.
   # This code is extremely fragile and probably won't work on any system but GNU/Linux with gcc.
   # This is because Cmake will not allow me to *just call the mex linker*, and so I have to do this the hard way.
@@ -64,7 +68,7 @@ if(TPL_ENABLE_MATLAB)
   LINK_DIRECTORIES(${MATLAB_LIBRARY_DIRS})
   TRIBITS_ADD_EXECUTABLE(mlmex.${MEX_EXTENSION} SOURCES mlmex.cpp NOEXEPREFIX NOEXESUFFIX)
   SET_TARGET_PROPERTIES(mlmex.${MEX_EXTENSION} PROPERTIES SUFFIX "") # remove .exe extension
-  TARGET_LINK_LIBRARIES(mlmex.${MEX_EXTENSION} ${MLMEX_OPTS1} ${LINK_LIBS} ${MLMEX_OPTS2})
+  TARGET_LINK_LIBRARIES(mlmex.${MEX_EXTENSION} ${MLMEX_OPTS1} ${LINK_LIBS} ${MLMEX_OPTS2} ${${PROJECT_NAME}_EXTRA_LINK_FLAGS})
 
   # Copy over the ml.m file from src
   CONFIGURE_FILE("ml.m" "ml.m" COPYONLY)  


### PR DESCRIPTION
These lines are a one to one copy from the MueLu project that enable proper build of the Matlab interface on macOS without any manual user modifications.