### PR TITLE
Tpetra: Silence unused variable warning.

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1407,7 +1407,9 @@ namespace Tpetra {
     // anything).
     typedef Kokkos::HostSpace HMS;
 
+#ifdef HAVE_TPETRA_DEBUG
     const char tfecfFuncName[] = "unpackAndCombineNew: ";
+#endif
     //const char suffix[] = "  Please report this bug to the Tpetra developers."; // unused
 
     // mfh 03 Aug 2017: Set this to true for copious debug output to


### PR DESCRIPTION
Guard unused `const char tfecFuncName[]` with `#ifdef HAVE_TPETRA_DEBUG`

Addresses: #1701

Build/Test Cases Summary
Enabled Packages: TpetraCore
Disabled Packages: PyTrilinos,Claps,TriKota
Enabled all Forward Packages
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) MPI_RELEASE_SHARED_OPENMP_PT => passed: passed=1509,notpassed=0 (83.61 min)