### PR TITLE
Kokkoskernels: spgemm disabling mkl flag on mkl2phase.

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -47,7 +47,7 @@
 //#define HAVE_KOKKOSKERNELS_MKL
 
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef HAVE_KOKKOSKERNELS_MKL_DISABLED
 #include "mkl.h"
 #endif
 
@@ -81,7 +81,7 @@ void mkl2phase_symbolic(
     cin_row_index_view_type row_mapC,
     bool verbose = false){
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef HAVE_KOKKOSKERNELS_MKL_DISABLED
 
   typedef typename KernelHandle::nnz_lno_t idx;
   
@@ -216,7 +216,7 @@ void mkl2phase_symbolic(
       cin_nonzero_value_view_type &valuesC,
       bool verbose = false){
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef HAVE_KOKKOSKERNELS_MKL_DISABLED
 
     typedef typename KernelHandle::nnz_lno_t idx;
     


### PR DESCRIPTION
This pull requests disables the compilation of MKL-2phase-based SpGEMM method in kokkoskernels.
It is not used as a default methods, and compilation will be turned on for the next kokkoskernels promotion.

@trilinos/kokkos-kernels
@mhoemmen
Description

The compilation was failing when MKL is enabled. This is already fixed in KokkosKernels's develop branch. Current fix in trilinos is to disable the compilation for the TPL which is not executed as a default method.