### PR TITLE
[WIP] Tpetra: Fix #1889

### DIFF
--- a/packages/teuchos/kokkoscompat/src/CMakeLists.txt
+++ b/packages/teuchos/kokkoscompat/src/CMakeLists.txt
@@ -31,4 +31,8 @@ SET(TRILINOS_INCDIR ${CMAKE_INSTALL_PREFIX}/${${PROJECT_NAME}_INSTALL_INCLUDE_DI
 
 INSTALL(FILES ${HEADERS} DESTINATION ${TRILINOS_INCDIR}/)
 
-#-----------------------------------------------------------------------------
+#
+# Make a trivial change to this comment if you add / remove a file
+# either to / from this directory.  That ensures that running "make"
+# will also rerun CMake in order to regenerate Makefiles.
+#

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_ClassicNodeAPI_Wrapper.cpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_ClassicNodeAPI_Wrapper.cpp
@@ -1,390 +1,66 @@
-#include <KokkosCompat_ClassicNodeAPI_Wrapper.hpp>
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "KokkosCompat_Details_KokkosInit.hpp"
 #include <Kokkos_Core.hpp>
-#include <cerrno>
-#include <cstdlib> // getenv
-#include <sstream>
-
-
-#if defined(KOKKOS_HAVE_OPENMP) || defined(KOKKOS_HAVE_PTHREAD) || defined(KOKKOS_HAVE_CUDA)
-  // The struct and function here only get used if at least one of
-  // Kokkos::Cuda, Kokkos::OpenMP, or Kokkos::Threads are enabled.
-
-namespace { // (anonymous)
-
-  struct CmdLineArgs {
-    int numThreads;
-    int numNuma;
-    int deviceId;
-    int numDevices;
-
-    CmdLineArgs () : // Default values let Kokkos decide
-      numThreads (-1), numNuma (-1), deviceId (-1), numDevices (-1)
-    {}
-  };
-
-  CmdLineArgs
-  getCommandLineArgs ()
-  {
-    using std::cerr;
-    using std::endl;
-
-    const bool debug = false;
-    if (debug) {
-      cerr << "Tpetra: get command-line arguments for Kokkos wrapper Nodes"
-           << endl;
-    }
-
-    CmdLineArgs argsOut;
-    // Some flag value that Kokkos::initialize uses; I just imitated
-    // its logic.
-    int skip_device = 9999;
-
-    // Attempt to read command-line arguments that were stored in
-    // Teuchos::GlobalMPISession. User settings override these.
-
-    const auto argv = ::Teuchos::GlobalMPISession::getArgv ();
-    bool gotNumDevices = false;
-
-    // Loop over all command-line arguments.  If the same argument
-    // name occurs multiple times, we read all of them and use the
-    // last provided value.
-    const int narg = static_cast<int> (argv.size ());
-    for (int iarg = 0; iarg < narg; ++iarg) {
-      // getArgv() only promises to return an array whose entries are
-      // convertible to std::string.  Thus, it's not legit to assign
-      // to const std::string&; we actually must create an std::string
-      // from the array entry.
-      const std::string curArg = argv[iarg];
-
-      if (debug) {
-        cerr << "  Current command-line argument: " << curArg << endl;
-      }
-
-      // Find "--" and "=".  These two together, "--" before "=", with
-      // something after "=", indicate a valid command-line argument.
-      // It might be a Kokkos one, or it might be something else.
-      const size_t posDash = curArg.find ("--");
-      if (posDash == std::string::npos) {
-        continue; // argument name must start with "--"
-      }
-      const size_t posEqual = curArg.find ("=");
-      if (posEqual == std::string::npos ||
-          ! (posDash + static_cast<size_t> (2) < posEqual) ||
-          posEqual + static_cast<size_t> (1) == curArg.size ()) {
-        // Command-line argument must contain "=",
-        // "--" must come before "=" with >= 1 characters in between,
-        // and >= 1 characters must follow "=".
-        continue;
-      }
-
-      // Does the command-line argument start with "--kokkos-"?  If
-      // so, it's a Kokkos-specific command-line argument.  Otherwise,
-      // Kokkos still reads it.
-      const size_t posKokkos = curArg.find ("kokkos-", posDash+2);
-      const size_t posArgStart =
-        (posKokkos == std::string::npos) ? (posDash+2) : (posKokkos+7);
-
-      // Figure out _which_ Kokkos argument we got.  Put "ndevices" in
-      // front of "device", since the latter is a substring of the
-      // former.
-      const char* validArgNames[4] = {"threads", "numa", "ndevices", "device"};
-      const int numValidArgNames = 4;
-      const int numDevicesInd = 2;
-
-      int argNameInd = 0; // need to save this for below
-      for ( ; argNameInd < numValidArgNames; ++argNameInd) {
-        const size_t posArgName =
-          curArg.find (validArgNames[argNameInd], posArgStart);
-        if (posArgName != std::string::npos) {
-          if (argNameInd == numDevicesInd) { // "ndevices" is a special case
-            gotNumDevices = true;
-          }
-          break;
-        }
-      }
-
-      // Get the one or two numbers that follow the "=".  "ndevices"
-      // is the only argument take takes two numbers (separated by
-      // ",").  All other cases take just one number.  For simplicity,
-      // we always look for both numbers, and ignore the second one if
-      // the command-line option doesn't use it.
-
-      int firstNum = 0;
-      int secondNum = 0;
-      bool gotFirstNum = false;
-      bool gotSecondNum = false;
-
-      const size_t posComma = curArg.find (",", posEqual+1);
-      if (posComma == std::string::npos) { // no comma after "="
-        // "--kokkos-$NAME=$NUMBER1" -- just read first number $NUMBER1
-        const std::string arg1 = curArg.substr (posEqual + 1, std::string::npos);
-        if (arg1.size () != 0) {
-          std::istringstream istr1 (arg1);
-          bool threw = false;
-          try {
-            istr1 >> firstNum;
-          }
-          catch (...) {
-            threw = true;
-            gotFirstNum = false;
-          }
-          if (! threw) {
-            // Yes, I could write ! (! istr1), but that looks ridiculous.
-            gotFirstNum = ! istr1.bad () && ! istr1.fail ();
-          }
-        }
-      }
-      else if (posComma == posEqual + 1) { // comma right after "="
-        // "--kokkos-$NAME=,$NUMBER2" -- just read second number $NUMBER2
-        const std::string arg2 = curArg.substr (posComma + 1, std::string::npos);
-        if (arg2.size () != 0) {
-          std::istringstream istr2 (arg2);
-          bool threw = false;
-          try {
-            istr2 >> secondNum;
-          }
-          catch (...) {
-            threw = true;
-            gotSecondNum = false;
-          }
-          if (! threw) {
-            // Yes, I could write ! (! istr2), but that looks ridiculous.
-            gotSecondNum = ! istr2.bad () && ! istr2.fail ();
-          }
-        }
-      }
-      else { // comma follows "=", with >= 1 intervening characters
-        // "--kokkos-$NAME=$NUMBER1,$NUMBER2" -- read both numbers
-        const std::string arg1 = curArg.substr (posEqual + 1, std::string::npos);
-        if (arg1.size () != 0) {
-          std::istringstream istr1 (arg1);
-          bool threw = false;
-          try {
-            istr1 >> firstNum;
-          }
-          catch (...) {
-            threw = true;
-            gotFirstNum = false;
-          }
-          if (! threw) {
-            // Yes, I could write ! (! istr1), but that looks ridiculous.
-            gotFirstNum = ! istr1.bad () && ! istr1.fail ();
-          }
-        }
-        const std::string arg2 = curArg.substr (posComma + 1, std::string::npos);
-        if (arg2.size () != 0) {
-          std::istringstream istr2 (arg2);
-          bool threw = false;
-          try {
-            istr2 >> secondNum;
-          }
-          catch (...) {
-            threw = true;
-            gotSecondNum = false;
-          }
-          if (! threw) {
-            // Yes, I could write ! (! istr2), but that looks ridiculous.
-            gotSecondNum = ! istr2.bad () && ! istr2.fail ();
-          }
-        }
-      }
-
-      if (argNameInd == 0) {
-        argsOut.numThreads = firstNum;
-      }
-      else if (argNameInd == 1) {
-        argsOut.numNuma = firstNum;
-      }
-      else if (argNameInd == 2) {
-        if (gotFirstNum) {
-          argsOut.numDevices = firstNum;
-        }
-        else {
-          continue; // TODO REPORT ERROR
-        }
-        if (gotSecondNum) {
-          skip_device = secondNum;
-        }
-
-        argsOut.numDevices = secondNum;
-        gotNumDevices = true;
-      }
-      else if (argNameInd == 3) {
-        argsOut.deviceId = firstNum;
-      }
-      else if (argNameInd == numValidArgNames) {
-        continue; // name wasn't in the list of valid names
-      }
-    } // for each command-line argument
-
-    // If Kokkos::initialize doesn't get the --kokkos-ndevices option,
-    // it tries to use environment variables to figure this out.
-    if (! gotNumDevices) {
-      char* str = getenv ("SLURM_LOCALID");
-      if (str == NULL) {
-        str = getenv ("MV2_COMM_WORLD_LOCAL_RANK");
-      }
-      if (str == NULL) {
-        str = getenv ("OMPI_COMM_WORLD_LOCAL_RANK");
-      }
-
-      if (str != NULL) {
-        const std::string sstr (str);
-        std::istringstream istr (sstr);
-
-        int localRank = -1;
-        bool gotLocalRank = false;
-        try {
-          istr >> localRank;
-          gotLocalRank = true;
-        }
-        catch (...) {
-          gotLocalRank = false;
-        }
-        if (! istr.bad () && ! istr.fail ()) {
-          gotLocalRank = true;
-        }
-
-        if (gotLocalRank) {
-          argsOut.deviceId = localRank % argsOut.numDevices;
-          if (argsOut.deviceId >= skip_device) {
-            argsOut.deviceId++;
-          }
-        }
-      }
-
-      if (argsOut.deviceId == -1) {
-        argsOut.deviceId = 0;
-        // mfh 24 Apr 2016: This looks a little funny (why isn't it
-        // outside the argsOut.deviceId == -1 test?), but it imitates
-        // the implementation of Kokkos::initialize.  See
-        // kokkos/core/src/impl/Kokkos_Core.cpp, lines 368-371.
-        if (argsOut.deviceId >= skip_device) {
-          argsOut.deviceId++;
-        }
-      }
-    }
-
-    if (debug) {
-      cerr << "Tpetra: got command-line arguments: {"
-           << "numThreads: " << argsOut.numThreads << ','
-           << "numNuma: " << argsOut.numNuma << ','
-           << "deviceId: " << argsOut.deviceId << ','
-           << "numDevices: " << argsOut.numDevices << '}' << endl;
-    }
-    return argsOut;
-  }
-
-} // namespace (anonymous)
-
-#endif // defined(KOKKOS_HAVE_OPENMP) || defined(KOKKOS_HAVE_PTHREAD)
+#include <iostream>
 
 namespace Kokkos {
   namespace Compat {
-    namespace Details {
-      bool
-      getVerboseParameter (const Teuchos::ParameterList& params)
-      {
-        const bool defaultValue = false; // default value of the parameter
-
-        if (params.isParameter ("Verbose")) {
-          if (params.isType<bool> ("Verbose")) { // is it a bool?
-            return params.get<bool> ("Verbose");
-          }
-          else if (params.isType<int> ("Verbose")) { // is it an int?
-            return params.get<int> ("Verbose");
-          }
-          // It might be polite to throw at this point with a helpful
-          // message explaining that the parameter has the wrong type,
-          // but that would change current behavior, so I'll just
-          // leave it.
-        }
-        return defaultValue;
-      }
-
-      Teuchos::ParameterList getDefaultNodeParameters ()
-      {
-        Teuchos::ParameterList params;
-        params.set ("Verbose", 0);
-        // -1 says "Let Kokkos pick"
-        params.set ("Num Threads", -1);
-        params.set ("Num NUMA", -1);
-        params.set ("Num CoresPerNUMA", -1);
-        params.set ("Device", 0);
-        return params;
-      }
-    } // namespace Details
 
 #ifdef KOKKOS_HAVE_PTHREAD
     template<>
     KokkosDeviceWrapperNode<Kokkos::Threads>::
-    ~KokkosDeviceWrapperNode<Kokkos::Threads> ()
+    KokkosDeviceWrapperNode ()
     {
-      count--;
-      // Only call Kokkos::Threads::finalize if the Node reference
-      // count is zero, if Kokkos::Threads is already initialized, and
-      // if Node's constructor was responsible for initializing it.
-      // (See Github Issue #510.)
-      if (count == 0 && Threads::is_initialized () && nodeResponsibleForFinalizingExecutionSpace_) {
-#ifdef KOKKOS_HAVE_CUDA
-        // If any instances of KokkosDeviceWrapperNode<Kokkos::Cuda>
-        // exist, they are responsible for calling finalize on Cuda's
-        // host execution space.
-        if (! Impl::is_same<Kokkos::Threads,HostSpace::execution_space>::value ||
-            KokkosDeviceWrapperNode<Kokkos::Cuda>::count == 0)
-#endif // KOKKOS_HAVE_CUDA
-          Threads::finalize ();
-      }
-      checkDestructorEnd ();
+      KokkosCompat::Details::initializeKokkos ();
     }
 
     template<>
-    void KokkosDeviceWrapperNode<Kokkos::Threads>::
-    init (int NumThreads, int NumNUMA, int NumCoresPerNUMA, int /* Device */) {
-      using std::cerr;
-      using std::endl;
-      const bool debug = false;
+    KokkosDeviceWrapperNode<Kokkos::Threads>::
+    KokkosDeviceWrapperNode (Teuchos::ParameterList& params)
+    {
+      using ::KokkosCompat::Details::getNodeParameters;
 
-      if (! Kokkos::Threads::is_initialized ()) {
-
-        // Attempt to read command-line arguments that were stored in
-        // Teuchos::GlobalMPISession. User settings override these.
-        CmdLineArgs args = getCommandLineArgs ();
-
-        if (args.numThreads != -1) {
-          NumThreads = args.numThreads;
-        }
-        if (args.numNuma != -1) {
-          NumNUMA = args.numNuma;
-        }
-        if (args.deviceId != -1) {
-          NumCoresPerNUMA = args.deviceId;
-        }
-        // if (args.numDevice != -1) {
-        //   Device = args.numDevice; // Threads doesn't need this one
-        // }
-
-        if (NumNUMA > 0 && NumCoresPerNUMA > 0) {
-          Kokkos::Threads::initialize (NumThreads, NumNUMA, NumCoresPerNUMA);
-        }
-        else if (NumNUMA > 0) {
-          Kokkos::Threads::initialize (NumThreads, NumNUMA);
-        }
-        else if (NumThreads > 0) {
-          if (debug) {
-            cerr << "Tpetra Threads wrapper Node: NumThreads = "
-                 << NumThreads << endl;
-          }
-          Kokkos::Threads::initialize (NumThreads);
-          if (debug) {
-            cerr << "Tpetra Threads wrapper Node: Concurrency = "
-                 << Kokkos::Threads::concurrency () << endl;
-          }
-        }
-        else {
-          Kokkos::Threads::initialize ();
-        }
+      int curNumThreads = -1; // -1 says "let Kokkos pick"
+      int curNumNUMA = -1; // -1 says "let Kokkos pick"
+      int curNumCoresPerNUMA = -1; // -1 says "let Kokkos pick"
+      int curDevice = 0; // -1 does NOT say "let Kokkos pick"
+      bool verbose = false;
+      getNodeParameters (curNumThreads, curNumNUMA, curNumCoresPerNUMA,
+                         curDevice, verbose, params);
+      if (verbose) {
+        std::ostream& out = std::cout;
+        out << "DeviceWrapperNode with ExecutionSpace = Kokkos::Threads "
+            << " initializing with "
+            << "\"Num Threads\" = " << curNumThreads
+            << ", \"Num NUMA\" = " << curNumNUMA
+            << ", \"Num CoresPerNUMA\" = " << curNumCoresPerNUMA
+            << " \"Device\" = " << curDevice << std::endl;
       }
+
+      Kokkos::InitArguments args;
+      args.num_threads = curNumThreads;
+      args.num_numa = curNumNUMA;
+      (void) curNumCoresPerNUMA;
+      (void) curDevice;
+      // initializes at most once
+      KokkosCompat::Details::initializeKokkos (args);
+    }
+
+    template<>
+    Teuchos::ParameterList
+    KokkosDeviceWrapperNode<Kokkos::Threads>::
+    getDefaultParameters ()
+    {
+      using ::KokkosCompat::Details::getDefaultNodeParameters;
+      return getDefaultNodeParameters ();
+    }
+
+    template<>
+    void
+    KokkosDeviceWrapperNode<Kokkos::Threads>::
+    sync () const
+    {
+      Kokkos::Threads::fence ();
     }
 
     template<>
@@ -395,61 +71,60 @@ namespace Kokkos {
 
 #ifdef KOKKOS_HAVE_OPENMP
     template<>
-    KokkosDeviceWrapperNode<Kokkos::OpenMP>::~KokkosDeviceWrapperNode<Kokkos::OpenMP>() {
-      count--;
-      // Only call Kokkos::OpenMP::finalize if the Node reference
-      // count is zero, if Kokkos::OpenMP is already initialized, and
-      // if Node's constructor was responsible for initializing it.
-      // (See Github Issue #510.)
-      if (count == 0 && OpenMP::is_initialized () && nodeResponsibleForFinalizingExecutionSpace_) {
-#ifdef KOKKOS_HAVE_CUDA
-        // If any instances of KokkosDeviceWrapperNode<Kokkos::Cuda>
-        // exist, they are responsible for calling finalize on Cuda's
-        // host execution space.
-        if (! Impl::is_same<Kokkos::OpenMP, HostSpace::execution_space>::value ||
-            KokkosDeviceWrapperNode<Kokkos::Cuda>::count == 0)
-#endif // KOKKOS_HAVE_CUDA
-        OpenMP::finalize ();
-      }
-      checkDestructorEnd ();
+    KokkosDeviceWrapperNode<Kokkos::OpenMP>::
+    KokkosDeviceWrapperNode ()
+    {
+      KokkosCompat::Details::initializeKokkos ();
     }
 
     template<>
-    void KokkosDeviceWrapperNode<Kokkos::OpenMP>::
-    init (int NumThreads, int NumNUMA, int NumCoresPerNUMA, int /* Device */)
+    KokkosDeviceWrapperNode<Kokkos::OpenMP>::
+    KokkosDeviceWrapperNode (Teuchos::ParameterList& params)
     {
-      if (! Kokkos::OpenMP::is_initialized ()) {
+      using ::KokkosCompat::Details::getNodeParameters;
 
-        // Attempt to read command-line arguments that were stored in
-        // Teuchos::GlobalMPISession. User settings override these.
-        CmdLineArgs args = getCommandLineArgs ();
+      int curNumThreads = -1; // -1 says "let Kokkos pick"
+      int curNumNUMA = -1; // -1 says "let Kokkos pick"
+      int curNumCoresPerNUMA = -1; // -1 says "let Kokkos pick"
+      int curDevice = 0; // -1 does NOT say "let Kokkos pick" for Cuda Devices
+      bool verbose = false;
 
-        if (args.numThreads != -1) {
-          NumThreads = args.numThreads;
-        }
-        if (args.numNuma != -1) {
-          NumNUMA = args.numNuma;
-        }
-        if (args.deviceId != -1) {
-          NumCoresPerNUMA = args.deviceId;
-        }
-        // if (args.numDevice != -1) {
-        //   Device = args.numDevice; // OpenMP doesn't need this one
-        // }
-
-        if (NumNUMA > 0 && NumCoresPerNUMA > 0) {
-          Kokkos::OpenMP::initialize (NumThreads, NumNUMA, NumCoresPerNUMA);
-        }
-        else if (NumNUMA > 0) {
-          Kokkos::OpenMP::initialize (NumThreads, NumNUMA);
-        }
-        else if (NumThreads > 0) {
-          Kokkos::OpenMP::initialize (NumThreads);
-        }
-        else {
-          Kokkos::OpenMP::initialize ();
-        }
+      getNodeParameters (curNumThreads, curNumNUMA, curNumCoresPerNUMA,
+                         curDevice, verbose, params);
+      if (verbose) {
+        std::ostream& out = std::cout;
+        out << "DeviceWrapperNode with ExecutionSpace = Kokkos::OpenMP "
+            << " initializing with "
+            << "\"Num Threads\" = " << curNumThreads
+            << ", \"Num NUMA\" = " << curNumNUMA
+            << ", \"Num CoresPerNUMA\" = " << curNumCoresPerNUMA
+            << " \"Device\" = " << curDevice << std::endl;
       }
+
+      Kokkos::InitArguments args;
+      args.num_threads = curNumThreads;
+      args.num_numa = curNumNUMA;
+      (void) curNumCoresPerNUMA;
+      (void) curDevice;
+      // initializes at most once
+      KokkosCompat::Details::initializeKokkos (args);
+    }
+
+    template<>
+    Teuchos::ParameterList
+    KokkosDeviceWrapperNode<Kokkos::OpenMP>::
+    getDefaultParameters ()
+    {
+      using ::KokkosCompat::Details::getDefaultNodeParameters;
+      return getDefaultNodeParameters ();
+    }
+
+    template<>
+    void
+    KokkosDeviceWrapperNode<Kokkos::OpenMP>::
+    sync () const
+    {
+      Kokkos::OpenMP::fence ();
     }
 
     template<>
@@ -460,35 +135,57 @@ namespace Kokkos {
 
 #ifdef KOKKOS_HAVE_SERIAL
     template<>
-    KokkosDeviceWrapperNode<Kokkos::Serial>::~KokkosDeviceWrapperNode<Kokkos::Serial>() {
-      count--;
-      // Only call Kokkos::Serial::finalize if the Node reference
-      // count is zero, if Kokkos::Serial is already initialized, and
-      // if Node's constructor was responsible for initializing it.
-      // (See Github Issue #510.)
-      if (count == 0 && Serial::is_initialized () && nodeResponsibleForFinalizingExecutionSpace_) {
-#ifdef KOKKOS_HAVE_CUDA
-        // If any instances of KokkosDeviceWrapperNode<Kokkos::Cuda>
-        // exist, they are responsible for calling finalize on Cuda's
-        // host execution space.
-        if (! Impl::is_same<Kokkos::Serial, HostSpace::execution_space>::value ||
-            KokkosDeviceWrapperNode<Kokkos::Cuda>::count == 0)
-#endif // KOKKOS_HAVE_CUDA
-          Serial::finalize ();
-      }
-      checkDestructorEnd ();
+    KokkosDeviceWrapperNode<Kokkos::Serial>::
+    KokkosDeviceWrapperNode ()
+    {
+      KokkosCompat::Details::initializeKokkos ();
     }
 
     template<>
-    void KokkosDeviceWrapperNode<Kokkos::Serial>::
-    init (int /* NumThreads */,
-          int /* NumNUMA */,
-          int /* NumCoresPerNUMA */,
-          int /* Device */)
+    KokkosDeviceWrapperNode<Kokkos::Serial>::
+    KokkosDeviceWrapperNode (Teuchos::ParameterList& params)
     {
-      if (! Kokkos::Serial::is_initialized ()) {
-        Kokkos::Serial::initialize ();
+      using ::KokkosCompat::Details::getNodeParameters;
+
+      int curNumThreads = -1; // -1 says "let Kokkos pick"
+      int curNumNUMA = -1; // -1 says "let Kokkos pick"
+      int curNumCoresPerNUMA = -1; // -1 says "let Kokkos pick"
+      int curDevice = 0; // -1 does NOT say "let Kokkos pick" for Cuda Devices
+      bool verbose = false;
+
+      getNodeParameters (curNumThreads, curNumNUMA, curNumCoresPerNUMA,
+                         curDevice, verbose, params);
+      if (verbose) {
+        std::ostream& out = std::cout;
+        out << "DeviceWrapperNode with ExecutionSpace = Kokkos::Serial "
+            << " initializing with "
+            << "\"Num Threads\" = " << curNumThreads
+            << ", \"Num NUMA\" = " << curNumNUMA
+            << ", \"Num CoresPerNUMA\" = " << curNumCoresPerNUMA
+            << " \"Device\" = " << curDevice << std::endl;
       }
+      (void) curNumThreads;
+      (void) curNumNUMA;
+      (void) curNumCoresPerNUMA;
+      (void) curDevice;
+      KokkosCompat::Details::initializeKokkos ();
+    }
+
+    template<>
+    Teuchos::ParameterList
+    KokkosDeviceWrapperNode<Kokkos::Serial>::
+    getDefaultParameters ()
+    {
+      using ::KokkosCompat::Details::getDefaultNodeParameters;
+      return getDefaultNodeParameters ();
+    }
+
+    template<>
+    void
+    KokkosDeviceWrapperNode<Kokkos::Serial>::
+    sync () const
+    {
+      Kokkos::Serial::fence ();
     }
 
     template<>
@@ -499,135 +196,60 @@ namespace Kokkos {
 
 #ifdef KOKKOS_HAVE_CUDA
     template<>
-    KokkosDeviceWrapperNode<Kokkos::Cuda>::~KokkosDeviceWrapperNode<Kokkos::Cuda>() {
-      count--;
-      if (count == 0) {
-        // Don't call finalize on the host execution space until all
-        // Node instances corresponding to the host execution space
-        // are gone.  Also, don't call finalize on it if Node wasn't
-        // responsible for calling initialize on it (see Github Issue
-        // #510).
-        if (HostSpace::execution_space::is_initialized () &&
-            KokkosDeviceWrapperNode<HostSpace::execution_space>::count == 0 &&
-            KokkosDeviceWrapperNode<HostSpace::execution_space>::nodeResponsibleForFinalizingExecutionSpace_) {
-          HostSpace::execution_space::finalize ();
-        }
-        // Only call Kokkos::Cuda::finalize if the Node reference
-        // count is zero, if Kokkos::Cuda is already initialized, and
-        // if Node's constructor was responsible for initializing it.
-        // (See Github Issue #510.)
-        if (Cuda::is_initialized () && nodeResponsibleForFinalizingExecutionSpace_) {
-          Cuda::finalize ();
-        }
-      }
-      checkDestructorEnd ();
+    KokkosDeviceWrapperNode<Kokkos::Cuda>::
+    KokkosDeviceWrapperNode ()
+    {
+      KokkosCompat::Details::initializeKokkos ();
     }
 
     template<>
-    void KokkosDeviceWrapperNode<Kokkos::Cuda>::
-    init (int NumThreads, int NumNUMA, int NumCoresPerNUMA, int Device)
+    KokkosDeviceWrapperNode<Kokkos::Cuda>::
+    KokkosDeviceWrapperNode (Teuchos::ParameterList& params)
     {
-      // Setting (currently) necessary environment variables for NVIDIA UVM
-#ifdef KOKKOS_USE_CUDA_UVM
-      // We want to override any existing setting of CUDA_LAUNCH_BLOCKING.
-      const int overwrite = 1;
-      const int errCode = setenv ("CUDA_LAUNCH_BLOCKING", "1", overwrite);
+      using ::KokkosCompat::Details::getNodeParameters;
 
-      //putenv("CUDA_LAUNCH_BLOCKING=1"); // see note below
+      int curNumThreads = -1; // -1 says "let Kokkos pick"
+      int curNumNUMA = -1; // -1 says "let Kokkos pick"
+      int curNumCoresPerNUMA = -1; // -1 says "let Kokkos pick"
+      int curDevice = 0; // -1 does NOT say "let Kokkos pick" for Cuda Devices
+      bool verbose = false;
 
-      // mfh 22 Jul 2016: POSIX prefers use of setenv over putenv:
-      //
-      // http://pubs.opengroup.org/onlinepubs/009695399/functions/putenv.html
-      //
-      // There are two problems with putenv:
-      //
-      // 1. It takes its input as a nonconst pointer.  This causes a
-      //    build warning (e.g., "conversion from a string literal to
-      //    'char *' is deprecated") when using a string literal, in
-      //    this case "CUDA_LAUNCH_BLOCKING=1", as the input argument.
-      //
-      // 2. putenv does not let us fix the above build warning by
-      //    copying into a temporary nonconst char array and passing
-      //    that into putenv.  This is because putenv is free to keep
-      //    the original input pointer, rather than copying the input
-      //    string.  Thus, if anyone tries to read the environment
-      //    variable (via getenv) after the temporary array has been
-      //    freed, they would be reading invalid memory.  The above
-      //    POSIX standard entry alludes to this: "A potential error
-      //    is to call putenv() with an automatic variable as the
-      //    argument, then return from the calling function while
-      //    string is still part of the environment."
-
-      if (errCode != 0) {
-        // Printing operations may change errno, so we save it first.
-        const int savedErrno = errno;
-        std::ostringstream os;
-        os << "KokkosCudaWrapperNode attempted to call "
-          "setenv(\"CUDA_LAUNCH_BLOCKING\", \"1\", " << overwrite << "), "
-          "but it returned a nonzero error code.  ";
-        if (savedErrno == EINVAL) {
-          os << "errno == EINVAL; this should never happen, because it implies "
-            "that the input strings were NULL; they certainly were not in this "
-            "case.";
-          throw std::logic_error (os.str ());
-        }
-        else if (savedErrno == ENOMEM) {
-          // If setenv ran out of memory, we're probably in trouble
-          // and not even able to construct the error string, but
-          // we'll try regardless.
-          os << "errno == ENOMEM; this means setenv ran out of memory.";
-          throw std::runtime_error (os.str ());
-        }
-        else {
-          os << "errno != EINVAL && errno != ENOMEM; not sure what this means.";
-          throw std::runtime_error (os.str ());
-        }
-      }
-#else
-      throw std::runtime_error ("Using KokkosCudaWrapperNode "
-                                "(KokkosDeviceWrapperNode<Kokkos::Cuda, ...> "
-                                "without UVM is not allowed.");
-#endif // KOKKOS_USE_CUDA_UVM
-
-      // Attempt to read command-line arguments that were stored in
-      // Teuchos::GlobalMPISession. User settings override these.
-      CmdLineArgs args = getCommandLineArgs ();
-
-      if (args.numThreads != -1) {
-        NumThreads = args.numThreads;
-      }
-      if (args.numNuma != -1) {
-        NumNUMA = args.numNuma;
-      }
-      // mfh 22 Jul 2016: Kokkos::initialize doesn't actually set
-      // NumCoresPerNUMA when it reads command-line arguments, in the
-      // Cuda case.
-      //
-      // if (args.numDevices != -1) {
-      //   NumCoresPerNUMA = args.numDevices; // ???
-      // }
-      if (args.deviceId != -1) {
-        Device = args.deviceId;
+      getNodeParameters (curNumThreads, curNumNUMA, curNumCoresPerNUMA,
+                         curDevice, verbose, params);
+      if (verbose) {
+        std::ostream& out = std::cout;
+        out << "DeviceWrapperNode with ExecutionSpace = Kokkos::Cuda "
+            << " initializing with "
+            << "\"Num Threads\" = " << curNumThreads
+            << ", \"Num NUMA\" = " << curNumNUMA
+            << ", \"Num CoresPerNUMA\" = " << curNumCoresPerNUMA
+            << " \"Device\" = " << curDevice << std::endl;
       }
 
-      if (! Kokkos::HostSpace::execution_space::is_initialized ()) {
-        if (NumNUMA > 0 && NumCoresPerNUMA > 0) {
-          Kokkos::HostSpace::execution_space::initialize (NumThreads, NumNUMA, NumCoresPerNUMA);
-        }
-        else if (NumNUMA > 0) {
-          Kokkos::HostSpace::execution_space::initialize (NumThreads, NumNUMA);
-        }
-        else if (NumThreads > 0) {
-          Kokkos::HostSpace::execution_space::initialize (NumThreads);
-        }
-        else {
-          Kokkos::HostSpace::execution_space::initialize ();
-        }
-      }
-      Kokkos::Cuda::SelectDevice select_device (Device);
-      if (! Kokkos::Cuda::is_initialized ()) {
-        Kokkos::Cuda::initialize (select_device);
-      }
+      ::KokkosCompat::Details::setUpEnvironmentForCuda ();
+      Kokkos::InitArguments args;
+      args.num_threads = curNumThreads;
+      args.num_numa = curNumNUMA;
+      (void) curNumCoresPerNUMA;
+      args.device_id = curDevice;
+      KokkosCompat::Details::initializeKokkos (args);
+    }
+
+    template<>
+    Teuchos::ParameterList
+    KokkosDeviceWrapperNode<Kokkos::Cuda>::
+    getDefaultParameters ()
+    {
+      using ::KokkosCompat::Details::getDefaultNodeParameters;
+      return getDefaultNodeParameters ();
+    }
+
+    template<>
+    void
+    KokkosDeviceWrapperNode<Kokkos::Cuda>::
+    sync () const
+    {
+      Kokkos::Cuda::fence ();
     }
 
     template<>

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_ClassicNodeAPI_Wrapper.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_ClassicNodeAPI_Wrapper.hpp
@@ -2,40 +2,18 @@
 #define KOKKOSCOMPAT_CLASSICNODEAPI_WRAPPER_HPP
 
 #include "TeuchosKokkosCompat_config.h"
-#include "KokkosCompat_View.hpp"
+#include "KokkosCompat_View.hpp" // why do we need to include this?
 #include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 
-#ifdef KOKKOS_HAVE_CUDA
-  #ifndef KERNEL_PREFIX
-    #ifdef __CUDACC__
-    #define KERNEL_PREFIX __host__ __device__
-    #endif
-  #endif
-#endif
-
 namespace Kokkos {
 namespace Compat {
-namespace Details {
-
-/// \brief Get the value of the "Verbose" parameter as a \c bool.
-///
-/// This method lets the "Verbose" parameter have type either \c int
-/// or \c bool, and returns its value as \c bool.  If the "Verbose"
-/// parameter does not exist in the given list, return the default
-/// value, which is \c false.
-bool
-getVerboseParameter (const Teuchos::ParameterList& params);
-
-Teuchos::ParameterList getDefaultNodeParameters ();
-
-} // namespace Details
 
 /// \brief Node that wraps a new Kokkos execution space.
+///
 /// \tparam ExecutionSpace The type of the Kokkos execution space to wrap.
 /// \tparam MemorySpace The Kokkos memory space in which to work.
 ///   Defaults to the default memory space of ExecutionSpace.
-/// \ingroup kokkos_node_api
 template<class ExecutionSpace,
          class MemorySpace = typename ExecutionSpace::memory_space>
 class KokkosDeviceWrapperNode {
@@ -54,32 +32,7 @@ public:
   /// We will deprecate the "classic" Node types with the 11.14
   /// release of Trilinos, and remove them entirely with the 12.0
   /// release.  This Node type is safe to use.
-  static const bool classic = false;
-
-  /// \brief Reference count of Node instances.
-  ///
-  /// \warning Do NOT read or modify this.  This is an implementation
-  ///   detail of the class.
-  ///
-  /// If Node originally called ExecutionSpace::initialize() (see
-  /// Github Issue #510), and if the count reaches zero in the
-  /// destructor, we call ExecutionSpace::finalize().
-  static int count;
-
-  /// \brief Is the Node responsible for finalizing its execution space?
-  ///
-  /// \warning Do NOT read or modify this.  This is an implementation
-  ///   detail of the class.
-  ///
-  /// In Node's constructor, was it ever true that count == 0 and
-  /// execution_space::is_initialized()?  If so, this means that
-  /// somebody else (the user, or some other library) initialized the
-  /// execution space before Node got to it.  In that case, the Node's
-  /// destructor should NOT call (is not responsible for calling)
-  /// execution_space::finalize().
-  ///
-  /// This fixes Github Issue #510.
-  static bool nodeResponsibleForFinalizingExecutionSpace_;
+  static constexpr bool classic = false;
 
   /// \brief Constructor (that takes a Teuchos::ParameterList).
   ///
@@ -90,33 +43,13 @@ public:
   //! Default constructor (sets default parameters).
   KokkosDeviceWrapperNode ();
 
-  //! Destructor
-  ~KokkosDeviceWrapperNode ();
-
   //! Get a filled-in set of parameters for Node, with their default values.
-  static Teuchos::ParameterList getDefaultParameters ()
-  {
-    return Details::getDefaultNodeParameters ();
-  }
+  static Teuchos::ParameterList getDefaultParameters ();
 
-  /// \brief Initialize the Node
-  ///
-  /// \warning This is an implementation detail; do not call it directly!
-  void init (int numthreads, int numnuma, int numcorespernuma, int device);
+  void sync () const;
 
-  void sync () const { ExecutionSpace::fence (); }
-
-  /// \brief Return the human-readable name of this Node.
-  ///
-  /// See \ref kokkos_node_api "Kokkos Node API"
-  static std::string name();
-
-private:
-  //! Make sure that the constructor initialized everything.
-  void checkConstructorEnd () const;
-
-  //! Make sure that the destructor did its job.
-  void checkDestructorEnd () const;
+  //! Human-readable name of this Node.
+  static std::string name ();
 };
 
 #ifdef KOKKOS_HAVE_CUDA
@@ -135,162 +68,10 @@ private:
   typedef KokkosDeviceWrapperNode<Kokkos::Serial> KokkosSerialWrapperNode;
 #endif // KOKKOS_HAVE_SERIAL
 
-  // These definitions / initializations of class (static) variables
-  // need to precede the first use of these variables.  Otherwise,
-  // CUDA 7.5 with GCC 4.8.4 emits a warning ("explicit specialization
-  // of member ... must precede its first use").
-
-  template<class ExecutionSpace, class MemorySpace>
-  int KokkosDeviceWrapperNode<ExecutionSpace, MemorySpace>::count = 0;
-
-  template<class ExecutionSpace, class MemorySpace>
-  bool KokkosDeviceWrapperNode<ExecutionSpace, MemorySpace>::nodeResponsibleForFinalizingExecutionSpace_ = true;
-
-  template<class ExecutionSpace, class MemorySpace>
-  KokkosDeviceWrapperNode<ExecutionSpace, MemorySpace>::
-  KokkosDeviceWrapperNode (Teuchos::ParameterList& params)
-  {
-    // Fix for Github Issue #510.  If count is zero, yet the execution
-    // space is already initialized, then Node is not responsible for
-    // finalizing the execution space.
-    if (count == 0 && ExecutionSpace::is_initialized ()) {
-      nodeResponsibleForFinalizingExecutionSpace_ = false;
-    }
-#ifdef KOKKOS_HAVE_CUDA
-    // The Cuda Node also handles its host execution space.
-    typedef ::Kokkos::HostSpace::execution_space host_execution_space;
-    if (count == 0 &&
-        std::is_same<ExecutionSpace, ::Kokkos::Cuda>::value &&
-        host_execution_space::is_initialized ()) {
-      KokkosDeviceWrapperNode<host_execution_space>::nodeResponsibleForFinalizingExecutionSpace_ = false;
-    }
-#endif // KOKKOS_HAVE_CUDA
-
-    // Kokkos insists that if Kokkos::Cuda is initialized, then its
-    // host execution space must also be initialized.  Thus, it
-    // suffices to check whether Kokkos::Cuda has been initialized; we
-    // don't also have to check the host execution space.
-    if (count == 0 && nodeResponsibleForFinalizingExecutionSpace_) {
-      int curNumThreads = -1; // -1 says "let Kokkos pick"
-      if (params.isType<int> ("Num Threads")) {
-        curNumThreads = params.get<int> ("Num Threads");
-      }
-      int curNumNUMA = -1; // -1 says "let Kokkos pick"
-      if (params.isType<int> ("Num NUMA")) {
-        curNumNUMA = params.get<int> ("Num NUMA");
-      }
-      int curNumCoresPerNUMA = -1; // -1 says "let Kokkos pick"
-      if (params.isType<int> ("Num CoresPerNUMA")) {
-        curNumCoresPerNUMA = params.get<int> ("Num CoresPerNUMA");
-      }
-      int curDevice = 0; // -1 does NOT say "let Kokkos pick" for Cuda Devices
-      if (params.isType<int> ("Device")) {
-        curDevice = params.get<int> ("Device");
-      }
-      const bool verbose = Details::getVerboseParameter (params);
-
-      if (verbose) {
-        std::ostream& out = std::cout;
-        out << "DeviceWrapperNode with ExecutionSpace = "
-            << typeid (ExecutionSpace).name () << " initializing with "
-            << "\"Num Threads\" = " << curNumThreads
-            << ", \"Num NUMA\" = " << curNumNUMA
-            << ", \"Num CoresPerNUMA\" = " << curNumCoresPerNUMA
-            << " \"Device\" = " << curDevice << std::endl;
-      }
-      init (curNumThreads, curNumNUMA, curNumCoresPerNUMA, curDevice);
-    }
-    count++;
-    checkConstructorEnd ();
-  }
-
-  template<class ExecutionSpace, class MemorySpace>
-  KokkosDeviceWrapperNode<ExecutionSpace, MemorySpace>::
-  KokkosDeviceWrapperNode ()
-  {
-    if (count == 0 && nodeResponsibleForFinalizingExecutionSpace_) {
-      const int curNumThreads = -1; // -1 means "let Kokkos pick"
-      const int curNumNUMA = -1;
-      const int curNumCoresPerNUMA = -1;
-      const int curDevice = 0;
-
-      init (curNumThreads, curNumNUMA, curNumCoresPerNUMA, curDevice);
-    }
-    count++;
-    checkConstructorEnd ();
-  }
-
-  template<class ExecutionSpace, class MemorySpace>
-  void
-  KokkosDeviceWrapperNode<ExecutionSpace, MemorySpace>::
-  checkConstructorEnd () const
-  {
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (count <= 0, std::logic_error,
-       "Kokkos::Compat::KokkosDeviceWrapperNode<ExecutionSpace="
-       << typeid (ExecutionSpace).name () << ", MemorySpace="
-       << typeid (MemorySpace).name () << " > constructor: "
-       "count = " << count << " <= 0 at end of constructor.  "
-       "Please report this bug to the Tpetra developers.");
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (! ExecutionSpace::is_initialized (), std::logic_error,
-       "Kokkos::Compat::KokkosDeviceWrapperNode<ExecutionSpace="
-       << typeid (ExecutionSpace).name () << ", MemorySpace="
-       << typeid (MemorySpace).name () << " > constructor: "
-       "Failed to initialize ExecutionSpace.");
-#ifdef KOKKOS_HAVE_CUDA
-    // This must be outside the macro, since it has a comma.
-    constexpr bool isCuda =
-      std::is_same<ExecutionSpace, Kokkos::Cuda>::value;
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (isCuda && ! Kokkos::HostSpace::execution_space::is_initialized (),
-       std::logic_error,
-       "Kokkos::Compat::KokkosDeviceWrapperNode<ExecutionSpace=Kokkos::Cuda, "
-       "MemorySpace=" << typeid (MemorySpace).name () << " > constructor: "
-       "Failed to initialize Kokkos::HostSpace::execution_space.");
-#endif // KOKKOS_HAVE_CUDA
-  }
-
-  template<class ExecutionSpace, class MemorySpace>
-  void
-  KokkosDeviceWrapperNode<ExecutionSpace, MemorySpace>::
-  checkDestructorEnd () const
-  {
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (count < 0, std::logic_error,
-       "Kokkos::Compat::KokkosDeviceWrapperNode<ExecutionSpace="
-       << typeid (ExecutionSpace).name () << ", MemorySpace="
-       << typeid (MemorySpace).name () << " > destructor: "
-       "count = " << count << " < 0 at end of destructor.  "
-       "Please report this bug to the Tpetra developers.");
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (count == 0 &&
-       nodeResponsibleForFinalizingExecutionSpace_ &&
-       ExecutionSpace::is_initialized (),
-       std::logic_error,
-       "Kokkos::Compat::KokkosDeviceWrapperNode<ExecutionSpace="
-       << typeid (ExecutionSpace).name () << ", MemorySpace="
-       << typeid (MemorySpace).name () << " > destructor: "
-       "count == 0 and the Node is responsible for finalizing ExecutionSpace, "
-       "but its destructor did not.  "
-       "Please report this bug to the Tpetra developers.");
-#ifdef KOKKOS_HAVE_CUDA
-    // This must be outside the macro, since it has a comma.
-    constexpr bool isCuda =
-      std::is_same<ExecutionSpace, Kokkos::Cuda>::value;
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (isCuda &&
-       count == 0 &&
-       KokkosDeviceWrapperNode<Kokkos::HostSpace::execution_space>::nodeResponsibleForFinalizingExecutionSpace_ &&
-       Kokkos::HostSpace::execution_space::is_initialized (),
-       std::logic_error,
-       "Kokkos::Compat::KokkosDeviceWrapperNode<ExecutionSpace=Kokkos::Cuda, "
-       "MemorySpace=" << typeid (MemorySpace).name () << " > destructor: "
-       "count == 0 and the Node is responsible for finalizing "
-       "Kokkos::HostSpace::execution_space, but its destructor did not.  "
-       "Please report this bug to the Tpetra developers.");
-#endif // KOKKOS_HAVE_CUDA
-  }
+  // The above definitions / initializations of class (static)
+  // variables need to precede the first use of these variables.
+  // Otherwise, CUDA 7.5 with GCC 4.8.4 emits a warning ("explicit
+  // specialization of member ... must precede its first use").
 
 } // namespace Compat
 } // namespace Kokkos

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.cpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.cpp
@@ -1,0 +1,211 @@
+#include "KokkosCompat_Details_KokkosInit.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Kokkos_Core.hpp"
+#include <cstdlib> // std::atexit, setenv
+#include <mutex> // std::call_once, std::once_flag
+#include <stdexcept>
+#include <vector>
+
+namespace KokkosCompat {
+namespace Details {
+
+bool
+isKokkosInitialized ()
+{
+  // Kokkos doesn't have a way to tell whether Kokkos as a whole has
+  // been initialized, i.e., if Kokkos::initialize(...) has been
+  // called.  However, Kokkos::initialize(...) always initializes
+  // the default execution space, so we can just check that.
+  return Kokkos::DefaultExecutionSpace::is_initialized ();
+}
+
+namespace { // (anonymous)
+
+void
+initializeKokkosWithCmdLineArgs (int& numArgs, char* theArgs[])
+{
+  if (! isKokkosInitialized ()) {
+    Kokkos::initialize (numArgs, theArgs);
+    // Since Tpetra initialized Kokkos, it can finalize all the
+    // execution spaces.
+    std::atexit (Kokkos::finalize_all);
+  }
+}
+
+void
+initializeKokkosWithStruct (const Kokkos::InitArguments& args)
+{
+  if (! isKokkosInitialized ()) {
+    Kokkos::initialize (args);
+    // Since Tpetra initialized Kokkos, it can finalize all the
+    // execution spaces.
+    std::atexit (Kokkos::finalize_all);
+  }
+}
+
+void
+initializeKokkosWithNoArgs ()
+{
+  if (! isKokkosInitialized ()) {
+    std::vector<std::string> args =
+      Teuchos::GlobalMPISession::getArgv ();
+    int narg = static_cast<int> (args.size ());
+    if (narg == 0) {
+      initializeKokkosWithCmdLineArgs (narg, NULL);
+    }
+    else {
+      std::vector<char*> args_c (narg);
+      for (int k = 0; k < narg; ++k) {
+        // mfh 25 Oct 2017: I feel a bit uncomfortable about this
+        // const_cast, but there is no other way to pass
+        // command-line arguments to Kokkos::initialize.
+        args_c[k] = const_cast<char*> (args[k].c_str ());
+      }
+      initializeKokkosWithCmdLineArgs (narg, args_c.data ());
+    }
+  }
+}
+
+} // namespace (anonymous)
+
+std::once_flag initKokkosWithCmdLineArgs_flag;
+
+void
+initializeKokkos (int& numArgs, char* theArgs[])
+{
+  std::call_once (initKokkosWithCmdLineArgs_flag,
+                  initializeKokkosWithCmdLineArgs,
+                  std::ref (numArgs), theArgs);
+}
+
+std::once_flag initKokkosWithStructArgs_flag;
+
+void
+initializeKokkos (const Kokkos::InitArguments& theArgs)
+{
+  std::call_once (initKokkosWithCmdLineArgs_flag,
+                  initializeKokkosWithStruct, theArgs);
+}
+
+std::once_flag initKokkosWithNoArgs_flag;
+
+void
+initializeKokkos ()
+{
+  std::call_once (initKokkosWithNoArgs_flag,
+                  initializeKokkosWithNoArgs);
+}
+
+void
+setUpEnvironmentForCuda ()
+{
+#ifdef KOKKOS_ENABLE_CUDA
+  // mfh 24 Oct 2017: This code used to call setenv to set the
+  // CUDA_LAUNCH_BLOCKING environment variable to 1.  This doesn't
+  // necessarily have an effect, since the CUDA run-time system may
+  // not read environment variables after the process has started.
+  // Thus, we instead read the environment variable and throw if it
+  // is not set.
+  const char varName[] = "CUDA_LAUNCH_BLOCKING";
+  const char* varVal = std::getenv (varName);
+  if (varVal == NULL) {
+    throw std::runtime_error ("When running Tpetra with CUDA, Tpetra "
+                              "requires that the environment variable "
+                              "CUDA_LAUNCH_BLOCKING be set (e.g., to 1).");
+  }
+  //putenv("CUDA_LAUNCH_BLOCKING=1"); // see note below
+
+  // mfh 22 Jul 2016: POSIX prefers use of setenv over putenv:
+  //
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/putenv.html
+  //
+  // There are two problems with putenv:
+  //
+  // 1. It takes its input as a nonconst pointer.  This causes a
+  //    build warning (e.g., "conversion from a string literal to
+  //    'char *' is deprecated") when using a string literal, in
+  //    this case "CUDA_LAUNCH_BLOCKING=1", as the input argument.
+  //
+  // 2. putenv does not let us fix the above build warning by
+  //    copying into a temporary nonconst char array and passing
+  //    that into putenv.  This is because putenv is free to keep
+  //    the original input pointer, rather than copying the input
+  //    string.  Thus, if anyone tries to read the environment
+  //    variable (via getenv) after the temporary array has been
+  //    freed, they would be reading invalid memory.  The above
+  //    POSIX standard entry alludes to this: "A potential error
+  //    is to call putenv() with an automatic variable as the
+  //    argument, then return from the calling function while
+  //    string is still part of the environment."
+
+#endif // KOKKOS_ENABLE_CUDA
+}
+
+/// \brief Get the value of the "Verbose" parameter as a \c bool.
+///
+/// This method lets the "Verbose" parameter have type either \c int
+/// or \c bool, and returns its value as \c bool.  If the "Verbose"
+/// parameter does not exist in the given list, return the default
+/// value, which is \c false.
+bool
+getVerboseParameter (const Teuchos::ParameterList& params)
+{
+  const bool defaultValue = false; // default value of the parameter
+
+  if (params.isParameter ("Verbose")) {
+    if (params.isType<bool> ("Verbose")) { // is it a bool?
+      return params.get<bool> ("Verbose");
+    }
+    else if (params.isType<int> ("Verbose")) { // is it an int?
+      return params.get<int> ("Verbose");
+    }
+    // It might be polite to throw at this point with a helpful
+    // message explaining that the parameter has the wrong type,
+    // but that would change current behavior, so I'll just
+    // leave it.
+  }
+  return defaultValue;
+}
+
+Teuchos::ParameterList getDefaultNodeParameters ()
+{
+  Teuchos::ParameterList params;
+  params.set ("Verbose", 0);
+  // -1 says "Let Kokkos pick"
+  params.set ("Num Threads", -1);
+  params.set ("Num NUMA", -1);
+  params.set ("Num CoresPerNUMA", -1);
+  params.set ("Device", 0);
+  return params;
+}
+
+void
+getNodeParameters (int& curNumThreads,
+                   int& curNumNUMA,
+                   int& curNumCoresPerNUMA,
+                   int& curDevice,
+                   bool& verbose,
+                   const Teuchos::ParameterList& params)
+{
+  curNumThreads = -1; // -1 says "let Kokkos pick"
+  if (params.isType<int> ("Num Threads")) {
+    curNumThreads = params.get<int> ("Num Threads");
+  }
+  curNumNUMA = -1; // -1 says "let Kokkos pick"
+  if (params.isType<int> ("Num NUMA")) {
+    curNumNUMA = params.get<int> ("Num NUMA");
+  }
+  curNumCoresPerNUMA = -1; // -1 says "let Kokkos pick"
+  if (params.isType<int> ("Num CoresPerNUMA")) {
+    curNumCoresPerNUMA = params.get<int> ("Num CoresPerNUMA");
+  }
+  curDevice = 0; // -1 does NOT say "let Kokkos pick" for Cuda Devices
+  if (params.isType<int> ("Device")) {
+    curDevice = params.get<int> ("Device");
+  }
+  verbose = getVerboseParameter (params);
+}
+
+} // namespace Details
+} // namespace KokkosCompat

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.hpp
@@ -1,0 +1,63 @@
+#ifndef KOKKOSCOMPAT_DETAILS_KOKKOSINIT_HPP
+#define KOKKOSCOMPAT_DETAILS_KOKKOSINIT_HPP
+
+#include "TeuchosKokkosCompat_config.h"
+
+namespace Kokkos {
+  struct InitArguments; // forward declaration
+}
+
+namespace Teuchos {
+  class ParameterList; // forward declaration
+}
+
+namespace KokkosCompat {
+namespace Details {
+
+//! Has Kokkos::initialize been called yet in this run?
+bool
+isKokkosInitialized ();
+
+/// \brief If Kokkos::initialize has not yet been called, call it,
+///   passing in the given command-line arguments.
+///
+/// Kokkos::initialize initializes all enabled Kokkos execution
+/// spaces.
+void
+initializeKokkos (int& narg, char* arg[]);
+
+/// \brief If Kokkos::initialize has not yet been called, call it.
+///   Attempt to get command-line arguments from
+///   Teuchos::GlobalMPISession.
+///
+/// Kokkos::initialize initializes all enabled Kokkos execution
+/// spaces.
+void
+initializeKokkos ();
+
+/// \brief If Kokkos::initialize has not yet been called, call it.
+///   Use the version that takes arguments through Kokkos' struct.
+///
+/// Kokkos::initialize initializes all enabled Kokkos execution
+/// spaces.
+void
+initializeKokkos (const Kokkos::InitArguments& args);
+
+void
+getNodeParameters (int& curNumThreads,
+                   int& curNumNUMA,
+                   int& curNumCoresPerNUMA,
+                   int& curDevice,
+                   bool& verbose,
+                   const Teuchos::ParameterList& params);
+
+Teuchos::ParameterList
+getDefaultNodeParameters ();
+
+void
+setUpEnvironmentForCuda ();
+
+} // namespace Details
+} // namespace KokkosCompat
+
+#endif // KOKKOSCOMPAT_DETAILS_KOKKOSINIT_HPP

--- a/packages/teuchos/kokkoscompat/test/CMakeLists.txt
+++ b/packages/teuchos/kokkoscompat/test/CMakeLists.txt
@@ -19,3 +19,33 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  nodeKokkosInitialized
+  SOURCES
+    nodeKokkosInitialized.cpp 
+  ARGS ""
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  FAIL_REGULAR_EXPRESSION "FAILED:"
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  nodeKokkosNotInitializedMainScope
+  SOURCES
+    nodeKokkosNotInitializedMainScope.cpp 
+  ARGS ""
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  FAIL_REGULAR_EXPRESSION "FAILED:"
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  nodeKokkosNotInitializedInnerScope
+  SOURCES
+    nodeKokkosNotInitializedInnerScope.cpp 
+  ARGS ""
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  FAIL_REGULAR_EXPRESSION "FAILED:"
+  )

--- a/packages/teuchos/kokkoscompat/test/nodeKokkosInitialized.cpp
+++ b/packages/teuchos/kokkoscompat/test/nodeKokkosInitialized.cpp
@@ -1,0 +1,79 @@
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Kokkos_Core.hpp"
+#include <iostream>
+#include <cstdlib> // EXIT_SUCCESS, EXIT_FAILURE
+
+// Test that Node does not initializes Kokkos if it is already
+// initialized, and does not attempt to double-finalize Kokkos
+// in this case.
+
+namespace { // (anonymous)
+
+// Is Kokkos initialized?
+//
+// https://github.com/kokkos/kokkos/issues/1184 means that this
+// function doesn't return something meaningful with Kokkos::Serial.
+bool isKokkosInitialized ()
+{
+  // When https://github.com/kokkos/kokkos/issues/1060 is fixed, use
+  // Kokkos::is_initialized here, instead of asking the default
+  // execution space whether it is initialized.
+  typedef Kokkos::DefaultExecutionSpace::execution_space
+    execution_space;
+  return execution_space::is_initialized ();
+}
+
+} // namespace (anonymous)
+
+int
+main (int argc, char* argv[])
+{
+  using std::cerr;
+  using std::endl;
+  typedef Kokkos::DefaultExecutionSpace execution_space;
+  typedef Kokkos::Compat::KokkosDeviceWrapperNode<execution_space>
+    node_type;
+
+  Kokkos::initialize (argc, argv);
+  if (! isKokkosInitialized ()) {
+    cerr << "FAILED: After calling Kokkos::initialize, "
+      "Kokkos is still not initialized!" << endl;
+    return EXIT_FAILURE;
+  }
+
+  // Create a node instance.  Make sure that this does not make Kokkos
+  // raise an exception, e.g., due to double initialization.
+  node_type node1;
+
+  if (! isKokkosInitialized ()) {
+    cerr << "FAILED: After calling Kokkos::initialize, "
+      "and after calling Node's constructor once, "
+      "Kokkos is still not initialized!" << endl;
+    return EXIT_FAILURE;
+  }
+  {
+    node_type node2; // inner scope, so its destructor gets invoked
+    if (! isKokkosInitialized ()) {
+      cerr << "FAILED: After calling Kokkos::initialize, "
+        "and after calling Node's constructor twice, "
+        "Kokkos is still not initialized!" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+  if (! isKokkosInitialized ()) {
+    cerr << "FAILED: After calling Kokkos::initialize, "
+      "after calling Node's constructor twice, "
+      "and after calling Node's destructor once, "
+      "Kokkos is still not initialized!" << endl;
+    return EXIT_FAILURE;
+  }
+
+  Kokkos::finalize ();
+  // Node's destructor will be called after Kokkos::finalize.  We thus
+  // implicitly test whether this makes Kokkos raise an exception.
+  // Don't print PASSED!  That will make the test think that it
+  // passed.  We use FAIL_REGULAR_EXPRESSION (see CMakeLists.txt) so
+  // that the test fails if and only if it prints "FAILED:".
+  return EXIT_SUCCESS;
+}
+

--- a/packages/teuchos/kokkoscompat/test/nodeKokkosNotInitializedInnerScope.cpp
+++ b/packages/teuchos/kokkoscompat/test/nodeKokkosNotInitializedInnerScope.cpp
@@ -1,0 +1,98 @@
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Kokkos_Core.hpp"
+#include <iostream>
+#include <cstdlib> // EXIT_SUCCESS, EXIT_FAILURE
+#ifdef KOKKOS_ENABLE_SERIAL
+#  include <type_traits>
+#endif // KOKKOS_ENABLE_SERIAL
+
+// Test that Node initializes Kokkos if it is not already initialized.
+// It must also finalize Kokkos at exit, but the only portable way to
+// test that would be to run Valgrind and ensure no memory leaks.
+
+namespace { // (anonymous)
+
+// Is Kokkos initialized?
+//
+// https://github.com/kokkos/kokkos/issues/1184 means that this
+// function doesn't return something meaningful with Kokkos::Serial.
+bool isKokkosInitialized ()
+{
+  // When https://github.com/kokkos/kokkos/issues/1060 is fixed, use
+  // Kokkos::is_initialized here, instead of asking the default
+  // execution space whether it is initialized.
+  typedef Kokkos::DefaultExecutionSpace::execution_space
+    execution_space;
+  return execution_space::is_initialized ();
+}
+
+} // namespace (anonymous)
+
+int
+main (int argc, char* argv[])
+{
+  using std::cerr;
+  using std::endl;
+  typedef Kokkos::DefaultExecutionSpace execution_space;
+  typedef Kokkos::Compat::KokkosDeviceWrapperNode<execution_space>
+    node_type;
+#ifdef KOKKOS_ENABLE_SERIAL
+  constexpr bool defaultExecSpaceIsSerial =
+    std::is_same<execution_space, Kokkos::Serial>::value;
+#else
+  constexpr bool defaultExecSpaceIsSerial = false;
+#endif // KOKKOS_ENABLE_SERIAL
+
+  if (! defaultExecSpaceIsSerial) {
+    // https://github.com/kokkos/kokkos/issues/1184 means that this
+    // function doesn't return something meaningful with
+    // Kokkos::Serial.
+    if (isKokkosInitialized ()) {
+      cerr << "FAILED: "
+        "Before calling Node's constructor, "
+        "and without having called Kokkos::initialize ourselves, "
+        "Kokkos claims to be initialized!" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  {
+    // Create a node instance.  Make sure that this does not make
+    // Kokkos raise an exception, e.g., due to double initialization.
+    // Do this in an inner (within main()) scope, so we can test that
+    // case.  We'll have another test for where node instances are
+    // always at main() scope.
+    node_type node1;
+
+    if (! isKokkosInitialized ()) {
+      cerr << "FAILED: After calling Kokkos::initialize, "
+        "and after calling Node's constructor once, "
+        "Kokkos is still not initialized!" << endl;
+      return EXIT_FAILURE;
+    }
+    {
+      node_type node2; // inner scope, so its destructor gets invoked
+      if (! isKokkosInitialized ()) {
+        cerr << "FAILED: After calling Kokkos::initialize, "
+          "and after calling Node's constructor twice, "
+          "Kokkos is still not initialized!" << endl;
+        return EXIT_FAILURE;
+      }
+    }
+    if (! isKokkosInitialized ()) {
+      cerr << "FAILED: After calling Kokkos::initialize, "
+        "after calling Node's constructor twice, "
+        "and after calling Node's destructor once, "
+        "Kokkos is still not initialized!" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  // Don't print PASSED!  That will make the test think that it
+  // passed, even though things may still be happening (due to atexit)
+  // after main() exits.  We use FAIL_REGULAR_EXPRESSION (see
+  // CMakeLists.txt) so that the test fails if and only if it prints
+  // "FAILED:".
+  return EXIT_SUCCESS;
+}
+

--- a/packages/teuchos/kokkoscompat/test/nodeKokkosNotInitializedMainScope.cpp
+++ b/packages/teuchos/kokkoscompat/test/nodeKokkosNotInitializedMainScope.cpp
@@ -1,0 +1,95 @@
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Kokkos_Core.hpp"
+#include <iostream>
+#include <cstdlib> // EXIT_SUCCESS, EXIT_FAILURE
+#ifdef KOKKOS_ENABLE_SERIAL
+#  include <type_traits>
+#endif // KOKKOS_ENABLE_SERIAL
+
+// Test that Node initializes Kokkos if it is not already initialized.
+// It must also finalize Kokkos at exit, but the only portable way to
+// test that would be to run Valgrind and ensure no memory leaks.
+
+namespace { // (anonymous)
+
+// Is Kokkos initialized?
+//
+// https://github.com/kokkos/kokkos/issues/1184 means that this
+// function doesn't return something meaningful with Kokkos::Serial.
+bool isKokkosInitialized ()
+{
+  // When https://github.com/kokkos/kokkos/issues/1060 is fixed, use
+  // Kokkos::is_initialized here, instead of asking the default
+  // execution space whether it is initialized.
+  typedef Kokkos::DefaultExecutionSpace::execution_space
+    execution_space;
+  return execution_space::is_initialized ();
+}
+
+} // namespace (anonymous)
+
+int
+main (int argc, char* argv[])
+{
+  using std::cerr;
+  using std::endl;
+  typedef Kokkos::DefaultExecutionSpace execution_space;
+  typedef Kokkos::Compat::KokkosDeviceWrapperNode<execution_space>
+    node_type;
+#ifdef KOKKOS_ENABLE_SERIAL
+  constexpr bool defaultExecSpaceIsSerial =
+    std::is_same<execution_space, Kokkos::Serial>::value;
+#else
+  constexpr bool defaultExecSpaceIsSerial = false;
+#endif // KOKKOS_ENABLE_SERIAL
+
+  if (! defaultExecSpaceIsSerial) {
+    // https://github.com/kokkos/kokkos/issues/1184 means that this
+    // function doesn't return something meaningful with
+    // Kokkos::Serial.
+    if (isKokkosInitialized ()) {
+      cerr << "FAILED: "
+        "Before calling Node's constructor, "
+        "and without having called Kokkos::initialize ourselves, "
+        "Kokkos claims to be initialized!" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  // Create a node instance.  Make sure that this does not make Kokkos
+  // raise an exception, e.g., due to double initialization.  Do this
+  // at main() scope, so we can test that case.  We'll have another
+  // test for where node instances are always in an inner scope.
+  node_type node1;
+
+  if (! isKokkosInitialized ()) {
+    cerr << "FAILED: After calling Kokkos::initialize, "
+      "and after calling Node's constructor once, "
+      "Kokkos is still not initialized!" << endl;
+    return EXIT_FAILURE;
+  }
+  {
+    node_type node2; // inner scope, so its destructor gets invoked
+    if (! isKokkosInitialized ()) {
+      cerr << "FAILED: After calling Kokkos::initialize, "
+        "and after calling Node's constructor twice, "
+        "Kokkos is still not initialized!" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+  if (! isKokkosInitialized ()) {
+    cerr << "FAILED: After calling Kokkos::initialize, "
+      "after calling Node's constructor twice, "
+      "and after calling Node's destructor once, "
+      "Kokkos is still not initialized!" << endl;
+    return EXIT_FAILURE;
+  }
+
+  // Don't print PASSED!  That will make the test think that it
+  // passed, even though things are still happening (due to atexit)
+  // after main() exits.  We use FAIL_REGULAR_EXPRESSION (see
+  // CMakeLists.txt) so that the test fails if and only if it prints
+  // "FAILED:".
+  return EXIT_SUCCESS;
+}
+

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -839,45 +839,44 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, operations_test,SC,LO, GO, NT) 
     std::string op = currentSystem.get<std::string> ("op");
 
     RCP<Matrix_t> A, B, C, D;
-    const RCP<NT> my_node = Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
 
     if (A_file != ""){
       if (A_domainmap_file == "" || A_rangemap_file == "" || A_rowmap_file == "" || A_colmap_file == "")
         A = Reader<Matrix_t>::readSparseFile (A_file, comm);
       else {
-        RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (A_domainmap_file, comm, my_node);
-        RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (A_rangemap_file, comm, my_node);
-        RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (A_rowmap_file, comm, my_node);
-        RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (A_colmap_file, comm, my_node);
+        RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (A_domainmap_file, comm);
+        RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (A_rangemap_file, comm);
+        RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (A_rowmap_file, comm);
+        RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (A_colmap_file, comm);
         A = Reader<Matrix_t>::readSparseFile (A_file, rowmap, colmap, domainmap, rangemap);
       }
     }
     if (B_domainmap_file == "" || B_rangemap_file == "" || B_rowmap_file == "" || B_colmap_file == "")
       B = Reader<Matrix_t>::readSparseFile (B_file, comm);
     else {
-      RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (B_domainmap_file, comm, my_node);
-      RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (B_rangemap_file, comm, my_node);
-      RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (B_rowmap_file, comm, my_node);
-      RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (B_colmap_file, comm, my_node);
+      RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (B_domainmap_file, comm);
+      RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (B_rangemap_file, comm);
+      RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (B_rowmap_file, comm);
+      RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (B_colmap_file, comm);
       B = Reader<Matrix_t>::readSparseFile (B_file, rowmap, colmap, domainmap, rangemap);
     }
     if (C_domainmap_file == "" || C_rangemap_file == "" || C_rowmap_file == "" || C_colmap_file == "")
       C = Reader<Matrix_t>::readSparseFile (C_file, comm);
     else {
-      RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (C_domainmap_file, comm, my_node);
-      RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (C_rangemap_file, comm, my_node);
-      RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (C_rowmap_file, comm, my_node);
-      RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (C_colmap_file, comm, my_node);
+      RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (C_domainmap_file, comm);
+      RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (C_rangemap_file, comm);
+      RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (C_rowmap_file, comm);
+      RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (C_colmap_file, comm);
       C = Reader<Matrix_t>::readSparseFile (C_file, rowmap, colmap, domainmap, rangemap);
     }
     if (D_file != "") {
       if (D_domainmap_file == "" || D_rangemap_file == "" || D_rowmap_file == "" || D_colmap_file == "")
         D = Reader<Matrix_t>::readSparseFile (D_file, comm);
       else {
-        RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (D_domainmap_file, comm, my_node);
-        RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (D_rangemap_file, comm, my_node);
-        RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (D_rowmap_file, comm, my_node);
-        RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (D_colmap_file, comm, my_node);
+        RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (D_domainmap_file, comm);
+        RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (D_rangemap_file, comm);
+        RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (D_rowmap_file, comm);
+        RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (D_colmap_file, comm);
         D = Reader<Matrix_t>::readSparseFile (D_file, rowmap, colmap, domainmap, rangemap);
       }
     }
@@ -900,7 +899,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, operations_test,SC,LO, GO, NT) 
         newOut << "\tEpsilon: "  << results.epsilon  << endl;
         newOut << "\tcNorm: "    << results.cNorm    << endl;
         newOut << "\tcompNorm: " << results.compNorm << endl;
-	newOut << "\tisImportValid: " <<results.isImportValid << endl;
+        newOut << "\tisImportValid: " <<results.isImportValid << endl;
       }
       TEST_COMPARE(results.epsilon, <, epsilon);
       TEUCHOS_TEST_FOR_EXCEPTION(!results.isImportValid,std::logic_error,std::string("ManualFC: Import validity failed: ") + currentSystem.name());
@@ -915,7 +914,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, operations_test,SC,LO, GO, NT) 
         newOut << "\tEpsilon: "  << results.epsilon  << endl;
         newOut << "\tcNorm: "    << results.cNorm    << endl;
         newOut << "\tcompNorm: " << results.compNorm << endl;
-	newOut << "\tisImportValid: " <<results.isImportValid << endl;
+        newOut << "\tisImportValid: " <<results.isImportValid << endl;
       }
       TEST_COMPARE(results.epsilon, <, epsilon);
       TEUCHOS_TEST_FOR_EXCEPTION(!results.isImportValid,std::logic_error,std::string("AutoFC: Import validity failed: ") + currentSystem.name());


### PR DESCRIPTION
@trilinos/tpetra Simplify how Node constructors initialize and
finalize Kokkos.  In particular, get rid of the "count" and use
std::call_once + atexit; this ensures the following:

  - Kokkos initialization will happen at most once
  - It won't matter whether users or Tpetra create Node instances

It will also make the ultimate deprecation and removal of Node easier.

This commit includes three tests that exercise different combinations
of calling Kokkos::initialize (or not) vs. creating Node instances.  I
have tested (build and tests) with all four Kokkos execution spaces
that Tpetra supports: Cuda, OpenMP, Serial, and Threads.