### PR TITLE
Kokkos: another hot patch for a memory leak

### DIFF
--- a/packages/kokkos/core/src/impl/Kokkos_Core.cpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Core.cpp
@@ -373,6 +373,7 @@ void initialize(int& narg, char* arg[])
         }
         if((strncmp(arg[iarg],"--kokkos-ndevices",17) == 0) || !kokkos_ndevices_found)
           ndevices = atoi(num1_only);
+        delete [] num1_only;
 
         if( num2 != NULL ) {
           if(( !Impl::is_unsigned_int(num2+1) ) || (strlen(num2)==1) )


### PR DESCRIPTION
A C string was allocated with raw 'new'
and never deleted inside Kokkos::initialize

@crtrott @dsunder @mhoemmen 

I'm in a rush to get a Kokkos-based code to pass Valgrind, will run the checkin script on this soon.