### PR TITLE
EpetraExt: fix memspace handle closing

### DIFF
--- a/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
+++ b/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
@@ -1080,9 +1080,9 @@ void EpetraExt::HDF5::Write(const std::string& GroupName, const Epetra_MultiVect
       status = H5Dwrite(dset_id, H5T_NATIVE_DOUBLE, memspace_id, filespace_id,
                         plist_id_, LinearX->operator[](n));
       CHECK_STATUS(status);
+      H5Sclose(memspace_id);
     }
   H5Gclose(group_id);
-  H5Sclose(memspace_id);
   H5Sclose(filespace_id);
   H5Dclose(dset_id);
   H5Pclose(plist_id_);


### PR DESCRIPTION
This was pointed out by GCC's "maybe uninitialized variable" warning (`memspace_id` would be closed uninitialized if the loop iterates zero times). However, it seems to be a legitimate bug in closing this handle, i.e. it seems like it is only closing the last created handle but it should close all of them. I suspect the old code leaks memory.

@trilinos/epetra 