### PR TITLE
TpetraExt_MatrixMatrix_ExtraKernels_def.hpp: correct a second shadowe…

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
@@ -127,12 +127,12 @@ void mult_A_B_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOr
   const size_t INVALID = Teuchos::OrdinalTraits<size_t>::invalid();
   
   // Grab the  Kokkos::SparseCrsMatrices & inner cstuff
-  const KCRS & Ak = Aview.origMatrix->getLocalMatrix();
-  const KCRS & Bk = Bview.origMatrix->getLocalMatrix();
+  const KCRS & Amat = Aview.origMatrix->getLocalMatrix();
+  const KCRS & Bmat = Bview.origMatrix->getLocalMatrix();
 
-  c_lno_view_t Arowptr = Ak.graph.row_map, Browptr = Bk.graph.row_map;
-  const lno_nnz_view_t Acolind = Ak.graph.entries, Bcolind = Bk.graph.entries;
-  const scalar_view_t Avals = Ak.values, Bvals = Bk.values;
+  c_lno_view_t Arowptr = Amat.graph.row_map, Browptr = Bmat.graph.row_map;
+  const lno_nnz_view_t Acolind = Amat.graph.entries, Bcolind = Bmat.graph.entries;
+  const scalar_view_t Avals = Amat.values, Bvals = Bmat.values;
 
   c_lno_view_t  Irowptr;
   lno_nnz_view_t  Icolind;


### PR DESCRIPTION
…d variable

This was hiding behind the one in TpetraExt_MatrixMatrix_def.hpp This
should resolve ticket #2069.

@trilinos/tpetra 

## How Has This Been Tested?
Built with warnings-as-errors enables - got a clean build for anasazi and zoltan2
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ x ] My commit messages mention the appropriate GitHub issue numbers.
- [ x ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

