### PR TITLE
Tpetra: FEMA Example update

### DIFF
--- a/packages/tpetra/core/example/Finite-Element-Assembly/typedefs.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/typedefs.hpp
@@ -50,13 +50,12 @@
 #include <Tpetra_CrsGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
+typedef double Scalar;
+
 // Get LocalOrdinal & GlobalOrdinal from Map defaults.
 typedef Tpetra::Map<>::local_ordinal_type LocalOrdinal;
 typedef Tpetra::Map<>::global_ordinal_type GlobalOrdinal;
-
-typedef double Scalar;
-
-typedef Tpetra::Details::DefaultTypes::node_type NT;
+typedef Tpetra::Map<>::node_type NT;
 
 typedef Kokkos::DefaultExecutionSpace ExecutionSpace;
 


### PR DESCRIPTION
@mhoemmen 
@trilinos/tpetra 

## Description
Changed the NodeType typedef in the Finite Element Mesh assembly example per my conversation today with @mhoemmen.

## Motivation and Context
Mark and I discussed this change today on a teleconference.

## How Has This Been Tested?
Consultation with @mhoemmen and compiled/tested on my workstation.

## Checklist
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
