### PR TITLE
KokkosKernels:disabling MKL based SpGEMM until next kokkoskernels pro…

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -44,10 +44,9 @@
 #ifndef _KOKKOSSPGEMMMKL_HPP
 #define _KOKKOSSPGEMMMKL_HPP
 
-//#define HAVE_KOKKOSKERNELS_MKL
 
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef HAVE_KOKKOSKERNELS_MKL_DISABLED
 #include "mkl_spblas.h"
 #include "mkl.h"
 #endif
@@ -83,7 +82,7 @@ void mkl_symbolic(
     cin_row_index_view_type row_mapC,
     bool verbose = false){
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef HAVE_KOKKOSKERNELS_MKL_DISABLED
 
   typedef typename KernelHandle::nnz_lno_t idx;
   typedef typename KernelHandle::size_type size_type;
@@ -388,7 +387,7 @@ void mkl_symbolic(
       cin_nonzero_value_view_type valuesC,
       bool verbose = false){
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef HAVE_KOKKOSKERNELS_MKL_DISABLED
 
     typedef typename KernelHandle::nnz_lno_t idx;
     typedef typename KernelHandle::size_type size_type;

--- a/packages/kokkos-kernels/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/packages/kokkos-kernels/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -308,7 +308,7 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
 
     case SPGEMM_MKL:
       algo = "SPGEMM_MKL";
-#ifndef HAVE_KOKKOSKERNELS_MKL
+#ifndef HAVE_KOKKOSKERNELS_MKL_DISABLED
       is_expected_to_fail = true;
 #endif
       //MKL requires scalar to be either float or double


### PR DESCRIPTION
This pull requests disables the compilation of MKL based SpGEMM method in kokkoskernels. 
It is not used as a default methods, and compilation will be turned on for the next kokkoskernels promotion.

@trilinos/kokkos-kernels  
@mhoemmen 


## Description
The compilation was failing when MKL is enabled. This is already fixed in KokkosKernels's develop branch. Current fix in trilinos is to disable the compilation for the TPL which is not executed as a default method.

