### PR TITLE
ML: fix GCC diagnostic pragma

### DIFF
--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner_Smoothers.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner_Smoothers.cpp
@@ -1575,7 +1575,7 @@ myaztecParams = m_smootherAztecParams;
 
 #if defined(GCC_VERSION) && GCC_VERSION >= 460
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-pedantic"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
         if ( (*MySubSmType == "MLS") || (*MySubSmType == "Chebyshev"))
         {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ml

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
With GCC 6.3.0 I get a warning
stating that '-pedantic' is not
an option that controls warnings.
Changing this to '-Wpedantic' silences
the warning

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Trilinos should ideally build without warnings on relevant compilers, and the pragma changed is specifically intended to silence a warning so it is especially problematic if it instead emits one

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A quick spot check was done with an Albany-supporting build of Trilinos.
The checkin script will provide more thorough testing.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.