### PR TITLE
 ROL: remove unneeded specialized std::is_pointer

### DIFF
--- a/packages/rol/src/compatibility/teuchos/rcp/ROL_Ptr.hpp
+++ b/packages/rol/src/compatibility/teuchos/rcp/ROL_Ptr.hpp
@@ -63,17 +63,6 @@ template<class T> using Ptr = Teuchos::RCP<T>;
 
 static const Teuchos::ENull nullPtr = Teuchos::null;
 
-}
-
-namespace std {
-
-template<class T>
-struct is_pointer<ROL::Ptr<T>> : public std::true_type { };
-
-}
-
-namespace ROL {
-
 // Special case handling until C++14 (auto type deduction) is required
 // because template type deduction does not work for initializer_list here. 
 


### PR DESCRIPTION
[#2175]

<!--- Provide a general summary of your changes in the Title above. -->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
This fixes #2175 directly in Trilinos, using the fix suggested by @gregvw .

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
We need this soon because it is preventing Albany nightly tests from compiling.
I should be safe to resolve with the fix in the ROL repository later.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes #2175 