### PR TITLE
SEMS intel workaround

### DIFF
--- a/cmake/load_sems_dev_env.sh
+++ b/cmake/load_sems_dev_env.sh
@@ -116,6 +116,15 @@ module load sems-env
 module load $sems_python_and_version_default
 module load $sems_cmake_and_version_load
 module load $sems_git_and_version_default
+
+# The SEMS Intel modules point to an unsupported version of GCC.
+# until this is fixed, the workaround is below.
+# Please see https://github.com/trilinos/Trilinos/issues/2142
+# for updates regarding the right solution.
+if [[ $sems_compiler_and_version_load == "sems-intel/"* ]]; then
+  module load sems-gcc/4.8.4
+fi
+
 module load $sems_compiler_and_version_load
 module load $sems_mpi_and_version_load
 module load $sems_boost_and_version_default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 
@bartlettroscoe 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
Forces the `sems-gcc/4.8.4` module to be loaded before any `sems-intel` modules, working around the fact that those Intel modules point to an old, unsupported version of GCC.

## Motivation and Context
Several users have reported Trilinos compile failures due to this problem with the SEMS modules. This mitigates that issue at least for users and automated tests which use the script being modified.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Related to #2128 #2172 #2142 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Nothing yet