### PR TITLE
Remove Panzer Warnings

### DIFF
--- a/packages/panzer/adapters-stk/test/panzer_workset_builder/hdiv_basis.cpp
+++ b/packages/panzer/adapters-stk/test/panzer_workset_builder/hdiv_basis.cpp
@@ -299,7 +299,6 @@ namespace panzer {
     out <<  worksets[0].bases.size() << std::endl;
     
     const BasisValues2<double> & hdiv_basis_values = *worksets[0].bases[0];
-    const BasisValues2<double> & hcurl_basis_values = *worksets[0].bases[1];
     out << (*worksets[0].basis_names)[0]
         << " " << (*worksets[0].basis_names)[1] << std::endl;
 

--- a/packages/panzer/adapters-stk/test/periodic_bcs/periodic_bcs.cpp
+++ b/packages/panzer/adapters-stk/test/periodic_bcs/periodic_bcs.cpp
@@ -882,10 +882,6 @@ namespace panzer {
                  RCP<std::vector<Tuple<double,3> > > > idsAndCoords_top = panzer_stk::periodic_helpers::getSideIdsAndCoords(*mesh,"top");
        std::pair<RCP<std::vector<std::size_t> >,
                  RCP<std::vector<Tuple<double,3> > > > idsAndCoords_bottom = panzer_stk::periodic_helpers::getSideIdsAndCoords(*mesh,"bottom");
-       std::vector<std::size_t> & sideIds_top = *idsAndCoords_top.first;
-       std::vector<std::size_t> & sideIds_bottom = *idsAndCoords_bottom.first;
-       std::vector<Tuple<double,3> > & sideCoords_top = *idsAndCoords_top.second;
-       std::vector<Tuple<double,3> > & sideCoords_bottom = *idsAndCoords_bottom.second;
 
     // Nodes
     {

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_impl.hpp
@@ -205,7 +205,6 @@ evaluateFields(typename TRAITS::EvalData workset)
    for (std::size_t fieldIndex=0; fieldIndex<gatherFields_.size();fieldIndex++) {
      auto offsets = scratch_offsets_[fieldIndex];
      auto gather_field = gatherFields_[fieldIndex];
-     int fieldNum = fieldIds_[fieldIndex];
 
      Kokkos::parallel_for(localCellIds.size(), KOKKOS_LAMBDA (std::size_t worksetCellIndex) {
        // loop over basis functions and fill the fields

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_impl.hpp
@@ -416,12 +416,12 @@ evaluateFields(typename TRAITS::EvalData workset)
       auto rLIDs = globalIndexer_->getElementLIDs(cellLocalId); 
       auto initial_cLIDs = colGlobalIndexer->getElementLIDs(cellLocalId);
       std::vector<int> cLIDs;
-      for (int i=0;i<initial_cLIDs.extent(0); ++i)
+      for (int i(0); i < static_cast<int>(initial_cLIDs.extent(0)); ++i)
         cLIDs.push_back(initial_cLIDs(i));
       if (Teuchos::nonnull(workset.other)) {
         const std::size_t other_cellLocalId = workset.other->cell_local_ids[worksetCellIndex];
 	auto other_cLIDs = colGlobalIndexer->getElementLIDs(other_cellLocalId);
-        for (int i=0;i<other_cLIDs.extent(0); ++i)
+        for (int i(0); i < static_cast<int>(other_cLIDs.extent(0)); ++i)
           cLIDs.push_back(other_cLIDs(i));
       }
 

--- a/packages/panzer/mini-em/src/closures/MiniEM_BCStrategy_Dirichlet_AuxConstant.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_BCStrategy_Dirichlet_AuxConstant.hpp
@@ -17,16 +17,16 @@ namespace mini_em {
     
   public:    
     
-    BCStrategy_Dirichlet_AuxConstant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data);
+    BCStrategy_Dirichlet_AuxConstant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& /* global_data */);
     
     void setup(const panzer::PhysicsBlock& side_pb,
-	       const Teuchos::ParameterList& user_data);
+	       const Teuchos::ParameterList& /* user_data */);
     
     void buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				    const panzer::PhysicsBlock& pb,
-				    const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-				    const Teuchos::ParameterList& models,
-				    const Teuchos::ParameterList& user_data) const;
+				    const panzer::PhysicsBlock& /* pb */,
+				    const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+				    const Teuchos::ParameterList& /* models */,
+				    const Teuchos::ParameterList& /* user_data */) const;
 
     void buildAndRegisterGatherScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
                                                  const panzer::PhysicsBlock& side_pb,

--- a/packages/panzer/mini-em/src/closures/MiniEM_BCStrategy_Dirichlet_AuxConstant_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_BCStrategy_Dirichlet_AuxConstant_impl.hpp
@@ -23,7 +23,7 @@
 template <typename EvalT>
 mini_em::BCStrategy_Dirichlet_AuxConstant<EvalT>::
 BCStrategy_Dirichlet_AuxConstant(const panzer::BC& bc,
-    const Teuchos::RCP<panzer::GlobalData>& global_data) 
+    const Teuchos::RCP<panzer::GlobalData>& /* global_data */) 
   : panzer::BCStrategy<EvalT>(bc)
 {
   TEUCHOS_ASSERT(this->m_bc.strategy() == "AuxConstant");
@@ -33,7 +33,7 @@ BCStrategy_Dirichlet_AuxConstant(const panzer::BC& bc,
 template <typename EvalT>
 void mini_em::BCStrategy_Dirichlet_AuxConstant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -63,10 +63,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void mini_em::BCStrategy_Dirichlet_AuxConstant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -109,17 +109,17 @@ buildAndRegisterGatherScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
 template <typename EvalT>
 void mini_em::BCStrategy_Dirichlet_AuxConstant<EvalT>::
-buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-                                  const panzer::PhysicsBlock& side_pb,
-				  const panzer::LinearObjFactory<panzer::Traits> & lof,
-				  const Teuchos::ParameterList& user_data) const {}
+buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+                                  const panzer::PhysicsBlock& /* side_pb */,
+				  const panzer::LinearObjFactory<panzer::Traits> & /* lof */,
+				  const Teuchos::ParameterList& /* user_data */) const {}
 
 template <typename EvalT>
 void mini_em::BCStrategy_Dirichlet_AuxConstant<EvalT>::
-buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-                                                 const panzer::PhysicsBlock& side_pb,
-                                                 const panzer::LinearObjFactory<panzer::Traits> & lof,
-                                                 const Teuchos::ParameterList& user_data) const {}
+buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+                                                 const panzer::PhysicsBlock& /* side_pb */,
+                                                 const panzer::LinearObjFactory<panzer::Traits> & /* lof */,
+                                                 const Teuchos::ParameterList& /* user_data */) const {}
 
 template < >
 void mini_em::BCStrategy_Dirichlet_AuxConstant<panzer::Traits::Jacobian>::
