### PR TITLE
Teuchos: try to silence RCPNodeInfo() warning

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCPNode.cpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.cpp
@@ -70,7 +70,7 @@ namespace {
 
 
 struct RCPNodeInfo {
-  RCPNodeInfo() : nodePtr(0) {}
+  RCPNodeInfo() = delete;
   RCPNodeInfo(const std::string &info_in, Teuchos::RCPNode* nodePtr_in)
     : info(info_in), nodePtr(nodePtr_in)
     {}
@@ -494,7 +494,7 @@ void RCPNodeTracer::addNewRCPNode( RCPNode* rcp_node, const std::string &info )
     // creates an owning RCP to an object already owned by another RCPNode.
 
     // Add the new RCP node keyed as described above.
-    (*rcp_node_list()).insert(
+    (*rcp_node_list()).emplace_hint(
       itr_itr.second,
       std::make_pair(map_key_void_ptr, RCPNodeInfo(info, rcp_node))
       );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
It seems certain compilers are smart enough
to realize that no code will ever call
RCPNodeInfo's default constructor, and it
is therefore pointless to define it.
To make this clear, I've changed its definition
to be "= delete;" (C++11 !) and changed the
one place where RCPNodeInfo is constructed to
use emplace_hint, which really isn't too
critical but may improve performance a bit.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This change resolves this warning on GCC 4.9.3 and 5.4.0:
```
src/Trilinos/packages/teuchos/core/src/Teuchos_RCPNode.cpp(73): warning: function "::RCPNodeInfo::RCPNodeInfo()" was declared but never referenced
```

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A build of Teuchos passed regression tests
