### PR TITLE
MueLu: print data in advanced xml mode (#2260)

### DIFF
--- a/packages/muelu/doc/Tutorial/src/xml/s6_export.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s6_export.xml
@@ -15,9 +15,9 @@
     </ParameterList>
     
     <ParameterList name="DataToWrite">
-      <Parameter name="Matrices" type="string" value="{0,1,2}"/>
-      <Parameter name="Prolongators" type="string" value="{1,2}"/>
-      <Parameter name="Restrictors" type="string" value="{1,2}"/>
+      <Parameter name="A" type="string" value="{0,1,2}"/>
+      <Parameter name="P" type="string" value="{1,2}"/>
+      <Parameter name="R" type="string" value="{1,2}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1817,16 +1817,41 @@ namespace MueLu {
       if (hieraList.isSublist("DataToWrite")) {
         //TODO We should be able to specify any data.  If it exists, write it.
         //TODO This would requires something like std::set<dataName, Array<int> >
+
+        // Process sublist to find data that is supposed to be written to files
         ParameterList foo = hieraList.sublist("DataToWrite");
-        std::string dataName = "Matrices";
+        std::string dataName = "A";
         if (foo.isParameter(dataName))
           this->matricesToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        dataName = "Prolongators";
+        dataName = "P";
         if (foo.isParameter(dataName))
           this->prolongatorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        dataName = "Restrictors";
+        dataName = "R";
         if (foo.isParameter(dataName))
           this->restrictorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
+        dataName = "Nullspace";
+        if (foo.isParameter(dataName))
+          this->nullspaceToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
+        dataName = "Coordinates";
+        if (foo.isParameter(dataName))
+          this->coordinatesToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
+
+        // Take care of some deprecated options
+        dataName = "Matrices";
+        if (foo.isParameter(dataName)) {
+          this->GetOStream(Warnings0) << "Parameter 'Matrices' in 'DataToWrite' deprecated. Use 'A' instead." << std::endl;
+          this->matricesToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
+        }
+        dataName = "Prolongators";
+        if (foo.isParameter(dataName)) {
+          this->GetOStream(Warnings0) << "Parameter 'Prolongators' in 'DataToWrite' deprecated. Use 'P' instead." << std::endl;
+          this->prolongatorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
+        }
+        dataName = "Restrictors";
+        if (foo.isParameter(dataName)) {
+          this->GetOStream(Warnings0) << "Parameter 'Restrictors' in 'DataToWrite' deprecated. Use 'R' instead." << std::endl;
+          this->restrictorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
+        }
       }
 
       // Get level configuration


### PR DESCRIPTION
Allow to print "Nullspace" and "Coordinates" to files from the advanced xml input deck.

## Description
In the 'expert' xml interface (Tobias' style), the parameter list 'DataToWrite' controls output of quantities to files. Now, we can also print 'Nullspace' and 'Coordinates'. This has been available in the simple xml-file for quite a while.

Now, xml parameters for printing level matrices, prolongators, and restrictors are consistently named "A", "P", and "R". A deprecation warning is issued if the advanced xml input uses its old parameter names.

## Related Issues
* Closes #2260 

## How Has This Been Tested?
- ctest passes on my machine
- Correct behaviour of new output capability has been verified locally

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

@trilinos/muelu 