### PR TITLE
Allow change cmake version to fix Intel 15.0.2 build (fixes #2160)

### DIFF
--- a/cmake/ctest/drivers/artemis/cron_driver.sh
+++ b/cmake/ctest/drivers/artemis/cron_driver.sh
@@ -26,7 +26,11 @@ module load sems-env
 module load kokkos-env
 
 module load sems-python/2.7.9
-module load sems-cmake/2.8.12
+if [ "${CMAKE_SUFFIX}" != "" ] ; then
+  module load sems-${CMAKE_SUFFIX}
+else
+  module load sems-cmake/2.8.12
+fi
 module load sems-git/2.1.3
 module load sems-${COMPILER_SUFFIX}
 


### PR DESCRIPTION
This simple change allows the Jenkins job `Kokkos_Trilinos_packages` to set `CMAKE_SUFFIX=cmake-3.5.2` in order to fix the Inter 15.0.2 compiler detection problem with CMake 2.8.14 described in #2160. 
