### PR TITLE
Teuchos: Reader should check success of file open

### DIFF
--- a/packages/teuchos/parser/src/Teuchos_Reader.cpp
+++ b/packages/teuchos/parser/src/Teuchos_Reader.cpp
@@ -312,6 +312,9 @@ void Reader::read_string(any& result, std::string const& string, std::string con
 
 void Reader::read_file(any& result, std::string const& file_name) {
   std::ifstream stream(file_name.c_str());
+  TEUCHOS_TEST_FOR_EXCEPTION(!stream.is_open(),
+      ParserFail,
+      "Could not open file " << file_name);
   read_stream(result, stream, file_name);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
Checks whether the file stream to parse actually opened successfully, via `TEUCHOS_TEST_FOR_EXCEPTION`.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Without this change, if the file doesn't exist, users would get an error saying that parsing the first character had failed. It is more appropriate that they get an error indicating the file could not be opened in the first place.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.