### PR TITLE
Panzer:  Unused Parameter Warnings (#1702)

### DIFF
--- a/packages/panzer/adapters-ioss/src/Panzer_IOSSConnManager.hpp
+++ b/packages/panzer/adapters-ioss/src/Panzer_IOSSConnManager.hpp
@@ -229,7 +229,7 @@ public:
        * parallel operation. In many applications, the outcome indicating
        * correctness is that the returned vector is empty.
        */
-     std::vector<std::string> checkAssociateElementsInSidesets(const Teuchos::Comm<int>& comm) const {
+     std::vector<std::string> checkAssociateElementsInSidesets(const Teuchos::Comm<int>& /* comm */) const {
        std::vector<std::string> placeholder;
        return placeholder;
      };
@@ -237,7 +237,7 @@ public:
      /** Get elements, if any, associated with <code>el</code>, excluding
        * <code>el</code> itself.
        */
-     virtual const std::vector<LocalOrdinal>& getAssociatedNeighbors(const LocalOrdinal& el) const {
+     virtual const std::vector<LocalOrdinal>& getAssociatedNeighbors(const LocalOrdinal& /* el */) const {
        return placeholder_;
      };
 

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -69,7 +69,7 @@ BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::G
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -108,10 +108,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_ClosureModel_Factory_impl.hpp
@@ -73,10 +73,10 @@ buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models,  
 		   const panzer::FieldLayoutLibrary& fl,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
-		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
   using std::string;
   using std::vector;

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
@@ -132,8 +132,8 @@ CurlLaplacianEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void Example::CurlLaplacianEquationSet<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlSolution_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlSolution_impl.hpp
@@ -78,7 +78,7 @@ CurlSolution<EvalT,Traits>::CurlSolution(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void CurlSolution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -69,7 +69,7 @@ BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::G
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -108,10 +108,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_ClosureModel_Factory_impl.hpp
@@ -72,10 +72,10 @@ buildClosureModels(const std::string& model_id,
                  const Teuchos::ParameterList& models,  
                  const panzer::FieldLayoutLibrary& fl,
                  const Teuchos::RCP<panzer::IntegrationRule>& ir,
-                 const Teuchos::ParameterList& default_params,
-                 const Teuchos::ParameterList& user_data,
-                 const Teuchos::RCP<panzer::GlobalData>& global_data,
-                 PHX::FieldManager<panzer::Traits>& fm) const
+                 const Teuchos::ParameterList& /* default_params */,
+                 const Teuchos::ParameterList& /* user_data */,
+                 const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+                 PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
   using std::string;
   using std::vector;

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_MixedPoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_MixedPoissonEquationSet_impl.hpp
@@ -132,8 +132,8 @@ MixedPoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void Example::MixedPoissonEquationSet<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -69,7 +69,7 @@ BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::G
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -108,10 +108,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_ClosureModel_Factory_impl.hpp
@@ -69,10 +69,10 @@ buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models, 
 		   const panzer::FieldLayoutLibrary& fl,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
-		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
   using std::string;
   using std::vector;

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_PoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_PoissonEquationSet_impl.hpp
@@ -132,8 +132,8 @@ PoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void Example::PoissonEquationSet<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -69,7 +69,7 @@ BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::G
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -108,10 +108,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void Example::BCStrategy_Dirichlet_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_NeumannMatch_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_NeumannMatch_impl.hpp
@@ -72,7 +72,7 @@ BCStrategy_Interface_NeumannMatch(const panzer::BC& bc, const Teuchos::RCP<panze
 template <typename EvalT>
 void Example::BCStrategy_Interface_NeumannMatch<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -104,9 +104,9 @@ template <typename EvalT>
 void Example::BCStrategy_Interface_NeumannMatch<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -193,8 +193,8 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
 // ***********************************************************************
 template <typename EvalT>
 void Example::BCStrategy_Interface_NeumannMatch<EvalT>::
-postRegistrationSetup(typename panzer::Traits::SetupData d,
-		      PHX::FieldManager<panzer::Traits>& vm)
+postRegistrationSetup(typename panzer::Traits::SetupData /* d */,
+		      PHX::FieldManager<panzer::Traits>& /* vm */)
 {
   
 }
@@ -203,7 +203,7 @@ postRegistrationSetup(typename panzer::Traits::SetupData d,
 // ***********************************************************************
 template <typename EvalT>
 void Example::BCStrategy_Interface_NeumannMatch<EvalT>::
-evaluateFields(typename panzer::Traits::EvalData d)
+evaluateFields(typename panzer::Traits::EvalData /* d */)
 {
   
 }

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_Robin_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_Robin_impl.hpp
@@ -95,7 +95,7 @@ BCStrategy_Interface_Robin(const panzer::BC& bc, const Teuchos::RCP<panzer::Glob
 template <typename EvalT>
 void Example::BCStrategy_Interface_Robin<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -146,9 +146,9 @@ template <typename EvalT>
 void Example::BCStrategy_Interface_Robin<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -275,13 +275,13 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
 
 template <typename EvalT>
 void Example::BCStrategy_Interface_Robin<EvalT>::
-postRegistrationSetup(typename panzer::Traits::SetupData d,
-		      PHX::FieldManager<panzer::Traits>& vm)
+postRegistrationSetup(typename panzer::Traits::SetupData /* d */,
+		      PHX::FieldManager<panzer::Traits>& /* vm */)
 { 
 }
 
 template <typename EvalT>
 void Example::BCStrategy_Interface_Robin<EvalT>::
-evaluateFields(typename panzer::Traits::EvalData d)
+evaluateFields(typename panzer::Traits::EvalData /* d */)
 {  
 }

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_WeakDirichletMatch_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_WeakDirichletMatch_impl.hpp
@@ -74,7 +74,7 @@ BCStrategy_Interface_WeakDirichletMatch(const panzer::BC& bc, const Teuchos::RCP
 template <typename EvalT>
 void Example::BCStrategy_Interface_WeakDirichletMatch<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -125,9 +125,9 @@ template <typename EvalT>
 void Example::BCStrategy_Interface_WeakDirichletMatch<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -263,8 +263,8 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
 // ***********************************************************************
 template <typename EvalT>
 void Example::BCStrategy_Interface_WeakDirichletMatch<EvalT>::
-postRegistrationSetup(typename panzer::Traits::SetupData d,
-		      PHX::FieldManager<panzer::Traits>& vm)
+postRegistrationSetup(typename panzer::Traits::SetupData /* d */,
+		      PHX::FieldManager<panzer::Traits>& /* vm */)
 {
   
 }
@@ -273,7 +273,7 @@ postRegistrationSetup(typename panzer::Traits::SetupData d,
 // ***********************************************************************
 template <typename EvalT>
 void Example::BCStrategy_Interface_WeakDirichletMatch<EvalT>::
-evaluateFields(typename panzer::Traits::EvalData d)
+evaluateFields(typename panzer::Traits::EvalData /* d */)
 {
   
 }

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Neumann_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Neumann_Constant_impl.hpp
@@ -70,7 +70,7 @@ BCStrategy_Neumann_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::Glo
 template <typename EvalT>
 void Example::BCStrategy_Neumann_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -101,9 +101,9 @@ template <typename EvalT>
 void Example::BCStrategy_Neumann_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -173,8 +173,8 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
 // ***********************************************************************
 template <typename EvalT>
 void Example::BCStrategy_Neumann_Constant<EvalT>::
-postRegistrationSetup(typename panzer::Traits::SetupData d,
-		      PHX::FieldManager<panzer::Traits>& vm)
+postRegistrationSetup(typename panzer::Traits::SetupData /* d */,
+		      PHX::FieldManager<panzer::Traits>& /* vm */)
 {
   
 }
@@ -183,7 +183,7 @@ postRegistrationSetup(typename panzer::Traits::SetupData d,
 // ***********************************************************************
 template <typename EvalT>
 void Example::BCStrategy_Neumann_Constant<EvalT>::
-evaluateFields(typename panzer::Traits::EvalData d)
+evaluateFields(typename panzer::Traits::EvalData /* d */)
 {
   
 }

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_ClosureModel_Factory_impl.hpp
@@ -65,10 +65,10 @@ buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models, 
 		   const panzer::FieldLayoutLibrary& fl,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
-		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
   using std::string;
   using std::vector;

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_PoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_PoissonEquationSet_impl.hpp
@@ -134,8 +134,8 @@ PoissonEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void Example::PoissonEquationSet<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_NOXObserver_NeumannBCAnalyticSystemTest.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_NOXObserver_NeumannBCAnalyticSystemTest.hpp
@@ -62,17 +62,17 @@ namespace user_app {
 
     }
       
-    void runPreIterate(const NOX::Solver::Generic& solver)
+    void runPreIterate(const NOX::Solver::Generic& /* solver */)
     {
 
     }
     
-    void runPostIterate(const NOX::Solver::Generic& solver)
+    void runPostIterate(const NOX::Solver::Generic& /* solver */)
     {
 
     }
     
-    void runPreSolve(const NOX::Solver::Generic& solver)
+    void runPreSolve(const NOX::Solver::Generic& /* solver */)
     {
 
     }

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_NOXObserver_WriteToExodus.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_NOXObserver_WriteToExodus.hpp
@@ -90,17 +90,17 @@ namespace user_app {
       m_response_library->addResponse("Main Field Output",eBlocks,builder);
     }
       
-    void runPreIterate(const NOX::Solver::Generic& solver)
+    void runPreIterate(const NOX::Solver::Generic& /* solver */)
     {
 
     }
     
-    void runPostIterate(const NOX::Solver::Generic& solver)
+    void runPostIterate(const NOX::Solver::Generic& /* solver */)
     {
 
     }
     
-    void runPreSolve(const NOX::Solver::Generic& solver)
+    void runPreSolve(const NOX::Solver::Generic& /* solver */)
     {
 
     }

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_RythmosObserver_CoordinateUpdate.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_RythmosObserver_CoordinateUpdate.hpp
@@ -67,12 +67,12 @@ namespace user_app {
     cloneIntegrationObserver() const
     { return Teuchos::rcp(new RythmosObserver_CoordinateUpdate(m_workset_container)); }
 
-    void resetIntegrationObserver(const Rythmos::TimeRange<double> &integrationTimeDomain)
+    void resetIntegrationObserver(const Rythmos::TimeRange<double>& /* integrationTimeDomain */)
     { }
 
-    void observeCompletedTimeStep(const Rythmos::StepperBase<double> &stepper,
-				  const Rythmos::StepControlInfo<double> &stepCtrlInfo,
-				  const int timeStepIter)
+    void observeCompletedTimeStep(const Rythmos::StepperBase<double>& /* stepper */,
+				  const Rythmos::StepControlInfo<double>& /* stepCtrlInfo */,
+				  const int /* timeStepIter */)
     { TEUCHOS_ASSERT(m_workset_container!=Teuchos::null); 
       m_workset_container->clear(); }
     

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_RythmosObserver_WriteToExodus.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_RythmosObserver_WriteToExodus.hpp
@@ -86,12 +86,12 @@ namespace user_app {
       return Teuchos::rcp(new RythmosObserver_WriteToExodus(m_mesh, m_dof_manager, m_lof,m_response_library));
     }
 
-    void resetIntegrationObserver(const Rythmos::TimeRange<double> &integrationTimeDomain)
+    void resetIntegrationObserver(const Rythmos::TimeRange<double>& /* integrationTimeDomain */)
     { }
 
     void observeCompletedTimeStep(const Rythmos::StepperBase<double> &stepper,
-				  const Rythmos::StepControlInfo<double> &stepCtrlInfo,
-				  const int timeStepIter)
+				  const Rythmos::StepControlInfo<double>& /* stepCtrlInfo */,
+				  const int /* timeStepIter */)
     { 
       Teuchos::RCP<const Thyra::VectorBase<double> > solution = stepper.getStepStatus().solution;
       

--- a/packages/panzer/adapters-stk/src/Panzer_STKConnManager_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STKConnManager_impl.hpp
@@ -311,7 +311,7 @@ std::string STKConnManager<GO>::getBlockId(STKConnManager::LocalOrdinal localElm
 
 template <typename GO>
 void STKConnManager<GO>::applyPeriodicBCs( const panzer::FieldPattern & fp, GlobalOrdinal nodeOffset, GlobalOrdinal edgeOffset, 
-                                                                        GlobalOrdinal faceOffset, GlobalOrdinal cellOffset)
+                                                                        GlobalOrdinal faceOffset, GlobalOrdinal /* cellOffset */)
 {
    using Teuchos::RCP;
    using Teuchos::rcp;

--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -503,7 +503,7 @@ setupLocalMeshBlockInfo(const panzer_stk::STK_Interface & mesh,
 template<typename LO, typename GO>
 void
 setupLocalMeshSidesetInfo(const panzer_stk::STK_Interface & mesh,
-                          panzer::ConnManager<LO,GO> & conn,
+                          panzer::ConnManager<LO,GO>& /* conn */,
                           const panzer::LocalMeshInfo<LO,GO> & mesh_info,
                           const std::string & element_block_name,
                           const std::string & sideset_name,

--- a/packages/panzer/adapters-stk/src/Panzer_STK_SurfaceNodeNormals.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_SurfaceNodeNormals.cpp
@@ -68,7 +68,7 @@ namespace panzer_stk {
 				 const Teuchos::RCP<const panzer_stk::STK_Interface>& mesh,
 				 const std::string& sidesetName,
 				 const std::string& elementBlockName,
-				 std::ostream* out,
+				 std::ostream* /* out */,
 				 std::ostream* pout)
   {    
     using panzer::Cell;

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherFields_impl.hpp
@@ -84,7 +84,7 @@ panzer_stk::GatherFields<EvalT, Traits>::
 // **********************************************************************
 template<typename EvalT, typename Traits> 
 void panzer_stk::GatherFields<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d, 
+postRegistrationSetup(typename Traits::SetupData /* d */, 
 		      PHX::FieldManager<Traits>& fm)
 {
   for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherRefCoords_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherRefCoords_impl.hpp
@@ -74,7 +74,7 @@ GatherRefCoords(const Teuchos::RCP<const STK_Interface> & mesh,
 // **********************************************************************
 template<typename EvalT, typename Traits> 
 void panzer_stk::GatherRefCoords<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d, 
+postRegistrationSetup(typename Traits::SetupData /* d */, 
 		      PHX::FieldManager<Traits>& fm)
 {
   // setup the field data object

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
@@ -89,7 +89,7 @@ PHX_EVALUATOR_CTOR(ScatterCellAvgQuantity,p) :
   this->setName(scatterName+": STK-Scatter Cell Fields");
 }
 
-PHX_POST_REGISTRATION_SETUP(ScatterCellAvgQuantity,d,fm)
+PHX_POST_REGISTRATION_SETUP(ScatterCellAvgQuantity, /* d */, fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
     std::string fieldName = scatterFields_[fd].fieldTag().name();

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
@@ -91,7 +91,7 @@ PHX_EVALUATOR_CTOR(ScatterCellAvgVector,p) :
 }
 
 
-PHX_POST_REGISTRATION_SETUP(ScatterCellAvgVector,d,fm)
+PHX_POST_REGISTRATION_SETUP(ScatterCellAvgVector, /* d */, fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) 
   {

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_impl.hpp
@@ -87,7 +87,7 @@ PHX_EVALUATOR_CTOR(ScatterCellQuantity,p) :
   this->setName(scatterName+": STK-Scatter Cell Quantity Fields");
 }
 
-PHX_POST_REGISTRATION_SETUP(ScatterCellQuantity,d,fm)
+PHX_POST_REGISTRATION_SETUP(ScatterCellQuantity, /* d */, fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
     std::string fieldName = scatterFields_[fd].fieldTag().name();

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterFields_impl.hpp
@@ -120,7 +120,7 @@ initialize(const std::string & scatterName,
 
 template <typename EvalT,typename TraitsT>
 void ScatterFields<EvalT,TraitsT>::
-postRegistrationSetup(typename TraitsT::SetupData d, 
+postRegistrationSetup(typename TraitsT::SetupData /* d */, 
                       PHX::FieldManager<TraitsT>& fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
@@ -133,7 +133,7 @@ postRegistrationSetup(typename TraitsT::SetupData d,
 
 template <typename EvalT,typename TraitsT>
 void ScatterFields<EvalT,TraitsT>::
-evaluateFields(typename TraitsT::EvalData d)
+evaluateFields(typename TraitsT::EvalData /* d */)
 {
    TEUCHOS_ASSERT(false);
 }

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_impl.hpp
@@ -99,7 +99,7 @@ ScatterVectorFields(const std::string & scatterName,
   this->setName(scatterName+": STK-Scatter Vector Fields");
 }
 
-PHX_POST_REGISTRATION_SETUP(ScatterVectorFields,d,fm)
+PHX_POST_REGISTRATION_SETUP(ScatterVectorFields, /* d */, fm)
 {
   // this->utils.setFieldData(pointField_,fm);
 
@@ -109,7 +109,7 @@ PHX_POST_REGISTRATION_SETUP(ScatterVectorFields,d,fm)
   }
 }
 
-PHX_EVALUATE_FIELDS(ScatterVectorFields,workset)
+PHX_EVALUATE_FIELDS(ScatterVectorFields, /* workset */)
 {
    TEUCHOS_ASSERT(false);
 }

--- a/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
+++ b/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
@@ -42,7 +42,7 @@ public:
    virtual Teuchos::RCP<panzer::ResponseBase> buildResponseObject(const std::string & responseName) const;
 
    virtual Teuchos::RCP<panzer::ResponseBase> buildResponseObject(const std::string & responseName,
-                                                          const std::vector<panzer::WorksetDescriptor> & wkstDesc) const 
+                                                          const std::vector<panzer::WorksetDescriptor>& /* wkstDesc */) const 
    { return buildResponseObject(responseName); }
    
    /** Build and register evaluators for a response on a particular physics

--- a/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter_impl.hpp
+++ b/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter_impl.hpp
@@ -36,10 +36,10 @@ buildResponseObject(const std::string & responseName) const
    
 template <typename EvalT> 
 void ResponseEvaluatorFactory_SolutionWriter<EvalT>:: 
-buildAndRegisterEvaluators(const std::string & responseName,
+buildAndRegisterEvaluators(const std::string& /* responseName */,
                            PHX::FieldManager<panzer::Traits> & fm,
                            const panzer::PhysicsBlock & physicsBlock,
-                           const Teuchos::ParameterList & user_data) const
+                           const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::RCP;
   using Teuchos::rcp;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.cpp
@@ -225,7 +225,7 @@ void CubeHexMeshFactory::initializeWithDefaults()
    setParameterList(validParams);
 }
 
-void CubeHexMeshFactory::buildMetaData(stk::ParallelMachine parallelMach, STK_Interface & mesh) const
+void CubeHexMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, STK_Interface & mesh) const
 {
    typedef shards::Hexahedron<8> HexTopo;
    const CellTopologyData * ctd = shards::getCellTopologyData<HexTopo>();
@@ -290,7 +290,7 @@ void CubeHexMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_Int
    mesh.endModification();
 }
 
-void CubeHexMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,int yBlock,int zBlock,STK_Interface & mesh) const
+void CubeHexMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,int xBlock,int yBlock,int zBlock,STK_Interface & mesh) const
 {
    // grab this processors rank and machine size
    std::pair<panzer::Ordinal64,panzer::Ordinal64> sizeAndStartX = determineXElemSizeAndStart(xBlock,xProcs_,machRank_);
@@ -353,7 +353,7 @@ void CubeHexMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock
    }
 }
 
-std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int rank) const
+std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t xProcLoc = procTuple_[0];
    panzer::Ordinal64 minElements = nXElems_/size;
@@ -376,7 +376,7 @@ std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineXEle
    return std::make_pair(start+nXElems_*xBlock,nume);
 }
 
-std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int rank) const
+std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int /* rank */) const
 {
    // int start = yBlock*nYElems_;
    // return std::make_pair(start,nYElems_);
@@ -402,7 +402,7 @@ std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineYEle
    return std::make_pair(start+nYElems_*yBlock,nume);
 }
 
-std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineZElemSizeAndStart(int zBlock,unsigned int size,unsigned int rank) const
+std::pair<panzer::Ordinal64,panzer::Ordinal64> CubeHexMeshFactory::determineZElemSizeAndStart(int zBlock,unsigned int size,unsigned int /* rank */) const
 {
    // int start = zBlock*nZElems_;
    // return std::make_pair(start,nZElems_);

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
@@ -202,7 +202,7 @@ void CubeTetMeshFactory::initializeWithDefaults()
    setParameterList(validParams);
 }
 
-void CubeTetMeshFactory::buildMetaData(stk::ParallelMachine parallelMach, STK_Interface & mesh) const
+void CubeTetMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, STK_Interface & mesh) const
 {
    typedef shards::Tetrahedron<4> TetTopo;
    const CellTopologyData * ctd = shards::getCellTopologyData<TetTopo>();
@@ -248,7 +248,7 @@ void CubeTetMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_Int
    mesh.endModification();
 }
 
-void CubeTetMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,int yBlock,int zBlock,STK_Interface & mesh) const
+void CubeTetMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,int xBlock,int yBlock,int zBlock,STK_Interface & mesh) const
 {
    // grab this processors rank and machine size
    std::pair<int,int> sizeAndStartX = determineXElemSizeAndStart(xBlock,xProcs_,machRank_);
@@ -375,7 +375,7 @@ void CubeTetMeshFactory::buildTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
    }
 }
 
-std::pair<int,int> CubeTetMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> CubeTetMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t xProcLoc = procTuple_[0];
    unsigned int minElements = nXElems_/size;
@@ -398,7 +398,7 @@ std::pair<int,int> CubeTetMeshFactory::determineXElemSizeAndStart(int xBlock,uns
    return std::make_pair(start+nXElems_*xBlock,nume);
 }
 
-std::pair<int,int> CubeTetMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> CubeTetMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int /* rank */) const
 {
    // int start = yBlock*nYElems_;
    // return std::make_pair(start,nYElems_);
@@ -424,7 +424,7 @@ std::pair<int,int> CubeTetMeshFactory::determineYElemSizeAndStart(int yBlock,uns
    return std::make_pair(start+nYElems_*yBlock,nume);
 }
 
-std::pair<int,int> CubeTetMeshFactory::determineZElemSizeAndStart(int zBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> CubeTetMeshFactory::determineZElemSizeAndStart(int zBlock,unsigned int size,unsigned int /* rank */) const
 {
    // int start = zBlock*nZElems_;
    // return std::make_pair(start,nZElems_);

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -1485,7 +1485,7 @@ Teuchos::RCP<Teuchos::MpiComm<int> > STK_Interface::getSafeCommunicator(stk::Par
    return Teuchos::rcp(new Teuchos::MpiComm<int>(Teuchos::opaqueWrapper (newComm,MPI_Comm_free)));
 }
 
-void STK_Interface::rebalance(const Teuchos::ParameterList & params)
+void STK_Interface::rebalance(const Teuchos::ParameterList & /* params */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "Rebalance not currently supported");
 #if 0

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_LineMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_LineMeshFactory.cpp
@@ -162,7 +162,7 @@ void LineMeshFactory::initializeWithDefaults()
    setParameterList(validParams);
 }
 
-void LineMeshFactory::buildMetaData(stk::ParallelMachine parallelMach, STK_Interface & mesh) const
+void LineMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, STK_Interface & mesh) const
 {
    typedef shards::Line<2> LineTopo;
    const CellTopologyData * ctd = shards::getCellTopologyData<LineTopo>();
@@ -196,7 +196,7 @@ void LineMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_Interf
    mesh.endModification();
 }
 
-void LineMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,STK_Interface & mesh) const
+void LineMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */, int xBlock, STK_Interface& mesh) const
 {
    // grab this processors rank and machine size
    std::pair<int,int> sizeAndStartX = determineXElemSizeAndStart(xBlock,machSize_,machRank_);
@@ -230,7 +230,7 @@ void LineMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,ST
    }
 }
 
-std::pair<int,int> LineMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> LineMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t xProcLoc = procTuple_[0];
    unsigned int minElements = nXElems_/size;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_MultiBlockMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_MultiBlockMeshFactory.cpp
@@ -105,7 +105,7 @@ void MultiBlockMeshFactory::completeMeshConstruction(STK_Interface & mesh,stk::P
 }
 
 //! From ParameterListAcceptor
-void MultiBlockMeshFactory::setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & paramList)
+void MultiBlockMeshFactory::setParameterList(const Teuchos::RCP<Teuchos::ParameterList>& /* paramList */)
 {
 }
 
@@ -131,7 +131,7 @@ void MultiBlockMeshFactory::initializeWithDefaults()
    nYElems_ = 2;
 }
 
-void MultiBlockMeshFactory::buildMetaData(stk::ParallelMachine parallelMach, STK_Interface & mesh) const
+void MultiBlockMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, STK_Interface& mesh) const
 {
    typedef shards::Quadrilateral<4> QuadTopo;
    const CellTopologyData * ctd = shards::getCellTopologyData<QuadTopo>();
@@ -170,7 +170,7 @@ void MultiBlockMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_
    mesh.endModification();
 }
 
