### PR TITLE
Teuchos warnings

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCPNode.cpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.cpp
@@ -84,22 +84,6 @@ typedef std::pair<const void*, RCPNodeInfo> VoidPtrNodeRCPInfoPair_t;
 
 typedef std::multimap<const void*, RCPNodeInfo> rcp_node_list_t;
 
-
-class RCPNodeInfoListPred {
-public:
-  bool operator()(const rcp_node_list_t::value_type &v1,
-    const rcp_node_list_t::value_type &v2
-    ) const
-    {
-#ifdef TEUCHOS_DEBUG
-      return v1.second.nodePtr->insertion_number() < v2.second.nodePtr->insertion_number();
-#else
-      return v1.first < v2.first;
-#endif
-    }
-};
-
-
 //
 // Local static functions returning references to local static objects to
 // ensure objects are initilaized.
@@ -396,7 +380,16 @@ void RCPNodeTracer::printActiveRCPNodes(std::ostream &out)
       // debug-mode build.
       typedef std::vector<VoidPtrNodeRCPInfoPair_t> rcp_node_vec_t;
       rcp_node_vec_t rcp_node_vec(rcp_node_list()->begin(), rcp_node_list()->end());
-      std::sort(rcp_node_vec.begin(), rcp_node_vec.end(), RCPNodeInfoListPred());
+      std::sort(rcp_node_vec.begin(), rcp_node_vec.end(),
+          [] (const rcp_node_list_t::value_type &v1, const rcp_node_list_t::value_type &v2)
+          {
+#ifdef TEUCHOS_DEBUG
+            return v1.second.nodePtr->insertion_number() < v2.second.nodePtr->insertion_number();
+#else
+            return v1.first < v2.first;
+#endif
+          }
+      );
       // Print the RCPNode objects sorted by insertion number
       typedef rcp_node_vec_t::const_iterator itr_t;
       int i = 0;

--- a/packages/teuchos/parser/src/Teuchos_YAML.cpp
+++ b/packages/teuchos/parser/src/Teuchos_YAML.cpp
@@ -5,32 +5,11 @@
 namespace Teuchos {
 namespace YAML {
 
-Language make_language() {
-  Language out;
-  Language::Productions& prods = out.productions;
-  Language::Tokens& toks = out.tokens;
+namespace {
+
+Language::Productions make_productions() {
+  Language::Productions prods;
   prods.resize(NPRODS);
-  toks.resize(NTOKS);
-  toks[TOK_NEWLINE]("NEWLINE", "((#[^\r\n]*)?\r?\n[ \t]*)+");
-  toks[TOK_INDENT]("INDENT", "((#[^\r\n]*)?\r?\n[ \t]*)+");
-  toks[TOK_DEDENT]("DEDENT", "((#[^\r\n]*)?\r?\n[ \t]*)+");
-  toks[TOK_SPACE]("WS", "[ \t]");
-  toks[TOK_COLON](":", ":");
-  toks[TOK_DOT](".", "\\.");
-  toks[TOK_DASH]("-", "\\-");
-  toks[TOK_DQUOT]("\"", "\"");
-  toks[TOK_SQUOT]("'", "'");
-  toks[TOK_SLASH]("\\", "\\\\");
-  toks[TOK_PIPE]("|", "\\|");
-  toks[TOK_LSQUARE]("[", "\\[");
-  toks[TOK_RSQUARE]("]", "\\]");
-  toks[TOK_LCURLY]("{", "{");
-  toks[TOK_RCURLY]("}", "}");
-  toks[TOK_RANGLE](">", ">");
-  toks[TOK_COMMA](",", ",");
-  toks[TOK_PERCENT]("%", "%");
-  toks[TOK_EXCL]("!", "!");
-  toks[TOK_OTHER]("OTHERCHAR", "[^ \t:\\.\\-\"'\\\\\\|\\[\\]{}>,%#!\n\r]");
   prods[PROD_DOC]("doc") >> "top_items";
   prods[PROD_DOC2]("doc") >> "NEWLINE", "top_items";
   prods[PROD_TOP_FIRST]("top_items") >> "top_item";
@@ -150,6 +129,37 @@ Language make_language() {
   prods[PROD_SPACE_STAR_NEXT]("WS*") >> "WS*", "WS";
   prods[PROD_SPACE_PLUS_FIRST]("WS+") >> "WS";
   prods[PROD_SPACE_PLUS_NEXT]("WS+") >> "WS+", "WS";
+  return prods;
+}
+
+} // end anonymous namespace
+
+Language make_language() {
+  Language out;
+  Language::Productions& prods = out.productions;
+  prods = make_productions();
+  Language::Tokens& toks = out.tokens;
+  toks.resize(NTOKS);
+  toks[TOK_NEWLINE]("NEWLINE", "((#[^\r\n]*)?\r?\n[ \t]*)+");
+  toks[TOK_INDENT]("INDENT", "((#[^\r\n]*)?\r?\n[ \t]*)+");
+  toks[TOK_DEDENT]("DEDENT", "((#[^\r\n]*)?\r?\n[ \t]*)+");
+  toks[TOK_SPACE]("WS", "[ \t]");
+  toks[TOK_COLON](":", ":");
+  toks[TOK_DOT](".", "\\.");
+  toks[TOK_DASH]("-", "\\-");
+  toks[TOK_DQUOT]("\"", "\"");
+  toks[TOK_SQUOT]("'", "'");
+  toks[TOK_SLASH]("\\", "\\\\");
+  toks[TOK_PIPE]("|", "\\|");
+  toks[TOK_LSQUARE]("[", "\\[");
+  toks[TOK_RSQUARE]("]", "\\]");
+  toks[TOK_LCURLY]("{", "{");
+  toks[TOK_RCURLY]("}", "}");
+  toks[TOK_RANGLE](">", ">");
+  toks[TOK_COMMA](",", ",");
+  toks[TOK_PERCENT]("%", "%");
+  toks[TOK_EXCL]("!", "!");
+  toks[TOK_OTHER]("OTHERCHAR", "[^ \t:\\.\\-\"'\\\\\\|\\[\\]{}>,%#!\n\r]");
   return out;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos
<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
Silence some warnings by separating code and replacing a functor with a lambda.

## Motivation and Context
These warnings pop up in CUDA builds of Trilinos.
This is all towards the lofty goal of compiling with `-Werror`.

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A CUDA build of Trilinos I have emits no Teuchos warnings, and a non-CUDA build passes all Teuchos tests.
