### PR TITLE
Tpetra: quick fix for shadowed variable warning

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -430,10 +430,10 @@ packCrsMatrixRow (const ColumnMap& col_map,
   const size_t gids_beg = num_ent_beg + num_ent_len;
   const size_t gids_len = num_ent * PackTraits<GO, BDT>::packValueCount (gid_example);
 
-  const int pid = 0; // packValueCount wants this
+  const int pid_example = 0; // packValueCount wants this
   const size_t pids_beg = gids_beg + gids_len;
   const size_t pids_len = pack_pids ?
-    num_ent * PackTraits<int, BDT>::packValueCount (pid) :
+    num_ent * PackTraits<int, BDT>::packValueCount (pid_example) :
     static_cast<size_t> (0);
 
   const size_t vals_beg = gids_beg + gids_len + pids_len;


### PR DESCRIPTION
There may be a more systematic resolution via
issue #1672, but for now this quick patch
will silence the warning

@trilinos/tpetra