### PR TITLE
ctest_linux_nightly_generic_sierra.cmake: add flag for cuda

### DIFF
--- a/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
+++ b/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
@@ -120,6 +120,7 @@ SET(EXTRA_CONFIGURE_OPTIONS
   "-DTpetraCore_ENABLE_TSQR:BOOL=ON"
   "-DTrilinos_ENABLE_TpetraTSQR:BOOL=ON" 
   "-DTrilinos_ENABLE_Tpetra:BOOL=ON" 
+  -"DKokkos_ENABLE_Cuda_Lambda:BOOL=$ENV{JENKINS_DO_COMPLEX}"
 
   "-DMueLu_ENABLE_Epetra=OFF"
   "-DMueLu_ENABLE_Tpetra=ON"


### PR DESCRIPTION
The default is to turn off Kokkos cuda but we need it.

