### PR TITLE
Stop throwing from destructors

### DIFF
--- a/packages/belos/epetra/src/BelosEpetraAdapter.cpp
+++ b/packages/belos/epetra/src/BelosEpetraAdapter.cpp
@@ -273,7 +273,7 @@ namespace Belos {
 
 	  const int info = 
 	    const_cast<Epetra_Operator &>(Op_).SetUseTranspose (originalTransposeFlag_);
-	  TEUCHOS_TEST_FOR_EXCEPTION(info != 0, EpetraOpFailure,
+	  TEUCHOS_TEST_FOR_TERMINATION(info != 0,
 			     "Resetting the original "
 			     "transpose flag value of the Epetra_Operator failed, "
 			     "returning a nonzero error code of " << info << ".  "
@@ -301,8 +301,7 @@ namespace Belos {
 	// have the right value on the second call.  This would make the
 	// resulting exception message confusing.
 	const bool finalTransposeFlag = Op_.UseTranspose ();
-	TEUCHOS_TEST_FOR_EXCEPTION(originalTransposeFlag_ != finalTransposeFlag,
-			   std::logic_error,
+	TEUCHOS_TEST_FOR_TERMINATION(originalTransposeFlag_ != finalTransposeFlag,
 			   "Belos::OperatorTraits::Apply: The value of the "
 			   "Epetra_Operator's transpose flag changed unexpectedly!"
 			   "  The original value at the top of this method was "

--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.h
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.h
@@ -1051,7 +1051,7 @@ template <class T> void MLVec<T>::wrap(T *start, T *end, bool okToChangePtr,
 
 template <class T> MLVec<T>::~MLVec()              { 
    if (data_ != NULL) {
-      TEUCHOS_TEST_FOR_EXCEPTION(size_ == 0,std::logic_error,
+      TEUCHOS_TEST_FOR_TERMINATION(size_ == 0,
       "MLVec error, data pointer should be null for 0 length vectors\n");
       if (okToChangePtr_ && (freeType_ == useFree))   ML_free(data_); 
       if (okToChangePtr_ && (freeType_ == useDelete)) delete data_;

--- a/packages/teuchos/core/src/Teuchos_RCPNode.cpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.cpp
@@ -691,7 +691,7 @@ ActiveRCPNodesSetup::~ActiveRCPNodesSetup()
     std::cerr << "\nPrint active nodes!\n";
 #endif // TEUCHOS_SHOW_ACTIVE_REFCOUNTPTR_NODE_TRACE
     std::cout << std::flush;
-    TEUCHOS_TEST_FOR_EXCEPT(0==rcp_node_list());
+    TEUCHOS_TEST_FOR_TERMINATION(nullptr==rcp_node_list(), "rcp_node_list() is null in ~ActiveRCPNodesSetup");
     RCPNodeTracer::RCPNodeStatistics rcpNodeStatistics =
       RCPNodeTracer::getRCPNodeStatistics();
     if (rcpNodeStatistics.maxNumRCPNodes

--- a/packages/teuchos/core/src/Teuchos_RCPNode.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.hpp
@@ -586,7 +586,7 @@ public:
   ~RCPNodeTmpl()
     {
 #ifdef TEUCHOS_DEBUG
-      TEUCHOS_TEST_FOR_EXCEPTION( ptr_!=0, std::logic_error,
+      TEUCHOS_TEST_FOR_TERMINATION( ptr_!=0,
         "Error, the underlying object must be explicitly deleted before deleting"
         " the node object!" );
 #endif

--- a/packages/teuchos/core/src/Teuchos_TestForException.cpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.cpp
@@ -41,6 +41,7 @@
 
 #include "Teuchos_TestForException.hpp"
 
+#include <iostream>
 
 //
 // ToDo: Make these functions thread-safe!
@@ -108,4 +109,9 @@ void Teuchos::TestForException_setEnableStacktrace(bool enableStrackTrace)
 bool Teuchos::TestForException_getEnableStacktrace()
 {
   return loc_enableStackTrace();
+}
+
+void Teuchos::TestForTermination_terminate(const std::string &msg) {
+  std::cerr << msg;
+  std::terminate();
 }

--- a/packages/teuchos/core/src/Teuchos_TestForException.hpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.hpp
@@ -361,6 +361,21 @@ catch(const std::exception &except) { \
   throw std::runtime_error(omsg.str()); \
 }
 
+/** \brief This macro is to be used instead of
+ * <tt>TEUCHOS_TEST_FOR_EXCEPTION()</tt> to report an error in situations
+ * where an exception can't be throw (like in an destructor).
+ *
+ * \param terminate_test [in] See <tt>TEUCHOS_TEST_FOR_EXCEPTION()</tt>.
+ *
+ * \param msg [in] See <tt>TEUCHOS_TEST_FOR_EXCEPTION()</tt>.
+ *
+ * If the termination test evaluates to <tt>true</tt>, then
+ * <tt>std::terminate()</tt> is called (which should bring down an entire
+ * multi-process MPI program even if only one process calls
+ * <tt>std::terminate()</tt> with most MPI implementation).
+ *
+ * \ingroup TestForException_grp
+ */
 #define TEUCHOS_TEST_FOR_TERMINATION(terminate_test, msg) \
 { \
   const bool call_terminate = (terminate_test); \

--- a/packages/teuchos/core/src/Teuchos_TestForException.hpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.hpp
@@ -75,6 +75,9 @@ TEUCHOSCORE_LIB_DLL_EXPORT void TestForException_setEnableStacktrace(bool enable
  * exceptions are thrown. */
 TEUCHOSCORE_LIB_DLL_EXPORT bool TestForException_getEnableStacktrace();
 
+/** \brief Prints the message to std::cerr and calls std::terminate. */
+TEUCHOSCORE_LIB_DLL_EXPORT [[noreturn]] void TestForTermination_terminate(const std::string &msg);
+
 
 } // namespace Teuchos
 
@@ -358,7 +361,19 @@ catch(const std::exception &except) { \
   throw std::runtime_error(omsg.str()); \
 }
 
-
-
+#define TEUCHOS_TEST_FOR_TERMINATION(terminate_test, msg) \
+{ \
+  const bool call_terminate = (terminate_test); \
+  if (call_terminate) { \
+    std::ostringstream omsg; \
+    omsg \
+      << __FILE__ << ":" << __LINE__ << ":\n\n" \
+      << "Terminate test that evaluated to true: "#terminate_test \
+      << "\n\n" \
+      << msg << "\n\n"; \
+    auto str = omsg.str(); \
+    Teuchos::TestForTermination_terminate(str); \
+  } \
+}
 
 #endif // TEUCHOS_TEST_FOR_EXCEPTION_H

--- a/packages/teuchos/core/src/Teuchos_TestForException.hpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.hpp
@@ -372,7 +372,7 @@ catch(const std::exception &except) { \
  * If the termination test evaluates to <tt>true</tt>, then
  * <tt>std::terminate()</tt> is called (which should bring down an entire
  * multi-process MPI program even if only one process calls
- * <tt>std::terminate()</tt> with most MPI implementation).
+ * <tt>std::terminate()</tt> with most MPI implementations).
  *
  * \ingroup TestForException_grp
  */

--- a/packages/teuchos/core/src/Teuchos_Workspace.cpp
+++ b/packages/teuchos/core/src/Teuchos_Workspace.cpp
@@ -160,8 +160,8 @@ RawWorkspace::~RawWorkspace()
   }
   else {
     if(workspace_store_) {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        workspace_store_->curr_ws_ptr_ != workspace_end_, std::logic_error
+      TEUCHOS_TEST_FOR_TERMINATION(
+        workspace_store_->curr_ws_ptr_ != workspace_end_
         ,"RawWorkspace::~RawWorkspace(...): Error, "
         "Invalid usage of RawWorkspace class, corrupted WorspaceStore object!" );
       workspace_store_->curr_ws_ptr_ = workspace_begin_;

--- a/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
+++ b/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
@@ -405,6 +405,17 @@ FOREACH(PID RANGE ${testTeuchosTestForTermination_NP_m_1})
 ENDFOREACH()
 
 
+# Test call to terminate on bad destructor call
+IF (${PARENT_PACKAGE_NAME}_ENABLE_DEBUG)
+  TRIBITS_ADD_EXECUTABLE_AND_TEST( testTeuchosRCPNodeImplDestructTerminate
+    SOURCES testTeuchosRCPNodeImplDestructTerminate.cpp
+    NUM_MPI_PROCS 1
+    PASS_REGULAR_EXPRESSION
+      "Error, the underlying object must be explicitly deleted before deleting the node object"
+    )
+ENDIF()
+
+
 #
 # RCP Beginners Guide example code
 #

--- a/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
+++ b/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
@@ -373,7 +373,7 @@ ENDIF()
 #
 # Test TEUCHOS_TEST_FOR_TERMINATION()
 #
-# This aborts the program so the only way to test it is to run a program.
+# This macro aborts the program so the only way to test it is to run a program.
 #
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST( testTeuchosTestForTermination
@@ -401,7 +401,8 @@ FOREACH(PID RANGE ${testTeuchosTestForTermination_NP_m_1})
       "Bingo, we are terminating on procid == terminate_on_procid = ${PID}"
     )
   # NOTE: If each of these tests does not terminate right away, then that is a
-  # sign that std::terminate() on a single process does not
+  # sign that std::terminate() on a single MPI process does not cause all other
+  # processes to also terminate.
 ENDFOREACH()
 
 

--- a/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
+++ b/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
@@ -371,6 +371,41 @@ ENDIF()
 
 
 #
+# Test TEUCHOS_TEST_FOR_TERMINATION()
+#
+# This aborts the program so the only way to test it is to run a program.
+#
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST( testTeuchosTestForTermination
+  SOURCES testTeuchosTestForTermination.cpp
+  NUM_MPI_PROCS 1
+  PASS_REGULAR_EXPRESSION
+    "Bingo, we are terminating on procid == terminate_on_procid = 0"
+  )
+
+
+SET(testTeuchosTestForTermination_NP 4)
+MATH(EXPR testTeuchosTestForTermination_NP_m_1
+  "${testTeuchosTestForTermination_NP}-1")
+FOREACH(PID RANGE ${testTeuchosTestForTermination_NP_m_1})
+  TRIBITS_ADD_ADVANCED_TEST(
+    testTeuchosTestForTermination_${PID}_MPI_${testTeuchosTestForTermination_NP}
+    COMM mpi
+    TEST_0
+      MESSAGE "Call TEUCHOS_TEST_FOR_TERMINATION(true) only on PID=${PID} which should terminate all processes"
+      EXEC testTeuchosTestForTermination
+      ARGS --terminate-on-procid=${PID}
+      NUM_MPI_PROCS ${testTeuchosTestForTermination_NP}
+      PASS_REGULAR_EXPRESSION_ALL
+      "p=${PID}: .*/testTeuchosTestForTermination.cpp"
+      "Bingo, we are terminating on procid == terminate_on_procid = ${PID}"
+    )
+  # NOTE: If each of these tests does not terminate right away, then that is a
+  # sign that std::terminate() on a single process does not
+ENDFOREACH()
+
+
+#
 # RCP Beginners Guide example code
 #
 SET(EXAMPLE_RAW_CPP_POINTERS_CPP

--- a/packages/teuchos/core/test/MemoryManagement/testTeuchosRCPNodeImplDestructTerminate.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/testTeuchosRCPNodeImplDestructTerminate.cpp
@@ -1,0 +1,63 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+// @HEADER
+*/
+
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_RCPNode.hpp"
+
+int main(int argc, char* argv[])
+{
+
+  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+
+  {
+    int obj = 1;
+    using Dealloc_T = Teuchos::DeallocDelete<int>;
+    Teuchos::RCPNodeTmpl<int, Teuchos::DeallocDelete<int> >
+      rcpNode(&obj, Dealloc_T(), false);
+  }
+  // When the above destructor executes it should terminate the program with
+  // an error message!
+
+  return 1; // Will never be called!
+
+}

--- a/packages/teuchos/core/test/MemoryManagement/testTeuchosTestForTermination.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/testTeuchosTestForTermination.cpp
@@ -1,3 +1,4 @@
+/*
 // @HEADER
 // ***********************************************************************
 //
@@ -38,84 +39,29 @@
 //
 // ***********************************************************************
 // @HEADER
+*/
 
-#include "Teuchos_TestForException.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_TestForException.hpp"
 
-#include <iostream>
-
-//
-// ToDo: Make these functions thread-safe!
-//
-
-
-namespace {
-
-
-int throwNumber = 0;
-
-
-bool& loc_enableStackTrace()
+int main(int argc, char* argv[])
 {
-  static bool static_enableStackTrace =
-#ifdef HAVE_TEUCHOS_DEFAULT_STACKTRACE
-    true
-#else
-    false
-#endif
-    ;
-  return static_enableStackTrace;
-}
 
+  using Teuchos::GlobalMPISession;
+  GlobalMPISession mpiSession(&argc,&argv);
 
-} // namespace
+  Teuchos::CommandLineProcessor clp;
+  int terminate_on_procid = 0;
+  clp.setOption("terminate-on-procid", &terminate_on_procid);
+  (void)clp.parse(argc, argv);
 
+  TEUCHOS_TEST_FOR_TERMINATION(
+    GlobalMPISession::getRank() == terminate_on_procid,
+    "Bingo, we are terminating on procid == "
+    "terminate_on_procid = "<<GlobalMPISession::getRank()<<"!"
+    );
 
-void Teuchos::TestForException_incrThrowNumber()
-{
-  ++throwNumber;
-}
+  return 1; // Will never be called!
 
-
-int Teuchos::TestForException_getThrowNumber()
-{
-  return throwNumber;
-}
-
-
-void Teuchos::TestForException_break( const std::string &errorMsg )
-{
-  size_t break_on_me;
-  break_on_me = errorMsg.length(); // Use errMsg to avoid compiler warning.
-  if (break_on_me)
-    ; // Avoid 'used var' warning
-  // Above is just some statement for the debugger to break on.  Note: now is
-  // a good time to examine the stack trace and look at the error message in
-  // 'errorMsg' to see what happened.  In GDB just type 'where' or you can go
-  // up by typing 'up' and moving up in the stack trace to see where you are
-  // and how you got to this point in the code where you are throwning this
-  // exception!  Typing in a 'p errorMsg' will show you what the error message
-  // is.  Also, you should consider adding a conditional breakpoint in this
-  // function based on a specific value of 'throwNumber' if the exception you
-  // want to examine is not the first exception thrown.
-}
-
-
-void Teuchos::TestForException_setEnableStacktrace(bool enableStrackTrace)
-{
-  loc_enableStackTrace() = enableStrackTrace;
-}
-
-
-bool Teuchos::TestForException_getEnableStacktrace()
-{
-  return loc_enableStackTrace();
-}
-
-void Teuchos::TestForTermination_terminate(const std::string &msg) {
-  if (GlobalMPISession::getNProc() > 1) {
-    std::cerr << "p="<<GlobalMPISession::getRank()<<": ";
-  }
-  std::cerr << msg << "\n";
-  std::terminate();
 }

--- a/packages/teuchos/doc/build_docs
+++ b/packages/teuchos/doc/build_docs
@@ -23,12 +23,20 @@ echo
 echo "Generating RefCountPtrBeginnersGuideSAND.pdf file ..."
 echo
 
-pushd ../../../doc/RefCountPtr/beginners; make pdf ; popd
-cp ../../../doc/RefCountPtr/beginners/RefCountPtrBeginnersGuideSAND.pdf html/.
+if [ -e ../../../doc/RefCountPtr/beginners ] ; then
+  pushd ../../../doc/RefCountPtr/beginners; make pdf ; popd
+  cp ../../../doc/RefCountPtr/beginners/RefCountPtrBeginnersGuideSAND.pdf html/.
+else
+  echo "Skipping building RefCountPtrBeginnersGuideSAND.pdf because source directory does not exist!"
+fi
 
 echo
 echo "Generating TeuchosMemoryManagementSAND.pdf file ..."
 echo
 
-pushd ../../../doc/TeuchosMemoryManagementSAND; make; popd
-cp ../../../doc/TeuchosMemoryManagementSAND/TeuchosMemoryManagementSAND.pdf html/.
+if [ -e ../../../doc/TeuchosMemoryManagementSAND ] ; then
+  pushd ../../../doc/TeuchosMemoryManagementSAND; make; popd
+  cp ../../../doc/TeuchosMemoryManagementSAND/TeuchosMemoryManagementSAND.pdf html/.
+else
+  echo "Skipping building TeuchosMemoryManagementSAND.pdf because directory does not exist!"
+fi

--- a/packages/teuchos/doc/index.doc
+++ b/packages/teuchos/doc/index.doc
@@ -215,14 +215,14 @@ contains basic, general-purpose utilities.
 
   <ul>
 
-  <li> <em>Testing for Exceptions</em>: The TEUCHOS_TEST_FOR_EXCEPTION() macro accepts
-  a logical test, an exception handler, and a message.  It then throws
-  an "intelligent" exception informing the user of the file, line, and
-  message where the exception was thrown.  The macro
-  TEUCHOS_TEST_FOR_EXCEPT() is a shorter macro that just accepts a
-  logic test and is therefore easier to write.  Please use
-  TEUCHOS_TEST_FOR_EXCEPT(!test) as a safer, more informative
-  alternative to assert(test).</li>
+  <li> <em>Testing for Exceptions</em>: The TEUCHOS_TEST_FOR_EXCEPTION() macro
+  accepts a logical test, an exception handler, and a message.  It then throws
+  an "intelligent" exception informing the user of the file, line, and message
+  where the exception was thrown.  The macro TEUCHOS_TEST_FOR_EXCEPT() is a
+  shorter macro that just accepts a logic test and is therefore easier to
+  write.  Please use TEUCHOS_TEST_FOR_EXCEPT(!test) as a safer, more
+  informative alternative to assert(test).  For related error handling
+  utilties, see \ref TestForException_grp</li>
 
   <li> <em>Stack Tracing</em>: When a debug build is enabled
   (CMAKE_BUILD_TYPE=DEBUG OR Trilinos_ENABLE_DEBUG=ON) and when using GCC and

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DetachedVectorView.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DetachedVectorView.hpp
@@ -342,7 +342,7 @@ public:
   ~DetachedVectorView()
     {
       if( sv_s_.stride() != sv_.stride() ) {
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "I don't think non-unit stride has ever been tested!");
+        Teuchos::TestForTermination_terminate("I don't think non-unit stride has ever been tested!");
         //Teuchos_Ordinal i; Scalar *sv_v; const Scalar *values;
         //for (
         //  sv_v = sv_s_.values().get(), values = sv_.values().get(), i=0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 
@trilinos/thyra 
@trilinos/belos 
@trilinos/ml 
@lxmota 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
From the first commit message:

This is the foundation for fixing #1303.
First, the macro TEUCHOS_TEST_FOR_TERMINATION
is introduced, which calls std::terminate()
instead of throwing an exception.

I think std::terminate() is the most appropriate
exit call here, because it is exactly what the
compiler would have done anyway. In particular,
the warnings we were getting said
"warning: throw will always call terminate() [-Wterminate]"
As such, if we explicitly call std::terminate ourselves,
we are preserving the existing behavior while silencing
the warning.

TEUCHOS_TEST_FOR_TERMINATION takes stream message code,
and that message will be sent to std::cerr.

This commit also replaces all calls in Teuchos, Belos, Thyra, and ML to
TEUCHOS_TEST_FOR_EXCEPTION (and similar macros) from
within destructors with TEUCHOS_TEST_FOR_TERMINATION.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
See #1303 for general discussion, but here is some data to put this issue into perspective, also from the first commit message:

The most important change is the one in ~RCPNodeTmpl()
in Teuchos_RCPNode.hpp which is guarded by TEUCHOS_DEBUG.
When TEUCHOS_DEBUG is defined, this instance alone emitted
its warning at least 136702 times in one user's reported build
of Trilinos, due to the ubuquitous use of RCP in Trilinos.
Given that one warning and its associated notes are close to 1KB
of text, this dominated and bloated all other build output
for a total of around 100MB of text output from the build.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes #1303 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A debug build of only Teuchos with `-Werror` and `TEUCHOS_DEBUG` defined built successfully and passed all Teuchos tests. Will rely on PR testing as well.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.