### PR TITLE
Lift Teuchos::any restrictions by metaprogramming

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_CTimeMonitor.cpp
+++ b/packages/teuchos/comm/src/Teuchos_CTimeMonitor.cpp
@@ -109,6 +109,5 @@ void Teuchos_stopTimer( int timerID )
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(true,
     *Teuchos::VerboseObjectBase::getDefaultOStream(), success);
-  if (!success)
-    ; // Avoid unused var warning (we don't need to check)
+  if (!success) {} // Avoid warnings
 }

--- a/packages/teuchos/core/src/Teuchos_TestForException.cpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.cpp
@@ -87,8 +87,7 @@ void Teuchos::TestForException_break( const std::string &errorMsg )
 {
   size_t break_on_me;
   break_on_me = errorMsg.length(); // Use errMsg to avoid compiler warning.
-  if (break_on_me)
-    ; // Avoid 'used var' warning
+  if (break_on_me) {} // Avoid warning
   // Above is just some statement for the debugger to break on.  Note: now is
   // a good time to examine the stack trace and look at the error message in
   // 'errorMsg' to see what happened.  In GDB just type 'where' or you can go

--- a/packages/teuchos/core/src/Teuchos_any.hpp
+++ b/packages/teuchos/core/src/Teuchos_any.hpp
@@ -114,7 +114,9 @@ struct compare<T, std::false_type> {
   bool operator()(T const&, T const&) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
         "Trying to compare type " << typeid(T).name() << " which is not comparable");
+#ifndef __CUDACC__
     return false;
+#endif
   }
 };
 
@@ -133,7 +135,9 @@ struct print<T, std::false_type> {
   std::ostream& operator()(std::ostream& s, T const&) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
         "Trying to print type " << typeid(T).name() << " which is not printable");
+#ifndef __CUDACC__
     return s;
+#endif
   }
 };
 

--- a/packages/teuchos/core/src/Teuchos_any.hpp
+++ b/packages/teuchos/core/src/Teuchos_any.hpp
@@ -216,7 +216,10 @@ public:
       return content ? content->typeName() : "NONE";
     }
 
-  //! \brief Return if two any objects are the same or not.
+  /*! \brief Return if two any objects are the same or not.
+   *  \warning This function with throw an exception if
+   *           operator== can't be applied to the held type!
+   */
   bool same( const any &other ) const
     {
       if( this->empty() && other.empty() )
@@ -229,7 +232,10 @@ public:
       return content->same(*other.content);
     }
 
