### PR TITLE
Amesos2 Fix for older Umfpack versions. #1584 #1846

### DIFF
--- a/cmake/TPLs/FindTPLUMFPACK.cmake
+++ b/cmake/TPLs/FindTPLUMFPACK.cmake
@@ -58,3 +58,36 @@ TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( UMFPACK
   REQUIRED_HEADERS umfpack.h amd.h
   REQUIRED_LIBS_NAMES umfpack amd
   )
+
+# Amesos2 has Umfpack wrappers which depend on being able to
+# send complex as Real-Im as a single array.
+# Old versions of Umfpack don't support this so for now we are
+# just disabling the complex tests for Umfpack version < 5.
+
+include(CheckCSourceCompiles)
+FUNCTION(CHECK_UMFPACK_HAS_VERSION_5  VARNAME)
+  SET(SOURCE
+  "
+  #include <stdio.h>
+  #include <umfpack.h>
+  int main()
+  {
+    // this got added in Umfpack version 4.5
+    #if UMFPACK_MAIN_VERSION >= 5
+      return 0;
+    #else
+      umfpack_version_failure
+    #endif
+  }
+
+  "
+  )
+  SET(CMAKE_REQUIRED_INCLUDES ${TPL_UMFPACK_INCLUDE_DIRS})
+  SET(CMAKE_REQUIRED_LIBRARIES ${TPL_UMFPACK_LIBRARIES})
+  SET(CMAKE_REQUIRED_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+  CHECK_C_SOURCE_COMPILES("${SOURCE}" ${VARNAME})
+ENDFUNCTION()
+
+IF(TPL_ENABLE_UMFPACK)
+  CHECK_UMFPACK_HAS_VERSION_5(HAVE_UMFPACK_VERSION_5)
+ENDIF()

--- a/packages/amesos2/src/Amesos2_Umfpack_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_Umfpack_FunctionMap.hpp
@@ -51,9 +51,10 @@
 #include "Amesos2_FunctionMap.hpp"
 #include "Amesos2_Umfpack_TypeMap.hpp"
 
-namespace UMFPACK {
+extern "C"
+{
   #include "umfpack.h"
-} // end namespace UMFPACK
+}
 
 namespace Amesos2 {
 
@@ -82,7 +83,7 @@ namespace Amesos2 {
     const double Control [UMFPACK_CONTROL],
     double Info [UMFPACK_INFO])
     {
-      return UMFPACK::umfpack_di_solve(sys, Ap, Ai, Ax, X, B, Numeric, Control, Info);
+      return ::umfpack_di_solve(sys, Ap, Ai, Ax, X, B, Numeric, Control, Info);
     }
 
     static int umfpack_numeric(
@@ -94,7 +95,7 @@ namespace Amesos2 {
     const double Control [UMFPACK_CONTROL],
     double Info [UMFPACK_INFO])
     {
-      return UMFPACK::umfpack_di_numeric(Ap, Ai, Ax, Symbolic, Numeric, Control, Info);
+      return ::umfpack_di_numeric(Ap, Ai, Ax, Symbolic, Numeric, Control, Info);
     }
 
     static int umfpack_symbolic(
@@ -107,23 +108,23 @@ namespace Amesos2 {
     const double Control [UMFPACK_CONTROL],
     double Info [UMFPACK_INFO])
     {
-      return UMFPACK::umfpack_di_symbolic(n_row, n_col, Ap, Ai, Ax, Symbolic, Control, Info);
+      return ::umfpack_di_symbolic(n_row, n_col, Ap, Ai, Ax, Symbolic, Control, Info);
     }
 
     static void umfpack_defaults(
     double Control [UMFPACK_CONTROL])
     {
-      UMFPACK::umfpack_di_defaults(Control);
+      ::umfpack_di_defaults(Control);
     }
 
     static void umfpack_free_numeric(void **Numeric)
     {
-      return UMFPACK::umfpack_di_free_numeric(Numeric);
+      return ::umfpack_di_free_numeric(Numeric);
     }
 
     static void umfpack_free_symbolic(void **Symbolic)
     {
-      return UMFPACK::umfpack_di_free_symbolic(Symbolic);
+      return ::umfpack_di_free_symbolic(Symbolic);
     }
   };
 
@@ -156,7 +157,7 @@ namespace Amesos2 {
     const double Control [UMFPACK_CONTROL],
     double Info [UMFPACK_INFO])
     {
-      return UMFPACK::umfpack_zi_solve(sys, Ap, Ai,
+      return umfpack_zi_solve(sys, Ap, Ai,
         stdComplexToUmfpackDoubleConversion(Ax), NULL,
         stdComplexToUmfpackDoubleConversion(X), NULL,
         stdComplexToUmfpackDoubleConversion(B), NULL,
@@ -172,7 +173,7 @@ namespace Amesos2 {
     const double Control[UMFPACK_CONTROL],
     double Info[UMFPACK_INFO])
     {
-      return UMFPACK::umfpack_zi_numeric(Ap, Ai, stdComplexToUmfpackDoubleConversion(Ax), NULL, Symbolic, Numeric, Control, Info);
+      return ::umfpack_zi_numeric(Ap, Ai, stdComplexToUmfpackDoubleConversion(Ax), NULL, Symbolic, Numeric, Control, Info);
     }
 
     static int umfpack_symbolic(
@@ -185,22 +186,22 @@ namespace Amesos2 {
     const double Control [UMFPACK_CONTROL],
     double Info [UMFPACK_INFO])
     {
-      return UMFPACK::umfpack_zi_symbolic(n_row, n_col, Ap, Ai, stdComplexToUmfpackDoubleConversion(Ax), NULL, Symbolic, Control, Info);
+      return ::umfpack_zi_symbolic(n_row, n_col, Ap, Ai, stdComplexToUmfpackDoubleConversion(Ax), NULL, Symbolic, Control, Info);
     }
 
     static void umfpack_defaults(double Control [UMFPACK_CONTROL])
     {
-      UMFPACK::umfpack_zi_defaults(Control);
+      ::umfpack_zi_defaults(Control);
     }
 
     static void umfpack_free_numeric(void **Numeric)
     {
-      UMFPACK::umfpack_zi_free_numeric(Numeric);
+      ::umfpack_zi_free_numeric(Numeric);
     }
 
     static void umfpack_free_symbolic(void **Symbolic)
     {
-      UMFPACK::umfpack_zi_free_symbolic(Symbolic);
+      ::umfpack_zi_free_symbolic(Symbolic);
     }
   };
 

--- a/packages/amesos2/test/solvers/CMakeLists.txt
+++ b/packages/amesos2/test/solvers/CMakeLists.txt
@@ -61,17 +61,25 @@ ENDIF()
 ASSERT_DEFINED(${PACKAGE_NAME}_ENABLE_UMFPACK)
 IF (${PACKAGE_NAME}_ENABLE_UMFPACK)
 
+  IF (HAVE_UMFPACK_VERSION_5)
+    SET(umpack_test_name "Umfpack_Solver_Test")
+    SET(umfpack_test_xml_file "umfpack_test.xml")
+  ELSE()
+    MESSAGE(STATUS "Disabling Amesos2 Umfpack Complex Test because Umfpack version is not >= 5. This Umfpack does not support Real-Im as a single array which is currently used in the wrapper.")
+    SET(umpack_test_name "Umfpack_Solver_Test_No_Complex")
+    SET(umfpack_test_xml_file "umfpack_test_no_complex.xml")
+  ENDIF()
+
   TRIBITS_COPY_FILES_TO_BINARY_DIR(SolverTestCopyUmfpackFiles
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-    SOURCE_FILES umfpack_test.xml
+    SOURCE_FILES ${umfpack_test_xml_file}
     EXEDEPS Solver_Test
     )
 
-
   TRIBITS_ADD_TEST(
     Solver_Test
-    NAME Umfpack_Solver_Test
-    ARGS "--xml-params=umfpack_test.xml --filedir=${CMAKE_CURRENT_BINARY_DIR}/../matrices/ --multiple-solves --refactor"
+    NAME ${umpack_test_name}
+    ARGS "--xml-params=${umfpack_test_xml_file} --filedir=${CMAKE_CURRENT_BINARY_DIR}/../matrices/ --multiple-solves --refactor"
     STANDARD_PASS_OUTPUT
     COMM serial mpi
     )

--- a/packages/amesos2/test/solvers/umfpack_test_no_complex.xml
+++ b/packages/amesos2/test/solvers/umfpack_test_no_complex.xml
@@ -1,0 +1,57 @@
+<ParameterList name="test_params">
+  <!-- Any of the test driver's command-line parameters may also be specified here -->
+  <ParameterList name="arc130.mtx">
+    <!-- Optional parameter, used for debugging and for deciding whether to use epetra -->
+    <Parameter name="complex" type="bool" value="false"/>
+    <ParameterList name="Umfpack">
+
+      <!-- Test Epetra objects first -->
+      <ParameterList name="epetra">
+	<!-- A non-list entry for epetra denotes a default run, name, type, and value are arbitrary -->
+	<Parameter name="defaultrun" type="bool" value="true"/>
+      </ParameterList>
+
+      <!-- Next test Tpetra objects -->
+      <ParameterList name="tpetra">
+	<!-- these `run*' sublist names are arbitrary -->
+	<ParameterList name="run0">
+	  <Parameter name="Scalar" type="string" value="float"/>
+	  <Parameter name="LocalOrdinal" type="string" value="int"/>
+	  <Parameter name="GlobalOrdinal" type="string" value="int"/>
+	</ParameterList>
+	  <!-- The `Node' parameter is not yet supported -->
+	<ParameterList name="run1">
+	  <Parameter name="Scalar" type="string" value="float"/>
+	  <Parameter name="LocalOrdinal" type="string" value="int"/>
+	  <Parameter name="GlobalOrdinal" type="string" value="long int"/>
+	</ParameterList>
+	<ParameterList name="run2">
+	  <Parameter name="Scalar" type="string" value="double"/>
+	  <Parameter name="LocalOrdinal" type="string" value="int"/>
+	  <Parameter name="GlobalOrdinal" type="string" value="int"/>
+	</ParameterList>
+	<ParameterList name="run3">
+	  <Parameter name="Scalar" type="string" value="double"/>
+	  <Parameter name="LocalOrdinal" type="string" value="int"/>
+	  <Parameter name="GlobalOrdinal" type="string" value="long int"/>
+	</ParameterList>
+	<ParameterList name="run4 - transpose">
+	  <Parameter name="Scalar" type="string" value="double"/>
+	  <Parameter name="LocalOrdinal" type="string" value="int"/>
+	  <Parameter name="GlobalOrdinal" type="string" value="int"/>
+	  <ParameterList name="amesos2_params">
+	    <Parameter name="Transpose" type="bool" value="true"/>
+	  </ParameterList>
+	</ParameterList>
+      </ParameterList>
+      <ParameterList name="solver_params">
+      </ParameterList>
+    </ParameterList> <!-- end Umfpack -->
+    <ParameterList name="all_solver_params">
+      <Parameter name="Transpose" type="bool" value="false"/>
+    </ParameterList>
+  </ParameterList> <!-- end arc130.mtx -->
+
+  <!-- currently identical to umfpack_test.xml except we removed the complex here -->
+  <!-- this is used only for old umfpack versions not supporting the complex re-im as a single array -->
+</ParameterList>


### PR DESCRIPTION
For Umfpack versions <5 this changes the Umfpack test so it does not call complex.

This is because the wrapper currently relies on being able to pass Re-Im as a single array.
That is not supported in older Umfpack versions.

This PR also includes the changes taken from #1846 to remove the UMFPACK namespace and add the extern "C", which is not included in older umfpack.h files.

This PR will fix the Amesos2 Umfpack test to pass for both old and new versions.

This was tested on a gcc 4.8.5 linux machine for both Umfpack 4.1 and the most recent Umfpack from SuiteSparse.  Also ran a default SEMS for Amesos2 enabled.