### PR TITLE
ctest_linux_nightly_generic_sierra.cmake: change the c standard to gnu11

### DIFF
--- a/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
+++ b/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic_sierra.cmake
@@ -132,7 +132,7 @@ SET(EXTRA_CONFIGURE_OPTIONS
   "-DCMAKE_C_FLAGS:STRING=$ENV{JENKINS_C_FLAGS}"
   "-DCMAKE_Fortran_FLAGS=$ENV{JENKINS_Fortran_FLAGS}"
 
-  "-DTrilinos_C_Standard=c11"
+  "-DTrilinos_C_Standard=gnu11"
 
 )
 


### PR DESCRIPTION
Not sure why this would resolve gethostname while c11 will not.

## Description
<!--- Describe your changes in detail. -->
Changed the s standard to use from c11 to c11 with gnu extensions. This was needed to resolve gethostname and matches sierras normal behavior.

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
This was tested by compiling the failing ml_util.c.o object with the new standard and then configuring/compiling all of ml with it as well.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