-  //! Print this value to the output stream <tt>os</tt>
+  /*! \brief Print this value to the output stream <tt>os</tt>
+   *  \warning This function with throw an exception if
+   *           the held type can't be printed via operator<< !
+   */
   void print(std::ostream& os) const
     {
       if (content) content->print(os);
@@ -386,6 +392,8 @@ ValueType& any_ref_cast(any &operand)
 
 /*! \relates any
     \brief Converts the value in <tt>any</tt> to a std::string.
+    \warning This function with throw an exception if
+             the held type can't be printed via operator<< !
 */
 inline std::string toString(const any &rhs)
 {
@@ -396,6 +404,8 @@ inline std::string toString(const any &rhs)
 
 /*! \relates any
     \brief Returns true if two any objects have the same value.
+    \warning This function with throw an exception if
+             operator== can't be applied to the held type!
 */
 inline bool operator==( const any &a, const any &b )
 {
@@ -404,6 +414,8 @@ inline bool operator==( const any &a, const any &b )
 
 /*! \relates any
     \brief Returns true if two any objects <b>do not</b> have the same value.
+    \warning This function with throw an exception if
+             operator== can't be applied to the held type!
 */
 inline bool operator!=( const any &a, const any &b )
 {
@@ -412,6 +424,8 @@ inline bool operator!=( const any &a, const any &b )
 
 /*! \relates any
     \brief Writes "any" input <tt>rhs</tt> to the output stream <tt>os</tt>.
+    \warning This function with throw an exception if
+             the held type can't be printed via operator<< !
 */
 inline std::ostream & operator<<(std::ostream & os, const any &rhs)
 {

--- a/packages/teuchos/core/test/MemoryManagement/Any_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/Any_UnitTests.cpp
@@ -1,0 +1,91 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+// @HEADER
+*/
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_any.hpp"
+
+#include <sstream>
+
+namespace {
+
+
+TEUCHOS_UNIT_TEST( any, noThrowComparePrintDouble )
+{
+  double value = 25.0;
+  auto a = Teuchos::any(value);
+  auto b = Teuchos::any(value);
+  TEST_NOTHROW(a == b);
+  TEST_EQUALITY_CONST(true, b.same(a));
+  std::stringstream ss;
+  TEST_NOTHROW(ss << a);
+}
+
+TEUCHOS_UNIT_TEST( any, throwPrintVector )
+{
+  std::vector<double> value;
+  auto a = Teuchos::any(value);
+  auto b = Teuchos::any(value);
+  TEST_NOTHROW(a == b);
+  TEST_EQUALITY_CONST(true, b.same(a));
+  std::stringstream ss;
+  TEST_THROW(ss << a, std::runtime_error);
+  TEST_THROW(ss << b, std::runtime_error);
+}
+
+struct NotComparableOrPrintable {
+  int x;
+};
+
+TEUCHOS_UNIT_TEST( any, throwComparePrintStruct )
+{
+  NotComparableOrPrintable value;
+  value.x = 15;
+  auto a = Teuchos::any(value);
+  auto b = Teuchos::any(value);
+  TEST_THROW(a == b, std::runtime_error);
+  std::stringstream ss;
+  TEST_THROW(ss << a, std::runtime_error);
+  TEST_THROW(ss << b, std::runtime_error);
+}
+
+} // namespace

--- a/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
+++ b/packages/teuchos/core/test/MemoryManagement/CMakeLists.txt
@@ -130,6 +130,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
     ArrayView_UnitTests.cpp
     ArrayRCP_UnitTests.cpp
     ArrayConversions_UnitTests.cpp
+    Any_UnitTests.cpp
     TestClasses.cpp
     ${TEUCHOS_STD_UNIT_TEST_MAIN}
   COMM serial mpi

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
@@ -324,7 +324,11 @@ ParameterEntry::ParameterEntry(
     isDefault_(isDefault_in),
     docString_(docString_in),
     validator_(validator_in)
-{}
+{
+  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value &&
+                std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value,
+                "ParameterList values must be comparable and printable!");
+}
 
 // Set Methods
 
@@ -335,6 +339,9 @@ void ParameterEntry::setValue(
   RCP<const ParameterEntryValidator> const& validator_in
   )
 {
+  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value &&
+                std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value,
+                "ParameterList values must be comparable and printable!");
   val_ = value_in;
   isDefault_ = isDefault_in;
   if(docString_in.length())

--- a/packages/teuchos/parser/example/Calc.cpp
+++ b/packages/teuchos/parser/example/Calc.cpp
@@ -18,16 +18,6 @@ struct CallArgs {
   int n;
 };
 
-bool operator==(CallArgs const&, CallArgs const&) {
-  throw std::logic_error("CallArgs operator== is just to satisfy Teuchos");
-  return false;
-}
-
-std::ostream& operator<<(std::ostream& os, CallArgs const&) {
-  throw std::logic_error("CallArgs operator<< is just to satisfy Teuchos");
-  return os;
-}
-
 class Reader : public Teuchos::Reader {
  public:
   Reader():Teuchos::Reader(Teuchos::MathExpr::ask_reader_tables()) {

--- a/packages/teuchos/parser/src/Teuchos_set.hpp
+++ b/packages/teuchos/parser/src/Teuchos_set.hpp
@@ -41,12 +41,6 @@ bool intersects(std::set<T> const& a, std::set<T> const& b) {
   return false;
 }
 
-/* NOTE: this is only required to support Teuchos::any's non-standard print functionality ! */
-template <typename T>
-std::ostream& operator<<(std::ostream& os, std::set<T> const&) {
-  return os;
-}
-
 }
 
 #endif


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
From the first commit message:
```
By using C++11 template metaprogramming, we can
continue to support the comparison and print
extensions of Teuchos::any while still having
a safe compilation path in the case that the
held type doesn't have comparison or print operators.
Exceptions will be thrown if an unsupported operation
is attempted.
We can even automatically detect whether types
have this support by using SFINAE techniques.
This safely allows users to hold types in
Teuchos::any that don't have both comparison and
print operators.
```

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
As `Teuchos::any` is used more and more via `Teuchos::Reader`, I am frequently encountering cases that require defining comparison and print operators for objects that don't have them. This is especially bad design when those types are from other packages (e.g. `Kokkos::View`) or even the standard library (`std::set`, `std::vector` have no print operators). Relaxing the requirement of having those operators makes or breaks usability for `Teuchos::any` in my opinion.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes #1377 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A custom build of Teuchos passed all tests. Will still wait for the autotester.