### PR TITLE
Panzer: Relative tolerance for periodic bcs

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_MatchConditions.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_MatchConditions.hpp
@@ -55,6 +55,7 @@ namespace panzer_stk {
 class CoordMatcher {
    double error_;
    int index_;
+   bool relative_; // compute error relative to length of domain
    char labels_[3];
 
    void buildLabels()
@@ -62,29 +63,39 @@ class CoordMatcher {
 
    void parseParams(const std::vector<std::string> & params) 
    { 
-      std::string errStr = "CoordMatcher \"" + std::string(1,labels_[index_]) + "-coord\" takes at most one parameter <tol>";
-      TEUCHOS_TEST_FOR_EXCEPTION(params.size()>1,std::logic_error,errStr);
+      std::string errStr = "CoordMatcher \"" + std::string(1,labels_[index_]) + "-coord\" takes at most two parameters <tol, relative>";
+      TEUCHOS_TEST_FOR_EXCEPTION(params.size()>2,std::logic_error,errStr);
  
       // read in string, get double
-      if(params.size()==1) {
+      if(params.size()>0) {
          std::stringstream ss;
          ss << params[0];
-         ss >> error_; 
+         ss >> error_;
+         if(params.size()==2){
+           std::string errStr = params[1] + " is not a valid periodic option (try \"relative\")";
+           TEUCHOS_TEST_FOR_EXCEPTION(params[1]!="relative",std::logic_error,errStr);
+           relative_ = true;
+         }
       }
       // else use default value for error
    }
 
 public:
-   CoordMatcher(int index) : error_(1e-8),index_(index) { buildLabels(); }
-   CoordMatcher(int index,double error) : error_(error),index_(index) { buildLabels(); }
-   CoordMatcher(int index,const std::vector<std::string> & params) : error_(1e-8),index_(index) 
+   CoordMatcher(int index) : error_(1e-8),index_(index),relative_(false) { buildLabels(); }
+   CoordMatcher(int index,double error) : error_(error),index_(index),relative_(false) { buildLabels(); }
+   CoordMatcher(int index,const std::vector<std::string> & params) : error_(1e-8),index_(index),relative_(false)
    { buildLabels(); parseParams(params); }
 
-   CoordMatcher(const CoordMatcher & cm) : error_(cm.error_),index_(cm.index_) { buildLabels(); }
+   CoordMatcher(const CoordMatcher & cm) : error_(cm.error_),index_(cm.index_),relative_(cm.relative_) { buildLabels(); }
 
    bool operator()(const Teuchos::Tuple<double,3> & a,
                    const Teuchos::Tuple<double,3> & b) const
-   { return std::fabs(a[index_]-b[index_])<error_; /* I'm being lazy here! */ }
+   {
+     double error = error_;
+     if(relative_) // scale error by length of domain
+       error*=std::fabs(a[1-index_]-b[1-index_]);
+     return std::fabs(a[index_]-b[index_])<error; /* I'm being lazy here! */
+   }
 
    std::string getString() const 
    { 
@@ -99,6 +110,7 @@ public:
 class PlaneMatcher {
    double error_;
    int index0_, index1_;
+   bool relative_; // compute error relative to length of domain
    char labels_[3];
   
    void buildLabels()
@@ -107,36 +119,46 @@ class PlaneMatcher {
    void parseParams(const std::vector<std::string> & params) 
    { 
       std::string errStr = "PlaneMatcher \"" + std::string(1,labels_[index0_])+std::string(1,labels_[index1_]) 
-                         + "-coord\" takes only one parameter <tol>";
-      TEUCHOS_TEST_FOR_EXCEPTION(params.size()>1,std::logic_error,errStr);
+                         + "-coord\" takes at most two parameter <tol, relative>";
+      TEUCHOS_TEST_FOR_EXCEPTION(params.size()>2,std::logic_error,errStr);
  
       // read in string, get double
       if(params.size()==1) {
          std::stringstream ss;
          ss << params[0];
          ss >> error_; 
+         if(params.size()==2){
+           std::string errStr = params[1] + " is not a valid periodic option (try \"relative\")";
+           TEUCHOS_TEST_FOR_EXCEPTION(params[1]!="relative",std::logic_error,errStr);
+           relative_ = true;
+         }
       }
       // else use default value for error
    }
 
 public:
-   PlaneMatcher(int index0,int index1) : error_(1e-8),index0_(index0), index1_(index1) 
+   PlaneMatcher(int index0,int index1) : error_(1e-8),index0_(index0), index1_(index1), relative_(false)
    { TEUCHOS_ASSERT(index0!=index1); buildLabels(); }
 
-   PlaneMatcher(int index0,int index1,double error) : error_(error),index0_(index0), index1_(index1) 
+   PlaneMatcher(int index0,int index1,double error) : error_(error),index0_(index0), index1_(index1), relative_(false)
    { TEUCHOS_ASSERT(index0!=index1); buildLabels(); }
 
    PlaneMatcher(int index0,int index1,const std::vector<std::string> & params) 
-      : error_(1e-8), index0_(index0), index1_(index1) 
+      : error_(1e-8), index0_(index0), index1_(index1), relative_(false)
    { TEUCHOS_ASSERT(index0!=index1); buildLabels(); parseParams(params); }
 
-   PlaneMatcher(const PlaneMatcher & cm) : error_(cm.error_),index0_(cm.index0_), index1_(cm.index1_) 
+   PlaneMatcher(const PlaneMatcher & cm) : error_(cm.error_),index0_(cm.index0_), index1_(cm.index1_), relative_(cm.relative_)
    { buildLabels(); }
 
    bool operator()(const Teuchos::Tuple<double,3> & a,
                    const Teuchos::Tuple<double,3> & b) const
-   { return (std::fabs(a[index0_]-b[index0_])<error_) 
-         && (std::fabs(a[index1_]-b[index1_])<error_) ; /* I'm being lazy here! */ }
+   {
+     double error = error_;
+     if(relative_) // scale error by length of domain in normal direction
+       error*=std::fabs(a[3-index0_-index1_]-b[3-index0_-index1_]);
+     return (std::fabs(a[index0_]-b[index0_])<error_) 
+         && (std::fabs(a[index1_]-b[index1_])<error_) ; /* I'm being lazy here! */
+   }
 
    std::string getString() const 
    { 

--- a/packages/panzer/adapters-stk/test/periodic_bcs/periodic_bcs.cpp
+++ b/packages/panzer/adapters-stk/test/periodic_bcs/periodic_bcs.cpp
@@ -850,6 +850,76 @@ namespace panzer {
     
   }
 
+  TEUCHOS_UNIT_TEST(periodic_bcs, PeriodicBC_Matcher_relative)
+  {
+    using Teuchos::RCP;
+    using Teuchos::Tuple;
+
+
+    Epetra_MpiComm Comm(MPI_COMM_WORLD);
+
+    panzer_stk::SquareQuadMeshFactory mesh_factory;
+
+    // setup mesh
+    /////////////////////////////////////////////
+    RCP<panzer_stk::STK_Interface> mesh;
+    {
+       // make a mesh with small length-scale
+       RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+       pl->set("X Blocks",2);
+       pl->set("Y Blocks",1);
+       pl->set("X Elements",6);
+       pl->set("Y Elements",4);
+       pl->set("X0",0.0);
+       pl->set("Xf",1.0e-6);
+       pl->set("Y0",0.0);
+       pl->set("Yf",1.0e-6);
+       mesh_factory.setParameterList(pl);
+       mesh = mesh_factory.buildMesh(MPI_COMM_WORLD);
+    }
+
+       std::pair<RCP<std::vector<std::size_t> >,
+                 RCP<std::vector<Tuple<double,3> > > > idsAndCoords_top = panzer_stk::periodic_helpers::getSideIdsAndCoords(*mesh,"top");
+       std::pair<RCP<std::vector<std::size_t> >,
+                 RCP<std::vector<Tuple<double,3> > > > idsAndCoords_bottom = panzer_stk::periodic_helpers::getSideIdsAndCoords(*mesh,"bottom");
+       std::vector<std::size_t> & sideIds_top = *idsAndCoords_top.first;
+       std::vector<std::size_t> & sideIds_bottom = *idsAndCoords_bottom.first;
+       std::vector<Tuple<double,3> > & sideCoords_top = *idsAndCoords_top.second;
+       std::vector<Tuple<double,3> > & sideCoords_bottom = *idsAndCoords_bottom.second;
+
+    // Nodes
+    {
+       // set up a matcher with a tolerance of 1e-6
+       std::vector<std::string> params;
+       params.push_back("1e-6");
+       CoordMatcher bad_matcher(0,params);
+       Teuchos::RCP<const panzer_stk::PeriodicBC_MatcherBase> bad_pMatch 
+             = panzer_stk::buildPeriodicBC_Matcher("top","bottom",bad_matcher);
+
+       // matching should fail since the tolerance is larger than the mesh size
+       TEST_THROW(bad_pMatch->getMatchedPair(*mesh),std::logic_error);
+
+       // make the tolerance relative, then matching shouldn't fail
+       params.push_back("relative");
+       CoordMatcher matcher(0,params);
+       Teuchos::RCP<const panzer_stk::PeriodicBC_MatcherBase> pMatch 
+             = panzer_stk::buildPeriodicBC_Matcher("top","bottom",matcher);
+
+       RCP<std::vector<std::pair<std::size_t,std::size_t> > > globallyMatchedIds = pMatch->getMatchedPair(*mesh);
+
+       // for testing purposes!
+       RCP<std::vector<std::size_t> > locallyRequiredIds = panzer_stk::periodic_helpers::getLocalSideIds(*mesh,"top");
+
+       TEST_EQUALITY(globallyMatchedIds->size(),locallyRequiredIds->size()); 
+
+       // match top & bottom sides
+       for(std::size_t i=0;i<globallyMatchedIds->size();i++) {
+          std::pair<std::size_t,std::size_t> pair = (*globallyMatchedIds)[i];
+          TEST_EQUALITY(pair.first,pair.second+52);
+       }
+    }
+  }
+  
   TEUCHOS_UNIT_TEST(periodic_bcs, PeriodicBC_Matcher_multi)
   {
     using Teuchos::RCP;

--- a/packages/panzer/adapters-stk/test/periodic_bcs/periodic_mesh.cpp
+++ b/packages/panzer/adapters-stk/test/periodic_bcs/periodic_mesh.cpp
@@ -139,6 +139,18 @@ namespace panzer {
        matcher_obj = parser.buildMatcher("xy-face left;right");
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<QuarterPlaneMatcher> >(matcher_obj));
 
+       matcher_obj = parser.buildMatcher("x-coord 1e-8: left;right");
+       TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(matcher_obj));
+   
+       matcher_obj = parser.buildMatcher("xy-edge 1e-8: left;right");
+       TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(matcher_obj));
+   
+       matcher_obj = parser.buildMatcher("x-coord 1e-8, relative: left;right");
+       TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(matcher_obj));
+   
+       matcher_obj = parser.buildMatcher("xy-edge 1e-8, relative: left;right");
+       TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(matcher_obj));
+   
        TEST_THROW(parser.buildMatcher("dog-coord left;right"),std::logic_error);
 
        TEST_THROW(parser.buildMatcher("dog-edge left;right"),std::logic_error);
@@ -148,6 +160,8 @@ namespace panzer {
        TEST_THROW(parser.buildMatcher("x-face left;right"),std::logic_error);
 
        TEST_THROW(parser.buildMatcher("xface left;right"),std::logic_error);
+
+       TEST_THROW(parser.buildMatcher("x-coord 1e-8, misspelled-relatiive: left;right"),std::logic_error);
     }
 
     // test parameter list based construction
@@ -163,14 +177,10 @@ namespace panzer {
        pl->set("Periodic Condition 6","x-edge top;bottom");
        pl->set("Periodic Condition 7","yz-edge fake_a;fake_b");
        pl->set("Periodic Condition 8","yz-face fake_a;fake_b");
-std::cout << "1" << std::endl;      
        parser.setParameterList(pl);
-std::cout << "2" << std::endl;      
 
        TEST_EQUALITY(parser.getMatchers().size(),8);
-std::cout << "3" << std::endl;      
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(parser.getMatchers()[0]));
-std::cout << "4" << std::endl;      
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(parser.getMatchers()[1]));
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<PlaneMatcher> >(parser.getMatchers()[2]));
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<QuarterPlaneMatcher> >(parser.getMatchers()[3]));
@@ -178,7 +188,6 @@ std::cout << "4" << std::endl;
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<CoordMatcher> >(parser.getMatchers()[5]));
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<PlaneMatcher> >(parser.getMatchers()[6]));
        TEST_NOTHROW(rcp_dynamic_cast<const PeriodicBC_Matcher<PlaneMatcher> >(parser.getMatchers()[7]));
-std::cout << "5" << std::endl;      
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
Added an option to use relative tolerances in Panzer periodic BC matching rather than absolute. For example, one can replace "y-all 1e-8: right;left" with "y-all 1e-8, relative: right;left" and the matching will use a tolerance of 1e-8*(length of domain in x direction).

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
For problems with small length scales, we've seen errors arise if the matcher tolerance is larger than the mesh size.

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Added tests to periodic_mesh and periodic_bcs unit tests. Tests validity of input strings, and checks that when an absolute tolerance fails for a small length scale mesh, the relative tolerance succeeds.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.