### PR TITLE
Teuchos: use provided stream formatting flags in TimeMonitor summarize()

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_TableColumn.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TableColumn.cpp
@@ -55,12 +55,13 @@ TableColumn::TableColumn(const Array<std::string>& vals)
 
 
 TableColumn::TableColumn(const Array<double>& vals,
-                         int precision)
+                         int precision,
+                         const std::ios_base::fmtflags& flags)
   : data_(vals.size())
 {
   for (Array<double>::size_type i=0; i<vals.size(); i++)
     {
-      data_[i] = rcp(new DoubleEntry(vals[i], precision));
+      data_[i] = rcp(new DoubleEntry(vals[i], precision, flags));
     }
 }
 
@@ -68,13 +69,17 @@ TableColumn::TableColumn(const Array<double>& vals,
 TableColumn::TableColumn(const Array<double>& first,
                          const Array<double>& second,
                          int precision,
+                         const std::ios_base::fmtflags& flags,
                          bool spaceBeforeParentheses)
   : data_(first.size())
 {
+  std::ios_base::fmtflags fixedflags = flags;
+  fixedflags &= ~std::cout.scientific;   // unset scientific
+  fixedflags &= ~std::cout.fixed;        // unset fixed
   for (Array<double>::size_type i=0; i<first.size(); i++)
     {
-      RCP<DoubleEntry> x1 = rcp(new DoubleEntry(first[i], precision));
-      RCP<DoubleEntry> x2 = rcp(new DoubleEntry(second[i], precision));
+      RCP<DoubleEntry> x1 = rcp(new DoubleEntry(first[i],  precision, flags));
+      RCP<DoubleEntry> x2 = rcp(new DoubleEntry(second[i], precision, fixedflags));
       data_[i]
         = rcp(new CompoundEntryWithParentheses(x1, x2,
                                                spaceBeforeParentheses));

--- a/packages/teuchos/comm/src/Teuchos_TableColumn.hpp
+++ b/packages/teuchos/comm/src/Teuchos_TableColumn.hpp
@@ -50,6 +50,8 @@
 #include "Teuchos_TableEntry.hpp"
 #include "Teuchos_Array.hpp"
 
+#include <iomanip>
+
 namespace Teuchos
 {
   /**
@@ -66,11 +68,11 @@ namespace Teuchos
     TableColumn(const Array<std::string>& vals);
 
     /** \brief  Form a column of double entries */
-    TableColumn(const Array<double>& vals, int precision);
+    TableColumn(const Array<double>& vals, int precision, const std::ios_base::fmtflags& flags);
 
     /** \brief  Form a column of compound entries written as "first(second)" */
     TableColumn(const Array<double>& first, const Array<double>& second,
-                int precision,
+                int precision, const std::ios_base::fmtflags& flags,
                 bool spaceBeforeParentheses);
 
     /** */

--- a/packages/teuchos/comm/src/Teuchos_TableEntry.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TableEntry.cpp
@@ -55,13 +55,14 @@ std::string TableEntry::toChoppedString(int maxWidth) const
 
 /* --------- DoubleEntry methods -------------------------------------------- */
 
-DoubleEntry::DoubleEntry(const double& value, int precision)
-  : TableEntry(), data_(value), precision_(precision)
+DoubleEntry::DoubleEntry(const double& value, int precision, const std::ios_base::fmtflags& flags)
+  : TableEntry(), data_(value), precision_(precision), fmtflags_(flags)
 {}
 
 std::string DoubleEntry::toString() const
 {
   std::ostringstream toss;
+  toss.setf(fmtflags_);
   toss << std::setprecision(precision_) << data_;
   return toss.str();
 }
@@ -70,13 +71,14 @@ std::string DoubleEntry::toString() const
 
 /* --------- IntEntry methods -------------------------------------------- */
 
-IntEntry::IntEntry(int value)
-  : TableEntry(), data_(value)
+IntEntry::IntEntry(int value, const std::ios_base::fmtflags& flags)
+  : TableEntry(), data_(value), fmtflags_(flags)
 {}
 
 std::string IntEntry::toString() const
 {
   std::ostringstream toss;
+  toss.setf(fmtflags_);
   toss << data_;
   return toss.str();
 }

--- a/packages/teuchos/comm/src/Teuchos_TableEntry.hpp
+++ b/packages/teuchos/comm/src/Teuchos_TableEntry.hpp
@@ -55,6 +55,7 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_Array.hpp"
 #include <iostream>
+#include <iomanip>
 
 namespace Teuchos
 {
@@ -98,14 +99,15 @@ namespace Teuchos
   public:
     /** \brief Construct with a value
      * and a precision */
-    DoubleEntry(const double& value, int precision);
+    DoubleEntry(const double& value, int precision, const std::ios_base::fmtflags& flags);
 
     /** \brief Write the specified entry to a std::string */
     virtual std::string toString() const ;
 
   private:
-    double data_;
-    int precision_;
+    double                  data_;
+    int                     precision_;
+    std::ios_base::fmtflags fmtflags_;
   };
 
 
@@ -116,13 +118,14 @@ namespace Teuchos
   {
   public:
     /** \brief Construct with a value */
-    IntEntry(int value);
+    IntEntry(int value, const std::ios_base::fmtflags& flags);
 
     /** \brief Write the specified entry to a std::string */
     virtual std::string toString() const ;
 
   private:
-    int data_;
+    int                     data_;
+    std::ios_base::fmtflags fmtflags_;
   };
 
 

--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
@@ -46,7 +46,9 @@
 #include "Teuchos_TableFormat.hpp"
 #include "Teuchos_StandardParameterEntryValidators.hpp"
 #include "Teuchos_ScalarTraits.hpp"
+
 #include <functional>
+#include <iomanip>
 
 
 namespace Teuchos {
@@ -928,6 +930,7 @@ namespace Teuchos {
 
     // Precision of floating-point numbers in the table.
     const int precision = format().precision();
+    const std::ios_base::fmtflags& flags = out.flags();
 
     // All columns of the table, in order.
     Array<TableColumn> tableColumns;
@@ -976,7 +979,7 @@ namespace Teuchos {
         localTimings.push_back (it->second.first);
         localNumCalls.push_back (static_cast<double> (it->second.second));
       }
-      TableColumn timeAndCalls (localTimings, localNumCalls, precision, true);
+      TableColumn timeAndCalls (localTimings, localNumCalls, precision, flags, true);
       tableColumns.append (timeAndCalls);
       columnWidths.append (format().computeRequiredColumnWidth (titles.back(), timeAndCalls));
     }
@@ -997,7 +1000,7 @@ namespace Teuchos {
         }
         // Print the table column.
         titles.append ("Global time (num calls)");
-        TableColumn timeAndCalls (globalTimings, globalNumCalls, precision, true);
+        TableColumn timeAndCalls (globalTimings, globalNumCalls, precision, flags, true);
         tableColumns.append (timeAndCalls);
         columnWidths.append (format().computeRequiredColumnWidth (titles.back(), timeAndCalls));
       }
@@ -1021,7 +1024,7 @@ namespace Teuchos {
           const std::string& statisticName = statNames[statInd];
           const std::string titleString = statisticName;
           titles.append (titleString);
-          TableColumn timeAndCalls (statTimings, statCallCounts, precision, true);
+          TableColumn timeAndCalls (statTimings, statCallCounts, precision, flags, true);
           tableColumns.append (timeAndCalls);
           columnWidths.append (format().computeRequiredColumnWidth (titles.back(), timeAndCalls));
         }

--- a/packages/teuchos/comm/test/TimeMonitor/TimeMonitor_UnitTests.cpp
+++ b/packages/teuchos/comm/test/TimeMonitor/TimeMonitor_UnitTests.cpp
@@ -62,5 +62,28 @@ TEUCHOS_UNIT_TEST( TimeMonitor, someFunction_timed )
   TEST_EQUALITY(rtn, 5);
 }
 
+TEUCHOS_UNIT_TEST( TimeMonitor, formatting)
+{
+    using namespace Teuchos;
+
+    // Zero out previous timers
+    TimeMonitor::zeroOutTimers();
+
+    std::ostringstream out1, out2;
+    const std::string filter = "";
+
+    // Check std::fixed formatting
+    out1 << std::fixed;
+    TimeMonitor::report(out1, filter);
+    bool test1 = (out1.str().find("someFunction1    0.0000 (0)") != std::string::npos);
+    TEST_EQUALITY(test1, true);
+
+    // Check std::scientific formatting
+    out2 << std::scientific;
+    TimeMonitor::report(out2, filter);
+    bool test2 = (out2.str().find("someFunction1    0.0000e+00 (0)") != std::string::npos);
+    TEST_EQUALITY(test2, true);
+}
+
 
 } // namespace


### PR DESCRIPTION
@trilinos/teuchos @bartlettroscoe 

This allows the user to control the formatting of the timer columns.
The cost is storing an extra std::ios_base::fmtflags in TableEntry.

The original output may look like this:
```
MueLu: CoalesceDropFactory_kokkos: Build (total)                                                6.066 (4)                  
MueLu: CoalesceDropFactory_kokkos: Build (total, level=0)                                       4.69 (1)                   
MueLu: CoalesceDropFactory_kokkos: Build (total, level=1)                                       1.276 (1)                  
MueLu: CoalesceDropFactory_kokkos: Build (total, level=2)                                       0.0962 (1)                 
MueLu: CoalesceDropFactory_kokkos: Build (total, level=3)                                       0.003703 (1)               
MueLu: CoarseMapFactory_kokkos: Build                                                           0.0007512 (4)              
MueLu: CoarseMapFactory_kokkos: Build (level=0)                                                 0.0005596 (1)              
---------------------------------------------------------------------------------------------------------------------------
MueLu: CoarseMapFactory_kokkos: Build (level=1)                                                 4.289e-05 (1)              
MueLu: CoarseMapFactory_kokkos: Build (level=2)                                                 4.606e-05 (1)              
MueLu: CoarseMapFactory_kokkos: Build (level=3)                                                 3.998e-05 (1)              
MueLu: CoarseMapFactory_kokkos: Build (total)                                                   0.0007804 (4)              
MueLu: CoarseMapFactory_kokkos: Build (total, level=0)                                          0.000583 (1)               
MueLu: CoarseMapFactory_kokkos: Build (total, level=1)                                          5.083e-05 (1)              
MueLu: CoarseMapFactory_kokkos: Build (total, level=2)                                          5.396e-05 (1)              
MueLu: CoarseMapFactory_kokkos: Build (total, level=3)                                          4.722e-05 (1)
```
which is a mix of scientific and non-scientific notations with different precisions. The new output (when controlled with `std::fixed` or `std::scientific` before `TimeMonitor::report`) will look like this:
```
Driver: 5 - Belos Solve                                                                  3.1061 (1)
Driver: S - Global Time                                                                  7.2109 (1)
Ifpack2::Chebyshev::apply                                                                1.4155 (96)
Ifpack2::Chebyshev::compute                                                              0.3570 (3)
--------------------------------------------------------------------------------------------------------------------
MueLu: AggregationPhase1Algorithm: BuildAggregates (total)                               0.0687 (3)
MueLu: AggregationPhase2aAlgorithm: BuildAggregates (total)                              0.0266 (3)
MueLu: AggregationPhase2bAlgorithm: BuildAggregates (total)                              0.0454 (3)
MueLu: AggregationPhase3Algorithm: BuildAggregates (total)                               0.0010 (3)
MueLu: AmalgamationFactory: Build                                                        0.0001 (3)
```
or this
```
Driver: 1 - Matrix Build                                                                 5.7187e+00 (1)
Driver: 2 - MueLu Setup                                                                  9.0275e+00 (1)
Driver: 3 - LHS and RHS initialization                                                   8.5122e-03 (1)
Driver: 5 - Belos Solve                                                                  9.9469e+00 (1)
Driver: S - Global Time                                                                  2.4731e+01 (1)
Ifpack2::Chebyshev::apply                                                                4.5091e+00 (96)
Ifpack2::Chebyshev::compute                                                              1.1264e+00 (3)
--------------------------------------------------------------------------------------------------------------------
MueLu: AggregationPhase1Algorithm: BuildAggregates (total)                               2.3058e-01 (3)
MueLu: AggregationPhase2aAlgorithm: BuildAggregates (total)                              9.2283e-02 (3)
MueLu: AggregationPhase2bAlgorithm: BuildAggregates (total)                              1.5934e-01 (3)
```