### PR TITLE
Workset changes for handling the Basis/IntegrationDescriptor Interfaces

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_Workset.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.cpp
@@ -252,6 +252,22 @@ WorksetDetails::getIntegrationRule(const panzer::IntegrationDescriptor & descrip
   return *(itr->second);
 }
 
+panzer::BasisValues2<double> &
+WorksetDetails::getBasisValues(const panzer::BasisDescriptor & basis_description, 
+                               const panzer::IntegrationDescriptor & integration_description)
+{
+  const auto itr = _basis_map.find(basis_description.getKey());
+  TEUCHOS_TEST_FOR_EXCEPT_MSG(itr == _basis_map.end(),
+                              "Workset::getBasisValues: Can't find basis \"" + basis_description.getType() + "\" " 
+                              "of order " + std::to_string(basis_description.getOrder()));
+  const auto & integration_map = itr->second;
+  const auto itr2 = integration_map.find(integration_description.getKey());
+  TEUCHOS_TEST_FOR_EXCEPT_MSG(itr2 == integration_map.end(),
+                              "Workset::getBasisValues: Can't find integration " + std::to_string(integration_description.getType()) + " " 
+                              "of order " + std::to_string(integration_description.getOrder()));
+  return *(itr2->second);
+}
+
 const panzer::BasisValues2<double> &
 WorksetDetails::getBasisValues(const panzer::BasisDescriptor & basis_description, 
                                const panzer::PointDescriptor & point_description) const

