### PR TITLE
Teuchos KokkosCompat: missing include, Kokkos::is_initialized

### DIFF
--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.cpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.cpp
@@ -15,11 +15,7 @@ namespace Details {
 bool
 isKokkosInitialized ()
 {
-  // Kokkos doesn't have a way to tell whether Kokkos as a whole has
-  // been initialized, i.e., if Kokkos::initialize(...) has been
-  // called.  However, Kokkos::initialize(...) always initializes
-  // the default execution space, so we can just check that.
-  return Kokkos::DefaultExecutionSpace::is_initialized ();
+  return Kokkos::is_initialized();
 }
 
 namespace { // (anonymous)

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.cpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_Details_KokkosInit.cpp
@@ -2,10 +2,12 @@
 #include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Kokkos_Core.hpp"
+
 #include <cstdlib> // std::atexit, setenv
 #include <mutex> // std::call_once, std::once_flag
 #include <stdexcept>
 #include <vector>
+#include <functional> // std::ref
 
 namespace KokkosCompat {
 namespace Details {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
First, include `<functional>` in a file that uses `std::ref`. This error was being hidden by excessive includes in `Teuchos_ConfigDefs`, which @mhoemmen has been cleaning up. The need was revealed ultimately by this Albany dashboard:

http://my.cdash.org/viewBuildError.php?buildid=1324432

In addition, I noticed a function working around the lack of `Kokkos::is_initialized`, and changed it to call that function now that it exists.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This change is required due to cleanups in the core of Teuchos to avoid compilation errors and also required for correct Kokkos initialization behavior (see kokkos/kokkos#1184).


## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
None yet, will rely on new PR testing system or checkin script.