### PR TITLE
Tpetra: silence warning about shadowed gid var

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -426,9 +426,9 @@ packCrsMatrixRow (const ColumnMap& col_map,
   const size_t num_ent_beg = offset;
   const size_t num_ent_len = PackTraits<LO, BDT>::packValueCount (num_ent_LO);
 
-  const GO gid = 0; // packValueCount wants this
+  const GO gid_example = 0; // packValueCount wants this
   const size_t gids_beg = num_ent_beg + num_ent_len;
-  const size_t gids_len = num_ent * PackTraits<GO, BDT>::packValueCount (gid);
+  const size_t gids_len = num_ent * PackTraits<GO, BDT>::packValueCount (gid_example);
 
   const int pid = 0; // packValueCount wants this
   const size_t pids_beg = gids_beg + gids_len;


### PR DESCRIPTION
This fixes a warning about a shadowed variable name.
Personally, I think the need to pass a value to `packValueCount` is really causing more trouble than its worth. I don't see a scenario in which a value-dependent packing scheme would give any benefit, and I suspect not all users of `packValueCount` correctly call it for such a change.