### PR TITLE
lcm-mods: Modifications required for Schwarz alternating method in Albany (LCM)

### DIFF
--- a/packages/nox/src-loca/src/LOCA_Stepper.C
+++ b/packages/nox/src-loca/src/LOCA_Stepper.C
@@ -879,7 +879,7 @@ LOCA::Stepper::getList() const
 }
 
 Teuchos::RCP<NOX::Solver::Generic>
-LOCA::Stepper::getSolver() const
+LOCA::Stepper::getSolver()
 {
   if (solverPtr.get() == NULL) {
     globalData->locaErrorCheck->throwError(
@@ -1035,13 +1035,13 @@ LOCA::Stepper::withinThreshold()
 }
 
 Teuchos::ParameterList &
-LOCA::Stepper::getParams() const
+LOCA::Stepper::getParams()
 {
   return *stepperList;
 }
 
 Teuchos::ParameterList &
-LOCA::Stepper::getStepSizeParams() const
+LOCA::Stepper::getStepSizeParams()
 {
   return *parsedParams->getSublist("Step Size");
 }

--- a/packages/nox/src-loca/src/LOCA_Stepper.C
+++ b/packages/nox/src-loca/src/LOCA_Stepper.C
@@ -878,7 +878,7 @@ LOCA::Stepper::getList() const
   return paramListPtr;
 }
 
-Teuchos::RCP<const NOX::Solver::Generic>
+Teuchos::RCP<NOX::Solver::Generic>
 LOCA::Stepper::getSolver() const
 {
   if (solverPtr.get() == NULL) {
@@ -1032,4 +1032,16 @@ LOCA::Stepper::withinThreshold()
   double conParam = curGroupPtr->getContinuationParameter();
 
   return (fabs(conParam-targetValue) < relt*fabs(initialStep));
+}
+
+Teuchos::ParameterList &
+LOCA::Stepper::getParams() const
+{
+  return *stepperList;
+}
+
+Teuchos::ParameterList &
+LOCA::Stepper::getStepSizeParams() const
+{
+  return *parsedParams->getSublist("Step Size");
 }

--- a/packages/nox/src-loca/src/LOCA_Stepper.H
+++ b/packages/nox/src-loca/src/LOCA_Stepper.H
@@ -173,7 +173,7 @@ namespace LOCA {
      *
      * Will throw an error if the solver does not exist yet.
      */
-    virtual Teuchos::RCP<const NOX::Solver::Generic>
+    virtual Teuchos::RCP<NOX::Solver::Generic>
     getSolver() const;
 
     /*! @brief Return the current continuation parameter from the underlying LOCA::MultiContinuation::AbstractStrategy.
@@ -181,6 +181,14 @@ namespace LOCA {
      */
     virtual double
     getContinuationParameter() const;
+
+    //! Get parameter list
+    Teuchos::ParameterList &
+    getParams() const;
+
+    //! Get step size parameter list
+    Teuchos::ParameterList &
+    getStepSizeParams() const;
 
   protected:
 

--- a/packages/nox/src-loca/src/LOCA_Stepper.H
+++ b/packages/nox/src-loca/src/LOCA_Stepper.H
@@ -174,7 +174,7 @@ namespace LOCA {
      * Will throw an error if the solver does not exist yet.
      */
     virtual Teuchos::RCP<NOX::Solver::Generic>
-    getSolver() const;
+    getSolver();
 
     /*! @brief Return the current continuation parameter from the underlying LOCA::MultiContinuation::AbstractStrategy.
      *
@@ -184,11 +184,11 @@ namespace LOCA {
 
     //! Get parameter list
     Teuchos::ParameterList &
-    getParams() const;
+    getParams();
 
     //! Get step size parameter list
     Teuchos::ParameterList &
-    getStepSizeParams() const;
+    getStepSizeParams();
 
   protected:
 

--- a/packages/piro/src/Piro_LOCASolver.hpp
+++ b/packages/piro/src/Piro_LOCASolver.hpp
@@ -72,6 +72,18 @@ public:
   ~LOCASolver();
   //@}
 
+  //! Return the current nonlinear solver pointer.
+  Teuchos::RCP<NOX::Solver::Generic>
+  getSolver() const;
+
+  //! Return stepper parameters
+  Teuchos::ParameterList &
+  getStepperParams() const;
+
+  //! Return step size parameters
+  Teuchos::ParameterList &
+  getStepSizeParams() const;
+
 private:
   /** \name Overridden from Thyra::ModelEvaluatorDefaultBase . */
   //@{

--- a/packages/piro/src/Piro_LOCASolver.hpp
+++ b/packages/piro/src/Piro_LOCASolver.hpp
@@ -74,15 +74,15 @@ public:
 
   //! Return the current nonlinear solver pointer.
   Teuchos::RCP<NOX::Solver::Generic>
-  getSolver() const;
+  getSolver();
 
   //! Return stepper parameters
   Teuchos::ParameterList &
-  getStepperParams() const;
+  getStepperParams();
 
   //! Return step size parameters
   Teuchos::ParameterList &
-  getStepSizeParams() const;
+  getStepSizeParams();
 
 private:
   /** \name Overridden from Thyra::ModelEvaluatorDefaultBase . */

--- a/packages/piro/src/Piro_LOCASolver_Def.hpp
+++ b/packages/piro/src/Piro_LOCASolver_Def.hpp
@@ -145,21 +145,21 @@ Piro::LOCASolver<Scalar>::~LOCASolver()
 
 template<typename Scalar>
 Teuchos::RCP<NOX::Solver::Generic>
-Piro::LOCASolver<Scalar>::getSolver() const
+Piro::LOCASolver<Scalar>::getSolver()
 {
   return stepper_->getSolver();
 }
 
 template<typename Scalar>
 Teuchos::ParameterList &
-Piro::LOCASolver<Scalar>::getStepperParams() const
+Piro::LOCASolver<Scalar>::getStepperParams()
 {
   return stepper_->getParams();
 }
 
 template<typename Scalar>
 Teuchos::ParameterList &
-Piro::LOCASolver<Scalar>::getStepSizeParams() const
+Piro::LOCASolver<Scalar>::getStepSizeParams()
 {
   return stepper_->getStepSizeParams();
 }

--- a/packages/piro/src/Piro_LOCASolver_Def.hpp
+++ b/packages/piro/src/Piro_LOCASolver_Def.hpp
@@ -143,6 +143,27 @@ Piro::LOCASolver<Scalar>::~LOCASolver()
   LOCA::destroyGlobalData(globalData_);
 }
 
+template<typename Scalar>
+Teuchos::RCP<NOX::Solver::Generic>
+Piro::LOCASolver<Scalar>::getSolver() const
+{
+  return stepper_->getSolver();
+}
+
+template<typename Scalar>
+Teuchos::ParameterList &
+Piro::LOCASolver<Scalar>::getStepperParams() const
+{
+  return stepper_->getParams();
+}
+
+template<typename Scalar>
+Teuchos::ParameterList &
+Piro::LOCASolver<Scalar>::getStepSizeParams() const
+{
+  return stepper_->getStepSizeParams();
+}
+
 template <typename Scalar>
 void
 Piro::LOCASolver<Scalar>::evalModelImpl(


### PR DESCRIPTION
This proposed changes to LOCA and Piro are necessary for the implementation of the Schwarz alternating method in Albany, specifically LCM.

This is really important for LCM, as the Schwarz method is currently being used for production runs in concurrent multiscale calculations for coupling small scale microstructure to macroscopic models.

I understand that they are not the cleanest changes, in that they expose some internals, but they are needed.