-void MultiBlockMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,int yBlock,STK_Interface & mesh) const
+void MultiBlockMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */, int xBlock, int yBlock, STK_Interface& mesh) const
 {
    int myXElems_start = (machRank_==0 ? 0 : 2);
    int myXElems_end  = (machRank_==0 ? 1 : 3);
@@ -240,7 +240,7 @@ std::pair<int,int> MultiBlockMeshFactory::determineXElemSizeAndStart(int xBlock,
    return std::make_pair(start+nXElems_*xBlock,nume);
 }
 
-std::pair<int,int> MultiBlockMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> MultiBlockMeshFactory::determineYElemSizeAndStart(int yBlock, unsigned int /* size */, unsigned int /* rank */) const
 {
    int start = yBlock*nYElems_;
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.cpp
@@ -51,7 +51,7 @@ using Teuchos::rcp;
 
 namespace panzer_stk {
 
-SquareQuadMeshFactory::SquareQuadMeshFactory(bool enableRebalance)
+SquareQuadMeshFactory::SquareQuadMeshFactory(bool /* enableRebalance */)
 {
    initializeWithDefaults();
 }
@@ -199,7 +199,7 @@ void SquareQuadMeshFactory::initializeWithDefaults()
    setParameterList(validParams);
 }
 
-void SquareQuadMeshFactory::buildMetaData(stk::ParallelMachine parallelMach, STK_Interface & mesh) const
+void SquareQuadMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, STK_Interface & mesh) const
 {
    typedef shards::Quadrilateral<4> QuadTopo;
    const CellTopologyData * ctd = shards::getCellTopologyData<QuadTopo>();
@@ -258,7 +258,7 @@ void SquareQuadMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_
    mesh.endModification();
 }
 
-void SquareQuadMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,int yBlock,STK_Interface & mesh) const
+void SquareQuadMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,int xBlock,int yBlock,STK_Interface & mesh) const
 {
    // grab this processors rank and machine size
    std::pair<int,int> sizeAndStartX = determineXElemSizeAndStart(xBlock,xProcs_,machRank_);
@@ -306,7 +306,7 @@ void SquareQuadMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBl
    }
 }
 
-std::pair<int,int> SquareQuadMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> SquareQuadMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t xProcLoc = procTuple_[0];
    unsigned int minElements = nXElems_/size;
@@ -329,7 +329,7 @@ std::pair<int,int> SquareQuadMeshFactory::determineXElemSizeAndStart(int xBlock,
    return std::make_pair(start+nXElems_*xBlock,nume);
 }
 
-std::pair<int,int> SquareQuadMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> SquareQuadMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t yProcLoc = procTuple_[1];
    unsigned int minElements = nYElems_/size;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareTriMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareTriMeshFactory.cpp
@@ -193,7 +193,7 @@ void SquareTriMeshFactory::initializeWithDefaults()
    setParameterList(validParams);
 }
 
-void SquareTriMeshFactory::buildMetaData(stk::ParallelMachine parallelMach, STK_Interface & mesh) const
+void SquareTriMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, STK_Interface & mesh) const
 {
    typedef shards::Triangle<> TriTopo;
    const CellTopologyData * ctd = shards::getCellTopologyData<TriTopo>();
@@ -238,7 +238,7 @@ void SquareTriMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_I
    mesh.endModification();
 }
 
-void SquareTriMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlock,int yBlock,STK_Interface & mesh) const
+void SquareTriMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */, int xBlock, int yBlock, STK_Interface& mesh) const
 {
    // grab this processors rank and machine size
    std::pair<int,int> sizeAndStartX = determineXElemSizeAndStart(xBlock,xProcs_,machRank_);
@@ -295,7 +295,7 @@ void SquareTriMeshFactory::buildBlock(stk::ParallelMachine parallelMach,int xBlo
    }
 }
 
