### PR TITLE
Fix duplicate copy targets caught by Ninja (#2245)

### DIFF
--- a/packages/muelu/doc/Tutorial/CMakeLists.txt
+++ b/packages/muelu/doc/Tutorial/CMakeLists.txt
@@ -1,2 +1,9 @@
 ADD_SUBDIRECTORY(src) 
 ADD_SUBDIRECTORY(tex)
+
+TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_tutorial_build_files
+  SOURCE_FILES
+    src/Challenge.cpp
+    src/MLParameterList.cpp
+    src/laplace2d.cpp
+  )

--- a/packages/muelu/doc/Tutorial/src/CMakeLists.txt
+++ b/packages/muelu/doc/Tutorial/src/CMakeLists.txt
@@ -26,7 +26,6 @@ IF (${PACKAGE_NAME}_ENABLE_Amesos       AND
   TRIBITS_COPY_FILES_TO_BINARY_DIR(tutorial_laplace2d_cp
     SOURCE_FILES hands-on.py MueLu_Agg2VTK.py
     tmpl/MueLu_Agg2VTK.py_TMPL tmpl/muelu.xml_TMPL tmpl/muelu_easy.xml_TMPL
-    laplace2d.cpp
     xml/s1_easy.xml xml/s1_easy_3levels_smoothed.xml xml/s1_easy_3levels_unsmoothed.xml
     xml/s1_easy_10levels.xml xml/s1_easy_exercise.xml xml/s1_easy_jacobi.xml xml/s1_easy_jacobi2.xml
     xml/s2_adv_a.xml xml/s2_adv_b.xml xml/s2_adv_c.xml
@@ -37,6 +36,7 @@ IF (${PACKAGE_NAME}_ENABLE_Amesos       AND
     xml/s2_easy.xml xml/s3a_easy.xml xml/s3b_easy.xml xml/s3c_easy.xml
     xml/n1_easy.xml xml/n1_easy_pg.xml
     xml/n2_easy_agg.xml xml/n2_easy_agg2.xml xml/n2_easy_agg3.xml xml/n2_easy_export.xml
+    EXEDEPS tutorial_laplace2d
     )
 
   TRIBITS_ADD_EXECUTABLE(
@@ -47,6 +47,7 @@ IF (${PACKAGE_NAME}_ENABLE_Amesos       AND
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(tutorial_recirc2d_cp
     SOURCE_FILES xml/s3a.xml xml/s3b.xml xml/s3c.xml xml/s3b1.xml xml/s3b2.xml xml/s3b3.xml
+    EXEDEPS tutorial_recirc2d
     )
 
   TRIBITS_ADD_EXECUTABLE(
@@ -57,6 +58,7 @@ IF (${PACKAGE_NAME}_ENABLE_Amesos       AND
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(userguide_srcfiles_cp
     SOURCE_FILES ScalingTest.cpp ScalingTestParamList.cpp
+    EXEDEPS tutorial_recirc2d_api
     )
 
   TRIBITS_ADD_EXECUTABLE(

--- a/packages/muelu/doc/Tutorial/tex/CMakeLists.txt
+++ b/packages/muelu/doc/Tutorial/tex/CMakeLists.txt
@@ -11,9 +11,6 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(tutorial_generateTutorial
     SOURCE_FILES prepareTexTutorial.py main.tex definitions.tex bookstyle.tex
-    ../src/Challenge.cpp
-    ../src/MLParameterList.cpp
-    ../src/laplace2d.cpp
     pics/1level_100jac09.png   
     pics/1level_1000jac09.png  
     pics/3level_1jac09.png       

--- a/packages/muelu/test/unit_tests/ParameterList/MLParameterListInterpreter/CMakeLists.txt
+++ b/packages/muelu/test/unit_tests/ParameterList/MLParameterListInterpreter/CMakeLists.txt
@@ -5,8 +5,6 @@
 # FILE TO FORCE THE RECONFIGURE ON OTHER PEOPLE'S BUILDS.
 FILE(GLOB xmlFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.xml)
 
-LIST(APPEND xmlFiles "../../../../example/ParameterList/ml_ParameterList.xml")
-
 TRIBITS_COPY_FILES_TO_BINARY_DIR(ParameterList_MLParameterListInterpreter_cp
   SOURCE_FILES ${xmlFiles}
   )


### PR DESCRIPTION
This fixes the ninja warnings produced in #2245.

I think the fix for the duplicate copy of the the file `laplace2d.cpp` is rock solid.

The fix for the duplicate copy of the the file  `ml_ParameterList.xml` is a little more uncertain.  I don't understand how it was supposed to work the way it was.   Do the MueLu unit tests read the file `ml_ParameterList.xml` out of the direcrtory `${MueLu_BINARY_DIR}/example/ParameterList/`?  That is the only way this would make sense.