### PR TITLE
Massif snapshots

### DIFF
--- a/TPLsList.cmake
+++ b/TPLsList.cmake
@@ -157,6 +157,7 @@ TRIBITS_REPOSITORY_DEFINE_TPLS(
   SimParasolid    "SCOREC/cmake/TPLs/"    EX
   SimAcis         "SCOREC/cmake/TPLs/"    EX
   SimField        "SCOREC/cmake/TPLs/"    EX
+  Valgrind        "cmake/TPLs/"    EX
   )
 
 # NOTES:

--- a/cmake/TPLs/FindTPLValgrind.cmake
+++ b/cmake/TPLs/FindTPLValgrind.cmake
@@ -1,0 +1,60 @@
+# @HEADER
+# ************************************************************************
+#
+#            Trilinos: An Object-Oriented Solver Framework
+#                 Copyright (2001) Sandia Corporation
+#
+#
+# Copyright (2001) Sandia Corporation. Under the terms of Contract
+# DE-AC04-94AL85000, there is a non-exclusive license for use of this
+# work by or on behalf of the U.S. Government.  Export of this program
+# may require a license from the United States Government.
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the Corporation nor the names of the
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# NOTICE:  The United States Government is granted for itself and others
+# acting on its behalf a paid-up, nonexclusive, irrevocable worldwide
+# license in this data to reproduce, prepare derivative works, and
+# perform publicly and display publicly.  Beginning five (5) years from
+# July 25, 2001, the United States Government is granted for itself and
+# others acting on its behalf a paid-up, nonexclusive, irrevocable
+# worldwide license in this data to reproduce, prepare derivative works,
+# distribute copies to the public, perform publicly and display
+# publicly, and to permit others to do so.
+#
+# NEITHER THE UNITED STATES GOVERNMENT, NOR THE UNITED STATES DEPARTMENT
+# OF ENERGY, NOR SANDIA CORPORATION, NOR ANY OF THEIR EMPLOYEES, MAKES
+# ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LEGAL LIABILITY OR
+# RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY
+# INFORMATION, APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS
+# THAT ITS USE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
+#
+# ************************************************************************
+# @HEADER
+
+
+TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( Valgrind
+  REQUIRED_HEADERS valgrind.h
+  MUST_FIND_ALL_HEADERS
+  )

--- a/packages/teuchos/CMakeLists.txt
+++ b/packages/teuchos/CMakeLists.txt
@@ -322,6 +322,17 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   OFF
   )
 
+# Heap profiling using massif
+TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_TIME_MASSIF_SNAPSHOTS
+  HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+  "Enable memory profiling using massif."
+  OFF)
+
+IF (${PACKAGE_NAME}_TIME_MASSIF_SNAPSHOTS)
+  MESSAGE(STATUS "Enabling memory profiling using massif")
+ENDIF()
+
+
 #
 # D) Process the subpackages for Teuchos
 #

--- a/packages/teuchos/CMakeLists.txt
+++ b/packages/teuchos/CMakeLists.txt
@@ -322,14 +322,16 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   OFF
   )
 
-# Heap profiling using massif
-TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_TIME_MASSIF_SNAPSHOTS
-  HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
-  "Enable memory profiling using massif."
-  OFF)
-
-IF (${PACKAGE_NAME}_TIME_MASSIF_SNAPSHOTS)
-  MESSAGE(STATUS "Enabling memory profiling using massif")
+ASSERT_DEFINED(TPL_ENABLE_Valgrind)
+IF(TPL_ENABLE_Valgrind)
+  # Heap profiling using massif
+  TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_TIME_MASSIF_SNAPSHOTS
+    HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+    "Enable memory profiling using massif."
+    OFF)
+  IF (${PACKAGE_NAME}_TIME_MASSIF_SNAPSHOTS)
+    MESSAGE(STATUS "Enabling memory profiling using massif")
+  ENDIF()
 ENDIF()
 
 

--- a/packages/teuchos/cmake/Dependencies.cmake
+++ b/packages/teuchos/cmake/Dependencies.cmake
@@ -9,3 +9,5 @@ TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
     KokkosCompat  kokkoscompat  PS  OPTIONAL
     KokkosComm    kokkoscomm    PS  OPTIONAL
   )
+
+SET(LIB_OPTIONAL_DEP_TPLS Valgrind)

--- a/packages/teuchos/cmake/Dependencies.cmake
+++ b/packages/teuchos/cmake/Dependencies.cmake
@@ -9,5 +9,3 @@ TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
     KokkosCompat  kokkoscompat  PS  OPTIONAL
     KokkosComm    kokkoscomm    PS  OPTIONAL
   )
