### PR TITLE
Tempus:  Add combined, staggered, and pseudotransient FSA methods

### DIFF
--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -380,7 +380,6 @@ NOX::Thyra::Group::getJacobian() const
 Teuchos::RCP< ::Thyra::PreconditionerBase<double> >
 NOX::Thyra::Group::getNonconstPreconditioner()
 {
-  NOX_ASSERT(nonnull(prec_));
   return prec_;
 }
 
@@ -388,7 +387,6 @@ NOX::Thyra::Group::getNonconstPreconditioner()
 Teuchos::RCP<const ::Thyra::PreconditionerBase<double> >
 NOX::Thyra::Group::getPreconditioner() const
 {
-  NOX_ASSERT(nonnull(prec_));
   return prec_;
 }
 

--- a/packages/tempus/src/CMakeLists.txt
+++ b/packages/tempus/src/CMakeLists.txt
@@ -10,7 +10,7 @@ SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_SOURCE_DIR})
 APPEND_GLOB(HEADERS ${DIR}/*.hpp)
 APPEND_GLOB(SOURCES ${DIR}/*.cpp)
 
-# Must glob the binary dir last to get all of the 
+# Must glob the binary dir last to get all of the
 # auto-generated ETI headers
 TRILINOS_CREATE_CLIENT_TEMPLATE_HEADERS(${DIR})
 SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -21,3 +21,4 @@ TRIBITS_ADD_LIBRARY(
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
   )
+

--- a/packages/tempus/src/Tempus_CombinedForwardSensitivityModelEvaluator.cpp
+++ b/packages/tempus/src/Tempus_CombinedForwardSensitivityModelEvaluator.cpp
@@ -1,0 +1,19 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_CombinedForwardSensitivityModelEvaluator_decl.hpp"
+#include "Tempus_CombinedForwardSensitivityModelEvaluator_impl.hpp"
+
+namespace Tempus {
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(CombinedForwardSensitivityModelEvaluator)
+}
+
+#endif

--- a/packages/tempus/src/Tempus_CombinedForwardSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_CombinedForwardSensitivityModelEvaluator_decl.hpp
@@ -1,0 +1,136 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_CombinedForwardSensitivityModelEvaluator_decl_hpp
+#define Tempus_CombinedForwardSensitivityModelEvaluator_decl_hpp
+
+#include "Thyra_StateFuncModelEvaluatorBase.hpp"
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+
+namespace Tempus {
+
+/** \brief Transform a ModelEvaluator's sensitivity equations to its residual
+ *
+ * This class wraps a given ModelEvalutor encapsulating f(x,p) and creates
+ * a new "residual" for it and the forward sensitivity equations:
+ *        F(X) = [                f(x,p)             ] = 0
+ *               [ (df/dx)(x,p) * dx/dp + df/dp(x,p) ]
+ * where X = [ x; dx/dp ] (transient terms supressed for simplicity). This model
+ * evaluator can then be handed to a regular (non)linear solver to compute X.
+ * Note that even though these equations are linear in X, it is not necessarily
+ * the case that the underlying model evaluator accurately computes df/dx in its
+ * evaluation of W.  Therefore this model evaluator can optionally reinterpret
+ * the model's df/dp out-arg as (df/dx)(x,p) * dx/dp + df/dp(x,p) where dx/dp is
+ * passed as another parameter (product) vector (encapsulated in the
+ * Thyra::DefaultMultiVectorProductVector).  This is not standard model
+ * evaluator behavior, but is useful for models where W is only an approximation
+ * to df/dx and/or the model is capable of directly computing
+ * (df/dx)(x,p) * dx/dp + df/dp(x,p).
+ */
+template <typename Scalar>
+class CombinedForwardSensitivityModelEvaluator :
+    public Thyra::StateFuncModelEvaluatorBase<Scalar> {
+public:
+  typedef Thyra::VectorBase<Scalar>  Vector;
+  typedef Thyra::MultiVectorBase<Scalar>  MultiVector;
+
+  //! Constructor
+  /*!
+   * The optionally supplied parameter list supports the following options:
+   * <ul>
+   *   <li> "Use DfDp as Tangent" (default:  false) Reinterpret the df/dp
+   *        out-arg as the tangent vector (df/dx)(x,p) * dx/dp + df/dp(x,p)
+   *        as described above.  If it is false, this implementation will
+   *        compute the tangent through several calls to the models
+   *        evalModel().
+   *   <li> "Sensitivity Parameter Index" (default: 0) Model evaluator
+   *        parameter index for which sensitivities will be computed.
+   *   <li> "Sensitivity X Tangent Index" (default: 1) If "Use DfDp as Tangent"
+   *        is true, the model evaluator parameter index for passing dx/dp
+   *        as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot Tangent Index" (default: 2) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot/dp as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot-Dot Tangent Index" (default: 3) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot_dot/dp as a
+   *        Thyra::DefaultMultiVectorProductVector (if the model supports
+   *        x_dot_dot).
+   * </ul>
+   */
+  CombinedForwardSensitivityModelEvaluator(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+    const Teuchos::RCP<const Teuchos::ParameterList>& pList = Teuchos::null,
+    const Teuchos::RCP<MultiVector>& dxdp_init = Teuchos::null,
+    const Teuchos::RCP<MultiVector>& dx_dotdp_init = Teuchos::null,
+    const Teuchos::RCP<MultiVector>& dx_dotdot_dp_init = Teuchos::null);
+
+  //! Get the underlying model 'f'
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
+  { return model_; }
+
+  /** \name Public functions overridden from ModelEvaulator. */
+  //@{
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int p) const;
+
+  Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int p) const;
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_f_space() const;
+
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
+
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+  get_W_factory() const;
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
+
+  //@}
+
+  static Teuchos::RCP<const Teuchos::ParameterList> getValidParameters();
+
+private:
+
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
+
+  void evalModelImpl(
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+    const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const;
+
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> prototypeInArgs_;
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> prototypeOutArgs_;
+
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<MultiVector> dxdp_init_;
+  Teuchos::RCP<MultiVector> dx_dotdp_init_;
+  Teuchos::RCP<MultiVector> dx_dotdotdp_init_;
+  int p_index_;
+  int x_tangent_index_;
+  int xdot_tangent_index_;
+  int xdotdot_tangent_index_;
+  bool use_dfdp_as_tangent_;
+
+  int num_param_;
+  Teuchos::RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > dxdp_space_;
+  Teuchos::RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > x_dxdp_space_;
+  Teuchos::RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > dfdp_space_;
+  Teuchos::RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > f_dfdp_space_;
+
+  mutable Teuchos::RCP<Thyra::LinearOpBase<Scalar> > my_dfdx_;
+  mutable Teuchos::RCP<Thyra::LinearOpBase<Scalar> > my_dfdxdot_;
+  mutable Teuchos::RCP<Thyra::LinearOpBase<Scalar> > my_dfdxdotdot_;
+};
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_CombinedForwardSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_CombinedForwardSensitivityModelEvaluator_impl.hpp
@@ -1,0 +1,413 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_CombinedForwardSensitivityModelEvaluator_impl_hpp
+#define Tempus_CombinedForwardSensitivityModelEvaluator_impl_hpp
+
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
+#include "Thyra_MultiVectorLinearOp.hpp"
+#include "Thyra_MultiVectorLinearOpWithSolveFactory.hpp"
+#include "Thyra_ReuseLinearOpWithSolveFactory.hpp"
+
+namespace Tempus {
+
+template <typename Scalar>
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+CombinedForwardSensitivityModelEvaluator(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+  const Teuchos::RCP<const Teuchos::ParameterList>& pList,
+  const Teuchos::RCP<MultiVector>& dxdp_init,
+  const Teuchos::RCP<MultiVector>& dx_dotdp_init,
+  const Teuchos::RCP<MultiVector>& dx_dotdotdp_init) :
+  model_(model),
+  dxdp_init_(dxdp_init),
+  dx_dotdp_init_(dx_dotdp_init),
+  dx_dotdotdp_init_(dx_dotdotdp_init),
+  p_index_(0),
+  x_tangent_index_(1),
+  xdot_tangent_index_(2),
+  xdotdot_tangent_index_(3),
+  use_dfdp_as_tangent_(false)
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+
+  // Set parameters
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::rcp(new Teuchos::ParameterList);
+  if (pList != Teuchos::null)
+    *pl = *pList;
+  pl->validateParametersAndSetDefaults(*this->getValidParameters());
+  use_dfdp_as_tangent_ = pl->get<bool>("Use DfDp as Tangent");
+  p_index_ = pl->get<int>("Sensitivity Parameter Index");
+  x_tangent_index_ = pl->get<int>("Sensitivity X Tangent Index");
+  xdot_tangent_index_ = pl->get<int>("Sensitivity X-Dot Tangent Index");
+  xdotdot_tangent_index_ = pl->get<int>("Sensitivity X-Dot-Dot Tangent Index");
+
+  num_param_ = model_->get_p_space(p_index_)->dim();
+  dxdp_space_ =
+    Thyra::multiVectorProductVectorSpace(model_->get_x_space(), num_param_);
+  x_dxdp_space_ =
+    Thyra::multiVectorProductVectorSpace(model_->get_x_space(), num_param_+1);
+  dfdp_space_ =
+    Thyra::multiVectorProductVectorSpace(model_->get_f_space(), num_param_);
+  f_dfdp_space_ =
+    Thyra::multiVectorProductVectorSpace(model_->get_f_space(), num_param_+1);
+
+  MEB::InArgs<Scalar> me_inArgs = model_->createInArgs();
+  MEB::InArgsSetup<Scalar> inArgs;
+  inArgs.setModelEvalDescription(this->description());
+  inArgs.setSupports(MEB::IN_ARG_x);
+  if (me_inArgs.supports(MEB::IN_ARG_x_dot))
+    inArgs.setSupports(MEB::IN_ARG_x_dot);
+  if (me_inArgs.supports(MEB::IN_ARG_t))
+    inArgs.setSupports(MEB::IN_ARG_t);
+  if (me_inArgs.supports(MEB::IN_ARG_alpha))
+    inArgs.setSupports(MEB::IN_ARG_alpha);
+  if (me_inArgs.supports(MEB::IN_ARG_beta))
+    inArgs.setSupports(MEB::IN_ARG_beta);
+  if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+    inArgs.setSupports(MEB::IN_ARG_W_x_dot_dot_coeff);
+
+  // Support additional parameters for x and xdot
+  inArgs.set_Np(me_inArgs.Np());
+  prototypeInArgs_ = inArgs;
+
+  MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+  MEB::OutArgsSetup<Scalar> outArgs;
+  outArgs.setModelEvalDescription(this->description());
+  outArgs.set_Np_Ng(me_inArgs.Np(),0);
+  outArgs.setSupports(MEB::OUT_ARG_f);
+  if (me_outArgs.supports(MEB::OUT_ARG_W_op))
+    outArgs.setSupports(MEB::OUT_ARG_W_op);
+  prototypeOutArgs_ = outArgs;
+
+  TEUCHOS_ASSERT(me_outArgs.supports(MEB::OUT_ARG_DfDp, p_index_).supports(MEB::DERIV_MV_JACOBIAN_FORM));
+  if (!use_dfdp_as_tangent_)
+    TEUCHOS_ASSERT(me_outArgs.supports(MEB::OUT_ARG_W_op));
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+get_p_space(int p) const
+{
+  TEUCHOS_ASSERT(p < model_->Np());
+  return model_->get_p_space(p);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Teuchos::Array<std::string> >
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+get_p_names(int p) const
+{
+  TEUCHOS_ASSERT(p < model_->Np());
+  return model_->get_p_names(p);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+get_x_space() const
+{
+  return x_dxdp_space_;
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+get_f_space() const
+{
+  return f_dfdp_space_;
+}
+
+template <typename Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+create_W_op() const
+{
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > op = model_->create_W_op();
+  return Thyra::nonconstMultiVectorLinearOp(op, num_param_+1);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+get_W_factory() const
+{
+  typedef Thyra::DefaultMultiVectorProductVectorSpace<Scalar> DMVPVS;
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > factory =
+    model_->get_W_factory();
+  RCP<Thyra::LinearOpBase<Scalar> > mv_op = this->create_W_op();
+  RCP<const DMVPVS> mv_domain =
+    rcp_dynamic_cast<const DMVPVS>(mv_op->domain());
+  RCP<const DMVPVS> mv_range =
+    rcp_dynamic_cast<const DMVPVS>(mv_op->range());
+  return Thyra::multiVectorLinearOpWithSolveFactory(factory,
+                                                    mv_range,
+                                                    mv_domain);
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+createInArgs() const
+{
+  return prototypeInArgs_;
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+getNominalValues() const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  using Teuchos::Range1D;
+
+  MEB::InArgs<Scalar> me_nominal = model_->getNominalValues();
+  MEB::InArgs<Scalar> nominal = this->createInArgs();
+
+  const Teuchos::Range1D rng(1,num_param_);
+  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+
+  // Set initial x.  If dxdp_init == null, set initial dx/dp = 0
+  RCP< const Thyra::VectorBase<Scalar> > me_x = me_nominal.get_x();
+  if (me_x != Teuchos::null) {
+    RCP< Thyra::VectorBase<Scalar> > x = Thyra::createMember(*x_dxdp_space_);
+    RCP<DMVPV> x_dxdp = rcp_dynamic_cast<DMVPV>(x);
+    Thyra::assign(x_dxdp->getNonconstMultiVector()->col(0).ptr(), *me_x);
+    if (dxdp_init_ == Teuchos::null)
+      Thyra::assign(x_dxdp->getNonconstMultiVector()->subView(rng).ptr(),
+                    zero);
+    else
+      Thyra::assign(x_dxdp->getNonconstMultiVector()->subView(rng).ptr(),
+                    *dxdp_init_);
+    nominal.set_x(x);
+  }
+
+  // Set initial xdot.  If dx_dotdp_init == null, set initial dxdot/dp = 0
+  RCP< const Thyra::VectorBase<Scalar> > me_xdot;
+  if (me_nominal.supports(MEB::IN_ARG_x_dot))
+    me_xdot = me_nominal.get_x_dot();
+  if (me_xdot != Teuchos::null) {
+    RCP< Thyra::VectorBase<Scalar> > xdot = Thyra::createMember(*x_dxdp_space_);
+    RCP<DMVPV> xdot_dxdp = rcp_dynamic_cast<DMVPV>(xdot);
+    Thyra::assign(xdot_dxdp->getNonconstMultiVector()->col(0).ptr(), *me_xdot);
+    if (dx_dotdp_init_ == Teuchos::null)
+      Thyra::assign(xdot_dxdp->getNonconstMultiVector()->subView(rng).ptr(),
+                    zero);
+    else
+      Thyra::assign(xdot_dxdp->getNonconstMultiVector()->subView(rng).ptr(),
+                    *dx_dotdp_init_);
+    nominal.set_x_dot(xdot);
+  }
+
+  // Set initial xdotdot.  If dx_dotdotdp_init == null, set initial dxdotdot/dp = 0
+  RCP< const Thyra::VectorBase<Scalar> > me_xdotdot;
+  if (me_nominal.supports(MEB::IN_ARG_x_dot_dot))
+    me_xdotdot = me_nominal.get_x_dot_dot();
+  if (me_xdotdot != Teuchos::null) {
+    RCP< Thyra::VectorBase<Scalar> > xdotdot =
+      Thyra::createMember(*x_dxdp_space_);
+    RCP<DMVPV> xdotdot_dxdp = rcp_dynamic_cast<DMVPV>(xdotdot);
+    Thyra::assign(xdotdot_dxdp->getNonconstMultiVector()->col(0).ptr(), *me_xdotdot);
+    if (dx_dotdotdp_init_ == Teuchos::null)
+      Thyra::assign(xdotdot_dxdp->getNonconstMultiVector()->subView(rng).ptr(),
+                    zero);
+    else
+      Thyra::assign(xdotdot_dxdp->getNonconstMultiVector()->subView(rng).ptr(),
+                    *dx_dotdotdp_init_);
+    nominal.set_x_dot_dot(xdotdot);
+  }
+
+  const int np = model_->Np();
+  for (int i=0; i<np; ++i)
+    nominal.set_p(i, me_nominal.get_p(i));
+
+  return nominal;
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+createOutArgsImpl() const
+{
+  return prototypeOutArgs_;
+}
+
+template <typename Scalar>
+void
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+              const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  using Teuchos::Range1D;
+
+  // setup input arguments for model
+  RCP< const Thyra::VectorBase<Scalar> > x, xdot, xdotdot;
+  RCP< const Thyra::MultiVectorBase<Scalar> > dxdp, dxdotdp, dxdotdotdp;
+  MEB::InArgs<Scalar> me_inArgs = model_->getNominalValues();
+  RCP<const DMVPV> x_dxdp = rcp_dynamic_cast<const DMVPV>(inArgs.get_x());
+  x = x_dxdp->getMultiVector()->col(0);
+  dxdp = x_dxdp->getMultiVector()->subView(Range1D(1,num_param_));
+  me_inArgs.set_x(x);
+  if (use_dfdp_as_tangent_) {
+    RCP< const Thyra::VectorBase<Scalar> > dxdp_vec =
+      Thyra::multiVectorProductVector(dxdp_space_, dxdp);
+    me_inArgs.set_p(x_tangent_index_, dxdp_vec);
+  }
+  if (me_inArgs.supports(MEB::IN_ARG_x_dot)) {
+    if (inArgs.get_x_dot() != Teuchos::null) {
+      RCP<const DMVPV> xdot_dxdotdp =
+        rcp_dynamic_cast<const DMVPV>(inArgs.get_x_dot());
+      xdot = xdot_dxdotdp->getMultiVector()->col(0);
+      dxdotdp = xdot_dxdotdp->getMultiVector()->subView(Range1D(1,num_param_));
+      me_inArgs.set_x_dot(xdot);
+      if (use_dfdp_as_tangent_) {
+        RCP< const Thyra::VectorBase<Scalar> > dxdotdp_vec =
+          Thyra::multiVectorProductVector(dxdp_space_, dxdotdp);
+        me_inArgs.set_p(xdot_tangent_index_, dxdotdp_vec);
+      }
+    }
+    else // clear out xdot if it was set in nominalValues
+      me_inArgs.set_x_dot(Teuchos::null);
+  }
+  if (me_inArgs.supports(MEB::IN_ARG_x_dot_dot)) {
+    if (inArgs.get_x_dot_dot() != Teuchos::null) {
+      RCP<const DMVPV> xdotdot_dxdotdotdp =
+        rcp_dynamic_cast<const DMVPV>(inArgs.get_x_dot_dot());
+      xdotdot = xdotdot_dxdotdotdp->getMultiVector()->col(0);
+      dxdotdotdp = xdotdot_dxdotdotdp->getMultiVector()->subView(Range1D(1,num_param_));
+      me_inArgs.set_x_dot_dot(xdotdot);
+      if (use_dfdp_as_tangent_) {
+        RCP< const Thyra::VectorBase<Scalar> > dxdotdotdp_vec =
+          Thyra::multiVectorProductVector(dxdp_space_, dxdotdotdp);
+        me_inArgs.set_p(xdotdot_tangent_index_, dxdotdotdp_vec);
+      }
+    }
+    else // clear out xdotdot if it was set in nominalValues
+      me_inArgs.set_x_dot_dot(Teuchos::null);
+  }
+  if (me_inArgs.supports(MEB::IN_ARG_t))
+    me_inArgs.set_t(inArgs.get_t());
+  if (me_inArgs.supports(MEB::IN_ARG_alpha))
+    me_inArgs.set_alpha(inArgs.get_alpha());
+  if (me_inArgs.supports(MEB::IN_ARG_beta))
+    me_inArgs.set_beta(inArgs.get_beta());
+  if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+    me_inArgs.set_W_x_dot_dot_coeff(inArgs.get_W_x_dot_dot_coeff());
+
+  // Set parameters -- be careful to only set ones that were set in our
+  // inArgs to not null out any specified through nominalValues or
+  // dx/dp above
+  const int np = me_inArgs.Np();
+  for (int i=0; i<np; ++i) {
+    if (inArgs.get_p(i) != Teuchos::null)
+      if (!use_dfdp_as_tangent_ ||
+          (use_dfdp_as_tangent_ && i != x_tangent_index_ &&
+                                   i != xdot_tangent_index_ &&
+                                   i != xdotdot_tangent_index_ ))
+        me_inArgs.set_p(i, inArgs.get_p(i));
+  }
+
+  // setup output arguments for model
+  RCP< Thyra::VectorBase<Scalar> > f;
+  RCP< Thyra::MultiVectorBase<Scalar> > dfdp;
+  MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+  if (outArgs.get_f() != Teuchos::null) {
+    RCP<DMVPV> f_dfdp = rcp_dynamic_cast<DMVPV>(outArgs.get_f());
+    f = f_dfdp->getNonconstMultiVector()->col(0);
+    dfdp = f_dfdp->getNonconstMultiVector()->subView(Range1D(1,num_param_));
+    me_outArgs.set_f(f);
+    me_outArgs.set_DfDp(p_index_, dfdp);
+  }
+  if (outArgs.get_W_op() != Teuchos::null) {
+    RCP< Thyra::LinearOpBase<double> > op = outArgs.get_W_op();
+    RCP< Thyra::MultiVectorLinearOp<double> > mv_op =
+      rcp_dynamic_cast< Thyra::MultiVectorLinearOp<double> >(op);
+    me_outArgs.set_W_op(mv_op->getNonconstLinearOp());
+  }
+
+  // build residual and jacobian
+  model_->evalModel(me_inArgs, me_outArgs);
+
+  // Compute (df/dx) * (dx/dp) + (df/dxdot) * (dxdot/dp) + (df/dxdotdot) * (dxdotdot/dp) + (df/dp)
+  // if the underlying ME doesn't already do this.  This requires computing
+  // df/dx, df/dxdot, df/dxdotdot as separate operators
+  if (!use_dfdp_as_tangent_) {
+    if (dxdp != Teuchos::null && dfdp != Teuchos::null) {
+      if (my_dfdx_ == Teuchos::null)
+        my_dfdx_ = model_->create_W_op();
+      MEB::OutArgs<Scalar> meo = model_->createOutArgs();
+      meo.set_W_op(my_dfdx_);
+      if (me_inArgs.supports(MEB::IN_ARG_alpha))
+        me_inArgs.set_alpha(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_beta))
+        me_inArgs.set_beta(1.0);
+      if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+        me_inArgs.set_W_x_dot_dot_coeff(0.0);
+      model_->evalModel(me_inArgs, meo);
+      my_dfdx_->apply(Thyra::NOTRANS, *dxdp, dfdp.ptr(), Scalar(1.0), Scalar(1.0));
+    }
+    if (dxdotdp != Teuchos::null && dfdp != Teuchos::null) {
+      if (my_dfdxdot_ == Teuchos::null)
+        my_dfdxdot_ = model_->create_W_op();
+      MEB::OutArgs<Scalar> meo = model_->createOutArgs();
+      meo.set_W_op(my_dfdxdot_);
+      if (me_inArgs.supports(MEB::IN_ARG_alpha))
+        me_inArgs.set_alpha(1.0);
+      if (me_inArgs.supports(MEB::IN_ARG_beta))
+        me_inArgs.set_beta(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+        me_inArgs.set_W_x_dot_dot_coeff(0.0);
+      model_->evalModel(me_inArgs, meo);
+      my_dfdxdot_->apply(Thyra::NOTRANS, *dxdotdp, dfdp.ptr(), Scalar(1.0), Scalar(1.0));
+    }
+    if (dxdotdotdp != Teuchos::null && dfdp != Teuchos::null) {
+      if (my_dfdxdotdot_ == Teuchos::null)
+        my_dfdxdotdot_ = model_->create_W_op();
+      MEB::OutArgs<Scalar> meo = model_->createOutArgs();
+      meo.set_W_op(my_dfdxdotdot_);
+      if (me_inArgs.supports(MEB::IN_ARG_alpha))
+        me_inArgs.set_alpha(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_beta))
+        me_inArgs.set_beta(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+        me_inArgs.set_W_x_dot_dot_coeff(1.0);
+      model_->evalModel(me_inArgs, meo);
+      my_dfdxdotdot_->apply(Thyra::NOTRANS, *dxdotdotdp, dfdp.ptr(), Scalar(1.0), Scalar(1.0));
+    }
+  }
+}
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+CombinedForwardSensitivityModelEvaluator<Scalar>::
+getValidParameters()
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+  pl->set<bool>("Use DfDp as Tangent", false);
+  pl->set<int>("Sensitivity Parameter Index", 0);
+  pl->set<int>("Sensitivity X Tangent Index", 1);
+  pl->set<int>("Sensitivity X-Dot Tangent Index", 2);
+  pl->set<int>("Sensitivity X-Dot-Dot Tangent Index", 3);
+  return pl;
+}
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -100,9 +100,9 @@ public:
       Teuchos::RCP<SolutionState<Scalar> > state = Teuchos::null);
     /// Set the initial state from Thyra::VectorBase(s)
     virtual void setInitialState(Scalar t0,
-      Teuchos::RCP<Thyra::VectorBase<Scalar> > x0,
-      Teuchos::RCP<Thyra::VectorBase<Scalar> > xdot0 = Teuchos::null,
-      Teuchos::RCP<Thyra::VectorBase<Scalar> > xdotdot0 = Teuchos::null);
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0 = Teuchos::null,
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0 = Teuchos::null);
     /// Get the SolutionHistory
     virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override
       {return solutionHistory_;}
@@ -138,6 +138,9 @@ public:
     /// Get current state
     virtual Teuchos::RCP<SolutionState<Scalar> > getCurrentState()
       {return solutionHistory_->getCurrentState();}
+
+    Teuchos::RCP<Teuchos::ParameterList> getIntegratorParameterList()
+      { return integratorPL_; }
   //@}
 
   /// Parse when screen output should be executed

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -156,9 +156,9 @@ setInitialState(Teuchos::RCP<SolutionState<Scalar> >  state)
 template<class Scalar>
 void IntegratorBasic<Scalar>::
 setInitialState(Scalar t0,
-  Teuchos::RCP<Thyra::VectorBase<Scalar> > x0,
-  Teuchos::RCP<Thyra::VectorBase<Scalar> > xdot0,
-  Teuchos::RCP<Thyra::VectorBase<Scalar> > xdotdot0)
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0)
 {
   using Teuchos::RCP;
   using Teuchos::ParameterList;
@@ -192,7 +192,7 @@ setInitialState(Scalar t0,
     Thyra::assign(xdotdot.ptr(), *(xdotdot0));
 
   RCP<SolutionState<Scalar> > newState = rcp(new SolutionState<Scalar>(
-    md, x0, xdot, xdotdot, stepper_->getDefaultStepperState()));
+    md, x0->clone_v(), xdot, xdotdot, stepper_->getDefaultStepperState()));
 
   solutionHistory_->addState(newState);
 }
@@ -696,6 +696,17 @@ Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integratorBasic(
 {
   Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integrator =
     Teuchos::rcp(new Tempus::IntegratorBasic<Scalar>(pList, model));
+  return(integrator);
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integratorBasic(
+  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+  const Teuchos::RCP<Stepper<Scalar> >&                    stepper)
+{
+  Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorBasic<Scalar>(pList, stepper));
   return(integrator);
 }
 

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity.cpp
@@ -1,0 +1,37 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_IntegratorForwardSensitivity.hpp"
+#include "Tempus_IntegratorForwardSensitivity_impl.hpp"
+
+namespace Tempus {
+
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorForwardSensitivity)
+
+  // non-member ctor
+  template Teuchos::RCP<IntegratorForwardSensitivity<double> >
+  integratorForwardSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>        parameterList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
+
+  // non-member ctor
+  template Teuchos::RCP<IntegratorForwardSensitivity<double> >
+  integratorForwardSensitivity(
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
+    std::string stepperType);
+
+  // non-member ctor
+  template Teuchos::RCP<IntegratorForwardSensitivity<double> >
+  integratorForwardSensitivity();
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_decl.hpp
@@ -1,0 +1,259 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorForwardSensitivity_decl_hpp
+#define Tempus_IntegratorForwardSensitivity_decl_hpp
+
+// Tempus
+#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_StepperStaggeredForwardSensitivity.hpp"
+
+namespace Tempus {
+
+
+/** \brief Time integrator implementing forward sensitivity analysis */
+/**
+ * This integrator implements forward parameter sensitivity analysis by
+ * propagating the derivative of the solution with respect to model parameters
+ * alongside the solution.  It supports sensitivity propagation methods:
+ * <ul>
+ *  <li> "Combined" where the sensitivity and state equations are solved
+ *       simultaneously.  This is most appropriate for explicit time
+ *       integration methods or implicit methods where a very-lightweight
+ *       nonlinear solution strategy is used.
+ *  <li> "Staggered" where the sensitivity equations are solved at each time
+ *       step immediately after the state equations are solved.  This is
+ *       useful for implicit methods since it saves the cost of solving the
+ *       sensitivity equations while the state equations are being solved.  It
+ *       generally does not work for explicit methods (and wouldn't be more
+ *       efficient than the combined method even if it did).
+ * </ul>
+ *
+ * Note that this integrator implements all of the same functions as the
+ * IntegratorBasic, but is not derived from IntegratorBasic.  It also provides
+ * functions for setting the sensitivity initial conditions and extracting the
+ * sensitivity at the final time.  Also the vectors stored in the solution
+ * history store product vectors of the state and sensitivities using
+ * Thyra;:DefaultMultiVectorProductVector.
+ */
+template<class Scalar>
+class IntegratorForwardSensitivity : virtual public Tempus::Integrator<Scalar>
+{
+public:
+
+  /** \brief Constructor with ParameterList and model, and will be fully
+   * initialized. */
+  /*!
+   * In addition to all of the regular integrator options, the supplied
+   * parameter list supports the following options contained within a sublist
+   * "Sensitivities" from the top-level parameter list:
+   * <ul>
+   *   <li> "Sensitivity Method" (default: "Combined") The sensitivity
+   *        analysis method as described above.
+   *   <li> "Reuse State Linear Solver" (default: false) For the staggered
+   *        method, whether to reuse the model's W matrix, solver, and
+   *        preconditioner when solving the sensitivity equations.  If they
+   *        can be reused, substantial savings in compute time are possible.
+   *   <li> "Use DfDp as Tangent" (default:  false) Reinterpret the df/dp
+   *        out-arg as the tangent vector (df/dx)(x,p) * dx/dp + df/dp(x,p)
+   *        as described in the Tempus::CombinedForwardSensitivityModelEvaluator
+   *        documentation.
+   *   <li> "Sensitivity Parameter Index" (default: 0) Model evaluator
+   *        parameter index for which sensitivities will be computed.
+   *   <li> "Sensitivity X Tangent Index" (default: 1) If "Use DfDp as Tangent"
+   *        is true, the model evaluator parameter index for passing dx/dp
+   *        as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot Tangent Index" (default: 2) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot/dp as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot-Dot Tangent Index" (default: 3) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot_dot/dp as a
+   *        Thyra::DefaultMultiVectorProductVector (if the model supports
+   *        x_dot_dot).
+   * </ul>
+   */
+  IntegratorForwardSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>                pList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+
+  /** \brief Constructor with model and "Stepper Type" and is fully initialized with default settings. */
+  IntegratorForwardSensitivity(
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    std::string stepperType);
+
+  /// Destructor
+  /** \brief Constructor that requires a subsequent setParameterList, setStepper, and initialize calls. */
+  IntegratorForwardSensitivity();
+
+  /// Destructor
+  virtual ~IntegratorForwardSensitivity() {}
+
+  /// \name Basic integrator methods
+  //@{
+    /// Advance the solution to timeMax, and return true if successful.
+  virtual bool advanceTime()
+    { return integrator_->advanceTime(); }
+    /// Advance the solution to timeFinal, and return true if successful.
+  virtual bool advanceTime(const Scalar timeFinal) override
+    { return integrator_->advanceTime(timeFinal); }
+  /// Perform tasks before start of integrator.
+  virtual void startIntegrator()
+    { integrator_->startIntegrator(); }
+  /// Start time step.
+  virtual void startTimeStep()
+    { integrator_->startTimeStep(); }
+  /// Only accept step after meeting time step criteria.
+  virtual void acceptTimeStep()
+    { integrator_->acceptTimeStep(); }
+  /// Perform tasks after end of integrator.
+  virtual void endIntegrator()
+    { integrator_->endIntegrator(); }
+  /// Return a copy of the Tempus ParameterList
+  virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() override
+    { return integrator_->getTempusParameterList(); }
+  virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override
+    { integrator_->setTempusParameterList(pl); }
+  //@}
+
+  /// \name Accessor methods
+  //@{
+  /// Get current time
+  virtual Scalar getTime() const override
+    { return integrator_->getTime(); }
+  /// Get current index
+  virtual Scalar getIndex() const override
+    { return integrator_->getIndex(); }
+  /// Get Status
+  virtual Status getStatus() const override
+    { return integrator_->getStatus(); }
+  /// Get the Stepper
+  virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const override
+    { return integrator_->getStepper(); }
+
+  /// Set the Stepper
+  virtual void setStepper(Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model);
+
+  /// Set the Stepper
+  virtual void setStepperWStepper(Teuchos::RCP<Stepper<Scalar> > stepper)
+    { integrator_->setStepperWStepper(stepper); }
+  /// Set the initial state which has the initial conditions
+  virtual void setInitialState(
+    Teuchos::RCP<SolutionState<Scalar> > state = Teuchos::null)
+    { integrator_->setInitialState(state); }
+
+  /// Set the initial state from Thyra::VectorBase(s)
+  virtual void setInitialState(
+    Scalar t0,
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxDp0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotDp0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotdotDp0 = Teuchos::null);
+
+  /// Get the SolutionHistory
+  virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override
+    { return integrator_->getSolutionHistory(); }
+  /// Set the SolutionHistory
+  virtual void setSolutionHistory(
+    Teuchos::RCP<SolutionHistory<Scalar> > sh = Teuchos::null)
+    { integrator_->setSolutionHistory(sh); }
+  /// Get the TimeStepControl
+  virtual Teuchos::RCP<const TimeStepControl<Scalar> > getTimeStepControl() const override
+    { return integrator_->getTimeStepControl(); }
+  /// Set the TimeStepControl
+  virtual void setTimeStepControl(
+    Teuchos::RCP<TimeStepControl<Scalar> > tsc = Teuchos::null)
+    { integrator_->setTimeStepControl(tsc); }
+  /// Get the Observer
+  virtual Teuchos::RCP<IntegratorObserver<Scalar> > getObserver()
+    { return integrator_->getObserver(); }
+  /// Set the Observer
+  virtual void setObserver(
+    Teuchos::RCP<IntegratorObserver<Scalar> > obs = Teuchos::null)
+    { integrator_->setObserver(obs); }
+  /// Initializes the Integrator after set* function calls
+  virtual void initialize()
+    { integrator_->initialize(); }
+
+  /// Get current the solution, x
+  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getX() const;
+  virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDxDp() const;
+  /// Get current the time derivative of the solution, xdot
+  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getXdot() const;
+  virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDxdotDp() const;
+  /// Get current the second time derivative of the solution, xdotdot
+  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getXdotdot() const;
+  virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDxdotdotDp() const;
+
+  /// Get current state
+  virtual Teuchos::RCP<SolutionState<Scalar> > getCurrentState()
+    {return integrator_->getCurrentState();}
+  //@}
+
+  /// Parse when screen output should be executed
+  void parseScreenOutput() { integrator_->parseScreenOutput(); }
+
+  /// \name Overridden from Teuchos::ParameterListAcceptor
+  //@{
+    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl);
+    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override
+      { return tempus_pl_; }
+    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override;
+
+    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters()
+      const override;
+  //@}
+
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    std::string description() const override;
+    void describe(Teuchos::FancyOStream        & out,
+                  const Teuchos::EVerbosityLevel verbLevel) const override;
+  //@}
+
+protected:
+
+  // Create sensitivity model evaluator from application model
+  void
+  createSensitivityModelAndStepper(
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > sens_model_;
+  Teuchos::RCP<StepperStaggeredForwardSensitivity<Scalar> > sens_stepper_;
+  Teuchos::RCP<IntegratorBasic<Scalar> > integrator_;
+  Teuchos::RCP<Teuchos::ParameterList> tempus_pl_;
+  Teuchos::RCP<Teuchos::ParameterList> sens_pl_;
+  Teuchos::RCP<Teuchos::ParameterList> stepper_pl_;
+  bool use_combined_method_;
+};
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> >
+integratorForwardSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> >
+integratorForwardSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  std::string stepperType);
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> >
+integratorForwardSensitivity();
+
+} // namespace Tempus
+
+#endif // Tempus_IntegratorForwardSensitivity_decl_hpp

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -1,0 +1,359 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorForwardSensitivity_impl_hpp
+#define Tempus_IntegratorForwardSensitivity_impl_hpp
+
+#include "Teuchos_VerboseObjectParameterListHelpers.hpp"
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
+#include "Tempus_CombinedForwardSensitivityModelEvaluator.hpp"
+
+namespace Tempus {
+
+template<class Scalar>
+IntegratorForwardSensitivity<Scalar>::
+IntegratorForwardSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
+{
+  model_ = model;
+  integrator_ = integratorBasic<Scalar>();
+  this->setParameterList(inputPL);
+  createSensitivityModelAndStepper(model);
+  if (use_combined_method_)
+    integrator_ = integratorBasic<Scalar>(tempus_pl_, sens_model_);
+  else {
+    integrator_ = integratorBasic<Scalar>();
+    integrator_->setTempusParameterList(tempus_pl_);
+    integrator_->setStepperWStepper(sens_stepper_);
+    integrator_->initialize();
+  }
+}
+
+template<class Scalar>
+IntegratorForwardSensitivity<Scalar>::
+IntegratorForwardSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  std::string stepperType)
+{
+  model_ = model;
+  integrator_ = integratorBasic<Scalar>();
+  this->setParameterList(Teuchos::null);
+  createSensitivityModelAndStepper(model);
+  if (use_combined_method_)
+    integrator_ = integratorBasic<Scalar>(sens_model_, stepperType);
+  else {
+    integrator_ = integratorBasic<Scalar>();
+    integrator_->setParameterList(tempus_pl_);
+    integrator_->setStepperWStepper(sens_stepper_);
+    integrator_->initialize();
+  }
+
+}
+
+template<class Scalar>
+IntegratorForwardSensitivity<Scalar>::
+IntegratorForwardSensitivity()
+{
+  integrator_ = integratorBasic<Scalar>();
+  this->setParameterList(Teuchos::null);
+}
+
+template<class Scalar>
+void IntegratorForwardSensitivity<Scalar>::
+setStepper(
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model)
+{
+  createSensitivityModelAndStepper(model);
+  if (use_combined_method_)
+    integrator_->setStepper(sens_model_);
+  else
+    integrator_->setStepperWStepper(sens_stepper_);
+}
+
+template<class Scalar>
+void IntegratorForwardSensitivity<Scalar>::
+setInitialState(Scalar t0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxDp0,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotDp0,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotdotDp0)
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  using Thyra::VectorSpaceBase;
+  using Thyra::assign;
+  using Thyra::createMember;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  //
+  // Create and initialize product X, Xdot, Xdotdot
+
+  RCP< const VectorSpaceBase<Scalar> > space;
+  if (use_combined_method_)
+    space = sens_model_->get_x_space();
+  else
+    space = sens_stepper_->get_x_space();
+  RCP<DMVPV> X       = rcp_dynamic_cast<DMVPV>(createMember(space));
+  RCP<DMVPV> Xdot    = rcp_dynamic_cast<DMVPV>(createMember(space));
+  RCP<DMVPV> Xdotdot = rcp_dynamic_cast<DMVPV>(createMember(space));
+
+  const int num_param = X->getNonconstMultiVector()->domain()->dim()-1;
+  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+  const Teuchos::Range1D rng(1,num_param);
+
+  // x
+  assign(X->getNonconstMultiVector()->col(0).ptr(), *x0);
+  if (DxDp0 == Teuchos::null)
+    assign(X->getNonconstMultiVector()->subView(rng).ptr(), zero);
+  else
+    assign(X->getNonconstMultiVector()->subView(rng).ptr(), *DxDp0);
+
+  // xdot
+  if (xdot0 == Teuchos::null)
+    assign(Xdot->getNonconstMultiVector()->col(0).ptr(), zero);
+  else
+    assign(Xdot->getNonconstMultiVector()->col(0).ptr(), *xdot0);
+  if (DxdotDp0 == Teuchos::null)
+    assign(Xdot->getNonconstMultiVector()->subView(rng).ptr(), zero);
+  else
+    assign(Xdot->getNonconstMultiVector()->subView(rng).ptr(), *DxdotDp0);
+
+  // xdotdot
+  if (xdotdot0 == Teuchos::null)
+    assign(Xdotdot->getNonconstMultiVector()->col(0).ptr(), zero);
+  else
+    assign(Xdotdot->getNonconstMultiVector()->col(0).ptr(), *xdotdot0);
+  if (DxdotDp0 == Teuchos::null)
+    assign(Xdotdot->getNonconstMultiVector()->subView(rng).ptr(), zero);
+  else
+    assign(Xdotdot->getNonconstMultiVector()->subView(rng).ptr(), *DxdotdotDp0);
+
+  integrator_->setInitialState(t0, X, Xdot, Xdotdot);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorBase<Scalar> >
+IntegratorForwardSensitivity<Scalar>::
+getX() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> X = rcp_dynamic_cast<const DMVPV>(integrator_->getX());
+  return X->getMultiVector()->col(0);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> >
+IntegratorForwardSensitivity<Scalar>::
+getDxDp() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> X = rcp_dynamic_cast<const DMVPV>(integrator_->getX());
+  const int num_param = X->getMultiVector()->domain()->dim()-1;
+  const Teuchos::Range1D rng(1,num_param);
+  return X->getMultiVector()->subView(rng);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorBase<Scalar> >
+IntegratorForwardSensitivity<Scalar>::
+getXdot() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdot = rcp_dynamic_cast<const DMVPV>(integrator_->getXdot());
+  return Xdot->getMultiVector()->col(0);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> >
+IntegratorForwardSensitivity<Scalar>::
+getDxdotDp() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdot = rcp_dynamic_cast<const DMVPV>(integrator_->getXdot());
+  const int num_param = Xdot->getMultiVector()->domain()->dim()-1;
+  const Teuchos::Range1D rng(1,num_param);
+  return Xdot->getMultiVector()->subView(rng);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorBase<Scalar> >
+IntegratorForwardSensitivity<Scalar>::
+getXdotdot() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdotdot =
+    rcp_dynamic_cast<const DMVPV>(integrator_->getXdotdot());
+  return Xdotdot->getMultiVector()->col(0);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> >
+IntegratorForwardSensitivity<Scalar>::
+getDxdotdotDp() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdotdot =
+    rcp_dynamic_cast<const DMVPV>(integrator_->getXdotdot());
+  const int num_param = Xdotdot->getMultiVector()->domain()->dim()-1;
+  const Teuchos::Range1D rng(1,num_param);
+  return Xdotdot->getMultiVector()->subView(rng);
+}
+
+template<class Scalar>
+std::string
+IntegratorForwardSensitivity<Scalar>::
+description() const
+{
+  std::string name = "Tempus::IntegratorForwardSensitivity";
+  return(name);
+}
+
+template<class Scalar>
+void
+IntegratorForwardSensitivity<Scalar>::
+describe(
+  Teuchos::FancyOStream          &out,
+  const Teuchos::EVerbosityLevel verbLevel) const
+{
+  out << description() << "::describe" << std::endl;
+  integrator_->describe(out, verbLevel);
+}
+
+template<class Scalar>
+void
+IntegratorForwardSensitivity<Scalar>::
+setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & inputPL)
+{
+  tempus_pl_ = Teuchos::parameterList();
+  if (inputPL != Teuchos::null)
+    *tempus_pl_ = *inputPL;
+  tempus_pl_->setParametersNotAlreadySet(*this->getValidParameters());
+  sens_pl_ = Teuchos::sublist(tempus_pl_, "Sensitivities", false);
+  std::string integratorName =
+    tempus_pl_->get<std::string>("Integrator Name", "Default Integrator");
+  std::string stepperName =
+    tempus_pl_->sublist(integratorName).get<std::string>("Stepper Name");
+  stepper_pl_ = Teuchos::sublist(tempus_pl_, stepperName, true);
+  use_combined_method_ =
+    sens_pl_->get<std::string>("Sensitivity Method") == "Combined";
+}
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+IntegratorForwardSensitivity<Scalar>::
+unsetParameterList()
+{
+  Teuchos::RCP<Teuchos::ParameterList> temp_param_list = tempus_pl_;
+  tempus_pl_ = Teuchos::null;
+  sens_pl_ = Teuchos::null;
+  stepper_pl_ = Teuchos::null;
+  integrator_->unsetParameterList();
+  return temp_param_list;
+}
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+IntegratorForwardSensitivity<Scalar>::
+getValidParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::rcp(new Teuchos::ParameterList);
+  Teuchos::RCP<const Teuchos::ParameterList> integrator_pl =
+    integrator_->getValidParameters();
+  Teuchos::RCP<const Teuchos::ParameterList> sensitivity_pl =
+    CombinedForwardSensitivityModelEvaluator<Scalar>::getValidParameters();
+  pl->setParameters(*integrator_pl);
+  Teuchos::ParameterList& spl = pl->sublist("Sensitivities");
+  spl.setParameters(*sensitivity_pl);
+  spl.set("Sensitivity Method", "Combined");
+  spl.set("Reuse State Linear Solver", false);
+
+  return pl;
+}
+
+template <class Scalar>
+void
+IntegratorForwardSensitivity<Scalar>::
+createSensitivityModelAndStepper(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
+{
+  using Teuchos::rcp;
+
+  Teuchos::RCP<Teuchos::ParameterList> spl = Teuchos::parameterList();
+  *spl = *sens_pl_;
+  spl->remove("Sensitivity Method");
+
+  if (use_combined_method_) {
+    spl->remove("Reuse State Linear Solver");
+    sens_model_ =
+      rcp(new CombinedForwardSensitivityModelEvaluator<Scalar>(model_, spl));
+  }
+  else {
+    sens_stepper_ =
+      rcp(new StepperStaggeredForwardSensitivity<Scalar>(
+            model_, stepper_pl_, spl));
+  }
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> >
+integratorForwardSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
+{
+  Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorForwardSensitivity<Scalar>(pList, model));
+  return(integrator);
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> >
+integratorForwardSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
+  std::string stepperType)
+{
+  Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorForwardSensitivity<Scalar>(model, stepperType));
+  return(integrator);
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> >
+integratorForwardSensitivity()
+{
+  Teuchos::RCP<Tempus::IntegratorForwardSensitivity<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorForwardSensitivity<Scalar>());
+  return(integrator);
+}
+
+} // namespace Tempus
+#endif // Tempus_IntegratorForwardSensitivity_impl_hpp

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity.cpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity.cpp
@@ -1,0 +1,37 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_IntegratorPseudoTransientForwardSensitivity.hpp"
+#include "Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp"
+
+namespace Tempus {
+
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorPseudoTransientForwardSensitivity)
+
+  // non-member ctor
+  template Teuchos::RCP<IntegratorPseudoTransientForwardSensitivity<double> >
+  integratorPseudoTransientForwardSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>        parameterList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model);
+
+  // non-member ctor
+  template Teuchos::RCP<IntegratorPseudoTransientForwardSensitivity<double> >
+  integratorPseudoTransientForwardSensitivity(
+    const Teuchos::RCP<Thyra::ModelEvaluator<double> >& model,
+    std::string stepperType);
+
+  // non-member ctor
+  template Teuchos::RCP<IntegratorPseudoTransientForwardSensitivity<double> >
+  integratorPseudoTransientForwardSensitivity();
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_decl.hpp
@@ -1,0 +1,190 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorPseudoTransientForwardSensitivity_decl_hpp
+#define Tempus_IntegratorPseudoTransientForwardSensitivity_decl_hpp
+
+// Tempus
+#include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_StaggeredForwardSensitivityModelEvaluator.hpp"
+
+namespace Tempus {
+
+
+/** \brief Time integrator suitable for pseudotransient forward sensitivity
+ * analysis */
+/**
+ * For some problems, time integrators are used to compute steady-state
+ * solutions (also known as pseudo-transient solvers).  When computing
+ * sensitivities, it is not necessary in these cases to propagate sensitivities
+ * all the way through the forward time integration.  Instead the steady-state
+ * is first computed as usual, and then the sensitivities are computed using
+ * a similar pseudo-transient time integration applied to the sensitivity
+ * equations with the state frozen to the computed steady-state.  This
+ * integrator specializes the transient sensitivity methods implemented by
+ * Tempus::IntegratorForwardSensitivity to this case.
+ */
+template<class Scalar>
+class IntegratorPseudoTransientForwardSensitivity :
+    virtual public Tempus::Integrator<Scalar>
+{
+public:
+
+  /** \brief Constructor with ParameterList and model, and will be fully
+   * initialized. */
+  /*!
+   * In addition to all of the regular integrator options, the supplied
+   * parameter list supports the following options contained within a sublist
+   * "Sensitivities" from the top-level parameter list:
+   * <ul>
+   *   <li> "Reuse State Linear Solver" (default: false) Whether to reuse the
+   *        model's W matrix, solver, and preconditioner when solving the
+   *        sensitivity equations.  If they can be reused, substantial savings
+   *        in compute time are possible.
+   *   <li> "Force W Update" (default: false) When reusing the solver as above
+   *        whether to force recomputation of W.  This can be necessary when
+   *        the solver overwrites it during the solve-phase (e.g., by a
+   *        factorization).
+   *   <li> "Use DfDp as Tangent" (default:  false) Reinterpret the df/dp
+   *        out-arg as the tangent vector (df/dx)(x,p) * dx/dp + df/dp(x,p)
+   *        as described in the Tempus::CombinedForwardSensitivityModelEvaluator
+   *        documentation.
+   *   <li> "Sensitivity Parameter Index" (default: 0) Model evaluator
+   *        parameter index for which sensitivities will be computed.
+   *   <li> "Sensitivity X Tangent Index" (default: 1) If "Use DfDp as Tangent"
+   *        is true, the model evaluator parameter index for passing dx/dp
+   *        as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot Tangent Index" (default: 2) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot/dp as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot-Dot Tangent Index" (default: 3) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot_dot/dp as a
+   *        Thyra::DefaultMultiVectorProductVector (if the model supports
+   *        x_dot_dot).
+   * </ul>
+   */
+  IntegratorPseudoTransientForwardSensitivity(
+    Teuchos::RCP<Teuchos::ParameterList>                pList,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+
+  /** \brief Constructor with model and "Stepper Type" and is fully initialized with default settings. */
+  IntegratorPseudoTransientForwardSensitivity(
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    std::string stepperType);
+
+  /// Destructor
+  /** \brief Constructor that requires a subsequent setParameterList, setStepper, and initialize calls. */
+  IntegratorPseudoTransientForwardSensitivity();
+
+  /// Destructor
+  virtual ~IntegratorPseudoTransientForwardSensitivity() {}
+
+  /// \name Basic integrator methods
+  //@{
+
+  /// Advance the solution to timeMax, and return true if successful.
+  virtual bool advanceTime();
+  /// Advance the solution to timeFinal, and return true if successful.
+  virtual bool advanceTime(const Scalar timeFinal) override;
+  /// Get current time
+  virtual Scalar getTime() const override;
+  /// Get current index
+  virtual Scalar getIndex() const override;
+  /// Get Status
+  virtual Status getStatus() const override;
+  /// Get the Stepper
+  virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const override;
+  /// Return a copy of the Tempus ParameterList
+  virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() override;
+  virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) override;
+  /// Get the SolutionHistory
+  virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const override;
+   /// Get the TimeStepControl
+  virtual Teuchos::RCP<const TimeStepControl<Scalar> > getTimeStepControl() const override;
+
+  //@}
+
+  /// Set the initial state from Thyra::VectorBase(s)
+  virtual void setInitialState(
+    Scalar t0,
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxDp0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotDp0 = Teuchos::null,
+    Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotdotDp0 = Teuchos::null);
+
+  /// Get current the solution, x
+  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getX() const;
+  virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDxDp() const;
+  /// Get current the time derivative of the solution, xdot
+  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getXdot() const;
+  virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDxdotDp() const;
+  /// Get current the second time derivative of the solution, xdotdot
+  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getXdotdot() const;
+  virtual Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > getDxdotdotDp() const;
+
+  /// \name Overridden from Teuchos::ParameterListAcceptor
+  //@{
+    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl);
+    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList() override;
+    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList() override;
+
+    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters()
+      const override;
+  //@}
+
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    std::string description() const override;
+    void describe(Teuchos::FancyOStream        & out,
+                  const Teuchos::EVerbosityLevel verbLevel) const override;
+  //@}
+
+protected:
+
+  // Create sensitivity model evaluator from application model
+  Teuchos::RCP<StaggeredForwardSensitivityModelEvaluator<Scalar> >
+  createSensitivityModel(
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+    const Teuchos::RCP<Teuchos::ParameterList>& inputPL);
+
+  void buildSolutionHistory();
+
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<StaggeredForwardSensitivityModelEvaluator<Scalar> > sens_model_;
+  Teuchos::RCP<IntegratorBasic<Scalar> > state_integrator_;
+  Teuchos::RCP<IntegratorBasic<Scalar> > sens_integrator_;
+  Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory_;
+  bool reuse_solver_;
+  bool force_W_update_;
+};
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
+integratorPseudoTransientForwardSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model);
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
+integratorPseudoTransientForwardSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  std::string stepperType);
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
+integratorPseudoTransientForwardSensitivity();
+
+} // namespace Tempus
+
+#endif // Tempus_IntegratorPseudoTransientForwardSensitivity_decl_hpp

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
@@ -1,0 +1,581 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorPseudoTransientForwardSensitivity_impl_hpp
+#define Tempus_IntegratorPseudoTransientForwardSensitivity_impl_hpp
+
+#include "Teuchos_VerboseObjectParameterListHelpers.hpp"
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
+#include "NOX_Thyra.H"
+
+namespace Tempus {
+
+template<class Scalar>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+IntegratorPseudoTransientForwardSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                inputPL,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model) :
+  reuse_solver_(false)
+{
+  model_ = model;
+  sens_model_ = createSensitivityModel(model_, inputPL);
+  state_integrator_ = integratorBasic<Scalar>(inputPL, model_);
+  sens_integrator_ = integratorBasic<Scalar>(inputPL, sens_model_);
+}
+
+template<class Scalar>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+IntegratorPseudoTransientForwardSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  std::string stepperType) :
+  reuse_solver_(false),
+  force_W_update_(false)
+{
+  model_ = model;
+  sens_model_ = createSensitivityModel(model, Teuchos::null);
+  state_integrator_ = integratorBasic<Scalar>(model_, stepperType);
+  sens_integrator_ = integratorBasic<Scalar>(sens_model_, stepperType);
+}
+
+template<class Scalar>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+IntegratorPseudoTransientForwardSensitivity() :
+  reuse_solver_(false),
+  force_W_update_(false)
+{
+  state_integrator_ = integratorBasic<Scalar>();
+  sens_integrator_ = integratorBasic<Scalar>();
+}
+
+template<class Scalar>
+bool
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+advanceTime()
+{
+  using Teuchos::RCP;
+  using Thyra::VectorBase;
+
+  // Run state integrator and get solution
+  bool state_status = state_integrator_->advanceTime();
+  RCP<VectorBase<Scalar> > x = state_integrator_->getX();
+  RCP<VectorBase<Scalar> > x_dot = state_integrator_->getXdot();
+  RCP<VectorBase<Scalar> > x_dot_dot = state_integrator_->getXdotdot();
+
+  // Set solution in sensitivity ME
+  sens_model_->setModelX(x);
+  sens_model_->setModelXDot(x_dot);
+  sens_model_->setModelXDotDot(x_dot_dot);
+
+  // Reuse state solver if requested
+  if (reuse_solver_ &&
+      state_integrator_->getStepper()->getSolver() != Teuchos::null) {
+    RCP<Thyra::NOXNonlinearSolver> nox_solver =
+      Teuchos::rcp_dynamic_cast<Thyra::NOXNonlinearSolver>(
+        state_integrator_->getStepper()->getSolver());
+    sens_model_->setLO(nox_solver->get_nonconst_W_op(force_W_update_));
+    sens_model_->setPO(nox_solver->get_nonconst_prec_op());
+  }
+
+  // Run sensitivity integrator
+  bool sens_status = sens_integrator_->advanceTime();
+
+  buildSolutionHistory();
+
+  return state_status && sens_status;
+}
+
+template<class Scalar>
+bool
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+advanceTime(const Scalar timeFinal)
+{
+  using Teuchos::RCP;
+  using Thyra::VectorBase;
+
+  // Run state integrator and get solution
+  bool state_status = state_integrator_->advanceTime(timeFinal);
+  RCP<VectorBase<Scalar> > x = state_integrator_->getX();
+  RCP<VectorBase<Scalar> > x_dot = state_integrator_->getXdot();
+  RCP<VectorBase<Scalar> > x_dot_dot = state_integrator_->getXdotdot();
+
+  // Set solution in sensitivity ME
+  sens_model_->setModelX(x);
+  sens_model_->setModelXDot(x_dot);
+  sens_model_->setModelXDotDot(x_dot_dot);
+
+  // Reuse state solver if requested
+  if (reuse_solver_ &&
+      state_integrator_->getStepper()->getSolver() != Teuchos::null) {
+    RCP<Thyra::NOXNonlinearSolver> nox_solver =
+      Teuchos::rcp_dynamic_cast<Thyra::NOXNonlinearSolver>(
+        state_integrator_->getStepper()->getSolver());
+    sens_model_->setLO(nox_solver->get_nonconst_W_op(force_W_update_));
+    sens_model_->setPO(nox_solver->get_nonconst_prec_op());
+  }
+
+  // Run sensitivity integrator
+  bool sens_status = sens_integrator_->advanceTime(timeFinal);
+
+  buildSolutionHistory();
+
+  return state_status && sens_status;
+}
+
+template<class Scalar>
+Scalar
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getTime() const
+{
+  return solutionHistory_->getCurrentTime();
+}
+
+template<class Scalar>
+Scalar
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getIndex() const
+{
+  return solutionHistory_->getCurrentIndex();
+}
+
+template<class Scalar>
+Status
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getStatus() const
+{
+  Status state_status = state_integrator_->getStatus();
+  Status sens_status = sens_integrator_->getStatus();
+  if (state_status == FAILED || sens_status == FAILED)
+    return FAILED;
+  if (state_status == WORKING || sens_status == WORKING)
+    return WORKING;
+  return PASSED;
+}
+
+template<class Scalar>
+Teuchos::RCP<Stepper<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getStepper() const
+{
+  return state_integrator_->getStepper();
+}
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getTempusParameterList()
+{
+  return state_integrator_->getTempusParameterList();
+}
+
+template<class Scalar>
+void
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl)
+{
+  state_integrator_->setTempusParameterList(pl);
+  sens_integrator_->setTempusParameterList(pl);
+}
+
+template<class Scalar>
+Teuchos::RCP<const SolutionHistory<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getSolutionHistory() const
+{
+  return solutionHistory_;
+}
+
+template<class Scalar>
+Teuchos::RCP<const TimeStepControl<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getTimeStepControl() const
+{
+  return state_integrator_->getTimeStepControl();
+}
+
+template<class Scalar>
+void IntegratorPseudoTransientForwardSensitivity<Scalar>::
+setInitialState(Scalar t0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0,
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxDp0,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotDp0,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotdotDp0)
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  using Thyra::VectorSpaceBase;
+  using Thyra::assign;
+  using Thyra::createMember;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  //
+  // Create and initialize product X, Xdot, Xdotdot
+
+  RCP< const VectorSpaceBase<Scalar> > space = sens_model_->get_x_space();
+  RCP<DMVPV> X       = rcp_dynamic_cast<DMVPV>(createMember(space));
+  RCP<DMVPV> Xdot    = rcp_dynamic_cast<DMVPV>(createMember(space));
+  RCP<DMVPV> Xdotdot = rcp_dynamic_cast<DMVPV>(createMember(space));
+  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+
+  // x
+  if (DxDp0 == Teuchos::null)
+    assign(X->getNonconstMultiVector().ptr(), zero);
+  else
+    assign(X->getNonconstMultiVector().ptr(), *DxDp0);
+
+  // xdot
+  if (DxdotDp0 == Teuchos::null)
+    assign(Xdot->getNonconstMultiVector().ptr(), zero);
+  else
+    assign(Xdot->getNonconstMultiVector().ptr(), *DxdotDp0);
+
+  // xdotdot
+  if (DxdotDp0 == Teuchos::null)
+    assign(Xdotdot->getNonconstMultiVector().ptr(), zero);
+  else
+    assign(Xdotdot->getNonconstMultiVector().ptr(), *DxdotdotDp0);
+
+  state_integrator_->setInitialState(t0, x0, xdot0, xdotdot0);
+  sens_integrator_->setInitialState(t0, X, Xdot, Xdotdot);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorBase<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getX() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> X =
+    rcp_dynamic_cast<const DMVPV>(solutionHistory_->getCurrentState()->getX());
+  return X->getMultiVector()->col(0);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getDxDp() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> X =
+    rcp_dynamic_cast<const DMVPV>(solutionHistory_->getCurrentState()->getX());
+  const int num_param = X->getMultiVector()->domain()->dim()-1;
+  const Teuchos::Range1D rng(1,num_param);
+  return X->getMultiVector()->subView(rng);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorBase<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getXdot() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdot =
+    rcp_dynamic_cast<const DMVPV>(solutionHistory_->getCurrentState()->getXDot());
+  return Xdot->getMultiVector()->col(0);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getDxdotDp() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdot =
+    rcp_dynamic_cast<const DMVPV>(solutionHistory_->getCurrentState()->getXDot());
+  const int num_param = Xdot->getMultiVector()->domain()->dim()-1;
+  const Teuchos::Range1D rng(1,num_param);
+  return Xdot->getMultiVector()->subView(rng);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorBase<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getXdotdot() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdotdot =
+    rcp_dynamic_cast<const DMVPV>(solutionHistory_->getCurrentState()->getXDotDot());
+  return Xdotdot->getMultiVector()->col(0);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getDxdotdotDp() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  RCP<const DMVPV> Xdotdot =
+    rcp_dynamic_cast<const DMVPV>(solutionHistory_->getCurrentState()->getXDotDot());
+  const int num_param = Xdotdot->getMultiVector()->domain()->dim()-1;
+  const Teuchos::Range1D rng(1,num_param);
+  return Xdotdot->getMultiVector()->subView(rng);
+}
+
+template<class Scalar>
+std::string
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+description() const
+{
+  std::string name = "Tempus::IntegratorPseudoTransientForwardSensitivity";
+  return(name);
+}
+
+template<class Scalar>
+void
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+describe(
+  Teuchos::FancyOStream          &out,
+  const Teuchos::EVerbosityLevel verbLevel) const
+{
+  out << description() << "::describe" << std::endl;
+  state_integrator_->describe(out, verbLevel);
+  sens_integrator_->describe(out, verbLevel);
+}
+
+template<class Scalar>
+void
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & inputPL)
+{
+  state_integrator_->setParameterList(inputPL);
+  sens_integrator_->setParameterList(inputPL);
+  reuse_solver_ =
+    inputPL->sublist("Sensitivities").get("Reuse State Linear Solver", false);
+  force_W_update_ =
+    inputPL->sublist("Sensitivities").get("Force W Update", false);
+}
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+unsetParameterList()
+{
+  state_integrator_->unsetParameterList();
+  return sens_integrator_->unsetParameterList();
+}
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getValidParameters() const
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::rcp(new Teuchos::ParameterList);
+  Teuchos::RCP<const Teuchos::ParameterList> integrator_pl =
+    state_integrator_->getValidParameters();
+  Teuchos::RCP<const Teuchos::ParameterList> sensitivity_pl =
+    StaggeredForwardSensitivityModelEvaluator<Scalar>::getValidParameters();
+  pl->setParameters(*integrator_pl);
+  pl->sublist("Sensitivities").setParameters(*sensitivity_pl);
+  pl->sublist("Sensitivities").set("Reuse State Linear Solver", false);
+  pl->sublist("Sensitivities").set("Force W Update", false);
+
+  return pl;
+}
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+getNonconstParameterList()
+{
+  return state_integrator_->getNonconstParameterList();
+}
+
+template <class Scalar>
+Teuchos::RCP<Tempus::StaggeredForwardSensitivityModelEvaluator<Scalar> >
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+createSensitivityModel(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model,
+  const Teuchos::RCP<Teuchos::ParameterList>& inputPL)
+{
+  using Teuchos::rcp;
+
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+  if (inputPL != Teuchos::null) {
+    *pl = inputPL->sublist("Sensitivities");
+  }
+  reuse_solver_ = pl->get("Reuse State Linear Solver", false);
+  force_W_update_ = pl->get("Force W Update", true);
+  pl->remove("Reuse State Linear Solver");
+  pl->remove("Force W Update");
+  return rcp(new StaggeredForwardSensitivityModelEvaluator<Scalar>(model, pl));
+}
+
+template<class Scalar>
+void
+IntegratorPseudoTransientForwardSensitivity<Scalar>::
+buildSolutionHistory()
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::rcp_dynamic_cast;
+  using Teuchos::ParameterList;
+  using Thyra::VectorBase;
+  using Thyra::MultiVectorBase;
+  using Thyra::VectorSpaceBase;
+  using Thyra::createMembers;
+  using Thyra::multiVectorProductVector;
+  using Thyra::assign;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+
+  // Create combined solution histories, first for the states with zero
+  // sensitivities and then for the sensitivities with frozen states
+  RCP<ParameterList> shPL =
+    Teuchos::sublist(state_integrator_->getIntegratorParameterList(),
+                     "Solution History", true);
+  solutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+
+  const int num_param =
+    rcp_dynamic_cast<const DMVPV>(sens_integrator_->getX())->getMultiVector()->domain()->dim();
+  RCP<const VectorSpaceBase<Scalar> > x_space = model_->get_x_space();
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > prod_space =
+    Thyra::multiVectorProductVectorSpace(x_space, num_param+1);
+  const Teuchos::Range1D rng(1,num_param);
+  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+
+  RCP<const SolutionHistory<Scalar> > state_solution_history =
+    state_integrator_->getSolutionHistory();
+  int num_states = state_solution_history->getNumStates();
+  for (int i=0; i<num_states; ++i) {
+    RCP<const SolutionState<Scalar> > state = (*state_solution_history)[i];
+
+    // X
+    RCP< MultiVectorBase<Scalar> > x_mv =
+      createMembers(x_space, num_param+1);
+    assign(x_mv->col(0).ptr(), *(state->getX()));
+    assign(x_mv->subView(rng).ptr(), zero);
+    RCP<DMVPV> x = multiVectorProductVector(prod_space, x_mv);
+
+    // X-Dot
+    RCP< MultiVectorBase<Scalar> > x_dot_mv =
+      createMembers(x_space, num_param+1);
+    assign(x_dot_mv->col(0).ptr(), *(state->getXDot()));
+    assign(x_dot_mv->subView(rng).ptr(), zero);
+    RCP<DMVPV> x_dot = multiVectorProductVector(prod_space, x_dot_mv);
+
+    // X-Dot-Dot
+    RCP< MultiVectorBase<Scalar> > x_dot_dot_mv =
+      createMembers(x_space, num_param+1);
+    assign(x_dot_dot_mv->col(0).ptr(), *(state->getXDotDot()));
+    assign(x_dot_dot_mv->subView(rng).ptr(), zero);
+    RCP<DMVPV> x_dot_dot = multiVectorProductVector(prod_space, x_dot_dot_mv);
+
+    RCP<SolutionState<Scalar> > prod_state =
+      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
+                                    x, x_dot, x_dot_dot,
+                                    state->getStepperState()->clone()));
+    solutionHistory_->addState(prod_state);
+  }
+
+  RCP<const VectorBase<Scalar> > frozen_x =
+    state_solution_history->getCurrentState()->getX();
+  RCP<const VectorBase<Scalar> > frozen_x_dot =
+    state_solution_history->getCurrentState()->getXDot();
+  RCP<const VectorBase<Scalar> > frozen_x_dot_dot =
+    state_solution_history->getCurrentState()->getXDotDot();
+  RCP<const SolutionHistory<Scalar> > sens_solution_history =
+    sens_integrator_->getSolutionHistory();
+  num_states = sens_solution_history->getNumStates();
+  for (int i=0; i<num_states; ++i) {
+    RCP<const SolutionState<Scalar> > state = (*sens_solution_history)[i];
+
+    // X
+    RCP< MultiVectorBase<Scalar> > x_mv =
+      createMembers(x_space, num_param+1);
+    RCP<const MultiVectorBase<Scalar> > dxdp =
+      rcp_dynamic_cast<const DMVPV>(state->getX())->getMultiVector();
+    assign(x_mv->col(0).ptr(), *(frozen_x));
+    assign(x_mv->subView(rng).ptr(), *dxdp);
+    RCP<DMVPV> x = multiVectorProductVector(prod_space, x_mv);
+
+    // X-Dot
+    RCP< MultiVectorBase<Scalar> > x_dot_mv =
+      createMembers(x_space, num_param+1);
+    RCP<const MultiVectorBase<Scalar> > dxdotdp =
+      rcp_dynamic_cast<const DMVPV>(state->getXDot())->getMultiVector();
+    assign(x_dot_mv->col(0).ptr(), *(frozen_x_dot));
+    assign(x_dot_mv->subView(rng).ptr(), *dxdotdp);
+    RCP<DMVPV> x_dot = multiVectorProductVector(prod_space, x_dot_mv);
+
+    // X-Dot-Dot
+    RCP< MultiVectorBase<Scalar> > x_dot_dot_mv =
+      createMembers(x_space, num_param+1);
+    RCP<const MultiVectorBase<Scalar> > dxdotdotdp =
+      rcp_dynamic_cast<const DMVPV>(state->getXDotDot())->getMultiVector();
+    assign(x_dot_dot_mv->col(0).ptr(), *(frozen_x_dot_dot));
+    assign(x_dot_dot_mv->subView(rng).ptr(), *dxdotdotdp);
+    RCP<DMVPV> x_dot_dot = multiVectorProductVector(prod_space, x_dot_dot_mv);
+
+    RCP<SolutionState<Scalar> > prod_state =
+      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
+                                    x, x_dot, x_dot_dot,
+                                    state->getStepperState()->clone()));
+    solutionHistory_->addState(prod_state);
+  }
+
+  // Set current state to the last added state
+  RCP<SolutionState<Scalar> > last_state =
+    (*solutionHistory_)[solutionHistory_->getNumStates()-1];
+  solutionHistory_->setCurrentState(last_state);
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
+integratorPseudoTransientForwardSensitivity(
+  Teuchos::RCP<Teuchos::ParameterList>                     pList,
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model)
+{
+  Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar>(pList, model));
+  return(integrator);
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
+integratorPseudoTransientForwardSensitivity(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
+  std::string stepperType)
+{
+  Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar>(model, stepperType));
+  return(integrator);
+}
+
+/// Non-member constructor
+template<class Scalar>
+Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> >
+integratorPseudoTransientForwardSensitivity()
+{
+  Teuchos::RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar> > integrator =
+    Teuchos::rcp(new Tempus::IntegratorPseudoTransientForwardSensitivity<Scalar>());
+  return(integrator);
+}
+
+} // namespace Tempus
+#endif // Tempus_IntegratorPseudoTransientForwardSensitivity_impl_hpp

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -120,6 +120,10 @@ public:
     Teuchos::RCP<SolutionState<Scalar> > getCurrentState() const
       { return currentState_; }
 
