### PR TITLE
Tpetra: Change named Tpetra::Behavior::[debug,verbose] separator from ":" to ","

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -40,7 +40,7 @@ namespace { // (anonymous)
   void
   split(const std::string& s,
         std::function<void(const std::string&)> f,
-        const char sep=':')
+        const char sep=',')
   {
     typedef std::string::size_type size_type;
     size_type cur_pos, last_pos=0, length=s.length();

--- a/packages/tpetra/core/test/Behavior/Behavior_Named.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Named.cpp
@@ -63,8 +63,8 @@ namespace {
 
 TEUCHOS_STATIC_SETUP()
 {
-  setenv("TPETRA_DEBUG", "Dbg1:Dbg2", 1);
-  setenv("TPETRA_VERBOSE", "Verb1:Verb2", 1);
+  setenv("TPETRA_DEBUG", "Dbg1,Dbg2", 1);
+  setenv("TPETRA_VERBOSE", "Verb1,Verb2", 1);
 }
 
 TEUCHOS_UNIT_TEST(Behavior, Named)
@@ -75,6 +75,10 @@ TEUCHOS_UNIT_TEST(Behavior, Named)
 #else
   bool debug_default = false;
 #endif
+
+  // TPETRA_DEBUG was set globally in TEUCHOS_STATIC_SETUP to a named value, so
+  // any query on TPETRA_DEBUG should evaluate to the default value, unless the
+  // query is performed on one of the named values.
   bool dbg = Tpetra::Details::Behavior::debug();
   TEUCHOS_TEST_ASSERT(dbg==debug_default, out, success);
   bool dbg_1 = Tpetra::Details::Behavior::debug("Dbg1");
@@ -84,6 +88,9 @@ TEUCHOS_UNIT_TEST(Behavior, Named)
   bool dbg_3 = Tpetra::Details::Behavior::debug("Dbg3");
   TEUCHOS_TEST_ASSERT(dbg_3==debug_default, out, success);
 
+  // TPETRA_VERBOSE was set globally in TEUCHOS_STATIC_SETUP to a named value,
+  // so any query on TPETRA_VERBOSE should evaluate to false, unless the query
+  // is performed on one of the named values.
   bool verbose_default = false;
   bool verb = Tpetra::Details::Behavior::verbose();
   TEUCHOS_TEST_ASSERT(verb==verbose_default, out, success);

--- a/packages/tpetra/core/test/Behavior/Behavior_Off.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Off.cpp
@@ -71,16 +71,22 @@ TEUCHOS_STATIC_SETUP()
 TEUCHOS_UNIT_TEST(Behavior, Off)
 {
 
+  // TPETRA_DEBUG was set globally in TEUCHOS_STATIC_SETUP to OFF, so any query
+  // on TPETRA_DEBUG should evaluate to false, including named variants.
   bool dbg = Tpetra::Details::Behavior::debug();
   TEUCHOS_TEST_ASSERT(!dbg, out, success);
   bool dbg_named = Tpetra::Details::Behavior::debug("Named");
   TEUCHOS_TEST_ASSERT(!dbg_named, out, success);
 
+  // TPETRA_VERBOSE was set globally in TEUCHOS_STATIC_SETUP to OFF, so any query
+  // on TPETRA_VERBOSE should evaluate to false, including named variants.
   bool verb = Tpetra::Details::Behavior::verbose();
   TEUCHOS_TEST_ASSERT(!verb, out, success);
   bool verb_named = Tpetra::Details::Behavior::verbose("Named");
   TEUCHOS_TEST_ASSERT(!verb_named, out, success);
 
+  // TPETRA_ASSUME_CUDA_AWARE_MPI was set globally in TEUCHOS_STATIC_SETUP to OFF,
+  // so any query on TPETRA_ASSUME_CUDA_AWARE_MPI should evaluate to false.
   bool cuda_aware_mpi = Tpetra::Details::Behavior::assumeMpiIsCudaAware();
   TEUCHOS_TEST_ASSERT(!cuda_aware_mpi, out, success);
 }

--- a/packages/tpetra/core/test/Behavior/Behavior_On.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_On.cpp
@@ -71,16 +71,22 @@ TEUCHOS_STATIC_SETUP()
 TEUCHOS_UNIT_TEST(Behavior, On)
 {
 
+  // TPETRA_DEBUG was set globally in TEUCHOS_STATIC_SETUP to ON, so any query
+  // on TPETRA_DEBUG should evaluate to true, including named variants.
   bool dbg = Tpetra::Details::Behavior::debug();
   TEUCHOS_TEST_ASSERT(dbg, out, success);
   bool dbg_named = Tpetra::Details::Behavior::debug("Named");
   TEUCHOS_TEST_ASSERT(dbg_named, out, success);
 
+  // TPETRA_VERBOSE was set globally in TEUCHOS_STATIC_SETUP to ON, so any query
+  // on TPETRA_VERBOSE should evaluate to true, including named variants.
   bool verb = Tpetra::Details::Behavior::verbose();
   TEUCHOS_TEST_ASSERT(verb, out, success);
   bool verb_named = Tpetra::Details::Behavior::verbose("Named");
   TEUCHOS_TEST_ASSERT(verb_named, out, success);
 
+  // TPETRA_ASSUME_CUDA_AWARE_MPI was set globally in TEUCHOS_STATIC_SETUP to ON,
+  // so any query on TPETRA_ASSUME_CUDA_AWARE_MPI should evaluate to true
   bool cuda_aware_mpi = Tpetra::Details::Behavior::assumeMpiIsCudaAware();
   TEUCHOS_TEST_ASSERT(cuda_aware_mpi, out, success);
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description

Changes the separator for named variants of `TPETRA_DEBUG` and `TPETRA_VERBOSE` from ":" to ","

## Motivation and Context

This change allows specifying [debug,verbose] for namespace qualified names.

@mhoemmen, I had intended for this to be the behavior when I initially committed the code (I believe we even spoke about it), but the initial separator of ":" was never changed to ",".

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

Enabled packages: Tpetra, MueLu, Ifpack2
Compiler: clang 4.0, openmpi 1.10.3
All built tests pass

## Screenshots
<!--- Not obligatory, but is there anything pertinent that we should see? -->

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility (however, the changes are in the `Tpetra::Details` namespace and affect an unused code path.  The changes should not effect code external to Tpetra)

## Additional Information
<!--- Anything else we need to know in evaluating this merge request? -->