-
-SET(LIB_OPTIONAL_DEP_TPLS Valgrind)

--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.hpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.hpp
@@ -163,6 +163,12 @@ typedef std::map<std::string, std::vector<std::pair<double, double> > > stat_map
 /// statistics, if you wish to use them in your program or output them
 /// in a different format than that of these methods.
 ///
+/// If Teuchos is compiled with
+/// <tt>Teuchos_TIME_MASSIF_SNAPSHOTS=ON</tt>
+/// Valgrind Massif snapshots are taken before and after each timer.
+/// The resulting memory profile can be plotted using
+/// <tt>core/utils/plotMassifMemoryUsage.py</tt>
+///
 /// \warning This class must only be used to time functions that are
 ///   called only within the main program.  It may <i>not</i> be used
 ///   in pre-program setup or post-program teardown!

--- a/packages/teuchos/core/cmake/Dependencies.cmake
+++ b/packages/teuchos/core/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
   LIB_OPTIONAL_PACKAGES  KokkosCore
-  LIB_OPTIONAL_TPLS  BinUtils  Boost  MPI  ARPREC  QD  QT  quadmath yaml-cpp  Pthread
+  LIB_OPTIONAL_TPLS  BinUtils  Boost  MPI  ARPREC  QD  QT  quadmath yaml-cpp  Pthread  Valgrind
   )
 
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(KokkosCore)

--- a/packages/teuchos/core/cmake/Teuchos_config.h.in
+++ b/packages/teuchos/core/cmake/Teuchos_config.h.in
@@ -137,6 +137,8 @@
 
 #cmakedefine HAVE_TEUCHOS_GLOBALLY_REDUCE_UNITTEST_RESULTS
 
+#cmakedefine HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+
 /* template qualifier required for calling template methods from non-template
    code */
 #define INVALID_TEMPLATE_QUALIFIER @INVALID_TEMPLATE_QUALIFIER@

--- a/packages/teuchos/core/src/CMakeLists.txt
+++ b/packages/teuchos/core/src/CMakeLists.txt
@@ -94,6 +94,11 @@ IF (NOT ${PROJECT_NAME}_ENABLE_CXX11)
 ENDIF()
 
 
+ASSERT_DEFINED(TPL_ENABLE_Valgrind)
+IF(TPL_ENABLE_Valgrind)
+  INCLUDE_DIRECTORIES(${TPL_Valgrind_INCLUDE_DIRS})
+ENDIF()
+
 #
 # C) Define the targets for package's library(s)
 #

--- a/packages/teuchos/core/src/Teuchos_Time.cpp
+++ b/packages/teuchos/core/src/Teuchos_Time.cpp
@@ -73,7 +73,7 @@ inline void seconds_initialize() {
 #endif // defined(__INTEL_COMPILER) && defined(_WIN32)
 
 #ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
-#include <valgrind/valgrind.h>
+#include <valgrind.h>
 #include <algorithm>
 #include <unistd.h>
 #endif

--- a/packages/teuchos/core/src/Teuchos_Time.cpp
+++ b/packages/teuchos/core/src/Teuchos_Time.cpp
@@ -72,13 +72,34 @@ inline void seconds_initialize() {
 
 #endif // defined(__INTEL_COMPILER) && defined(_WIN32)
 
+#ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+#include <valgrind/valgrind.h>
+#include <algorithm>
+#include <unistd.h>
+#endif
+
+
 namespace Teuchos {
+
+#ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+  void removeIllegalChars(std::string& s){
+    std::string illegalChars = "\\/:?\"<>|";
+    for (auto it = s.begin() ; it < s.end() ; ++it){
+      bool found = illegalChars.find(*it) != std::string::npos;
+      if(found)
+        *it = ' ';
+    }
+  }
+#endif
 
 //=============================================================================
 Time::Time(const std::string& name_in, bool start_in)
   : startTime_(0), totalTime_(0), isRunning_(false), enabled_ (true), name_(name_in), numCalls_(0)
 {
   if(start_in) this->start();
+#ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+  numCallsMassifSnapshots_ = 0;
+#endif
 }
 
 void Time::start(bool reset_in)
@@ -86,6 +107,15 @@ void Time::start(bool reset_in)
   if (enabled_) {
     isRunning_ = true;
     if (reset_in) totalTime_ = 0;
+#ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+    if (numCallsMassifSnapshots_ < 100) {
+      std::string filename = "massif.out." + std::to_string(::getpid()) + "." + name_ + "." + std::to_string(numCallsMassifSnapshots_) + ".start.out";
+      removeIllegalChars(filename);
+      std::replace(filename.begin(), filename.end(), ' ', '_');
+      std::string cmd = "snapshot " + filename;
+      VALGRIND_MONITOR_COMMAND(cmd.data());
+    }
+#endif
     startTime_ = wallTime();
   }
 }
