### PR TITLE
ctest_linux_nightly_generic_sierra.cmake: remove claps

### DIFF
--- a/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
+++ b/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
@@ -77,7 +77,7 @@ SET(Trilinos_TRACK  $ENV{JENKINS_JOB_TYPE})
 SET(CTEST_TEST_TIMEOUT 900)
 # SET(CTEST_DO_SUBMIT FALSE)
 
-SET(Trilinos_PACKAGES Amesos Amesos2 Anasazi AztecOO Belos Claps Epetra EpetraExt FEI Ifpack Ifpack2 Intrepid Kokkos ML MueLu NOX Pamgen RTOp Sacado Shards Teuchos Thyra Tpetra TrilinosSS Triutils Xpetra Zoltan Zoltan2)
+SET(Trilinos_PACKAGES Amesos Amesos2 Anasazi AztecOO Belos Epetra EpetraExt FEI Ifpack Ifpack2 Intrepid Kokkos ML MueLu NOX Pamgen RTOp Sacado Shards Teuchos Thyra Tpetra TrilinosSS Triutils Xpetra Zoltan Zoltan2)
 
 SET(EXTRA_EXCLUDE_PACKAGES Galeri Intrepid2 Isorropia Stratimikos Teko SEACAS STK)
 


### PR DESCRIPTION
While investigating the build failures it was
determined that sierra no longer uses the library.