### PR TITLE
Tpetra: Change to default return value from a named query of TPETRA_DEBUG

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -290,7 +290,7 @@ bool Behavior::assumeMpiIsCudaAware ()
 bool Behavior::debug (const char name[])
 {
   constexpr char envVarName[] = "TPETRA_DEBUG";
-  constexpr bool defaultValue = debugDefault();
+  constexpr bool defaultValue = false;
 
   static std::once_flag flag_;
   static bool initialized_ = false;
@@ -304,7 +304,7 @@ bool Behavior::debug (const char name[])
 bool Behavior::verbose (const char name[])
 {
   constexpr char envVarName[] = "TPETRA_VERBOSE";
-  constexpr bool defaultValue = verboseDefault();
+  constexpr bool defaultValue = false;
 
   static std::once_flag flag_;
   static bool initialized_ = false;

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -66,9 +66,15 @@ namespace Details {
 /// The environment variables are understood to be "on" or "off" and recognized
 /// if specified in one of two ways.  The first is to specify the variable
 /// unconditionally ON or OFF.  e.g., TPETRA_VERBOSE=ON or TPETRA_VERBOSE=OFF.
+/// The default value of TPETRA_VERBOSE is always OFF.  The default value for
+/// TPETRA_DEBUG is ON if Tpetra is configured with Tpetra_ENABLE_DEBUG,
+/// otherwise it is OFF
+///
 /// The second is to specify the variable on a per class/object basis, e.g.,
-/// TPETRA_VERBOSE=CrsGraph:CrsMatrix:Distributor means that verbose output
-/// will be enabled for CrsGraph, CrsMatrix, and Distributor classes.
+/// TPETRA_VERBOSE=CrsGraph,CrsMatrix,Distributor means that verbose output
+/// will be enabled for CrsGraph, CrsMatrix, and Distributor classes.  For this
+/// second method, the default values of both TPETRA_VERBOSE and TPETRA_DEBUG
+/// is OFF.
 class Behavior {
 public:
   /// \brief Whether Tpetra is in debug mode.
@@ -83,7 +89,7 @@ public:
   ///
   /// \param name [in] Name of the Tpetra object.  Typically, the object would
   ///        be a class name, e.g., "CrsGraph" or method, e.g.,
-  ///        "CrsGraph.insertLocalIndices".
+  ///        "CrsGraph::insertLocalIndices".
   static bool debug (const char name[]);
 
   /// \brief Whether Tpetra is in verbose mode.
@@ -97,7 +103,7 @@ public:
   ///
   /// \param name [in] Name of the Tpetra object.  Typically, the object would
   ///        be a class name, e.g., "CrsGraph" or method, e.g.,
-  ///        "CrsGraph.insertLocalIndices".
+  ///        "CrsGraph::insertLocalIndices".
   static bool verbose (const char name[]);
 
   /// \brief Whether to assume that MPI is CUDA aware.

--- a/packages/tpetra/core/test/Behavior/Behavior_Named.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Named.cpp
@@ -77,8 +77,9 @@ TEUCHOS_UNIT_TEST(Behavior, Named)
 #endif
 
   // TPETRA_DEBUG was set globally in TEUCHOS_STATIC_SETUP to a named value, so
-  // any query on TPETRA_DEBUG should evaluate to the default value, unless the
-  // query is performed on one of the named values.
+  // any named query on TPETRA_DEBUG should evaluate to false, unless the
+  // query is performed on one of the named values.  Unnamed queries should
+  // return the default value.
   bool dbg = Tpetra::Details::Behavior::debug();
   TEUCHOS_TEST_ASSERT(dbg==debug_default, out, success);
   bool dbg_1 = Tpetra::Details::Behavior::debug("Dbg1");
@@ -86,7 +87,7 @@ TEUCHOS_UNIT_TEST(Behavior, Named)
   bool dbg_2 = Tpetra::Details::Behavior::debug("Dbg2");
   TEUCHOS_TEST_ASSERT(dbg_2, out, success);
   bool dbg_3 = Tpetra::Details::Behavior::debug("Dbg3");
-  TEUCHOS_TEST_ASSERT(dbg_3==debug_default, out, success);
+  TEUCHOS_TEST_ASSERT(!dbg_3, out, success);
 
   // TPETRA_VERBOSE was set globally in TEUCHOS_STATIC_SETUP to a named value,
   // so any query on TPETRA_VERBOSE should evaluate to false, unless the query


### PR DESCRIPTION
For named query of `TPETRA_DEBUG`, return `true` if and only if the name appears in `TPETRA_DEBUG`.

Built on RHEL6 with sems gcc-4.9.3 software stack.  All Tpetra tests pass