### PR TITLE
Thyra: Fix #2061

### DIFF
--- a/packages/thyra/adapters/epetra/src/Thyra_EpetraThyraWrappers.cpp
+++ b/packages/thyra/adapters/epetra/src/Thyra_EpetraThyraWrappers.cpp
@@ -201,6 +201,10 @@ Thyra::create_Vector(
   RCP<const SpmdVectorSpaceBase<double> >
     space = Teuchos::rcp_dynamic_cast<const SpmdVectorSpaceBase<double> >(
       space_in,true);
+  // mfh 06 Dec 2017: This return should not trigger an issue like
+  // #1941, because if epetra_v is NULL on some process but not
+  // others, then that process should not be participating in
+  // collectives with the other processes anyway.
   if(!epetra_v.get())
     return Teuchos::null;
   // New local view of raw data
@@ -233,6 +237,10 @@ Thyra::create_Vector(
   RCP<const SpmdVectorSpaceBase<double> >
     space = Teuchos::rcp_dynamic_cast<const SpmdVectorSpaceBase<double> >(
       space_in,true);
+  // mfh 06 Dec 2017: This return should not trigger an issue like
+  // #1941, because if epetra_v is NULL on some process but not
+  // others, then that process should not be participating in
+  // collectives with the other processes anyway.
   if(!epetra_v.get())
     return Teuchos::null;
   // New local view of raw data
@@ -274,6 +282,10 @@ Thyra::create_MultiVector(
       unwrapSingleProductVectorSpace(domain_in),
       true
       );
+  // mfh 06 Dec 2017: This return should not trigger an issue like
+  // #1941, because if epetra_mv is NULL on some process but not
+  // others, then that process should not be participating in
+  // collectives with the other processes anyway.
   if (!epetra_mv.get() )
     return Teuchos::null;
   if ( is_null(domain) ) {
@@ -326,6 +338,10 @@ Thyra::create_MultiVector(
       unwrapSingleProductVectorSpace(domain_in),
       true
       );
+  // mfh 06 Dec 2017: This return should not trigger an issue like
+  // #1941, because if epetra_mv is NULL on some process but not
+  // others, then that process should not be participating in
+  // collectives with the other processes anyway.
   if (!epetra_mv.get())
     return Teuchos::null;
   if ( is_null(domain) ) {
@@ -502,6 +518,8 @@ Thyra::get_Epetra_Vector(
   const Ptr<const RCP<Epetra_Vector> >
     epetra_v_ptr = get_optional_extra_data<RCP<Epetra_Vector> >(
       v,"Epetra_Vector");
+  // mfh 06 Dec 2017: This should be consistent over all processes
+  // that participate in v's communicator.
   if(!is_null(epetra_v_ptr)) {
     return *epetra_v_ptr;
   }
@@ -579,11 +597,15 @@ Thyra::get_Epetra_Vector(
   const Ptr<const RCP<const Epetra_Vector> >
     epetra_v_ptr = get_optional_extra_data<RCP<const Epetra_Vector> >(
       v,"Epetra_Vector");
+  // mfh 06 Dec 2017: This should be consistent over all processes
+  // that participate in v's communicator.
   if(!is_null(epetra_v_ptr))
     return *epetra_v_ptr;
   const Ptr<const RCP<Epetra_Vector> >
     epetra_nonconst_v_ptr = get_optional_extra_data<RCP<Epetra_Vector> >(
       v,"Epetra_Vector");
+  // mfh 06 Dec 2017: This should be consistent over all processes
+  // that participate in v's communicator.
   if(!is_null(epetra_nonconst_v_ptr))
     return *epetra_nonconst_v_ptr;
   //
@@ -646,6 +668,8 @@ Thyra::get_Epetra_MultiVector(
   const Ptr<const RCP<Epetra_MultiVector> >
     epetra_mv_ptr = get_optional_extra_data<RCP<Epetra_MultiVector> >(
       mv,"Epetra_MultiVector");
+  // mfh 06 Dec 2017: This should be consistent over all processes
+  // that participate in v's communicator.
   if(!is_null(epetra_mv_ptr)) {
     return *epetra_mv_ptr;
   }
@@ -729,6 +753,8 @@ Thyra::get_Epetra_MultiVector(
     epetra_mv_ptr
     = get_optional_extra_data<RCP<const Epetra_MultiVector> >(
       mv,"Epetra_MultiVector" );
+  // mfh 06 Dec 2017: This should be consistent over all processes
+  // that participate in v's communicator.
   if(!is_null(epetra_mv_ptr)) {
     return *epetra_mv_ptr;
   }
@@ -786,25 +812,27 @@ Thyra::get_Epetra_MultiVector(
   )
 {
   using Teuchos::rcpWithEmbeddedObj;
-  using Teuchos::rcpFromRef;
   using Teuchos::ptrFromRef;
   using Teuchos::ptr_dynamic_cast;
   using Teuchos::outArg;
+
+  double* rawMvData = NULL;
+  Ordinal mvLeadingDim = 0;
+
+  Ptr<SpmdMultiVectorBase<double> > mvSpmdMv =
+    ptr_dynamic_cast<SpmdMultiVectorBase<double> >(ptrFromRef(mv));
   ArrayRCP<double> mvData;
-  Ordinal mvLeadingDim = -1;
-  Ptr<SpmdMultiVectorBase<double> > mvSpmdMv;
-  if (nonnull(mvSpmdMv = ptr_dynamic_cast<SpmdMultiVectorBase<double> >(ptrFromRef(mv)))) {
+  if (nonnull(mvSpmdMv)) {
     mvSpmdMv->getNonconstLocalData(outArg(mvData), outArg(mvLeadingDim));
+    rawMvData = mvData.getRawPtr();
   }
-  if (nonnull(mvData)) {
-    return rcpWithEmbeddedObj(
-      new Epetra_MultiVector(
-        ::View, map, mvData.getRawPtr(), mvLeadingDim, mv.domain()->dim()
-        ),
-      mvData
-      );
-  }
-  return ::Thyra::get_Epetra_MultiVector(map, rcpFromRef(mv));
+
+  return rcpWithEmbeddedObj(
+    new Epetra_MultiVector(
+      ::View, map, mvData.getRawPtr(), mvLeadingDim, mv.domain()->dim()
+      ),
+    mvData
+    );
 }
 
 
@@ -815,7 +843,6 @@ Thyra::get_Epetra_MultiVector(
   )
 {
   using Teuchos::rcpWithEmbeddedObj;
-  using Teuchos::rcpFromRef;
   using Teuchos::ptrFromRef;
   using Teuchos::ptr_dynamic_cast;
   using Teuchos::outArg;

--- a/packages/thyra/adapters/epetra/test/TestThyraDebugHang.cpp
+++ b/packages/thyra/adapters/epetra/test/TestThyraDebugHang.cpp
@@ -1,5 +1,6 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_CommHelpers.hpp"
 #include "Epetra_MpiComm.h"
 #include "Epetra_Map.h"
 #include "Thyra_VectorSpaceFactoryBase.hpp"
@@ -21,9 +22,16 @@
 // processors.
 TEUCHOS_UNIT_TEST( ThyraEpetraMultiVector, HangingInParallelDebug )
 {
+   using Teuchos::outArg;
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcp_dynamic_cast;
+   using Teuchos::REDUCE_MIN;
+   using Teuchos::reduceAll;
    using std::cerr;
    using std::endl;
-
+   int lclSuccess = 1; // to be revised below
+   int gblSuccess = 1; // to be revised below
    int myRank = 0;
    int numProcs = 1;
 #ifdef HAVE_MPI
@@ -53,45 +61,123 @@ TEUCHOS_UNIT_TEST( ThyraEpetraMultiVector, HangingInParallelDebug )
      os << prefix << "Creating Teuchos::Comm" << endl;
      cerr << os.str ();
    }
-   Teuchos::RCP<const Teuchos::Comm<Teuchos_Ordinal> > comm =
+   RCP<const Teuchos::Comm<Teuchos_Ordinal> > comm =
      Teuchos::DefaultComm<Teuchos_Ordinal>::getComm ();
+   // Make sure that everything is OK on all processes.
+   TEST_ASSERT( ! comm.is_null () );
+   lclSuccess = success ? 1 : 0;
+   reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+   TEST_EQUALITY( gblSuccess, 1 );
+   if (gblSuccess != 1) {
+     out << "FAILED; some process(es) have a null Teuchos::Comm" << endl;
+     return;
+   }
 
    // Some processors have to have data and some not.
    const int localDim  = myRank % 2;
    const int globalDim = numProcs / 2;
-   Teuchos::RCP<const Epetra_Map> epetra_map;
+   RCP<const Epetra_Map> epetra_map;
    {
      std::ostringstream os;
      os << prefix << "Creating Epetra_Map: localDim=" << localDim << ", globalDim=" << globalDim << endl;
      cerr << os.str ();
    }
-   epetra_map = Teuchos::rcp(new Epetra_Map(globalDim,localDim,0,epetra_comm));
+   epetra_map = rcp (new Epetra_Map (globalDim, localDim, 0, epetra_comm));
+   // Make sure that everything is OK on all processes.
+   TEST_ASSERT( ! epetra_map.is_null () );
+   lclSuccess = success ? 1 : 0;
+   reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+   TEST_EQUALITY( gblSuccess, 1 );
+   if (gblSuccess != 1) {
+     out << "FAILED; some process(es) have a null Epetra_Map" << endl;
+     return;
+   }
+
    {
      std::ostringstream os;
      os << prefix << "Creating Thyra::DefaultSpmdVectorSpace" << endl;
      cerr << os.str ();
    }
-   Teuchos::RCP<Thyra::DefaultSpmdVectorSpace<double>> SPMD = Thyra::DefaultSpmdVectorSpace<double>::create();
+   RCP<Thyra::DefaultSpmdVectorSpace<double> > SPMD =
+     Thyra::DefaultSpmdVectorSpace<double>::create();
+
+   // Make sure that everything is OK on all processes.
+   TEST_ASSERT( ! epetra_map.is_null () );
+   lclSuccess = success ? 1 : 0;
+   reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+   TEST_EQUALITY( gblSuccess, 1 );
+   if (gblSuccess != 1) {
+     out << "FAILED; some process(es) have a null SPMD" << endl;
+     return;
+   }
+
    SPMD->initialize(comm, localDim, globalDim);
+
    {
      std::ostringstream os;
      os << prefix << "Creating Thyra::MultiVectorBase" << endl;
      cerr << os.str ();
    }
-   Teuchos::RCP<const Thyra::MultiVectorBase<double>> spmd =
-      Teuchos::rcp(
-         new Thyra::DefaultSpmdMultiVector<double>(
-            SPMD,
-            Teuchos::rcp_dynamic_cast<const Thyra::ScalarProdVectorSpaceBase<double>>(
-               SPMD->smallVecSpcFcty()->createVecSpc(1),true)
-            )
-        );
+   RCP<const Thyra::MultiVectorBase<double> > spmd =
+      rcp (new Thyra::DefaultSpmdMultiVector<double> (
+        SPMD,
+        rcp_dynamic_cast<const Thyra::ScalarProdVectorSpaceBase<double> > (
+          SPMD->smallVecSpcFcty()->createVecSpc(1),true)
+        )
+      );
+   // Make sure that everything is OK on all processes.
+   TEST_ASSERT( ! spmd.is_null () );
+   lclSuccess = success ? 1 : 0;
+   reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+   TEST_EQUALITY( gblSuccess, 1 );
+   if (gblSuccess != 1) {
+     out << "FAILED; some process(es) have a null Thyra::MultiVectorBase"
+         << endl;
+     return;
+   }
+
    {
      std::ostringstream os;
-     os << prefix << "Creating Thyra::get_Epetra_MultiVector" << endl;
+     os << prefix << "Calling Thyra::get_Epetra_MultiVector "
+       "(const overload; see #1941)" << endl;
      cerr << os.str ();
    }
-   Thyra::get_Epetra_MultiVector(*epetra_map,*spmd);
+   // Make sure that we invoke the const overload.
+   RCP<const Epetra_MultiVector> mv_c =
+     Thyra::get_Epetra_MultiVector (*epetra_map,
+       const_cast<const Thyra::MultiVectorBase<double>& > (*spmd));
+   // Make sure that everything is OK on all processes.
+   TEST_ASSERT( ! mv_c.is_null () );
+   lclSuccess = success ? 1 : 0;
+   reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+   TEST_EQUALITY( gblSuccess, 1 );
+   if (gblSuccess != 1) {
+     out << "FAILED; some process(es) have a null const Epetra_MultiVector"
+         << endl;
+     return;
+   }
+
+   {
+     std::ostringstream os;
+     os << prefix << "Calling Thyra::get_Epetra_MultiVector "
+       "(nonconst overload; see #2061)" << endl;
+     cerr << os.str ();
+   }
+   // Make sure that we invoke the nonconst overload.
+   RCP<Epetra_MultiVector> mv_nc =
+     Thyra::get_Epetra_MultiVector (*epetra_map,
+       const_cast<Thyra::MultiVectorBase<double>& > (*spmd));
+   // Make sure that everything is OK on all processes.
+   TEST_ASSERT( ! mv_nc.is_null () );
+   lclSuccess = success ? 1 : 0;
+   reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+   TEST_EQUALITY( gblSuccess, 1 );
+   if (gblSuccess != 1) {
+     out << "FAILED; some process(es) have a null nonconst Epetra_MultiVector"
+         << endl;
+     return;
+   }
+
    {
      std::ostringstream os;
      os << prefix << "Done with test on this process" << endl;


### PR DESCRIPTION
@trilinos/thyra Fix the nonconst overload of Thyra::get_Epetra_MultiVector, so that it no longer hangs in debug mode, when some (but not all) MPI processes have zero rows.  #1941 related to the const overload of Thyra::get_Epetra_MultiVector; #2061 relates to the nonconst overload.  This commit fixes #2061.  It also improves the #1941 unit test to exercise both overloads; the test passes.

@trilinos/thyra @micahahoward

## Motivation and Context

Fixes #2061.

## Related Issues

* Closes #2061 
* Related to #1941 

## How Has This Been Tested?

Clang 3.9, debug build.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.