--- a/packages/panzer/disc-fe/src/Panzer_Workset.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.hpp
@@ -119,6 +119,10 @@ namespace panzer {
     const panzer::IntegrationRule & getIntegrationRule(const panzer::IntegrationDescriptor & description) const;
 
     /// Grab the basis values for a given basis description and integration description (throws error if it doesn't exist)
+    panzer::BasisValues2<double> & getBasisValues(const panzer::BasisDescriptor & basis_description, 
+                                                  const panzer::IntegrationDescriptor & integration_description);
+
+    /// Grab the basis values for a given basis description and integration description (throws error if it doesn't exist)
     const panzer::BasisValues2<double> & getBasisValues(const panzer::BasisDescriptor & basis_description, 
                                                         const panzer::IntegrationDescriptor & integration_description) const;
 
@@ -151,7 +155,7 @@ namespace panzer {
     std::map<size_t,Teuchos::RCP<const panzer::IntegrationValues2<double> > > _integrator_map;
 
     std::map<size_t,Teuchos::RCP<const panzer::PureBasis > > _pure_basis_map;
-    std::map<size_t,std::map<size_t,Teuchos::RCP<const panzer::BasisValues2<double> > > > _basis_map;
+    std::map<size_t,std::map<size_t,Teuchos::RCP<panzer::BasisValues2<double> > > > _basis_map;
 
     std::map<size_t,Teuchos::RCP<const panzer::PointRule > > _point_rule_map;
     std::map<size_t,Teuchos::RCP<const panzer::PointValues2<double> > > _point_map;

--- a/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
@@ -266,51 +266,87 @@ applyOrientations(const std::string & eBlock, std::vector<Workset> & worksets) c
 
   // loop over each basis requiring orientations, then apply them
   //////////////////////////////////////////////////////////////////////////////////
-
+  
   // Note: It may be faster to loop over the basis pairs on the inside (not really sure)
 
   const WorksetNeeds & needs = lookupNeeds(eBlock);
-  TEUCHOS_ASSERT(needs.bases.size()==needs.rep_field_name.size());
 
-  for(std::size_t w=0;w<needs.bases.size();w++) {
-    //const std::string & fieldName = needs.rep_field_name[i];
-    const PureBasis & basis = *needs.bases[w];
+  if(needs.bases.size()>0) {
+    // sanity check that we aren't missing something (the old and new "needs" should not be used together)
+    TEUCHOS_ASSERT(needs.getBases().size()==0);
 
-    // no need for this if orientations are not required!
-    if(!basis.requiresOrientations()) continue;
-
-    // build accessors for orientation fields
-    std::vector<Intrepid2::Orientation> ortsPerBlock;
-
-    // loop over worksets compute and apply orientations
-    for(std::size_t i=0;i<worksets.size();i++) {
-      // break out of the workset loop
-      if(worksets[i].num_cells<=0) continue;
-
-      for(std::size_t j=0;j<worksets[i].numDetails();j++) {
-        WorksetDetails & details = worksets[i](j);
-
-        ortsPerBlock.clear();
-        for (int k=0;k<worksets[i].num_cells;++k) {
-          ortsPerBlock.push_back((*orientations_)[details.cell_local_ids[k]]);
-        }
-
-        for(std::size_t basis_index=0;basis_index<details.bases.size();basis_index++) {
-          Teuchos::RCP<const BasisIRLayout> layout = details.bases[basis_index]->basis_layout;
-
-          // only apply orientations if its relevant to the current needs
-          if(layout->getBasis()->name()!=basis.name())
-            continue;
-
-          TEUCHOS_ASSERT(layout!=Teuchos::null);
-          TEUCHOS_ASSERT(layout->getBasis()!=Teuchos::null);
-          if(layout->getBasis()->requiresOrientations()) {
-            // apply orientations for this basis
-            details.bases[basis_index]->applyOrientations(ortsPerBlock);
+    for(std::size_t w=0;w<needs.bases.size();w++) {
+      const PureBasis & basis = *needs.bases[w];
+  
+      // no need for this if orientations are not required!
+      if(!basis.requiresOrientations())
+        continue;
+  
+      // build accessors for orientation fields
+      std::vector<Intrepid2::Orientation> ortsPerBlock;
+  
+      // loop over worksets compute and apply orientations
+      for(std::size_t i=0;i<worksets.size();i++) {
+        // break out of the workset loop
+        if(worksets[i].num_cells<=0) continue;
+  
+        for(std::size_t j=0;j<worksets[i].numDetails();j++) {
+          WorksetDetails & details = worksets[i](j);
+  
+          ortsPerBlock.clear();
+          for (int k=0;k<worksets[i].num_cells;++k) {
+            ortsPerBlock.push_back((*orientations_)[details.cell_local_ids[k]]);
+          }
+  
+          for(std::size_t basis_index=0;basis_index<details.bases.size();basis_index++) {
+            Teuchos::RCP<const BasisIRLayout> layout = details.bases[basis_index]->basis_layout;
+  
+            // only apply orientations if its relevant to the current needs
+            if(layout->getBasis()->name()!=basis.name())
+              continue;
+  
+            TEUCHOS_ASSERT(layout!=Teuchos::null);
+            TEUCHOS_ASSERT(layout->getBasis()!=Teuchos::null);
+            if(layout->getBasis()->requiresOrientations()) {
+              // apply orientations for this basis
+              details.bases[basis_index]->applyOrientations(ortsPerBlock);
+            }
           }
         }
       }
-    }
+    } // end for w
+  }
+  else if(needs.getBases().size()>0) {
+    // sanity check that we aren't missing something (the old and new "needs" should not be used together)
+    TEUCHOS_ASSERT(needs.bases.size()==0);
+
+    // This is for forwards compatibility, the needs now use "getBasis" calls as opposed
+    // to director accessors.
+    for(const auto & bd : needs.getBases()) {
+  
+      // build accessors for orientation fields
+      std::vector<Intrepid2::Orientation> ortsPerBlock;
+  
+      // loop over worksets compute and apply orientations
+      for(std::size_t i=0;i<worksets.size();i++) {
+        // break out of the workset loop
+        if(worksets[i].num_cells<=0) continue;
+  
+        for(std::size_t j=0;j<worksets[i].numDetails();j++) {
+          WorksetDetails & details = worksets[i](j);
+  
+          ortsPerBlock.clear();
+          for (int k=0;k<worksets[i].num_cells;++k) {
+            ortsPerBlock.push_back((*orientations_)[details.cell_local_ids[k]]);
+          }
+  
+          for(const auto & id : needs.getIntegrators()) {
+            // apply orientations for this basis
+            details.getBasisValues(bd,id).applyOrientations(ortsPerBlock);
+          }
+        }
+      }
+    } // end for w
   }
 }
   
@@ -340,49 +376,85 @@ applyOrientations(const WorksetDescriptor & desc,std::map<unsigned,Workset> & wo
   
   // Note: It may be faster to loop over the basis pairs on the inside (not really sure)
   const WorksetNeeds & needs = lookupNeeds(desc.getElementBlock());
-  TEUCHOS_ASSERT(needs.bases.size()==needs.rep_field_name.size());
+
+  if(needs.bases.size()>0) {
+    // sanity check that we aren't missing something (the old and new "needs" should not be used together)
+    TEUCHOS_ASSERT(needs.getBases().size()==0);
+    for(std::size_t i=0;i<needs.bases.size();i++) {
+      const PureBasis & basis = *needs.bases[i];
+      
+      // no need for this if orientations are not required!
+      if(!basis.requiresOrientations()) continue;
+      
+      // build accessors for orientation fields
+      std::vector<Intrepid2::Orientation> ortsPerBlock;  
+      
+      // loop over worksets compute and apply orientations
+      for(std::map<unsigned,Workset>::iterator itr=worksets.begin(); 
+          itr!=worksets.end();++itr) { 
+        
+        // break out of the workset loop
+        if(itr->second.num_cells<=0) continue;
+        
+        for(std::size_t j=0;j<itr->second.numDetails();j++) {  
+          WorksetDetails & details = itr->second(j);
   
-  for(std::size_t i=0;i<needs.bases.size();i++) {
-    //const std::string & fieldName = needs.rep_field_name[i];
-    const PureBasis & basis = *needs.bases[i];
-    
-    // no need for this if orientations are not required!
-    if(!basis.requiresOrientations()) continue;
-    
-    // build accessors for orientation fields
-    std::vector<Intrepid2::Orientation> ortsPerBlock;  
-    
-    // loop over worksets compute and apply orientations
-    for(std::map<unsigned,Workset>::iterator itr=worksets.begin(); 
-        itr!=worksets.end();++itr) { 
-      
-      // break out of the workset loop
-      if(itr->second.num_cells<=0) continue;
-      
-      for(std::size_t j=0;j<itr->second.numDetails();j++) {  
-        WorksetDetails & details = itr->second(j);
-
-        ortsPerBlock.clear();
-        for (int k=0;k<itr->second.num_cells;++k) {
-          ortsPerBlock.push_back((*orientations_)[details.cell_local_ids[k]]);
-        }
-
-        for(std::size_t basis_index=0;basis_index<details.bases.size();basis_index++) {
-          Teuchos::RCP<const BasisIRLayout> layout = details.bases[basis_index]->basis_layout;
-
-          // only apply orientations if its relevant to the current needs
-          if(layout->getBasis()->name()!=basis.name())
-            continue;
-
-          TEUCHOS_ASSERT(layout!=Teuchos::null);
-          TEUCHOS_ASSERT(layout->getBasis()!=Teuchos::null);
-          if(layout->getBasis()->requiresOrientations()) {
-            // apply orientations for this basis
-            details.bases[basis_index]->applyOrientations(ortsPerBlock);
+          ortsPerBlock.clear();
+          for (int k=0;k<itr->second.num_cells;++k) {
+            ortsPerBlock.push_back((*orientations_)[details.cell_local_ids[k]]);
+          }
+  
+          for(std::size_t basis_index=0;basis_index<details.bases.size();basis_index++) {
+            Teuchos::RCP<const BasisIRLayout> layout = details.bases[basis_index]->basis_layout;
+  
+            // only apply orientations if its relevant to the current needs
+            if(layout->getBasis()->name()!=basis.name())
+              continue;
+  
+            TEUCHOS_ASSERT(layout!=Teuchos::null);
+            TEUCHOS_ASSERT(layout->getBasis()!=Teuchos::null);
+            if(layout->getBasis()->requiresOrientations()) {
+              // apply orientations for this basis
+              details.bases[basis_index]->applyOrientations(ortsPerBlock);
+            }
           }
         }
       }
-    }
+    } // end for i
+  }
+  else if(needs.getBases().size()>0) {
+    // sanity check that we aren't missing something (the old and new "needs" should not be used together)
+    TEUCHOS_ASSERT(needs.bases.size()==0);
+
+    // This is for forwards compatibility, the needs now use "getBasis" calls as opposed
+    // to director accessors.
+    for(const auto & bd : needs.getBases()) {
+  
+      // build accessors for orientation fields
+      std::vector<Intrepid2::Orientation> ortsPerBlock;
+  
+      // loop over worksets compute and apply orientations
+      for(std::map<unsigned,Workset>::iterator itr=worksets.begin(); 
+          itr!=worksets.end();++itr) { 
+        
+        // break out of the workset loop
+        if(itr->second.num_cells<=0) continue;
+        
+        for(std::size_t j=0;j<itr->second.numDetails();j++) {  
+          WorksetDetails & details = itr->second(j);
+  
+          ortsPerBlock.clear();
+          for (int k=0;k<itr->second.num_cells;++k) {
+            ortsPerBlock.push_back((*orientations_)[details.cell_local_ids[k]]);
+          }
+  
+          for(const auto & id : needs.getIntegrators()) {
+            // apply orientations for this basis
+            details.getBasisValues(bd,id).applyOrientations(ortsPerBlock);
+          }
+        }
+      }
+    } // end for w
   }
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_decl.hpp
@@ -61,6 +61,12 @@ protected:
 public:
   void operator()(const size_t &cell) const;
 
+  /**
+   * \brief Tag only constructor for this class.
+   */
+  ScalarToVector(const std::vector<PHX::Tag<ScalarT>> & input,
+                 const PHX::FieldTag & output);
+
 PANZER_EVALUATOR_CLASS_END
 
 }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_impl.hpp
@@ -78,6 +78,31 @@ PHX_EVALUATOR_CTOR(ScalarToVector,p)
 }
 
 //**********************************************************************
+
+template<typename EvalT, typename Traits>				\
+ScalarToVector<EvalT,Traits>::
+ScalarToVector(const std::vector<PHX::Tag<ScalarT>> & input,
+               const PHX::FieldTag & output)
+{
+  // setup the fields
+  vector_field = output;
+
+  scalar_fields.resize(input.size());
+  for(std::size_t i=0;i<input.size();i++) 
+    scalar_fields[i] = input[i];
+
+  // add dependent/evaluate fields
+  this->addEvaluatedField(vector_field);
+  
+  for (std::size_t i=0; i < scalar_fields.size(); ++i)
+    this->addDependentField(scalar_fields[i]);
+  
+  // name array
+  std::string n = "ScalarToVector: " + vector_field.fieldTag().name();
+  this->setName(n);
+}
+
+//**********************************************************************
 PHX_POST_REGISTRATION_SETUP(ScalarToVector, /* worksets */, fm)
 {
   internal_scalar_fields = Kokkos::View<KokkosScalarFields_t*>("ScalarToVector::internal_scalar_fields", scalar_fields.size());

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_decl.hpp
@@ -56,6 +56,14 @@ PANZER_EVALUATOR_CLASS(VectorToScalar)
   std::vector< PHX::MDField<ScalarT,Cell,Point> > scalar_fields;
   PHX::MDField<const ScalarT,Cell,Point,Dim> vector_field;
 
+public:
+ 
+  /**
+   * \brief Tag only constructor for this class.
+   */
+  VectorToScalar(const PHX::FieldTag & input,
+                 const std::vector<PHX::Tag<ScalarT>> & output);
+
 PANZER_EVALUATOR_CLASS_END
 
 /** This is a function constructor for an evaluator

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_impl.hpp
@@ -78,6 +78,31 @@ PHX_EVALUATOR_CTOR(VectorToScalar,p)
 }
 
 //**********************************************************************
+
+template<typename EvalT, typename Traits>				\
+VectorToScalar<EvalT,Traits>::
+VectorToScalar(const PHX::FieldTag & input,
+               const std::vector<PHX::Tag<ScalarT>> & output)
+{
+  // setup the fields
+  vector_field = input;
+
+  scalar_fields.resize(output.size());
+  for(std::size_t i=0;i<output.size();i++) 
+    scalar_fields[i] = output[i];
+
+  // add dependent/evaluate fields
+  this->addDependentField(vector_field);
+  
+  for (std::size_t i=0; i < scalar_fields.size(); ++i)
+    this->addEvaluatedField(scalar_fields[i]);
+  
+  // name array
+  std::string n = "VectorToScalar: " + vector_field.fieldTag().name();
+  this->setName(n);
+}
+
+//**********************************************************************
 PHX_POST_REGISTRATION_SETUP(VectorToScalar, /* worksets */, fm)
 {
   for (std::size_t i=0; i < scalar_fields.size(); ++i)


### PR DESCRIPTION
This is a change that indicates a broader problem with the "two path" worksets. Basically, the *Descriptor version of the needs, and the PureBasis, IntegrationRule versions. The primary contribution of this merge is to make sure the applyOrientation works for *Descriptor version. All panzer tests pass.