### PR TITLE
Teuchos: Fix YAML comment-after-block-scalar bug

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser_decl.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser_decl.hpp
@@ -151,7 +151,7 @@ std::string convertXmlToYaml(const std::string& xmlFileName); //returns filename
 void convertXmlToYaml(const std::string& xmlFileName, const std::string& yamlFileName); //writes to given filename
 void convertXmlToYaml(std::istream& xmlStream, std::ostream& yamlStream);
 
-//Class modeled after Teuchos::XMLParameterListReader
+//Functions modeled after Teuchos::XMLParameterListReader
 namespace YAMLParameterList
 {
   Teuchos::RCP<Teuchos::ParameterList> parseYamlText(const std::string& text,

--- a/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
+++ b/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
@@ -220,5 +220,30 @@ namespace TeuchosTests
       "#   Stride Time: 5.0e-12\n");
   }
 
+  TEUCHOS_UNIT_TEST(YAML, Issue2090)
+  {
+    auto params = Teuchos::getParametersFromYamlString(
+      "Parameter List:\n"
+      "  Boundary Conditions:\n"
+      "    Bottom:\n"
+      "      Dirichlet:\n"
+      "        Sideset: bottom\n"
+      "        Field:   ES_POTENTIAL\n"
+      "        Value: |\n"
+      "          double r_sq = xin*xin+yin*yin;\n"
+      "          double factor = 0.5*1.e8*1.60217662e-19/(2*3.14159265358979323846*8.854187817e-12);\n"
+      "          ES_POTENTIAL= factor*log(r_sq) +3*xin-3*yin;\n"
+      "  # end Boundary Conditions\n");
+    TEST_EQUALITY(
+        Teuchos::getParameter<std::string>(
+           params->sublist("Boundary Conditions", true)
+           .sublist("Bottom", true)
+           .sublist("Dirichlet", true)
+          ,"Value"),
+      "double r_sq = xin*xin+yin*yin;\n"
+      "double factor = 0.5*1.e8*1.60217662e-19/(2*3.14159265358979323846*8.854187817e-12);\n"
+      "ES_POTENTIAL= factor*log(r_sq) +3*xin-3*yin;\n");
+  }
+
 } //namespace TeuchosTests
 

--- a/packages/teuchos/parser/src/Teuchos_Reader.cpp
+++ b/packages/teuchos/parser/src/Teuchos_Reader.cpp
@@ -341,7 +341,6 @@ void DebugReader::at_shift(any& result, int token, std::string& text) {
     }
   }
   os << "SHIFT (" << at(grammar->symbol_names, token) << ")[" << text_escaped << "]\n";
-  os << "symbol_indentation_stack.back() " << symbol_indentation_stack.back() << '\n';
 }
 
 void DebugReader::at_reduce(any& result, int prod_i, std::vector<any>& rhs) {
@@ -356,7 +355,6 @@ void DebugReader::at_reduce(any& result, int prod_i, std::vector<any>& rhs) {
   }
   const std::string& lhs_name = at(grammar->symbol_names, prod.lhs);
   os << " -> (" << lhs_name << ")[" << lhs_text << "]\n";
-  os << "symbol_indentation_stack.back() " << symbol_indentation_stack.back() << '\n';
 }
 
 }  // namespace Teuchos


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
As shown in #2090, having an un-indented comment right after a block scalar would cause the text of that comment to become part of the block scalar. I first added a test to confirm that the block scalar content was not what we want, and coded a trimming procedure to remove such trailing things from block scalars.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Without this fix, comments cannot be safely placed after a block scalar.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes #2090 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A build of Teuchos passed all tests, including the new one that specifically reproduces #2090.
