### PR TITLE
Teuchos: allow assignments in MathExpr Language

### DIFF
--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -8,6 +8,12 @@ Teuchos::Language make_language() {
   Teuchos::Language out;
   Teuchos::Language::Productions& prods = out.productions;
   prods.resize(NPRODS);
+  prods[PROD_PROGRAM]("program") >> "statements", "expr?";
+  prods[PROD_NO_STATEMENTS]("statements");
+  prods[PROD_NEXT_STATEMENT]("statements") >> "statements", "statement", ";", "S?";
+  prods[PROD_ASSIGN]("statement") >> "name", "S?", "=", "S?", "expr";
+  prods[PROD_NO_EXPR]("expr?");
+  prods[PROD_YES_EXPR]("expr?") >> "expr";
   prods[PROD_EXPR]("expr") >> "ternary";
   prods[PROD_TERNARY_DECAY]("ternary") >> "add_sub";
   prods[PROD_OR_DECAY]("or") >> "and";
@@ -65,6 +71,8 @@ Teuchos::Language make_language() {
   out.tokens[TOK_OR]("||", "\\|\\|");
   out.tokens[TOK_CONST]("constant",
       "(0|([1-9][0-9]*))(\\.[0-9]*)?([eE]\\-?[1-9][0-9]*)?");
+  out.tokens[TOK_SEMICOLON](";", ";");
+  out.tokens[TOK_ASSIGN]("=", "=");
   return out;
 }
 

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.hpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.hpp
@@ -11,6 +11,12 @@ namespace Teuchos {
 namespace MathExpr {
 
 enum {
+  PROD_PROGRAM,
+  PROD_NO_STATEMENTS,
+  PROD_NEXT_STATEMENT,
+  PROD_ASSIGN,
+  PROD_NO_EXPR,
+  PROD_YES_EXPR,
   PROD_EXPR,
   PROD_TERNARY_DECAY,
   PROD_OR_DECAY,
@@ -68,10 +74,12 @@ enum {
   TOK_EQ,
   TOK_AND,
   TOK_OR,
-  TOK_CONST
+  TOK_CONST,
+  TOK_SEMICOLON,
+  TOK_ASSIGN
 };
 
-enum { NTOKS = TOK_CONST + 1 };
+enum { NTOKS = TOK_ASSIGN + 1 };
 
 Language make_language();
 

--- a/packages/teuchos/parser/test/unit_tests.cpp
+++ b/packages/teuchos/parser/test/unit_tests.cpp
@@ -487,20 +487,20 @@ TEUCHOS_UNIT_TEST( Parser, mathexpr_language ) {
 }
 
 void test_mathexpr_reader(std::string const& str) {
-  DebugReader reader(MathExpr::ask_reader_tables(), std::cout);
+  Reader reader(MathExpr::ask_reader_tables());
   Teuchos::any result;
   reader.read_string(result, str, "test_mathexpr_reader");
 }
 
 TEUCHOS_UNIT_TEST( Parser, mathexpr_reader ) {
-//test_mathexpr_reader("1 + 1");
-//test_mathexpr_reader("concat(one, two, three)");
-//test_mathexpr_reader("x < 0.5 ? 1 : 0");
-//test_mathexpr_reader("sqrt(x^2 + y^2) < 0.5 ? 1 : 0");
-//test_mathexpr_reader("1.22+30.*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
-//test_mathexpr_reader("1.23e5+8.07e10*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
-//test_mathexpr_reader("---16");
-//test_mathexpr_reader("((1 < 2) && (2 < 1)) ? 42 : 9");
+  test_mathexpr_reader("1 + 1");
+  test_mathexpr_reader("concat(one, two, three)");
+  test_mathexpr_reader("x < 0.5 ? 1 : 0");
+  test_mathexpr_reader("sqrt(x^2 + y^2) < 0.5 ? 1 : 0");
+  test_mathexpr_reader("1.22+30.*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+  test_mathexpr_reader("1.23e5+8.07e10*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+  test_mathexpr_reader("---16");
+  test_mathexpr_reader("((1 < 2) && (2 < 1)) ? 42 : 9");
   test_mathexpr_reader("x = 2; y = 5; x^2 + y^2");
 }
 

--- a/packages/teuchos/parser/test/unit_tests.cpp
+++ b/packages/teuchos/parser/test/unit_tests.cpp
@@ -487,20 +487,21 @@ TEUCHOS_UNIT_TEST( Parser, mathexpr_language ) {
 }
 
 void test_mathexpr_reader(std::string const& str) {
-  Reader reader(MathExpr::ask_reader_tables());
+  DebugReader reader(MathExpr::ask_reader_tables(), std::cout);
   Teuchos::any result;
   reader.read_string(result, str, "test_mathexpr_reader");
 }
 
 TEUCHOS_UNIT_TEST( Parser, mathexpr_reader ) {
-  test_mathexpr_reader("1 + 1");
-  test_mathexpr_reader("concat(one, two, three)");
-  test_mathexpr_reader("x < 0.5 ? 1 : 0");
-  test_mathexpr_reader("sqrt(x^2 + y^2) < 0.5 ? 1 : 0");
-  test_mathexpr_reader("1.22+30.*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
-  test_mathexpr_reader("1.23e5+8.07e10*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
-  test_mathexpr_reader("---16");
-  test_mathexpr_reader("((1 < 2) && (2 < 1)) ? 42 : 9");
+//test_mathexpr_reader("1 + 1");
+//test_mathexpr_reader("concat(one, two, three)");
+//test_mathexpr_reader("x < 0.5 ? 1 : 0");
+//test_mathexpr_reader("sqrt(x^2 + y^2) < 0.5 ? 1 : 0");
+//test_mathexpr_reader("1.22+30.*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+//test_mathexpr_reader("1.23e5+8.07e10*exp(-((x^2 + (y-180)^2))/(2.*(2.2)^2))");
+//test_mathexpr_reader("---16");
+//test_mathexpr_reader("((1 < 2) && (2 < 1)) ? 42 : 9");
+  test_mathexpr_reader("x = 2; y = 5; x^2 + y^2");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 
@bathmatt 
@eric-c-cyr 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
Add some new syntax to the `Teuchos::MathExpr` language such that you can now assign values to variables. There are no types, so one does:
```
a = sin(x);
b = cos(x);
a * b^2 + b * a^2
```
Where previously one would have to have done:
```
sin(x) * cos(x)^2 + cos(x) * sin(x)^2
```

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This is part of what is needed to have a user-friendly and Kokkos-parallel evaluation framework for Sandia applications, which initially will live in the Panzer package.