### PR TITLE
Intrepid2: fix doxygen file paths

### DIFF
--- a/packages/intrepid2/doc/Doxyfile
+++ b/packages/intrepid2/doc/Doxyfile
@@ -479,10 +479,10 @@ WARN_LOGFILE           =
 # with spaces.
 
 INPUT              = \
-../refactor/src/Cell \
-../refactor/src/Discretization \
-../refactor/src/Shared \
-../refactor/src/Orientation 
+../src/Cell \
+../src/Discretization \
+../src/Shared \
+../src/Orientation 
 
 # This tag can be used to specify the character encoding of the source files that 
 # doxygen parses. Internally doxygen uses the UTF-8 encoding, which is also the default 


### PR DESCRIPTION
Intrepid2 doxygen was pointing to old directory structure (refactor). This fixes the paths.