### PR TITLE
Fix find library for ptscotch on SEMS machines

### DIFF
--- a/cmake/std/sems/SEMSDevEnv.cmake
+++ b/cmake/std/sems/SEMSDevEnv.cmake
@@ -155,7 +155,7 @@ IF (TPL_ENABLE_MPI)
   SEMS_SELECT_TPL_ROOT_DIR(SCOTCH Scotch_ROOT)
   SET(TPL_Scotch_INCLUDE_DIRS "${Scotch_ROOT}/include"
     CACHE PATH "Set in SEMSDevEnv.cmake")
-  SET(Scotch_LIBRARY_DIRS "${Scotch_ROOT}/lib}"
+  SET(Scotch_LIBRARY_DIRS "${Scotch_ROOT}/lib"
     CACHE PATH "Set in SEMSDevEnv.cmake")
 ENDIF()
 


### PR DESCRIPTION
## Description
Remove erroneous trailing '}'.

## Motivation and Context
Prior to this change, we were unable to successfully configure Trilinos on crf450 using CMake v3.10.1.

## How Has This Been Tested?
By using this change on crf450 to configure Trilinos using CMake v3.10.1.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [X] My commit messages mention the appropriate GitHub issue numbers.
- [X] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
- [X] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.