-std::pair<int,int> SquareTriMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> SquareTriMeshFactory::determineXElemSizeAndStart(int xBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t xProcLoc = procTuple_[0];
    unsigned int minElements = nXElems_/size;
@@ -318,7 +318,7 @@ std::pair<int,int> SquareTriMeshFactory::determineXElemSizeAndStart(int xBlock,u
    return std::make_pair(start+nXElems_*xBlock,nume);
 }
 
-std::pair<int,int> SquareTriMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int rank) const
+std::pair<int,int> SquareTriMeshFactory::determineYElemSizeAndStart(int yBlock,unsigned int size,unsigned int /* rank */) const
 {
    std::size_t yProcLoc = procTuple_[1];
    unsigned int minElements = nYElems_/size;

--- a/packages/panzer/adapters-stk/test/bcstrategy/user_app_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/test/bcstrategy/user_app_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -71,7 +71,7 @@ BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::G
 template <typename EvalT>
 void user_app::BCStrategy_Dirichlet_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -120,10 +120,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void user_app::BCStrategy_Dirichlet_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/test/bcstrategy/user_app_BCStrategy_Neumann_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/test/bcstrategy/user_app_BCStrategy_Neumann_Constant_impl.hpp
@@ -69,7 +69,7 @@ BCStrategy_Neumann_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::Glo
 template <typename EvalT>
 void user_app::BCStrategy_Neumann_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   // need the dof value to form the residual
   this->requireDOFGather(this->m_bc.equationSetName());
@@ -86,10 +86,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void user_app::BCStrategy_Neumann_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -119,8 +119,8 @@ buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 // ***********************************************************************
 template <typename EvalT>
 void user_app::BCStrategy_Neumann_Constant<EvalT>::
-postRegistrationSetup(typename panzer::Traits::SetupData d,
-		      PHX::FieldManager<panzer::Traits>& vm)
+postRegistrationSetup(typename panzer::Traits::SetupData /* d */,
+		      PHX::FieldManager<panzer::Traits>& /* vm */)
 {
   
 }
@@ -129,7 +129,7 @@ postRegistrationSetup(typename panzer::Traits::SetupData d,
 // ***********************************************************************
 template <typename EvalT>
 void user_app::BCStrategy_Neumann_Constant<EvalT>::
-evaluateFields(typename panzer::Traits::EvalData d)
+evaluateFields(typename panzer::Traits::EvalData /* d */)
 {
   
 }

--- a/packages/panzer/adapters-stk/test/evaluator_tests/RandomFieldEvaluator.hpp
+++ b/packages/panzer/adapters-stk/test/evaluator_tests/RandomFieldEvaluator.hpp
@@ -73,13 +73,13 @@ PHX_EVALUATOR_CTOR(RandomFieldEvaluator,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(RandomFieldEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(RandomFieldEvaluator, /* sd */, fm)
 {
   this->utils.setFieldData(field,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(RandomFieldEvaluator,workset)
+PHX_EVALUATE_FIELDS(RandomFieldEvaluator, /* workset */)
 {
    for(int i=0;i<static_cast<int>(field.size());i++)
       field[i] = double(std::rand())/double(RAND_MAX);

--- a/packages/panzer/adapters-stk/test/face_to_elem/SillyEquationSet.hpp
+++ b/packages/panzer/adapters-stk/test/face_to_elem/SillyEquationSet.hpp
@@ -57,9 +57,9 @@ public:
 
   }
 
-  void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-      const panzer::FieldLibrary& field_library,
-      const Teuchos::ParameterList& user_data) const{}
+  void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+      const panzer::FieldLibrary& /* field_library */,
+      const Teuchos::ParameterList& /* user_data */) const{}
 private:
   int dimension_;
 

--- a/packages/panzer/adapters-stk/test/gather_scatter_evaluators/scatter_field_evaluator.cpp
+++ b/packages/panzer/adapters-stk/test/gather_scatter_evaluators/scatter_field_evaluator.cpp
@@ -105,7 +105,7 @@ namespace panzer {
      this->addEvaluatedField(xcoord);
   }
 
-  PHX_POST_REGISTRATION_SETUP(XCoordinate,sd,fm)
+  PHX_POST_REGISTRATION_SETUP(XCoordinate, /* sd */, fm)
   { this->utils.setFieldData(xcoord,fm); }
 
   PHX_EVALUATE_FIELDS(XCoordinate,workset)

--- a/packages/panzer/adapters-stk/test/initial_condition_builder/initial_condition_builder2.cpp
+++ b/packages/panzer/adapters-stk/test/initial_condition_builder/initial_condition_builder2.cpp
@@ -226,7 +226,7 @@ namespace panzer {
   }
 
   void testInitialzation_blockStructure(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
-			 std::vector<panzer::BC>& bcs)
+			 std::vector<panzer::BC>& /* bcs */)
   {
     // Physics block
     Teuchos::ParameterList& physics_block_a = ipb->sublist("PB A");

--- a/packages/panzer/adapters-stk/test/initial_condition_builder/user_app_STKClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/test/initial_condition_builder/user_app_STKClosureModel_Factory_impl.hpp
@@ -62,10 +62,10 @@ buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models, 
 		   const panzer::FieldLayoutLibrary& fl,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
-		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
 
   using std::string;

--- a/packages/panzer/adapters-stk/test/model_evaluator/model_evaluator_mass_check.cpp
+++ b/packages/panzer/adapters-stk/test/model_evaluator/model_evaluator_mass_check.cpp
@@ -217,7 +217,7 @@ namespace panzer {
   }
   
   void testInitialzation(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
-			 std::vector<panzer::BC>& bcs)
+			 std::vector<panzer::BC>& /* bcs */)
   {
     // Physics block
     Teuchos::ParameterList& physics_block = ipb->sublist("test physics");

--- a/packages/panzer/adapters-stk/test/response_library/TestEvaluators.hpp
+++ b/packages/panzer/adapters-stk/test/response_library/TestEvaluators.hpp
@@ -77,7 +77,7 @@ PHX_EVALUATOR_CTOR(TestEvaluator,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(TestEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(TestEvaluator, /* sd */, fm)
 {
   this->utils.setFieldData(dogValues,fm);
   this->utils.setFieldData(hrsValues,fm);

--- a/packages/panzer/adapters-stk/test/response_library/user_app_STKClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/test/response_library/user_app_STKClosureModel_Factory_impl.hpp
@@ -60,12 +60,12 @@ Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
 user_app::STKModelFactory<EvalT>::
 buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models,  
-		   const panzer::FieldLayoutLibrary& fl,
+		   const panzer::FieldLayoutLibrary& /* fl */,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
+		   const Teuchos::ParameterList& /* default_params */,
 		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
 
   using std::string;

--- a/packages/panzer/adapters-stk/test/response_library/volumetric_side_response.cpp
+++ b/packages/panzer/adapters-stk/test/response_library/volumetric_side_response.cpp
@@ -460,9 +460,9 @@ namespace panzer_stk {
 
   void buildPhysicsBlocks(panzer_stk::STK_Interface & mesh,
                           std::vector<Teuchos::RCP<panzer::PhysicsBlock> > & physics_blocks,
-                          panzer::ClosureModelFactory_TemplateManager<panzer::Traits> & cm_factory,
-                          Teuchos::ParameterList & closure_models,
-                          Teuchos::ParameterList & user_data)
+                          panzer::ClosureModelFactory_TemplateManager<panzer::Traits> & /* cm_factory */,
+                          Teuchos::ParameterList & /* closure_models */,
+                          Teuchos::ParameterList & /* user_data */)
   {
     Teuchos::RCP<user_app::MyFactory> eqset_factory = Teuchos::rcp(new user_app::MyFactory);
     user_app::BCFactory bc_factory;

--- a/packages/panzer/adapters-stk/test/solver/user_app_RythmosObserver_Epetra.hpp
+++ b/packages/panzer/adapters-stk/test/solver/user_app_RythmosObserver_Epetra.hpp
@@ -78,12 +78,12 @@ namespace user_app {
       return Teuchos::rcp(new RythmosObserver_Epetra(m_mesh, m_dof_manager, m_lof));
     }
 
-    void resetIntegrationObserver(const Rythmos::TimeRange<double> &integrationTimeDomain)
+    void resetIntegrationObserver(const Rythmos::TimeRange<double>& /* integrationTimeDomain */)
     { }
 
     void observeCompletedTimeStep(const Rythmos::StepperBase<double> &stepper,
-				  const Rythmos::StepControlInfo<double> &stepCtrlInfo,
-				  const int timeStepIter)
+				  const Rythmos::StepControlInfo<double>& /* stepCtrlInfo */,
+				  const int /* timeStepIter */)
     { 
       std::cout << "*************************ROGER in Time************************************"  << std::endl;
       std::cout << "time = " << stepper.getStepStatus().time << std::endl;

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tSTK_IO.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tSTK_IO.cpp
@@ -72,8 +72,8 @@ void buildLocalIds(const STK_Interface & mesh,
 void assignBlock(FieldContainer & block,FieldContainer & vertices, double (* func)(double,double));
 void assignBlock(FieldContainer & block,FieldContainer & vertices, double val);
 
-double xval(double x,double y) { return x; }
-double yval(double x,double y) { return y; }
+double xval(double x, double /* y */) { return x; }
+double yval(double /* x */, double y) { return y; }
 double block2(double x,double y) { return (x-0.5)*(x-0.5)+y; }
 
 // triangle tests

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tScatterSpeed_Epetra.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tScatterSpeed_Epetra.cpp
@@ -101,7 +101,7 @@ int main(int argc,char * argv[])
 //                          Standard Usage Functions
 //******************************************************************************
 
-void newAssembly(Teuchos::FancyOStream &out)
+void newAssembly(Teuchos::FancyOStream& /* out */)
 {
   RCP<panzer::DOFManager<int,int> > my_dofM;
   RCP<Map> rowmap;

--- a/packages/panzer/adapters-stk/tutorial/siamCse17/myBCStrategyImpl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/siamCse17/myBCStrategyImpl.hpp
@@ -90,7 +90,7 @@ void
 MyBCStrategy<EvalT>::
 setup(
   const panzer::PhysicsBlock&   sidePB,
-  const Teuchos::ParameterList& userData)
+  const Teuchos::ParameterList& /* userData */)
 {
   using   std::runtime_error;
   using   Teuchos::is_null;
@@ -128,10 +128,10 @@ void
 MyBCStrategy<EvalT>::
 buildAndRegisterEvaluators(
   PHX::FieldManager<panzer::Traits>&                                 fm,
-  const panzer::PhysicsBlock&                                        pb,
-  const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-  const Teuchos::ParameterList&                                      models,
-  const Teuchos::ParameterList&                                      userData)
+  const panzer::PhysicsBlock&                                        /* pb  */,
+  const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* fac */,
+  const Teuchos::ParameterList&                                      /* mod */,
+  const Teuchos::ParameterList&                                      /* ud  */)
   const
 {
   using panzer::Constant;

--- a/packages/panzer/adapters-stk/tutorial/siamCse17/myClosureModelFactoryImpl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/siamCse17/myClosureModelFactoryImpl.hpp
@@ -81,12 +81,12 @@ MyClosureModelFactory<EvalT>::
 buildClosureModels(
   const std::string&                           modelId,
   const Teuchos::ParameterList&                models,
-  const panzer::FieldLayoutLibrary&            fl,
+  const panzer::FieldLayoutLibrary&            /* fl            */,
   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-  const Teuchos::ParameterList&                defaultParams,
-  const Teuchos::ParameterList&                userData,
-  const Teuchos::RCP<panzer::GlobalData>&      globalData,
-  PHX::FieldManager<panzer::Traits>&           fm) const
+  const Teuchos::ParameterList&                /* defaultParams */,
+  const Teuchos::ParameterList&                /* userData      */,
+  const Teuchos::RCP<panzer::GlobalData>&      /* globalData    */,
+  PHX::FieldManager<panzer::Traits>&           /* fm            */) const
 {
   using   panzer::BasisIRLayout;
   using   panzer::Constant;

--- a/packages/panzer/adapters-stk/tutorial/siamCse17/myEquationSetImpl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/siamCse17/myEquationSetImpl.hpp
@@ -129,8 +129,8 @@ void
 MyEquationSet<EvalT>::
 buildAndRegisterEquationSetEvaluators(
   PHX::FieldManager<panzer::Traits>& fm,
-  const panzer::FieldLibrary&        fl,
-  const Teuchos::ParameterList&      userData) const
+  const panzer::FieldLibrary&        /* fl       */,
+  const Teuchos::ParameterList&      /* userData */) const
 {
   using panzer::BasisIRLayout;
   using panzer::IntegrationRule;

--- a/packages/panzer/adapters-stk/tutorial/siamCse17/mySourceTermImpl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/siamCse17/mySourceTermImpl.hpp
@@ -104,7 +104,7 @@ void
 MySourceTerm<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
   using panzer::getIntegrationRuleIndex;
   irIndex_ = getIntegrationRuleIndex(irDegree_, (*sd.worksets_)[0]);

--- a/packages/panzer/adapters-stk/tutorial/step01/Step01_BCStrategy_Factory.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step01/Step01_BCStrategy_Factory.hpp
@@ -56,7 +56,7 @@ class BCStrategyFactory : public panzer::BCStrategyFactory {
 public:
 
   Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> >
-  buildBCStrategy(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data) const
+  buildBCStrategy(const panzer::BC& /* bc */, const Teuchos::RCP<panzer::GlobalData>& /* global_data */) const
   {
     Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> > bcs_tm = 
         Teuchos::rcp(new panzer::BCStrategy_TemplateManager<panzer::Traits>);

--- a/packages/panzer/adapters-stk/tutorial/step01/Step01_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step01/Step01_ClosureModel_Factory_impl.hpp
@@ -68,10 +68,10 @@ buildClosureModels(const std::string& model_id,
     const Teuchos::ParameterList& models,
     const panzer::FieldLayoutLibrary& fl,
     const Teuchos::RCP<panzer::IntegrationRule>& ir,
-    const Teuchos::ParameterList& default_params,
-    const Teuchos::ParameterList& user_data,
-    const Teuchos::RCP<panzer::GlobalData>& global_data,
-    PHX::FieldManager<panzer::Traits>& fm) const
+    const Teuchos::ParameterList& /* default_params */,
+    const Teuchos::ParameterList& /* user_data */,
+    const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+    PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
   using Teuchos::RCP;
   using Teuchos::rcp;

--- a/packages/panzer/adapters-stk/tutorial/step01/Step01_EquationSet_Projection_impl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step01/Step01_EquationSet_Projection_impl.hpp
@@ -106,8 +106,8 @@ EquationSet_Projection(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void user_app::EquationSet_Projection<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/example/SacadoExample/example.cpp
+++ b/packages/panzer/disc-fe/example/SacadoExample/example.cpp
@@ -76,7 +76,7 @@ inline SecondFadType seed_second_deriv(int num_vars,int index,double xi,double v
   return x;
 }
 
-int main(int argc,char * argv[])
+int main(int /* argc */, char*[] /* argv[] */)
 {
   std::cout << "Outputting" << std::endl;
 

--- a/packages/panzer/disc-fe/src/Panzer_BCStrategy_Dirichlet_DefaultImpl_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BCStrategy_Dirichlet_DefaultImpl_impl.hpp
@@ -112,7 +112,7 @@ void panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
                                   const panzer::PhysicsBlock& pb,
 			          const LinearObjFactory<panzer::Traits> & lof,
-			          const Teuchos::ParameterList& user_data) const
+			          const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -203,7 +203,7 @@ void panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT>::
 buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 	                                       const panzer::PhysicsBlock& pb,
 					       const LinearObjFactory<panzer::Traits> & lof,
-					       const Teuchos::ParameterList& user_data) const
+					       const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/src/Panzer_BCStrategy_Interface_DefaultImpl_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BCStrategy_Interface_DefaultImpl_impl.hpp
@@ -163,9 +163,9 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
 template <typename EvalT>
 void panzer::BCStrategy_Interface_DefaultImpl<EvalT>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-  		                  const panzer::PhysicsBlock& pb,
+  		                  const panzer::PhysicsBlock& /* pb */,
 			          const panzer::LinearObjFactory<panzer::Traits> & lof,
-			  	  const Teuchos::ParameterList& user_data) const
+			  	  const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/src/Panzer_BCStrategy_Neumann_DefaultImpl_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BCStrategy_Neumann_DefaultImpl_impl.hpp
@@ -163,9 +163,9 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
 template <typename EvalT>
 void panzer::BCStrategy_Neumann_DefaultImpl<EvalT>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-  		                  const panzer::PhysicsBlock& pb,
+  		                  const panzer::PhysicsBlock& /* pb */,
 			          const panzer::LinearObjFactory<panzer::Traits> & lof,
-			  	  const Teuchos::ParameterList& user_data) const
+			  	  const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/src/Panzer_BlockedVector_ReadOnly_GlobalEvaluationData.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_BlockedVector_ReadOnly_GlobalEvaluationData.cpp
@@ -108,7 +108,7 @@ namespace panzer
   BlockedVector_ReadOnly_GlobalEvaluationData::
   initialize(
     const Teuchos::RCP<const Thyra::VectorSpaceBase<double>>& ghostedSpace,
-    const Teuchos::RCP<const Thyra::VectorSpaceBase<double>>& ownedSpace,
+    const Teuchos::RCP<const Thyra::VectorSpaceBase<double>>& /* ownedSpace */,
     const std::vector<Teuchos::RCP<ReadOnlyVector_GlobalEvaluationData>>&
       gedBlocks)
   {

--- a/packages/panzer/disc-fe/src/Panzer_EpetraVector_ReadOnly_GlobalEvaluationData.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_EpetraVector_ReadOnly_GlobalEvaluationData.cpp
@@ -152,7 +152,7 @@ namespace panzer
   void
   EpetraVector_ReadOnly_GlobalEvaluationData::
   globalToGhost(
-    int mem)
+    int /* mem */)
   {
     using std::logic_error;
     using Teuchos::RCP;
@@ -196,6 +196,18 @@ namespace panzer
         (*ghostedVector_)[lids[j]] = filteredPairs_[i].second;
     } // end loop over filteredPairs_
   } // end of initializeData()
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  ghostToGlobal()
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  void
+  EpetraVector_ReadOnly_GlobalEvaluationData::
+  ghostToGlobal(
+    int /* mem = 0 */)
+  {
+  } // end of ghostToGlobal()
 
   /////////////////////////////////////////////////////////////////////////////
   //

--- a/packages/panzer/disc-fe/src/Panzer_EpetraVector_ReadOnly_GlobalEvaluationData.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_EpetraVector_ReadOnly_GlobalEvaluationData.hpp
@@ -187,9 +187,7 @@ namespace panzer
        */
       virtual void
       ghostToGlobal(
-        int mem = 0)
-      {
-      } // end of ghostToGlobal()
+        int mem = 0);
 
       /**
        *  \brief Determine if a Dirichlet adjustment is necessary.

--- a/packages/panzer/disc-fe/src/Panzer_EpetraVector_Write_GlobalEvaluationData.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_EpetraVector_Write_GlobalEvaluationData.cpp
@@ -103,7 +103,7 @@ namespace panzer
   void 
   EpetraVector_Write_GlobalEvaluationData::
   ghostToGlobal(
-    int mem)
+    int /* mem */)
   {
     using std::invalid_argument;
     using std::logic_error;

--- a/packages/panzer/disc-fe/src/Panzer_EquationSet_DefaultImpl_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_EquationSet_DefaultImpl_impl.hpp
@@ -163,9 +163,9 @@ void panzer::EquationSet_DefaultImpl<EvalT>::setupDeprecatedDOFsSupport()
 template <typename EvalT>
 void panzer::EquationSet_DefaultImpl<EvalT>::
 buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-                                               const panzer::FieldLibrary& fl,
+                                               const panzer::FieldLibrary& /* fl */,
                                                const LinearObjFactory<panzer::Traits> & lof,
-                                               const Teuchos::ParameterList& user_data) const
+                                               const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -362,7 +362,7 @@ buildAndRegisterDOFProjectionsToIPEvaluators(PHX::FieldManager<panzer::Traits>& 
                                              const panzer::FieldLayoutLibrary& fl,
                                              const Teuchos::RCP<panzer::IntegrationRule>& ir,
                                              const Teuchos::Ptr<const panzer::LinearObjFactory<panzer::Traits> > & lof,
-                                             const Teuchos::ParameterList& user_data) const
+                                             const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -539,7 +539,7 @@ buildAndRegisterDOFProjectionsToIPEvaluators(PHX::FieldManager<panzer::Traits>& 
 template <typename EvalT>
 void panzer::EquationSet_DefaultImpl<EvalT>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-                                  const panzer::FieldLibrary& fl,
+                                  const panzer::FieldLibrary& /* fl */,
                                   const LinearObjFactory<panzer::Traits> & lof,
                                   const Teuchos::ParameterList& user_data) const
 {

--- a/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.cpp
@@ -165,7 +165,7 @@ void panzer::FieldManagerBuilder::setupVolumeFieldManagers(
 void panzer::FieldManagerBuilder::
 setupBCFieldManagers(const std::vector<panzer::BC> & bcs,
                      const std::vector<Teuchos::RCP<panzer::PhysicsBlock> >& physicsBlocks,
-                     const Teuchos::Ptr<const panzer::EquationSetFactory> & eqset_factory,
+                     const Teuchos::Ptr<const panzer::EquationSetFactory>& /* eqset_factory */,
                      const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& cm_factory,
                      const panzer::BCStrategyFactory& bc_factory,
                      const Teuchos::ParameterList& closure_models,

--- a/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.hpp
@@ -74,7 +74,7 @@ namespace panzer {
 
   class EmptyEvaluatorFactory : public GenericEvaluatorFactory {
   public:
-    bool registerEvaluators(PHX::FieldManager<panzer::Traits> & fm, const WorksetDescriptor & wd, const PhysicsBlock & pb) const 
+    bool registerEvaluators(PHX::FieldManager<panzer::Traits> & /* fm */, const WorksetDescriptor & /* wd */, const PhysicsBlock & /* pb */) const 
     { return false; }
   };
 

--- a/packages/panzer/disc-fe/src/Panzer_GlobalEvaluationData.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_GlobalEvaluationData.hpp
@@ -77,8 +77,8 @@ public:
    GlobalEvaluationData_Default(const GlobalEvaluationData_Default & s) 
    { requiresDirichletAdjustment_ = s.requiresDirichletAdjustment(); }
 
-   virtual void ghostToGlobal(int mem) {}
-   virtual void globalToGhost(int mem) {}
+   virtual void ghostToGlobal(int /* mem */) {}
+   virtual void globalToGhost(int /* mem */) {}
    virtual void initializeData() {}
 
    void setRequiresDirichletAdjustment(bool b) { requiresDirichletAdjustment_ = b; }

--- a/packages/panzer/disc-fe/src/Panzer_InitialCondition_Builder.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_InitialCondition_Builder.cpp
@@ -249,9 +249,9 @@ public:
     
    /** The specific evaluators are registered with the field manager argument.
      */
-   void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<Traits>& fm,
-                                              const FieldLibrary& field_library,
-                                              const Teuchos::ParameterList& user_data) const {}
+   void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<Traits>& /* fm */,
+                                              const FieldLibrary& /* field_library */,
+                                              const Teuchos::ParameterList& /* user_data */) const {}
 
 };
 

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -1112,7 +1112,7 @@ getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-evaluateValuesCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates)
+evaluateValuesCV(const PHX::MDField<Scalar, Cell, NODE, Dim>& /* in_node_coordinates */)
 {
 
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;

--- a/packages/panzer/disc-fe/src/Panzer_LocalPartitioningUtilities.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_LocalPartitioningUtilities.cpp
@@ -328,9 +328,9 @@ splitMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & mesh_info,
 
 template<typename LO, typename GO>
 void
-partitionMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & mesh_info,
-                 const size_t requested_partition_size,
-                 std::vector<panzer::LocalMeshPartition<LO,GO> > & partitions)
+partitionMeshInfo(const panzer::LocalMeshInfoBase<LO,GO>& /* mesh_info */,
+                 const size_t /* requested_partition_size */,
+                 std::vector<panzer::LocalMeshPartition<LO,GO>>& /* partitions */)
 {
   // Not yet sure how to do this
   TEUCHOS_ASSERT(false);

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_Epetra.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_Epetra.cpp
@@ -650,7 +650,7 @@ void panzer::ModelEvaluator_Epetra::evalModel_basic( const InArgs& inArgs,
 
 void 
 panzer::ModelEvaluator_Epetra::
-evalModel_basic_g(AssemblyEngineInArgs ae_inargs,const InArgs & inArgs,const OutArgs & outArgs) const
+evalModel_basic_g(AssemblyEngineInArgs ae_inargs, const InArgs& /* inArgs */, const OutArgs& outArgs) const
 {
    // optional sanity check
    // TEUCHOS_ASSERT(required_basic_g(outArgs));
@@ -672,7 +672,7 @@ evalModel_basic_g(AssemblyEngineInArgs ae_inargs,const InArgs & inArgs,const Out
 
 void 
 panzer::ModelEvaluator_Epetra::
-evalModel_basic_dgdx(AssemblyEngineInArgs ae_inargs,const InArgs & inArgs,const OutArgs & outArgs) const
+evalModel_basic_dgdx(AssemblyEngineInArgs ae_inargs, const InArgs& /* inArgs */, const OutArgs& outArgs) const
 {
    // optional sanity check
    TEUCHOS_ASSERT(required_basic_dgdx(outArgs));
@@ -700,7 +700,7 @@ evalModel_basic_dgdx(AssemblyEngineInArgs ae_inargs,const InArgs & inArgs,const 
 
 void 
 panzer::ModelEvaluator_Epetra::
-evalModel_basic_dfdp(AssemblyEngineInArgs ae_inargs,const InArgs & inArgs,const OutArgs & outArgs) const
+evalModel_basic_dfdp(AssemblyEngineInArgs ae_inargs, const InArgs& /* inArgs */, const OutArgs& outArgs) const
 {
    using Teuchos::RCP;
    using Teuchos::rcp_dynamic_cast;

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
@@ -2239,9 +2239,9 @@ void panzer::ModelEvaluator<Scalar>::
 buildDistroParamDgDp_RL(
        const Teuchos::RCP<panzer::WorksetContainer> & wc,
        const std::vector<Teuchos::RCP<panzer::PhysicsBlock> >& physicsBlocks,
-       const std::vector<panzer::BC> & bcs,
+       const std::vector<panzer::BC>& /* bcs */,
        const panzer::EquationSetFactory & eqset_factory,
-       const panzer::BCStrategyFactory& bc_factory,
+       const panzer::BCStrategyFactory& /* bc_factory */,
        const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& cm_factory,
        const Teuchos::ParameterList& closure_models,
        const Teuchos::ParameterList& user_data,

--- a/packages/panzer/disc-fe/src/Panzer_ParameterList_GlobalEvaluationData.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ParameterList_GlobalEvaluationData.hpp
@@ -60,8 +60,8 @@ public:
      : activeParameters_(activeParameters) {}
    virtual ~ParameterList_GlobalEvaluationData() {} 
 
-   virtual void ghostToGlobal(int mem) {}
-   virtual void globalToGhost(int mem) {}
+   virtual void ghostToGlobal(int /* mem */) {}
+   virtual void globalToGhost(int /* mem */) {}
 
    virtual bool requiresDirichletAdjustment() const { return false; }
 

--- a/packages/panzer/disc-fe/src/Panzer_ReadOnlyVector_GlobalEvaluationData.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ReadOnlyVector_GlobalEvaluationData.hpp
@@ -74,7 +74,7 @@ public:
 
   /** For this class, this method does nothing.
     */
-  virtual void ghostToGlobal(int mem) {}
+  virtual void ghostToGlobal(int /* mem */) {}
 
   //! Set the owned vector
   virtual void setOwnedVector(const Teuchos::RCP<const Thyra::VectorBase<double> > & ownedVector) = 0;

--- a/packages/panzer/disc-fe/src/Panzer_TpetraVector_ReadOnly_GlobalEvaluationData.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_TpetraVector_ReadOnly_GlobalEvaluationData.hpp
@@ -118,7 +118,7 @@ public:
    virtual void initializeData(); 
   
    //! For this class this method does nothing.
-   virtual void ghostToGlobal(int mem) {} 
+   virtual void ghostToGlobal(int /* mem */) {} 
 
    //! Nothing to do (its read only)
    virtual bool requiresDirichletAdjustment() const { return false; }

--- a/packages/panzer/disc-fe/src/Panzer_TpetraVector_ReadOnly_GlobalEvaluationData_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_TpetraVector_ReadOnly_GlobalEvaluationData_impl.hpp
@@ -110,7 +110,7 @@ initialize(const RCP<const ImportType>& importer,
 template <typename ScalarT,typename LocalOrdinalT,typename GlobalOrdinalT,typename NodeT>
 void 
 TpetraVector_ReadOnly_GlobalEvaluationData<ScalarT,LocalOrdinalT,GlobalOrdinalT,NodeT>::
-globalToGhost(int mem)
+globalToGhost(int /* mem */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(ownedVector_ == Teuchos::null, std::logic_error,
     "Owned vector has not been set, can't perform the halo exchange!");

--- a/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
@@ -259,7 +259,7 @@ setIdentifiers(const WorksetDescriptor & wd,std::map<unsigned,Workset> & workset
 #if defined(__KK__)
 void WorksetContainer::
 applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
-                  const std::string & eBlock, 
+                  const std::string& /* eBlock */,
                   std::vector<Workset> & worksets) const
 {
   using Teuchos::RCP;
@@ -314,7 +314,7 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
 
 void WorksetContainer::
 applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
-                  const WorksetDescriptor & desc,
+                  const WorksetDescriptor& /* desc */,
                   std::map<unsigned,Workset> & worksets) const
 {
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/src/Panzer_WriteVector_GlobalEvaluationData.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_WriteVector_GlobalEvaluationData.hpp
@@ -82,7 +82,7 @@ public:
 
   /** For this class, this method does nothing.
     */
-  virtual void globalToGhost(int mem) { }
+  virtual void globalToGhost(int /* mem */) { }
 
   /** For this class, this method does the halo exchange for the
     * vector.

--- a/packages/panzer/disc-fe/src/Panzer_ZeroSensitivities.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ZeroSensitivities.hpp
@@ -53,7 +53,7 @@ namespace panzer {
   // void zeroSensitivities(ScalarT& s);
 
   //! Specialization for Residual
-  inline void zeroSensitivities(panzer::Traits::RealType& s) {}
+  inline void zeroSensitivities(panzer::Traits::RealType& /* s */) {}
 
   //! Specialization for Fad type Jacobian
   inline void zeroSensitivities(panzer::Traits::FadType& s) 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_impl.hpp
@@ -164,7 +164,7 @@ void BasisValues_Evaluator<EvalT,TRAITST>::initialize(const Teuchos::RCP<const p
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(BasisValues_Evaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(BasisValues_Evaluator, /* sd */, fm)
 {
   int space_dim = basis->dimension();
 
@@ -219,7 +219,7 @@ PHX_POST_REGISTRATION_SETUP(BasisValues_Evaluator,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(BasisValues_Evaluator,workset)
+PHX_EVALUATE_FIELDS(BasisValues_Evaluator, /* workset */)
 { 
   // evaluate the point values (construct jacobians etc...)
   basisValues->evaluateValues(pointValues.coords_ref,

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantFlux_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantFlux_impl.hpp
@@ -62,7 +62,7 @@ PHX_EVALUATOR_CTOR(ConstantFlux,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(ConstantFlux,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(ConstantFlux, /* worksets */, fm)
 {
   using namespace PHX;
   this->utils.setFieldData(flux,fm);
@@ -76,7 +76,7 @@ PHX_POST_REGISTRATION_SETUP(ConstantFlux,worksets,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(ConstantFlux,d)
+PHX_EVALUATE_FIELDS(ConstantFlux, /* d */)
 { }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantVector_impl.hpp
@@ -65,14 +65,14 @@ PHX_EVALUATOR_CTOR(ConstantVector,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(ConstantVector,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(ConstantVector, /* worksets */, fm)
 {
   using namespace PHX;
   this->utils.setFieldData(vector,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(ConstantVector,d)
+PHX_EVALUATE_FIELDS(ConstantVector, /* d */)
 { 
   for(int c=0;c<vector.extent_int(0);c++)
     for(int p=0;p<vector.extent_int(1);p++)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Constant_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Constant_impl.hpp
@@ -58,7 +58,7 @@ PHX_EVALUATOR_CTOR(Constant,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Constant,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(Constant, /* worksets */, fm)
 {
   using namespace PHX;
   this->utils.setFieldData(constant,fm);
@@ -67,7 +67,7 @@ PHX_POST_REGISTRATION_SETUP(Constant,worksets,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Constant,d)
+PHX_EVALUATE_FIELDS(Constant, /* d */)
 { }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator_impl.hpp
@@ -58,7 +58,7 @@ PHX_EVALUATOR_CTOR(CoordinatesEvaluator,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(CoordinatesEvaluator,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(CoordinatesEvaluator, /* worksets */, fm)
 {
   using namespace PHX;
   this->utils.setFieldData(coordinate,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_impl.hpp
@@ -67,7 +67,7 @@ PHX_EVALUATOR_CTOR(Copy,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Copy,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(Copy, /* worksets */, fm)
 {
   this->utils.setFieldData(input,fm);
   this->utils.setFieldData(output,fm);
@@ -76,7 +76,7 @@ PHX_POST_REGISTRATION_SETUP(Copy,worksets,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Copy,workset)
+PHX_EVALUATE_FIELDS(Copy, /* workset */)
 { 
   output.deep_copy(input);
 }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct_impl.hpp
@@ -82,7 +82,7 @@ PHX_EVALUATOR_CTOR(CrossProduct,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(CrossProduct,sd,fm)
+PHX_POST_REGISTRATION_SETUP(CrossProduct, /* sd */, fm)
 {
   this->utils.setFieldData(vec_a_cross_vec_b,fm);
   this->utils.setFieldData(vec_a,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv_impl.hpp
@@ -55,7 +55,7 @@ namespace {
 //**********************************************************************
 template<typename ScalarT,typename ArrayT>                   
 void evaluateDiv_withSens(int numCells,
-                          int basis_dimension,
+                          int /* basis_dimension */,
                           PHX::MDField<ScalarT,Cell,IP> & dof_div, 
                           PHX::MDField<const ScalarT,Cell,Point> & dof_value,
                           const ArrayT & div_basis)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_BasisToBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_BasisToBasis_impl.hpp
@@ -98,8 +98,8 @@ DOF_BasisToBasis(const std::string & fieldName,
 
 //**********************************************************************
 template <typename EvalT, typename TRAITST>
-void DOF_BasisToBasis<EvalT,TRAITST>::postRegistrationSetup(typename TRAITST::SetupData d,
-			                                  PHX::FieldManager<TRAITST>& fm)
+void DOF_BasisToBasis<EvalT,TRAITST>::postRegistrationSetup(typename TRAITST::SetupData /* d */,
+			                                  PHX::FieldManager<TRAITST>& /* fm */)
 {
   // not needed anymore
   // this->utils.setFieldData(dof_source_coeff,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointField_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointField_impl.hpp
@@ -89,7 +89,7 @@ void DOF_PointField<EvalT,TRAITST>::initialize(const std::string & fieldName,
 
 //**********************************************************************
 template <typename EvalT, typename TRAITST>
-void DOF_PointField<EvalT,TRAITST>::postRegistrationSetup(typename TRAITST::SetupData d,
+void DOF_PointField<EvalT,TRAITST>::postRegistrationSetup(typename TRAITST::SetupData /* d */,
 			                                  PHX::FieldManager<TRAITST>& fm)
 {
   this->utils.setFieldData(coordinates,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointValues_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointValues_impl.hpp
@@ -119,7 +119,7 @@ DOF_PointValues(const Teuchos::ParameterList & p)
 //**********************************************************************
 template<typename EvalT, typename TRAITS>                   
 void DOF_PointValues<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData sd,
+postRegistrationSetup(typename TRAITS::SetupData /* sd */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   this->utils.setFieldData(dof_basis,fm);
@@ -240,7 +240,7 @@ DOF_PointValues(const Teuchos::ParameterList & p)
 //**********************************************************************
 template<typename TRAITS>                   
 void DOF_PointValues<typename TRAITS::Jacobian, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData sd,
+postRegistrationSetup(typename TRAITS::SetupData /* sd */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   this->utils.setFieldData(dof_basis,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
@@ -109,7 +109,7 @@ PHX_EVALUATOR_CTOR(DirichletResidual_EdgeBasis,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DirichletResidual_EdgeBasis,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(DirichletResidual_EdgeBasis, /* worksets */, fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(dof,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
@@ -101,7 +101,7 @@ PHX_EVALUATOR_CTOR(DirichletResidual_FaceBasis,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DirichletResidual_FaceBasis,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(DirichletResidual_FaceBasis, /* worksets */, fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(dof,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_impl.hpp
@@ -72,7 +72,7 @@ PHX_EVALUATOR_CTOR(DirichletResidual,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DirichletResidual,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(DirichletResidual, /* worksets */, fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(dof,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_impl.hpp
@@ -110,7 +110,7 @@ PHX_EVALUATOR_CTOR(DotProduct,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DotProduct,sd,fm)
+PHX_POST_REGISTRATION_SETUP(DotProduct, /* sd */, fm)
 {
   this->utils.setFieldData(vec_a_dot_vec_b,fm);
   this->utils.setFieldData(vec_a,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_FieldSpy_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_FieldSpy_impl.hpp
@@ -71,7 +71,7 @@ FieldSpy<EvalT,Traits>::FieldSpy(const std::string & name,
 
 //**********************************************************************
 template <typename EvalT,typename Traits>
-void FieldSpy<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
+void FieldSpy<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData /* sd */,
                                                        PHX::FieldManager<Traits>& fm)
 {
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherNormals_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherNormals_impl.hpp
@@ -93,7 +93,7 @@ GatherNormals(
 // **********************************************************************
 template<typename EvalT,typename Traits>
 void panzer::GatherNormals<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d, 
+postRegistrationSetup(typename Traits::SetupData /* d */, 
 		      PHX::FieldManager<Traits>& fm)
 {
   // setup the field data object

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherOrientation_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherOrientation_impl.hpp
@@ -114,7 +114,7 @@ GatherOrientation(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,GO
 // **********************************************************************
 template<typename EvalT,typename TRAITS,typename LO,typename GO>
 void panzer::GatherOrientation<EvalT, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
 		      PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFieldOrientations_.size() == indexerNames_->size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedEpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedEpetra_Hessian_impl.hpp
@@ -135,8 +135,8 @@ template<typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherSolution_BlockedEpetra<panzer::Traits::Hessian, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::size_t;
   using std::string;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedEpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedEpetra_impl.hpp
@@ -151,8 +151,8 @@ void
 panzer::
 GatherSolution_BlockedEpetra<panzer::Traits::Residual, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::size_t;
   using std::string;
@@ -401,8 +401,8 @@ template<typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherSolution_BlockedEpetra<panzer::Traits::Tangent, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::size_t;
   using std::string;
@@ -664,8 +664,8 @@ void
 panzer::
 GatherSolution_BlockedEpetra<panzer::Traits::Jacobian, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::size_t;
   using std::string;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedTpetra_Hessian.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedTpetra_Hessian.hpp
@@ -65,15 +65,15 @@ public:
    GatherSolution_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer)
      : gidIndexer_(indexer) {}
 
-   GatherSolution_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer,
-                                const Teuchos::ParameterList& p) {}
+   GatherSolution_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */,
+                                const Teuchos::ParameterList& /* p */) {}
 
-  void postRegistrationSetup(typename TRAITS::SetupData d,
-                             PHX::FieldManager<TRAITS>& vm) {}
+  void postRegistrationSetup(typename TRAITS::SetupData /* d */,
+                             PHX::FieldManager<TRAITS>& /* vm */) {}
 
-  void preEvaluate(typename TRAITS::PreEvalData d) {}
+  void preEvaluate(typename TRAITS::PreEvalData /* d */) {}
 
-  void evaluateFields(typename TRAITS::EvalData d) {}
+  void evaluateFields(typename TRAITS::EvalData /* d */) {}
 
   virtual Teuchos::RCP<CloneableEvaluator> clone(const Teuchos::ParameterList & pl) const
   { return Teuchos::rcp(new GatherSolution_BlockedTpetra<panzer::Traits::Hessian,TRAITS,S,LO,GO>(gidIndexer_,pl)); }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedTpetra_impl.hpp
@@ -141,7 +141,7 @@ GatherSolution_BlockedTpetra(
 // **********************************************************************
 template <typename TRAITS,typename S,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_BlockedTpetra<panzer::Traits::Residual, TRAITS,S,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
@@ -305,7 +305,7 @@ GatherSolution_BlockedTpetra(
 // **********************************************************************
 template <typename TRAITS,typename S,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_BlockedTpetra<panzer::Traits::Tangent, TRAITS,S,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
@@ -469,7 +469,7 @@ GatherSolution_BlockedTpetra(
 // **********************************************************************
 template <typename TRAITS,typename S,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_BlockedTpetra<panzer::Traits::Jacobian, TRAITS,S,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Epetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Epetra_Hessian_impl.hpp
@@ -136,8 +136,8 @@ template<typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherSolution_Epetra<panzer::Traits::Hessian, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::logic_error;
   using std::size_t;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Epetra_impl.hpp
@@ -145,8 +145,8 @@ template<typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherSolution_Epetra<panzer::Traits::Residual, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::logic_error;
   using std::size_t;
@@ -387,8 +387,8 @@ template<typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherSolution_Epetra<panzer::Traits::Tangent, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::logic_error;
   using std::size_t;
@@ -638,8 +638,8 @@ template<typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherSolution_Epetra<panzer::Traits::Jacobian, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::logic_error;
   using std::size_t;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_Hessian.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_Hessian.hpp
@@ -66,15 +66,15 @@ public:
   GatherSolution_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer) :
      globalIndexer_(indexer) {}
 
-  GatherSolution_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer,
-                        const Teuchos::ParameterList& p) {}
+  GatherSolution_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* indexer */,
+                        const Teuchos::ParameterList& /* p */) {}
 
-  void postRegistrationSetup(typename TRAITS::SetupData d,
-                             PHX::FieldManager<TRAITS>& vm) {}
+  void postRegistrationSetup(typename TRAITS::SetupData /* d */,
+                             PHX::FieldManager<TRAITS>& /* vm */) {}
 
-  void preEvaluate(typename TRAITS::PreEvalData d) {}
+  void preEvaluate(typename TRAITS::PreEvalData /* d */) {}
 
-  void evaluateFields(typename TRAITS::EvalData d) {}
+  void evaluateFields(typename TRAITS::EvalData /* d */) {}
 
   virtual Teuchos::RCP<CloneableEvaluator> clone(const Teuchos::ParameterList & pl) const
   { return Teuchos::rcp(new GatherSolution_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>(globalIndexer_,pl)); }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_impl.hpp
@@ -119,7 +119,7 @@ GatherSolution_Tpetra(
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_Tpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
@@ -268,7 +268,7 @@ GatherSolution_Tpetra(
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_Tpetra<panzer::Traits::Tangent, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_BlockedEpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_BlockedEpetra_impl.hpp
@@ -133,8 +133,8 @@ template<typename EvalT, typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherTangent_BlockedEpetra<EvalT, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::size_t;
   using std::string;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_BlockedTpetra_impl.hpp
@@ -95,7 +95,7 @@ GatherTangent_BlockedTpetra(
 // **********************************************************************
 template <typename EvalT,typename TRAITS,typename S,typename LO,typename GO,typename NodeT>
 void panzer::GatherTangent_BlockedTpetra<EvalT, TRAITS,S,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_->size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Epetra_impl.hpp
@@ -129,8 +129,8 @@ template<typename EvalT, typename TRAITS, typename LO, typename GO>
 void
 panzer::GatherTangent_Epetra<EvalT, TRAITS, LO, GO>::
 postRegistrationSetup(
-  typename TRAITS::SetupData d,
-  PHX::FieldManager<TRAITS>& fm)
+  typename TRAITS::SetupData /* d  */,
+  PHX::FieldManager<TRAITS>& /* fm */)
 {
   using std::logic_error;
   using std::size_t;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Tpetra_impl.hpp
@@ -96,7 +96,7 @@ GatherTangent_Tpetra(
 // **********************************************************************
 template<typename EvalT,typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherTangent_Tpetra<EvalT, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_->size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangents_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangents_impl.hpp
@@ -93,7 +93,7 @@ GatherTangents(
 // **********************************************************************
 template<typename EvalT,typename Traits>
 void panzer::GatherTangents<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d, 
+postRegistrationSetup(typename Traits::SetupData /* d */, 
 		      PHX::FieldManager<Traits>& fm)
 {
   // setup the field data object

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_impl.hpp
@@ -155,7 +155,7 @@ PHX_EVALUATE_FIELDS(GlobalStatistics,workset)
 }
 
 //**********************************************************************
-PHX_PRE_EVALUATE_FIELDS(GlobalStatistics,data)
+PHX_PRE_EVALUATE_FIELDS(GlobalStatistics, /* data */)
 {
   total_volume = Teuchos::ScalarTraits<ScalarT>::zero();
 
@@ -170,14 +170,14 @@ PHX_PRE_EVALUATE_FIELDS(GlobalStatistics,data)
 }
 
 //**********************************************************************
-PHX_POST_EVALUATE_FIELDS(GlobalStatistics,data)
+PHX_POST_EVALUATE_FIELDS(GlobalStatistics, /* data */)
 {
   this->postprocess(*(global_data->os));
 }
 
 //**********************************************************************
 template<typename EvalT, typename TRAITS>
-void GlobalStatistics<EvalT, TRAITS>::postprocess(std::ostream& os)
+void GlobalStatistics<EvalT, TRAITS>::postprocess(std::ostream& /* os */)
 {
   // throw unless specialized for residual evaluations
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"SHOULD NEVER BE CALLED!");

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar_impl.hpp
@@ -174,7 +174,7 @@ namespace panzer
   Integrator_BasisTimesScalar<EvalT, Traits>::
   postRegistrationSetup(
     typename Traits::SetupData sd,
-    PHX::FieldManager<Traits>& fm)
+    PHX::FieldManager<Traits>& /* fm */)
   {
     using panzer::getBasisIndex;
     using std::size_t;
@@ -201,7 +201,7 @@ namespace panzer
   void
   Integrator_BasisTimesScalar<EvalT, Traits>::
   operator()(
-    const FieldMultTag<NUM_FIELD_MULT>& tag,
+    const FieldMultTag<NUM_FIELD_MULT>& /* tag */,
     const size_t&                       cell) const
   {
     using panzer::EvaluatorStyle;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesVector_impl.hpp
@@ -178,7 +178,7 @@ namespace panzer
   Integrator_BasisTimesVector<EvalT, Traits>::
   postRegistrationSetup(
     typename Traits::SetupData sd,
-    PHX::FieldManager<Traits>& fm)
+    PHX::FieldManager<Traits>& /* fm */)
   {
     using panzer::getBasisIndex;
     using std::size_t;
@@ -207,7 +207,7 @@ namespace panzer
   void
   Integrator_BasisTimesVector<EvalT, Traits>::
   operator()(
-    const FieldMultTag<NUM_FIELD_MULT>& tag,
+    const FieldMultTag<NUM_FIELD_MULT>& /* tag */,
     const size_t&                       cell) const
   {
     using panzer::EvaluatorStyle;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
@@ -188,7 +188,7 @@ namespace panzer
   Integrator_GradBasisDotVector<EvalT, Traits>::
   postRegistrationSetup(
     typename Traits::SetupData sd,
-    PHX::FieldManager<Traits>& fm)
+    PHX::FieldManager<Traits>& /* fm */)
   {
     using panzer::getBasisIndex;
     using std::size_t;
@@ -217,7 +217,7 @@ namespace panzer
   void
   Integrator_GradBasisDotVector<EvalT, Traits>::
   operator()(
-    const FieldMultTag<NUM_FIELD_MULT>& tag,
+    const FieldMultTag<NUM_FIELD_MULT>& /* tag */,
     const size_t&                       cell) const
   {
     using panzer::EvaluatorStyle;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_MultiVariateParameter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_MultiVariateParameter_impl.hpp
@@ -82,7 +82,7 @@ MultiVariateParameter(const std::string parameter_name,
 //**********************************************************************
 template<typename EvalT, typename TRAITS>
 void MultiVariateParameter<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData worksets,
+postRegistrationSetup(typename TRAITS::SetupData /* worksets */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   this->utils.setFieldData(target_field,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Parameter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Parameter_impl.hpp
@@ -75,7 +75,7 @@ Parameter(const std::string parameter_name,
 //**********************************************************************
 template<typename EvalT, typename TRAITS>
 void Parameter<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData worksets,
+postRegistrationSetup(typename TRAITS::SetupData /* worksets */,
 		      PHX::FieldManager<TRAITS>& fm)
 {
   this->utils.setFieldData(target_field,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Product_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Product_impl.hpp
@@ -77,7 +77,7 @@ PHX_EVALUATOR_CTOR(Product,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Product,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(Product, /* worksets */, fm)
 {
   this->utils.setFieldData(product,fm);
   for (std::size_t i=0; i < values.size(); ++i)
@@ -85,7 +85,7 @@ PHX_POST_REGISTRATION_SETUP(Product,worksets,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Product,workset)
+PHX_EVALUATE_FIELDS(Product, /* workset */)
 { 
     product.deep_copy(ScalarT(scaling));
     for (std::size_t j = 0; j < values.size(); ++j)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToEdges_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToEdges_impl.hpp
@@ -117,7 +117,7 @@ ProjectToEdges(
 // **********************************************************************
 template<typename EvalT,typename Traits>
 void panzer::ProjectToEdges<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d, 
+postRegistrationSetup(typename Traits::SetupData /* d */, 
 		      PHX::FieldManager<Traits>& fm)
 {
   // setup the field data object

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToFaces_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToFaces_impl.hpp
@@ -118,7 +118,7 @@ ProjectToFaces(
 // **********************************************************************
 template<typename EvalT,typename Traits>
 void panzer::ProjectToFaces<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d, 
+postRegistrationSetup(typename Traits::SetupData /* d */, 
 		      PHX::FieldManager<Traits>& fm)
 {
   // setup the field data object

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ReorderADValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ReorderADValues_Evaluator_impl.hpp
@@ -57,9 +57,9 @@ panzer::ReorderADValues_Evaluator<EvalT, TRAITS>::
 ReorderADValues_Evaluator(const std::string & outPrefix,
                           const std::vector<std::string> & inFieldNames,
                           const std::vector<Teuchos::RCP<PHX::DataLayout> > & fieldLayouts,
-                          const std::string & elementBlock,
-                          const UniqueGlobalIndexerBase & indexerSrc,
-                          const UniqueGlobalIndexerBase & indexerDest)
+                          const std::string & /* elementBlock */,
+                          const UniqueGlobalIndexerBase & /* indexerSrc */,
+                          const UniqueGlobalIndexerBase & /* indexerDest */)
 { 
   TEUCHOS_ASSERT(inFieldNames.size()==fieldLayouts.size());
 
@@ -84,9 +84,9 @@ ReorderADValues_Evaluator(const std::string & outPrefix,
                           const std::vector<std::string> & inDOFs,
                           const std::vector<std::string> & outDOFs,
                           const std::vector<Teuchos::RCP<PHX::DataLayout> > & fieldLayouts,
-                          const std::string & elementBlock,
-                          const UniqueGlobalIndexerBase & indexerSrc,
-                          const UniqueGlobalIndexerBase & indexerDest)
+                          const std::string & /* elementBlock */,
+                          const UniqueGlobalIndexerBase & /* indexerSrc */,
+                          const UniqueGlobalIndexerBase & /* indexerDest */)
 { 
   TEUCHOS_ASSERT(inFieldNames.size()==fieldLayouts.size());
   TEUCHOS_ASSERT(inDOFs.size()==outDOFs.size());
@@ -107,7 +107,7 @@ ReorderADValues_Evaluator(const std::string & outPrefix,
 // **********************************************************************
 template<typename EvalT,typename TRAITS>
 void panzer::ReorderADValues_Evaluator<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
 		      PHX::FieldManager<TRAITS>& fm)
 {
   // load required field numbers for fast use
@@ -121,7 +121,7 @@ postRegistrationSetup(typename TRAITS::SetupData d,
 // **********************************************************************
 template<typename EvalT,typename TRAITS>
 void panzer::ReorderADValues_Evaluator<EvalT, TRAITS>::
-evaluateFields(typename TRAITS::EvalData workset)
+evaluateFields(typename TRAITS::EvalData /* workset */)
 {
   // just copy fields if there is no AD data
   //for(std::size_t i = 0; i < inFields_.size(); ++i)
@@ -213,7 +213,7 @@ ReorderADValues_Evaluator(const std::string & outPrefix,
 // **********************************************************************
 template<typename TRAITS>
 void panzer::ReorderADValues_Evaluator<typename TRAITS::Jacobian, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
 		      PHX::FieldManager<TRAITS>& fm)
 {
   // load required field numbers for fast use
@@ -227,7 +227,7 @@ postRegistrationSetup(typename TRAITS::SetupData d,
 // **********************************************************************
 template<typename TRAITS>
 void panzer::ReorderADValues_Evaluator<typename TRAITS::Jacobian, TRAITS>::
-evaluateFields(typename TRAITS::EvalData workset)
+evaluateFields(typename TRAITS::EvalData /* workset */)
 {
   // for AD data do a reordering
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_impl.hpp
@@ -78,7 +78,7 @@ PHX_EVALUATOR_CTOR(ScalarToVector,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(ScalarToVector,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(ScalarToVector, /* worksets */, fm)
 {
   internal_scalar_fields = Kokkos::View<KokkosScalarFields_t*>("ScalarToVector::internal_scalar_fields", scalar_fields.size());
   for (std::size_t i=0; i < scalar_fields.size(); ++i) {

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_Hessian_impl.hpp
@@ -60,7 +60,7 @@ ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
 ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
                                        const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
                                        const Teuchos::ParameterList& p,
-                                       bool useDiscreteAdjoint)
+                                       bool /* useDiscreteAdjoint */)
    : rowIndexers_(rIndexers)
    , colIndexers_(cIndexers)
    , globalDataKey_("Residual Scatter Container")
@@ -115,7 +115,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 template<typename TRAITS,typename LO,typename GO>
 void
 ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm) 
 {
   indexerIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_decl.hpp
@@ -113,7 +113,7 @@ class ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Residual,TRAITS,LO,
 public:
 
   ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
-                                         const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers)
+                                         const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & /* cIndexers */)
      : rowIndexers_(rIndexers) {}
   
   ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
@@ -185,7 +185,7 @@ class ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Tangent,TRAITS,LO,G
 public:
 
   ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
-                                         const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers)
+                                         const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & /* cIndexers */)
      : rowIndexers_(rIndexers) {}
   
   ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_impl.hpp
@@ -80,7 +80,7 @@ panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Residual, TRAITS,
 ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
                                        const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
                                        const Teuchos::ParameterList& p,
-                                       bool useDiscreteAdjoint)
+                                       bool /* useDiscreteAdjoint */)
    : rowIndexers_(rIndexers)
    , colIndexers_(cIndexers)
    , globalDataKey_("Residual Scatter Container")
@@ -137,7 +137,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Residual, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   indexerIds_.resize(scatterFields_.size());
@@ -298,7 +298,7 @@ panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Tangent, TRAITS,L
 ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
                                        const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
                                        const Teuchos::ParameterList& p,
-                                       bool useDiscreteAdjoint)
+                                       bool /* useDiscreteAdjoint */)
    : rowIndexers_(rIndexers)
    , colIndexers_(cIndexers)
    , globalDataKey_("Residual Scatter Container")
@@ -355,7 +355,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   indexerIds_.resize(scatterFields_.size());
@@ -517,7 +517,7 @@ panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Jacobian, TRAITS,
 ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
                                        const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
                                        const Teuchos::ParameterList& p,
-                                       bool useDiscreteAdjoint)
+                                       bool /* useDiscreteAdjoint */)
    : rowIndexers_(rIndexers)
    , colIndexers_(cIndexers)
    , globalDataKey_("Residual Scatter Container")
@@ -572,7 +572,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   indexerIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra.hpp
@@ -81,7 +81,7 @@ class ScatterDirichletResidual_BlockedTpetra
     public panzer::CloneableEvaluator  {
 public:
    typedef typename EvalT::ScalarT ScalarT;
-   ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer)
+   ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */)
    { }
 
    ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & gidProviders,
@@ -90,9 +90,9 @@ public:
   virtual Teuchos::RCP<CloneableEvaluator> clone(const Teuchos::ParameterList & pl) const
   { return Teuchos::rcp(new ScatterDirichletResidual_BlockedTpetra<EvalT,TRAITS,LO,GO,NodeT>(Teuchos::null,pl)); }
 
-  void postRegistrationSetup(typename TRAITS::SetupData d, PHX::FieldManager<TRAITS>& vm) 
+  void postRegistrationSetup(typename TRAITS::SetupData /* d */, PHX::FieldManager<TRAITS>& /* vm */) 
    { }
-  void evaluateFields(typename TRAITS::EvalData d) 
+  void evaluateFields(typename TRAITS::EvalData /* d */) 
    { std::cout << "unspecialized version of \"ScatterDirichletResidual_BlockedTpetra::evaluateFields\" on \""+PHX::typeAsString<EvalT>()+"\" should not be used!" << std::endl;
     TEUCHOS_ASSERT(false); }
 };

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_Hessian_impl.hpp
@@ -55,7 +55,7 @@ namespace panzer {
 // **************************************************************
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 ScatterDirichletResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer,
+ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */,
                                       const Teuchos::ParameterList& p)
 {
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -70,22 +70,22 @@ ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManage
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterDirichletResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& vm)
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
+                      PHX::FieldManager<TRAITS>& /* vm */)
 {
 }
 
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterDirichletResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-preEvaluate(typename TRAITS::PreEvalData d)
+preEvaluate(typename TRAITS::PreEvalData /* d */)
 {
 }
   
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterDirichletResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-evaluateFields(typename TRAITS::EvalData workset)
+evaluateFields(typename TRAITS::EvalData /* workset */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                              "ScatterDirichletResidual_BlockedTpetra<Hessian> is not yet implemented"); // just in case

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_impl.hpp
@@ -70,7 +70,7 @@
 
 template <typename EvalT,typename TRAITS,typename LO,typename GO,typename NodeT>
 panzer::ScatterDirichletResidual_BlockedTpetra<EvalT,TRAITS,LO,GO,NodeT>::
-ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer,
+ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */,
                                        const Teuchos::ParameterList& p)
 { 
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -162,7 +162,7 @@ ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManage
 // **********************************************************************
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterDirichletResidual_BlockedTpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -367,7 +367,7 @@ ScatterDirichletResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManage
 // **********************************************************************
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterDirichletResidual_BlockedTpetra<panzer::Traits::Jacobian, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_Hessian_impl.hpp
@@ -116,7 +116,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO>
 void
 ScatterDirichletResidual_Epetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm) 
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_decl.hpp
@@ -93,7 +93,7 @@ class ScatterDirichletResidual_Epetra<panzer::Traits::Residual,TRAITS,LO,GO>
   
 public:
   ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,
-                                  const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer=Teuchos::null)
+                                  const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer=Teuchos::null */)
      : globalIndexer_(indexer) {}
   
   ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,
@@ -163,7 +163,7 @@ class ScatterDirichletResidual_Epetra<panzer::Traits::Tangent,TRAITS,LO,GO>
   
 public:
   ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,
-                                  const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer=Teuchos::null)
+                                  const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer=Teuchos::null */)
      : globalIndexer_(indexer) {}
   
   ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_impl.hpp
@@ -70,7 +70,7 @@
 template<typename TRAITS,typename LO,typename GO>
 panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,
-                                const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer,
+                                const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer */,
                                 const Teuchos::ParameterList& p)
    : globalIndexer_(indexer)
    , globalDataKey_("Residual Scatter Container")
@@ -127,7 +127,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Residual, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -259,7 +259,7 @@ evaluateFields(typename TRAITS::EvalData workset)
 template<typename TRAITS,typename LO,typename GO>
 panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,
-                                const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer,
+                                const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer */,
                                 const Teuchos::ParameterList& p)
    : globalIndexer_(indexer)
    , globalDataKey_("Residual Scatter Container")
@@ -316,7 +316,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -540,7 +540,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Tpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Tpetra_Hessian_impl.hpp
@@ -56,7 +56,7 @@ namespace panzer {
 // **************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 ScatterDirichletResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & indexer,
+ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & /* indexer */,
                                 const Teuchos::ParameterList& p) 
 {
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -71,22 +71,22 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterDirichletResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& vm) 
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
+                      PHX::FieldManager<TRAITS>& /* vm */) 
 {
 }
 
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterDirichletResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-preEvaluate(typename TRAITS::PreEvalData d) 
+preEvaluate(typename TRAITS::PreEvalData /* d */) 
 {
 }
   
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterDirichletResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-evaluateFields(typename TRAITS::EvalData workset) 
+evaluateFields(typename TRAITS::EvalData /* workset */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                              "ScatterDirichletResidual_Tpetra<Hessian> is not yet implemented"); // just in case

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Tpetra_impl.hpp
@@ -122,7 +122,7 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT> 
 void panzer::ScatterDirichletResidual_Tpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -319,7 +319,7 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT> 
 void panzer::ScatterDirichletResidual_Tpetra<panzer::Traits::Tangent, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -547,7 +547,7 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT> 
 void panzer::ScatterDirichletResidual_Tpetra<panzer::Traits::Jacobian, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_Hessian_impl.hpp
@@ -109,7 +109,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 template<typename TRAITS,typename LO,typename GO>
 void
 ScatterResidual_BlockedEpetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm) 
 {
   indexerIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_decl.hpp
@@ -109,8 +109,8 @@ class ScatterResidual_BlockedEpetra<panzer::Traits::Residual,TRAITS,LO,GO>
 public:
 
   ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
-                                const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
-                                bool useDiscreteAdjoint=false)
+                                const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & /* cIndexers */,
+                                bool /* useDiscreteAdjoint=false */)
      : rowIndexers_(rIndexers) {}
   
   ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
@@ -168,8 +168,8 @@ class ScatterResidual_BlockedEpetra<panzer::Traits::Tangent,TRAITS,LO,GO>
 public:
 
   ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
-                                const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
-                                bool useDiscreteAdjoint=false)
+                                const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & /* cIndexers */,
+                                bool /* useDiscreteAdjoint=false */)
      : rowIndexers_(rIndexers) {}
   
   ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_impl.hpp
@@ -79,7 +79,7 @@ panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
                               const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
                               const Teuchos::ParameterList& p,
-                              bool useDiscreteAdjoint)
+                              bool /* useDiscreteAdjoint */)
   : rowIndexers_(rIndexers) 
   , colIndexers_(cIndexers) 
   , globalDataKey_("Residual Scatter Container")
@@ -112,8 +112,6 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 
   if (p.isType<std::string>("Global Data Key"))
      globalDataKey_ = p.get<std::string>("Global Data Key");
-  if (p.isType<bool>("Use Discrete Adjoint"))
-     useDiscreteAdjoint = p.get<bool>("Use Discrete Adjoint");
 
   this->setName(scatterName+" Scatter Residual");
 }
@@ -121,7 +119,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Residual, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
 		      PHX::FieldManager<TRAITS>& fm)
 {
   indexerIds_.resize(scatterFields_.size());
@@ -220,7 +218,7 @@ panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & rIndexers,
                               const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,int> > > & cIndexers,
                               const Teuchos::ParameterList& p,
-                              bool useDiscreteAdjoint)
+                              bool /* useDiscreteAdjoint */)
   : rowIndexers_(rIndexers) 
   , colIndexers_(cIndexers) 
   , globalDataKey_("Residual Scatter Container")
@@ -260,7 +258,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
 		      PHX::FieldManager<TRAITS>& fm)
 {
   indexerIds_.resize(scatterFields_.size());
@@ -411,7 +409,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
 		      PHX::FieldManager<TRAITS>& fm)
 {
   indexerIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra.hpp
@@ -74,7 +74,7 @@ class ScatterResidual_BlockedTpetra
 public:
    typedef typename EvalT::ScalarT ScalarT;
  
-   ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer)
+   ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */)
    { }
    ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & gidProviders,
                                 const Teuchos::ParameterList& p);
@@ -82,9 +82,9 @@ public:
    virtual Teuchos::RCP<CloneableEvaluator> clone(const Teuchos::ParameterList & pl) const
    { return Teuchos::rcp(new ScatterResidual_BlockedTpetra<EvalT,TRAITS,LO,GO,NodeT>(Teuchos::null,pl)); }
 
-  void postRegistrationSetup(typename TRAITS::SetupData d, PHX::FieldManager<TRAITS>& vm)
+  void postRegistrationSetup(typename TRAITS::SetupData /* d */, PHX::FieldManager<TRAITS>& /* vm */)
    { }
-  void evaluateFields(typename TRAITS::EvalData d)
+  void evaluateFields(typename TRAITS::EvalData /* d */)
    { std::cout << "unspecialized version of \"ScatterResidual_BlockedTpetra::evaluateFields\" on \""+PHX::typeAsString<EvalT>()+"\" should not be used!" << std::endl;
      TEUCHOS_ASSERT(false); }
 };

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_Hessian_impl.hpp
@@ -56,7 +56,7 @@ namespace panzer {
 
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 ScatterResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer,
+ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */,
                               const Teuchos::ParameterList& p) 
 {
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -71,22 +71,22 @@ ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> 
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& vm) 
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
+                      PHX::FieldManager<TRAITS>& /* vm */) 
 {
 }
 
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-preEvaluate(typename TRAITS::PreEvalData d) 
+preEvaluate(typename TRAITS::PreEvalData /* d */) 
 {
 }
 
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterResidual_BlockedTpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-evaluateFields(typename TRAITS::EvalData workset) 
+evaluateFields(typename TRAITS::EvalData /* workset */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                              "ScatterResidual_BlockedTpetra<Hessian> is not yet implemented"); // just in case

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_impl.hpp
@@ -65,7 +65,7 @@
 
 template <typename EvalT,typename TRAITS,typename LO,typename GO,typename NodeT>
 panzer::ScatterResidual_BlockedTpetra<EvalT,TRAITS,LO,GO,NodeT>::
-ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & indexer,
+ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> > & /* indexer */,
                               const Teuchos::ParameterList& p)
 { 
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -139,7 +139,7 @@ ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> 
 // **********************************************************************
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_BlockedTpetra<panzer::Traits::Residual,TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
 		      PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -277,7 +277,7 @@ ScatterResidual_BlockedTpetra(const Teuchos::RCP<const BlockedDOFManager<LO,GO> 
 // **********************************************************************
 template <typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_BlockedTpetra<panzer::Traits::Jacobian,TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
 		      PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_Hessian_impl.hpp
@@ -123,7 +123,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & i
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Hessian, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_decl.hpp
@@ -102,7 +102,7 @@ class ScatterResidual_Epetra<panzer::Traits::Residual,TRAITS,LO,GO>
   
 public:
   ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer,
-                         const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer=Teuchos::null,
+                         const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer=Teuchos::null */,
                          bool useDiscreteAdjoint=false) 
      : globalIndexer_(indexer),useDiscreteAdjoint_(useDiscreteAdjoint)  {}
   
@@ -158,7 +158,7 @@ class ScatterResidual_Epetra<panzer::Traits::Tangent,TRAITS,LO,GO>
   
 public:
   ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer,
-                         const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer=Teuchos::null,
+                         const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer=Teuchos::null */,
                          bool useDiscreteAdjoint=false) 
      : globalIndexer_(indexer),useDiscreteAdjoint_(useDiscreteAdjoint)  {}
   

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_impl.hpp
@@ -70,7 +70,7 @@
 template<typename TRAITS,typename LO,typename GO>
 panzer::ScatterResidual_Epetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer,
-                       const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer,
+                       const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer */,
                        const Teuchos::ParameterList& p,
                        bool useDiscreteAdjoint)
   : globalIndexer_(indexer) 
@@ -112,7 +112,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Residual, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -188,9 +188,9 @@ evaluateFields(typename TRAITS::EvalData workset)
 template<typename TRAITS,typename LO,typename GO>
 panzer::ScatterResidual_Epetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer,
-                       const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & cIndexer,
+                       const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* cIndexer */,
                        const Teuchos::ParameterList& p,
-                       bool useDiscreteAdjoint)
+                       bool /* useDiscreteAdjoint */)
   : globalIndexer_(indexer) 
 { 
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -225,7 +225,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d, 
+postRegistrationSetup(typename TRAITS::SetupData /* d */, 
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -356,7 +356,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & i
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   // globalIndexer_ = d.globalIndexer_;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_Hessian_impl.hpp
@@ -56,7 +56,7 @@ namespace panzer {
 // **************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 ScatterResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & indexer,
+ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & /* indexer */,
                        const Teuchos::ParameterList& p) 
 {
   std::string scatterName = p.get<std::string>("Scatter Name");
@@ -71,22 +71,22 @@ ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& vm) 
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
+                      PHX::FieldManager<TRAITS>& /* vm */) 
 {
 }
 
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-preEvaluate(typename TRAITS::PreEvalData d) 
+preEvaluate(typename TRAITS::PreEvalData /* d */) 
 {
 }
   
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void
 ScatterResidual_Tpetra<panzer::Traits::Hessian,TRAITS,LO,GO,NodeT>::
-evaluateFields(typename TRAITS::EvalData workset) 
+evaluateFields(typename TRAITS::EvalData /* workset */) 
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                              "ScatterResidual_Tpetra<Hessian> is not yet implemented"); // just in case

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_impl.hpp
@@ -108,7 +108,7 @@ ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_Tpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());
@@ -228,7 +228,7 @@ ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_Tpetra<panzer::Traits::Tangent, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   fieldIds_.resize(scatterFields_.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_impl.hpp
@@ -79,7 +79,7 @@ PHX_EVALUATOR_CTOR(SubcellSum,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(SubcellSum,sd,fm)
+PHX_POST_REGISTRATION_SETUP(SubcellSum, /* sd */, fm)
 {
   this->utils.setFieldData(inField,fm);
   this->utils.setFieldData(outField,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
@@ -104,7 +104,7 @@ PHX_EVALUATOR_CTOR(Sum,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Sum,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(Sum, /* worksets */, fm)
 {
   this->utils.setFieldData(sum,fm);
   for (std::size_t i=0; i < scalars.dimension_0(); ++i)
@@ -175,7 +175,7 @@ void Sum<EvalT, TRAITS>::operator() (PanzerSumTag<RANK>, const int &i) const{
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Sum,workset)
+PHX_EVALUATE_FIELDS(Sum, /* workset */)
 {   
 
   sum.deep_copy(ScalarT(0.0));
@@ -261,7 +261,7 @@ SumStatic(const Teuchos::ParameterList& p)
 
 template<typename EvalT, typename TRAITS,typename Tag0>
 void SumStatic<EvalT,TRAITS,Tag0,void,void>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   this->utils.setFieldData(sum,fm);
@@ -273,7 +273,7 @@ postRegistrationSetup(typename TRAITS::SetupData d,
 
 template<typename EvalT, typename TRAITS,typename Tag0>
 void SumStatic<EvalT,TRAITS,Tag0,void,void>::
-evaluateFields(typename TRAITS::EvalData d)
+evaluateFields(typename TRAITS::EvalData /* d */)
 {
   sum.deep_copy(ScalarT(0.0));
   for (std::size_t i = 0; i < sum.dimension_0(); ++i)
@@ -338,7 +338,7 @@ SumStatic(const Teuchos::ParameterList& p)
 
 template<typename EvalT, typename TRAITS,typename Tag0,typename Tag1>
 void SumStatic<EvalT,TRAITS,Tag0,Tag1,void>::
-postRegistrationSetup(typename TRAITS::SetupData d,
+postRegistrationSetup(typename TRAITS::SetupData /* d */,
                       PHX::FieldManager<TRAITS>& fm)
 {
   this->utils.setFieldData(sum,fm);
@@ -352,7 +352,7 @@ postRegistrationSetup(typename TRAITS::SetupData d,
 
 template<typename EvalT, typename TRAITS,typename Tag0,typename Tag1>
 void SumStatic<EvalT,TRAITS,Tag0,Tag1,void>::
-evaluateFields(typename TRAITS::EvalData d)
+evaluateFields(typename TRAITS::EvalData /* d */)
 {
   sum.deep_copy(ScalarT(0.0));
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_impl.hpp
@@ -78,7 +78,7 @@ PHX_EVALUATOR_CTOR(TensorToStdVector, p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(TensorToStdVector, worksets, fm)
+PHX_POST_REGISTRATION_SETUP(TensorToStdVector, /* worksets */, fm)
 {
   for (std::size_t i=0; i < vector_fields.size(); ++i)
     this->utils.setFieldData(vector_fields[i], fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_impl.hpp
@@ -68,7 +68,7 @@ PHX_EVALUATOR_CTOR(TestScatter,p)
   this->setName(n);
 }
 
-PHX_POST_REGISTRATION_SETUP(TestScatter,setupData,fm)
+PHX_POST_REGISTRATION_SETUP(TestScatter, /* setupData */, fm)
 {
   this->utils.setFieldData(scatter_value,fm);
   this->utils.setFieldData(value,fm);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_impl.hpp
@@ -78,7 +78,7 @@ PHX_EVALUATOR_CTOR(VectorToScalar,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(VectorToScalar,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(VectorToScalar, /* worksets */, fm)
 {
   for (std::size_t i=0; i < scalar_fields.size(); ++i)
     this->utils.setFieldData(scalar_fields[i],fm);

--- a/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory.hpp
@@ -101,10 +101,10 @@ public:
 
 /*************** Linear object factory methods *******************/
 
-   virtual void readVector(const std::string & identifier,LinearObjContainer & loc,int id) const 
+   virtual void readVector(const std::string & /* identifier */, LinearObjContainer & /* loc */, int /* id */) const 
    { TEUCHOS_ASSERT(false); }
 
-   virtual void writeVector(const std::string & identifier,const LinearObjContainer & loc,int id) const
+   virtual void writeVector(const std::string & /* identifier */, const LinearObjContainer & /* loc */, int /* id */) const
    { TEUCHOS_ASSERT(false); }
 
    virtual Teuchos::RCP<LinearObjContainer> buildLinearObjContainer() const;

--- a/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory_impl.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory_impl.hpp
@@ -320,8 +320,8 @@ adjustForDirichletConditions(const VectorType & local_bcs,
 
 template <typename Traits,typename ScalarT,typename LocalOrdinalT,typename GlobalOrdinalT,typename NodeT>
 void BlockedTpetraLinearObjFactory<Traits,ScalarT,LocalOrdinalT,GlobalOrdinalT,NodeT>::
-applyDirichletBCs(const LinearObjContainer & counter,
-                  LinearObjContainer & result) const
+applyDirichletBCs(const LinearObjContainer & /* counter */,
+                  LinearObjContainer & /* result */) const
 {
   TEUCHOS_ASSERT(false); // not yet implemented
 }

--- a/packages/panzer/disc-fe/src/lof/Panzer_LinearObjFactory.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_LinearObjFactory.hpp
@@ -273,8 +273,8 @@ public:
    //! Get the range global indexer object associated with this factory
    virtual Teuchos::RCP<const panzer::UniqueGlobalIndexerBase> getRangeGlobalIndexer() const = 0;
 
-   virtual void beginFill(LinearObjContainer & loc) const {}
-   virtual void endFill(LinearObjContainer & loc) const {}
+   virtual void beginFill(LinearObjContainer & /* loc */) const {}
+   virtual void endFill(LinearObjContainer & /* loc */) const {}
 
 private:
    typedef PHX::TemplateManager<typename Traits::EvalTypes,

--- a/packages/panzer/disc-fe/src/lof/Panzer_TpetraLinearObjFactory_decl.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_TpetraLinearObjFactory_decl.hpp
@@ -94,10 +94,10 @@ public:
 
 /*************** Linear object factory methods *******************/
 
-   virtual void readVector(const std::string & identifier,LinearObjContainer & loc,int id) const 
+   virtual void readVector(const std::string & /* identifier */, LinearObjContainer & /* loc */, int /* id */) const 
    { TEUCHOS_ASSERT(false); }
 
-   virtual void writeVector(const std::string & identifier,const LinearObjContainer & loc,int id) const
+   virtual void writeVector(const std::string & /* identifier */, const LinearObjContainer & /* loc */, int /* id */) const
    { TEUCHOS_ASSERT(false); }
 
    virtual Teuchos::RCP<LinearObjContainer> buildLinearObjContainer() const;

--- a/packages/panzer/disc-fe/src/lof/Panzer_TpetraLinearObjFactory_impl.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_TpetraLinearObjFactory_impl.hpp
@@ -292,8 +292,8 @@ adjustForDirichletConditions(const LinearObjContainer & localBCRows,
 template <typename Traits,typename ScalarT,typename LocalOrdinalT,typename GlobalOrdinalT,typename NodeT>
 void 
 TpetraLinearObjFactory<Traits,ScalarT,LocalOrdinalT,GlobalOrdinalT,NodeT>::
-applyDirichletBCs(const LinearObjContainer & counter,
-                  LinearObjContainer & result) const
+applyDirichletBCs(const LinearObjContainer & /* counter */,
+                  LinearObjContainer & /* result */) const
 {
   TEUCHOS_ASSERT(false); // not yet implemented
 }

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_Functional.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_Functional.hpp
@@ -85,7 +85,7 @@ public:
    virtual Teuchos::RCP<ResponseBase> buildResponseObject(const std::string & responseName) const;
 
    virtual Teuchos::RCP<ResponseBase> buildResponseObject(const std::string & responseName,
-                                                          const std::vector<WorksetDescriptor> & wkstDesc) const 
+                                                          const std::vector<WorksetDescriptor> & /* wkstDesc */) const 
    { return buildResponseObject(responseName); }
 
    /** Build and register evaluators for a response on a particular physics

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_Functional_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_Functional_impl.hpp
@@ -72,7 +72,7 @@ void ResponseEvaluatorFactory_Functional<EvalT,LO,GO>::
 buildAndRegisterEvaluators(const std::string & responseName,
                            PHX::FieldManager<panzer::Traits> & fm,
                            const panzer::PhysicsBlock & physicsBlock,
-                           const Teuchos::ParameterList & user_data) const
+                           const Teuchos::ParameterList & /* user_data */) const
 {
    using Teuchos::RCP;
    using Teuchos::rcp;

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_IPCoordinates_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_IPCoordinates_impl.hpp
@@ -78,8 +78,8 @@ template <typename EvalT>
 void ResponseEvaluatorFactory_IPCoordinates<EvalT>::
 buildAndRegisterEvaluators(const std::string & responseName,
                            PHX::FieldManager<panzer::Traits> & fm,
-                           const panzer::PhysicsBlock & physicsBlock,
-                           const Teuchos::ParameterList & user_data) const
+                           const panzer::PhysicsBlock& /* physicsBlock */,
+                           const Teuchos::ParameterList& /* user_data */) const
 {
    using Teuchos::RCP;
    using Teuchos::rcp;

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseFactory_BCStrategyAdapter.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseFactory_BCStrategyAdapter.hpp
@@ -86,7 +86,7 @@ namespace response_bc_adapters {
     //! \name Derived from BCStrategy
     //@{ 
 
-    virtual void setup(const panzer::PhysicsBlock& side_pb, const Teuchos::ParameterList& user_data) {}
+    virtual void setup(const panzer::PhysicsBlock& /* side_pb */, const Teuchos::ParameterList& /* user_data */) {}
       
     virtual void buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 					    const panzer::PhysicsBlock& side_pb,
@@ -107,10 +107,10 @@ namespace response_bc_adapters {
     }
 
     virtual void 
-    buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::PhysicsBlock& side_pb,
-				      const LinearObjFactory<panzer::Traits> & lof,
-				      const Teuchos::ParameterList& user_data) const {}
+    buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+				      const panzer::PhysicsBlock& /* side_pb */,
+				      const LinearObjFactory<panzer::Traits> & /* lof */,
+				      const Teuchos::ParameterList& /* user_data */) const {}
 
     virtual void
     buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>& fm,
@@ -173,7 +173,7 @@ namespace response_bc_adapters {
       : hashMap_(hashMap) {}
 
     Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> >
-    buildBCStrategy(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data) const
+    buildBCStrategy(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& /* global_data */) const
     {
       Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> > bcstrategy_tm 
           = Teuchos::rcp(new panzer::BCStrategy_TemplateManager<panzer::Traits>);

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue_impl.hpp
@@ -134,7 +134,7 @@ preEvaluate(typename Traits::PreEvalData d)
 
 template<typename EvalT, typename Traits>
 void ResponseScatterEvaluator_ExtremeValue<EvalT,Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
+postRegistrationSetup(typename Traits::SetupData /* d */,
                       PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(cellExtremeValue_,fm);

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Functional_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Functional_impl.hpp
@@ -133,7 +133,7 @@ preEvaluate(typename Traits::PreEvalData d)
 
 template<typename EvalT, typename Traits>
 void ResponseScatterEvaluator_Functional<EvalT,Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
+postRegistrationSetup(typename Traits::SetupData /* d */,
                       PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(cellIntegral_,fm);

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_IPCoordinates_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_IPCoordinates_impl.hpp
@@ -94,7 +94,7 @@ preEvaluate(typename Traits::PreEvalData d)
 template<typename EvalT, typename Traits>
 void ResponseScatterEvaluator_IPCoordinates<EvalT,Traits>::
 postRegistrationSetup(typename Traits::SetupData sd,
-                      PHX::FieldManager<Traits>& fm)
+                      PHX::FieldManager<Traits>& /* fm */)
 {
   ir_index_ = panzer::getIntegrationRuleIndex(ir_order_,(*sd.worksets_)[0], this->wda);
 }
@@ -124,7 +124,7 @@ evaluateFields(typename Traits::EvalData workset)
 //**********************************************************************
 template<typename EvalT, typename Traits>
 void ResponseScatterEvaluator_IPCoordinates<EvalT,Traits>::
-postEvaluate(typename Traits::PostEvalData data)
+postEvaluate(typename Traits::PostEvalData /* data */)
 {
   std::vector<panzer::Traits::Residual::ScalarT> & coords = *responseObj_->getNonconstCoords();
   coords.clear();

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Probe_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Probe_impl.hpp
@@ -127,7 +127,7 @@ preEvaluate(typename Traits::PreEvalData d)
 
 template<typename EvalT, typename Traits, typename LO, typename GO>
 void ResponseScatterEvaluator_ProbeBase<EvalT,Traits,LO,GO>::
-postRegistrationSetup(typename Traits::SetupData d,
+postRegistrationSetup(typename Traits::SetupData /* d */,
                       PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(field_,fm);

--- a/packages/panzer/disc-fe/src/responses/Panzer_Response_ExtremeValue_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_Response_ExtremeValue_impl.hpp
@@ -161,7 +161,7 @@ scatterResponse()
 // Do nothing unless derivatives are actually required
 template <typename EvalT>
 void Response_ExtremeValue<EvalT>::
-setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & soln_vs) { }
+setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & /* soln_vs */) { }
 
 // derivatives are required for
 template < >
@@ -184,7 +184,7 @@ setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & s
 // Do nothing unless derivatives are required
 template <typename EvalT>
 void Response_ExtremeValue<EvalT>::
-adjustForDirichletConditions(const GlobalEvaluationData & localBCRows,const GlobalEvaluationData & globalBCRows) { }
+adjustForDirichletConditions(const GlobalEvaluationData & /* localBCRows */, const GlobalEvaluationData & /* globalBCRows */) { }
 
 // Do nothing unless derivatives are required
 template < >

--- a/packages/panzer/disc-fe/src/responses/Panzer_Response_Functional_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_Response_Functional_impl.hpp
@@ -157,7 +157,7 @@ scatterResponse()
 // Do nothing unless derivatives are actually required
 template <typename EvalT>
 void Response_Functional<EvalT>::
-setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & soln_vs) { }
+setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & /* soln_vs */) { }
 
 // derivatives are required for
 template < >
@@ -180,7 +180,7 @@ setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & s
 // Do nothing unless derivatives are required
 template <typename EvalT>
 void Response_Functional<EvalT>::
-adjustForDirichletConditions(const GlobalEvaluationData & localBCRows,const GlobalEvaluationData & globalBCRows) { }
+adjustForDirichletConditions(const GlobalEvaluationData & /* localBCRows */, const GlobalEvaluationData & /* globalBCRows */) { }
 
 // Do nothing unless derivatives are required
 template < >

--- a/packages/panzer/disc-fe/src/responses/Panzer_Response_Probe_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_Response_Probe_impl.hpp
@@ -189,7 +189,7 @@ scatterResponse()
 // Do nothing unless derivatives are actually required
 template <typename EvalT>
 void Response_Probe<EvalT>::
-setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & soln_vs) { }
+setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & /* soln_vs */) { }
 
 // derivatives are required for
 template < >
@@ -212,7 +212,7 @@ setSolnVectorSpace(const Teuchos::RCP<const Thyra::VectorSpaceBase<double> > & s
 // Do nothing unless derivatives are required
 template <typename EvalT>
 void Response_Probe<EvalT>::
-adjustForDirichletConditions(const GlobalEvaluationData & localBCRows,const GlobalEvaluationData & globalBCRows) { }
+adjustForDirichletConditions(const GlobalEvaluationData & /* localBCRows */, const GlobalEvaluationData & /* globalBCRows */) { }
 
 // Do nothing unless derivatives are required
 template < >

--- a/packages/panzer/disc-fe/src/responses/Panzer_Response_Residual.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_Response_Residual.hpp
@@ -64,7 +64,7 @@ template <typename EvalT>
 class Response_Residual : public ResponseBase {
 public:
   Response_Residual(const std::string & responseName,
-                     const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > & lof) :
+                     const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > & /* lof */) :
     ResponseBase(responseName) {}
   virtual ~Response_Residual() {}
   virtual void scatterResponse() {}

--- a/packages/panzer/disc-fe/test/closure_model/user_app_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/disc-fe/test/closure_model/user_app_ClosureModel_Factory_impl.hpp
@@ -77,7 +77,7 @@ buildClosureModels(const std::string& model_id,
     const Teuchos::ParameterList& models,
     const panzer::FieldLayoutLibrary& fl,
     const Teuchos::RCP<panzer::IntegrationRule>& ir,
-    const Teuchos::ParameterList& default_params,
+    const Teuchos::ParameterList& /* default_params */,
     const Teuchos::ParameterList& user_data,
     const Teuchos::RCP<panzer::GlobalData>& global_data,
     PHX::FieldManager<panzer::Traits>& fm) const

--- a/packages/panzer/disc-fe/test/closure_model_composite/user_app_ClosureModel_Factory_Physics1_impl.hpp
+++ b/packages/panzer/disc-fe/test/closure_model_composite/user_app_ClosureModel_Factory_Physics1_impl.hpp
@@ -71,10 +71,10 @@ buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models,
 		   const panzer::FieldLayoutLibrary& fl,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir, 
-		   const Teuchos::ParameterList& default_params,
-		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
 
   using std::string;

--- a/packages/panzer/disc-fe/test/closure_model_composite/user_app_ClosureModel_Factory_Physics2_impl.hpp
+++ b/packages/panzer/disc-fe/test/closure_model_composite/user_app_ClosureModel_Factory_Physics2_impl.hpp
@@ -69,9 +69,9 @@ Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
 user_app::MyModelFactory_Physics2<EvalT>::
 buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models, 
-		   const panzer::FieldLayoutLibrary& fl,
+		   const panzer::FieldLayoutLibrary& /* fl */,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
+		   const Teuchos::ParameterList& /* default_params */,
 		   const Teuchos::ParameterList& user_data,
 		   const Teuchos::RCP<panzer::GlobalData>& global_data,
 		   PHX::FieldManager<panzer::Traits>& fm) const

--- a/packages/panzer/disc-fe/test/dofmngr_test/TestFieldPattern.hpp
+++ b/packages/panzer/disc-fe/test/dofmngr_test/TestFieldPattern.hpp
@@ -56,7 +56,7 @@ public:
    /* This function has no functionality in this case.
     * If called it will throw an assertion failure
     */
-   virtual void getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+   virtual void getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int> & /* indices */) const
    { TEUCHOS_ASSERT(false); }
 
    virtual int getSubcellCount(int dim) const

--- a/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_ConnManager.cpp
+++ b/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_ConnManager.cpp
@@ -120,7 +120,7 @@ const typename ConnManager<GO>::GlobalOrdinal * ConnManager<GO>::getConnectivity
 }
 
 template <typename GO>
-typename ConnManager<GO>::LocalOrdinal ConnManager<GO>::getConnectivitySize(typename ConnManager<GO>::LocalOrdinal localElmtId) const
+typename ConnManager<GO>::LocalOrdinal ConnManager<GO>::getConnectivitySize(typename ConnManager<GO>::LocalOrdinal /* localElmtId */) const
 { return 4; }
 
 template <typename GO>

--- a/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_ConnManager.hpp
+++ b/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_ConnManager.hpp
@@ -195,7 +195,7 @@ public:
    { static std::vector<int> empty; return empty; }
 
    //! Not used.
-   virtual const std::vector<int>& getAssociatedNeighbors(const LocalOrdinal& el) const
+   virtual const std::vector<int>& getAssociatedNeighbors(const LocalOrdinal& /* el */) const
    { static std::vector<int> empty; return empty; }
    //! Not used.
    virtual bool hasAssociatedNeighbors() const { return false; }

--- a/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_UniqueGlobalIndexer.cpp
+++ b/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_UniqueGlobalIndexer.cpp
@@ -127,7 +127,7 @@ const std::vector<short> & UniqueGlobalIndexer::getElementBlock(const std::strin
                       "Can't find block ID \"" << blockId << "\" in unit_test::UniqueGlobalIndexer");
 }
 
-void UniqueGlobalIndexer::getElementGIDs(short localElmtId,std::vector<int> & gids,const std::string & blockId) const
+void UniqueGlobalIndexer::getElementGIDs(short localElmtId,std::vector<int> & gids,const std::string & /* blockId */) const
 {
    if(localElmtId==0) {
       gids.resize(8);
@@ -209,8 +209,8 @@ const std::vector<int> & UniqueGlobalIndexer::getGIDFieldOffsets(const std::stri
 }
 
 const std::pair<std::vector<int>,std::vector<int> > & 
-UniqueGlobalIndexer::getGIDFieldOffsets_closure(const std::string & blockId, int fieldNum,
-                                                int subcellDim,int subcellId) const
+UniqueGlobalIndexer::getGIDFieldOffsets_closure(const std::string & /* blockId */, int /* fieldNum */,
+                                                int /* subcellDim */, int /* subcellId */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                       "unit_test::UniqueGlobalIndexer::getGIDFieldOffsets_closure is not implemented yet.");

--- a/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_UniqueGlobalIndexer.hpp
+++ b/packages/panzer/disc-fe/test/dofmngr_test/UnitTest_UniqueGlobalIndexer.hpp
@@ -116,7 +116,7 @@ public:
      */
    virtual void getElementGIDs(short localElmtId,std::vector<int> & gids,const std::string & blockId="") const;
 
-   virtual void getElementOrientation(short localElmtId,std::vector<double> & gidsOrientation) const
+   virtual void getElementOrientation(short /* localElmtId */, std::vector<double> & /* gidsOrientation */) const
    { TEUCHOS_ASSERT(false); }
 
    /** \brief Use the field pattern so that you can find a particular

--- a/packages/panzer/disc-fe/test/equation_set/user_app_Convection_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_Convection_impl.hpp
@@ -81,7 +81,7 @@ PHX_EVALUATOR_CTOR(Convection,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Convection,worksets,fm)
+PHX_POST_REGISTRATION_SETUP(Convection, /* worksets */, fm)
 {
   this->utils.setFieldData(conv,fm);
   this->utils.setFieldData(a,fm);

--- a/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_Energy_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_Energy_impl.hpp
@@ -124,8 +124,8 @@ EquationSet_Energy(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void user_app::EquationSet_Energy<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_MeshCoords_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_MeshCoords_impl.hpp
@@ -120,8 +120,8 @@ EquationSet_MeshCoords(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void user_app::EquationSet_MeshCoords<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& fl,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/disc-fe/test/evaluator_tests/UnitValueEvaluator.hpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/UnitValueEvaluator.hpp
@@ -74,13 +74,13 @@ PHX_EVALUATOR_CTOR(UnitValueEvaluator,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(UnitValueEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(UnitValueEvaluator, /* sd */, fm)
 {
   this->utils.setFieldData(unitValue,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(UnitValueEvaluator,workset)
+PHX_EVALUATE_FIELDS(UnitValueEvaluator, /* workset */)
 { 
   for(int cell=0;cell<unitValue.extent_int(0);++cell)
     for(int ip=0;ip<unitValue.extent_int(1);++ip)

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
@@ -102,14 +102,14 @@ PHX_EVALUATOR_CTOR(DummyFieldEvaluator,p)
   std::string n = "DummyFieldEvaluator: " + name;
   this->setName(n);
 }
-PHX_POST_REGISTRATION_SETUP(DummyFieldEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(DummyFieldEvaluator, /* sd */, fm)
 {
   this->utils.setFieldData(fieldValue,fm);
 
   
 }
 
-PHX_EVALUATE_FIELDS(DummyFieldEvaluator,workset)
+PHX_EVALUATE_FIELDS(DummyFieldEvaluator, /* workset */)
 { 
   fieldValue(0,0) = 1.0;
   fieldValue(0,1) = 2.0;

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_pointfield.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_pointfield.cpp
@@ -102,9 +102,9 @@ PHX_EVALUATOR_CTOR(DummyFieldEvaluator,p)
   std::string n = "DummyFieldEvaluator: " + name;
   this->setName(n);
 }
-PHX_POST_REGISTRATION_SETUP(DummyFieldEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(DummyFieldEvaluator, /* sd */, fm)
 { this->utils.setFieldData(fieldValue,fm); }
-PHX_EVALUATE_FIELDS(DummyFieldEvaluator,workset)
+PHX_EVALUATE_FIELDS(DummyFieldEvaluator, /* workset */)
 { 
   int i = 0;
   for(int cell=0;cell<fieldValue.extent_int(0);cell++) {
@@ -137,9 +137,9 @@ PHX_EVALUATOR_CTOR(RefCoordEvaluator,p)
   std::string n = "RefCoordEvaluator: " + name;
   this->setName(n);
 }
-PHX_POST_REGISTRATION_SETUP(RefCoordEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(RefCoordEvaluator, /* sd */, fm)
 { this->utils.setFieldData(fieldValue,fm); }
-PHX_EVALUATE_FIELDS(RefCoordEvaluator,workset)
+PHX_EVALUATE_FIELDS(RefCoordEvaluator, /* workset */)
 { 
   for(int cell=0;cell<fieldValue.extent_int(0);cell++)
     for(int pt=0;pt<fieldValue.extent_int(1);pt++)

--- a/packages/panzer/disc-fe/test/evaluator_tests/hessian_test.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/hessian_test.cpp
@@ -80,7 +80,7 @@ namespace panzer {
   * \param[in] xi Value of the x vector to seed with
   * \param[in] vi Value of the v vector to seed with
   */
-inline panzer::Traits::HessianType seed_second_deriv(int num_vars,int index,double xi,double vi)
+inline panzer::Traits::HessianType seed_second_deriv(int num_vars, int index, double /* xi */, double vi)
 {
   typedef panzer::Traits::HessianType SecondFadType;
 
@@ -106,7 +106,7 @@ public:
 PHX_EVALUATOR_CLASS_END
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(InputConditionsEvaluator,p)
+PHX_EVALUATOR_CTOR(InputConditionsEvaluator, /* p */)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -134,7 +134,7 @@ PHX_EVALUATOR_CTOR(InputConditionsEvaluator,p)
 
 //**********************************************************************
 
-PHX_POST_REGISTRATION_SETUP(InputConditionsEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(InputConditionsEvaluator, /* sd */, fm)
 {
   this->utils.setFieldData(x,fm);
   this->utils.setFieldData(y,fm);
@@ -143,7 +143,7 @@ PHX_POST_REGISTRATION_SETUP(InputConditionsEvaluator,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(InputConditionsEvaluator,workset)
+PHX_EVALUATE_FIELDS(InputConditionsEvaluator, /* workset */)
 { 
   double x_val = 0.25;
   double y_val = 0.5;
@@ -169,7 +169,7 @@ public:
 PHX_EVALUATOR_CLASS_END
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(HessianTestEvaluator,p)
+PHX_EVALUATOR_CTOR(HessianTestEvaluator, /* p */)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -196,7 +196,7 @@ PHX_EVALUATOR_CTOR(HessianTestEvaluator,p)
 
 //**********************************************************************
 
-PHX_POST_REGISTRATION_SETUP(HessianTestEvaluator,sd,fm)
+PHX_POST_REGISTRATION_SETUP(HessianTestEvaluator, /* sd */, fm)
 {
   this->utils.setFieldData(x,fm);
   this->utils.setFieldData(y,fm);
@@ -204,7 +204,7 @@ PHX_POST_REGISTRATION_SETUP(HessianTestEvaluator,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(HessianTestEvaluator,workset)
+PHX_EVALUATE_FIELDS(HessianTestEvaluator, /* workset */)
 { 
   // Grad = y * std::cos(x*y)
   //      = x * std::cos(x*y)-0.25*std::sin(y)

--- a/packages/panzer/disc-fe/test/la_factory/UnitTest_UniqueGlobalIndexer.cpp
+++ b/packages/panzer/disc-fe/test/la_factory/UnitTest_UniqueGlobalIndexer.cpp
@@ -126,7 +126,7 @@ const std::vector<LocalOrdinalT> & UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdin
 }
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-void UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getElementGIDs(LocalOrdinalT localElmtId,std::vector<GlobalOrdinalT> & gids,const std::string & blockId) const
+void UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getElementGIDs(LocalOrdinalT /* localElmtId */, std::vector<GlobalOrdinalT>& gids, const std::string& /* blockId */) const
 {
    gids.resize(8);
 
@@ -174,8 +174,8 @@ const std::vector<int> & UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getG
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
 const std::pair<std::vector<int>,std::vector<int> > & 
-UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getGIDFieldOffsets_closure(const std::string & blockId, int fieldNum,
-                                                int subcellDim,int subcellId) const
+UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getGIDFieldOffsets_closure(const std::string& /* blockId */, int /* fieldNum */,
+                                                int /* subcellDim */, int /* subcellId */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                       "unit_test::UniqueGlobalIndexer::getGIDFieldOffsets_closure is not implemented yet.");
@@ -335,7 +335,7 @@ void UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::ownedIndices(const std::
 /** Get field numbers associated with a particular element block.
   */
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-const std::vector<int> & UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getBlockFieldNumbers(const std::string & blockId) const
+const std::vector<int> & UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getBlockFieldNumbers(const std::string & /* blockId */) const
 {
    static std::vector<int> fieldNums;
    if(fieldNums.size()==0) {
@@ -351,7 +351,7 @@ const std::vector<int> & UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getB
 }
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-void UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getCoordinates(LocalOrdinalT localElementId,Kokkos::DynRankView<double,PHX::Device> & vertices)
+void UniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::getCoordinates(LocalOrdinalT /* localElementId */, Kokkos::DynRankView<double,PHX::Device>& vertices)
 {
   vertices = Kokkos::DynRankView<double,PHX::Device>("vertices",1,4,2);
    switch(procRank_) {
@@ -464,7 +464,7 @@ const std::vector<LocalOrdinalT> & UniqueGlobalIndexer_Element<LocalOrdinalT,Glo
 }
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-void UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getElementGIDs(LocalOrdinalT localElmtId,std::vector<GlobalOrdinalT> & gids,const std::string & blockId) const
+void UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getElementGIDs(LocalOrdinalT /* localElmtId */, std::vector<GlobalOrdinalT>& gids, const std::string& /* blockId */) const
 {
    gids.resize(2);
 
@@ -502,8 +502,8 @@ const std::vector<int> & UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinal
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
 const std::pair<std::vector<int>,std::vector<int> > & 
-UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getGIDFieldOffsets_closure(const std::string & blockId, int fieldNum,
-                                                int subcellDim,int subcellId) const
+UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getGIDFieldOffsets_closure(const std::string& /* blockId */, int /* fieldNum */,
+                                                int /* subcellDim */, int /* subcellId */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                       "unit_test::UniqueGlobalIndexer_Element::getGIDFieldOffsets_closure is not implemented yet.");
@@ -559,7 +559,7 @@ void UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::ownedIndices(con
 /** Get field numbers associated with a particular element block.
   */
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-const std::vector<int> & UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getBlockFieldNumbers(const std::string & blockId) const
+const std::vector<int> & UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getBlockFieldNumbers(const std::string & /* blockId */) const
 {
    static std::vector<int> fieldNums;
    if(fieldNums.size()==0) {
@@ -572,7 +572,7 @@ const std::vector<int> & UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinal
 }
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-void UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getCoordinates(LocalOrdinalT localElementId,Kokkos::DynRankView<double,PHX::Device> & vertices)
+void UniqueGlobalIndexer_Element<LocalOrdinalT,GlobalOrdinalT>::getCoordinates(LocalOrdinalT /* localElementId */, Kokkos::DynRankView<double,PHX::Device>& vertices)
 {
    vertices = Kokkos::DynRankView<double,PHX::Device>("vertices",1,1,2);
    switch(procRank_) {
@@ -605,7 +605,7 @@ getElementBlockGIDCount(const std::size_t &) const
 /////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename LocalOrdinalT,typename GlobalOrdinalT>
-BlockUniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::BlockUniqueGlobalIndexer(int blocks,int rank,int procCount)
+BlockUniqueGlobalIndexer<LocalOrdinalT,GlobalOrdinalT>::BlockUniqueGlobalIndexer(int /* blocks */, int rank, int procCount)
    : procRank_(rank)
 {
    TEUCHOS_TEST_FOR_EXCEPTION(procCount!=2,std::runtime_error,"unit_test::BlockUniqueGlobalIndexer runs on only two processors!");

--- a/packages/panzer/disc-fe/test/la_factory/UnitTest_UniqueGlobalIndexer.hpp
+++ b/packages/panzer/disc-fe/test/la_factory/UnitTest_UniqueGlobalIndexer.hpp
@@ -131,7 +131,7 @@ public:
      */
    virtual void getElementGIDs(LocalOrdinalT localElmtId,std::vector<GlobalOrdinalT> & gids,const std::string & blockId="") const;
 
-   virtual void getElementOrientation(LocalOrdinalT localElmtId,std::vector<double> & gidsOrientation) const
+   virtual void getElementOrientation(LocalOrdinalT /* localElmtId */, std::vector<double>& /* gidsOrientation */) const
    { TEUCHOS_ASSERT(false); }
 
    /** \brief Use the field pattern so that you can find a particular
@@ -307,7 +307,7 @@ public:
      */
    virtual void getElementGIDs(LocalOrdinalT localElmtId,std::vector<GlobalOrdinalT> & gids,const std::string & blockId="") const;
 
-   virtual void getElementOrientation(LocalOrdinalT localElmtId,std::vector<double> & gidsOrientation) const
+   virtual void getElementOrientation(LocalOrdinalT /* localElmtId */, std::vector<double>& /* gidsOrientation */) const
    { TEUCHOS_ASSERT(false); }
 
    /** \brief Use the field pattern so that you can find a particular
@@ -383,14 +383,14 @@ public:
      *          field if the field exisits. Otherwise
      *          a -1 is returned.
      */
-   virtual int getFieldNum(const std::string & str) const
+   virtual int getFieldNum(const std::string& /* str */) const
    { TEUCHOS_ASSERT(false); return -1; }
 
    virtual int getNumFields() const { return 2; }
    virtual void getFieldOrder(std::vector<std::string> & order) const 
    { order.push_back("U"); order.push_back("T"); }
 
-   virtual const std::string & getFieldString(int field) const
+   virtual const std::string& getFieldString(int /* field */) const
    { TEUCHOS_ASSERT(false); static std::string empty = "EMPTY"; return empty; }
 
    virtual Teuchos::RCP<Teuchos::Comm<int> > getComm() const
@@ -402,7 +402,7 @@ public:
 
    /** Is the specified field in the element block? 
      */
-   virtual bool fieldInBlock(const std::string & field, const std::string & block) const
+   virtual bool fieldInBlock(const std::string& /* field */, const std::string& /* block */) const
    { TEUCHOS_ASSERT(false); return false; }
 
    /** Get the local element IDs for a paricular element
@@ -416,22 +416,22 @@ public:
 
    /** Get field numbers associated with a particular element block.
      */
-   virtual const std::vector<int> & getBlockFieldNumbers(const std::string & blockId) const
+   virtual const std::vector<int>& getBlockFieldNumbers(const std::string& /* blockId */) const
    { static std::vector<int> data; TEUCHOS_ASSERT(false); return data; }
 
    /** \brief Get the global IDs for a particular element. This function
      * overwrites the <code>gids</code> variable.
      */
-   virtual void getElementGIDs(LocalOrdinalT localElmtId,std::vector<std::pair<int,GlobalOrdinalT> > & gids,const std::string & blockId="") const
+   virtual void getElementGIDs(LocalOrdinalT /* localElmtId */, std::vector<std::pair<int, GlobalOrdinalT>>& /* gids */, const std::string& /* blockId="" */) const
    { TEUCHOS_ASSERT(false); }
 
-   virtual void getElementOrientation(LocalOrdinalT localElmtId,std::vector<double> & gidsOrientation) const
+   virtual void getElementOrientation(LocalOrdinalT /* localElmtId */, std::vector<double>& /* gidsOrientation */) const
    { TEUCHOS_ASSERT(false); }
 
    /** \brief Use the field pattern so that you can find a particular
      *        field in the GIDs array.
      */
-   virtual const std::vector<int> & getGIDFieldOffsets(const std::string & blockId,int fieldNum) const
+   virtual const std::vector<int>& getGIDFieldOffsets(const std::string& /* blockId */, int /* fieldNum */) const
    { TEUCHOS_ASSERT(false); }
 
    /** \brief Use the field pattern so that you can find a particular
@@ -448,27 +448,27 @@ public:
      */
    // virtual const std::vector<int> & 
    virtual const std::pair<std::vector<int>,std::vector<int> > & 
-   getGIDFieldOffsets_closure(const std::string & blockId, int fieldNum,
-                                                               int subcellDim,int subcellId) const
+   getGIDFieldOffsets_closure(const std::string& /* blockId */, int /* fieldNum */,
+                                                               int /* subcellDim */, int /* subcellId */) const
    { static std::pair<std::vector<int>,std::vector<int> >  p; TEUCHOS_ASSERT(false); return p; }
 
    /** Get set of indices owned by this processor
      */
-   virtual void getOwnedIndices(std::vector<std::pair<int,GlobalOrdinalT> > & indices) const
+   virtual void getOwnedIndices(std::vector<std::pair<int, GlobalOrdinalT>>& /* indices */) const
    { TEUCHOS_ASSERT(false); }
 
    /** Get set of indices owned and ghosted by this processor.
      * This can be thought of as the ``ghosted'' indices.
      */
-   virtual void getOwnedAndGhostedIndices(std::vector<std::pair<int,GlobalOrdinalT> > & indices) const
+   virtual void getOwnedAndGhostedIndices(std::vector<std::pair<int, GlobalOrdinalT>>& /* indices */) const
    { TEUCHOS_ASSERT(false); }
 
    /** Get a yes/no on ownership for each index in a vector
      */
-   virtual void ownedIndices(const std::vector<std::pair<int,GlobalOrdinalT> > & indices,std::vector<bool> & isOwned) const
+   virtual void ownedIndices(const std::vector<std::pair<int, GlobalOrdinalT>>& /* indices */, std::vector<bool>& /* isOwned */) const
    { TEUCHOS_ASSERT(false); }
 
-   void getCoordinates(LocalOrdinalT localElementId,Kokkos::DynRankView<double,PHX::Device> & points)
+   void getCoordinates(LocalOrdinalT /* localElementId */, Kokkos::DynRankView<double, PHX::Device>& /* points */)
    { TEUCHOS_ASSERT(false); }
 
    int getElementBlockGIDCount(const std::string &) const { TEUCHOS_ASSERT(false); }

--- a/packages/panzer/disc-fe/test/physics_block/UnitTest_UniqueGlobalIndexer.cpp
+++ b/packages/panzer/disc-fe/test/physics_block/UnitTest_UniqueGlobalIndexer.cpp
@@ -105,7 +105,7 @@ const std::vector<int> & UniqueGlobalIndexer::getElementBlock(const std::string 
    return *elements_;
 }
 
-void UniqueGlobalIndexer::getElementGIDs(int localElmtId,std::vector<int> & gids,const std::string & blockId) const
+void UniqueGlobalIndexer::getElementGIDs(int localElmtId,std::vector<int> & gids,const std::string & /* blockId */) const
 {
    gids.resize(8);
 
@@ -151,8 +151,8 @@ const std::vector<int> & UniqueGlobalIndexer::getGIDFieldOffsets(const std::stri
 }
 
 const std::pair<std::vector<int>,std::vector<int> > & 
-UniqueGlobalIndexer::getGIDFieldOffsets_closure(const std::string & blockId, int fieldNum,
-                                                int subcellDim,int subcellId) const
+UniqueGlobalIndexer::getGIDFieldOffsets_closure(const std::string & /* blockId */, int /* fieldNum */,
+                                                int /* subcellDim */,int /* subcellId */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                       "unit_test::UniqueGlobalIndexer::getGIDFieldOffsets_closure is not implemented yet.");
@@ -257,7 +257,7 @@ void UniqueGlobalIndexer::ownedIndices(const std::vector<int> & indices,std::vec
 
 /** Get field numbers associated with a particular element block.
   */
-const std::vector<int> & UniqueGlobalIndexer::getBlockFieldNumbers(const std::string & blockId) const
+const std::vector<int> & UniqueGlobalIndexer::getBlockFieldNumbers(const std::string & /* blockId */) const
 {
    static std::vector<int> fieldNums;
    if(fieldNums.size()==0) {
@@ -272,12 +272,12 @@ const std::vector<int> & UniqueGlobalIndexer::getBlockFieldNumbers(const std::st
    return fieldNums;
 
 }
-int UniqueGlobalIndexer::getElementBlockGIDCount(const std::string & block) const
+int UniqueGlobalIndexer::getElementBlockGIDCount(const std::string & /* block */) const
 {
    return 8;
 }
 
-int UniqueGlobalIndexer::getElementBlockGIDCount(const std::size_t & block) const
+int UniqueGlobalIndexer::getElementBlockGIDCount(const std::size_t & /* block */) const
 {
    return 8;
 }

--- a/packages/panzer/disc-fe/test/physics_block/UnitTest_UniqueGlobalIndexer.hpp
+++ b/packages/panzer/disc-fe/test/physics_block/UnitTest_UniqueGlobalIndexer.hpp
@@ -128,7 +128,7 @@ public:
      */
    virtual void getElementGIDs(int localElmtId,std::vector<int> & gids,const std::string & blockId="") const;
 
-   virtual void getElementOrientation(int localElmtId,std::vector<double> & gidsOrientation) const
+   virtual void getElementOrientation(int /* localElmtId */, std::vector<double>& /* gidsOrientation */) const
    { TEUCHOS_ASSERT(false); }
 
    /** \brief Use the field pattern so that you can find a particular

--- a/packages/panzer/dof-mgr/src/Panzer_BlockedDOFManager.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_BlockedDOFManager.hpp
@@ -316,7 +316,7 @@ public:
      */
    void getFieldOrder(std::vector<std::vector<std::string> > & fieldOrder) const;
 
-   void getFieldOrder(std::vector<std::string> & fieldOrder) const {TEUCHOS_ASSERT(false); } // what???
+   void getFieldOrder(std::vector<std::string>& /* fieldOrder */) const { TEUCHOS_ASSERT(false); } // what???
 
    /** \brief Find a field pattern stored for a particular block and field number. This will
      *        retrive the pattern added with <code>addField(blockId,fieldNum)</code>.

--- a/packages/panzer/dof-mgr/src/Panzer_DOFManager_impl.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_DOFManager_impl.hpp
@@ -370,7 +370,7 @@ const std::vector<int> & DOFManager<LO,GO>::getGIDFieldOffsets(const std::string
 }
 
 template <typename LO, typename GO>
-void DOFManager<LO,GO>::getElementGIDs(LO localElementID, std::vector<GO> & gids, const std::string & blockIdHint) const
+void DOFManager<LO,GO>::getElementGIDs(LO localElementID, std::vector<GO>& gids, const std::string& /* blockIdHint */) const
 {
   gids = elementGIDs_[localElementID];
 }

--- a/packages/panzer/dof-mgr/src/Panzer_EdgeFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_EdgeFieldPattern.cpp
@@ -79,7 +79,7 @@ const std::vector<int> & EdgeFieldPattern::getSubcellIndices(int dim,int cellInd
    return empty_;
 }
 
-void EdgeFieldPattern::getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+void EdgeFieldPattern::getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int>& /* indices */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                       "EdgeFieldPattern::getSubcellClosureIndices should not be called"); 

--- a/packages/panzer/dof-mgr/src/Panzer_ElemFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_ElemFieldPattern.cpp
@@ -78,7 +78,7 @@ const std::vector<int> & ElemFieldPattern::getSubcellIndices(int dim,int cellInd
    return empty_;
 }
 
-void ElemFieldPattern::getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+void ElemFieldPattern::getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int>& /* indices */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                       "ElemFieldPattern::getSubcellClosureIndices should not be called");

--- a/packages/panzer/dof-mgr/src/Panzer_FaceFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_FaceFieldPattern.cpp
@@ -81,7 +81,7 @@ const std::vector<int> & FaceFieldPattern::getSubcellIndices(int dim,int cellInd
    return empty_;
 }
 
-void FaceFieldPattern::getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+void FaceFieldPattern::getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int>& /* indices */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                       "FaceFieldPattern::getSubcellClosureIndices should not be called");

--- a/packages/panzer/dof-mgr/src/Panzer_GeometricAggFieldPattern.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_GeometricAggFieldPattern.hpp
@@ -115,7 +115,7 @@ public:
    /* This function has no functionality in this case.
     * If called it will throw an assertion failure
     */
-   virtual void getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+   virtual void getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int>& /* indices */) const
    { TEUCHOS_ASSERT(false); }
 
    /** Returns the dimension (see <code>FieldPattern</code>) if 

--- a/packages/panzer/dof-mgr/src/Panzer_NodalFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_NodalFieldPattern.cpp
@@ -78,7 +78,7 @@ const std::vector<int> & NodalFieldPattern::getSubcellIndices(int dim,int cellIn
    return empty_;
 }
 
-void NodalFieldPattern::getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+void NodalFieldPattern::getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int>& /* indices */) const
 {
    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
                       "NodalFieldPattern::getSubcellClosureIndices should not be called"); 

--- a/packages/panzer/dof-mgr/test/cartesian_topology/CartesianConnManager.hpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/CartesianConnManager.hpp
@@ -221,10 +221,10 @@ public:
      */
    virtual const std::vector<LocalOrdinal> & getElementBlock(const std::string & blockId) const;
 
-   virtual const std::vector<LocalOrdinal> & getNeighborElementBlock(const std::string & s) const
+   virtual const std::vector<LocalOrdinal> & getNeighborElementBlock(const std::string & /* s */) const
    { return emptyVector_; }
 
-   virtual const std::vector<LocalOrdinal> & getAssociatedNeighbors(const LocalOrdinal& el) const
+   virtual const std::vector<LocalOrdinal> & getAssociatedNeighbors(const LocalOrdinal& /* el */) const
    { return emptyVector_; }
 
    virtual bool hasAssociatedNeighbors() const 

--- a/packages/panzer/dof-mgr/test/field_pattern/TestFieldPattern.hpp
+++ b/packages/panzer/dof-mgr/test/field_pattern/TestFieldPattern.hpp
@@ -56,7 +56,7 @@ public:
    /* This function has no functionality in this case.
     * If called it will throw an assertion failure
     */
-   virtual void getSubcellClosureIndices(int dim,int cellIndex,std::vector<int> & indices) const
+   virtual void getSubcellClosureIndices(int /* dim */, int /* cellIndex */, std::vector<int>& /* indices */) const
    { TEUCHOS_ASSERT(false); }
 
    virtual int getSubcellCount(int dim) const


### PR DESCRIPTION
Panzer suffered from a great many unused-parameter warnings when
compiling with -Wall -Wextra.  These have been addressed by commenting
out the variable names in function definitions.

Closes #1702.

@trilinos/panzer 