@@ -97,6 +127,17 @@ double Time::stop()
       totalTime_ += ( wallTime() - startTime_ );
       isRunning_ = false;
       startTime_ = 0;
+#ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+      if (numCallsMassifSnapshots_ < 100) {
+        std::string filename = "massif.out." + std::to_string(::getpid()) + "." + name_ + "." + std::to_string(numCallsMassifSnapshots_) + ".stop.out";
+        removeIllegalChars(filename);
+        std::replace(filename.begin(), filename.end(), ' ', '_');
+        std::string cmd = "snapshot " + filename;
+        VALGRIND_MONITOR_COMMAND(cmd.data());
+        numCallsMassifSnapshots_++;
+      }
+#endif
+
     }
   }
   return totalTime_;

--- a/packages/teuchos/core/src/Teuchos_Time.hpp
+++ b/packages/teuchos/core/src/Teuchos_Time.hpp
@@ -158,6 +158,12 @@ private:
   bool enabled_;
   std::string name_;
   int numCalls_;
+#ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
+  // We don't want to rely on incrementNumCalls being called,
+  // because this does not seem to always happen in the same order.
+  // Sometimes after start() is called, sometimes after stop().
+  int numCallsMassifSnapshots_;
+#endif
 };
 
 

--- a/packages/teuchos/core/src/Teuchos_Time.hpp
+++ b/packages/teuchos/core/src/Teuchos_Time.hpp
@@ -78,10 +78,10 @@ namespace Teuchos {
 /// behavior in reentrant code.
 ///
 /// If Teuchos is compiled with
-/// Teuchos_TIME_MASSIF_SNAPSHOTS:BOOL=ON
+/// <tt>Teuchos_TIME_MASSIF_SNAPSHOTS=ON</tt>
 /// Valgrind Massif snapshots are taken before and after each timer.
 /// The resulting memory profile can be plotted using
-/// core/utils/plotMassifMemoryUsage.py
+/// <tt>core/utils/plotMassifMemoryUsage.py</tt>
 class TEUCHOSCORE_LIB_DLL_EXPORT Time {
 public:
   /// \brief Constructor

--- a/packages/teuchos/core/src/Teuchos_Time.hpp
+++ b/packages/teuchos/core/src/Teuchos_Time.hpp
@@ -76,6 +76,12 @@ namespace Teuchos {
 /// and stop().  It is better to access this class through the
 /// TimeMonitor class (which see) for exception safety and correct
 /// behavior in reentrant code.
+///
+/// If Teuchos is compiled with
+/// Teuchos_TIME_MASSIF_SNAPSHOTS:BOOL=ON
+/// Valgrind Massif snapshots are taken before and after each timer.
+/// The resulting memory profile can be plotted using
+/// core/utils/plotMassifMemoryUsage.py
 class TEUCHOSCORE_LIB_DLL_EXPORT Time {
 public:
   /// \brief Constructor

--- a/packages/teuchos/core/utils/plotMassifMemoryUsage.py
+++ b/packages/teuchos/core/utils/plotMassifMemoryUsage.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+
+# pip install msparser, path.py
+from __future__ import print_function, division
+try:
+    import msparser
+except ImportError:
+    print('Need to install msparser.\npip install msparser\n')
+    raise
+try:
+    from path import Path
+except ImportError:
+    print('Need to install path.py.\npip install path.py\n')
+    raise
+import matplotlib.pyplot as plt
+import re
+import matplotlib.patches as patches
+import numpy as np
+import argparse
+
+
+def formatMem(bytes, memUnit):
+    if memUnit == 'MB':
+        exp = 2
+    elif memUnit == 'KB':
+        exp = 1
+    else:
+        raise NotImplementedError('Unknown memory unit')
+    return bytes/1024**exp
+
+
+def tex_escape(text):
+    """
+        :param text: a plain text message
+        :return: the message escaped to appear correctly in LaTeX
+    """
+    conv = {
+        '&': r'\&',
+        '%': r'\%',
+        '$': r'\$',
+        '#': r'\#',
+        '_': r'\_',
+        '{': r'\{',
+        '}': r'\}',
+        '~': r'\textasciitilde{}',
+        '^': r'\^{}',
+        '\\': r'\textbackslash{}',
+        '<': r'\textless ',
+        '>': r'\textgreater ',
+    }
+    regex = re.compile('|'.join(re.escape(key) for key in sorted(conv.keys(), key = lambda item: - len(item))))
+    textNew = regex.sub(lambda match: conv[match.group()], text)
+    return textNew
+
+
+def plotMem(massifFile,
+            filter,        # filter by timer name
+            minTimeDiff,   # filter by difference in beginning and end
+            minMemDiff,    # filter by change in memory usage
+            shortTimers,   # exclude short timers
+            memUnit='MB',  # unit for memory
+            displayTimers=True
+):
+
+    # first parse the log file valgrind created for us
+    data = msparser.parse_file(massifFile)
+    massifFile = Path(massifFile)
+    cmd = data['cmd']
+    timeUnit = data['time_unit']
+    snapshots = data['snapshots']
+    times = []
+    memHeap = []
+    for s in snapshots:
+        try:
+            times.append(s['time'])
+            memHeap.append(formatMem(s['mem_heap'], memUnit))
+        except:
+            pass
+
+    # now parse all the snapshot pairs we took in the timers
+    # (We compile MueLu with MueLu_TIMEMONITOR_MASSIF_SNAPSHOTS=1 )
+    snapshotPairs = []
+    for f in Path('.').glob(massifFile+"*start.out"):
+        fEnd = f.replace('start.out', 'stop.out')
+        label = Path(f).basename().stripext().replace('.start', '')
+        label = label.replace(massifFile.basename()+'.', '')
+        try:
+            label, counter = label.rsplit('.', 1)
+        except:
+            pass
+        try:
+            data = msparser.parse_file(f)
+            dataEnd = msparser.parse_file(fEnd)
+            assert data['time_unit'] == timeUnit
+            assert dataEnd['time_unit'] == timeUnit
+            data = data['snapshots']
+            dataEnd = dataEnd['snapshots']
+            assert(len(data)) == 1
+            assert(len(dataEnd)) == 1
+            assert data[0]['time'] <= dataEnd[0]['time'], f
+            data[0]['label'] = label
+            data[0]['counter'] = counter
+            data[0]['mem_heap'] = formatMem(data[0]['mem_heap'], memUnit)
+            dataEnd[0]['mem_heap'] = formatMem(dataEnd[0]['mem_heap'], memUnit)
+
+            times.append(data[0]['time'])
+            times.append(dataEnd[0]['time'])
+            memHeap.append(data[0]['mem_heap'])
+            memHeap.append(dataEnd[0]['mem_heap'])
+
+            snapshotPairs += [(data[0], dataEnd[0])]
+        except FileNotFoundError:
+            print(f)
+
+    # sort the snapshots
+    times = np.array(times)
+    memHeap = np.array(memHeap)
+    idx = np.argsort(times)
+    print('maximum heap memory usage: {}'.format(memHeap.max()))
+    times = times[idx]
+    memHeap = memHeap[idx]
+
+    times = times[memHeap > minMemDiff]
+    memHeap = memHeap[memHeap > minMemDiff]
+    assert(len(times) > 0)
+
+    # plot the curve of memory usage
+    plt.plot(times, memHeap)
+
+    if displayTimers:
+        # now, filter through the snapshot pairs
+        # otherwise, the plot becomes very messy
+        filter = re.compile(filter)
+
+        told = (-2*minTimeDiff, -2*minTimeDiff)
+        snapshotPairsNew = []
+        for i, pair in enumerate(sorted(snapshotPairs, key=lambda x: x[0]['time'])):
+            if (filter.search(pair[0]['label']) and
+                abs(pair[0]['mem_heap']-pair[1]['mem_heap']) > minMemDiff):
+                t = [pair[0]['time'], pair[1]['time']]
+                if (abs(t[0]-told[0]) < minTimeDiff and abs(t[1]-told[1]) < minTimeDiff):
+                    print('Timers "{}" and "{}" seems to coincide'.format(nameold, pair[0]['label']))
+                    continue
+                if (t[1]-t[0] < shortTimers):
+                    continue
+                told = t
+                nameold = pair[0]['label']
+                snapshotPairsNew.append(pair)
+        snapshotPairs = snapshotPairsNew
+
+        # stack the snapshot pairs
+        height = max(memHeap)/len(snapshotPairs)
+        for i, pair in enumerate(sorted(snapshotPairs, key=lambda x: x[0]['time'])):
+            plt.gca().add_patch(patches.Rectangle((pair[0]['time'], i*height),
+                                                  pair[1]['time']-pair[0]['time'],
+                                                  height, alpha=0.5, facecolor='red'))
+            plt.text(pair[0]['time'], (i+0.5)*height, tex_escape(pair[0]['label']))
+            # add vertical lines at start and end for each timer
+            plt.plot([pair[0]['time'], pair[0]['time']], [0, max(memHeap)], '-', c='grey', alpha=0.5)
+            plt.plot([pair[1]['time'], pair[1]['time']], [0, max(memHeap)], '-', c='grey', alpha=0.5)
+            # add circles on these lines for memory usage at beginning and end
+            plt.scatter([pair[0]['time'], pair[1]['time']],
+                        [pair[0]['mem_heap'], pair[1]['mem_heap']], c='r')
+    plt.xlabel(timeUnit)
+    plt.ylabel(memUnit)
+    plt.title(tex_escape(cmd))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="""Plot memory profile from massif.
+Massif spits out a log file in the form "massif.out.PID".
+If MueLu is compiler with MueLu_TIMEMONITOR_MASSIF_SNAPSHOTS=1, the
+corresponding snapshots of the form "massif.out.PID.Timer" for the timers
+are also included.""",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('massifFile', nargs=1, help='massif log file, something like "massif.out.PID"')
+    parser.add_argument('--minMemDiff',
+                        help='filter out timers that have small change in memory usage',
+                        type=float,
+                        default=0.05)
+    parser.add_argument('--minTimeDiff',
+                        help='filter out timers that coincide up to this many instructions',
+                        type=int,
+                        default=-1)
+    parser.add_argument('--shortTimers',
+                        help='filter out timers that have fewer instructions than this',
+                        type=int,
+                        default=-1)
+    parser.add_argument('--filter',
+                        help='regexp to filter for timers to include',
+                        type=str,
+                        default='\(level|\(total,_level|TpetraExt')
+    parser.add_argument('--memUnit',
+                        help='memory unit (KB, MB)',
+                        type=str,
+                        default='MB')
+    args = parser.parse_args()
+
+    massifFile = args.massifFile[0]
+    data = msparser.parse_file(massifFile)
+    timeUnit = data['time_unit']
+
+    if timeUnit == 'i':
+        if args.shortTimers is -1:
+            args.shortTimers = 5e7
+        if args.minTimeDiff is -1:
+            args.minTimeDiff = 1e7
+    elif timeUnit == 'ms':
+        if args.shortTimers is -1:
+            args.shortTimers = 90
+        if args.minTimeDiff is -1:
+            args.minTimeDiff = 20
+    else:
+        raise NotImplementedError()
+
+    plotMem(massifFile,
+            args.filter, args.minTimeDiff, args.minMemDiff,
+            args.shortTimers, args.memUnit)
+    plt.show()

--- a/packages/teuchos/doc/index.doc
+++ b/packages/teuchos/doc/index.doc
@@ -242,7 +242,7 @@ contains basic, general-purpose utilities.
   turned on and off at runtime using the function
   Teuchos::TestForException_setEnableStacktrace().  The configure variable
   Teuchos_ENABLE_DEFAULT_STACKTRACE determines if stack tracing is on or off
-  by defualt at runtime.
+  by default at runtime.
 
   NOTE: Stacktracing is always off by default in any build type except
   CMAKE_BUILD_TYPE=DEBUG and/or Trilinos_ENABLE_DEBUG=ON.  Therefore,
@@ -367,7 +367,11 @@ for SPMD parallel programs and useful utilities that depend on these.
     This may be used either by itself, or in combination with
     Teuchos::TimeMonitor for tracking global timer statistics over
     processes.
-  
+    If Teuchos is compiled with <tt>Teuchos_TIME_MASSIF_SNAPSHOTS=ON</tt>
+    Valgrind Massif snapshots are taken before and after each timer.
+    The resulting memory profile can be plotted using the script
+    <tt>core/utils/plotMassifMemoryUsage.py</tt>.
+
   <li> Teuchos::TimeMonitor: A class that automates (and makes
     exception safe) the process of starting and stopping timers, lets
     users create timers that are automatically registered and tracked,


### PR DESCRIPTION
When Teuchos is compiled with

    Teuchos_TIME_MASSIF_SNAPSHOTS:BOOL=ON

and an executable is run through valgrind's massif tool, e.g.

    valgrind --tool=massif ./MueLu_Driver.exe --matrixType=Laplace3D --nx=80 --ny=80 --nz=80

then memory snapshots are created before and after every Teuchos timer.
The snapshots can be plotted using the script `packages/teuchos/core/utils/plotMassifMemoryUsage.py`:
![memory_profile](https://user-images.githubusercontent.com/4666273/31446937-019506fe-ae5e-11e7-9772-f90fea6678c9.png)
The script has options to filter out short timers, or timers that see only a small change in memory usage.