### PR TITLE
MueLu: uncoupled aggregation refactor

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -430,10 +430,18 @@
     </parameter>
 
     <parameter>
-      <name>aggregation: phase 1 algorithm</name>
+      <name>aggregation: permute nodes by color</name>
+      <type>bool</type>
+      <default>false</default>
+      <description>Flag enable the use of an optimized version of the kokkos aggregation algorithms</description>
+      <comment-ML>parameter not existing in ML</comment-ML>
+    </parameter>
+
+    <parameter>
+      <name>aggregation: coloring algorithm</name>
       <type>string</type>
       <default>Serial</default>
-      <description>Choice of algorithm for aggregation phase 1.</description>
+      <description>Choice of algorithm for graph coloring during aggregation.</description>
       <comment-ML>parameter not existing in ML</comment-ML>
     </parameter>
 

--- a/packages/muelu/doc/UsersGuide/options_aggregation.tex
+++ b/packages/muelu/doc/UsersGuide/options_aggregation.tex
@@ -19,7 +19,9 @@
           
 \cbb{aggregation: Dirichlet threshold}{double}{0.0}{Threshold for determining whether entries are zero during Dirichlet row detection.}
           
-\cbb{aggregation: phase 1 algorithm}{string}{Serial}{Choice of algorithm for aggregation phase 1.}
+\cbb{aggregation: permute nodes by color}{bool}{false}{Flag enable the use of an optimized version of the kokkos aggregation algorithms}
+          
+\cbb{aggregation: coloring algorithm}{string}{Serial}{Choice of algorithm for graph coloring during aggregation.}
           
 \cbb{aggregation: export visualization data}{bool}{false}{Export data for visualization post-processing.}
           

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -66,7 +66,9 @@
           
 \cbb{aggregation: Dirichlet threshold}{double}{0.0}{Threshold for determining whether entries are zero during Dirichlet row detection.}
           
-\cbb{aggregation: phase 1 algorithm}{string}{Serial}{Choice of algorithm for aggregation phase 1.}
+\cbb{aggregation: permute nodes by color}{bool}{false}{Flag enable the use of an optimized version of the kokkos aggregation algorithms}
+          
+\cbb{aggregation: coloring algorithm}{string}{Serial}{Choice of algorithm for graph coloring during aggregation.}
           
 \cbb{aggregation: export visualization data}{bool}{false}{Export data for visualization post-processing.}
           

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -72,7 +72,9 @@
         
 \cbb{aggregation: Dirichlet threshold}{double}{0.0}{Threshold for determining whether entries are zero during Dirichlet row detection.}
         
-\cbb{aggregation: phase 1 algorithm}{string}{Serial}{Choice of algorithm for aggregation phase 1.}
+\cbb{aggregation: permute nodes by color}{bool}{false}{Flag enable the use of an optimized version of the kokkos aggregation algorithms}
+        
+\cbb{aggregation: coloring algorithm}{string}{Serial}{Choice of algorithm for graph coloring during aggregation.}
         
 \cbb{aggregation: enable phase 1}{bool}{true}{Turn on/off phase 1 of aggregation}
         

