### PR TITLE
MueLu: TpetraCore_MatrixMatrix_UnitTests Fix

### DIFF
--- a/packages/tpetra/core/test/MatrixMatrix/CMakeLists.txt
+++ b/packages/tpetra/core/test/MatrixMatrix/CMakeLists.txt
@@ -4,6 +4,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MatrixMatrix_UnitTests.cpp
   ${TEUCHOS_STD_UNIT_TEST_MAIN}
   ARGS "--matnames-file=\"matrixsystems.xml\" --v"
+  NUM_MPI_PROCS 4
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -15,13 +16,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 IF (KokkosKernels_ENABLE_Experimental)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
-		MatrixMatrixKernels_UnitTests
-		SOURCES
-		MatrixMatrixKernels_UnitTests.cpp
-		${TEUCHOS_STD_UNIT_TEST_MAIN}
-		ARGS "--matnames-file=\"matrixsystems.xml\" --v"
-		NUM_MPI_PROCS 1
-		)
+  MatrixMatrixKernels_UnitTests
+  SOURCES
+  MatrixMatrixKernels_UnitTests.cpp
+  ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  ARGS "--matnames-file=\"matrixsystems.xml\" --v"
+  NUM_MPI_PROCS 1
+  )
 ENDIF()
 
 


### PR DESCRIPTION
Setting the number of MPI processes to 4 for this test to fix an issue shown in the CDash run:
https://testing.sandia.gov/cdash/testDetails.php?test=42290438&build=3183867

Error Message:
```
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :

   Test requires exactly 4 MPI ranks.
```

Fixes issue #1907 