### PR TITLE
Use new kokkos functionality

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -12,6 +12,7 @@ IF(${Trilinos_ENABLE_Kokkos})
   include(${KOKKOS_SRC_PATH}/cmake/kokkos_functions.cmake)
   set_kokkos_cxx_compiler()
   set_kokkos_compiler_standard()
+  set_kokkos_cxx_standard()
   
   #------------ GET OPTIONS ----------------------------------------------------
   set(KOKKOS_CMAKE_VERBOSE True)

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -11,7 +11,6 @@ IF(${Trilinos_ENABLE_Kokkos})
   #------------ COMPILER AND FEATURE CHECKS ------------------------------------
   include(${KOKKOS_SRC_PATH}/cmake/kokkos_functions.cmake)
   set_kokkos_cxx_compiler()
-  set_kokkos_compiler_standard()
   set_kokkos_cxx_standard()
   
   #------------ GET OPTIONS ----------------------------------------------------
@@ -29,7 +28,7 @@ IF(${Trilinos_ENABLE_Kokkos})
     OUTPUT_FILE ${Kokkos_GEN_DIR}/core_src_make.out
     RESULT_VARIABLE res
   )
-  include(${Kokkos_GEN_DIR}/gen_kokkos.cmake)
+  include(${Kokkos_GEN_DIR}/kokkos_generated_settings.cmake)
 
   set(CXXFLAGS ${CXXFLAGS} ${KOKKOS_CXXFLAGS})
   # TODO -- need to remove the -lkokkos.  Check on LDFlags

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -23,7 +23,7 @@ IF(${Trilinos_ENABLE_Kokkos})
 
   #------------ GENERATE HEADER AND SOURCE FILES -------------------------------
   execute_process(
-    COMMAND ${KOKKOS_SETTINGS} make -f ${KOKKOS_SRC_PATH}/core/src/Makefile build-makefile-cmake-kokkos
+    COMMAND ${KOKKOS_SETTINGS} make -f ${KOKKOS_SRC_PATH}/cmake/Makefile.generate_cmake_settings CXX=${CMAKE_CXX_COMPILER} generate_cmake_settings
     WORKING_DIRECTORY "${Kokkos_GEN_DIR}"
     OUTPUT_FILE ${Kokkos_GEN_DIR}/core_src_make.out
     RESULT_VARIABLE res

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -1,0 +1,39 @@
+IF(${Trilinos_ENABLE_Kokkos})
+
+  # This is where to generate the gen_kokkos.cmake and KokkosCore_config.h 
+  # that we will use in the configuration
+  set(Kokkos_GEN_DIR ${CMAKE_BINARY_DIR})
+
+  # Basic initialization (Used in KOKKOS_SETTINGS)
+  set(KOKKOS_SRC_PATH ${Kokkos_SOURCE_DIR})
+  set(KOKKOS_PATH ${KOKKOS_SRC_PATH})
+
+  #------------ COMPILER AND FEATURE CHECKS ------------------------------------
+  include(${KOKKOS_SRC_PATH}/cmake/kokkos_functions.cmake)
+  set_kokkos_cxx_compiler()
+  set_kokkos_compiler_standard()
+  
+  #------------ GET OPTIONS ----------------------------------------------------
+  set(KOKKOS_CMAKE_VERBOSE True)
+  set(KOKKOS_HAS_TRILINOS True)
+  include(${KOKKOS_SRC_PATH}/cmake/kokkos_options.cmake)
+
+  #------------ COMPUTE KOKKOS_SETTINGS ----------------------------------------
+  include(${KOKKOS_SRC_PATH}/cmake/kokkos_settings.cmake)
+
+  #------------ GENERATE HEADER AND SOURCE FILES -------------------------------
+  execute_process(
+    COMMAND ${KOKKOS_SETTINGS} make -f ${KOKKOS_SRC_PATH}/core/src/Makefile build-makefile-cmake-kokkos
+    WORKING_DIRECTORY "${Kokkos_GEN_DIR}"
+    OUTPUT_FILE ${Kokkos_GEN_DIR}/core_src_make.out
+    RESULT_VARIABLE res
+  )
+  include(${Kokkos_GEN_DIR}/gen_kokkos.cmake)
+
+  set(CXXFLAGS ${CXXFLAGS} ${KOKKOS_CXXFLAGS})
+  # TODO -- need to remove the -lkokkos.  Check on LDFlags
+  #set(KOKKOS_LINK_DEPENDS libkokkos.a CACHE STRING "")
+  #set(KOKKOS_LIBS -lkokkos -ldl -lpthread CACHE STRING "")
+  #set(KOKKOS_LDFLAGS -L/scr_gabrielle/kruger/builds-ptsolve/trilinos/par2 --gcc-toolchain=/usr CACHE STRING "")
+
+ENDIF()

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -110,60 +110,62 @@ or CMake will automatically assume it is relative to the build dir!)
 Example: Configuring with Kokkos and advanced back-ends
 --------------------------------------------------------
 
