### PR TITLE
Add option necessary to tribits for single submission to cdash

### DIFF
--- a/cmake/std/PullRequestLinuxGCCTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCCTestingSettings.cmake
@@ -20,6 +20,7 @@ set (Trilinos_ENABLE_TESTS ON CACHE BOOL "Set by default for PR testing")
 set (Trilinos_TEST_CATEGORIES BASIC CACHE STRING "Set by default for PR testing")
 set (Trilinos_ENABLE_CONFIGURE_TIMING ON CACHE BOOL "Set by default for PR testing")
 set (Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_CTEST_USE_NEW_AAO_FEATURES ON CACHE BOOL "Set by default for PR testing")
 
 
 # Options from cmake/std/MpiReleaseDebugSharedPtSettings.cmake


### PR DESCRIPTION
Apply change necessary to support a single submit for subprojects to be applied correctly. Without this change all the build information is applied to the last subproject listed in cdash instead of the correct package.