@@ -135,9 +135,9 @@ buildAndRegisterGatherScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 template < >
 void mini_em::BCStrategy_Dirichlet_AuxConstant<panzer::Traits::Jacobian>::
 buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-                                                 const panzer::PhysicsBlock& side_pb,
+                                                 const panzer::PhysicsBlock& /* side_pb */,
                                                  const panzer::LinearObjFactory<panzer::Traits> & lof,
-                                                 const Teuchos::ParameterList& user_data) const 
+                                                 const Teuchos::ParameterList& /* user_data */) const 
 {
   typedef panzer::Traits::Jacobian EvalT;
 
@@ -168,7 +168,7 @@ void mini_em::BCStrategy_Dirichlet_AuxConstant<panzer::Traits::Jacobian>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
                                   const panzer::PhysicsBlock& side_pb,
 				  const panzer::LinearObjFactory<panzer::Traits> & lof,
-				  const Teuchos::ParameterList& user_data) const 
+				  const Teuchos::ParameterList& /* user_data */) const 
 {
   typedef panzer::Traits::Jacobian EvalT;
 

--- a/packages/panzer/mini-em/src/closures/MiniEM_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -32,7 +32,7 @@ BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::G
 template <typename EvalT>
 void mini_em::BCStrategy_Dirichlet_Constant<EvalT>::
 setup(const panzer::PhysicsBlock& side_pb,
-      const Teuchos::ParameterList& user_data)
+      const Teuchos::ParameterList& /* user_data */)
 {
   using Teuchos::RCP;
   using std::vector;
@@ -81,10 +81,10 @@ setup(const panzer::PhysicsBlock& side_pb,
 template <typename EvalT>
 void mini_em::BCStrategy_Dirichlet_Constant<EvalT>::
 buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-			   const panzer::PhysicsBlock& pb,
-			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
-			   const Teuchos::ParameterList& models,
-			   const Teuchos::ParameterList& user_data) const
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
@@ -22,10 +22,10 @@ buildClosureModels(const std::string& model_id,
 		   const Teuchos::ParameterList& models, 
 		   const panzer::FieldLayoutLibrary& fl,
 		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
-		   const Teuchos::ParameterList& default_params,
-		   const Teuchos::ParameterList& user_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   PHX::FieldManager<panzer::Traits>& fm) const
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
 {
   using std::string;
   using std::vector;

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix.hpp
@@ -24,8 +24,8 @@ namespace mini_em {
 		             const bool build_transient_support);
     
     void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-					       const panzer::FieldLibrary& field_library,
-                                               const Teuchos::ParameterList& user_data) const;
+					       const panzer::FieldLibrary& /* field_library */,
+                                               const Teuchos::ParameterList& /* user_data */) const;
 
     void buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 					   const panzer::FieldLibrary& field_library,

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix_impl.hpp
@@ -74,8 +74,8 @@ AuxiliaryEquationSet_MassMatrix(
 template <typename EvalT>
 void mini_em::AuxiliaryEquationSet_MassMatrix<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& field_library,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* field_library */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -112,10 +112,10 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 // ***********************************************************************
 template <typename EvalT >
 void mini_em::AuxiliaryEquationSet_MassMatrix<EvalT>::
-buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				  const panzer::FieldLibrary& field_library,
-                                  const panzer::LinearObjFactory<panzer::Traits> & lof,
-                                  const Teuchos::ParameterList& user_data) const
+buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+				  const panzer::FieldLibrary& /* field_library */,
+                                  const panzer::LinearObjFactory<panzer::Traits> & /* lof */,
+                                  const Teuchos::ParameterList& /* user_data */) const
 {
 }
 
