### PR TITLE
Add Issue and Pull Request Templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,104 @@
+<!--- Provide a general summary of the issue in the Title above. -->
+
+<!---
+Note that anything between these delimiters is a comment that will not appear
+in the issue description once created.  Click on the Preview tab to see what
+everything will look like when you submit.
+-->
+
+<!---
+Feel free to delete anything from this template that is not applicable to the
+issue you are submitting.
+-->
+
+<!---
+Replace <teamName> below with the appropriate Trilinos package/team name.
+-->
+@trilinos/<teamName>
+
+<!---
+Assignees:  If you know anyone who should likely tackle this issue, select them
+from the Assignees drop-down on the right.
+-->
+
+<!---
+Lables:  Choose any applicable package names from the Labels drop-down on the
+right.  Additionally, choose a label to indicate the type of issue, for
+instance, bug, build, documentation, enhancement, etc.
+-->
+
+## Expectations
+<!---
+Tell us what you think should happen, how you think things should work, what
+you would like to see in the documentation, etc.
+-->
+
+## Current Behavior
+<!---
+Tell us how the current behavior fails to meet your expectations in some way.
+-->
+
+## Motivation and Context
+<!---
+How has this expectation failure affected you?  What are you trying to
+accomplish?  Why do we need to address this?  What does it have to do with
+anything?  Providing context helps us come up with a solution that is most
+useful in the real world.
+-->
+
+## Definition of Done
+<!---
+Tell us what needs to happen.  If necessary, give us a task lisk along the
+lines of:                                                   
+- [ ] First do this.
+- [ ] Then do that.
+- [ ] Also this other thing.
+-->
+
+## Possible Solution
+<!---
+Not obligatory, but suggest a fix for the bug or documentation, or suggest
+ideas on how to implement the addition or change.
+-->
+
+## Steps to Reproduce
+<!---
+Provide a link to a live example, or an unambiguous set of steps to reproduce
+this issue.  Include code to reproduce, if relevant. 
+1. Do this.
+1. Do that.
+1. Shake fist angrily at computer.
+-->
+
+## Your Environment
+<!---
+Include relevant details about your environment such that we can replicate this
+issue.
+-->
+- **Relevant repo SHA1s:**  
+- **Relevant configure flags or configure script:**  
+- **Operating system and version:**  
+- **Compiler and TPL versions:**  
+
+## Related Issues
+<!---
+If applicable, let us know how this bug is related to any other open issues:
+-->
+* Blocks 
+* Is blocked by 
+* Follows 
+* Precedes 
+* Related to 
+* Part of 
+* Composed of 
+
+## Additional Information
+<!---
+Anything else that might be helpful for us to know in addressing this issue:
+* Configure log file:  
+* Build log file:  
+* Test log file:  
+* When was the last time everything worked (date/time; SHA1s; etc.)?
+* What did you do that made the bug rear its ugly head?
+* Have you tried turning it off and on again?
+-->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,77 @@
+<!--- Provide a general summary of your changes in the Title above. -->
+
+<!---
+Note that anything between these delimiters is a comment that will not appear
+in the pull request description once created.
+-->
+
+<!---
+Replace <teamName> below with the appropriate Trilinos package/team name.
+-->
+@trilinos/<teamName>
+
+<!---
+Reviewers:  If you know someone who is knowledgeable about what you are
+changing, or perhaps someone who should be, and you would like them to review
+your changes before they are accepted, select them from the Reviewers drop-down
+on the right.
+-->
+
+<!---
+Assignees:  If you know anyone who should likely handle bringing this pull
+request to completion, select them from the Assignees drop-down on the right.
+If you have write-access to Trilinos, this should likely be you.
+-->
+
+<!---
+Lables:  Choose any applicable package names from the Labels drop-down on the
+right.  Additionally, choose a label to indicate the type of issue, for
+instance, bug, build, documentation, enhancement, etc.
+-->
+
+## Description
+<!--- Describe your changes in detail. -->
+
+## Motivation and Context
+<!--- Why is this change required?  What problem does it solve? -->
+
+## Related Issues
+<!---
+If applicable, let us know how this merge request is related to any other open
+issues or pull requests:
+-->
+* Closes 
+* Blocks 
+* Is blocked by 
+* Follows 
+* Precedes 
+* Related to 
+* Part of 
+* Composed of 
+
+## How Has This Been Tested?
+<!---
+Please describe in detail how you tested your changes.  Include details of your
+testing environment and the tests you ran to see how your change affects other
+areas of the code.  Consider including configure, build, and test log files.
+-->
+
+## Screenshots
+<!--- Not obligatory, but is there anything pertinent that we should see? -->
+
+## Checklist
+<!---
+Go over all the following points, and put an `x` in all the boxes that apply.
+If you are unsure about any of these, please ask&mdash;we are here to help.
+-->
+- [ ] My code follows the code style of the affected package(s).
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.
+- [ ] No new compiler warnings were introduced.
+- [ ] These changes break backwards compatibility.
+
+## Additional Information
+<!--- Anything else we need to know in evaluating this merge request? -->


### PR DESCRIPTION
A few months back I whipped up a handful of issue and merge requests templates to use in some of my GitLab projects.  Unfortunately GitHub only allows a single template for either issues or pull requests, so I've consolidated the ones I've used before and tried to make them generic enough that they apply to bug reports, feature requests, documentation issues, discussions, or just arbitrary tasks.  These templates were pieced together taking inspiration from various best practices examples I found around the web, but I'm afraid I didn't keep track of my sources when putting them together.

On the pull request side of things, it would be a good idea for us to actually fill out CONTRIBUTING.md so contributors know what's expected of them.  Perhaps this is part of the ongoing pull request auto-testing work; if not, it should be.

I'm more than happy to iterate on the design here.  Since they just pre-populate the Description field when creating an issue or pull request, a user can easily Ctrl+A, Delete, but the goal here is to stack the deck in our favor such that we receive all the information necessary to tackle an issue/pull request at the outset, rather than sending questions back and forth for a week before we have enough information to go on.

@trilinos/framework