### PR TITLE
Sacado:  Fix dynamic-to-static view assignment for contiguous layout.

### DIFF
--- a/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
@@ -736,8 +736,15 @@ public:
 
       const bool is_left =
         std::is_same<typename DstTraits::array_layout,Kokkos::LayoutLeft>::value;
+      typedef typename DstType::offset_type dst_offset_type;
+      typedef typename DstType::array_offset_type dst_array_offset_type;
       if (is_left) {
-        dst.m_map.m_array_offset.m_dim = src.m_map.m_array_offset.m_dim;
+        // Can't do this because can't assign dimension structs with different
+        // numbers of dimensions:
+        // dst.m_map.m_array_offset.m_dim = src.m_map.m_array_offset.m_dim;
+        dst.m_map.m_array_offset =
+          dst_array_offset_type(std::integral_constant<unsigned,0>(),
+                                src.m_map.m_array_offset.layout() );
       }
       else {
         AssignDim<SrcTraits::rank,0>::eval(dst.m_map.m_array_offset,
@@ -745,7 +752,12 @@ public:
       }
       dst.m_map.m_array_offset.m_stride = src.m_map.m_array_offset.m_stride ;
 
-      dst.m_map.m_offset.m_dim = src.m_map.m_offset.m_dim;
+      // Can't do this because can't assign dimension structs with different
+      // numbers of dimensions:
+      // dst.m_map.m_offset.m_dim = src.m_map.m_offset.m_dim;
+      dst.m_map.m_offset =
+        dst_offset_type(std::integral_constant<unsigned,0>(),
+                        src.m_map.m_offset.layout() );
       dst.m_map.m_offset.m_stride = src.m_map.m_offset.m_stride ;
 
       dst.m_map.m_handle = src.m_map.m_handle ;

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -814,7 +814,28 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
   // Check dimension scalar works
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v1), 0, out, success);
-TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
+  TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, DynRankAssignStatic, FadType, Layout, Device )
+{
+  typedef Kokkos::View<FadType**,Layout,Device> StaticViewType;
+  typedef Kokkos::DynRankView<FadType,Layout,Device> DynamicViewType;
+  typedef typename StaticViewType::size_type size_type;
+
+  const size_type num_rows = global_num_rows;
+  const size_type num_cols = global_num_cols;
+  const size_type fad_size = global_fad_size;
+
+  // Create views
+  StaticViewType v1("view", num_rows, num_cols, fad_size+1);
+  DynamicViewType v2 = v1;
+
+  // Check dimensions are correct
+  TEUCHOS_TEST_EQUALITY(v2.dimension_0(), num_rows, out, success);
+  TEUCHOS_TEST_EQUALITY(v2.dimension_1(), num_cols, out, success);
+  TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
@@ -1005,6 +1026,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos_View_Fad, DynRankDimensionScalar, FadType, Layout, Device ) {}
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, DynRankAssignStatic, FadType, Layout, Device ) {}
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos_View_Fad, DynRankMultiply, FadType, Layout, Device ) {}
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
@@ -1495,6 +1518,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, Roger, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AssignDifferentStrides, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, DynRankDimensionScalar, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, DynRankAssignStatic, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, DynRankMultiply, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, SubdynrankviewCol, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, SubdynrankviewRow, F, L, D ) \


### PR DESCRIPTION
@trilinos/sacado 

Fixes issue #2020.

A test demonstrating the compile error was added to the test suite and now passes.  Tested with Serial, OpenMP, and Cuda execution spaces.

## Checklist
- [x ] My commit messages mention the appropriate GitHub issue numbers.
- [x ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