@@ -125,7 +125,7 @@ void mini_em::AuxiliaryEquationSet_MassMatrix<panzer::Traits::Jacobian>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 				  const panzer::FieldLibrary& field_library,
                                   const panzer::LinearObjFactory<panzer::Traits> & lof,
-                                  const Teuchos::ParameterList& user_data) const
+                                  const Teuchos::ParameterList& /* user_data */) const
 {
    using Teuchos::RCP;
    using Teuchos::rcp;

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient.hpp
@@ -24,8 +24,8 @@ namespace mini_em {
 					  const bool build_transient_support);
     
     void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-					       const panzer::FieldLibrary& field_library, 
-                                               const Teuchos::ParameterList& user_data) const;
+					       const panzer::FieldLibrary& /* field_library */, 
+                                               const Teuchos::ParameterList& /* user_data */) const;
 
     void buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 					   const panzer::FieldLibrary& field_library, 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient_impl.hpp
@@ -72,8 +72,8 @@ AuxiliaryEquationSet_WeakGradient(
 template <typename EvalT>
 void mini_em::AuxiliaryEquationSet_WeakGradient<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& field_library,
-				      const Teuchos::ParameterList& user_data) const
+				      const panzer::FieldLibrary& /* field_library */,
+				      const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
@@ -106,10 +106,10 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 // ***********************************************************************
 template <typename EvalT >
 void mini_em::AuxiliaryEquationSet_WeakGradient<EvalT>::
-buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				  const panzer::FieldLibrary& field_library,
-                                  const panzer::LinearObjFactory<panzer::Traits> & lof,
-                                  const Teuchos::ParameterList& user_data) const
+buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+				  const panzer::FieldLibrary& /* field_library */,
+                                  const panzer::LinearObjFactory<panzer::Traits> & /* lof */,
+                                  const Teuchos::ParameterList& /* user_data */) const
 {
 }
 
@@ -119,7 +119,7 @@ void mini_em::AuxiliaryEquationSet_WeakGradient<panzer::Traits::Jacobian>::
 buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 				  const panzer::FieldLibrary& field_library,
                                   const panzer::LinearObjFactory<panzer::Traits> & lof,
-                                  const Teuchos::ParameterList& user_data) const
+                                  const Teuchos::ParameterList& /* user_data */) const
 {
    using Teuchos::RCP;
    using Teuchos::rcp;

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell_impl.hpp
@@ -90,8 +90,8 @@ EquationSet_Maxwell(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void mini_em::EquationSet_Maxwell<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-    const panzer::FieldLibrary& fl,
-    const Teuchos::ParameterList& user_data) const
+    const panzer::FieldLibrary& /* fl */,
+    const Teuchos::ParameterList& /* user_data */) const
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -27,7 +27,7 @@ namespace mini_em {
 // FullMaxwellPreconditionerFactory  //
 ///////////////////////////////////////
 
-Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Teko::BlockedLinearOp & blo, Teko::BlockPreconditionerState & state) const
+Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Teko::BlockedLinearOp & blo, Teko::BlockPreconditionerState & /* state */) const
 {
    Teuchos::RCP<Teuchos::TimeMonitor> tM = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(std::string("MaxwellPreconditioner::build"))));
 


### PR DESCRIPTION
@trilinos/panzer

## Description
This PR removes a number of warnings in Panzer, mostly in the Mini-EM subpackage.  Most were unused parameter warnings, which were fixed by `/* commenting out */` the appropriate parameters in the function definitions.  Some where unused variable warnings, in which case the variable declarations were simply removed.  @egphill, can you look specifically at these removed lines and make sure they don't need to stick around?

## Motivation and Context
It's hard to tell if changes are adding new warnings if Trilinos spits out thousands of them.  This is just cleaning up our little piece of the pie.

## How Has This Been Tested?
`ctest` shows all Panzer tests are passing on my machine.

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