+    /// Set the current state, i.e., the last accepted state
+    void setCurrentState(const Teuchos::RCP<SolutionState<Scalar> >& state)
+      { currentState_ = state; }
+
     /// Return the working state
     Teuchos::RCP<SolutionState<Scalar> > getWorkingState() const
       { return workingState_; }

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
@@ -51,7 +51,7 @@ public:
   SolutionStateMetaData(const SolutionStateMetaData<Scalar>& ssmd);
 
   /// Clone constructor
-  Teuchos::RCP<SolutionStateMetaData<Scalar> > clone();
+  Teuchos::RCP<SolutionStateMetaData<Scalar> > clone() const;
 
   /// This is a deep copy
   void copy(Teuchos::RCP<SolutionStateMetaData<Scalar> > ssmd);

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -84,7 +84,7 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData(const SolutionStateMetaData
 
 
 template<class Scalar>
-Teuchos::RCP<SolutionStateMetaData<Scalar> > SolutionStateMetaData<Scalar>::clone()
+Teuchos::RCP<SolutionStateMetaData<Scalar> > SolutionStateMetaData<Scalar>::clone() const
 {
   Teuchos::RCP<SolutionStateMetaData<Scalar> > md =
     rcp(new SolutionStateMetaData<Scalar> (

--- a/packages/tempus/src/Tempus_SolutionState_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_decl.hpp
@@ -122,10 +122,14 @@ public:
 
     /// Return the Stepper status
     virtual Status getStepperStatus() const
-      {return stepperState_->stepperStatus_;};
+      {return stepperState_->stepperStatus_;}
 
     /// Return Meta Data
     virtual Teuchos::RCP<SolutionStateMetaData<Scalar> > getMetaData()
+      { return metaData_; }
+
+    /// Return Meta Data
+    virtual Teuchos::RCP<const SolutionStateMetaData<Scalar> > getMetaData() const
       { return metaData_; }
 
     /// Get the current solution, x.
@@ -152,6 +156,10 @@ public:
 
     /// Get the StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getStepperState()
+      { return stepperState_; }
+
+    /// Get the StepperState
+    virtual Teuchos::RCP<const Tempus::StepperState<Scalar> > getStepperState() const
       { return stepperState_; }
 
   //@}

--- a/packages/tempus/src/Tempus_StaggeredForwardSensitivityModelEvaluator.cpp
+++ b/packages/tempus/src/Tempus_StaggeredForwardSensitivityModelEvaluator.cpp
@@ -1,0 +1,19 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_StaggeredForwardSensitivityModelEvaluator_decl.hpp"
+#include "Tempus_StaggeredForwardSensitivityModelEvaluator_impl.hpp"
+
+namespace Tempus {
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(StaggeredForwardSensitivityModelEvaluator)
+}
+
+#endif

--- a/packages/tempus/src/Tempus_StaggeredForwardSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_StaggeredForwardSensitivityModelEvaluator_decl.hpp
@@ -1,0 +1,168 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_StaggeredForwardSensitivityModelEvaluator_decl_hpp
+#define Tempus_StaggeredForwardSensitivityModelEvaluator_decl_hpp
+
+#include "Thyra_StateFuncModelEvaluatorBase.hpp"
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+
+namespace Tempus {
+
+/** \brief Transform a ModelEvaluator's sensitivity equations to its residual
+ *
+ * This class wraps a given ModelEvalutor encapsulating f(x,p) and creates
+ * a new "residual" for the forward sensitivity equations:
+ *        F(X) = (df/dx)(x,p) * X + df/dp(x,p) = 0
+ * where X = dx/dp (transient terms supressed for simplicity).  This model
+ * evaluator can then be handed to a regular (non)linear solver to compute X.
+ * Note that even though these equations are linear in X, it is not necessarily
+ * the case that the underlying model evaluator accurately computes df/dx in its
+ * evaluation of W.  Therefore this model evaluator can optionally reinterpret
+ * the model's df/dp out-arg as (df/dx)(x,p) * dx/dp + df/dp(x,p) where dx/dp is
+ * passed as another parameter (product) vector (encapsulated in the
+ * Thyra::DefaultMultiVectorProductVector).  This is not standard model
+ * evaluator behavior, but is useful for models where W is only an approximation
+ * to df/dx and/or the model is capable of directly computing
+ * (df/dx)(x,p) * dx/dp + df/dp(x,p).
+ *
+ * This model evaluator differes from CombinedForwardSensitivityModelEvaluator
+ * in that it doesn't include the state equations in the residual, just the
+ * sensitivity equations.  Therefore it provides methods to set the state
+ * solution vector (x) and time derivatives (x_dot, x_dot_dot) for use in
+ * evaluating the senstivity residual.  It also provides methods for setting
+ * the linear operator (W a.k.a. alpha*df/dx + beta*df/dx_dot) and its
+ * preconditioner in cases where they can be reused from the state model
+ * evaluations.
+ */
+template <typename Scalar>
+class StaggeredForwardSensitivityModelEvaluator :
+    public Thyra::StateFuncModelEvaluatorBase<Scalar> {
+public:
+  typedef Thyra::VectorBase<Scalar>  Vector;
+  typedef Thyra::MultiVectorBase<Scalar>  MultiVector;
+
+  //! Constructor
+  /*!
+   * The optionally supplied parameter list supports the following options:
+   * <ul>
+   *   <li> "Use DfDp as Tangent" (default:  false) Reinterpret the df/dp
+   *        out-arg as the tangent vector (df/dx)(x,p) * dx/dp + df/dp(x,p)
+   *        as described above.  If it is false, this implementation will
+   *        compute the tangent through several calls to the models
+   *        evalModel().
+   *   <li> "Sensitivity Parameter Index" (default: 0) Model evaluator
+   *        parameter index for which sensitivities will be computed.
+   *   <li> "Sensitivity X Tangent Index" (default: 1) If "Use DfDp as Tangent"
+   *        is true, the model evaluator parameter index for passing dx/dp
+   *        as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot Tangent Index" (default: 2) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot/dp as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot-Dot Tangent Index" (default: 3) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot_dot/dp as a
+   *        Thyra::DefaultMultiVectorProductVector (if the model supports
+   *        x_dot_dot).
+   * </ul>
+   */
+  StaggeredForwardSensitivityModelEvaluator(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+    const Teuchos::RCP<const Teuchos::ParameterList>& pList = Teuchos::null,
+    const Teuchos::RCP<MultiVector>& dxdp_init = Teuchos::null,
+    const Teuchos::RCP<MultiVector>& dx_dotdp_init = Teuchos::null,
+    const Teuchos::RCP<MultiVector>& dx_dotdot_dp_init = Teuchos::null);
+
+  //! Get the underlying model 'f'
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() const
+  { return model_; }
+
+  //! Set the x vector corresponding to the underlying model
+  void setModelX(const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& x)
+  { x_ = x; }
+
+  //! Set the x_dot vector corresponding to the underlying model
+  void setModelXDot(const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& x_dot)
+  { x_dot_ = x_dot; }
+
+  //! Set the x_dot_dot vector corresponding to the underlying model
+  void setModelXDotDot(const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& x_dot_dot)
+  { x_dot_dot_ = x_dot_dot; }
+
+  //! Set the LO (W) of the underlying model if you want to reuse it
+  void setLO(const Teuchos::RCP<Thyra::LinearOpBase<Scalar> >& lo)
+  { lo_ = lo; }
+
+  //! Set the preconditioner of the underlying model if you want to reuse it
+  void setPO(const Teuchos::RCP<Thyra::PreconditionerBase<Scalar> >& po)
+  { po_ = po; }
+
+  /** \name Public functions overridden from ModelEvaulator. */
+  //@{
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int p) const;
+
+  Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int p) const;
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_f_space() const;
+
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
+
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+  get_W_factory() const;
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
+
+  //@}
+
+  static Teuchos::RCP<const Teuchos::ParameterList> getValidParameters();
+
+private:
+
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
+
+  void evalModelImpl(
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+    const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const;
+
+
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> prototypeInArgs_;
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> prototypeOutArgs_;
+
+  Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<MultiVector> dxdp_init_;
+  Teuchos::RCP<MultiVector> dx_dotdp_init_;
+  Teuchos::RCP<MultiVector> dx_dotdotdp_init_;
+  int p_index_;
+  int x_tangent_index_;
+  int xdot_tangent_index_;
+  int xdotdot_tangent_index_;
+  bool use_dfdp_as_tangent_;
+
+  int num_param_;
+  Teuchos::RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > dxdp_space_;
+  Teuchos::RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > dfdp_space_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x_dot_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > x_dot_dot_;
+
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > lo_;
+  Teuchos::RCP<Thyra::PreconditionerBase<Scalar> > po_;
+
+  mutable Teuchos::RCP<Thyra::LinearOpBase<Scalar> > my_dfdx_;
+  mutable Teuchos::RCP<Thyra::LinearOpBase<Scalar> > my_dfdxdot_;
+  mutable Teuchos::RCP<Thyra::LinearOpBase<Scalar> > my_dfdxdotdot_;
+};
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_StaggeredForwardSensitivityModelEvaluator_impl.hpp
+++ b/packages/tempus/src/Tempus_StaggeredForwardSensitivityModelEvaluator_impl.hpp
@@ -1,0 +1,381 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_StaggeredForwardSensitivityModelEvaluator_impl_hpp
+#define Tempus_StaggeredForwardSensitivityModelEvaluator_impl_hpp
+
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
+#include "Thyra_MultiVectorLinearOp.hpp"
+#include "Thyra_MultiVectorLinearOpWithSolveFactory.hpp"
+#include "Thyra_ReuseLinearOpWithSolveFactory.hpp"
+
+namespace Tempus {
+
+template <typename Scalar>
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+StaggeredForwardSensitivityModelEvaluator(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & model,
+  const Teuchos::RCP<const Teuchos::ParameterList>& pList,
+  const Teuchos::RCP<MultiVector>& dxdp_init,
+  const Teuchos::RCP<MultiVector>& dx_dotdp_init,
+  const Teuchos::RCP<MultiVector>& dx_dotdotdp_init) :
+  model_(model),
+  dxdp_init_(dxdp_init),
+  dx_dotdp_init_(dx_dotdp_init),
+  dx_dotdotdp_init_(dx_dotdotdp_init),
+  p_index_(0),
+  x_tangent_index_(1),
+  xdot_tangent_index_(2),
+  xdotdot_tangent_index_(3),
+  use_dfdp_as_tangent_(false)
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+
+  // Set parameters
+  Teuchos::RCP<Teuchos::ParameterList> pl =
+    Teuchos::rcp(new Teuchos::ParameterList);
+  if (pList != Teuchos::null)
+    *pl = *pList;
+  pl->validateParametersAndSetDefaults(*this->getValidParameters());
+  use_dfdp_as_tangent_ = pl->get<bool>("Use DfDp as Tangent");
+  p_index_ = pl->get<int>("Sensitivity Parameter Index");
+  x_tangent_index_ = pl->get<int>("Sensitivity X Tangent Index");
+  xdot_tangent_index_ = pl->get<int>("Sensitivity X-Dot Tangent Index");
+  xdotdot_tangent_index_ = pl->get<int>("Sensitivity X-Dot-Dot Tangent Index");
+
+  num_param_ = model_->get_p_space(p_index_)->dim();
+  dxdp_space_ =
+    Thyra::multiVectorProductVectorSpace(model_->get_x_space(), num_param_);
+  dfdp_space_ =
+    Thyra::multiVectorProductVectorSpace(model_->get_f_space(), num_param_);
+
+  MEB::InArgs<Scalar> me_inArgs = model_->createInArgs();
+  MEB::InArgsSetup<Scalar> inArgs;
+  inArgs.setModelEvalDescription(this->description());
+  inArgs.setSupports(MEB::IN_ARG_x);
+  if (me_inArgs.supports(MEB::IN_ARG_x_dot))
+    inArgs.setSupports(MEB::IN_ARG_x_dot);
+  if (me_inArgs.supports(MEB::IN_ARG_t))
+    inArgs.setSupports(MEB::IN_ARG_t);
+  if (me_inArgs.supports(MEB::IN_ARG_alpha))
+    inArgs.setSupports(MEB::IN_ARG_alpha);
+  if (me_inArgs.supports(MEB::IN_ARG_beta))
+    inArgs.setSupports(MEB::IN_ARG_beta);
+  if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+    inArgs.setSupports(MEB::IN_ARG_W_x_dot_dot_coeff);
+
+  // Support additional parameters for x and xdot
+  inArgs.set_Np(me_inArgs.Np());
+  prototypeInArgs_ = inArgs;
+
+  MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+  MEB::OutArgsSetup<Scalar> outArgs;
+  outArgs.setModelEvalDescription(this->description());
+  outArgs.set_Np_Ng(me_inArgs.Np(),0);
+  outArgs.setSupports(MEB::OUT_ARG_f);
+  outArgs.setSupports(MEB::OUT_ARG_W_op);
+  prototypeOutArgs_ = outArgs;
+
+  TEUCHOS_ASSERT(me_outArgs.supports(MEB::OUT_ARG_DfDp, p_index_).supports(MEB::DERIV_MV_JACOBIAN_FORM));
+  if (!use_dfdp_as_tangent_)
+    TEUCHOS_ASSERT(me_outArgs.supports(MEB::OUT_ARG_W_op));
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+get_p_space(int p) const
+{
+  TEUCHOS_ASSERT(p < model_->Np());
+  return model_->get_p_space(p);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Teuchos::Array<std::string> >
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+get_p_names(int p) const
+{
+  TEUCHOS_ASSERT(p < model_->Np());
+  return model_->get_p_names(p);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+get_x_space() const
+{
+  return dxdp_space_;
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+get_f_space() const
+{
+  return dfdp_space_;
+}
+
+template <typename Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+create_W_op() const
+{
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > op;
+  if (lo_ != Teuchos::null)
+    op = lo_;
+  else
+    op = model_->create_W_op();
+  return Thyra::nonconstMultiVectorLinearOp(op, num_param_);
+}
+
+template <typename Scalar>
+Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+get_W_factory() const
+{
+  typedef Thyra::DefaultMultiVectorProductVectorSpace<Scalar> DMVPVS;
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > factory;
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > model_factory
+    = model_->get_W_factory();
+  if (po_ != Teuchos::null) {
+    factory =
+      Thyra::reuseLinearOpWithSolveFactory<Scalar>(model_factory, po_);
+  }
+  else
+    factory = model_factory;
+  RCP<Thyra::LinearOpBase<Scalar> > mv_op = this->create_W_op();
+  RCP<const DMVPVS> mv_domain =
+    rcp_dynamic_cast<const DMVPVS>(mv_op->domain());
+  RCP<const DMVPVS> mv_range =
+    rcp_dynamic_cast<const DMVPVS>(mv_op->range());
+  return Thyra::multiVectorLinearOpWithSolveFactory(factory,
+                                                    mv_range,
+                                                    mv_domain);
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+createInArgs() const
+{
+  return prototypeInArgs_;
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+getNominalValues() const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+
+  MEB::InArgs<Scalar> me_nominal = model_->getNominalValues();
+  MEB::InArgs<Scalar> nominal = this->createInArgs();
+
+  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+
+  // Set initial x.  If dxdp_init == null, set initial dx/dp = 0
+  RCP< Thyra::VectorBase<Scalar> > x = Thyra::createMember(*dxdp_space_);
+  RCP<DMVPV> dxdp = rcp_dynamic_cast<DMVPV>(x);
+  if (dxdp_init_ == Teuchos::null)
+    Thyra::assign(dxdp->getNonconstMultiVector().ptr(), zero);
+  else
+    Thyra::assign(dxdp->getNonconstMultiVector().ptr(), *dxdp_init_);
+  nominal.set_x(x);
+
+  // Set initial xdot.  If dx_dotdp_init == null, set initial dxdot/dp = 0
+  if (me_nominal.supports(MEB::IN_ARG_x_dot)) {
+    RCP< Thyra::VectorBase<Scalar> > xdot = Thyra::createMember(*dxdp_space_);
+    RCP<DMVPV> dxdotdp = rcp_dynamic_cast<DMVPV>(xdot);
+    if (dx_dotdp_init_ == Teuchos::null)
+      Thyra::assign(dxdotdp->getNonconstMultiVector().ptr(), zero);
+    else
+      Thyra::assign(dxdotdp->getNonconstMultiVector().ptr(), *dx_dotdp_init_);
+    nominal.set_x_dot(xdot);
+  }
+
+  // Set initial xdotdot.  If dx_dotdotdp_init == null, set initial dxdotdot/dp = 0
+  if (me_nominal.supports(MEB::IN_ARG_x_dot_dot)) {
+    RCP< Thyra::VectorBase<Scalar> > xdotdot =
+      Thyra::createMember(*dxdp_space_);
+    RCP<DMVPV> dxdotdotdp = rcp_dynamic_cast<DMVPV>(xdotdot);
+    if (dx_dotdotdp_init_ == Teuchos::null)
+      Thyra::assign(dxdotdotdp->getNonconstMultiVector().ptr(), zero);
+    else
+      Thyra::assign(dxdotdotdp->getNonconstMultiVector().ptr(),
+                    *dx_dotdotdp_init_);
+    nominal.set_x_dot_dot(xdotdot);
+  }
+
+  const int np = model_->Np();
+  for (int i=0; i<np; ++i)
+    nominal.set_p(i, me_nominal.get_p(i));
+  return nominal;
+}
+
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+createOutArgsImpl() const
+{
+  return prototypeOutArgs_;
+}
+
+template <typename Scalar>
+void
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+              const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs) const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+
+  // setup input arguments for model
+  RCP< const Thyra::MultiVectorBase<Scalar> > dxdp, dxdotdp, dxdotdotdp;
+  MEB::InArgs<Scalar> me_inArgs = model_->getNominalValues();
+  dxdp = rcp_dynamic_cast<const DMVPV>(inArgs.get_x())->getMultiVector();
+  TEUCHOS_ASSERT(x_ != Teuchos::null);
+  me_inArgs.set_x(x_);
+  if (use_dfdp_as_tangent_)
+    me_inArgs.set_p(x_tangent_index_, inArgs.get_x());
+  if (me_inArgs.supports(MEB::IN_ARG_x_dot)) {
+    if (inArgs.get_x_dot() != Teuchos::null) {
+      dxdotdp =
+        rcp_dynamic_cast<const DMVPV>(inArgs.get_x_dot())->getMultiVector();
+      TEUCHOS_ASSERT(x_dot_ != Teuchos::null);
+      me_inArgs.set_x_dot(x_dot_);
+      if (use_dfdp_as_tangent_)
+        me_inArgs.set_p(xdot_tangent_index_, inArgs.get_x_dot());
+    }
+    else // clear out xdot if it was set in nominalValues
+      me_inArgs.set_x_dot(Teuchos::null);
+  }
+  if (me_inArgs.supports(MEB::IN_ARG_x_dot_dot)) {
+    if (inArgs.get_x_dot_dot() != Teuchos::null) {
+      dxdotdotdp =
+        rcp_dynamic_cast<const DMVPV>(inArgs.get_x_dot_dot())->getMultiVector();
+      TEUCHOS_ASSERT(x_dot_dot_ != Teuchos::null);
+      me_inArgs.set_x_dot_dot(x_dot_dot_);
+      if (use_dfdp_as_tangent_)
+        me_inArgs.set_p(xdotdot_tangent_index_, inArgs.get_x_dot_dot());
+    }
+    else // clear out xdotdot if it was set in nominalValues
+      me_inArgs.set_x_dot_dot(Teuchos::null);
+  }
+  if (me_inArgs.supports(MEB::IN_ARG_t))
+    me_inArgs.set_t(inArgs.get_t());
+  if (me_inArgs.supports(MEB::IN_ARG_alpha))
+    me_inArgs.set_alpha(inArgs.get_alpha());
+  if (me_inArgs.supports(MEB::IN_ARG_beta))
+    me_inArgs.set_beta(inArgs.get_beta());
+  if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+    me_inArgs.set_W_x_dot_dot_coeff(inArgs.get_W_x_dot_dot_coeff());
+
+  // Set parameters -- be careful to only set ones that were set in our
+  // inArgs to not null out any specified through nominalValues or
+  // dx/dp above
+  const int np = me_inArgs.Np();
+  for (int i=0; i<np; ++i) {
+    if (inArgs.get_p(i) != Teuchos::null)
+      if (!use_dfdp_as_tangent_ ||
+          (use_dfdp_as_tangent_ && i != x_tangent_index_ &&
+                                   i != xdot_tangent_index_ &&
+                                   i != xdotdot_tangent_index_ ))
+        me_inArgs.set_p(i, inArgs.get_p(i));
+  }
+
+  // setup output arguments for model
+  RCP< Thyra::MultiVectorBase<Scalar> > dfdp;
+  MEB::OutArgs<Scalar> me_outArgs = model_->createOutArgs();
+  if (outArgs.get_f() != Teuchos::null) {
+    dfdp = rcp_dynamic_cast<DMVPV>(outArgs.get_f())->getNonconstMultiVector();
+    me_outArgs.set_DfDp(p_index_, dfdp);
+  }
+  if (lo_ == Teuchos::null && outArgs.get_W_op() != Teuchos::null) {
+    RCP<Thyra::LinearOpBase<double> > op = outArgs.get_W_op();
+    RCP<Thyra::MultiVectorLinearOp<double> > mv_op =
+      rcp_dynamic_cast<Thyra::MultiVectorLinearOp<double> >(op);
+    me_outArgs.set_W_op(mv_op->getNonconstLinearOp());
+  }
+
+  // build residual and jacobian
+  model_->evalModel(me_inArgs, me_outArgs);
+
+  // Compute (df/dx) * (dx/dp) + (df/dxdot) * (dxdot/dp) + (df/dxdotdot) * (dxdotdot/dp) + (df/dp)
+  // if the underlying ME doesn't already do this.  This requires computing
+  // df/dx, df/dxdot, df/dxdotdot as separate operators
+  if (!use_dfdp_as_tangent_) {
+    if (dxdp != Teuchos::null && dfdp != Teuchos::null) {
+      if (my_dfdx_ == Teuchos::null)
+        my_dfdx_ = model_->create_W_op();
+      MEB::OutArgs<Scalar> meo = model_->createOutArgs();
+      meo.set_W_op(my_dfdx_);
+      if (me_inArgs.supports(MEB::IN_ARG_alpha))
+        me_inArgs.set_alpha(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_beta))
+        me_inArgs.set_beta(1.0);
+      if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+        me_inArgs.set_W_x_dot_dot_coeff(0.0);
+      model_->evalModel(me_inArgs, meo);
+      my_dfdx_->apply(Thyra::NOTRANS, *dxdp, dfdp.ptr(), Scalar(1.0), Scalar(1.0));
+    }
+    if (dxdotdp != Teuchos::null && dfdp != Teuchos::null) {
+      if (my_dfdxdot_ == Teuchos::null)
+        my_dfdxdot_ = model_->create_W_op();
+      MEB::OutArgs<Scalar> meo = model_->createOutArgs();
+      meo.set_W_op(my_dfdxdot_);
+      if (me_inArgs.supports(MEB::IN_ARG_alpha))
+        me_inArgs.set_alpha(1.0);
+      if (me_inArgs.supports(MEB::IN_ARG_beta))
+        me_inArgs.set_beta(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+        me_inArgs.set_W_x_dot_dot_coeff(0.0);
+      model_->evalModel(me_inArgs, meo);
+      my_dfdxdot_->apply(Thyra::NOTRANS, *dxdotdp, dfdp.ptr(), Scalar(1.0), Scalar(1.0));
+    }
+    if (dxdotdotdp != Teuchos::null && dfdp != Teuchos::null) {
+      if (my_dfdxdotdot_ == Teuchos::null)
+        my_dfdxdotdot_ = model_->create_W_op();
+      MEB::OutArgs<Scalar> meo = model_->createOutArgs();
+      meo.set_W_op(my_dfdxdotdot_);
+      if (me_inArgs.supports(MEB::IN_ARG_alpha))
+        me_inArgs.set_alpha(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_beta))
+        me_inArgs.set_beta(0.0);
+      if (me_inArgs.supports(MEB::IN_ARG_W_x_dot_dot_coeff))
+        me_inArgs.set_W_x_dot_dot_coeff(1.0);
+      model_->evalModel(me_inArgs, meo);
+      my_dfdxdotdot_->apply(Thyra::NOTRANS, *dxdotdotdp, dfdp.ptr(), Scalar(1.0), Scalar(1.0));
+    }
+  }
+}
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+StaggeredForwardSensitivityModelEvaluator<Scalar>::
+getValidParameters()
+{
+  Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+  pl->set<bool>("Use DfDp as Tangent", false);
+  pl->set<int>("Sensitivity Parameter Index", 0);
+  pl->set<int>("Sensitivity X Tangent Index", 1);
+  pl->set<int>("Sensitivity X-Dot Tangent Index", 2);
+  pl->set<int>("Sensitivity X-Dot-Dot Tangent Index", 3);
+  return pl;
+}
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_Stepper.hpp
+++ b/packages/tempus/src/Tempus_Stepper.hpp
@@ -84,6 +84,8 @@ public:
     /// Set solver.
     virtual void setSolver(
         Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver) = 0;
+    /// Get solver
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const = 0;
 
     /// Initialize during construction and after changing input parameters.
     virtual void initialize() = 0;

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -60,6 +60,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
     virtual void setObserver(
       Teuchos::RCP<StepperBDF2Observer<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -52,6 +52,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
     virtual void setObserver(
       Teuchos::RCP<StepperBackwardEulerObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -105,6 +105,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL = Teuchos::null);
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
     virtual void setObserver(
       Teuchos::RCP<StepperDIRKObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -85,6 +85,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
         Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+    { return Teuchos::null; }
     virtual void setObserver(
       Teuchos::RCP<StepperExplicitRKObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -62,6 +62,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
         Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return Teuchos::null; }
     virtual void setObserver(
       Teuchos::RCP<StepperForwardEulerObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -62,6 +62,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
 
 
     /// Initialize during construction and after changing input parameters.

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -282,6 +282,8 @@ public:
     /// Set solver.
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
     virtual void setObserver(
       Teuchos::RCP<StepperIMEX_RKPartObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -283,6 +283,8 @@ public:
     /// Set solver.
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
     virtual void setObserver(
       Teuchos::RCP<StepperIMEX_RKObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -91,6 +91,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
         Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return Teuchos::null; }
     virtual void setObserver(
       Teuchos::RCP<StepperLeapfrogObserver<Scalar> > obs = Teuchos::null);
 

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -43,6 +43,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
         Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return Teuchos::null; }
 
     /// Initialize during construction and after changing input parameters.
     virtual void initialize(){}

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -63,6 +63,8 @@ public:
       Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
     virtual void setSolver(
       Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+      { return solver_; }
 
 
     /// Initialize during construction and after changing input parameters.

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -62,6 +62,8 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
   setSolver(Teuchos::RCP<Teuchos::ParameterList> solverPL = Teuchos::null);
   virtual void
   setSolver(Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar>> solver);
+  virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+  { return solver_; }
 
   /// Initialize during construction and after changing input parameters.
   virtual void

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity.cpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity.cpp
@@ -1,0 +1,19 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_StepperStaggeredForwardSensitivity_decl.hpp"
+#include "Tempus_StepperStaggeredForwardSensitivity_impl.hpp"
+
+namespace Tempus {
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(StepperStaggeredForwardSensitivity)
+}
+
+#endif

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -1,0 +1,143 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_StepperStaggeredForwardSensitivity_decl_hpp
+#define Tempus_StepperStaggeredForwardSensitivity_decl_hpp
+
+#include "Tempus_Stepper.hpp"
+#include "Tempus_StaggeredForwardSensitivityModelEvaluator.hpp"
+
+namespace Tempus {
+
+/** \brief A stepper implementing staggered forward sensitivity analysis.
+ */
+/**
+ * It constructs two internal steppers, one for the state equations as usual
+ * and one for the sensitivity equations using
+ * Tempus::StaggeredForwardSensitivityModelEvaluator.  It's implementation
+ * of takeStep() first takes a step using the state stepper, updates the
+ * sensitivity model evaluator with the compute state solution and time
+ * derivatives, and then takes a step using the sensitivity stepper. It
+ * optionally can reuse the state solver for the sensitivity equations as well.
+ */
+template<class Scalar>
+class StepperStaggeredForwardSensitivity :
+    virtual public Tempus::Stepper<Scalar>
+{
+public:
+
+  /// Constructor
+  /*!
+   * The first parameter list argument supplies supplies regular stepper
+   * options, while the second provides sensitivity specific options:
+   * <ul>
+   *   <li> "Reuse State Linear Solver" (default: false) Whether to reuse the
+   *        model's W matrix, solver, and preconditioner when solving the
+   *        sensitivity equations.  If they can be reused, substantial savings
+   *        in compute time are possible.
+   *   <li> "Force W Update" (default: false) When reusing the solver as above
+   *        whether to force recomputation of W.  This can be necessary when
+   *        the solver overwrites it during the solve-phase (e.g., by a
+   *        factorization).
+   *   <li> "Use DfDp as Tangent" (default:  false) Reinterpret the df/dp
+   *        out-arg as the tangent vector (df/dx)(x,p) * dx/dp + df/dp(x,p)
+   *        as described in the Tempus::CombinedForwardSensitivityModelEvaluator
+   *        documentation.
+   *   <li> "Sensitivity Parameter Index" (default: 0) Model evaluator
+   *        parameter index for which sensitivities will be computed.
+   *   <li> "Sensitivity X Tangent Index" (default: 1) If "Use DfDp as Tangent"
+   *        is true, the model evaluator parameter index for passing dx/dp
+   *        as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot Tangent Index" (default: 2) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot/dp as a Thyra::DefaultMultiVectorProductVector.
+   *   <li> "Sensitivity X-Dot-Dot Tangent Index" (default: 3) If
+   *        "Use DfDp as Tangent" is true, the model evaluator parameter index
+   *        for passing dx_dot_dot/dp as a
+   *        Thyra::DefaultMultiVectorProductVector (if the model supports
+   *        x_dot_dot).
+   * </ul>
+   */
+  StepperStaggeredForwardSensitivity(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+    const Teuchos::RCP<Teuchos::ParameterList>& pList = Teuchos::null,
+    const Teuchos::RCP<Teuchos::ParameterList>& sens_pList = Teuchos::null);
+
+  /// \name Basic stepper methods
+  //@{
+    virtual void setModel(
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
+    virtual void setNonConstModel(
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel();
+
+    virtual void setSolver(std::string solverName);
+    virtual void setSolver(
+      Teuchos::RCP<Teuchos::ParameterList> solverPL=Teuchos::null);
+    virtual void setSolver(
+      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
+    virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
+    { return stateStepper_->getSolver(); }
+
+    /// Initialize during construction and after changing input parameters.
+    virtual void initialize();
+
+    /// Take the specified timestep, dt, and return true if successful.
+    virtual void takeStep(
+      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+
+    /// Get a default (initial) StepperState
+    virtual Teuchos::RCP<Tempus::StepperState<Scalar> >
+      getDefaultStepperState();
+    virtual Scalar getOrder() const {return stateStepper_->getOrder();}
+    virtual Scalar getOrderMin() const {return stateStepper_->getOrderMin();}
+    virtual Scalar getOrderMax() const {return stateStepper_->getOrderMax();}
+  //@}
+
+  /// \name ParameterList methods
+  //@{
+    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl);
+    Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList();
+    Teuchos::RCP<Teuchos::ParameterList> unsetParameterList();
+    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+    Teuchos::RCP<Teuchos::ParameterList> getDefaultParameters() const;
+  //@}
+
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    virtual std::string description() const;
+    virtual void describe(Teuchos::FancyOStream        & out,
+                          const Teuchos::EVerbosityLevel verbLevel) const;
+  //@}
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
+
+private:
+
+  /// Default Constructor -- not allowed
+  StepperStaggeredForwardSensitivity();
+
+  void setParams(const Teuchos::RCP<Teuchos::ParameterList> & pl,
+                 const Teuchos::RCP<Teuchos::ParameterList> & spl);
+
+private:
+
+  Teuchos::RCP<Teuchos::ParameterList>               stepperPL_;
+  Teuchos::RCP<Teuchos::ParameterList>               sensPL_;
+  Teuchos::RCP<Stepper<Scalar> >                     stateStepper_;
+  Teuchos::RCP<Stepper<Scalar> >                     sensitivityStepper_;
+  Teuchos::RCP<StaggeredForwardSensitivityModelEvaluator<Scalar> > fsa_model_;
+  Teuchos::RCP<SolutionHistory<Scalar> > stateSolutionHistory_;
+  Teuchos::RCP<SolutionHistory<Scalar> > sensSolutionHistory_;
+  bool reuse_solver_;
+  bool force_W_update_;
+};
+
+} // namespace Tempus
+
+#endif // Tempus_StepperStaggeredForwardSensitivity_decl_hpp

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -1,0 +1,425 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_StepperStaggeredForwardSensitivity_impl_hpp
+#define Tempus_StepperStaggeredForwardSensitivity_impl_hpp
+
+#include "Tempus_config.hpp"
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_StaggeredForwardSensitivityModelEvaluator.hpp"
+#include "Teuchos_VerboseObjectParameterListHelpers.hpp"
+
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
+#include "NOX_Thyra.H"
+
+namespace Tempus {
+
+// Forward Declaration for recursive includes (this Stepper <--> StepperFactory)
+template<class Scalar> class StepperFactory;
+
+// StepperStaggeredForwardSensitivity definitions:
+template<class Scalar>
+StepperStaggeredForwardSensitivity<Scalar>::
+StepperStaggeredForwardSensitivity(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+  const Teuchos::RCP<Teuchos::ParameterList>& pList,
+  const Teuchos::RCP<Teuchos::ParameterList>& sens_pList)
+{
+  using Teuchos::RCP;
+  using Teuchos::ParameterList;
+
+  // Set all the input parameters and call initialize
+  this->setParams(pList, sens_pList);
+  this->setModel(appModel);
+  this->initialize();
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setModel(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel)
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::ParameterList;
+
+  // Create forward sensitivity model evaluator wrapper
+  Teuchos::RCP<Teuchos::ParameterList> spl = Teuchos::parameterList();
+  *spl = *sensPL_;
+  spl->remove("Reuse State Linear Solver");
+  spl->remove("Force W Update");
+  fsa_model_ =
+    rcp(new StaggeredForwardSensitivityModelEvaluator<Scalar>(
+          appModel, spl));
+
+  // Create state and sensitivity steppers
+  RCP<StepperFactory<Scalar> > sf =Teuchos::rcp(new StepperFactory<Scalar>());
+  if (stateStepper_ == Teuchos::null)
+    stateStepper_ = sf->createStepper(appModel, stepperPL_);
+  else
+    stateStepper_->setModel(appModel);
+  if (sensitivityStepper_ == Teuchos::null)
+    sensitivityStepper_ = sf->createStepper(fsa_model_, stepperPL_);
+  else
+    sensitivityStepper_->setModel(fsa_model_);
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setNonConstModel(
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel)
+{
+  this->setModel(appModel);
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setSolver(std::string solverName)
+{
+  stateStepper_->setSolver(solverName);
+  sensitivityStepper_->setSolver(solverName);
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
+StepperStaggeredForwardSensitivity<Scalar>::
+getModel()
+{
+  return stateStepper_->getModel();
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setSolver(
+  Teuchos::RCP<Teuchos::ParameterList> solverPL)
+{
+  stateStepper_->setSolver(solverPL);
+  sensitivityStepper_->setSolver(solverPL);
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setSolver(
+  Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver)
+{
+  stateStepper_->setSolver(solver);
+  sensitivityStepper_->setSolver(solver);
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+initialize()
+{
+  this->setSolver();
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+takeStep(
+  const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::rcp_dynamic_cast;
+  using Thyra::VectorBase;
+  using Thyra::MultiVectorBase;
+  using Thyra::assign;
+  using Thyra::createMember;
+  using Thyra::multiVectorProductVector;
+  using Thyra::multiVectorProductVectorSpace;
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  typedef Thyra::DefaultMultiVectorProductVectorSpace<Scalar> DMVPVS;
+
+  // Initialize state, sensitivity solution histories if necessary.
+  // We only need to split the solution history into state and sensitivity
+  // components for the first step, otherwise the state and sensitivity
+  // histories are updated from the previous step.
+  if (stateSolutionHistory_ == Teuchos::null) {
+    RCP<Teuchos::ParameterList> shPL =
+      solutionHistory->getNonconstParameterList();
+
+    // Get product X, XDot, XDotDot
+    RCP<SolutionState<Scalar> > state = solutionHistory->getCurrentState();
+    RCP<DMVPV> X, XDot, XDotDot;
+    X = rcp_dynamic_cast<DMVPV>(state->getX());
+    XDot = rcp_dynamic_cast<DMVPV>(state->getXDot());
+    if (state->getXDotDot() != Teuchos::null)
+      XDotDot = rcp_dynamic_cast<DMVPV>(state->getXDotDot());
+
+    // Pull out state components (has to be non-const because of SolutionState
+    // constructor)
+    RCP<VectorBase<Scalar> > x, xdot, xdotdot;
+    x = X->getNonconstMultiVector()->col(0);
+    xdot = XDot->getNonconstMultiVector()->col(0);
+    if (XDotDot != Teuchos::null)
+      xdotdot = XDotDot->getNonconstMultiVector()->col(0);
+
+    // Create state solution history
+    RCP<SolutionState<Scalar> > state_state =
+      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
+                                    x, xdot, xdotdot,
+                                    state->getStepperState()->clone()));
+    stateSolutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+    stateSolutionHistory_->addState(state_state);
+
+    const int num_param = X->getMultiVector()->domain()->dim()-1;
+    const Teuchos::Range1D rng(1,num_param);
+
+    // Pull out sensitivity components
+    RCP<MultiVectorBase<Scalar> > dxdp, dxdotdp, dxdotdotdp;
+    dxdp = X->getNonconstMultiVector()->subView(rng);
+    dxdotdp = XDot->getNonconstMultiVector()->subView(rng);
+    if (XDotDot != Teuchos::null)
+      dxdotdotdp = XDotDot->getNonconstMultiVector()->subView(rng);
+
+    // Create sensitivity product vectors
+    RCP<DMVPV> dxdp_vec, dxdotdp_vec, dxdotdotdp_vec;
+    RCP<const DMVPVS> prod_space =
+      multiVectorProductVectorSpace(X->getMultiVector()->range(), num_param);
+    dxdp_vec = multiVectorProductVector(prod_space, dxdp);
+    dxdotdp_vec = multiVectorProductVector(prod_space, dxdotdp);
+    if (XDotDot != Teuchos::null)
+      dxdotdotdp_vec = multiVectorProductVector(prod_space, dxdotdotdp);
+
+    // Create sensitivity solution history
+    RCP<SolutionState<Scalar> > sens_state =
+      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
+                                    dxdp_vec, dxdotdp_vec, dxdotdotdp_vec,
+                                    state->getStepperState()->clone()));
+    sensSolutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
+    sensSolutionHistory_->addState(sens_state);
+  }
+
+  // Take step for state equations
+  stateSolutionHistory_->initWorkingState();
+  stateSolutionHistory_->getWorkingState()->getMetaData()->copy(
+    solutionHistory->getWorkingState()->getMetaData());
+  stateStepper_->takeStep(stateSolutionHistory_);
+
+  // Get current state and set in sensitivity model evaluator
+   RCP<SolutionState<Scalar> > state =
+     stateSolutionHistory_->getWorkingState();
+  RCP<const VectorBase<Scalar> > x = state->getX();
+  RCP<const VectorBase<Scalar> > xdot = state->getXDot();
+  RCP<const VectorBase<Scalar> > xdotdot = state->getXDotDot();
+  fsa_model_->setModelX(x);
+  fsa_model_->setModelXDot(xdot);
+  fsa_model_->setModelXDotDot(xdotdot);
+
+  // Reuse state solver if requested
+  if (reuse_solver_ && stateStepper_->getSolver() != Teuchos::null) {
+    RCP<Thyra::NOXNonlinearSolver> nox_solver =
+      rcp_dynamic_cast<Thyra::NOXNonlinearSolver>(stateStepper_->getSolver());
+    fsa_model_->setLO(nox_solver->get_nonconst_W_op(force_W_update_));
+    fsa_model_->setPO(nox_solver->get_nonconst_prec_op());
+  }
+
+  // Take step in senstivity equations
+  sensSolutionHistory_->initWorkingState();
+  sensSolutionHistory_->getWorkingState()->getMetaData()->copy(
+    solutionHistory->getWorkingState()->getMetaData());
+  sensitivityStepper_->takeStep(sensSolutionHistory_);
+
+  // Get current sensitivities
+  RCP<const MultiVectorBase<Scalar> > dxdp, dxdotdp, dxdotdotdp;
+  RCP<SolutionState<Scalar> > sens_state =
+    sensSolutionHistory_->getWorkingState();
+  dxdp = rcp_dynamic_cast<const DMVPV>(
+    sens_state->getX())->getMultiVector();
+  dxdotdp = rcp_dynamic_cast<const DMVPV>(
+    sens_state->getXDot())->getMultiVector();
+  if (sens_state->getXDotDot() != Teuchos::null)
+    dxdotdotdp = rcp_dynamic_cast<const DMVPV>(
+      sens_state->getXDotDot())->getMultiVector();
+
+  const int num_param = dxdp->domain()->dim();
+  const Teuchos::Range1D rng(1,num_param);
+
+  // Form product solutions
+  RCP<DMVPV> X, XDot, XDotDot;
+  RCP<const Thyra::VectorSpaceBase<Scalar> > prod_space =
+    multiVectorProductVectorSpace(dxdp->range(), num_param+1);
+  X = rcp_dynamic_cast<DMVPV>(createMember(prod_space));
+  assign(X->getNonconstMultiVector()->col(0).ptr(), *x);
+  assign(X->getNonconstMultiVector()->subView(rng).ptr(), *dxdp);
+  XDot = rcp_dynamic_cast<DMVPV>(createMember(prod_space));
+  assign(XDot->getNonconstMultiVector()->col(0).ptr(), *xdot);
+  assign(XDot->getNonconstMultiVector()->subView(rng).ptr(), *dxdotdp);
+  if (xdotdot != Teuchos::null) {
+    XDotDot = rcp_dynamic_cast<DMVPV>(createMember(prod_space));
+    assign(XDotDot->getNonconstMultiVector()->col(0).ptr(), *xdot);
+    assign(XDotDot->getNonconstMultiVector()->subView(rng).ptr(), *dxdotdotdp);
+  }
+
+  // Add step to solution history
+  RCP<SolutionState<Scalar> > prod_state = solutionHistory->getWorkingState();
+  assign(prod_state->getX().ptr(), *X);
+  assign(prod_state->getXDot().ptr(), *XDot);
+  if (XDotDot != Teuchos::null)
+    assign(prod_state->getXDotDot().ptr(), *XDotDot);
+  prod_state->setOrder(std::min(state->getOrder(), sens_state->getOrder()));
+
+  // Determine whether step passed or failed
+  bool passed = true;
+  if (state->getStepperStatus() == Status::FAILED ||
+      state->getSolutionStatus() == Status::FAILED ||
+      sens_state->getStepperStatus() == Status::FAILED ||
+      sens_state->getSolutionStatus() == Status::FAILED)
+    passed = false;
+
+  if (passed) {
+    prod_state->getStepperState()->stepperStatus_ = Status::PASSED;
+    stateSolutionHistory_->promoteWorkingState();
+    sensSolutionHistory_->promoteWorkingState();
+  }
+  else
+     prod_state->getStepperState()->stepperStatus_ = Status::FAILED;
+}
+
+
+template<class Scalar>
+Teuchos::RCP<Tempus::StepperState<Scalar> >
+StepperStaggeredForwardSensitivity<Scalar>::
+getDefaultStepperState()
+{
+  // ETP:  Note, maybe this should be a special stepper state that combines
+  // states from both state and sensitivity steppers?
+  Teuchos::RCP<Tempus::StepperState<Scalar> > stepperState =
+    rcp(new StepperState<Scalar>(description()));
+  return stepperState;
+}
+
+
+template<class Scalar>
+std::string StepperStaggeredForwardSensitivity<Scalar>::
+description() const
+{
+  std::string name = "StepperStaggeredForwardSensitivity";
+  return(name);
+}
+
+
+template<class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+describe(
+   Teuchos::FancyOStream               &out,
+   const Teuchos::EVerbosityLevel      verbLevel) const
+{
+  out << description() << "::describe:" << std::endl;
+  stateStepper_->describe(out, verbLevel);
+  out << std::endl;
+  sensitivityStepper_->describe(out, verbLevel);
+}
+
+
+template <class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setParameterList(
+  Teuchos::RCP<Teuchos::ParameterList> const& pList)
+{
+  if (pList == Teuchos::null)
+    stepperPL_ = this->getDefaultParameters();
+  else
+    stepperPL_ = pList;
+  // Can not validate because of optional Parameters (e.g., Solver Name).
+  //stepperPL_->validateParametersAndSetDefaults(*this->getValidParameters());
+}
+
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+StepperStaggeredForwardSensitivity<Scalar>::
+getValidParameters() const
+{
+  return stateStepper_->getValidParameters();
+}
+
+
+template<class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+StepperStaggeredForwardSensitivity<Scalar>::
+getDefaultParameters() const
+{
+  return stateStepper_->getDefaultParameters();
+}
+
+
+template <class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+StepperStaggeredForwardSensitivity<Scalar>::
+getNonconstParameterList()
+{
+  return stepperPL_;
+}
+
+
+template <class Scalar>
+Teuchos::RCP<Teuchos::ParameterList>
+StepperStaggeredForwardSensitivity<Scalar>::
+unsetParameterList()
+{
+  Teuchos::RCP<Teuchos::ParameterList> temp_plist = stepperPL_;
+  stepperPL_ = Teuchos::null;
+  return temp_plist;
+}
+
+
+template <class Scalar>
+void StepperStaggeredForwardSensitivity<Scalar>::
+setParams(
+  Teuchos::RCP<Teuchos::ParameterList> const& pList,
+  Teuchos::RCP<Teuchos::ParameterList> const& spList)
+{
+  if (pList == Teuchos::null)
+    stepperPL_ = this->getDefaultParameters();
+  else
+    stepperPL_ = pList;
+
+  if (spList == Teuchos::null)
+    sensPL_ = Teuchos::parameterList();
+  else
+    sensPL_ = spList;
+
+  reuse_solver_ = sensPL_->get("Reuse State Linear Solver", false);
+  force_W_update_ = sensPL_->get("Force W Update", true);
+
+  // Can not validate because of optional Parameters (e.g., Solver Name).
+  //stepperPL_->validateParametersAndSetDefaults(*this->getValidParameters());
+}
+
+
+template <class Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+StepperStaggeredForwardSensitivity<Scalar>::
+get_x_space() const
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp_dynamic_cast;
+  typedef Thyra::DefaultMultiVectorProductVectorSpace<Scalar> DMVPVS;
+
+  RCP<const Thyra::VectorSpaceBase<Scalar> > x_space =
+    stateStepper_->getModel()->get_x_space();
+  RCP<const DMVPVS> dxdp_space =
+    rcp_dynamic_cast<const DMVPVS>(sensitivityStepper_->getModel()->get_x_space());
+  const int num_param = dxdp_space->numBlocks();
+  RCP<const Thyra::VectorSpaceBase<Scalar> > prod_space =
+    multiVectorProductVectorSpace(x_space, num_param+1);
+  return prod_space;
+}
+
+} // namespace Tempus
+
+#endif // Tempus_StepperStaggeredForwardSensitivity_impl_hpp

--- a/packages/tempus/src/Thyra_MultiVectorLinearOp.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorLinearOp.hpp
@@ -1,0 +1,359 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_MultiVectorLinearOp_hpp
+#define Thyra_MultiVectorLinearOp_hpp
+
+#include "Thyra_RowStatLinearOpBase.hpp"
+#include "Thyra_ScaledLinearOpBase.hpp"
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+#include "Teuchos_ConstNonconstObjectContainer.hpp"
+
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+#include "Thyra_AssertOp.hpp"
+#include "Teuchos_dyn_cast.hpp"
+
+namespace Thyra {
+
+/**
+ * \brief Implicit concrete <tt>LinearOpBase</tt> subclass that
+ * takes a flattended out multi-vector and performs a multi-RHS apply with it.
+ */
+template<class Scalar>
+class MultiVectorLinearOp :
+    virtual public RowStatLinearOpBase<Scalar>,
+    virtual public ScaledLinearOpBase<Scalar>
+{
+public:
+
+  /** @name Constructors/initializers/accessors */
+  //@{
+
+  /** \brief Construct to uninitialized. */
+  MultiVectorLinearOp() {}
+
+  /** \brief . */
+  void nonconstInitialize(
+    const RCP<LinearOpBase<Scalar> > &op,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+    validateInitialize(op,multiVecRange,multiVecDomain);
+    op_ = op;
+    multiVecRange_ = multiVecRange;
+    multiVecDomain_ = multiVecDomain;
+  }
+
+  /** \brief . */
+  void initialize(
+    const RCP<const LinearOpBase<Scalar> > &op,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+    validateInitialize(op,multiVecRange,multiVecDomain);
+    op_ = op;
+    multiVecRange_ = multiVecRange;
+    multiVecDomain_ = multiVecDomain;
+  }
+
+  /** \brief . */
+  RCP<LinearOpBase<Scalar> >
+  getNonconstLinearOp() { return op_.getNonconstObj(); }
+
+  /** \brief . */
+  RCP<const LinearOpBase<Scalar> >
+  getLinearOp() const { return op_.getConstObj(); }
+
+  /** \brief . */
+  void uninitialize() {
+    op_.uninitialize();
+    multiVecRange_ = Teuchos::null;
+    multiVecDomain_ = Teuchos::null;
+  }
+
+  //@}
+
+  /** @name Overridden from LinearOpBase */
+  //@{
+
+  /** \brief . */
+  RCP< const VectorSpaceBase<Scalar> > range() const { return multiVecRange_; }
+
+  /** \brief . */
+  RCP< const VectorSpaceBase<Scalar> > domain() const { return multiVecDomain_; }
+
+  /** \brief . */
+  RCP<const LinearOpBase<Scalar> > clone() const { return Teuchos::null; // ToDo: Implement if needed ???
+  }
+  //@}
+
+protected:
+
+  /** @name Overridden from LinearOpBase */
+  //@{
+  /** \brief . */
+  bool opSupportedImpl(EOpTransp M_trans) const {
+    return Thyra::opSupported(*op_.getConstObj(),M_trans);
+  }
+
+  /** \brief . */
+  void applyImpl(
+    const EOpTransp M_trans,
+    const MultiVectorBase<Scalar> &XX,
+    const Ptr<MultiVectorBase<Scalar> > &YY,
+    const Scalar alpha,
+    const Scalar beta
+    ) const {
+
+    using Teuchos::dyn_cast;
+    typedef DefaultMultiVectorProductVector<Scalar> MVPV;
+
+    const Ordinal numCols = XX.domain()->dim();
+
+    for (Ordinal col_j = 0; col_j < numCols; ++col_j) {
+
+      const RCP<const VectorBase<Scalar> > x = XX.col(col_j);
+      const RCP<VectorBase<Scalar> > y = YY->col(col_j);
+
+      RCP<const MultiVectorBase<Scalar> >
+        X = dyn_cast<const MVPV>(*x).getMultiVector().assert_not_null();
+      RCP<MultiVectorBase<Scalar> >
+        Y = dyn_cast<MVPV>(*y).getNonconstMultiVector().assert_not_null();
+
+      Thyra::apply( *op_.getConstObj(), M_trans, *X, Y.ptr(), alpha, beta );
+    }
+
+  }
+  //@}
+
+  /** @name Overridden from RowStatLinearOpBase */
+  //@{
+
+  /** \brief Determine if a given row stat is supported. */
+  bool rowStatIsSupportedImpl(
+    const RowStatLinearOpBaseUtils::ERowStat rowStat
+    ) const
+    { using Teuchos::rcp_dynamic_cast;
+      return rcp_dynamic_cast<const RowStatLinearOpBase<Scalar> >(op_.getConstObj())->rowStatIsSupported(rowStat); }
+
+  /** \brief Get some statistics about a supported row.
+   *
+   * \precondition <tt>this->rowStatIsSupported(rowStat)==true</tt>
+   */
+  void getRowStatImpl(
+    const RowStatLinearOpBaseUtils::ERowStat rowStat,
+    const Ptr<VectorBase<Scalar> > &rowStatVec
+    ) const
+    {
+      TEUCHOS_ASSERT(this->rowStatIsSupported(rowStat));
+
+      // Compute the scaling vector from the underlying operator and assign
+      // it to each column of the scaling multivector.  We only use the first
+      // column in the scaling below, but this makes the scaling vector
+      // consistent with a Kronecker-product operator
+      typedef DefaultMultiVectorProductVector<Scalar> MVPV;
+      using Teuchos::dyn_cast;
+      using Teuchos::rcp_dynamic_cast;
+      RCP<MultiVectorBase<Scalar> > rowStatMultiVec =
+        dyn_cast<MVPV>(*rowStatVec).getNonconstMultiVector().assert_not_null();
+      const Ordinal numCols = rowStatMultiVec->domain()->dim();
+      if (numCols > 0) {
+        rcp_dynamic_cast<const RowStatLinearOpBase<Scalar> >(op_.getConstObj())->getRowStat(rowStat, rowStatMultiVec->col(0).ptr());
+        for (Ordinal col=1; col<numCols; ++col) {
+          Thyra::copy(*(rowStatMultiVec->col(0)),
+                      rowStatMultiVec->col(col).ptr());
+        }
+      }
+    }
+
+  //@}
+
+  /** @name Overridden from ScaledLinearOpBase */
+  //@{
+
+  /** \brief . */
+  virtual bool supportsScaleLeftImpl() const {
+    using Teuchos::rcp_dynamic_cast;
+    return rcp_dynamic_cast<const ScaledLinearOpBase<Scalar> >(op_.getConstObj())->supportsScaleLeft();
+  }
+
+  /** \brief . */
+  virtual bool supportsScaleRightImpl() const {
+    using Teuchos::rcp_dynamic_cast;
+    return rcp_dynamic_cast<const ScaledLinearOpBase<Scalar> >(op_.getConstObj())->supportsScaleRight();
+  }
+
+  /** \brief . */
+  virtual void scaleLeftImpl(const VectorBase<Scalar> &row_scaling) {
+    TEUCHOS_ASSERT(this->supportsScaleLeft());
+
+    // Use the first column in the scaling vector to scale the operator
+    typedef DefaultMultiVectorProductVector<Scalar> MVPV;
+    using Teuchos::dyn_cast;
+    using Teuchos::rcp_dynamic_cast;
+    RCP<const MultiVectorBase<Scalar> > row_scaling_mv =
+      dyn_cast<const MVPV>(row_scaling).getMultiVector().assert_not_null();
+    const Ordinal numCols = row_scaling_mv->domain()->dim();
+    if (numCols > 0) {
+      rcp_dynamic_cast<ScaledLinearOpBase<Scalar> >(op_.getNonconstObj())->scaleLeft(*(row_scaling_mv->col(0)));
+    }
+
+    //row_scaling.describe(std::cout, Teuchos::VERB_EXTREME);
+  }
+
+  /** \brief . */
+  virtual void scaleRightImpl(const VectorBase<Scalar> &col_scaling) {
+    TEUCHOS_ASSERT(this->supportsScaleRight());
+
+    // Use the first column in the scaling vector to scale the operator
+    typedef DefaultMultiVectorProductVector<Scalar> MVPV;
+    using Teuchos::dyn_cast;
+    using Teuchos::rcp_dynamic_cast;
+    RCP<const MultiVectorBase<Scalar> > col_scaling_mv =
+      dyn_cast<const MVPV>(col_scaling).getMultiVector().assert_not_null();
+    const Ordinal numCols = col_scaling_mv->domain()->dim();
+    if (numCols > 0) {
+      rcp_dynamic_cast<ScaledLinearOpBase<Scalar> >(op_.getNonconstObj())->scaleRight(*(col_scaling_mv->col(0)));
+    }
+  }
+
+  //@}
+
+private:
+
+  // //////////////////////////////
+  // Private types
+
+  typedef Teuchos::ConstNonconstObjectContainer<LinearOpBase<Scalar> > CNOP;
+
+  // //////////////////////////////
+  // Private data members
+
+  CNOP op_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecRange_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecDomain_;
+
+  // //////////////////////////////
+  // Private member functions
+
+  static void validateInitialize(
+    const RCP<const LinearOpBase<Scalar> > &op,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+#ifdef TEUCHOS_DEBUG
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(op));
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecRange));
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecDomain));
+    TEUCHOS_TEST_FOR_EXCEPT( multiVecRange->numBlocks() != multiVecDomain->numBlocks() );
+    if (op->range() != Teuchos::null)
+      THYRA_ASSERT_VEC_SPACES(
+        "MultiVectorLinearOp<Scalar>::initialize(op,multiVecRange,multiVecDomain)",
+        *op->range(), *multiVecRange->getBlock(0) );
+    if (op->domain() != Teuchos::null)
+      THYRA_ASSERT_VEC_SPACES(
+        "MultiVectorLinearOp<Scalar>::initialize(op,multiVecRange,multiVecDomain)",
+        *op->domain(), *multiVecDomain->getBlock(0) );
+#endif
+}
+
+};
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorLinearOp
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOp<Scalar> >
+multiVectorLinearOp()
+{
+  return Teuchos::rcp(new MultiVectorLinearOp<Scalar>());
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorLinearOp
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOp<Scalar> >
+nonconstMultiVectorLinearOp(
+  const RCP<LinearOpBase<Scalar> > &op,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorLinearOp<Scalar> >
+    mvop = Teuchos::rcp(new MultiVectorLinearOp<Scalar>());
+  mvop->nonconstInitialize(op,multiVecRange,multiVecDomain);
+  return mvop;
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorLinearOp
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOp<Scalar> >
+nonconstMultiVectorLinearOp(
+  const RCP<LinearOpBase<Scalar> > &op,
+  const int num_blocks
+  )
+{
+  RCP<MultiVectorLinearOp<Scalar> >
+    mvop = Teuchos::rcp(new MultiVectorLinearOp<Scalar>());
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_domain =
+    Thyra::multiVectorProductVectorSpace(op->domain(), num_blocks);
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_range =
+    Thyra::multiVectorProductVectorSpace(op->range(), num_blocks);
+  mvop->nonconstInitialize(op,mv_range,mv_domain);
+  return mvop;
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorLinearOp
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOp<Scalar> >
+multiVectorLinearOp(
+  const RCP<const LinearOpBase<Scalar> > &op,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorLinearOp<Scalar> >
+    mvop = Teuchos::rcp(new MultiVectorLinearOp<Scalar>());
+  mvop->initialize(op,multiVecRange,multiVecDomain);
+  return mvop;
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorLinearOp
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOp<Scalar> >
+multiVectorLinearOp(
+  const RCP<const LinearOpBase<Scalar> > &op,
+  const int num_blocks
+  )
+{
+  RCP<MultiVectorLinearOp<Scalar> >
+    mvop = Teuchos::rcp(new MultiVectorLinearOp<Scalar>());
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_domain =
+    Thyra::multiVectorProductVectorSpace(op->domain(), num_blocks);
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_range =
+    Thyra::multiVectorProductVectorSpace(op->range(), num_blocks);
+  mvop->initialize(op,mv_range,mv_domain);
+  return mvop;
+}
+
+} // end namespace Thyra
+
+
+#endif

--- a/packages/tempus/src/Thyra_MultiVectorLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorLinearOpWithSolveFactory.hpp
@@ -1,0 +1,668 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_MultiVectorLinearOpWithSolveFactory_hpp
+#define Thyra_MultiVectorLinearOpWithSolveFactory_hpp
+
+#include "Thyra_LinearOpWithSolveFactoryBase.hpp"
+#include "Thyra_MultiVectorLinearOp.hpp"
+#include "Thyra_MultiVectorPreconditioner.hpp"
+#include "Thyra_MultiVectorPreconditionerFactory.hpp"
+#include "Thyra_DefaultMultiVectorLinearOpWithSolve.hpp"
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+#include "Thyra_DefaultLinearOpSource.hpp"
+
+namespace Thyra {
+
+/** \brief Create a LinearOpWithSolveFactory for a flattened-out multi-vector.
+ */
+template<class Scalar>
+class MultiVectorLinearOpWithSolveFactory
+  : virtual public LinearOpWithSolveFactoryBase<Scalar>
+{
+public:
+
+  /** @name Overridden from Constructors/Initializers/Accessors */
+  //@{
+
+  /** \brief Construct to uninitialized. */
+  MultiVectorLinearOpWithSolveFactory() {}
+
+  /** \brief Initialize given a single non-const LOWSFB object.
+   *
+   * \param lowsf [in,persisting] The LOWSFB object that will be used to
+   * create the LOWSB object for the diagonal blocks.
+   *
+   * <b>Preconditions:</b><ul>
+   * <li><tt>!is_null(lowsf)</tt>
+   * </ul>
+   *
+   */
+  void nonconstInitialize(
+    const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    );
+
+
+  /** \brief Initialize given a single const LOWSFB object.
+   *
+   * \param lowsf [in,persisting] The LOWSFB object that will be used to
+   * create the LOWSB object for the diagonal blocks.
+   *
+   * <b>Preconditions:</b><ul>
+   * <li><tt>!is_null(lowsf)</tt>
+   * </ul>
+   *
+   */
+  void initialize(
+    const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    );
+
+  /** \brief . */
+  RCP<LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF();
+
+  /** \brief . */
+  RCP<const LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF() const;
+
+  //@}
+
+  /** \name Overridden from Teuchos::Describable. */
+  //@{
+
+  /** \brief . */
+  std::string description() const;
+
+  //@}
+
+  /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
+  //@{
+
+  /** \brief . */
+  void setParameterList(RCP<ParameterList> const& paramList);
+  /** \brief . */
+  RCP<ParameterList> getNonconstParameterList();
+  /** \brief . */
+  RCP<ParameterList> unsetParameterList();
+  /** \brief . */
+  RCP<const ParameterList> getParameterList() const;
+  /** \brief . */
+  RCP<const ParameterList> getValidParameters() const;
+
+  //@}
+
+  /** \name Overridden from LinearOpWithSolveFactoyBase */
+  //@{
+
+  /** \brief returns false. */
+  virtual bool acceptsPreconditionerFactory() const;
+
+  /** \brief Throws exception. */
+  virtual void setPreconditionerFactory(
+    const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
+    const std::string &precFactoryName
+    );
+
+  /** \brief Returns null . */
+  virtual RCP<PreconditionerFactoryBase<Scalar> >
+  getPreconditionerFactory() const;
+
+  /** \brief Throws exception. */
+  virtual void unsetPreconditionerFactory(
+    RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
+    std::string *precFactoryName
+    );
+
+  /** \brief . */
+  virtual bool isCompatible(
+    const LinearOpSourceBase<Scalar> &fwdOpSrc
+    ) const;
+
+  /** \brief . */
+  virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const;
+
+  /** \brief . */
+  virtual void initializeOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    LinearOpWithSolveBase<Scalar> *Op,
+    const ESupportSolveUse supportSolveUse
+    ) const;
+
+  /** \brief . */
+  virtual void initializeAndReuseOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    LinearOpWithSolveBase<Scalar> *Op
+    ) const;
+
+  /** \brief . */
+  virtual void uninitializeOp(
+    LinearOpWithSolveBase<Scalar> *Op,
+    RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
+    RCP<const PreconditionerBase<Scalar> > *prec,
+    RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
+    ESupportSolveUse *supportSolveUse
+    ) const;
+
+  /** \brief . */
+  virtual bool supportsPreconditionerInputType(
+    const EPreconditionerInputType precOpType
+    ) const;
+
+  /** \brief . */
+  virtual void initializePreconditionedOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    const RCP<const PreconditionerBase<Scalar> > &prec,
+    LinearOpWithSolveBase<Scalar> *Op,
+    const ESupportSolveUse supportSolveUse
+    ) const;
+
+  /** \brief . */
+  virtual void initializeApproxPreconditionedOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
+    LinearOpWithSolveBase<Scalar> *Op,
+    const ESupportSolveUse supportSolveUse
+    ) const;
+
+  //@}
+
+protected:
+
+  /** \brief Overridden from Teuchos::VerboseObjectBase */
+  //@{
+
+  /** \brief . */
+  void informUpdatedVerbosityState() const;
+
+  //@}
+
+private:
+
+  typedef Teuchos::ConstNonconstObjectContainer<LinearOpWithSolveFactoryBase<Scalar> > LOWSF_t;
+
+  LOWSF_t lowsf_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecRange_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecDomain_;
+
+};
+
+/** \brief Nonmember constructor.
+ *
+ * \releates MultiVectorLinearOpWithSolveFactory
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
+nonconstMultiVectorLinearOpWithSolveFactory(
+  const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorLinearOpWithSolveFactory<Scalar> > mvlowsf =
+    Teuchos::rcp(new MultiVectorLinearOpWithSolveFactory<Scalar>);
+  mvlowsf->nonconstInitialize(lowsf,multiVecRange,multiVecDomain);
+  return mvlowsf;
+}
+
+/** \brief Nonmember constructor.
+ *
+ * \releates MultiVectorLinearOpWithSolveFactory
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
+nonconstMultiVectorLinearOpWithSolveFactory(
+  const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const int num_blocks
+  )
+{
+  RCP< LinearOpWithSolveBase<Scalar> > op = lowsf->createOp();
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_domain =
+    Thyra::multiVectorProductVectorSpace(op->domain(), num_blocks);
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_range =
+    Thyra::multiVectorProductVectorSpace(op->range(), num_blocks);
+  return nonconstMultiVectorLinearOpWithSolveFactory(lowsf, mv_range, mv_domain);
+}
+
+/** \brief Nonmember constructor.
+ *
+ * \releates MultiVectorLinearOpWithSolveFactory
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
+multiVectorLinearOpWithSolveFactory(
+  const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorLinearOpWithSolveFactory<Scalar> > mvlowsf =
+    Teuchos::rcp(new MultiVectorLinearOpWithSolveFactory<Scalar>);
+  mvlowsf->initialize(lowsf,multiVecRange,multiVecDomain);
+  return mvlowsf;
+}
+
+/** \brief Nonmember constructor.
+ *
+ * \releates MultiVectorLinearOpWithSolveFactory
+ */
+template<class Scalar>
+RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
+multiVectorLinearOpWithSolveFactory(
+  const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const int num_blocks
+  )
+{
+  RCP< LinearOpWithSolveBase<Scalar> > op = lowsf->createOp();
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_domain =
+    Thyra::multiVectorProductVectorSpace(op->domain(), num_blocks);
+  RCP<const Thyra::DefaultMultiVectorProductVectorSpace<Scalar> > mv_range =
+    Thyra::multiVectorProductVectorSpace(op->range(), num_blocks);
+  return multiVectorLinearOpWithSolveFactory(lowsf, mv_range, mv_domain);
+}
+
+// Overridden from Constructors/Initializers/Accessors
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+nonconstInitialize(
+  const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(is_null(lowsf));
+#endif
+  lowsf_.initialize(lowsf);
+  multiVecRange_ = multiVecRange;
+  multiVecDomain_ = multiVecDomain;
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+initialize(
+  const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(is_null(lowsf));
+#endif
+  lowsf_.initialize(lowsf);
+  multiVecRange_ = multiVecRange;
+  multiVecDomain_ = multiVecDomain;
+}
+
+template<class Scalar>
+RCP<LinearOpWithSolveFactoryBase<Scalar> >
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+getUnderlyingLOWSF()
+{
+  return lowsf_.getNonconstObj();
+}
+
+template<class Scalar>
+RCP<const LinearOpWithSolveFactoryBase<Scalar> >
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+getUnderlyingLOWSF() const
+{
+  return lowsf_.getConstObj();
+}
+
+// Overridden from Teuchos::Describable
+
+template<class Scalar>
+std::string
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+description() const
+{
+  std::ostringstream oss;
+  oss << this->Teuchos::Describable::description()
+      << "{"
+      << "lowsf=";
+  if (!is_null(lowsf_.getConstObj()))
+    oss << lowsf_.getConstObj()->description();
+  else
+    oss << "NULL";
+  oss << "}";
+  return oss.str();
+}
+
+// Overridden from ParameterListAcceptor
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+setParameterList(
+  RCP<ParameterList> const& paramList
+  )
+{
+  lowsf_.getNonconstObj()->setParameterList(paramList);
+}
+
+template<class Scalar>
+RCP<ParameterList>
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+getNonconstParameterList()
+{
+  return lowsf_.getNonconstObj()->getNonconstParameterList();
+}
+
+template<class Scalar>
+RCP<ParameterList>
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+unsetParameterList()
+{
+  return lowsf_.getNonconstObj()->unsetParameterList();
+}
+
+template<class Scalar>
+RCP<const ParameterList>
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+getParameterList() const
+{
+  return lowsf_.getConstObj()->getParameterList();
+}
+
+template<class Scalar>
+RCP<const ParameterList>
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+getValidParameters() const
+{
+  return lowsf_.getConstObj()->getValidParameters();
+}
+
+// Overridden from LinearOpWithSolveFactoyBase
+
+template<class Scalar>
+bool
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+acceptsPreconditionerFactory() const
+{
+  return lowsf_.getConstObj()->acceptsPreconditionerFactory();
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+setPreconditionerFactory(
+  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
+  const std::string &precFactoryName
+  )
+{
+  typedef MultiVectorPreconditionerFactory<Scalar> MVPF;
+  RCP<MVPF> mvpf = Teuchos::rcp_dynamic_cast<MVPF>(precFactory);
+  lowsf_.getNonconstObj()->setPreconditionerFactory(
+    mvpf->getNonconstPreconditionerFactory(),
+    precFactoryName);
+}
+
+template<class Scalar>
+RCP<PreconditionerFactoryBase<Scalar> >
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+getPreconditionerFactory() const
+{
+  RCP<PreconditionerFactoryBase<Scalar> > prec_fac =
+    lowsf_.getConstObj()->getPreconditionerFactory();
+  if (prec_fac == Teuchos::null)
+    return Teuchos::null;
+  else
+    return nonconstMultiVectorPreconditionerFactory(
+      prec_fac,
+      multiVecRange_, multiVecDomain_);
+}
+
+template<class Scalar>
+void MultiVectorLinearOpWithSolveFactory<Scalar>::
+unsetPreconditionerFactory(
+  RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
+  std::string *precFactoryName
+  )
+{
+  RCP<PreconditionerFactoryBase<Scalar> > inner_precFactory;
+  lowsf_.getNonconstObj()->unsetPreconditionerFactory(
+    precFactory ? &inner_precFactory : NULL,
+    precFactoryName);
+  if (precFactory)
+    *precFactory = nonconstMultiVectorPreconditionerFactory(inner_precFactory,
+                                                            multiVecRange_,
+                                                            multiVecDomain_);
+}
+
+template<class Scalar>
+bool
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+isCompatible(
+  const LinearOpSourceBase<Scalar> &fwdOpSrc
+  ) const
+{
+  typedef MultiVectorLinearOp<Scalar> MVLO;
+  RCP<const MVLO> mvlo =
+    Teuchos::rcp_dynamic_cast<const MVLO>(fwdOpSrc.getOp().assert_not_null());
+  RCP<const LinearOpSourceBase<Scalar> > inner_fwdOpSrc =
+    defaultLinearOpSource<Scalar>(mvlo->getLinearOp());
+  return lowsf_.getConstObj()->isCompatible(*inner_fwdOpSrc);
+}
+
+template<class Scalar>
+RCP<LinearOpWithSolveBase<Scalar> >
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+createOp() const
+{
+  return nonconstMultiVectorLinearOpWithSolve<Scalar>(
+    lowsf_.getConstObj()->createOp(),
+    multiVecRange_,
+    multiVecDomain_);
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+initializeOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  LinearOpWithSolveBase<Scalar> *Op,
+  const ESupportSolveUse supportSolveUse
+  ) const
+{
+  using Teuchos::dyn_cast;
+  using Teuchos::rcp_dynamic_cast;
+
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(0==Op);
+#endif
+
+  // Set the verbosity settings for the wrapped LOWSF object!
+  lowsf_.getConstObj()->setOStream(this->getOStream());
+  lowsf_.getConstObj()->setVerbLevel(this->getVerbLevel());
+
+  typedef MultiVectorLinearOp<Scalar> MVLO;
+  typedef DefaultMultiVectorLinearOpWithSolve<Scalar> MVLOWS;
+  const RCP<const MVLO> mvlo =
+    rcp_dynamic_cast<const MVLO>(fwdOpSrc->getOp().assert_not_null());
+  MVLOWS &mvlows = dyn_cast<MVLOWS>(*Op);
+
+  lowsf_.getConstObj()->initializeOp(
+    defaultLinearOpSource<Scalar>(mvlo->getLinearOp()),
+    mvlows.getNonconstLinearOpWithSolve().get(),
+    supportSolveUse);
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+initializeAndReuseOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  LinearOpWithSolveBase<Scalar> *Op
+  ) const
+{
+  using Teuchos::dyn_cast;
+  using Teuchos::rcp_dynamic_cast;
+
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(0==Op);
+#endif
+
+  // Set the verbosity settings for the wrapped LOWSF object!
+  lowsf_.getConstObj()->setOStream(this->getOStream());
+  lowsf_.getConstObj()->setVerbLevel(this->getVerbLevel());
+
+  typedef MultiVectorLinearOp<Scalar> MVLO;
+  typedef DefaultMultiVectorLinearOpWithSolve<Scalar> MVLOWS;
+  const RCP<const MVLO> mvlo =
+    rcp_dynamic_cast<const MVLO>(fwdOpSrc->getOp().assert_not_null());
+  MVLOWS &mvlows = dyn_cast<MVLOWS>(*Op);
+
+  lowsf_.getConstObj()->initializeAndReuseOp(
+    defaultLinearOpSource<Scalar>(mvlo->getLinearOp()),
+    mvlows.getNonconstLinearOpWithSolve().get());
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+uninitializeOp(
+  LinearOpWithSolveBase<Scalar> *Op,
+  RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
+  RCP<const PreconditionerBase<Scalar> > *prec,
+  RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
+  ESupportSolveUse *supportSolveUse
+  ) const
+{
+  using Teuchos::dyn_cast;
+
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(0==Op);
+#endif
+  typedef DefaultMultiVectorLinearOpWithSolve<Scalar> MVLOWS;
+  MVLOWS &mvlowsOp = dyn_cast<MVLOWS>(*Op);
+  RCP<const LinearOpSourceBase<Scalar> > inner_fwdOpSrc;
+  RCP<const PreconditionerBase<Scalar> > inner_prec;
+  RCP<const LinearOpSourceBase<Scalar> > inner_approxFwdOpSrc;
+  lowsf_.getConstObj()->uninitializeOp(
+    mvlowsOp.getNonconstLinearOpWithSolve().get(),
+    fwdOpSrc ? &inner_fwdOpSrc : NULL,
+    prec ? &inner_prec : NULL,
+    approxFwdOpSrc ? &inner_approxFwdOpSrc : NULL,
+    supportSolveUse);
+  if (fwdOpSrc)
+    *fwdOpSrc =
+      defaultLinearOpSource<Scalar>(multiVectorLinearOp(inner_fwdOpSrc->getOp(),
+                                                        multiVecRange_,
+                                                        multiVecDomain_));
+  if (prec)
+    *prec = multiVectorPreconditioner(inner_prec,
+                                      multiVecRange_,
+                                      multiVecDomain_);
+  if (fwdOpSrc)
+    *approxFwdOpSrc =
+      defaultLinearOpSource<Scalar>(multiVectorLinearOp(inner_approxFwdOpSrc->getOp(),
+                                                        multiVecRange_,
+                                                        multiVecDomain_));
+}
+
+template<class Scalar>
+bool
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+supportsPreconditionerInputType(
+  const EPreconditionerInputType precOpType
+  ) const
+{
+  return lowsf_.getConstObj()->supportsPreconditionerInputType(precOpType);
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+initializePreconditionedOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  const RCP<const PreconditionerBase<Scalar> > &prec,
+  LinearOpWithSolveBase<Scalar> *Op,
+  const ESupportSolveUse supportSolveUse
+  ) const
+{
+  using Teuchos::dyn_cast;
+  using Teuchos::rcp_dynamic_cast;
+
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(0==Op);
+#endif
+
+  // Set the verbosity settings for the wrapped LOWSF object!
+  lowsf_.getConstObj()->setOStream(this->getOStream());
+  lowsf_.getConstObj()->setVerbLevel(this->getVerbLevel());
+
+  typedef MultiVectorLinearOp<Scalar> MVLO;
+  typedef MultiVectorPreconditioner<Scalar> MVP;
+  typedef DefaultMultiVectorLinearOpWithSolve<Scalar> MVLOWS;
+  const RCP<const MVLO> mvlo =
+    rcp_dynamic_cast<const MVLO>(fwdOpSrc->getOp().assert_not_null());
+  const RCP<const MVP> mvp = rcp_dynamic_cast<const MVP>(prec);
+  MVLOWS &mvlows = dyn_cast<MVLOWS>(*Op);
+
+  lowsf_.getConstObj()->initializePreconditionedOp(
+    defaultLinearOpSource<Scalar>(mvlo->getLinearOp()),
+    mvp->getPreconditioner(),
+    mvlows.getNonconstLinearOpWithSolve().get(),
+    supportSolveUse);
+}
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+initializeApproxPreconditionedOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
+  LinearOpWithSolveBase<Scalar> *Op,
+  const ESupportSolveUse supportSolveUse
+  ) const
+{
+  using Teuchos::dyn_cast;
+  using Teuchos::rcp_dynamic_cast;
+
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(0==Op);
+#endif
+
+  // Set the verbosity settings for the wrapped LOWSF object!
+  lowsf_.getConstObj()->setOStream(this->getOStream());
+  lowsf_.getConstObj()->setVerbLevel(this->getVerbLevel());
+
+  typedef MultiVectorLinearOp<Scalar> MVLO;
+  typedef DefaultMultiVectorLinearOpWithSolve<Scalar> MVLOWS;
+  const RCP<const MVLO> mvlo =
+    rcp_dynamic_cast<const MVLO>(fwdOpSrc->getOp().assert_not_null());
+  const RCP<const MVLO> amvlo =
+    rcp_dynamic_cast<const MVLO>(approxFwdOpSrc->getOp().assert_not_null());
+  MVLOWS &mvlows = dyn_cast<MVLOWS>(*Op);
+
+  lowsf_.getConstObj()->initializeApproxPreconditionedOp(
+    defaultLinearOpSource<Scalar>(mvlo->getLinearOp()),
+    defaultLinearOpSource<Scalar>(amvlo->getLinearOp()),
+    mvlows.getNonconstLinearOpWithSolve().get(),
+    supportSolveUse);
+}
+
+// protected
+
+template<class Scalar>
+void
+MultiVectorLinearOpWithSolveFactory<Scalar>::
+informUpdatedVerbosityState() const
+{
+  lowsf_.getConstObj()->setVerbLevel(this->getVerbLevel());
+  lowsf_.getConstObj()->setOStream(this->getOStream());
+}
+
+} // namespace Thyra
+
+#endif

--- a/packages/tempus/src/Thyra_MultiVectorPreconditioner.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorPreconditioner.hpp
@@ -1,0 +1,213 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_MultiVectorPreconditioner_hpp
+#define Thyra_MultiVectorPreconditioner_hpp
+
+#include "Thyra_PreconditionerBase.hpp"
+#include "Teuchos_ConstNonconstObjectContainer.hpp"
+#include "Thyra_MultiVectorLinearOp.hpp"
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+
+namespace Thyra {
+
+/** \brief Concrete <tt>PreconditionerBase</tt> subclass that
+ * wraps a preconditioner operator in MultiVectorLinearOp.
+ */
+template<class Scalar>
+class MultiVectorPreconditioner : virtual public PreconditionerBase<Scalar>
+{
+public:
+
+  /** @name Constructors/initializers/accessors */
+  //@{
+
+  /** \brief Construct to uninitialized. */
+  MultiVectorPreconditioner() {}
+
+  /** \brief . */
+  void nonconstInitialize(
+    const RCP<PreconditionerBase<Scalar> > &prec,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+    validateInitialize(prec,multiVecRange,multiVecDomain);
+    prec_ = prec;
+    multiVecRange_ = multiVecRange;
+    multiVecDomain_ = multiVecDomain;
+  }
+
+  /** \brief . */
+  void initialize(
+    const RCP<const PreconditionerBase<Scalar> > &prec,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain) {
+    validateInitialize(prec,multiVecRange,multiVecDomain);
+    prec_ = prec;
+    multiVecRange_ = multiVecRange;
+    multiVecDomain_ = multiVecDomain;
+  }
+
+  /** \brief . */
+  RCP<PreconditionerBase<Scalar> >
+  getNonconstPreconditioner() { return prec_.getNonconstObj(); }
+
+  /** \brief . */
+  RCP<const PreconditionerBase<Scalar> >
+  getPreconditioner() const { return prec_.getConstObj(); }
+
+  /** \brief . */
+  void uninitialize() {
+    prec_.uninitialize();
+    multiVecRange_ = Teuchos::null;
+    multiVecDomain_ = Teuchos::null;
+  }
+
+  //@}
+
+  /** @name Overridden from PreconditionerBase */
+  //@{
+
+  /** \brief . */
+  bool isLeftPrecOpConst() const
+  { return prec_.getConstObj()->isLeftPrecOpConst(); }
+
+  /** \brief . */
+  Teuchos::RCP<LinearOpBase<Scalar> > getNonconstLeftPrecOp()
+  { return nonconstMultiVectorLinearOp(
+      prec_.getNonconstObj()->getNonconstLeftPrecOp(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  /** \brief . */
+  Teuchos::RCP<const LinearOpBase<Scalar> > getLeftPrecOp() const
+  { return multiVectorLinearOp(
+      prec_.getConstObj()->getLeftPrecOp(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  /** \brief . */
+  bool isRightPrecOpConst() const
+  { return prec_.getConstObj()->isRightPrecOpConst(); }
+
+  /** \brief . */
+  Teuchos::RCP<LinearOpBase<Scalar> > getNonconstRightPrecOp()
+  { return nonconstMultiVectorLinearOp(
+      prec_.getNonconstObj()->getNonconstRightPrecOp(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  /** \brief . */
+  Teuchos::RCP<const LinearOpBase<Scalar> > getRightPrecOp() const
+  { return multiVectorLinearOp(
+      prec_.getConstObj()->getRightPrecOp(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  /** \brief . */
+  bool isUnspecifiedPrecOpConst() const
+  { return prec_.getConstObj()->isUnspecifiedPrecOpConst(); }
+
+  /** \brief . */
+  Teuchos::RCP<LinearOpBase<Scalar> > getNonconstUnspecifiedPrecOp()
+  { return nonconstMultiVectorLinearOp(
+      prec_.getNonconstObj()->getNonconstUnspecifiedPrecOp(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  /** \brief . */
+  Teuchos::RCP<const LinearOpBase<Scalar> > getUnspecifiedPrecOp() const
+  { return multiVectorLinearOp(
+      prec_.getNonconstObj()->getUnspecifiedPrecOp(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  //@}
+
+private:
+
+  // //////////////////////////////
+  // Private types
+
+  typedef Teuchos::ConstNonconstObjectContainer<PreconditionerBase<Scalar> > CNPB;
+
+  // //////////////////////////////
+  // Private data members
+
+  CNPB prec_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecRange_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecDomain_;
+
+  // //////////////////////////////
+  // Private member functions
+
+  static void validateInitialize(
+    const RCP<const PreconditionerBase<Scalar> > &prec,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+#ifdef TEUCHOS_DEBUG
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(prec));
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecRange));
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecDomain));
+    TEUCHOS_TEST_FOR_EXCEPT( multiVecRange->numBlocks() != multiVecDomain->numBlocks() );
+#endif
+  }
+
+};
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorPreconditioner
+ */
+template<class Scalar>
+RCP<MultiVectorPreconditioner<Scalar> >
+multiVectorPreconditioner()
+{
+  return Teuchos::rcp(new MultiVectorPreconditioner<Scalar>());
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorPreconditioner
+ */
+template<class Scalar>
+RCP<MultiVectorPreconditioner<Scalar> >
+nonconstMultiVectorPreconditioner(
+  const RCP<PreconditionerBase<Scalar> > &prec,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorPreconditioner<Scalar> >
+    mvprec = Teuchos::rcp(new MultiVectorPreconditioner<Scalar>());
+  mvprec->nonconstInitialize(prec,multiVecRange,multiVecDomain);
+  return mvprec;
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorPreconditioner
+ */
+template<class Scalar>
+RCP<MultiVectorPreconditioner<Scalar> >
+multiVectorPreconditioner(
+  const RCP<const PreconditionerBase<Scalar> > &prec,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorPreconditioner<Scalar> >
+    mvprec = Teuchos::rcp(new MultiVectorPreconditioner<Scalar>());
+  mvprec->initialize(prec,multiVecRange,multiVecDomain);
+  return mvprec;
+}
+
+}       // end namespace Thyra
+
+#endif

--- a/packages/tempus/src/Thyra_MultiVectorPreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorPreconditionerFactory.hpp
@@ -1,0 +1,274 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_MultiVectorPreconditionerFactory_hpp
+#define Thyra_MultiVectorPreconditionerFactory_hpp
+
+#include "Thyra_PreconditionerFactoryBase.hpp"
+#include "Teuchos_ConstNonconstObjectContainer.hpp"
+#include "Thyra_MultiVectorLinearOp.hpp"
+#include "Thyra_MultiVectorPreconditioner.hpp"
+#include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
+
+namespace Thyra {
+
+/** \brief Concrete <tt>PreconditionerFactoryBase</tt> subclass that
+ * wraps a preconditioner in MultiVectorPreconditioner.
+ */
+template<class Scalar>
+class MultiVectorPreconditionerFactory
+  : virtual public PreconditionerFactoryBase<Scalar>
+{
+public:
+
+  /** @name Constructors/initializers/accessors */
+  //@{
+
+  /** \brief Construct to uninitialized. */
+  MultiVectorPreconditionerFactory() {}
+
+  /** \brief . */
+  void nonconstInitialize(
+    const RCP<PreconditionerFactoryBase<Scalar> > &prec_fac,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+    validateInitialize(prec_fac,multiVecRange,multiVecDomain);
+    prec_fac_ = prec_fac;
+    multiVecRange_ = multiVecRange;
+    multiVecDomain_ = multiVecDomain;
+  }
+
+  /** \brief . */
+  void initialize(
+    const RCP<const PreconditionerFactoryBase<Scalar> > &prec_fac,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain) {
+    validateInitialize(prec_fac,multiVecRange,multiVecDomain);
+    prec_fac_ = prec_fac;
+    multiVecRange_ = multiVecRange;
+    multiVecDomain_ = multiVecDomain;
+  }
+
+  /** \brief . */
+  RCP<PreconditionerFactoryBase<Scalar> >
+  getNonconstPreconditionerFactory() { return prec_fac_.getNonconstObj(); }
+
+  /** \brief . */
+  RCP<const PreconditionerFactoryBase<Scalar> >
+  getPreconditionerFactory() const { return prec_fac_.getConstObj(); }
+
+  /** \brief . */
+  void uninitialize() {
+    prec_fac_.uninitialize();
+    multiVecRange_ = Teuchos::null;
+    multiVecDomain_ = Teuchos::null;
+  }
+
+  /** \name Overridden from Teuchos::Describable. */
+  //@{
+
+  /** \brief . */
+  std::string description() const
+  {
+    std::ostringstream oss;
+    oss << this->Teuchos::Describable::description()
+        << "{"
+        << "prec_fac=";
+    if (!is_null(prec_fac_.getConstObj()))
+      oss << prec_fac_.getConstObj()->description();
+    else
+      oss << "NULL";
+    oss << "}";
+    return oss.str();
+  }
+
+  //@}
+
+  /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
+  //@{
+
+  /** \brief . */
+  void setParameterList(RCP<ParameterList> const& paramList)
+  {
+    prec_fac_.getNonconstObj()->setParameterList(paramList);
+  }
+
+  /** \brief . */
+  RCP<ParameterList> getNonconstParameterList()
+  {
+    return prec_fac_.getNonconstObj()->getNonconstParameterList();
+  }
+
+  /** \brief . */
+  RCP<ParameterList> unsetParameterList()
+  {
+    return prec_fac_.getNonconstObj()->unsetParameterList();
+  }
+
+  /** \brief . */
+  RCP<const ParameterList> getParameterList() const
+  {
+    return prec_fac_.getConstObj()->getParameterList();
+  }
+
+  /** \brief . */
+  RCP<const ParameterList> getValidParameters() const
+  {
+    return prec_fac_.getConstObj()->getValidParameters();
+  }
+
+  //@}
+
+  //@}
+
+  /** @name Overridden from PreconditionerFactoryBase */
+  //@{
+
+  /** \brief . */
+  bool isCompatible(const LinearOpSourceBase<Scalar> &fwdOpSrc) const
+  { return prec_fac_.getConstObj()->isCompatible(fwdOpSrc); }
+
+  /** \brief . */
+   RCP<PreconditionerBase<Scalar> > createPrec() const
+  { return nonconstMultiVectorPreconditioner(
+      prec_fac_.getConstObj()->createPrec(),
+      multiVecRange_,
+      multiVecDomain_); }
+
+  /** \brief . */
+  void initializePrec(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    PreconditionerBase<Scalar> *precOp,
+    const ESupportSolveUse supportSolveUse = SUPPORT_SOLVE_UNSPECIFIED
+    ) const
+  {
+    using Teuchos::dyn_cast;
+    using Teuchos::rcp_dynamic_cast;
+
+    typedef MultiVectorLinearOp<Scalar> MVLO;
+    typedef MultiVectorPreconditioner<Scalar> MVP;
+    const RCP<const MVLO> mvlo =
+      rcp_dynamic_cast<const MVLO>(fwdOpSrc->getOp().assert_not_null());
+    MVP &mvp = dyn_cast<MVP>(*precOp);
+    prec_fac_.getConstObj()->initializePrec(
+      defaultLinearOpSource<Scalar>(mvlo->getLinearOp()),
+      mvp.getNonconstPreconditioner().get(),
+      supportSolveUse);
+  }
+
+  /** \brief . */
+  void uninitializePrec(
+    PreconditionerBase<Scalar> *precOp,
+    RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc = NULL,
+    ESupportSolveUse *supportSolveUse = NULL
+    ) const
+  {
+    using Teuchos::dyn_cast;
+
+#ifdef TEUCHOS_DEBUG
+    TEUCHOS_TEST_FOR_EXCEPT(0==precOp);
+#endif
+    typedef MultiVectorPreconditioner<Scalar> MVP;
+    MVP &mvp = dyn_cast<MVP>(*precOp);
+    RCP<const LinearOpSourceBase<Scalar> > inner_fwdOpSrc;
+    prec_fac_.getConstObj()->uninitializePrec(
+      mvp.getNonconstPreconditioner().get(),
+      fwdOpSrc ? &inner_fwdOpSrc : NULL,
+      supportSolveUse);
+    if (fwdOpSrc)
+      *fwdOpSrc =
+        defaultLinearOpSource<Scalar>(multiVectorLinearOp(inner_fwdOpSrc->getOp(),
+                                                          multiVecRange_,
+                                                          multiVecDomain_));
+  }
+
+  //@}
+
+private:
+
+  // //////////////////////////////
+  // Private types
+
+  typedef Teuchos::ConstNonconstObjectContainer<PreconditionerFactoryBase<Scalar> > CNPFB;
+
+  // //////////////////////////////
+  // Private data members
+
+  CNPFB prec_fac_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecRange_;
+  RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > multiVecDomain_;
+
+  // //////////////////////////////
+  // Private member functions
+
+  static void validateInitialize(
+    const RCP<const PreconditionerFactoryBase<Scalar> > &prec_fac,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+    const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+    ) {
+#ifdef TEUCHOS_DEBUG
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(prec_fac));
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecRange));
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecDomain));
+    TEUCHOS_TEST_FOR_EXCEPT( multiVecRange->numBlocks() != multiVecDomain->numBlocks() );
+#endif
+  }
+
+};
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorPreconditionerFactory
+ */
+template<class Scalar>
+RCP<MultiVectorPreconditionerFactory<Scalar> >
+multiVectorPreconditionerFactory()
+{
+  return Teuchos::rcp(new MultiVectorPreconditionerFactory<Scalar>());
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorPreconditionerFactory
+ */
+template<class Scalar>
+RCP<MultiVectorPreconditionerFactory<Scalar> >
+nonconstMultiVectorPreconditionerFactory(
+  const RCP<PreconditionerFactoryBase<Scalar> > &prec_fac,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorPreconditionerFactory<Scalar> >
+    mvfac = Teuchos::rcp(new MultiVectorPreconditionerFactory<Scalar>());
+  mvfac->nonconstInitialize(prec_fac,multiVecRange,multiVecDomain);
+  return mvfac;
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates MultiVectorPreconditionerFactory
+ */
+template<class Scalar>
+RCP<MultiVectorPreconditionerFactory<Scalar> >
+multiVectorPreconditionerFactory(
+  const RCP<const PreconditionerFactoryBase<Scalar> > &prec_fac,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
+  const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
+  )
+{
+  RCP<MultiVectorPreconditionerFactory<Scalar> >
+    mvfac = Teuchos::rcp(new MultiVectorPreconditionerFactory<Scalar>());
+  mvfac->initialize(prec_fac,multiVecRange,multiVecDomain);
+  return mvfac;
+}
+
+}       // end namespace Thyra
+
+#endif

--- a/packages/tempus/src/Thyra_ReuseLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_ReuseLinearOpWithSolveFactory.hpp
@@ -1,0 +1,511 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_ReuseLinearOpWithSolveFactory_hpp
+#define Thyra_ReuseLinearOpWithSolveFactory_hpp
+
+#include "Thyra_LinearOpWithSolveFactoryBase.hpp"
+#include "Thyra_ReusePreconditionerFactory.hpp"
+
+namespace Thyra {
+
+/** \brief A LinearOpWithSolveFactory that is designed to reuse an already
+ * created/initialized preconditioner.
+ */
+template<class Scalar>
+class ReuseLinearOpWithSolveFactory
+  : virtual public LinearOpWithSolveFactoryBase<Scalar>
+{
+public:
+
+  /** @name Overridden from Constructors/Initializers/Accessors */
+  //@{
+
+  /** \brief Construct to uninitialized. */
+  ReuseLinearOpWithSolveFactory() {}
+
+  /** \brief Initialize given a single non-const LOWSFB object.
+   *
+   * \param lowsf [in,persisting] The LOWSFB object that will be used to
+   * create the LOWSB object for the diagonal blocks.
+   *
+   * <b>Preconditions:</b><ul>
+   * <li><tt>!is_null(lowsf)</tt>
+   * </ul>
+   *
+   */
+  void nonconstInitialize(
+    const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+    const RCP<PreconditionerBase<Scalar> > &prec
+    );
+
+
+  /** \brief Initialize given a single const LOWSFB object.
+   *
+   * \param lowsf [in,persisting] The LOWSFB object that will be used to
+   * create the LOWSB object for the diagonal blocks.
+   *
+   * <b>Preconditions:</b><ul>
+   * <li><tt>!is_null(lowsf)</tt>
+   * </ul>
+   *
+   */
+  void initialize(
+    const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+    const RCP<PreconditionerBase<Scalar> > &prec
+    );
+
+  /** \brief . */
+  RCP<LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF();
+
+  /** \brief . */
+  RCP<const LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF() const;
+
+  /** \brief . */
+  RCP<PreconditionerBase<Scalar> > getUnderlyingPreconditioner();
+
+  /** \brief . */
+  RCP<const PreconditionerBase<Scalar> > getUnderlyingPreconditioner() const;
+
+  //@}
+
+  /** \name Overridden from Teuchos::Describable. */
+  //@{
+
+  /** \brief . */
+  std::string description() const;
+
+  //@}
+
+  /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
+  //@{
+
+  /** \brief . */
+  void setParameterList(RCP<ParameterList> const& paramList);
+  /** \brief . */
+  RCP<ParameterList> getNonconstParameterList();
+  /** \brief . */
+  RCP<ParameterList> unsetParameterList();
+  /** \brief . */
+  RCP<const ParameterList> getParameterList() const;
+  /** \brief . */
+  RCP<const ParameterList> getValidParameters() const;
+
+  //@}
+
+  /** \name Overridden from LinearOpWithSolveFactoyBase */
+  //@{
+
+  /** \brief returns false. */
+  virtual bool acceptsPreconditionerFactory() const;
+
+  /** \brief Throws exception. */
+  virtual void setPreconditionerFactory(
+    const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
+    const std::string &precFactoryName
+    );
+
+  /** \brief Returns null . */
+  virtual RCP<PreconditionerFactoryBase<Scalar> >
+  getPreconditionerFactory() const;
+
+  /** \brief Throws exception. */
+  virtual void unsetPreconditionerFactory(
+    RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
+    std::string *precFactoryName
+    );
+
+  /** \brief . */
+  virtual bool isCompatible(
+    const LinearOpSourceBase<Scalar> &fwdOpSrc
+    ) const;
+
+  /** \brief . */
+  virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const;
+
+  /** \brief . */
+  virtual void initializeOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    LinearOpWithSolveBase<Scalar> *Op,
+    const ESupportSolveUse supportSolveUse
+    ) const;
+
+  /** \brief . */
+  virtual void initializeAndReuseOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    LinearOpWithSolveBase<Scalar> *Op
+    ) const;
+
+  /** \brief . */
+  virtual void uninitializeOp(
+    LinearOpWithSolveBase<Scalar> *Op,
+    RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
+    RCP<const PreconditionerBase<Scalar> > *prec,
+    RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
+    ESupportSolveUse *supportSolveUse
+    ) const;
+
+  /** \brief . */
+  virtual bool supportsPreconditionerInputType(
+    const EPreconditionerInputType precOpType
+    ) const;
+
+  /** \brief . */
+  virtual void initializePreconditionedOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    const RCP<const PreconditionerBase<Scalar> > &prec,
+    LinearOpWithSolveBase<Scalar> *Op,
+    const ESupportSolveUse supportSolveUse
+    ) const;
+
+  /** \brief . */
+  virtual void initializeApproxPreconditionedOp(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
+    LinearOpWithSolveBase<Scalar> *Op,
+    const ESupportSolveUse supportSolveUse
+    ) const;
+
+  //@}
+
+protected:
+
+  /** \brief Overridden from Teuchos::VerboseObjectBase */
+  //@{
+
+  /** \brief . */
+  void informUpdatedVerbosityState() const;
+
+  //@}
+
+private:
+
+  typedef Teuchos::ConstNonconstObjectContainer<LinearOpWithSolveFactoryBase<Scalar> > LOWSF_t;
+
+  LOWSF_t lowsf_;
+  RCP< PreconditionerBase<Scalar> > prec_;
+
+};
+
+/** \brief Nonmember constructor.
+ *
+ * \releates ReuseLinearOpWithSolveFactory
+ */
+template<class Scalar>
+RCP<ReuseLinearOpWithSolveFactory<Scalar> >
+nonconstReuseLinearOpWithSolveFactory(
+  const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<PreconditionerBase<Scalar> > &prec
+  )
+{
+  RCP<ReuseLinearOpWithSolveFactory<Scalar> > rlowsf =
+    Teuchos::rcp(new ReuseLinearOpWithSolveFactory<Scalar>);
+  rlowsf->nonconstInitialize(lowsf, prec);
+  return rlowsf;
+}
+
+/** \brief Nonmember constructor.
+ *
+ * \releates ReuseLinearOpWithSolveFactory
+ */
+template<class Scalar>
+RCP<ReuseLinearOpWithSolveFactory<Scalar> >
+reuseLinearOpWithSolveFactory(
+  const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<PreconditionerBase<Scalar> > &prec
+  )
+{
+  RCP<ReuseLinearOpWithSolveFactory<Scalar> > rlowsf =
+    Teuchos::rcp(new ReuseLinearOpWithSolveFactory<Scalar>);
+  rlowsf->initialize(lowsf, prec);
+  return rlowsf;
+}
+
+// Overridden from Constructors/Initializers/Accessors
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+nonconstInitialize(
+  const RCP<LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<PreconditionerBase<Scalar> > &prec
+  )
+{
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(is_null(lowsf));
+  TEUCHOS_TEST_FOR_EXCEPT(is_null(prec));
+#endif
+  lowsf_.initialize(lowsf);
+  prec_ = prec;
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+initialize(
+  const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf,
+  const RCP<PreconditionerBase<Scalar> > &prec
+  )
+{
+#ifdef TEUCHOS_DEBUG
+  TEUCHOS_TEST_FOR_EXCEPT(is_null(lowsf));
+  TEUCHOS_TEST_FOR_EXCEPT(is_null(prec));
+#endif
+  lowsf_.initialize(lowsf);
+  prec_ = prec;
+}
+
+template<class Scalar>
+RCP<LinearOpWithSolveFactoryBase<Scalar> >
+ReuseLinearOpWithSolveFactory<Scalar>::
+getUnderlyingLOWSF()
+{
+  return lowsf_.getNonconstObj();
+}
+
+template<class Scalar>
+RCP<const LinearOpWithSolveFactoryBase<Scalar> >
+ReuseLinearOpWithSolveFactory<Scalar>::
+getUnderlyingLOWSF() const
+{
+  return lowsf_.getConstObj();
+}
+
+template<class Scalar>
+RCP<PreconditionerBase<Scalar> >
+ReuseLinearOpWithSolveFactory<Scalar>::
+getUnderlyingPreconditioner()
+{
+  return prec_;
+}
+
+template<class Scalar>
+RCP<const PreconditionerBase<Scalar> >
+ReuseLinearOpWithSolveFactory<Scalar>::
+getUnderlyingPreconditioner() const
+{
+  return prec_;
+}
+
+// Overridden from Teuchos::Describable
+
+template<class Scalar>
+std::string
+ReuseLinearOpWithSolveFactory<Scalar>::
+description() const
+{
+  std::ostringstream oss;
+  oss << this->Teuchos::Describable::description()
+      << "{"
+      << "lowsf=";
+  if (!is_null(lowsf_.getConstObj()))
+    oss << lowsf_.getConstObj()->description();
+  else
+    oss << "NULL";
+  oss << std::endl
+      << "prec=";
+  if (!is_null(prec_))
+    oss << prec_->description();
+  else
+    oss << "NULL";
+  oss << "}";
+  return oss.str();
+}
+
+// Overridden from ParameterListAcceptor
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+setParameterList(
+  RCP<ParameterList> const& paramList
+  )
+{
+  lowsf_.getNonconstObj()->setParameterList(paramList);
+}
+
+template<class Scalar>
+RCP<ParameterList>
+ReuseLinearOpWithSolveFactory<Scalar>::
+getNonconstParameterList()
+{
+  return lowsf_.getNonconstObj()->getNonconstParameterList();
+}
+
+template<class Scalar>
+RCP<ParameterList>
+ReuseLinearOpWithSolveFactory<Scalar>::
+unsetParameterList()
+{
+  return lowsf_.getNonconstObj()->unsetParameterList();
+}
+
+template<class Scalar>
+RCP<const ParameterList>
+ReuseLinearOpWithSolveFactory<Scalar>::
+getParameterList() const
+{
+  return lowsf_.getConstObj()->getParameterList();
+}
+
+template<class Scalar>
+RCP<const ParameterList>
+ReuseLinearOpWithSolveFactory<Scalar>::
+getValidParameters() const
+{
+  return lowsf_.getConstObj()->getValidParameters();
+}
+
+// Overridden from LinearOpWithSolveFactoyBase
+
+template<class Scalar>
+bool
+ReuseLinearOpWithSolveFactory<Scalar>::
+acceptsPreconditionerFactory() const
+{
+  return false;
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+setPreconditionerFactory(
+  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
+  const std::string &precFactoryName
+  )
+{
+}
+
+template<class Scalar>
+RCP<PreconditionerFactoryBase<Scalar> >
+ReuseLinearOpWithSolveFactory<Scalar>::
+getPreconditionerFactory() const
+{
+  return Thyra::reusePreconditionerFactory<Scalar>(prec_);
+}
+
+template<class Scalar>
+void ReuseLinearOpWithSolveFactory<Scalar>::
+unsetPreconditionerFactory(
+  RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
+  std::string *precFactoryName
+  )
+{
+}
+
+template<class Scalar>
+bool
+ReuseLinearOpWithSolveFactory<Scalar>::
+isCompatible(
+  const LinearOpSourceBase<Scalar> &fwdOpSrc
+  ) const
+{
+  return lowsf_.getConstObj()->isCompatible(fwdOpSrc);
+}
+
+template<class Scalar>
+RCP<LinearOpWithSolveBase<Scalar> >
+ReuseLinearOpWithSolveFactory<Scalar>::
+createOp() const
+{
+  return lowsf_.getConstObj()->createOp();
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+initializeOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  LinearOpWithSolveBase<Scalar> *Op,
+  const ESupportSolveUse supportSolveUse
+  ) const
+{
+  lowsf_.getConstObj()->initializeOp(fwdOpSrc, Op, supportSolveUse);
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+initializeAndReuseOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  LinearOpWithSolveBase<Scalar> *Op
+  ) const
+{
+  lowsf_.getConstObj()->initializeAndReuseOp(fwdOpSrc, Op);
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+uninitializeOp(
+  LinearOpWithSolveBase<Scalar> *Op,
+  RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
+  RCP<const PreconditionerBase<Scalar> > *prec,
+  RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
+  ESupportSolveUse *supportSolveUse
+  ) const
+{
+  lowsf_.getConstObj()->uninitializeOp(Op, fwdOpSrc, prec, approxFwdOpSrc,
+                                       supportSolveUse);
+}
+
+template<class Scalar>
+bool
+ReuseLinearOpWithSolveFactory<Scalar>::
+supportsPreconditionerInputType(
+  const EPreconditionerInputType precOpType
+  ) const
+{
+  return lowsf_.getConstObj()->supportsPreconditionerInputType(precOpType);
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+initializePreconditionedOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  const RCP<const PreconditionerBase<Scalar> > &prec,
+  LinearOpWithSolveBase<Scalar> *Op,
+  const ESupportSolveUse supportSolveUse
+  ) const
+{
+  lowsf_.getConstObj()->initializePreconditionedOp(fwdOpSrc, prec, Op,
+                                                   supportSolveUse);
+}
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+initializeApproxPreconditionedOp(
+  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+  const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
+  LinearOpWithSolveBase<Scalar> *Op,
+  const ESupportSolveUse supportSolveUse
+  ) const
+{
+  lowsf_.getConstObj()->initializeApproxPreconditionedOp(fwdOpSrc,
+                                                         approxFwdOpSrc,
+                                                         Op,
+                                                         supportSolveUse);
+}
+
+// protected
+
+template<class Scalar>
+void
+ReuseLinearOpWithSolveFactory<Scalar>::
+informUpdatedVerbosityState() const
+{
+  lowsf_.getConstObj()->setVerbLevel(this->getVerbLevel());
+  lowsf_.getConstObj()->setOStream(this->getOStream());
+}
+
+} // namespace Thyra
+
+
+#endif

--- a/packages/tempus/src/Thyra_ReusePreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_ReusePreconditionerFactory.hpp
@@ -1,0 +1,179 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Thyra_ReusePreconditionerFactory_hpp
+#define Thyra_ReusePreconditionerFactory_hpp
+
+#include "Thyra_PreconditionerFactoryBase.hpp"
+
+namespace Thyra {
+
+/** \brief Concrete <tt>PreconditionerFactoryBase</tt> subclass that
+ * just returns an already created/initialized preconditioner object.
+ */
+template<class Scalar>
+class ReusePreconditionerFactory
+  : virtual public PreconditionerFactoryBase<Scalar>
+{
+public:
+
+  /** @name Constructors/initializers/accessors */
+  //@{
+
+  /** \brief Construct to uninitialized. */
+  ReusePreconditionerFactory() {}
+
+  /** \brief . */
+  void initialize(
+    const RCP<PreconditionerBase<Scalar> > &prec
+    ) {
+#ifdef TEUCHOS_DEBUG
+    TEUCHOS_TEST_FOR_EXCEPT(is_null(prec));
+#endif
+    prec_ = prec;
+  }
+
+  /** \brief . */
+  RCP<PreconditionerBase<Scalar> >
+  getNonconstPreconditioner() { return prec_; }
+
+  /** \brief . */
+  RCP<const PreconditionerBase<Scalar> >
+  getPreconditioner() const { return prec_; }
+
+  /** \brief . */
+  void uninitialize() {
+    prec_ = Teuchos::null;
+  }
+
+  /** \name Overridden from Teuchos::Describable. */
+  //@{
+
+  /** \brief . */
+  std::string description() const
+  {
+    std::ostringstream oss;
+    oss << this->Teuchos::Describable::description()
+        << "{"
+        << "prec=";
+    if (!is_null(prec_))
+      oss << prec_->description();
+    else
+      oss << "NULL";
+    oss << "}";
+    return oss.str();
+  }
+
+  //@}
+
+  /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
+  //@{
+
+  /** \brief . */
+  void setParameterList(RCP<ParameterList> const& paramList)
+  {
+  }
+
+  /** \brief . */
+  RCP<ParameterList> getNonconstParameterList()
+  {
+    return Teuchos::null;
+  }
+
+  /** \brief . */
+  RCP<ParameterList> unsetParameterList()
+  {
+    return Teuchos::null;
+  }
+
+  /** \brief . */
+  RCP<const ParameterList> getParameterList() const
+  {
+    return Teuchos::null;
+  }
+
+  /** \brief . */
+  RCP<const ParameterList> getValidParameters() const
+  {
+    return rcp(new ParameterList);
+  }
+
+  //@}
+
+  //@}
+
+  /** @name Overridden from PreconditionerFactoryBase */
+  //@{
+
+  /** \brief . */
+  bool isCompatible(const LinearOpSourceBase<Scalar> &fwdOpSrc) const
+  { return false; }
+
+  /** \brief . */
+   RCP<PreconditionerBase<Scalar> > createPrec() const
+  { return prec_; }
+
+  /** \brief . */
+  void initializePrec(
+    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
+    PreconditionerBase<Scalar> *precOp,
+    const ESupportSolveUse supportSolveUse = SUPPORT_SOLVE_UNSPECIFIED
+    ) const
+  {
+  }
+
+  /** \brief . */
+  void uninitializePrec(
+    PreconditionerBase<Scalar> *precOp,
+    RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc = NULL,
+    ESupportSolveUse *supportSolveUse = NULL
+    ) const
+  {
+  }
+
+  //@}
+
+private:
+
+  // //////////////////////////////
+  // Private data members
+
+  RCP< PreconditionerBase<Scalar> > prec_;
+
+};
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates ReusePreconditionerFactory
+ */
+template<class Scalar>
+RCP<ReusePreconditionerFactory<Scalar> >
+reusePreconditionerFactory()
+{
+  return Teuchos::rcp(new ReusePreconditionerFactory<Scalar>());
+}
+
+/** \brief Nonmember constructor function.
+ *
+ * \relates ReusePreconditionerFactory
+ */
+template<class Scalar>
+RCP<ReusePreconditionerFactory<Scalar> >
+reusePreconditionerFactory(
+  const RCP<PreconditionerBase<Scalar> > &prec
+  )
+{
+  RCP<ReusePreconditionerFactory<Scalar> >
+    fac = Teuchos::rcp(new ReusePreconditionerFactory<Scalar>());
+  fac->initialize(prec);
+  return fac;
+}
+
+}       // end namespace Thyra
+
+#endif

--- a/packages/tempus/test/BDF2/CMakeLists.txt
+++ b/packages/tempus/test/BDF2/CMakeLists.txt
@@ -10,12 +10,12 @@ INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING
 
 TRIBITS_ADD_EXECUTABLE(
   BDF2
-  SOURCES Tempus_BDF2Test.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN} 
+  SOURCES Tempus_BDF2Test.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
   TESTONLYLIBS tempus_test_models
-  COMM serial mpi 
+  COMM serial mpi
 )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Test_BDF2_CopyFiles
-  DEST_FILES Tempus_BDF2_SinCos.xml Tempus_BDF2_CDR.xml Tempus_BDF2_VanDerPol.xml
+  DEST_FILES Tempus_BDF2_SinCos.xml Tempus_BDF2_CDR.xml Tempus_BDF2_VanDerPol.xml Tempus_BDF2_SteadyQuadratic.xml
   EXEDEPS BDF2
   )

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -9,13 +9,17 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
 
 #include "Tempus_config.hpp"
 #include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorForwardSensitivity.hpp"
+#include "Tempus_IntegratorPseudoTransientForwardSensitivity.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
 #include "../TestModels/CDR_Model.hpp"
 #include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/SteadyQuadraticModel.hpp"
 #include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
 
 #include "Stratimikos_DefaultLinearSolverBuilder.hpp"
@@ -189,6 +193,251 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos)
          << error0*(StepSize[n]/StepSize[0]) << std::endl;
   }
   ftmp.close();
+}
+
+// ************************************************************
+// ************************************************************
+void test_sincos_fsa(const bool use_combined_method,
+                     const bool use_dfdp_as_tangent,
+                     Teuchos::FancyOStream &out, bool &success)
+{
+  std::vector<double> StepSize;
+  std::vector<double> ErrorNorm;
+  const int nTimeStepSizes = 7;
+  double dt = 0.2;
+  double order = 0.0;
+  Teuchos::RCP<const Teuchos::Comm<int> > comm =
+    Teuchos::DefaultComm<int>::getComm();
+  Teuchos::RCP<Teuchos::FancyOStream> my_out =
+    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
+  my_out->setOutputToRootOnly(0);
+  for (int n=0; n<nTimeStepSizes; n++) {
+
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_BDF2_SinCos.xml");
+
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    scm_pl->set("Use DfDp as Tangent", use_dfdp_as_tangent);
+    RCP<SinCosModel<double> > model =
+      Teuchos::rcp(new SinCosModel<double>(scm_pl));
+
+    dt /= 2;
+
+    // Setup sensitivities
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+    ParameterList& sens_pl = pl->sublist("Sensitivities");
+    if (use_combined_method)
+      sens_pl.set("Sensitivity Method", "Combined");
+    else {
+      sens_pl.set("Sensitivity Method", "Staggered");
+      sens_pl.set("Reuse State Linear Solver", true);
+    }
+    sens_pl.set("Use DfDp as Tangent", use_dfdp_as_tangent);
+
+    // Setup the Integrator and reset initial time step
+    pl->sublist("Default Integrator")
+       .sublist("Time Step Control").set("Initial Time Step", dt);
+    RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
+      Tempus::integratorForwardSensitivity<double>(pl, model);
+    order = integrator->getStepper()->getOrder();
+
+    // Initial Conditions
+    double t0 = pl->sublist("Default Integrator")
+      .sublist("Time Step Control").get<double>("Initial Time");
+    RCP<const Thyra::VectorBase<double> > x0 =
+      model->getExactSolution(t0).get_x();
+    const int num_param = model->get_p_space(0)->dim();
+    RCP<Thyra::MultiVectorBase<double> > DxDp0 =
+      Thyra::createMembers(model->get_x_space(), num_param);
+    for (int i=0; i<num_param; ++i)
+      Thyra::assign(DxDp0->col(i).ptr(),
+                    *(model->getExactSensSolution(i, t0).get_x()));
+    integrator->setInitialState(t0, x0, Teuchos::null, Teuchos::null,
+                                DxDp0, Teuchos::null, Teuchos::null);
+
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
+
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+    // Time-integrated solution and the exact solution
+    RCP<const Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::MultiVectorBase<double> > DxDp = integrator->getDxDp();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
+    RCP<Thyra::MultiVectorBase<double> > DxDp_exact =
+      Thyra::createMembers(model->get_x_space(), num_param);
+    for (int i=0; i<num_param; ++i)
+      Thyra::assign(DxDp_exact->col(i).ptr(),
+                    *(model->getExactSensSolution(i, time).get_x()));
+
+    // Plot sample solution and exact solution
+    if (comm->getRank() == 0 && n == nTimeStepSizes-1) {
+      typedef Thyra::DefaultMultiVectorProductVector<double> DMVPV;
+
+      std::ofstream ftmp("Tempus_BDF2_SinCos_Sens.dat");
+      RCP<const SolutionHistory<double> > solutionHistory =
+        integrator->getSolutionHistory();
+      RCP< Thyra::MultiVectorBase<double> > DxDp_exact_plot =
+        Thyra::createMembers(model->get_x_space(), num_param);
+      for (int i=0; i<solutionHistory->getNumStates(); i++) {
+        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
+        double time = solutionState->getTime();
+        RCP<const DMVPV> x_prod_plot =
+          Teuchos::rcp_dynamic_cast<const DMVPV>(solutionState->getX());
+        RCP<const Thyra::VectorBase<double> > x_plot =
+          x_prod_plot->getMultiVector()->col(0);
+        RCP<const Thyra::MultiVectorBase<double> > DxDp_plot =
+          x_prod_plot->getMultiVector()->subView(Teuchos::Range1D(1,num_param));
+        RCP<const Thyra::VectorBase<double> > x_exact_plot =
+          model->getExactSolution(time).get_x();
+        for (int j=0; j<num_param; ++j)
+          Thyra::assign(DxDp_exact_plot->col(j).ptr(),
+                        *(model->getExactSensSolution(j, time).get_x()));
+        ftmp << std::fixed << std::setprecision(7)
+             << time
+             << std::setw(11) << get_ele(*(x_plot), 0)
+             << std::setw(11) << get_ele(*(x_plot), 1);
+        for (int j=0; j<num_param; ++j)
+          ftmp << std::setw(11) << get_ele(*(DxDp_plot->col(j)), 0)
+               << std::setw(11) << get_ele(*(DxDp_plot->col(j)), 1);
+        ftmp << std::setw(11) << get_ele(*(x_exact_plot), 0)
+             << std::setw(11) << get_ele(*(x_exact_plot), 1);
+        for (int j=0; j<num_param; ++j)
+          ftmp << std::setw(11) << get_ele(*(DxDp_exact_plot->col(j)), 0)
+               << std::setw(11) << get_ele(*(DxDp_exact_plot->col(j)), 1);
+        ftmp << std::endl;
+      }
+      ftmp.close();
+    }
+
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    RCP<Thyra::MultiVectorBase<double> > DxDpdiff = DxDp->clone_mv();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    Thyra::V_VmV(DxDpdiff.ptr(), *DxDp_exact, *DxDp);
+    StepSize.push_back(dt);
+    double L2norm = Thyra::norm_2(*xdiff);
+    L2norm *= L2norm;
+    Teuchos::Array<double> L2norm_DxDp(num_param);
+    Thyra::norms_2(*DxDpdiff, L2norm_DxDp());
+    for (int i=0; i<num_param; ++i)
+      L2norm += L2norm_DxDp[i]*L2norm_DxDp[i];
+    L2norm = std::sqrt(L2norm);
+    ErrorNorm.push_back(L2norm);
+
+    *my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
+            << std::endl;
+
+  }
+
+  // Check the order and intercept
+  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
+  *my_out << "  Stepper = BDF2" << std::endl;
+  *my_out << "  =========================" << std::endl;
+  *my_out << "  Expected order: " << order << std::endl;
+  *my_out << "  Observed order: " << slope << std::endl;
+  *my_out << "  =========================" << std::endl;
+  TEST_FLOATING_EQUALITY( slope, order, 0.015 );
+  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.163653, 1.0e-4 );
+
+  if (comm->getRank() == 0) {
+    std::ofstream ftmp("Tempus_BDF2_SinCos_Sens-Error.dat");
+    double error0 = 0.8*ErrorNorm[0];
+    for (int n=0; n<nTimeStepSizes; n++) {
+      ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
+           << error0*(StepSize[n]/StepSize[0]) << std::endl;
+    }
+    ftmp.close();
+  }
+
+}
+
+TEUCHOS_UNIT_TEST(BDF2, SinCos_Combined_FSA)
+{
+  test_sincos_fsa(true, false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BDF2, SinCos_Combined_FSA_Tangent)
+{
+  test_sincos_fsa(true, true, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BDF2, SinCos_Staggered_FSA)
+{
+  test_sincos_fsa(false, false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BDF2, SinCos_Staggered_FSA_Tangent)
+{
+  test_sincos_fsa(false, true, out, success);
+}
+
+// ************************************************************
+// ************************************************************
+void test_pseudotransient_fsa(const bool use_dfdp_as_tangent,
+                              Teuchos::FancyOStream &out, bool &success)
+{
+  // Read params from .xml file
+  RCP<ParameterList> pList =
+    getParametersFromXmlFile("Tempus_BDF2_SteadyQuadratic.xml");
+
+  // Setup the SteadyQuadraticModel
+  RCP<ParameterList> scm_pl = sublist(pList, "SteadyQuadraticModel", true);
+  scm_pl->set("Use DfDp as Tangent", use_dfdp_as_tangent);
+  RCP<SteadyQuadraticModel<double> > model =
+    Teuchos::rcp(new SteadyQuadraticModel<double>(scm_pl));
+
+  // Setup sensitivities
+  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  ParameterList& sens_pl = pl->sublist("Sensitivities");
+  sens_pl.set("Use DfDp as Tangent", use_dfdp_as_tangent);
+  sens_pl.set("Reuse State Linear Solver", true);
+  sens_pl.set("Force W Update", true); // Have to do this because for this
+  // model the solver seems to be overwriting the matrix
+
+  // Setup the Integrator
+  RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<double> > integrator =
+    Tempus::integratorPseudoTransientForwardSensitivity<double>(pl, model);
+
+  // Integrate to timeMax
+  bool integratorStatus = integrator->advanceTime();
+  TEST_ASSERT(integratorStatus);
+
+  // Test if at 'Final Time'
+  double time = integrator->getTime();
+  double timeFinal =pl->sublist("Default Integrator")
+    .sublist("Time Step Control").get<double>("Final Time");
+  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+  // Time-integrated solution and the exact solution
+  RCP<const Thyra::VectorBase<double> > x_vec = integrator->getX();
+  RCP<const Thyra::MultiVectorBase<double> > DxDp_vec = integrator->getDxDp();
+  const double x = Thyra::get_ele(*x_vec, 0);
+  const double dxdb = Thyra::get_ele(*(DxDp_vec->col(0)), 0);
+  const double x_exact = model->getSteadyStateSolution();
+  const double dxdb_exact = model->getSteadyStateSolutionSensitivity();
+
+  TEST_FLOATING_EQUALITY( x,    x_exact,    1.0e-6 );
+  TEST_FLOATING_EQUALITY( dxdb, dxdb_exact, 1.0e-6 );
+}
+
+TEUCHOS_UNIT_TEST(BDF2, SteadyQuadratic_PseudoTransient_FSA)
+{
+  test_pseudotransient_fsa(false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BDF2, SteadyQuadratic_PseudoTransient_FSA_Tangent)
+{
+  test_pseudotransient_fsa(true, out, success);
 }
 
 // ************************************************************

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
@@ -1,13 +1,6 @@
-<ParameterList name="BDF2_SinCos">
-  <ParameterList name="SinCosModel">
-    <Parameter name="Accept model parameters"    type="bool" value="true"/>
-    <Parameter name="Provide nominal values"     type="bool" value="true"/>
-    <Parameter name="Coeff a" type="double" value="0.0"/>
-    <Parameter name="Coeff f" type="double" value="1.0"/>
-    <Parameter name="Coeff L" type="double" value="1.0"/>
-    <Parameter name="IC x0"   type="double" value="0.0"/>
-    <Parameter name="IC x1"   type="double" value="1.0"/>
-    <Parameter name="IC t0"   type="double" value="0.0"/>
+<ParameterList name="BackwardEuler_SteadyQuadratic">
+  <ParameterList name="SteadyQuadraticModel">
+    <Parameter name="Coeff b" type="double" value="1.0"/>
   </ParameterList>
   <ParameterList name="Tempus">
     <Parameter name="Integrator Name" type="string" value="Default Integrator"/>
@@ -23,12 +16,12 @@
       </ParameterList>
       <ParameterList name="Time Step Control">
         <Parameter name="Initial Time"           type="double" value="0.0"/>
-        <Parameter name="Final Time"             type="double" value="1.0"/>
+        <Parameter name="Final Time"             type="double" value="20.0"/>
         <Parameter name="Initial Time Index"     type="int"    value="0"/>
         <Parameter name="Final Time Index"       type="int"    value="10000"/>
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
-        <Parameter name="Initial Time Step"      type="double" value="0.1"/>
-        <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
+        <Parameter name="Initial Time Step"      type="double" value="1.0"/>
+        <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
         <Parameter name="Minimum Order"          type="int"    value="1"/>
         <Parameter name="Initial Order"          type="int"    value="1"/>
         <Parameter name="Maximum Order"          type="int"    value="1"/>

--- a/packages/tempus/test/BackwardEuler/CMakeLists.txt
+++ b/packages/tempus/test/BackwardEuler/CMakeLists.txt
@@ -9,6 +9,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Test_BackwardEuler_CopyFiles
-  DEST_FILES Tempus_BackwardEuler_SinCos.xml Tempus_BackwardEuler_CDR.xml Tempus_BackwardEuler_VanDerPol.xml
+  DEST_FILES Tempus_BackwardEuler_SinCos.xml Tempus_BackwardEuler_CDR.xml Tempus_BackwardEuler_VanDerPol.xml Tempus_BackwardEuler_SteadyQuadratic.xml
   EXEDEPS BackwardEuler
   )

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -9,17 +9,22 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
 
 #include "Tempus_config.hpp"
 #include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorForwardSensitivity.hpp"
+#include "Tempus_IntegratorPseudoTransientForwardSensitivity.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
 #include "../TestModels/CDR_Model.hpp"
 #include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/SteadyQuadraticModel.hpp"
 #include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
 
 #include "Stratimikos_DefaultLinearSolverBuilder.hpp"
 #include "Thyra_LinearOpWithSolveFactoryHelpers.hpp"
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
 
 #ifdef Tempus_ENABLE_MPI
 #include "Epetra_MpiComm.h"
@@ -189,6 +194,251 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
          << error0*(StepSize[n]/StepSize[0]) << std::endl;
   }
   ftmp.close();
+}
+
+// ************************************************************
+// ************************************************************
+void test_sincos_fsa(const bool use_combined_method,
+                     const bool use_dfdp_as_tangent,
+                     Teuchos::FancyOStream &out, bool &success)
+{
+  std::vector<double> StepSize;
+  std::vector<double> ErrorNorm;
+  const int nTimeStepSizes = 7;
+  double dt = 0.2;
+  double order = 0.0;
+  Teuchos::RCP<const Teuchos::Comm<int> > comm =
+    Teuchos::DefaultComm<int>::getComm();
+  Teuchos::RCP<Teuchos::FancyOStream> my_out =
+    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
+  my_out->setOutputToRootOnly(0);
+  for (int n=0; n<nTimeStepSizes; n++) {
+
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_BackwardEuler_SinCos.xml");
+
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    scm_pl->set("Use DfDp as Tangent", use_dfdp_as_tangent);
+    RCP<SinCosModel<double> > model =
+      Teuchos::rcp(new SinCosModel<double>(scm_pl));
+
+    dt /= 2;
+
+    // Setup sensitivities
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+    ParameterList& sens_pl = pl->sublist("Sensitivities");
+    if (use_combined_method)
+      sens_pl.set("Sensitivity Method", "Combined");
+    else {
+      sens_pl.set("Sensitivity Method", "Staggered");
+      sens_pl.set("Reuse State Linear Solver", true);
+    }
+    sens_pl.set("Use DfDp as Tangent", use_dfdp_as_tangent);
+
+    // Setup the Integrator and reset initial time step
+    pl->sublist("Default Integrator")
+       .sublist("Time Step Control").set("Initial Time Step", dt);
+    RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
+      Tempus::integratorForwardSensitivity<double>(pl, model);
+    order = integrator->getStepper()->getOrder();
+
+    // Initial Conditions
+    double t0 = pl->sublist("Default Integrator")
+      .sublist("Time Step Control").get<double>("Initial Time");
+    RCP<const Thyra::VectorBase<double> > x0 =
+      model->getExactSolution(t0).get_x();
+    const int num_param = model->get_p_space(0)->dim();
+    RCP<Thyra::MultiVectorBase<double> > DxDp0 =
+      Thyra::createMembers(model->get_x_space(), num_param);
+    for (int i=0; i<num_param; ++i)
+      Thyra::assign(DxDp0->col(i).ptr(),
+                    *(model->getExactSensSolution(i, t0).get_x()));
+    integrator->setInitialState(t0, x0, Teuchos::null, Teuchos::null,
+                                DxDp0, Teuchos::null, Teuchos::null);
+
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
+
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+    // Time-integrated solution and the exact solution
+    RCP<const Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::MultiVectorBase<double> > DxDp = integrator->getDxDp();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
+    RCP<Thyra::MultiVectorBase<double> > DxDp_exact =
+      Thyra::createMembers(model->get_x_space(), num_param);
+    for (int i=0; i<num_param; ++i)
+      Thyra::assign(DxDp_exact->col(i).ptr(),
+                    *(model->getExactSensSolution(i, time).get_x()));
+
+    // Plot sample solution and exact solution
+    if (comm->getRank() == 0 && n == nTimeStepSizes-1) {
+      typedef Thyra::DefaultMultiVectorProductVector<double> DMVPV;
+
+      std::ofstream ftmp("Tempus_BackwardEuler_SinCos_Sens.dat");
+      RCP<const SolutionHistory<double> > solutionHistory =
+        integrator->getSolutionHistory();
+      RCP< Thyra::MultiVectorBase<double> > DxDp_exact_plot =
+        Thyra::createMembers(model->get_x_space(), num_param);
+      for (int i=0; i<solutionHistory->getNumStates(); i++) {
+        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
+        double time = solutionState->getTime();
+        RCP<const DMVPV> x_prod_plot =
+          Teuchos::rcp_dynamic_cast<const DMVPV>(solutionState->getX());
+        RCP<const Thyra::VectorBase<double> > x_plot =
+          x_prod_plot->getMultiVector()->col(0);
+        RCP<const Thyra::MultiVectorBase<double> > DxDp_plot =
+          x_prod_plot->getMultiVector()->subView(Teuchos::Range1D(1,num_param));
+        RCP<const Thyra::VectorBase<double> > x_exact_plot =
+          model->getExactSolution(time).get_x();
+        for (int j=0; j<num_param; ++j)
+          Thyra::assign(DxDp_exact_plot->col(j).ptr(),
+                        *(model->getExactSensSolution(j, time).get_x()));
+        ftmp << std::fixed << std::setprecision(7)
+             << time
+             << std::setw(11) << get_ele(*(x_plot), 0)
+             << std::setw(11) << get_ele(*(x_plot), 1);
+        for (int j=0; j<num_param; ++j)
+          ftmp << std::setw(11) << get_ele(*(DxDp_plot->col(j)), 0)
+               << std::setw(11) << get_ele(*(DxDp_plot->col(j)), 1);
+        ftmp << std::setw(11) << get_ele(*(x_exact_plot), 0)
+             << std::setw(11) << get_ele(*(x_exact_plot), 1);
+        for (int j=0; j<num_param; ++j)
+          ftmp << std::setw(11) << get_ele(*(DxDp_exact_plot->col(j)), 0)
+               << std::setw(11) << get_ele(*(DxDp_exact_plot->col(j)), 1);
+        ftmp << std::endl;
+      }
+      ftmp.close();
+    }
+
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    RCP<Thyra::MultiVectorBase<double> > DxDpdiff = DxDp->clone_mv();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    Thyra::V_VmV(DxDpdiff.ptr(), *DxDp_exact, *DxDp);
+    StepSize.push_back(dt);
+    double L2norm = Thyra::norm_2(*xdiff);
+    L2norm *= L2norm;
+    Teuchos::Array<double> L2norm_DxDp(num_param);
+    Thyra::norms_2(*DxDpdiff, L2norm_DxDp());
+    for (int i=0; i<num_param; ++i)
+      L2norm += L2norm_DxDp[i]*L2norm_DxDp[i];
+    L2norm = std::sqrt(L2norm);
+    ErrorNorm.push_back(L2norm);
+
+    *my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
+            << std::endl;
+
+  }
+
+  // Check the order and intercept
+  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
+  *my_out << "  Stepper = BackwardEuler" << std::endl;
+  *my_out << "  =========================" << std::endl;
+  *my_out << "  Expected order: " << order << std::endl;
+  *my_out << "  Observed order: " << slope << std::endl;
+  *my_out << "  =========================" << std::endl;
+  TEST_FLOATING_EQUALITY( slope, order, 0.015 );
+  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.163653, 1.0e-4 );
+
+  if (comm->getRank() == 0) {
+    std::ofstream ftmp("Tempus_BackwardEuler_SinCos_Sens-Error.dat");
+    double error0 = 0.8*ErrorNorm[0];
+    for (int n=0; n<nTimeStepSizes; n++) {
+      ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
+           << error0*(StepSize[n]/StepSize[0]) << std::endl;
+    }
+    ftmp.close();
+  }
+
+}
+
+TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_Combined_FSA)
+{
+  test_sincos_fsa(true, false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_Combined_FSA_Tangent)
+{
+  test_sincos_fsa(true, true, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_Staggered_FSA)
+{
+  test_sincos_fsa(false, false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_Staggered_FSA_Tangent)
+{
+  test_sincos_fsa(false, true, out, success);
+}
+
+// ************************************************************
+// ************************************************************
+void test_pseudotransient_fsa(const bool use_dfdp_as_tangent,
+                              Teuchos::FancyOStream &out, bool &success)
+{
+  // Read params from .xml file
+  RCP<ParameterList> pList =
+    getParametersFromXmlFile("Tempus_BackwardEuler_SteadyQuadratic.xml");
+
+  // Setup the SteadyQuadraticModel
+  RCP<ParameterList> scm_pl = sublist(pList, "SteadyQuadraticModel", true);
+  scm_pl->set("Use DfDp as Tangent", use_dfdp_as_tangent);
+  RCP<SteadyQuadraticModel<double> > model =
+    Teuchos::rcp(new SteadyQuadraticModel<double>(scm_pl));
+
+  // Setup sensitivities
+  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  ParameterList& sens_pl = pl->sublist("Sensitivities");
+  sens_pl.set("Use DfDp as Tangent", use_dfdp_as_tangent);
+  sens_pl.set("Reuse State Linear Solver", true);
+  sens_pl.set("Force W Update", true); // Have to do this because for this
+  // model the solver seems to be overwriting the matrix
+
+  // Setup the Integrator
+  RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<double> > integrator =
+    Tempus::integratorPseudoTransientForwardSensitivity<double>(pl, model);
+
+  // Integrate to timeMax
+  bool integratorStatus = integrator->advanceTime();
+  TEST_ASSERT(integratorStatus);
+
+  // Test if at 'Final Time'
+  double time = integrator->getTime();
+  double timeFinal =pl->sublist("Default Integrator")
+    .sublist("Time Step Control").get<double>("Final Time");
+  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+  // Time-integrated solution and the exact solution
+  RCP<const Thyra::VectorBase<double> > x_vec = integrator->getX();
+  RCP<const Thyra::MultiVectorBase<double> > DxDp_vec = integrator->getDxDp();
+  const double x = Thyra::get_ele(*x_vec, 0);
+  const double dxdb = Thyra::get_ele(*(DxDp_vec->col(0)), 0);
+  const double x_exact = model->getSteadyStateSolution();
+  const double dxdb_exact = model->getSteadyStateSolutionSensitivity();
+
+  TEST_FLOATING_EQUALITY( x,    x_exact,    1.0e-6 );
+  TEST_FLOATING_EQUALITY( dxdb, dxdb_exact, 1.0e-6 );
+}
+
+TEUCHOS_UNIT_TEST(BackwardEuler, SteadyQuadratic_PseudoTransient_FSA)
+{
+  test_pseudotransient_fsa(false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(BackwardEuler, SteadyQuadratic_PseudoTransient_FSA_Tangent)
+{
+  test_pseudotransient_fsa(true, out, success);
 }
 
 // ************************************************************

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
@@ -1,6 +1,6 @@
 <ParameterList name="BackwardEuler_SinCos">
   <ParameterList name="SinCosModel">
-    <Parameter name="Accept model parameters"    type="bool" value="false"/>
+    <Parameter name="Accept model parameters"    type="bool" value="true"/>
     <Parameter name="Provide nominal values"     type="bool" value="true"/>
     <Parameter name="Coeff a" type="double" value="0.0"/>
     <Parameter name="Coeff f" type="double" value="1.0"/>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SteadyQuadratic.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SteadyQuadratic.xml
@@ -1,13 +1,6 @@
-<ParameterList name="BDF2_SinCos">
-  <ParameterList name="SinCosModel">
-    <Parameter name="Accept model parameters"    type="bool" value="true"/>
-    <Parameter name="Provide nominal values"     type="bool" value="true"/>
-    <Parameter name="Coeff a" type="double" value="0.0"/>
-    <Parameter name="Coeff f" type="double" value="1.0"/>
-    <Parameter name="Coeff L" type="double" value="1.0"/>
-    <Parameter name="IC x0"   type="double" value="0.0"/>
-    <Parameter name="IC x1"   type="double" value="1.0"/>
-    <Parameter name="IC t0"   type="double" value="0.0"/>
+<ParameterList name="BackwardEuler_SteadyQuadratic">
+  <ParameterList name="SteadyQuadraticModel">
+    <Parameter name="Coeff b" type="double" value="1.0"/>
   </ParameterList>
   <ParameterList name="Tempus">
     <Parameter name="Integrator Name" type="string" value="Default Integrator"/>
@@ -23,12 +16,12 @@
       </ParameterList>
       <ParameterList name="Time Step Control">
         <Parameter name="Initial Time"           type="double" value="0.0"/>
-        <Parameter name="Final Time"             type="double" value="1.0"/>
+        <Parameter name="Final Time"             type="double" value="20.0"/>
         <Parameter name="Initial Time Index"     type="int"    value="0"/>
         <Parameter name="Final Time Index"       type="int"    value="10000"/>
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
-        <Parameter name="Initial Time Step"      type="double" value="0.1"/>
-        <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
+        <Parameter name="Initial Time Step"      type="double" value="1.0"/>
+        <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
         <Parameter name="Minimum Order"          type="int"    value="1"/>
         <Parameter name="Initial Order"          type="int"    value="1"/>
         <Parameter name="Maximum Order"          type="int"    value="1"/>
@@ -46,7 +39,7 @@
 
     <ParameterList name="Default Stepper">
 
-      <Parameter name="Stepper Type"   type="string" value="BDF2"/>
+      <Parameter name="Stepper Type"   type="string" value="Backward Euler"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
       <Parameter name="Predictor Name" type="string" value="Default Predictor"/>
 

--- a/packages/tempus/test/ExplicitRK/CMakeLists.txt
+++ b/packages/tempus/test/ExplicitRK/CMakeLists.txt
@@ -9,6 +9,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Test_ExplicitRK_CopyFiles
-  DEST_FILES Tempus_ExplicitRK_SinCos.xml
+  DEST_FILES Tempus_ExplicitRK_SinCos.xml Tempus_ExplicitRK_SteadyQuadratic.xml
   EXEDEPS ExplicitRK
   )

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -9,12 +9,18 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
 
 #include "Thyra_VectorStdOps.hpp"
 
 #include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorForwardSensitivity.hpp"
+#include "Tempus_IntegratorPseudoTransientForwardSensitivity.hpp"
+
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/SteadyQuadraticModel.hpp"
 #include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
 
 #include <vector>
@@ -251,5 +257,279 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
   Teuchos::TimeMonitor::summarize();
 }
 
+// ************************************************************
+// ************************************************************
+void test_sincos_fsa(const bool use_combined_method,
+                     const bool use_dfdp_as_tangent,
+                     Teuchos::FancyOStream &out, bool &success)
+{
+  std::vector<std::string> RKMethods;
+  RKMethods.push_back("RK Forward Euler");
+  RKMethods.push_back("RK Explicit 4 Stage");
+  RKMethods.push_back("RK Explicit 3/8 Rule");
+  RKMethods.push_back("RK Explicit 4 Stage 3rd order by Runge");
+  RKMethods.push_back("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
+  RKMethods.push_back("RK Explicit 3 Stage 3rd order");
+  RKMethods.push_back("RK Explicit 3 Stage 3rd order TVD");
+  RKMethods.push_back("RK Explicit 3 Stage 3rd order by Heun");
+  RKMethods.push_back("RK Explicit 2 Stage 2nd order by Runge");
+  RKMethods.push_back("RK Explicit Trapezoidal");
+  RKMethods.push_back("General ERK");
+  std::vector<double> RKMethodErrors;
+  RKMethodErrors.push_back(0.183799);
+  RKMethodErrors.push_back(6.88637e-06);
+  RKMethodErrors.push_back(6.88637e-06);
+  RKMethodErrors.push_back(0.000264154);
+  RKMethodErrors.push_back(5.22798e-05);
+  RKMethodErrors.push_back(0.000261896);
+  RKMethodErrors.push_back(0.000261896);
+  RKMethodErrors.push_back(0.000261896);
+  RKMethodErrors.push_back(0.00934377);
+  RKMethodErrors.push_back(0.00934377);
+  RKMethodErrors.push_back(6.88637e-06);
+
+  Teuchos::RCP<const Teuchos::Comm<int> > comm =
+    Teuchos::DefaultComm<int>::getComm();
+  Teuchos::RCP<Teuchos::FancyOStream> my_out =
+    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
+  my_out->setOutputToRootOnly(0);
+
+  for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
+
+    std::string RKMethod_ = RKMethods[m];
+    std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');
+    std::replace(RKMethod_.begin(), RKMethod_.end(), '/', '.');
+    std::vector<double> StepSize;
+    std::vector<double> ErrorNorm;
+    const int nTimeStepSizes = 7;
+    double dt = 0.2;
+    double order = 0.0;
+    for (int n=0; n<nTimeStepSizes; n++) {
+
+      // Read params from .xml file
+      RCP<ParameterList> pList =
+        getParametersFromXmlFile("Tempus_ExplicitRK_SinCos.xml");
+
+      // Setup the SinCosModel
+      RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+      scm_pl->set("Use DfDp as Tangent", use_dfdp_as_tangent);
+      RCP<SinCosModel<double> > model =
+        Teuchos::rcp(new SinCosModel<double>(scm_pl));
+
+      // Set the Stepper
+      RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+      if (RKMethods[m] == "General ERK") {
+        pl->sublist("Demo Integrator").set("Stepper Name", "Demo Stepper 2");
+      } else {
+        pl->sublist("Demo Stepper").set("Stepper Type", RKMethods[m]);
+      }
+
+
+      dt /= 2;
+
+      // Setup sensitivities
+      ParameterList& sens_pl = pl->sublist("Sensitivities");
+      if (use_combined_method)
+        sens_pl.set("Sensitivity Method", "Combined");
+      else
+        sens_pl.set("Sensitivity Method", "Staggered");
+      sens_pl.set("Use DfDp as Tangent", use_dfdp_as_tangent);
+
+      // Setup the Integrator and reset initial time step
+      pl->sublist("Demo Integrator")
+        .sublist("Time Step Control").set("Initial Time Step", dt);
+      RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
+        Tempus::integratorForwardSensitivity<double>(pl, model);
+      order = integrator->getStepper()->getOrder();
+
+      // Initial Conditions
+      double t0 = pl->sublist("Demo Integrator")
+        .sublist("Time Step Control").get<double>("Initial Time");
+      // RCP<const Thyra::VectorBase<double> > x0 =
+      //   model->getExactSolution(t0).get_x()->clone_v();
+      RCP<Thyra::VectorBase<double> > x0 =
+        model->getNominalValues().get_x()->clone_v();
+      const int num_param = model->get_p_space(0)->dim();
+      RCP<Thyra::MultiVectorBase<double> > DxDp0 =
+        Thyra::createMembers(model->get_x_space(), num_param);
+      for (int i=0; i<num_param; ++i)
+        Thyra::assign(DxDp0->col(i).ptr(),
+                      *(model->getExactSensSolution(i, t0).get_x()));
+      integrator->setInitialState(t0, x0, Teuchos::null, Teuchos::null,
+                                  DxDp0, Teuchos::null, Teuchos::null);
+
+      // Integrate to timeMax
+      bool integratorStatus = integrator->advanceTime();
+      TEST_ASSERT(integratorStatus)
+
+      // Test if at 'Final Time'
+      double time = integrator->getTime();
+      double timeFinal = pl->sublist("Demo Integrator")
+        .sublist("Time Step Control").get<double>("Final Time");
+      TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+      // Time-integrated solution and the exact solution
+      RCP<const Thyra::VectorBase<double> > x = integrator->getX();
+      RCP<const Thyra::MultiVectorBase<double> > DxDp = integrator->getDxDp();
+      RCP<const Thyra::VectorBase<double> > x_exact =
+        model->getExactSolution(time).get_x();
+      RCP<Thyra::MultiVectorBase<double> > DxDp_exact =
+        Thyra::createMembers(model->get_x_space(), num_param);
+      for (int i=0; i<num_param; ++i)
+        Thyra::assign(DxDp_exact->col(i).ptr(),
+                      *(model->getExactSensSolution(i, time).get_x()));
+
+      // Plot sample solution and exact solution
+      if (comm->getRank() == 0 && n == nTimeStepSizes-1) {
+        typedef Thyra::DefaultMultiVectorProductVector<double> DMVPV;
+
+        std::ofstream ftmp("Tempus_"+RKMethod_+"_SinCos_Sens.dat");
+        RCP<const SolutionHistory<double> > solutionHistory =
+          integrator->getSolutionHistory();
+        RCP< Thyra::MultiVectorBase<double> > DxDp_exact_plot =
+          Thyra::createMembers(model->get_x_space(), num_param);
+        for (int i=0; i<solutionHistory->getNumStates(); i++) {
+          RCP<const SolutionState<double> > solutionState =
+            (*solutionHistory)[i];
+          double time = solutionState->getTime();
+          RCP<const DMVPV> x_prod_plot =
+            Teuchos::rcp_dynamic_cast<const DMVPV>(solutionState->getX());
+          RCP<const Thyra::VectorBase<double> > x_plot =
+            x_prod_plot->getMultiVector()->col(0);
+          RCP<const Thyra::MultiVectorBase<double> > DxDp_plot =
+            x_prod_plot->getMultiVector()->subView(Teuchos::Range1D(1,num_param));
+          RCP<const Thyra::VectorBase<double> > x_exact_plot =
+            model->getExactSolution(time).get_x();
+          for (int j=0; j<num_param; ++j)
+            Thyra::assign(DxDp_exact_plot->col(j).ptr(),
+                          *(model->getExactSensSolution(j, time).get_x()));
+          ftmp << std::fixed << std::setprecision(7)
+               << time
+               << std::setw(11) << get_ele(*(x_plot), 0)
+               << std::setw(11) << get_ele(*(x_plot), 1);
+          for (int j=0; j<num_param; ++j)
+            ftmp << std::setw(11) << get_ele(*(DxDp_plot->col(j)), 0)
+                 << std::setw(11) << get_ele(*(DxDp_plot->col(j)), 1);
+          ftmp << std::setw(11) << get_ele(*(x_exact_plot), 0)
+               << std::setw(11) << get_ele(*(x_exact_plot), 1);
+          for (int j=0; j<num_param; ++j)
+            ftmp << std::setw(11) << get_ele(*(DxDp_exact_plot->col(j)), 0)
+                 << std::setw(11) << get_ele(*(DxDp_exact_plot->col(j)), 1);
+          ftmp << std::endl;
+        }
+        ftmp.close();
+      }
+
+      // Calculate the error
+      RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+      RCP<Thyra::MultiVectorBase<double> > DxDpdiff = DxDp->clone_mv();
+      Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+      Thyra::V_VmV(DxDpdiff.ptr(), *DxDp_exact, *DxDp);
+      StepSize.push_back(dt);
+      double L2norm = Thyra::norm_2(*xdiff);
+      L2norm *= L2norm;
+      Teuchos::Array<double> L2norm_DxDp(num_param);
+      Thyra::norms_2(*DxDpdiff, L2norm_DxDp());
+      for (int i=0; i<num_param; ++i)
+        L2norm += L2norm_DxDp[i]*L2norm_DxDp[i];
+      L2norm = std::sqrt(L2norm);
+      ErrorNorm.push_back(L2norm);
+
+      *my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
+              << std::endl;
+    }
+
+    // Check the order and intercept
+    double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
+    *my_out << "  Stepper = " << RKMethods[m] << std::endl;
+    *my_out << "  =========================" << std::endl;
+    *my_out << "  Expected order: " << order << std::endl;
+    *my_out << "  Observed order: " << slope << std::endl;
+    *my_out << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY( slope, order, 0.015 );
+    TEST_FLOATING_EQUALITY( ErrorNorm[0], RKMethodErrors[m], 1.0e-4 );
+
+    if (comm->getRank() == 0) {
+      std::ofstream ftmp("Tempus_"+RKMethod_+"_SinCos_Sens-Error.dat");
+      double error0 = 0.8*ErrorNorm[0];
+      for (int n=0; n<nTimeStepSizes; n++) {
+        ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
+             << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
+      }
+      ftmp.close();
+    }
+  }
+
+  Teuchos::TimeMonitor::summarize();
+}
+
+TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_Combined_FSA)
+{
+  test_sincos_fsa(true, false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_Combined_FSA_Tangent)
+{
+  test_sincos_fsa(true, true, out, success);
+}
+
+// Note:  Staggered FSA approach not relevant for explicit methods
+
+// ************************************************************
+// ************************************************************
+void test_pseudotransient_fsa(const bool use_dfdp_as_tangent,
+                              Teuchos::FancyOStream &out, bool &success)
+{
+  // Read params from .xml file
+  RCP<ParameterList> pList =
+    getParametersFromXmlFile("Tempus_ExplicitRK_SteadyQuadratic.xml");
+
+  // Setup the SteadyQuadraticModel
+  RCP<ParameterList> scm_pl = sublist(pList, "SteadyQuadraticModel", true);
+  scm_pl->set("Use DfDp as Tangent", use_dfdp_as_tangent);
+  RCP<SteadyQuadraticModel<double> > model =
+    Teuchos::rcp(new SteadyQuadraticModel<double>(scm_pl));
+
+  // Setup sensitivities
+  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  ParameterList& sens_pl = pl->sublist("Sensitivities");
+  sens_pl.set("Use DfDp as Tangent", use_dfdp_as_tangent);
+
+  // Setup the Integrator
+  RCP<Tempus::IntegratorPseudoTransientForwardSensitivity<double> > integrator =
+    Tempus::integratorPseudoTransientForwardSensitivity<double>(pl, model);
+
+  // Integrate to timeMax
+  bool integratorStatus = integrator->advanceTime();
+  TEST_ASSERT(integratorStatus);
+
+  // Test if at 'Final Time'
+  double time = integrator->getTime();
+  double timeFinal = pl->sublist("Demo Integrator")
+    .sublist("Time Step Control").get<double>("Final Time");
+  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+  // Time-integrated solution and the exact solution
+  RCP<const Thyra::VectorBase<double> > x_vec = integrator->getX();
+  RCP<const Thyra::MultiVectorBase<double> > DxDp_vec = integrator->getDxDp();
+  const double x = Thyra::get_ele(*x_vec, 0);
+  const double dxdb = Thyra::get_ele(*(DxDp_vec->col(0)), 0);
+  const double x_exact = model->getSteadyStateSolution();
+  const double dxdb_exact = model->getSteadyStateSolutionSensitivity();
+
+  TEST_FLOATING_EQUALITY( x,    x_exact,    1.0e-6 );
+  TEST_FLOATING_EQUALITY( dxdb, dxdb_exact, 1.0e-6 );
+}
+
+TEUCHOS_UNIT_TEST(ExplicitRK, SteadyQuadratic_PseudoTransient_FSA)
+{
+  test_pseudotransient_fsa(false, out, success);
+}
+
+TEUCHOS_UNIT_TEST(ExplicitRK, SteadyQuadratic_PseudoTransient_FSA_Tangent)
+{
+  test_pseudotransient_fsa(true, out, success);
+}
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SteadyQuadratic.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SteadyQuadratic.xml
@@ -1,13 +1,6 @@
 <ParameterList name="ExplicitRK_SinCos">
-  <ParameterList name="SinCosModel">
-    <Parameter name="Accept model parameters"    type="bool" value="true"/>
-    <Parameter name="Provide nominal values"     type="bool" value="true"/>
-    <Parameter name="Coeff a" type="double" value="0.0"/>
-    <Parameter name="Coeff f" type="double" value="1.0"/>
-    <Parameter name="Coeff L" type="double" value="1.0"/>
-    <Parameter name="IC x0"   type="double" value="0.0"/>
-    <Parameter name="IC x1"   type="double" value="1.0"/>
-    <Parameter name="IC t0"   type="double" value="0.0"/>
+  <ParameterList name="SteadyQuadraticModel">
+    <Parameter name="Coeff b" type="double" value="1.0"/>
   </ParameterList>
   <ParameterList name="Tempus">
     <Parameter name="Integrator Name" type="string" value="Demo Integrator"/>
@@ -23,15 +16,15 @@
       </ParameterList>
       <ParameterList name="Time Step Control">
         <Parameter name="Initial Time"           type="double" value="0.0"/>
-        <Parameter name="Final Time"             type="double" value="1.0"/>
+        <Parameter name="Final Time"             type="double" value="20.0"/>
         <Parameter name="Initial Time Index"     type="int"    value="0"/>
         <Parameter name="Final Time Index"       type="int"    value="10000"/>
         <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
-        <Parameter name="Initial Time Step"      type="double" value="0.1"/>
-        <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
-        <Parameter name="Minimum Order"          type="int"    value="0"/>
-        <Parameter name="Initial Order"          type="int"    value="0"/>
-        <Parameter name="Maximum Order"          type="int"    value="0"/>
+        <Parameter name="Initial Time Step"      type="double" value="1.0"/>
+        <Parameter name="Maximum Time Step"      type="double" value="1.0"/>
+        <Parameter name="Minimum Order"          type="int"    value="1"/>
+        <Parameter name="Initial Order"          type="int"    value="1"/>
+        <Parameter name="Maximum Order"          type="int"    value="10"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
@@ -45,7 +38,7 @@
     </ParameterList>
 
     <ParameterList name="Demo Stepper">
-      <Parameter name="Stepper Type" type="string" value="RK Forward Euler"/>
+      <Parameter name="Stepper Type" type="string" value="RK Explicit 4 Stage"/>
     </ParameterList>
 
     <ParameterList name="Demo Stepper 2">

--- a/packages/tempus/test/TestModels/CMakeLists.txt
+++ b/packages/tempus/test/TestModels/CMakeLists.txt
@@ -10,7 +10,7 @@ SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_SOURCE_DIR})
 APPEND_GLOB(HEADERS ${DIR}/*.hpp)
 APPEND_GLOB(SOURCES ${DIR}/*.cpp)
 
-# Must glob the binary dir last to get all of the 
+# Must glob the binary dir last to get all of the
 # auto-generated ETI headers
 TRILINOS_CREATE_CLIENT_TEMPLATE_HEADERS(${DIR})
 SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/packages/tempus/test/TestModels/SinCosModel_decl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_decl.hpp
@@ -149,6 +149,7 @@ private:
   int ng_;          ///< Number of elements in this observation function (1)
   bool haveIC_;     ///< false => no nominal values are provided (default=true)
   bool acceptModelParams_; ///< Changes inArgs to require parameters
+  bool useDfDpAsTangent_; ///< Treat DfDp OutArg as tangent (df/dx*dx/dp+df/dp)
   mutable bool isInitialized_;
   mutable Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs_;
   mutable Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs_;
@@ -157,6 +158,7 @@ private:
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > f_space_;
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > p_space_;
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > g_space_;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > DxDp_space_;
 
   // Parameters for the model:  x_0(t) = a + b*sin(f*t+phi)
   //                            x_1(t) = b*f*cos(f*t+phi)

--- a/packages/tempus/test/TestModels/SinCosModel_impl.hpp
+++ b/packages/tempus/test/TestModels/SinCosModel_impl.hpp
@@ -18,6 +18,7 @@
 #include "Thyra_DefaultMultiVectorLinearOpWithSolve.hpp"
 #include "Thyra_DefaultLinearOpSource.hpp"
 #include "Thyra_VectorStdOps.hpp"
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
 
 #include <iostream>
 
@@ -30,11 +31,12 @@ SinCosModel(Teuchos::RCP<Teuchos::ParameterList> pList_)
 {
   isInitialized_ = false;
   dim_ = 2;
-  Np_ = 1; // Number of parameter vectors (1)
+  Np_ = 3; // Number of parameter vectors (p, dx/dp, dx_dot/dp)
   np_ = 3; // Number of parameters in this vector (3)
   Ng_ = 1; // Number of observation functions (1)
   ng_ = 1; // Number of elements in this observation function (1)
   acceptModelParams_ = false;
+  useDfDpAsTangent_ = false;
   haveIC_ = true;
   a_ = 0.0;
   f_ = 1.0;
@@ -51,6 +53,9 @@ SinCosModel(Teuchos::RCP<Teuchos::ParameterList> pList_)
   g_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(ng_);
 
   setParameterList(pList_);
+
+  // Create DxDp product space
+  DxDp_space_ = Thyra::multiVectorProductVectorSpace(x_space_, np_);
 }
 
 template<class Scalar>
@@ -275,8 +280,11 @@ evalModelImpl(
   const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs
   ) const
 {
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
   using Teuchos::RCP;
   using Thyra::VectorBase;
+  using Thyra::MultiVectorBase;
+  using Teuchos::rcp_dynamic_cast;
   TEUCHOS_TEST_FOR_EXCEPTION( !isInitialized_, std::logic_error,
       "Error, setupInOutArgs_ must be called first!\n");
 
@@ -294,6 +302,16 @@ evalModelImpl(
     a = p_in_view[0];
     f = p_in_view[1];
     L = p_in_view[2];
+  }
+
+  RCP<const MultiVectorBase<Scalar> > DxDp_in, DxdotDp_in;
+  if (acceptModelParams_) {
+    if (inArgs.get_p(1) != Teuchos::null)
+      DxDp_in =
+        rcp_dynamic_cast<const DMVPV>(inArgs.get_p(1))->getMultiVector();
+    if (inArgs.get_p(2) != Teuchos::null)
+      DxdotDp_in =
+        rcp_dynamic_cast<const DMVPV>(inArgs.get_p(2))->getMultiVector();
   }
 
   Scalar beta = inArgs.get_beta();
@@ -332,6 +350,17 @@ evalModelImpl(
       DfDp_out_view(1,0) = (f/L)*(f/L);
       DfDp_out_view(1,1) = (2.0*f/(L*L))*(a-x_in_view[0]);
       DfDp_out_view(1,2) = -(2.0*f*f/(L*L*L))*(a-x_in_view[0]);
+
+      // Compute df/dp + (df/dx) * (dx/dp)
+      if (useDfDpAsTangent_ && !is_null(DxDp_in)) {
+        Thyra::ConstDetachedMultiVectorView<Scalar> DxDp( *DxDp_in );
+        DfDp_out_view(0,0) +=  DxDp(1,0);
+        DfDp_out_view(0,1) +=  DxDp(1,1);
+        DfDp_out_view(0,2) +=  DxDp(1,2);
+        DfDp_out_view(1,0) += -(f/L)*(f/L) * DxDp(0,0);
+        DfDp_out_view(1,1) += -(f/L)*(f/L) * DxDp(0,1);
+        DfDp_out_view(1,2) += -(f/L)*(f/L) * DxDp(0,2);
+      }
     }
   } else {
 
@@ -363,6 +392,26 @@ evalModelImpl(
       DfDp_out_view(1,0) = -(f/L)*(f/L);
       DfDp_out_view(1,1) = -(2.0*f/(L*L))*(a-x_in_view[0]);
       DfDp_out_view(1,2) = +(2.0*f*f/(L*L*L))*(a-x_in_view[0]);
+
+      // Compute df/dp + (df/dx_dot) * (dx_dot/dp) + (df/dx) * (dx/dp)
+      if (useDfDpAsTangent_ && !is_null(DxdotDp_in)) {
+        Thyra::ConstDetachedMultiVectorView<Scalar> DxdotDp( *DxdotDp_in );
+        DfDp_out_view(0,0) += DxdotDp(0,0);
+        DfDp_out_view(0,1) += DxdotDp(0,1);
+        DfDp_out_view(0,2) += DxdotDp(0,2);
+        DfDp_out_view(1,0) += DxdotDp(1,0);
+        DfDp_out_view(1,1) += DxdotDp(1,1);
+        DfDp_out_view(1,2) += DxdotDp(1,2);
+      }
+      if (useDfDpAsTangent_ && !is_null(DxDp_in)) {
+        Thyra::ConstDetachedMultiVectorView<Scalar> DxDp( *DxDp_in );
+        DfDp_out_view(0,0) += -DxDp(1,0);
+        DfDp_out_view(0,1) += -DxDp(1,1);
+        DfDp_out_view(0,2) += -DxDp(1,2);
+        DfDp_out_view(1,0) +=  (f/L)*(f/L) * DxDp(0,0);
+        DfDp_out_view(1,1) +=  (f/L)*(f/L) * DxDp(0,1);
+        DfDp_out_view(1,2) +=  (f/L)*(f/L) * DxDp(0,2);
+      }
     }
   }
 }
@@ -376,7 +425,11 @@ get_p_space(int l) const
     return Teuchos::null;
   }
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( l, 0, Np_ );
-  return p_space_;
+  if (l == 0)
+    return p_space_;
+  else if (l == 1 || l == 2)
+    return DxDp_space_;
+  return Teuchos::null;
 }
 
 template<class Scalar>
@@ -390,9 +443,15 @@ get_p_names(int l) const
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( l, 0, Np_ );
   Teuchos::RCP<Teuchos::Array<std::string> > p_strings =
     Teuchos::rcp(new Teuchos::Array<std::string>());
-  p_strings->push_back("Model Coefficient:  a");
-  p_strings->push_back("Model Coefficient:  f");
-  p_strings->push_back("Model Coefficient:  L");
+  if (l == 0) {
+    p_strings->push_back("Model Coefficient:  a");
+    p_strings->push_back("Model Coefficient:  f");
+    p_strings->push_back("Model Coefficient:  L");
+  }
+  else if (l == 1)
+    p_strings->push_back("DxDp");
+  else if (l == 2)
+    p_strings->push_back("Dx_dotDp");
   return p_strings;
 }
 
@@ -494,6 +553,7 @@ setParameterList(Teuchos::RCP<Teuchos::ParameterList> const& paramList)
   Teuchos::RCP<ParameterList> pl = this->getMyNonconstParamList();
   bool acceptModelParams = get<bool>(*pl,"Accept model parameters");
   bool haveIC = get<bool>(*pl,"Provide nominal values");
+  bool useDfDpAsTangent = get<bool>(*pl, "Use DfDp as Tangent");
   if ( (acceptModelParams != acceptModelParams_) ||
        (haveIC != haveIC_)
      ) {
@@ -501,6 +561,7 @@ setParameterList(Teuchos::RCP<Teuchos::ParameterList> const& paramList)
   }
   acceptModelParams_ = acceptModelParams;
   haveIC_ = haveIC;
+  useDfDpAsTangent_ = useDfDpAsTangent;
   a_ = get<Scalar>(*pl,"Coeff a");
   f_ = get<Scalar>(*pl,"Coeff f");
   L_ = get<Scalar>(*pl,"Coeff L");
@@ -521,6 +582,7 @@ getValidParameters() const
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     pl->set("Accept model parameters", false);
     pl->set("Provide nominal values", true);
+    pl->set("Use DfDp as Tangent", false);
     Teuchos::setDoubleParameter(
         "Coeff a", 0.0, "Coefficient a in model", &*pl);
     Teuchos::setDoubleParameter(

--- a/packages/tempus/test/TestModels/SteadyQuadraticModel.cpp
+++ b/packages/tempus/test/TestModels/SteadyQuadraticModel.cpp
@@ -1,0 +1,19 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "SteadyQuadraticModel.hpp"
+#include "SteadyQuadraticModel_impl.hpp"
+
+namespace Tempus_Test {
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(SteadyQuadraticModel)
+}
+
+#endif

--- a/packages/tempus/test/TestModels/SteadyQuadraticModel_decl.hpp
+++ b/packages/tempus/test/TestModels/SteadyQuadraticModel_decl.hpp
@@ -1,0 +1,105 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef TEMPUS_TEST_STEADY_QUADRATIC_MODEL_DECL_HPP
+#define TEMPUS_TEST_STEADY_QUADRATIC_MODEL_DECL_HPP
+
+#include "Thyra_ModelEvaluator.hpp" // Interface
+#include "Thyra_StateFuncModelEvaluatorBase.hpp" // Implementation
+
+#include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+namespace Tempus_Test {
+
+/** \brief Simple quadratic equation with a stable steady-state.
+  * This is a simple differential equation
+  *   \f[
+  *   \mathbf{\dot{x}}=\mathbf{x}^2 - b^2
+  *   \f]
+  * which has steady state solutions \f$\mathbf{x} = \pm b\f$.  The solution
+  * \f$\mathbf{x} = b\f$ is stable if \f$b < 0\f$ and the solution
+  * \f$\mathbf{x} = -b\f$ is stable if \f$b > 0\f$.  This model is used to
+  * test pseudo-transient sensitivity analysis methods.
+  */
+template<class Scalar>
+class SteadyQuadraticModel
+  : public Thyra::StateFuncModelEvaluatorBase<Scalar>,
+    public Teuchos::ParameterListAcceptorDefaultBase
+{
+  public:
+
+  // Constructor
+  SteadyQuadraticModel(Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null);
+
+  // Exact solution
+  Scalar getSteadyStateSolution() const;
+
+  // Exact sensitivity solution
+  Scalar getSteadyStateSolutionSensitivity() const;
+
+  /** \name Public functions overridden from ModelEvaluator. */
+  //@{
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_f_space() const;
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
+  Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> > create_W() const;
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
+  Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > get_W_factory() const;
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
+
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
+  Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int l) const;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
+
+  //@}
+
+  /** \name Public functions overridden from ParameterListAcceptor. */
+  //@{
+  void setParameterList(Teuchos::RCP<Teuchos::ParameterList> const& paramList);
+  Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
+  //@}
+
+private:
+
+  void setupInOutArgs_() const;
+
+  /** \name Private functions overridden from ModelEvaluatorDefaultBase. */
+  //@{
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
+  void evalModelImpl(
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs_bar,
+    const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs_bar
+    ) const;
+  //@}
+
+private:
+  int dim_;         ///< Number of state unknowns (2)
+  int Np_;          ///< Number of parameter vectors (1)
+  int np_;          ///< Number of parameters in this vector (2)
+  int Ng_;          ///< Number of observation functions (1)
+  int ng_;          ///< Number of elements in this observation function (1)
+  bool useDfDpAsTangent_; ///< Treat DfDp OutArg as tangent (df/dx*dx/dp+df/dp)
+  mutable bool isInitialized_;
+  mutable Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs_;
+  mutable Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs_;
+  mutable Thyra::ModelEvaluatorBase::InArgs<Scalar>  nominalValues_;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > x_space_;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > f_space_;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > p_space_;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > g_space_;
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > DxDp_space_;
+
+  // Parameters for the model
+  Scalar b_;     ///< Model parameter
+};
+
+
+} // namespace Tempus_Test
+#endif // TEMPUS_TEST_STEADY_QUADRATIC_MODEL_DECL_HPP

--- a/packages/tempus/test/TestModels/SteadyQuadraticModel_impl.hpp
+++ b/packages/tempus/test/TestModels/SteadyQuadraticModel_impl.hpp
@@ -1,0 +1,420 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef TEMPUS_TEST_STEADY_QUADRATIC_MODEL_IMPL_HPP
+#define TEMPUS_TEST_STEADY_QUADRATIC_MODEL_IMPL_HPP
+
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+
+#include "Thyra_DefaultSpmdVectorSpace.hpp"
+#include "Thyra_DetachedVectorView.hpp"
+#include "Thyra_DetachedMultiVectorView.hpp"
+#include "Thyra_DefaultSerialDenseLinearOpWithSolveFactory.hpp"
+#include "Thyra_DefaultMultiVectorLinearOpWithSolve.hpp"
+#include "Thyra_DefaultLinearOpSource.hpp"
+#include "Thyra_VectorStdOps.hpp"
+#include "Thyra_DefaultMultiVectorProductVector.hpp"
+
+#include <iostream>
+
+
+namespace Tempus_Test {
+
+template<class Scalar>
+SteadyQuadraticModel<Scalar>::
+SteadyQuadraticModel(Teuchos::RCP<Teuchos::ParameterList> pList_)
+{
+  isInitialized_ = false;
+  dim_ = 1;
+  Np_ = 3; // Number of parameter vectors (p, dx/dp, dx_dot/dp)
+  np_ = 1; // Number of parameters in this vector (3)
+  Ng_ = 1; // Number of observation functions (1)
+  ng_ = 1; // Number of elements in this observation function (1)
+  useDfDpAsTangent_ = false;
+  b_ = 1.0;
+
+  // Create x_space and f_space
+  x_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(dim_);
+  f_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(dim_);
+  // Create p_space and g_space
+  p_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(np_);
+  g_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(ng_);
+
+  setParameterList(pList_);
+
+  // Create DxDp product space
+  DxDp_space_ = Thyra::multiVectorProductVectorSpace(x_space_, np_);
+}
+
+template<class Scalar>
+Scalar
+SteadyQuadraticModel<Scalar>::
+getSteadyStateSolution() const
+{
+  if (b_ < 0.0)
+    return b_;
+  return -b_;
+}
+
+template<class Scalar>
+Scalar
+SteadyQuadraticModel<Scalar>::
+getSteadyStateSolutionSensitivity() const
+{
+  if (b_ < 0.0)
+    return 1.0;
+  return -1.0;
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+get_x_space() const
+{
+  return x_space_;
+}
+
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+get_f_space() const
+{
+  return f_space_;
+}
+
+
+template<class Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+SteadyQuadraticModel<Scalar>::
+getNominalValues() const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( !isInitialized_, std::logic_error,
+      "Error, setupInOutArgs_ must be called first!\n");
+  return nominalValues_;
+}
+
+
+template<class Scalar>
+Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+create_W() const
+{
+  using Teuchos::RCP;
+  RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > W_factory = this->get_W_factory();
+  RCP<Thyra::LinearOpBase<Scalar> > matrix = this->create_W_op();
+  {
+    // 01/20/09 tscoffe:  This is a total hack to provide a full rank matrix to
+    // linearOpWithSolve because it ends up factoring the matrix during
+    // initialization, which it really shouldn't do, or I'm doing something
+    // wrong here.   The net effect is that I get exceptions thrown in
+    // optimized mode due to the matrix being rank deficient unless I do this.
+    RCP<Thyra::MultiVectorBase<Scalar> > multivec =
+      Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Scalar> >(matrix,true);
+    {
+      RCP<Thyra::VectorBase<Scalar> > vec = Thyra::createMember(x_space_);
+      {
+        Thyra::DetachedVectorView<Scalar> vec_view( *vec );
+        vec_view[0] = 1.0;
+      }
+      V_V(multivec->col(0).ptr(),*vec);
+    }
+  }
+  RCP<Thyra::LinearOpWithSolveBase<Scalar> > W =
+    Thyra::linearOpWithSolve<Scalar>(
+      *W_factory,
+      matrix
+      );
+  return W;
+}
+
+template<class Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+create_W_op() const
+{
+  Teuchos::RCP<Thyra::MultiVectorBase<Scalar> > matrix =
+    Thyra::createMembers(x_space_, dim_);
+  return(matrix);
+}
+
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+get_W_factory() const
+{
+  Teuchos::RCP<Thyra::LinearOpWithSolveFactoryBase<Scalar> > W_factory =
+    Thyra::defaultSerialDenseLinearOpWithSolveFactory<Scalar>();
+  return W_factory;
+}
+
+
+template<class Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+SteadyQuadraticModel<Scalar>::
+createInArgs() const
+{
+  setupInOutArgs_();
+  return inArgs_;
+}
+
+
+// Private functions overridden from ModelEvaluatorDefaultBase
+
+
+template<class Scalar>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+SteadyQuadraticModel<Scalar>::
+createOutArgsImpl() const
+{
+  setupInOutArgs_();
+  return outArgs_;
+}
+
+
+template<class Scalar>
+void
+SteadyQuadraticModel<Scalar>::
+evalModelImpl(
+  const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs
+  ) const
+{
+  typedef Thyra::DefaultMultiVectorProductVector<Scalar> DMVPV;
+  using Teuchos::RCP;
+  using Thyra::VectorBase;
+  using Thyra::MultiVectorBase;
+  using Teuchos::rcp_dynamic_cast;
+  TEUCHOS_TEST_FOR_EXCEPTION( !isInitialized_, std::logic_error,
+      "Error, setupInOutArgs_ must be called first!\n");
+
+  const RCP<const VectorBase<Scalar> > x_in = inArgs.get_x().assert_not_null();
+  Thyra::ConstDetachedVectorView<Scalar> x_in_view( *x_in );
+
+  Scalar b = b_;
+  const RCP<const VectorBase<Scalar> > p_in = inArgs.get_p(0);
+  if (p_in != Teuchos::null) {
+    Thyra::ConstDetachedVectorView<Scalar> p_in_view( *p_in );
+    b = p_in_view[0];
+  }
+
+  RCP<const MultiVectorBase<Scalar> > DxDp_in, DxdotDp_in;
+  if (inArgs.get_p(1) != Teuchos::null)
+    DxDp_in =
+      rcp_dynamic_cast<const DMVPV>(inArgs.get_p(1))->getMultiVector();
+  if (inArgs.get_p(2) != Teuchos::null)
+    DxdotDp_in =
+      rcp_dynamic_cast<const DMVPV>(inArgs.get_p(2))->getMultiVector();
+
+  Scalar beta = inArgs.get_beta();
+
+  const RCP<VectorBase<Scalar> > f_out = outArgs.get_f();
+  const RCP<Thyra::LinearOpBase<Scalar> > W_out = outArgs.get_W_op();
+  RCP<Thyra::MultiVectorBase<Scalar> > DfDp_out;
+  Thyra::ModelEvaluatorBase::Derivative<Scalar> DfDp = outArgs.get_DfDp(0);
+  DfDp_out = DfDp.getMultiVector();
+
+  if (inArgs.get_x_dot().is_null()) {
+
+    // Evaluate the Explicit ODE f(x,t) [= 0]
+    if (!is_null(f_out)) {
+      Thyra::DetachedVectorView<Scalar> f_out_view( *f_out );
+      f_out_view[0] = x_in_view[0]*x_in_view[0] - b*b;
+    }
+    if (!is_null(W_out)) {
+      RCP<Thyra::MultiVectorBase<Scalar> > matrix =
+        Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Scalar> >(W_out,true);
+      Thyra::DetachedMultiVectorView<Scalar> matrix_view( *matrix );
+      matrix_view(0,0) = beta*2.0*x_in_view[0];
+    }
+    if (!is_null(DfDp_out)) {
+      Thyra::DetachedMultiVectorView<Scalar> DfDp_out_view( *DfDp_out );
+      DfDp_out_view(0,0) = -2.0*b;
+
+      // Compute df/dp + (df/dx) * (dx/dp)
+      if (useDfDpAsTangent_ && !is_null(DxDp_in)) {
+        Thyra::ConstDetachedMultiVectorView<Scalar> DxDp( *DxDp_in );
+        DfDp_out_view(0,0) +=  2.0*x_in_view[0]*DxDp(0,0);
+      }
+    }
+  } else {
+
+    // Evaluate the implicit ODE f(xdot, x, t) [= 0]
+    RCP<const VectorBase<Scalar> > x_dot_in;
+    x_dot_in = inArgs.get_x_dot().assert_not_null();
+    Scalar alpha = inArgs.get_alpha();
+    if (!is_null(f_out)) {
+      Thyra::DetachedVectorView<Scalar> f_out_view( *f_out );
+      Thyra::ConstDetachedVectorView<Scalar> x_dot_in_view( *x_dot_in );
+      f_out_view[0] = x_dot_in_view[0] - (x_in_view[0]*x_in_view[0] - b*b);
+    }
+    if (!is_null(W_out)) {
+      RCP<Thyra::MultiVectorBase<Scalar> > matrix =
+        Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Scalar> >(W_out,true);
+      Thyra::DetachedMultiVectorView<Scalar> matrix_view( *matrix );
+      matrix_view(0,0) = alpha - beta*2.0*x_in_view[0];
+    }
+    if (!is_null(DfDp_out)) {
+      Thyra::DetachedMultiVectorView<Scalar> DfDp_out_view( *DfDp_out );
+      DfDp_out_view(0,0) = 2.0*b;
+
+      // Compute df/dp + (df/dx_dot) * (dx_dot/dp) + (df/dx) * (dx/dp)
+      if (useDfDpAsTangent_ && !is_null(DxdotDp_in)) {
+        Thyra::ConstDetachedMultiVectorView<Scalar> DxdotDp( *DxdotDp_in );
+        DfDp_out_view(0,0) += DxdotDp(0,0);
+      }
+      if (useDfDpAsTangent_ && !is_null(DxDp_in)) {
+        Thyra::ConstDetachedMultiVectorView<Scalar> DxDp( *DxDp_in );
+        DfDp_out_view(0,0) += -2.0*x_in_view[0]*DxDp(0,0);
+      }
+    }
+  }
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+get_p_space(int l) const
+{
+  TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( l, 0, Np_ );
+  if (l == 0)
+    return p_space_;
+  else if (l == 1 || l == 2)
+    return DxDp_space_;
+  return Teuchos::null;
+}
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::Array<std::string> >
+SteadyQuadraticModel<Scalar>::
+get_p_names(int l) const
+{
+  TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( l, 0, Np_ );
+  Teuchos::RCP<Teuchos::Array<std::string> > p_strings =
+    Teuchos::rcp(new Teuchos::Array<std::string>());
+  if (l == 0) {
+    p_strings->push_back("Model Coefficient:  b");
+  }
+  else if (l == 1)
+    p_strings->push_back("DxDp");
+  else if (l == 2)
+    p_strings->push_back("Dx_dotDp");
+  return p_strings;
+}
+
+template<class Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+SteadyQuadraticModel<Scalar>::
+get_g_space(int j) const
+{
+  TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( j, 0, Ng_ );
+  return g_space_;
+}
+
+// private
+
+template<class Scalar>
+void
+SteadyQuadraticModel<Scalar>::
+setupInOutArgs_() const
+{
+  if (isInitialized_) {
+    return;
+  }
+
+  {
+    // Set up prototypical InArgs
+    Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
+    inArgs.setModelEvalDescription(this->description());
+    inArgs.setSupports( Thyra::ModelEvaluatorBase::IN_ARG_t );
+    inArgs.setSupports( Thyra::ModelEvaluatorBase::IN_ARG_x );
+    inArgs.setSupports( Thyra::ModelEvaluatorBase::IN_ARG_beta );
+    inArgs.setSupports( Thyra::ModelEvaluatorBase::IN_ARG_x_dot );
+    inArgs.setSupports( Thyra::ModelEvaluatorBase::IN_ARG_alpha );
+    inArgs.set_Np(Np_);
+    inArgs_ = inArgs;
+  }
+
+  {
+    // Set up prototypical OutArgs
+    Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
+    outArgs.setModelEvalDescription(this->description());
+    outArgs.setSupports( Thyra::ModelEvaluatorBase::OUT_ARG_f );
+    outArgs.setSupports( Thyra::ModelEvaluatorBase::OUT_ARG_W_op );
+    outArgs.set_Np_Ng(Np_,Ng_);
+    outArgs.setSupports( Thyra::ModelEvaluatorBase::OUT_ARG_DfDp,0,
+                         Thyra::ModelEvaluatorBase::DERIV_MV_BY_COL );
+    outArgs_ = outArgs;
+  }
+
+  // Set up nominal values
+  nominalValues_ = inArgs_;
+  nominalValues_.set_t(0.0);
+  const Teuchos::RCP<Thyra::VectorBase<Scalar> > x_ic = createMember(x_space_);
+  { // scope to delete DetachedVectorView
+    Thyra::DetachedVectorView<Scalar> x_ic_view( *x_ic );
+    x_ic_view[0] = 0.0;
+  }
+  nominalValues_.set_x(x_ic);
+  const Teuchos::RCP<Thyra::VectorBase<Scalar> > p_ic = createMember(p_space_);
+  {
+    Thyra::DetachedVectorView<Scalar> p_ic_view( *p_ic );
+    p_ic_view[0] = b_;
+  }
+  nominalValues_.set_p(0,p_ic);
+
+  const Teuchos::RCP<Thyra::VectorBase<Scalar> > x_dot_ic =
+    createMember(x_space_);
+  { // scope to delete DetachedVectorView
+    Thyra::DetachedVectorView<Scalar> x_dot_ic_view( *x_dot_ic );
+    x_dot_ic_view[0] = 0.0;
+  }
+  nominalValues_.set_x_dot(x_dot_ic);
+
+  isInitialized_ = true;
+
+}
+
+template<class Scalar>
+void
+SteadyQuadraticModel<Scalar>::
+setParameterList(Teuchos::RCP<Teuchos::ParameterList> const& paramList)
+{
+  using Teuchos::get;
+  using Teuchos::ParameterList;
+  Teuchos::RCP<ParameterList> tmpPL =
+    Teuchos::rcp(new ParameterList("SteadyQuadraticModel"));
+  if (paramList != Teuchos::null) tmpPL = paramList;
+  tmpPL->validateParametersAndSetDefaults(*this->getValidParameters());
+  this->setMyParamList(tmpPL);
+  Teuchos::RCP<ParameterList> pl = this->getMyNonconstParamList();
+  useDfDpAsTangent_  = get<bool>(*pl, "Use DfDp as Tangent");
+  b_ = get<Scalar>(*pl,"Coeff b");
+  isInitialized_ = false; // For setup of new in/out args
+  setupInOutArgs_();
+}
+
+template<class Scalar>
+Teuchos::RCP<const Teuchos::ParameterList>
+SteadyQuadraticModel<Scalar>::
+getValidParameters() const
+{
+  static Teuchos::RCP<const Teuchos::ParameterList> validPL;
+  if (is_null(validPL)) {
+    Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
+    pl->set("Use DfDp as Tangent", false);
+    Teuchos::setDoubleParameter(
+        "Coeff b", 1.0, "Coefficient b in model", &*pl);
+    validPL = pl;
+  }
+  return validPL;
+}
+
+} // namespace Tempus_Test
+#endif // TEMPUS_TEST_STEADY_QUADRATIC_MODEL_IMPL_HPP


### PR DESCRIPTION
This pull-request adds integrators supporting the combined, staggered, and
pseudotransient forward sensitivity analysis methods where the
sensitivity equations are solved alongside the forward equations.  The
different methods refer to how the solves between states/sensitivities
are partitioned:

  * combined:  solved together (best for explicit)
  * staggered: solve state equations and then sensitivity equations for
    each time step (best for implicit)
  * pseudotransient: do full state equation integration followed by full
    sensitivity equation integration (for when time integrator is used
    as a steady-state solver)

In all cases there is an option, "Use DfDp as Tangent", that controls
whether the DfDp out-arg is interpreted as the tangent df/dp +
df/dx*dx/dp + df/dxdot*dxdot/dp, or not (which is not regular model
evaluator behavior).  If the model supports it, it is a much simpler and
more efficient way to assemble the sensitivity equations.

It also supports options to reuse the linear solver from the state
equations when solving the sensitivity equations.  This saves Jacobian
assembly time and preconditioner generation time.  Supporting it
required one small change to the NOX-Thyra interface to not throw when
accessing the preconditioner RCP if it is null (because there is no way
to know beforehand if it is null or not until you access it).

Tests were added for Backward Euler, Explicit RK, and BDF2 time
integration methods for all of the above methods and options.

@trilinos/tempus @trilinos/nox 

## Checklist
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ x] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.