### PR TITLE
Amesos2: Fix for issue #1987

### DIFF
--- a/packages/amesos2/cmake/Dependencies.cmake
+++ b/packages/amesos2/cmake/Dependencies.cmake
@@ -2,8 +2,8 @@
 # Need a flag for LGPL vs BSD, SuperLU is required only for BSD.
 #
 # SET(LIB_REQUIRED_DEP_PACKAGES Teuchos Tpetra KLU2)
-SET(LIB_REQUIRED_DEP_PACKAGES Teuchos Tpetra TrilinosSS)
-SET(LIB_OPTIONAL_DEP_PACKAGES Epetra EpetraExt ShyLU_NodeBasker ShyLU_NodeTacho Kokkos)
+SET(LIB_REQUIRED_DEP_PACKAGES Teuchos Tpetra TrilinosSS Kokkos)
+SET(LIB_OPTIONAL_DEP_PACKAGES Epetra EpetraExt ShyLU_NodeBasker ShyLU_NodeTacho)
 SET(TEST_REQUIRED_DEP_PACKAGES)
 SET(TEST_OPTIONAL_DEP_PACKAGES ShyLU_NodeBasker ShyLU_NodeTacho Kokkos TrilinosSS)
 # SET(LIB_REQUIRED_DEP_TPLS SuperLU)

--- a/packages/amesos2/src/Amesos2_KLU2.cpp
+++ b/packages/amesos2/src/Amesos2_KLU2.cpp
@@ -45,8 +45,8 @@
 
 #ifdef HAVE_AMESOS2_EXPLICIT_INSTANTIATION
 
-#  include "Amesos2_KLU2_def.hpp"
-#  include "Amesos2_ExplicitInstantiationHelpers.hpp"
+#include "Amesos2_KLU2_def.hpp"
+#include "Amesos2_ExplicitInstantiationHelpers.hpp"
 
 namespace Amesos2 {
 

--- a/packages/amesos2/src/Amesos2_Util.hpp
+++ b/packages/amesos2/src/Amesos2_Util.hpp
@@ -220,13 +220,15 @@ namespace Amesos2 {
     template < class T0, class T1 >
     struct getStdCplxType
     {
-      using type = T0;
+      using common_type = typename std::common_type<T0,T1>::type;
+      using type = common_type;
     };
 
     template < class T0, class T1 >
     struct getStdCplxType< T0, T1* >
     {
-      using type = T1;
+      using common_type = typename std::common_type<T0,T1>::type;
+      using type = common_type;
     };
 
 #if defined(HAVE_TEUCHOS_COMPLEX) && defined(HAVE_AMESOS2_KOKKOS)
@@ -234,6 +236,13 @@ namespace Amesos2 {
     struct getStdCplxType< T0, Kokkos::complex<T0>* >
     {
       using type = std::complex<T0>;
+    };
+
+    template < class T0 , class T1 >
+    struct getStdCplxType< T0, Kokkos::complex<T1>* >
+    {
+      using common_type = typename std::common_type<T0,T1>::type;
+      using type = std::complex<common_type>;
     };
 #endif
 


### PR DESCRIPTION
Two changes:
1. Amesos2 depends on Tpetra, which depends on Kokkos, however Amesos2
has optional dependency on Kokkos; change this from optional to required
dependency.

2. Compiling without ETI when using Amesos2 could result in errors as seen
in issue #1987, for example unable to convert between std::complex<float>*
and Kokkos::complex<double>*
Add specialization to getStdCplxType to properly select common type for
reinterpret_cast in these cases

<!--- Provide a general summary of your changes in the Title above. -->
Fixes for issue #1987.
1. Make Kokkos a required dependency in Amesos2 rather than optional (Tpetra is already a required dependency)
2. Add missing specialization to getStdCplxType to properly select common type for
reinterpret_cast in these cases.

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
1. Amesos2 depends on Tpetra, which depends on Kokkos, however Amesos2
has optional dependency on Kokkos; change this from optional to required
dependency.

2. Compiling without ETI when using Amesos2 could result in errors as seen
in issue #1987, for example unable to convert between std::complex<float>*
and Kokkos::complex<double>*
Add specialization to getStdCplxType to properly select common type for
reinterpret_cast in these cases
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes #1987 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #1986 
* Part of 
* Composed of 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Local build/testing of Amesos2 with various configurations (ETI on/off, complex on/off, KLU2 enabled and other solvers enabled, Epetra on/off, MPI on/off...)
Compiler: gcc/5.4
OS: OSX

## Screenshots
<!--- Not obligatory, but is there anything pertinent that we should see? -->

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

## Additional Information
<!--- Anything else we need to know in evaluating this merge request? -->
