### PR TITLE
Kokkos: patch kokkos/kokkos#1184

### DIFF
--- a/packages/kokkos/core/src/Kokkos_Serial.hpp
+++ b/packages/kokkos/core/src/Kokkos_Serial.hpp
@@ -145,7 +145,7 @@ public:
                           unsigned use_cores_per_numa = 0 ,
                           bool allow_asynchronous_threadpool = false);
 
-  static int is_initialized();
+  static bool is_initialized();
 
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency() {return 1;};

--- a/packages/kokkos/core/src/impl/Kokkos_Serial.cpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Serial.cpp
@@ -60,6 +60,8 @@ namespace {
 
 HostThreadTeamData g_serial_thread_team_data ;
 
+bool g_serial_is_initialized = false;
+
 }
 
 // Resize thread team data scratch memory
@@ -136,9 +138,9 @@ HostThreadTeamData * serial_get_thread_team_data()
 
 namespace Kokkos {
 
-int Serial::is_initialized()
+bool Serial::is_initialized()
 {
-  return 1 ;
+  return Impl::g_serial_is_initialized ;
 }
 
 void Serial::initialize( unsigned threads_count
@@ -158,6 +160,8 @@ void Serial::initialize( unsigned threads_count
   #if defined(KOKKOS_ENABLE_PROFILING)
     Kokkos::Profiling::initialize();
   #endif
+
+  Impl::g_serial_is_initialized = true;
 }
 
 void Serial::finalize()
@@ -177,6 +181,8 @@ void Serial::finalize()
   #if defined(KOKKOS_ENABLE_PROFILING)
     Kokkos::Profiling::finalize();
   #endif
+
+  Impl::g_serial_is_initialized = false;
 }
 
 const char* Serial::name() { return "Serial"; }


### PR DESCRIPTION
Kokkos::Serial::is_initialized always
returned one, which breaks the way that
libraries decide to call Kokkos::initialize
and Kokkos::finalize, causing memory leaks.
I am patching this in Trilinos immediately
because the Kokkos promotion is taking too long.
Once the Kokkos promotion is done, users
are encouraged to instead call the long-awaited
Kokkos::is_initialized function instead.

@crtrott @dsunder @mhoemmen 

I need this now to stop memory leaks.
Unless there is strong pushback, I'll start the checkin script on this.