### PR TITLE
Pamgen: fix compiler warnigns and bugs

### DIFF
--- a/packages/pamgen/mesh_spec_lt/pamgen_mesh_specification.C
+++ b/packages/pamgen/mesh_spec_lt/pamgen_mesh_specification.C
@@ -1056,8 +1056,6 @@ Mesh_Specification * Mesh_Specification::consolidateMS()
     std::vector<long>  elem_cmap_elem_cnts;
 
     Mesh_Specification * ms = this;
-    int nfound = 0;
-    int efound = 0;
     int node_offset = 0;
     int element_offset = 0;
     while(ms){

--- a/packages/pamgen/src/parse_routines.C
+++ b/packages/pamgen/src/parse_routines.C
@@ -1030,7 +1030,7 @@ namespace PAMGEN_NEVADA {
 
     //get function body
     Token token2 = token_stream->Shift();
-    if (!token2.Type() == TK_STRING){
+    if (token2.Type() != TK_STRING){
       token_stream->Parse_Error("expected a quoted C-language function body");
     }
     std::string funcBody = token2.As_Stripped_String();
@@ -1071,7 +1071,7 @@ namespace PAMGEN_NEVADA {
 
     //get function body
     Token token2 = token_stream->Shift();
-    if (!token2.Type() == TK_STRING){
+    if (token2.Type() != TK_STRING){
       token_stream->Parse_Error("expected a quoted C-language function body");
     }
     std::string funcBody = token2.As_Stripped_String();


### PR DESCRIPTION
The token checks I believe are actual
bugs which were spotted by newer compiler
warnings.
Also two unused variables are removed.

not sure who to mention besides @jgfouca 