### PR TITLE
Tempus: fix ETI builds #2109

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -734,17 +734,6 @@ Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integratorBasic(
 /// Non-member constructor
 template<class Scalar>
 Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integratorBasic(
-  Teuchos::RCP<Teuchos::ParameterList>                     pList,
-  const Teuchos::RCP<Stepper<Scalar> >&                    stepper)
-{
-  Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integrator =
-    Teuchos::rcp(new Tempus::IntegratorBasic<Scalar>(pList, stepper));
-  return(integrator);
-}
-
-/// Non-member constructor
-template<class Scalar>
-Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > integratorBasic(
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&      model,
   std::string stepperType)
 {


### PR DESCRIPTION
There was an extra nonmember ctor implementation in the impl file with an invalid input parameter. Probably a cut-n-paste error.