### PR TITLE
Resolves "NOX:  Treat Exception as Solve Failure"

### DIFF
--- a/packages/nox/src-loca/src/LOCA_Stepper.C
+++ b/packages/nox/src-loca/src/LOCA_Stepper.C
@@ -53,6 +53,7 @@
 // LOCA Includes
 #include "NOX_Utils.H"
 #include "NOX_Solver_Factory.H"
+#include "NOX_Exceptions.H"
 #include "LOCA_ErrorCheck.H"
 #include "LOCA_GlobalData.H"
 #include "LOCA_Factory.H"
@@ -588,7 +589,16 @@ LOCA::Stepper::compute(LOCA::Abstract::Iterator::StepStatus stepStatus)
   printStartStep();
 
   // Compute next point on continuation curve
-  solverStatus = solverPtr->solve();
+  try
+  {
+    solverStatus = solverPtr->solve();
+  }
+  catch (const NOX::Exceptions::SolverFailure& e)
+  {
+    globalData->locaUtils->err() << "Caught NOX::Exceptions::SolverFailure:"
+      << std::endl << e.what() << std::endl;
+    solverStatus = NOX::StatusTest::Failed;
+  }
 
   // Check solver status
   if (solverStatus == NOX::StatusTest::Failed) {

--- a/packages/nox/src/NOX_Exceptions.H
+++ b/packages/nox/src/NOX_Exceptions.H
@@ -1,0 +1,64 @@
+//@HEADER
+// ************************************************************************
+//
+//            NOX: An Object-Oriented Nonlinear Solver Package
+//                 Copyright (2002) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger Pawlowski (rppawlo@sandia.gov) or
+// Eric Phipps (etphipp@sandia.gov), Sandia National Laboratories.
+//@HEADER
+
+#ifndef   NOX_EXCEPTIONS_H
+#define   NOX_EXCEPTIONS_H
+
+namespace NOX {
+namespace Exceptions {
+
+  /*!
+    \brief A generic exception class denoting a solver failure.
+
+    This class is a member of namespace NOX::Exceptions.
+  */
+  class SolverFailure : public std::logic_error {
+
+  public:
+
+    //! Constructor.
+    SolverFailure(const std::string& what) : std::logic_error(what) {};
+
+  }; // end of class SolverFailure
+
+} // end of namespace Exceptions
+} // end of namespace NOX
+
+#endif // NOX_EXCEPTIONS_H


### PR DESCRIPTION
@trilinos/thyra, @trilinos/nox

## Description
<!--- Describe your changes in detail. -->
As per the discussion in #1608, a `LinearOpApplyFailed` exception was added to Thyra, documented with the `LinearOpBase::apply()` routine, and then caught in LOCA's `Stepper` to be treated as a solve failure, such that LOCA can back up, reduce its step size, and then keep on working.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
A simulation in Charon ran into a case where a Schur complement calculated as part of a preconditioner was singular, but instead of treating that as a solve failure, LOCA and the simulation just bailed.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes #1608

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Trying out the new pull request auto-tester.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

> Haven't checked on the compiler warnings yet, but I'll do that soon.