-Kokkos serves as a basis for many advanced trilinos packages, especially those
-wanting to take advantages of advanced hardware such as the latest GPU.  
-Kokkos has its own build system that can be invoked, and this build system has
-more options than that supported by Trilinos by default, as it includes a rich
-set of options.   If Trilinos has the ability to set a Kokkos setting, that will
+Kokkos (https://github.com/kokkos/kokkos) is a C++ implementation of a
+cross-platform shared-memory parallel programming model. Many Trilinos packages,
+and other stand-alone applications, use it to implement parallel algorithms.
+Kokkos has two different build systems: Trilinos' CMake-based build system, and
+its own separate build system.
+
+If Trilinos has the ability to set a Kokkos setting, that will
 be used, otherwise one has to use the Kokkos setting.  Below we list which
 options to use::
 
-  +----------------------------+----------------------------------------------+
-  | Functionality              | Option                                       |
-  +============================+==============================================+
-  | Specify architecture       | KOKKOS_HOST_ARCH                             |
-  +----------------------------+----------------------------------------------+
-  | Build with separate libs   | KOKKOS_SEPARATE_LIBS                         |
-  +----------------------------+----------------------------------------------+
-  | Debug builds               | KOKKOS_DEBUG                                 |
-  +----------------------------+----------------------------------------------+
-  | Devices Options                                                           |
-  +----------------------------+----------------------------------------------+
-  | Enable Cuda                | TPL_ENABLE_CUDA                              |
-  +----------------------------+----------------------------------------------+
-  | Enable OpenMP              | Trilinos_ENABLE_OpenMP                       |
-  +----------------------------+----------------------------------------------+
-  | Enable Pthread             | TPL_ENABLE_PThread                           |
-  +----------------------------+----------------------------------------------+
-  | Specify Serial             | TPL_ENABLE_MPI (not)                         |
-  +----------------------------+----------------------------------------------+
-  | Advanced options                                                          |
-  +----------------------------+----------------------------------------------+
-  | Enable compiler warnings   | KOKKOS_ENABLE_COMPILER_WARNINGS              |
-  +----------------------------+----------------------------------------------+
-  | Aggressive Vectorization   | KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION       |
-  +----------------------------+----------------------------------------------+
-  | Profiling                  | KOKKOS_ENABLE_PROFILING                      |
-  +----------------------------+----------------------------------------------+
-  | Enable profile load print  | KOKKOS_ENABLE_PROFILE_LOAD_PRINT             |
-  +----------------------------+----------------------------------------------+
-  | Enable dualview modify chk | KOKKOS_ENABLE_DUALVIEW_MODIFY_CHECK          |
-  +----------------------------+----------------------------------------------+
-  | TPLs                                                                      |
-  +----------------------------+----------------------------------------------+
-  | Use hwloc library          | TPL_ENABLE_HWLOC                             |
-  +----------------------------+----------------------------------------------+
-  | Use memkind library        | KOKKOS_ENABLE_MEMKIND                        |
-  +----------------------------+----------------------------------------------+
-  | Use librt                  | KOKKOS_ENABLE_LIBRT                          |
-  +----------------------------+----------------------------------------------+
-  | CUDA Options                                                              |
-  +----------------------------+----------------------------------------------+
-  | Enable CUDA LDG            | KOKKOS_ENABLE_CUDA_LDG_INTRINSIC             |
-  +----------------------------+----------------------------------------------+
-  | Enable CUDA UVM            | KOKKOS_ENABLE_CUDA_UVM (unified virtual mem) |
-  +----------------------------+----------------------------------------------+
-  | Enable CUDA RDC            | KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE   |
-  +----------------------------+----------------------------------------------+
-  | Enable CUDA LAMBDA         | KOKKOS_ENABLE_CUDA_LAMBDA                    |
-  +----------------------------+----------------------------------------------+
+  +----------------------------+----------------------------------------------------+
+  | Functionality              | Option                                             |
+  +============================+====================================================+
+  | Specify architecture       | KOKKOS_HOST_ARCH                                   |
+  +----------------------------+----------------------------------------------------+
+  | Build with separate libs   | KOKKOS_SEPARATE_LIBS                               |
+  +----------------------------+----------------------------------------------------+
+  | Debug builds               | KOKKOS_DEBUG                                       |
+  +----------------------------+----------------------------------------------------+
+  | Device options             |                                                    |
+  +----------------------------+----------------------------------------------------+
+  | Enable Cuda                | TPL_ENABLE_CUDA                                    |
+  +----------------------------+----------------------------------------------------+
+  | Enable OpenMP              | Trilinos_ENABLE_OpenMP                             |
+  +----------------------------+----------------------------------------------------+
+  | Enable Pthread             | TPL_ENABLE_PThread                                 |
+  +----------------------------+----------------------------------------------------+
+  | Specify Serial             | TPL_ENABLE_MPI (not)                               |
+  +----------------------------+----------------------------------------------------+
+  | Advanced options           |                                                    |
+  +----------------------------+----------------------------------------------------+
+  | Enable compiler warnings   | KOKKOS_ENABLE_COMPILER_WARNINGS                    |
+  +----------------------------+----------------------------------------------------+
+  | Aggressive Vectorization   | KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION             |
+  +----------------------------+----------------------------------------------------+
+  | Profiling                  | KOKKOS_ENABLE_PROFILING                            |
+  +----------------------------+----------------------------------------------------+
+  | Enable profile load print  | KOKKOS_ENABLE_PROFILE_LOAD_PRINT                   |
+  +----------------------------+----------------------------------------------------+
+  | Enable dualview modify chk | KOKKOS_ENABLE_DUALVIEW_MODIFY_CHECK                |
+  +----------------------------+----------------------------------------------------+
+  | TPLs                       |                                                    |
+  +----------------------------+----------------------------------------------------+
+  | Use hwloc library          | TPL_ENABLE_HWLOC                                   |
+  +----------------------------+----------------------------------------------------+
+  | Use memkind library        | KOKKOS_ENABLE_MEMKIND                              |
+  +----------------------------+----------------------------------------------------+
+  | Use librt                  | KOKKOS_ENABLE_LIBRT                                |
+  +----------------------------+----------------------------------------------------+
+  | CUDA Options               |                                                    |
+  +----------------------------+----------------------------------------------------+
+  | Enable CUDA LDG            | KOKKOS_ENABLE_CUDA_LDG_INTRINSIC (global mem load) |
+  +----------------------------+----------------------------------------------------+
+  | Enable CUDA UVM            | KOKKOS_ENABLE_CUDA_UVM (unified virtual mem)       |
+  +----------------------------+----------------------------------------------------+
+  | Enable CUDA RDC            | KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE         |
+  +----------------------------+----------------------------------------------------+
+  | Enable CUDA LAMBDA         | KOKKOS_ENABLE_CUDA_LAMBDA                          |
+  +----------------------------+----------------------------------------------------+

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -105,3 +105,65 @@ In order do co-development of TriBTS and Trilinos (see http://http://trac.trilin
 
 (NOTE: You have to use the data-type ``STRING`` with ``Trilinos_TRIBITS_DIR``
 or CMake will automatically assume it is relative to the build dir!)
+
+
+Example: Configuring with Kokkos and advanced back-ends
+--------------------------------------------------------
+
+Kokkos serves as a basis for many advanced trilinos packages, especially those
+wanting to take advantages of advanced hardware such as the latest GPU.  
+Kokkos has its own build system that can be invoked, and this build system has
+more options than that supported by Trilinos by default, as it includes a rich
+set of options.   If Trilinos has the ability to set a Kokkos setting, that will
+be used, otherwise one has to use the Kokkos setting.  Below we list which
+options to use::
+
+  +----------------------------+----------------------------------------------+
+  | Functionality              | Option                                       |
+  +============================+==============================================+
+  | Specify architecture       | KOKKOS_HOST_ARCH                             |
+  +----------------------------+----------------------------------------------+
+  | Build with separate libs   | KOKKOS_SEPARATE_LIBS                         |
+  +----------------------------+----------------------------------------------+
+  | Debug builds               | KOKKOS_DEBUG                                 |
+  +----------------------------+----------------------------------------------+
+  | Devices Options                                                           |
+  +----------------------------+----------------------------------------------+
+  | Enable Cuda                | TPL_ENABLE_CUDA                              |
+  +----------------------------+----------------------------------------------+
+  | Enable OpenMP              | Trilinos_ENABLE_OpenMP                       |
+  +----------------------------+----------------------------------------------+
+  | Enable Pthread             | TPL_ENABLE_PThread                           |
+  +----------------------------+----------------------------------------------+
+  | Specify Serial             | TPL_ENABLE_MPI (not)                         |
+  +----------------------------+----------------------------------------------+
+  | Advanced options                                                          |
+  +----------------------------+----------------------------------------------+
+  | Enable compiler warnings   | KOKKOS_ENABLE_COMPILER_WARNINGS              |
+  +----------------------------+----------------------------------------------+
+  | Aggressive Vectorization   | KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION       |
+  +----------------------------+----------------------------------------------+
+  | Profiling                  | KOKKOS_ENABLE_PROFILING                      |
+  +----------------------------+----------------------------------------------+
+  | Enable profile load print  | KOKKOS_ENABLE_PROFILE_LOAD_PRINT             |
+  +----------------------------+----------------------------------------------+
+  | Enable dualview modify chk | KOKKOS_ENABLE_DUALVIEW_MODIFY_CHECK          |
+  +----------------------------+----------------------------------------------+
+  | TPLs                                                                      |
+  +----------------------------+----------------------------------------------+
+  | Use hwloc library          | TPL_ENABLE_HWLOC                             |
+  +----------------------------+----------------------------------------------+
+  | Use memkind library        | KOKKOS_ENABLE_MEMKIND                        |
+  +----------------------------+----------------------------------------------+
+  | Use librt                  | KOKKOS_ENABLE_LIBRT                          |
+  +----------------------------+----------------------------------------------+
+  | CUDA Options                                                              |
+  +----------------------------+----------------------------------------------+
+  | Enable CUDA LDG            | KOKKOS_ENABLE_CUDA_LDG_INTRINSIC             |
+  +----------------------------+----------------------------------------------+
+  | Enable CUDA UVM            | KOKKOS_ENABLE_CUDA_UVM (unified virtual mem) |
+  +----------------------------+----------------------------------------------+
+  | Enable CUDA RDC            | KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE   |
+  +----------------------------+----------------------------------------------+
+  | Enable CUDA LAMBDA         | KOKKOS_ENABLE_CUDA_LAMBDA                    |
+  +----------------------------+----------------------------------------------+


### PR DESCRIPTION
cmake/ProjectCompilerPostConfig.cmake now invokes the kokkos
build system to get additional compiler information that is useful for
advanced architectures.  This enables the useful information that Kokkos
calculates can be more widely available.