--- a/packages/muelu/src/Graph/MueLu_Aggregates_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_Aggregates_kokkos_decl.hpp
@@ -157,6 +157,18 @@ namespace MueLu {
     */
     void SetNumAggregates(LO nAggregates) { numAggregates_ = nAggregates; }
 
+    void SetColorsCardinality(typename Kokkos::View<LO*, execution_space>::HostMirror colorsCardinality) {
+      colorsCardinality_ = colorsCardinality;
+    }
+
+    typename Kokkos::View<LO*, execution_space>::HostMirror& GetColorsCardinality() {return colorsCardinality_;}
+
+    void SetColorPermutation(Kokkos::View<LO*, execution_space> colorPermutation) {
+      colorPermutation_ = colorPermutation;
+    }
+
+    Kokkos::View<LO*, execution_space>& GetColorPermutation() {return colorPermutation_;}
+
     //! @brief Record whether aggregates include DOFs from other processes.
     KOKKOS_INLINE_FUNCTION void AggregatesCrossProcessors(const bool& flag) {
       aggregatesIncludeGhosts_ = flag;
@@ -248,6 +260,9 @@ namespace MueLu {
 
     //! Set to false iff aggregates do not include any DOFs belong to other processes.
     bool aggregatesIncludeGhosts_;
+
+    typename Kokkos::View<LO*, execution_space>::HostMirror colorsCardinality_;
+    Kokkos::View<LO*, execution_space> colorPermutation_;
 
     //! Array of sizes of each local aggregate.
     mutable

--- a/packages/muelu/src/Graph/MueLu_Aggregates_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_Aggregates_kokkos_decl.hpp
@@ -258,7 +258,8 @@ namespace MueLu {
     local_graph_type graph_;
 
     //! Get global number of aggregates
-    // This method is private because it is used only for printing and because with the current implementation, communication occurs each time this method is called.
+    // This method is private because it is used only for printing and because with the current
+    // implementation, communication occurs each time this method is called.
     GO GetNumGlobalAggregates() const;
   };
 

--- a/packages/muelu/src/Graph/MueLu_LWGraph_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_LWGraph_kokkos_decl.hpp
@@ -132,6 +132,16 @@ namespace MueLu {
       return graph_.row_map(GetNodeNumVertices());
     }
 
+    //! Return the row pointers
+    KOKKOS_INLINE_FUNCTION typename local_graph_type::row_map_type getRowPtrs() const {
+      return graph_.row_map;
+    }
+
+    //! Return the row pointers
+    KOKKOS_INLINE_FUNCTION typename local_graph_type::entries_type getEntries() const {
+      return graph_.entries;
+    }
+
     //! Return the list of vertices adjacent to the vertex 'v'.
     // Unfortunately, C++11 does not support the following:
     //    auto getNeighborVertices(LO i) const -> decltype(rowView)

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationAlgorithmBase_kokkos.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationAlgorithmBase_kokkos.hpp
@@ -86,8 +86,13 @@ namespace MueLu {
     //@{
 
     //! BuildAggregates routine.
-    virtual void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
-                                 std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const = 0;
+    virtual void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph,
+                                 Aggregates_kokkos& aggregates,Kokkos::View<unsigned*,
+                                 typename MueLu::LWGraph_kokkos<LO,GO,Node>::local_graph_type::
+                                 device_type::memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                                 Kokkos::View<LO*, typename MueLu::LWGraph_kokkos<LO,GO,Node>::
+                                 local_graph_type::device_type::memory_space>& colorsDevice,
+                                 LO& numColors) const = 0;
     //@}
   };
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
@@ -109,7 +109,12 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes, Kokkos::View<LO*,
+                         typename MueLu::LWGraph_kokkos<LO, GO, Node>::local_graph_type::
+                         device_type::memory_space>& colorsDevice, LO& numColors) const;
 
     void BuildAggregatesSerial(const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
       std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
@@ -117,7 +122,12 @@ namespace MueLu {
       LO maxNeighAlreadySelected, std::string& orderingStr) const;
 
     void BuildAggregatesDistance2(const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
-        std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes, LO maxAggSize) const;
+                                  Kokkos::View<unsigned*, typename MueLu::
+                                  LWGraph_kokkos<LO, GO, Node>::local_graph_type::device_type::
+                                  memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                                  LO maxAggSize, Kokkos::View<LO*, typename MueLu::
+                                  LWGraph_kokkos<LO, GO, Node>::local_graph_type::device_type::
+                                  memory_space>& colorsDevice, LO& numColors) const;
     //@}
 
     std::string description() const { return "Phase 1 (main)"; }
@@ -125,7 +135,7 @@ namespace MueLu {
     enum struct Algorithm
     {
       Serial,
-      Distance2 
+      Distance2
     };
 
     static Algorithm algorithmFromName(const std::string& name)

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
@@ -127,7 +127,8 @@ namespace MueLu {
                                   memory_space>& aggStatView, LO& numNonAggregatedNodes,
                                   LO maxAggSize, Kokkos::View<LO*, typename MueLu::
                                   LWGraph_kokkos<LO, GO, Node>::local_graph_type::device_type::
-                                  memory_space>& colorsDevice, LO& numColors) const;
+                                  memory_space>& colorsDevice, LO& numColors,
+                                  const bool colorPermuted) const;
     //@}
 
     std::string description() const { return "Phase 1 (main)"; }
@@ -140,8 +141,9 @@ namespace MueLu {
 
     static Algorithm algorithmFromName(const std::string& name)
     {
-      if(name == "Distance2")
+      if((name == "Distance 2 - serial") || (name == "Distance 2 - wml")) {
         return Algorithm::Distance2;
+      }
       return Algorithm::Serial;
     }
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
@@ -366,8 +366,7 @@ namespace MueLu {
                                       // This atomic guarentees that any other node trying to
                                       // join aggregate agg has the correct size.
                                       LO agg = vertex2AggIdView(nei, 0);
-                                      const LO aggSize =
-                                        Kokkos::atomic_fetch_add (&aggSizesView(agg), 1);
+                                      Kokkos::atomic_add (&aggSizesView(agg), 1);
                                       //assign vertex i to aggregate with root j
                                       vertex2AggIdView(i, 0) = agg;
                                       procWinnerView(i, 0)   = myRank;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
@@ -107,7 +107,12 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes, Kokkos::View<LO*,
+                         typename MueLu::LWGraph_kokkos<LO, GO, Node>::local_graph_type::
+                         device_type::memory_space>& colorsDevice, LO& numColors) const;
     //@}
 
     std::string description() const { return "Phase 2a (secondary)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
@@ -99,7 +99,7 @@ namespace MueLu {
 
     // Now we create new aggregates using root nodes in all colors other than the first color,
     // as the first color was already exhausted in Phase 1.
-    for(int color = 1; color < numColors + 1; ++color) {
+    for(int color = 2; color < numColors + 1; ++color) {
 
       LO tmpNumNonAggregatedNodes = 0;
       Kokkos::parallel_reduce("Aggregation Phase 2a: loop over each individual color", numRows,

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
@@ -63,8 +63,17 @@
 namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void AggregationPhase2aAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void AggregationPhase2aAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
+  BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                  Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                  LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                  memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                  Kokkos::View<LO*, typename MueLu::LWGraph_kokkos<LO, GO, Node>::
+                  local_graph_type::device_type::memory_space>& colorsDevice, LO& numColors) const {
     Monitor m(*this, "BuildAggregates");
+
+    typedef typename MueLu::LWGraph_kokkos<LO, GO, Node>::local_graph_type graph_t;
+    typedef typename graph_t::device_type::memory_space memory_space;
 
     int minNodesPerAggregate = params.get<int>("aggregation: min agg size");
     int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
@@ -72,69 +81,82 @@ namespace MueLu {
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
 
-    ArrayRCP<LO> vertex2AggId = aggregates.GetVertex2AggId()->getDataNonConst(0);
-    ArrayRCP<LO> procWinner   = aggregates.GetProcWinner()  ->getDataNonConst(0);
+    auto vertex2AggId = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
+    auto procWinner   = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
 
-    LO numLocalAggregates = aggregates.GetNumAggregates();
-
-    LO numLocalNodes      = procWinner.size();
+    LO numLocalNodes      = numRows;
     LO numLocalAggregated = numLocalNodes - numNonAggregatedNodes;
 
     const double aggFactor = 0.5;
     double       factor    = as<double>(numLocalAggregated)/(numLocalNodes+1);
     factor = pow(factor, aggFactor);
 
-    int              aggIndex = -1;
-    size_t           aggSize  =  0;
-    std::vector<int> aggList(graph.getNodeMaxNumRowEntries());
+    Kokkos::View<LO, memory_space> numLocalAggregates("numLocalAggregates");
+    typename Kokkos::View<LO, memory_space>::HostMirror h_numLocalAggregates =
+      Kokkos::create_mirror_view(numLocalAggregates);
+    h_numLocalAggregates() = aggregates.GetNumAggregates();
+    Kokkos::deep_copy(numLocalAggregates, h_numLocalAggregates);
 
-    for (LO rootCandidate = 0; rootCandidate < numRows; rootCandidate++) {
-      if (aggStat[rootCandidate] != READY)
-        continue;
+    // Now we create new aggregates using root nodes in all colors other than the first color,
+    // as the first color was already exhausted in Phase 1.
+    for(int color = 1; color < numColors + 1; ++color) {
 
-      aggSize = 0;
+      LO tmpNumNonAggregatedNodes = 0;
+      Kokkos::parallel_reduce("Aggregation Phase 2a: loop over each individual color", numRows,
+                              KOKKOS_LAMBDA (const LO rootCandidate, LO& lNumNonAggregatedNodes) {
+                                if(aggStatView(rootCandidate) == READY &&
+                                   colorsDevice(rootCandidate) == color) {
 
-      auto neighOfINode = graph.getNeighborVertices(rootCandidate);
+                                  LO aggSize = 0;
+                                  auto neighbors = graph.getNeighborVertices(rootCandidate);
 
-      LO numNeighbors = 0;
-      for (int j = 0; j < as<int>(neighOfINode.length); j++) {
-        LO neigh = neighOfINode(j);
+                                  // Loop over neighbors to count how many nodes could join
+                                  // the new aggregate
+                                  LO numNeighbors = 0;
+                                  for(int j = 0; j < neighbors.length; ++j) {
+                                    LO neigh = neighbors(j);
+                                    if(neigh != rootCandidate) {
+                                      if(graph.isLocalNeighborVertex(neigh) &&
+                                         aggStatView(neigh) == READY &&
+                                         aggSize < maxNodesPerAggregate) {
+                                        // aggList(aggSize) = neigh;
+                                        ++aggSize;
+                                      }
+                                      ++numNeighbors;
+                                    }
+                                  }
 
-        if (neigh != rootCandidate) {
-          if (graph.isLocalNeighborVertex(neigh) && aggStat[neigh] == READY) {
-            // If aggregate size does not exceed max size, add node to the tentative aggregate
-            // NOTE: We do not exit the loop over all neighbours since we have still
-            //       to count all aggregated neighbour nodes for the aggregation criteria
-            // NOTE: We check here for the maximum aggregation size. If we would do it below
-            //       with all the other check too big aggregates would not be accepted at all.
-            if (aggSize < as<size_t>(maxNodesPerAggregate))
-              aggList[aggSize++] = neigh;
-          }
+                                  // If a sufficient number of nodes can join the new aggregate
+                                  // then we actually create the aggregate.
+                                  if(aggSize > minNodesPerAggregate &&
+                                     aggSize > factor*numNeighbors) {
 
-          numNeighbors++;
-        }
-      }
+                                    // aggregates.SetIsRoot(rootCandidate);
+                                    LO aggIndex = Kokkos::
+                                      atomic_fetch_add(&numLocalAggregates(), 1);
 
-      // NOTE: ML uses a hardcoded value 3 instead of MinNodesPerAggregate
-      if (aggSize > as<size_t>(minNodesPerAggregate) &&
-          aggSize > factor*numNeighbors) {
-        // Accept new aggregate
-        // rootCandidate becomes the root of the newly formed aggregate
-        aggregates.SetIsRoot(rootCandidate);
-        aggIndex = numLocalAggregates++;
-
-        for (size_t k = 0; k < aggSize; k++) {
-          aggStat     [aggList[k]] = AGGREGATED;
-          vertex2AggId[aggList[k]] = aggIndex;
-          procWinner  [aggList[k]] = myRank;
-        }
-
-        numNonAggregatedNodes -= aggSize;
-      }
+                                    for(int j = 0; j < neighbors.length; ++j) {
+                                      LO neigh = neighbors(j);
+                                      if(neigh != rootCandidate) {
+                                        if(graph.isLocalNeighborVertex(neigh) &&
+                                           aggStatView(neigh) == READY &&
+                                           aggSize < maxNodesPerAggregate) {
+                                          aggStatView(neigh)   = AGGREGATED;
+                                          vertex2AggId(neigh, 0) = aggIndex;
+                                          procWinner(neigh, 0)   = myRank;
+                                        }
+                                      }
+                                    }
+                                    lNumNonAggregatedNodes -= aggSize;
+                                  }
+                                }
+                              }, tmpNumNonAggregatedNodes);
+      numNonAggregatedNodes += tmpNumNonAggregatedNodes;
     }
 
     // update aggregate object
-    aggregates.SetNumAggregates(numLocalAggregates);
+    Kokkos::deep_copy(h_numLocalAggregates, numLocalAggregates);
+    aggregates.SetNumAggregates(h_numLocalAggregates());
   }
 
 } // end namespace

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
@@ -104,7 +104,12 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes, Kokkos::View<LO*,
+                         typename MueLu::LWGraph_kokkos<LO, GO, Node>::local_graph_type::
+                         device_type::memory_space>& colorsDevice, LO& numColors) const;
     //@}
 
     std::string description() const { return "Phase 2b (expansion)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
@@ -83,7 +83,7 @@ namespace MueLu {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> > ScratchViewType;
 
     const LO  numRows = graph.GetNodeNumVertices();
-    const int myRank  = graph.GetComm()->getRank();
+    int myRank  = graph.GetComm()->getRank();
 
     auto vertex2AggIdView = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
     auto procWinnerView   = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
@@ -95,7 +95,7 @@ namespace MueLu {
 
     // This actually corresponds to the maximum number of entries per row in the matrix.
     const size_t maxNumNeighbors = graph.getNodeMaxNumRowEntries();
-    int scratch_size = ScratchViewType::shmem_size( maxNumNeighbors );
+    int scratch_size = ScratchViewType::shmem_size( 2*maxNumNeighbors );
 
     Kokkos::View<int*, memory_space> connectWeightView("connectWeight", numRows);
     Kokkos::View<int*, memory_space> aggPenaltiesView ("aggPenalties",  numRows);
@@ -114,7 +114,7 @@ namespace MueLu {
     int maxIters = 2;
     int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
     if(maxNodesPerAggregate == std::numeric_limits<int>::max()) {maxIters = 1;}
-    for (int k = 0; k < maxIters; k++) {
+    for (int iter = 0; iter < maxIters; ++iter) {
       // total work = numberOfTeams * teamSize
       Kokkos::TeamPolicy<execution_space> outerPolicy(numRows, Kokkos::AUTO);
       typedef typename Kokkos::TeamPolicy<execution_space>::member_type  member_type;
@@ -130,12 +130,40 @@ namespace MueLu {
                                 // allocate view locally so that threads do not trash the weigth
                                 // when working on the same aggregate.
                                 const int vertexIdx = teamMember.league_rank();
+                                ScratchViewType vertex2AggLIDView(teamMember.team_scratch( 0 ),
+                                                                  maxNumNeighbors);
                                 ScratchViewType aggWeightView(teamMember.team_scratch( 0 ),
                                                               maxNumNeighbors);
 
                                 if (aggStatView(vertexIdx) == READY) {
 
+                                  // neighOfINode should become scratch and shared among
+                                  // threads in the team...
                                   auto neighOfINode = graph.getNeighborVertices(vertexIdx);
+
+                                  // create a mapping from neighbor "lid" to aggregate "lid"
+                                  Kokkos::single( Kokkos::PerTeam( teamMember ), [&] () {
+                                      int aggLIDCount = 0;
+                                      for (int j = 0; j < as<int>(neighOfINode.length); ++j) {
+                                        LO jNodeID = neighOfINode(j);
+                                        if ( graph.isLocalNeighborVertex(jNodeID)
+                                             && (aggStatView(jNodeID) == AGGREGATED) ) {
+                                          bool useNewLID = true;
+                                          for(int k = 0; k < j; ++k) {
+                                            LO kNodeID = neighOfINode(k);
+                                            if(vertex2AggIdView(jNodeID, 0)
+                                               == vertex2AggIdView(kNodeID, 0)) {
+                                              vertex2AggLIDView(j) = vertex2AggLIDView(k);
+                                              useNewLID = false;
+                                            }
+                                          }
+                                          if(useNewLID) {
+                                            vertex2AggLIDView(j) = aggLIDCount;
+                                            ++aggLIDCount;
+                                          }
+                                        }
+                                      }
+                                    });
 
                                   for (int j = 0; j < as<int>(neighOfINode.length); j++) {
                                     LO neigh = neighOfINode(j);
@@ -144,8 +172,8 @@ namespace MueLu {
                                     // (aggStat[neigh] == AGGREGATED)
                                     if ( graph.isLocalNeighborVertex(neigh)
                                          && (aggStatView(neigh) == AGGREGATED) )
-                                      aggWeightView(j) = aggWeightView(j)
-                                        + connectWeightView(neigh);
+                                      aggWeightView(vertex2AggLIDView(j)) =
+                                        aggWeightView(vertex2AggLIDView(j)) + connectWeightView(neigh);
                                   }
 
                                   int bestScore   = -100000;
@@ -158,7 +186,8 @@ namespace MueLu {
                                     if ( graph.isLocalNeighborVertex(neigh)
                                          && (aggStatView(neigh) == AGGREGATED) ) {
                                       int aggId = vertex2AggIdView(neigh, 0);
-                                      int score = aggWeightView(j) - aggPenaltiesView(aggId);
+                                      int score = aggWeightView(vertex2AggLIDView(j))
+                                        - aggPenaltiesView(aggId);
 
                                       if (score > bestScore) {
                                         bestAggId   = aggId;
@@ -171,25 +200,27 @@ namespace MueLu {
                                       }
 
                                       // Reset the weights for the next loop
-                                      aggWeightView(j) = 0;
+                                      // LBV: this looks a little suspicious, it would probably
+                                      // need to be taken out of this inner for loop...
+                                      aggWeightView(vertex2AggLIDView(j)) = 0;
                                     }
                                   }
 
 				  // Do the actual aggregate update with a single thread!
 				  Kokkos::single( Kokkos::PerTeam( teamMember ), [&] () {
 				      if (bestScore >= 0) {
-					aggStatView   (vertexIdx)    = AGGREGATED;
-					vertex2AggIdView(vertexIdx, 0) = bestAggId;
-					procWinnerView  (vertexIdx, 0) = myRank;
+				        aggStatView     (vertexIdx)    = AGGREGATED;
+				        vertex2AggIdView(vertexIdx, 0) = bestAggId;
+				        procWinnerView  (vertexIdx, 0) = myRank;
 
-					lNumNonAggregatedNodes--;
+				        lNumNonAggregatedNodes--;
 
-					// This does not protect bestAggId's aggPenalties from being
-					// fetched by another thread before this update happens, it just
-					// guarantees that the update is performed correctly...
-					Kokkos::atomic_add(&aggPenaltiesView(bestAggId), 1);
-					connectWeightView(vertexIdx) = bestConnect
-					  - penaltyConnectWeight;
+				        // This does not protect bestAggId's aggPenalties from being
+				        // fetched by another thread before this update happens, it just
+				        // guarantees that the update is performed correctly...
+				        Kokkos::atomic_add(&aggPenaltiesView(bestAggId), 1);
+				        connectWeightView(vertexIdx) = bestConnect
+				          - penaltyConnectWeight;
 				      }
 				    });
                                 }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
@@ -102,7 +102,13 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                         Kokkos::View<LO*, typename MueLu::LWGraph_kokkos<LO, GO, Node>::
+                         local_graph_type::device_type::memory_space>& colorsDevice,
+                         LO& numColors) const;
     //@}
 
     std::string description() const { return "Phase 3 (cleanup)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_def.hpp
@@ -65,8 +65,18 @@ namespace MueLu {
   // Try to stick unaggregated nodes into a neighboring aggregate if they are
   // not already too big. Otherwise, make a new aggregate
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void AggregationPhase3Algorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void AggregationPhase3Algorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
+  BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                  Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                  LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                  memory_space>& aggStatView, LO& numNonAggregatedNodes, Kokkos::View<LO*,
+                  typename MueLu::LWGraph_kokkos<LO, GO, Node>::local_graph_type::device_type::
+                  memory_space>& colorsDevice, LO& numColors) const {
     Monitor m(*this, "BuildAggregates");
+
+    typedef typename MueLu::LWGraph_kokkos<LO, GO, Node>::local_graph_type graph_t;
+    typedef typename graph_t::device_type::memory_space memory_space;
+    typedef typename graph_t::device_type::execution_space execution_space;
 
     bool error_on_isolated = false;
     if(params.isParameter("aggregation: error on nodes with no on-rank neighbors"))
@@ -75,78 +85,103 @@ namespace MueLu {
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
 
-    ArrayRCP<LO> vertex2AggId = aggregates.GetVertex2AggId()->getDataNonConst(0);
-    ArrayRCP<LO> procWinner   = aggregates.GetProcWinner()  ->getDataNonConst(0);
+    auto vertex2AggId = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
+    auto procWinner   = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
 
     LO numLocalAggregates = aggregates.GetNumAggregates();
 
-    for (LO i = 0; i < numRows; i++) {
-      if (aggStat[i] == AGGREGATED || aggStat[i] == IGNORED)
-        continue;
+    // Create views for values accumulation
+    Kokkos::View<LO, memory_space> numLocalAggregatesView("numLocalAggregates");
+    typename Kokkos::View<LO, memory_space>::HostMirror h_numLocalAggregatesView =
+      Kokkos::create_mirror_view (numLocalAggregatesView);
+    h_numLocalAggregatesView() = numLocalAggregates;
+    Kokkos::deep_copy(numLocalAggregatesView, h_numLocalAggregatesView);
 
-      auto neighOfINode = graph.getNeighborVertices(i);
+    Kokkos::View<LO, memory_space> numNonAggregatedNodesView("numNonAggregatedNodes");
+    typename Kokkos::View<LO, memory_space>::HostMirror h_numNonAggregatedNodesView =
+      Kokkos::create_mirror_view (numNonAggregatedNodesView);
+    h_numNonAggregatedNodesView() = numNonAggregatedNodes;
+    Kokkos::deep_copy(numNonAggregatedNodesView, h_numNonAggregatedNodesView);
 
-      // We don't want a singleton. So lets see if there is an unaggregated
-      // neighbor that we can also put with this point.
-      bool isNewAggregate = false;
-      for (int j = 0; j < as<int>(neighOfINode.length); j++) {
-        LO neigh = neighOfINode(j);
+    Kokkos::parallel_for("Aggregation Phase 3: clean-up loop",Kokkos::RangePolicy<>(0, 1),
+                         KOKKOS_LAMBDA (const LO dummy) {
+                           for (LO i = 0; i < numRows; i++) {
+                             if (aggStatView(i) == AGGREGATED || aggStatView(i) == IGNORED)
+                               continue;
 
-        if (neigh != i && graph.isLocalNeighborVertex(neigh) && aggStat[neigh] == READY) {
-          isNewAggregate = true;
+                             auto neighOfINode = graph.getNeighborVertices(i);
 
-          aggStat     [neigh] = AGGREGATED;
-          vertex2AggId[neigh] = numLocalAggregates;
-          procWinner  [neigh] = myRank;
+                             // We don't want a singleton. So lets see if there is an unaggregated
+                             // neighbor that we can also put with this point.
+                             bool isNewAggregate = false;
+                             for (int j = 0; j < as<int>(neighOfINode.length); j++) {
+                               LO neigh = neighOfINode(j);
 
-          numNonAggregatedNodes--;
-        }
-      }
+                               if (neigh != i && graph.isLocalNeighborVertex(neigh)
+                                   && aggStatView(neigh) == READY) {
+                                 isNewAggregate = true;
 
-      if (isNewAggregate) {
-        // Create new aggregate (not singleton)
-        aggregates.SetIsRoot(i);
-        vertex2AggId[i] = numLocalAggregates++;
+                                 aggStatView (neigh)    = AGGREGATED;
+                                 vertex2AggId(neigh, 0) = numLocalAggregatesView();
+                                 procWinner  (neigh, 0) = myRank;
 
-      } else {
-        // We do not want a singleton, but there are no non-aggregated
-        // neighbors. Lets see if we can connect to any other aggregates
-        // NOTE: This is very similar to phase 2b, but simpler: we stop with
-        // the first found aggregate
-        int j = 0;
-        for (; j < as<int>(neighOfINode.length); j++) {
-          LO neigh = neighOfINode(j);
+                                 numNonAggregatedNodesView() = numNonAggregatedNodesView() - 1;
+                               }
+                             }
 
-          // We don't check (neigh != rootCandidate), as it is covered by checking (aggStat[neigh] == AGGREGATED)
-          if (graph.isLocalNeighborVertex(neigh) && aggStat[neigh] == AGGREGATED)
-            break;
-        }
+                             if (isNewAggregate) {
+                               // Create new aggregate (not singleton)
+                               // aggregates.SetIsRoot(i);
+                               vertex2AggId(i, 0) = numLocalAggregatesView();
+                               numLocalAggregatesView() = numLocalAggregatesView() + 1;
 
-        if (j < as<int>(neighOfINode.length)) {
-          // Assign to an adjacent aggregate
-          vertex2AggId[i] = vertex2AggId[neighOfINode(j)];
-        } else if (error_on_isolated) {
-          // Error on this isolated node, as the user has requested
-          std::ostringstream oss;
-          oss<<"MueLu::AggregationPhase3Algorithm::BuildAggregates: MueLu has detected a non-Dirichlet node that has no on-rank neighbors and is terminating (by user request). "<<std::endl;
-          oss<<"If this error is being generated at level 0, this is due to an initial partitioning problem in your matrix."<<std::endl;
-          oss<<"If this error is being generated at any other level, try turning on repartitioning, which may fix this problem."<<std::endl;
-          throw Exceptions::RuntimeError(oss.str());
-        } else {
-          // Create new aggregate (singleton)
-          this->GetOStream(Warnings1) << "Found singleton: " << i << std::endl;
+                             } else {
+                               // We do not want a singleton, but there are no non-aggregated
+                               // neighbors. Lets see if we can connect to any other aggregates
+                               // NOTE: This is very similar to phase 2b, but simpler: we stop with
+                               // the first found aggregate
+                               int j = 0;
+                               for (; j < as<int>(neighOfINode.length); ++j) {
+                                 LO neigh = neighOfINode(j);
 
-          aggregates.SetIsRoot(i);
-          vertex2AggId[i] = numLocalAggregates++;
-        }
-      }
+                                 // We don't check (neigh != rootCandidate), as it is covered by checking (aggStatView(neigh) == AGGREGATED)
+                                 if (graph.isLocalNeighborVertex(neigh)
+                                     && aggStatView(neigh) == AGGREGATED)
+                                   break;
+                               }
 
-      // One way or another, the node is aggregated (possibly into a singleton)
-      aggStat   [i] = AGGREGATED;
-      procWinner[i] = myRank;
-      numNonAggregatedNodes--;
+                               if (j < as<int>(neighOfINode.length)) {
+                                 // Assign to an adjacent aggregate
+                                 vertex2AggId(i, 0) = vertex2AggId(neighOfINode(j), 0);
+                               } else if (error_on_isolated) {
+                                 // Error on this isolated node, as the user has requested
+                                 std::ostringstream oss;
+                                 oss<<"MueLu::AggregationPhase3Algorithm::BuildAggregates: MueLu has detected a non-Dirichlet node that has no on-rank neighbors and is terminating (by user request). "<<std::endl;
+                                 oss<<"If this error is being generated at level 0, this is due to an initial partitioning problem in your matrix."<<std::endl;
+                                 oss<<"If this error is being generated at any other level, try turning on repartitioning, which may fix this problem."<<std::endl;
+                                 throw Exceptions::RuntimeError(oss.str());
+                               } else {
+                                 // Create new aggregate (singleton)
+                                 this->GetOStream(Warnings1) << "Found singleton: " << i << std::endl;
 
-    }
+                                 // aggregates.SetIsRoot(i);
+                                 vertex2AggId(i, 0) = numLocalAggregatesView();
+                                 numLocalAggregatesView() = numLocalAggregatesView() + 1;
+                               }
+                             }
+
+                             // One way or another, the node is aggregated (possibly into a singleton)
+                             aggStatView(i, 0) = AGGREGATED;
+                             procWinner (i, 0) = myRank;
+                             numNonAggregatedNodesView() = numNonAggregatedNodesView() - 1;
+                           }
+                         });
+
+    Kokkos::deep_copy(h_numLocalAggregatesView, numLocalAggregatesView);
+    Kokkos::deep_copy(h_numNonAggregatedNodesView, numNonAggregatedNodesView);
+
+    numLocalAggregates    = h_numLocalAggregatesView();
+    numNonAggregatedNodes = h_numNonAggregatedNodesView();
 
     // update aggregate object
     aggregates.SetNumAggregates(numLocalAggregates);

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
@@ -104,7 +104,13 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                         Kokkos::View<LO*, typename MueLu::LWGraph_kokkos<LO, GO, Node>::
+                         local_graph_type::device_type::memory_space>& colorsDevice,
+                         LO& numColors) const;
     //@}
 
     std::string description() const { return "Phase - (isolated)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_decl.hpp
@@ -103,7 +103,13 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(Teuchos::ParameterList const & params, LWGraph_kokkos const & graph, Aggregates_kokkos & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(Teuchos::ParameterList const & params, LWGraph_kokkos const & graph,
+                         Aggregates_kokkos & aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                         Kokkos::View<LO*, typename MueLu::LWGraph_kokkos<LO, GO, Node>::
+                         local_graph_type::device_type::memory_space>& colorsDevice,
+                         LO& numColors) const;
     //@}
 
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
@@ -109,7 +109,13 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates, Kokkos::View<unsigned*, typename MueLu::
+                         LWGraph_kokkos<LO,GO,Node>::local_graph_type::device_type::
+                         memory_space>& aggStatView, LO& numNonAggregatedNodes,
+                         Kokkos::View<LO*, typename MueLu::LWGraph_kokkos<LO, GO, Node>::
+                         local_graph_type::device_type::memory_space>& colorsDevice,
+                         LO& numColors) const;
     //@}
 
     std::string description() const { return "Phase - (Dirichlet)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -145,7 +145,7 @@ namespace MueLu {
     bDefinitionPhase_ = false;  // definition phase is finished, now all aggregation algorithm information is fixed
 
     if (pL.get<int>("aggregation: max agg size") == -1)
-      pL.set("aggregation: max agg size", Teuchos::OrdinalTraits<int>::max());
+      pL.set("aggregation: max agg size", std::numeric_limits<int>::max());
       // pL.set("aggregation: max agg size",INT_MAX);
 
     // define aggregation algorithms

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -229,7 +229,7 @@ namespace MueLu {
     LO numColors = 0;
 
     if (pL.get<std::string>("aggregation: phase 1 algorithm") == "Distance2") {
-      GetOStream(Runtime1)  << "Computing distance 2 graph coloring" << std::endl;
+      SubFactoryMonitor subM(*this, "Coloring", currentLevel);
 
       // The local CRS graph to Kokkos device views, then compute graph squared
       // Note: just using colinds_view in place of scalar_view_t type (it won't
@@ -259,6 +259,8 @@ namespace MueLu {
 
       //clean up coloring handle
       kh.destroy_graph_coloring_handle();
+      
+      GetOStream(Statistics1) << "  colors needed : " << numColors << std::endl;
     }
 
     for (size_t a = 0; a < algos_.size(); a++) {

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -267,10 +267,16 @@ namespace MueLu {
       std::string phase = algos_[a]->description();
       SubFactoryMonitor sfm(*this, "Algo \"" + phase + "\"", currentLevel);
 
-      int oldRank = algos_[a]->SetProcRankVerbose(this->GetProcRankVerbose());
-      algos_[a]->BuildAggregates(pL, *graph, *aggregates, aggStatView, numNonAggregatedNodes,
-                                 colorsDevice, numColors);
-      algos_[a]->SetProcRankVerbose(oldRank);
+      if(numNonAggregatedNodes > 0) {
+        int oldRank = algos_[a]->SetProcRankVerbose(this->GetProcRankVerbose());
+        algos_[a]->BuildAggregates(pL, *graph, *aggregates, aggStatView, numNonAggregatedNodes,
+                                   colorsDevice, numColors);
+        algos_[a]->SetProcRankVerbose(oldRank);
+        TEUCHOS_TEST_FOR_EXCEPTION(numNonAggregatedNodes < 0,
+                                   Exceptions::RuntimeError,
+                                   "the number of nodes aggregated is larger than the number of "
+                                   "nodes in the problem!");
+      }
 
       if (IsPrint(Statistics1)) {
         GO numLocalAggregated = numRows - numNonAggregatedNodes, numGlobalAggregated = 0;

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -911,20 +911,21 @@ namespace MueLu {
     if (aggType == "uncoupled") {
       MUELU_KOKKOS_FACTORY_NO_DECL(aggFactory, UncoupledAggregationFactory, UncoupledAggregationFactory_kokkos);
       ParameterList aggParams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: mode",               std::string, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: ordering",           std::string, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: min agg size",               int, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: max agg size",               int, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: max selected neighbors",     int, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: mode",                    std::string, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: ordering",                std::string, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: min agg size",                    int, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: max agg size",                    int, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: max selected neighbors",          int, aggParams);
       if(useKokkos_) {
         //if not using kokkos refactor Uncoupled, there is no algorithm option (always Serial)
-        MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: phase 1 algorithm",  std::string, aggParams);
+        MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: coloring algorithm",    std::string, aggParams);
+        MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: permute nodes by color",       bool, aggParams);
       }
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 1",            bool, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2a",           bool, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2b",           bool, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 3",            bool, aggParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: preserve Dirichlet points", bool, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 1",                 bool, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2a",                bool, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2b",                bool, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 3",                 bool, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: preserve Dirichlet points",      bool, aggParams);
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: error on nodes with no on-rank neighbors", bool, aggParams);
       aggFactory->SetParameterList(aggParams);
       // make sure that the aggregation factory has all necessary data

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -183,7 +183,8 @@ namespace MueLu {
   "<Parameter name=\"aggregation: brick z size\" type=\"int\" value=\"2\"/>"
   "<Parameter name=\"aggregation: max selected neighbors\" type=\"int\" value=\"0\"/>"
   "<Parameter name=\"aggregation: Dirichlet threshold\" type=\"double\" value=\"0.0\"/>"
-  "<Parameter name=\"aggregation: phase 1 algorithm\" type=\"string\" value=\"Serial\"/>"
+  "<Parameter name=\"aggregation: permute nodes by color\" type=\"bool\" value=\"false\"/>"
+  "<Parameter name=\"aggregation: coloring algorithm\" type=\"string\" value=\"Serial\"/>"
   "<Parameter name=\"aggregation: enable phase 1\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"aggregation: enable phase 2a\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"aggregation: enable phase 2b\" type=\"bool\" value=\"true\"/>"
@@ -506,7 +507,9 @@ namespace MueLu {
       
          ("aggregation: Dirichlet threshold","aggregation: Dirichlet threshold")
       
-         ("aggregation: phase 1 algorithm","aggregation: phase 1 algorithm")
+         ("aggregation: permute nodes by color","aggregation: permute nodes by color")
+      
+         ("aggregation: coloring algorithm","aggregation: coloring algorithm")
       
          ("aggregation: enable phase 1","aggregation: enable phase 1")
       

--- a/packages/muelu/test/scaling/Driver_backup.cpp
+++ b/packages/muelu/test/scaling/Driver_backup.cpp
@@ -1,0 +1,615 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//        MueLu: A package for multigrid based preconditioning
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <unistd.h>
+
+#include <Teuchos_XMLParameterListHelpers.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+
+// Xpetra
+#include <Xpetra_MultiVectorFactory.hpp>
+#include <Xpetra_ImportFactory.hpp>
+#include <Xpetra_Operator.hpp>
+#include <Xpetra_IO.hpp>
+
+// Galeri
+#include <Galeri_XpetraParameters.hpp>
+#include <Galeri_XpetraProblemFactory.hpp>
+#include <Galeri_XpetraUtils.hpp>
+#include <Galeri_XpetraMaps.hpp>
+
+#include <MueLu.hpp>
+
+#include <MueLu_BaseClass.hpp>
+#ifdef HAVE_MUELU_EXPLICIT_INSTANTIATION
+#include <MueLu_ExplicitInstantiation.hpp>
+#endif
+#include <MueLu_Level.hpp>
+#include <MueLu_MutuallyExclusiveTime.hpp>
+#include <MueLu_ParameterListInterpreter.hpp>
+#include <MueLu_Utilities.hpp>
+
+#ifdef HAVE_MUELU_BELOS
+#include <BelosConfigDefs.hpp>
+#include <BelosBiCGStabSolMgr.hpp>
+#include <BelosBlockCGSolMgr.hpp>
+#include <BelosBlockGmresSolMgr.hpp>
+#include <BelosLinearProblem.hpp>
+#include <BelosPseudoBlockCGSolMgr.hpp>
+#include <BelosXpetraAdapter.hpp>     // => This header defines Belos::XpetraOp
+#include <BelosMueLuAdapter.hpp>      // => This header defines Belos::MueLuOp
+#endif
+
+#include <MueLu_CreateXpetraPreconditioner.hpp>
+
+
+/*********************************************************************/
+// Support for ML interface
+#if defined(HAVE_MUELU_ML) and defined(HAVE_MUELU_EPETRA)
+#include <Xpetra_EpetraOperator.hpp>
+#include <ml_MultiLevelPreconditioner.h>
+
+// Helper functions for compilation purposes
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+struct ML_Wrapper{
+  static void Generate_ML_MultiLevelPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & A, Teuchos::ParameterList & mueluList,
+                                                   Teuchos::RCP<Xpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & mlopX) {
+    throw std::runtime_error("Template parameter mismatch");
+  }
+};
+
+
+template<class GlobalOrdinal>
+struct ML_Wrapper<double,int,GlobalOrdinal,Kokkos::Compat::KokkosSerialWrapperNode> {
+  static void Generate_ML_MultiLevelPreconditioner(Teuchos::RCP<Xpetra::Matrix<double,int,GlobalOrdinal,Kokkos::Compat::KokkosSerialWrapperNode> >& A,Teuchos::ParameterList & mueluList,
+                                                   Teuchos::RCP<Xpetra::Operator<double,int,GlobalOrdinal,Kokkos::Compat::KokkosSerialWrapperNode> >& mlopX) {  
+    typedef double SC;
+    typedef int LO;
+    typedef GlobalOrdinal GO;
+    typedef Kokkos::Compat::KokkosSerialWrapperNode NO;
+    Teuchos::RCP<const Epetra_CrsMatrix> Aep   = Xpetra::Helpers<SC, LO, GO, NO>::Op2EpetraCrs(A);
+    Teuchos::RCP<Epetra_Operator> mlop  = Teuchos::rcp<Epetra_Operator>(new ML_Epetra::MultiLevelPreconditioner(*Aep,mueluList));
+    mlopX = Teuchos::rcp(new Xpetra::EpetraOperator<GO,NO>(mlop));
+  }
+};
+#endif
+/*********************************************************************/
+
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int argc, char *argv[]) {
+#include <MueLu_UseShortNames.hpp>
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::ArrayRCP;
+  using Teuchos::TimeMonitor;
+  using Teuchos::ParameterList;
+
+  // =========================================================================
+  // MPI initialization using Teuchos
+  // =========================================================================
+  RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
+
+  // =========================================================================
+  // Convenient definitions
+  // =========================================================================
+  typedef Teuchos::ScalarTraits<SC> STS;
+  SC zero = STS::zero(), one = STS::one();
+
+  // =========================================================================
+  // Parameters initialization
+  // =========================================================================
+  GO nx = 100, ny = 100, nz = 100;
+  Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Laplace2D"); // manage parameters of the test case
+  Xpetra::Parameters             xpetraParameters(clp);                          // manage parameters of Xpetra
+
+  std::string xmlFileName       = "scaling.xml";     clp.setOption("xml",                   &xmlFileName,       "read parameters from a file");
+  bool        printTimings      = true;              clp.setOption("timings", "notimings",  &printTimings,      "print timings to screen");
+  std::string timingsFormat     = "table-fixed";     clp.setOption("time-format",           &timingsFormat,     "timings format (table-fixed | table-scientific | yaml)");
+  int         writeMatricesOPT  = -2;                clp.setOption("write",                 &writeMatricesOPT,  "write matrices to file (-1 means all; i>=0 means level i)");
+  std::string dsolveType        = "cg", solveType;   clp.setOption("solver",                &dsolveType,        "solve type: (none | cg | gmres | standalone)");
+  double      dtol              = 1e-12, tol;        clp.setOption("tol",                   &dtol,              "solver convergence tolerance");
+  bool        binaryFormat      = false;             clp.setOption("binary", "ascii",       &binaryFormat,      "print timings to screen");
+
+  std::string rowmapFile;                            clp.setOption("rowmap",                &rowmapFile,        "map data file");
+  std::string colMapFile;                            clp.setOption("colmap",                &colMapFile,        "colmap data file");
+  std::string domainMapFile;                         clp.setOption("domainmap",             &domainMapFile,     "domainmap data file");
+  std::string rangeMapFile;                          clp.setOption("rangemap",              &rangeMapFile,      "rangemap data file");
+  std::string matrixFile;                            clp.setOption("matrix",                &matrixFile,        "matrix data file");
+  std::string rhsFile;                               clp.setOption("rhs",                   &rhsFile,           "rhs data file");
+  std::string coordFile;                             clp.setOption("coords",                &coordFile,         "coordinates data file");
+  std::string nullFile;                              clp.setOption("nullspace",             &nullFile,          "nullspace data file");
+  int         numRebuilds       = 0;                 clp.setOption("rebuild",               &numRebuilds,       "#times to rebuild hierarchy");
+  int         maxIts            = 200;               clp.setOption("its",                   &maxIts,            "maximum number of solver iterations");
+  bool        scaleResidualHist = true;              clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");
+
+  clp.recogniseAllOptions(true);
+  switch (clp.parse(argc, argv)) {
+    case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
+    case Teuchos::CommandLineProcessor::PARSE_ERROR:
+    case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
+    case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
+  }
+
+
+  ParameterList paramList;
+  Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<ParameterList>(&paramList), *comm);
+  bool isDriver = paramList.isSublist("Run1");
+  if (isDriver) {
+    // update galeriParameters with the values from the XML file
+    ParameterList& realParams = galeriParameters.GetParameterList();
+
+    for (ParameterList::ConstIterator it = realParams.begin(); it != realParams.end(); it++) {
+      const std::string& name = realParams.name(it);
+      if (paramList.isParameter(name))
+        realParams.setEntry(name, paramList.getEntry(name));
+    }
+  }
+
+  // Retrieve matrix parameters (they may have been changed on the command line)
+  // [for instance, if we changed matrix type from 2D to 3D we need to update nz]
+  ParameterList galeriList = galeriParameters.GetParameterList();
+
+  // =========================================================================
+  // Problem construction
+  // =========================================================================
+  std::ostringstream galeriStream;
+#ifdef HAVE_MUELU_OPENMP
+  std::string node_name = Node::name();
+  if(!comm->getRank() && !node_name.compare("OpenMP/Wrapper"))
+    galeriStream<<"OpenMP Max Threads = "<<omp_get_max_threads()<<std::endl;
+#endif
+
+
+  comm->barrier();
+  RCP<TimeMonitor> globalTimeMonitor = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: S - Global Time")));
+  RCP<TimeMonitor> tm                = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 1 - Matrix Build")));
+
+  RCP<Matrix>      A;
+  RCP<const Map>   map;
+  RCP<MultiVector> coordinates;
+  RCP<MultiVector> nullspace;
+  if (matrixFile.empty()) {
+    galeriStream << "========================================================\n" << xpetraParameters << galeriParameters;
+
+    // Galeri will attempt to create a square-as-possible distribution of subdomains di, e.g.,
+    //                                 d1  d2  d3
+    //                                 d4  d5  d6
+    //                                 d7  d8  d9
+    //                                 d10 d11 d12
+    // A perfect distribution is only possible when the #processors is a perfect square.
+    // This *will* result in "strip" distribution if the #processors is a prime number or if the factors are very different in
+    // size. For example, np=14 will give a 7-by-2 distribution.
+    // If you don't want Galeri to do this, specify mx or my on the galeriList.
+    std::string matrixType = galeriParameters.GetMatrixType();
+
+    // Create map and coordinates
+    // In the future, we hope to be able to first create a Galeri problem, and then request map and coordinates from it
+    // At the moment, however, things are fragile as we hope that the Problem uses same map and coordinates inside
+    if (matrixType == "Laplace1D") {
+      map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian1D", comm, galeriList);
+      coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,MultiVector>("1D", map, galeriList);
+
+    } else if (matrixType == "Laplace2D" || matrixType == "Star2D" ||
+               matrixType == "BigStar2D" || matrixType == "Elasticity2D") {
+      map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian2D", comm, galeriList);
+      coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,MultiVector>("2D", map, galeriList);
+
+    } else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D") {
+      map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
+      coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,MultiVector>("3D", map, galeriList);
+    }
+
+    // Expand map to do multiple DOF per node for block problems
+    if (matrixType == "Elasticity2D")
+      map = Xpetra::MapFactory<LO,GO,Node>::Build(map, 2);
+    if (matrixType == "Elasticity3D")
+      map = Xpetra::MapFactory<LO,GO,Node>::Build(map, 3);
+
+    galeriStream << "Processor subdomains in x direction: " << galeriList.get<GO>("mx") << std::endl
+                 << "Processor subdomains in y direction: " << galeriList.get<GO>("my") << std::endl
+                 << "Processor subdomains in z direction: " << galeriList.get<GO>("mz") << std::endl
+                 << "========================================================" << std::endl;
+
+    if (matrixType == "Elasticity2D" || matrixType == "Elasticity3D") {
+      // Our default test case for elasticity: all boundaries of a square/cube have Neumann b.c. except left which has Dirichlet
+      galeriList.set("right boundary" , "Neumann");
+      galeriList.set("bottom boundary", "Neumann");
+      galeriList.set("top boundary"   , "Neumann");
+      galeriList.set("front boundary" , "Neumann");
+      galeriList.set("back boundary"  , "Neumann");
+    }
+
+    RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
+        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
+    A = Pr->BuildMatrix();
+
+    if (matrixType == "Elasticity2D" ||
+        matrixType == "Elasticity3D") {
+      nullspace = Pr->BuildNullspace();
+      A->SetFixedBlockSize((galeriParameters.GetMatrixType() == "Elasticity2D") ? 2 : 3);
+    }
+
+  } else {
+    if (!rowmapFile.empty())
+      map = Xpetra::IO<SC,LO,GO,Node>::ReadMap(rowmapFile, lib, comm);
+    comm->barrier();
+
+    if (!binaryFormat && !map.is_null()) {
+      RCP<const Map> colMap    = (!colMapFile.empty()    ? Xpetra::IO<SC,LO,GO,Node>::ReadMap(colMapFile,    lib, comm) : Teuchos::null);
+      RCP<const Map> domainMap = (!domainMapFile.empty() ? Xpetra::IO<SC,LO,GO,Node>::ReadMap(domainMapFile, lib, comm) : Teuchos::null);
+      RCP<const Map> rangeMap  = (!rangeMapFile.empty()  ? Xpetra::IO<SC,LO,GO,Node>::ReadMap(rangeMapFile,  lib, comm) : Teuchos::null);
+      A = Xpetra::IO<SC,LO,GO,Node>::Read(matrixFile, map, colMap, domainMap, rangeMap);
+
+    } else {
+      A = Xpetra::IO<SC,LO,GO,Node>::Read(matrixFile, lib, comm, binaryFormat);
+
+      if (!map.is_null()) {
+        RCP<Matrix> newMatrix = MatrixFactory::Build(map, 1);
+        RCP<Import> importer  = ImportFactory::Build(A->getRowMap(), map);
+        newMatrix->doImport(*A, *importer, Xpetra::INSERT);
+        newMatrix->fillComplete();
+
+        A.swap(newMatrix);
+      }
+    }
+    map = A->getMap();
+
+    comm->barrier();
+
+    if (!coordFile.empty()) {
+      // NOTE: currently we only allow reading scalar matrices, thus coordinate
+      // map is same as matrix map
+      coordinates = Xpetra::IO<SC,LO,GO,Node>::ReadMultiVector(coordFile, map);
+    }
+
+    if (!nullFile.empty())
+      nullspace = Xpetra::IO<SC,LO,GO,Node>::ReadMultiVector(nullFile, map);
+  }
+
+  RCP<MultiVector> X = VectorFactory::Build(map);
+  RCP<MultiVector> B = VectorFactory::Build(map);
+
+  if (rhsFile.empty()) {
+    // we set seed for reproducibility
+    Utilities::SetRandomSeed(*comm);
+    X->randomize();
+    A->apply(*X, *B, Teuchos::NO_TRANS, one, zero);
+
+    Teuchos::Array<typename STS::magnitudeType> norms(1);
+    B->norm2(norms);
+    B->scale(one/norms[0]);
+
+  } else {
+    // read in B
+    B = Xpetra::IO<SC,LO,GO,Node>::ReadMultiVector(rhsFile, map);
+  }
+
+  comm->barrier();
+  tm = Teuchos::null;
+
+  galeriStream << "Galeri complete.\n========================================================" << std::endl;
+
+
+  int numReruns = 1;
+  if (paramList.isParameter("number of reruns"))
+    numReruns = paramList.get<int>("number of reruns");
+
+  const bool mustAlreadyExist = true;
+  for (int rerunCount = 1; rerunCount <= numReruns; rerunCount++) {
+    ParameterList mueluList, runList;
+
+    bool stop = false;
+    if (isDriver) {
+      runList   = paramList.sublist("Run1",  mustAlreadyExist);
+      mueluList = runList  .sublist("MueLu", mustAlreadyExist);
+    } else {
+      mueluList = paramList;
+      stop = true;
+    }
+
+    if (nullspace.is_null()) {
+      int blkSize = 1;
+      if (mueluList.isSublist("Matrix")) {
+        // Factory style parameter list
+        const Teuchos::ParameterList& operatorList = paramList.sublist("Matrix");
+        if (operatorList.isParameter("PDE equations"))
+          blkSize = operatorList.get<int>("PDE equations");
+
+      } else if (paramList.isParameter("number of equations")) {
+        // Easy style parameter list
+        blkSize = paramList.get<int>("number of equations");
+      }
+
+      nullspace = MultiVectorFactory::Build(map, blkSize);
+      for (int i = 0; i < blkSize; i++) {
+        RCP<const Map> domainMap = A->getDomainMap();
+        GO             indexBase = domainMap->getIndexBase();
+
+        ArrayRCP<SC> nsData = nullspace->getDataNonConst(i);
+        for (int j = 0; j < nsData.size(); j++) {
+          GO GID = domainMap->getGlobalElement(j) - indexBase;
+
+          if ((GID-i) % blkSize == 0)
+            nsData[j] = Teuchos::ScalarTraits<SC>::one();
+        }
+      }
+    }
+
+    int runCount = 1;
+    do {
+      solveType = dsolveType;
+      tol       = dtol;
+
+      int   savedOut  = -1;
+      FILE* openedOut = NULL;
+      if (isDriver) {
+        if (runList.isParameter("filename")) {
+          // Redirect all output into a filename We have to redirect all output,
+          // including printf's, therefore we cannot simply replace C++ cout
+          // buffers, and have to use heavy machinary (dup2)
+          std::string filename = runList.get<std::string>("filename");
+          if (numReruns > 1)
+            filename += "_run" + MueLu::toString(rerunCount);
+          filename += (lib == Xpetra::UseEpetra ? ".epetra" : ".tpetra");
+
+          savedOut  = dup(STDOUT_FILENO);
+          openedOut = fopen(filename.c_str(), "w");
+          dup2(fileno(openedOut), STDOUT_FILENO);
+        }
+        if (runList.isParameter("solver")) solveType = runList.get<std::string>("solver");
+        if (runList.isParameter("tol"))    tol       = runList.get<double>     ("tol");
+      }
+
+      // Instead of checking each time for rank, create a rank 0 stream
+      RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+      Teuchos::FancyOStream& out = *fancy;
+      out.setOutputToRootOnly(0);
+
+      out << galeriStream.str();
+
+      // =========================================================================
+      // Preconditioner construction
+      // =========================================================================
+      comm->barrier();
+      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 2 - MueLu Setup")));
+      bool useAMGX = mueluList.isParameter("use external multigrid package") && (mueluList.get<std::string>("use external multigrid package") == "amgx");
+      bool useML = mueluList.isParameter("use external multigrid package") && (mueluList.get<std::string>("use external multigrid package") == "ml");
+      if(useML && lib != Xpetra::UseEpetra) throw std::runtime_error("Error: Cannot use ML on non-epetra matrices");
+
+      RCP<Hierarchy> H;
+#if defined (HAVE_MUELU_AMGX) and defined (HAVE_MUELU_TPETRA)
+      RCP<MueLu::AMGXOperator<SC,LO,GO,NO> > aH;
+#endif
+#if defined(HAVE_MUELU_ML) and defined(HAVE_MUELU_EPETRA)
+      RCP<Operator> mlopX;
+#endif
+      for (int i = 0; i <= numRebuilds; i++) {
+        A->SetMaxEigenvalueEstimate(-Teuchos::ScalarTraits<SC>::one());
+
+        if (useAMGX) {
+#if defined (HAVE_MUELU_AMGX) and defined (HAVE_MUELU_TPETRA)
+          aH = Teuchos::rcp_dynamic_cast<MueLu::AMGXOperator<SC, LO, GO, NO> >(tH);
+#endif
+        } 
+        else if(useML) {
+#if defined(HAVE_MUELU_ML) and defined(HAVE_MUELU_EPETRA)
+          mueluList.remove("use external multigrid package");
+          ML_Wrapper<SC, LO, GO, NO>::Generate_ML_MultiLevelPreconditioner(A,mueluList,mlopX);
+#endif        
+        }
+        else {
+          H = MueLu::CreateXpetraPreconditioner(A, mueluList, coordinates);
+        }
+      }
+
+      comm->barrier();
+      tm = Teuchos::null;
+
+      // =========================================================================
+      // System solution (Ax = b)
+      // =========================================================================
+      comm->barrier();
+      tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3 - LHS and RHS initialization")));
+      X->putScalar(zero);
+      tm = Teuchos::null;
+
+      if (writeMatricesOPT > -2) {
+        tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.5 - Matrix output")));
+        H->Write(writeMatricesOPT, writeMatricesOPT);
+        tm = Teuchos::null;
+      }
+
+      comm->barrier();
+      if (solveType == "none") {
+        // Do not perform a solve
+
+      } else if (solveType == "standalone") {
+        tm = rcp (new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 4 - Fixed Point Solve")));
+
+        if (useAMGX) {
+#if defined (HAVE_MUELU_AMGX) and defined (HAVE_MUELU_TPETRA)
+          aH->apply(*(Utilities::MV2TpetraMV(B)), *(Utilities::MV2NonConstTpetraMV(X)));
+#endif
+        } else {
+          H->IsPreconditioner(false);
+          H->Iterate(*B, *X, maxIts);
+        }
+
+      } else if (solveType == "cg" || solveType == "gmres" || solveType == "bicgstab") {
+#ifdef HAVE_MUELU_BELOS
+        tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 5 - Belos Solve")));
+
+        // Operator and Multivector type that will be used with Belos
+        typedef MultiVector          MV;
+        typedef Belos::OperatorT<MV> OP;
+
+        // Define Operator and Preconditioner
+        Teuchos::RCP<OP> belosOp   = Teuchos::rcp(new Belos::XpetraOp<SC, LO, GO, NO>(A)); // Turns a Xpetra::Matrix object into a Belos operator
+        Teuchos::RCP<OP> belosPrec; // Turns a MueLu::Hierarchy object into a Belos operator
+        if (useAMGX) {
+#if defined (HAVE_MUELU_AMGX) and defined (HAVE_MUELU_TPETRA)
+          belosPrec = Teuchos::rcp(new Belos::MueLuOp <SC, LO, GO, NO>(aH)); // Turns a MueLu::Hierarchy object into a Belos operator
+#endif
+        } 
+        else if(useML) {
+#if defined(HAVE_MUELU_ML) and defined(HAVE_MUELU_EPETRA)
+          belosPrec = Teuchos::rcp(new Belos::XpetraOp <SC, LO, GO, NO>(mlopX)); // Turns an Xpetra::Operator object into a Belos operator
+#endif  
+        }
+        else {
+          H->IsPreconditioner(true);
+          belosPrec = Teuchos::rcp(new Belos::MueLuOp <SC, LO, GO, NO>(H)); // Turns a MueLu::Hierarchy object into a Belos operator
+        }
+
+        // Construct a Belos LinearProblem object
+        RCP<Belos::LinearProblem<SC, MV, OP> > belosProblem = rcp(new Belos::LinearProblem<SC, MV, OP>(belosOp, X, B));
+        belosProblem->setRightPrec(belosPrec);
+
+        bool set = belosProblem->setProblem();
+        if (set == false) {
+          out << "\nERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+          // this fixes the resource leak detected by coverity (CID134984)
+          if (openedOut != NULL) {
+            fclose(openedOut);
+            openedOut = NULL;
+          }
+          return EXIT_FAILURE;
+        }
+
+        // Belos parameter list
+        Teuchos::ParameterList belosList;
+        belosList.set("Maximum Iterations",    maxIts); // Maximum number of iterations allowed
+        belosList.set("Convergence Tolerance", tol);    // Relative convergence tolerance requested
+        belosList.set("Verbosity",             Belos::Errors + Belos::Warnings + Belos::StatusTestDetails);
+        belosList.set("Output Frequency",      1);
+        belosList.set("Output Style",          Belos::Brief);
+        if (!scaleResidualHist)
+          belosList.set("Implicit Residual Scaling", "None");
+
+        // Create an iterative solver manager
+        RCP< Belos::SolverManager<SC, MV, OP> > solver;
+        if (solveType == "cg") {
+          solver = rcp(new Belos::PseudoBlockCGSolMgr   <SC, MV, OP>(belosProblem, rcp(&belosList, false)));
+        } else if (solveType == "gmres") {
+          solver = rcp(new Belos::BlockGmresSolMgr<SC, MV, OP>(belosProblem, rcp(&belosList, false)));
+        } else if (solveType == "bicgstab") {
+          solver = rcp(new Belos::BiCGStabSolMgr<SC, MV, OP>(belosProblem, rcp(&belosList, false)));
+        }
+
+        // Perform solve
+        Belos::ReturnType ret = Belos::Unconverged;
+        ret = solver->solve();
+
+        // Get the number of iterations for this solve.
+        out << "Number of iterations performed for this solve: " << solver->getNumIters() << std::endl;
+        // Check convergence
+        if (ret != Belos::Converged)
+          out << std::endl << "ERROR:  Belos did not converge! " << std::endl;
+        else
+          out << std::endl << "SUCCESS:  Belos converged!" << std::endl;
+#endif //ifdef HAVE_MUELU_BELOS
+      } else {
+        throw MueLu::Exceptions::RuntimeError("Unknown solver type: \"" + solveType + "\"");
+      }
+      comm->barrier();
+      tm = Teuchos::null;
+      globalTimeMonitor = Teuchos::null;
+
+      if (printTimings) {
+        RCP<ParameterList> reportParams = rcp(new ParameterList);
+        if (timingsFormat == "yaml") {
+          reportParams->set("Report format",             "YAML");            // "Table" or "YAML"
+          reportParams->set("YAML style",                "compact");         // "spacious" or "compact"
+        }
+        reportParams->set("How to merge timer sets",   "Union");
+        reportParams->set("alwaysWriteLocal",          false);
+        reportParams->set("writeGlobalStats",          true);
+        reportParams->set("writeZeroTimers",           false);
+        // FIXME: no "ignoreZeroTimers"
+
+        const std::string filter = "";
+
+        std::ios_base::fmtflags ff(out.flags());
+        if (timingsFormat == "table-fixed") out << std::fixed;
+        else                                out << std::scientific;
+        TimeMonitor::report(comm.ptr(), out, filter, reportParams);
+        out << std::setiosflags(ff);
+      }
+
+      TimeMonitor::clearCounters();
+
+      if (isDriver) {
+        if (openedOut != NULL) {
+          TEUCHOS_ASSERT(savedOut >= 0);
+          dup2(savedOut, STDOUT_FILENO);
+          fclose(openedOut);
+          openedOut = NULL;
+        }
+        try {
+          runList   = paramList.sublist("Run" + MueLu::toString(++runCount), mustAlreadyExist);
+          mueluList = runList  .sublist("MueLu", mustAlreadyExist);
+        } catch (Teuchos::Exceptions::InvalidParameterName& e) {
+          stop = true;
+        }
+      }
+
+    } while (!stop);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//- -- --------------------------------------------------------
+#define MUELU_AUTOMATIC_TEST_ETI_NAME main_
+#include "MueLu_Test_ETI.hpp"
+
+int main(int argc, char *argv[]) {
+  return Automatic_Test_ETI(argc,argv);
+}
+

--- a/packages/muelu/test/scaling/sa_aggregation_coloring.xml
+++ b/packages/muelu/test/scaling/sa_aggregation_coloring.xml
@@ -1,0 +1,19 @@
+<ParameterList name="MueLu">
+  <Parameter        name="verbosity"                            type="string"   value="high"/>
+
+  <Parameter        name="use kokkos refactor"                  type="bool"     value="true"/>
+
+  <Parameter        name="number of equations"                  type="int"      value="1"/>
+
+  <Parameter        name="coarse: max size"                     type="int"      value="1000"/>
+
+  <Parameter        name="multigrid algorithm"                  type="string"   value="sa"/>
+
+  <!-- ===========  AGGREGATION  =========== -->
+  <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
+  <Parameter        name="aggregation: drop scheme"             type="string"   value="distance laplacian"/>
+  <!-- <Parameter        name="aggregation: drop tol"                type="double"   value="0.1"/> -->
+  <Parameter        name="aggregation: coloring algorithm"      type="string"   value="Distance2"/>
+  <Parameter        name="aggregation: permute nodes by color"  type="bool"     value="false"/>
+
+</ParameterList>

--- a/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
@@ -149,7 +149,7 @@ namespace MueLuTests {
     aggFact->SetParameter("aggregation: max selected neighbors",Teuchos::ParameterEntry(0));
     aggFact->SetParameter("aggregation: ordering",Teuchos::ParameterEntry(std::string("natural")));
     aggFact->SetParameter("aggregation: enable phase 1",  Teuchos::ParameterEntry(true));
-    aggFact->SetParameter("aggregation: phase 1 algorithm",Teuchos::ParameterEntry(std::string("Distance2")));
+    aggFact->SetParameter("aggregation: coloring algorithm",Teuchos::ParameterEntry(std::string("Distance2")));
     aggFact->SetParameter("aggregation: enable phase 2a", Teuchos::ParameterEntry(true));
     aggFact->SetParameter("aggregation: enable phase 2b", Teuchos::ParameterEntry(true));
     aggFact->SetParameter("aggregation: enable phase 3",  Teuchos::ParameterEntry(true));


### PR DESCRIPTION
This pull request is providing a refactor of the uncoupled aggregation algorithms to leverage kokkos capabilities as well as the work done on distance 2 graph coloring.

@trilinos/muelu 

## Description
The interface of aggregation algorithms now requires the number of colors and color assignment from the distance 2 coloring graph algorithm as input.
At the moment the coloring algorithm is called in phase 1 of aggregation but this will be moved to the UncoupledAggregationFactory.
Another item to be modified is the aggStat vector that is created as an `std::vector<unsigned>` in UncoupledAggregationFactory 

## Motivation and Context
This provides an implementation of the uncoupled aggregation algorithms that is architecture portable and that should improve performance on manycore/GPU machines.

## Related Issues
* Closes #1366, #2430
* Blocks  #1219 

## How Has This Been Tested?
`muelu/test/scaling/Driver.cpp` is modified within this pull request and is used as the primary vehicle for tests but more tests needs to be added since the driver will return to its normal form upon merge of this pull request.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
