### PR TITLE
Backport patches to 12.12 branch required for ForTrilinos

### DIFF
--- a/packages/anasazi/src/AnasaziTraceMin.hpp
+++ b/packages/anasazi/src/AnasaziTraceMin.hpp
@@ -53,7 +53,9 @@
 #include "AnasaziBasicSort.hpp"
 #include "AnasaziTraceMinBase.hpp"
 
-#include "Epetra_Operator.h"
+#ifdef HAVE_ANASAZI_EPETRA
+  #include "Epetra_Operator.h"
+#endif
 
 #include "AnasaziEigensolver.hpp"
 #include "AnasaziMultiVecTraits.hpp"

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -1649,7 +1649,7 @@ namespace Tpetra {
                            const bool tolerant=false,
                            const bool debug=false)
       {
-        return readSparseGraph (filename, pComm, Teuchos::null, callFillComplete, tolerant, debug);
+        return readSparseGraphFile (filename, pComm, Teuchos::null, callFillComplete, tolerant, debug);
       }
 
       //! Variant of readSparseGraph that takes a Node object.
@@ -1716,9 +1716,9 @@ namespace Tpetra {
                        const bool tolerant=false,
                        const bool debug=false)
       {
-        return readSparseGraph (filename, pComm, Teuchos::null,
-                                constructorParams, fillCompleteParams,
-                                tolerant, debug);
+        return readSparseGraphFile (filename, pComm, Teuchos::null,
+                                    constructorParams, fillCompleteParams,
+                                    tolerant, debug);
       }
 
       //! Variant of readSparseFile above that takes a Node object.
@@ -1866,9 +1866,11 @@ namespace Tpetra {
                   const bool tolerant=false,
                   const bool debug=false)
       {
-        Teuchos::RCP<sparse_graph_type> graph = readSparseGraphHelper(in, pComm, pNode, Teuchos::null, Teuchos::null, Teuchos::null,tolerant,debug);
+        Teuchos::RCP<const map_type> rowMap;
+        Teuchos::RCP<const map_type> colMap;
+        Teuchos::RCP<sparse_graph_type> graph = readSparseGraphHelper(in, pComm, pNode, rowMap, colMap, Teuchos::null,tolerant,debug);
         if(callFillComplete)
-          graph->FillComplete();
+          graph->fillComplete();
         return graph;
       }
 
@@ -1922,9 +1924,11 @@ namespace Tpetra {
                   const bool tolerant=false,
                   const bool debug=false)
       {
+        Teuchos::RCP<const map_type> rowMap;
+        Teuchos::RCP<const map_type> colMap;
         Teuchos::RCP<sparse_graph_type> graph = readSparseGraphHelper(in, pComm, pNode,
-            Teuchos::null, Teuchos::null, constructorParams, tolerant, debug);
-        graph->FillComplete(fillCompleteParams);
+            rowMap, colMap, constructorParams, tolerant, debug);
+        graph->fillComplete(fillCompleteParams);
         return graph;
       }
 

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1248,7 +1248,9 @@ namespace Tpetra {
     /// getGlobalElement() (which is a host method, and therefore
     /// requires a host View) if necessary (only noncontiguous Maps
     /// need this).
+#ifndef SWIG
     mutable typename decltype (lgMap_)::HostMirror lgMapHost_;
+#endif
 
     //! Type of a mapping from global IDs to local IDs.
     typedef Details::FixedHashTable<GlobalOrdinal, LocalOrdinal, device_type>


### PR DESCRIPTION
**NOTE**: the PR is against `trilinos-release-12-12-branch`

This is a set of 3 patches required to compile ForTrilinos. Two of them (Anasazi and Tpetra SWIG fix) were backported from `develop` upstream. One (Tpetra MatrixMarket) was newly created and just fixes the compilation issues. The problem was fixed upstream too (see, for example, 45ffbb25237981ea9b3c1bb0677f473ad54e14ca) but slightly changed the interface (including variables) which would require further changes in ForTrilinos later. The patch itself is trivial here.

@bmpersc @jwillenbring @trilinos/framework 
