### PR TITLE
Teuchos: Fix #2271

### DIFF
--- a/packages/teuchos/core/cmake/Teuchos_config.h.in
+++ b/packages/teuchos/core/cmake/Teuchos_config.h.in
@@ -141,8 +141,6 @@
 
 #cmakedefine HAVE_TEUCHOS_KOKKOS_PROFILING
 
-#cmakedefine KOKKOS_ENABLE_PROFILING
-
 /* template qualifier required for calling template methods from non-template
    code */
 #define INVALID_TEMPLATE_QUALIFIER @INVALID_TEMPLATE_QUALIFIER@

--- a/packages/teuchos/core/src/Teuchos_Time.cpp
+++ b/packages/teuchos/core/src/Teuchos_Time.cpp
@@ -78,8 +78,13 @@ inline void seconds_initialize() {
 #include <unistd.h>
 #endif
 
-#if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE) && defined(KOKKOS_ENABLE_PROFILING)
-#include "Kokkos_Core.hpp"
+#if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
+namespace Kokkos {
+namespace Profiling {
+extern void pushRegion (const std::string&);
+extern void popRegion ();
+} // namespace Profiling
+} // namespace Kokkos
 #endif
 
 namespace Teuchos {
@@ -120,7 +125,7 @@ void Time::start(bool reset_in)
     }
 #endif
     startTime_ = wallTime();
-#if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE) && defined(KOKKOS_ENABLE_PROFILING)
+#if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
     ::Kokkos::Profiling::pushRegion (name_);
 #endif
   }
@@ -143,7 +148,7 @@ double Time::stop()
         numCallsMassifSnapshots_++;
       }
 #endif
-#if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE) && defined(KOKKOS_ENABLE_PROFILING)
+#if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
       ::Kokkos::Profiling::popRegion ();
 #endif
     }


### PR DESCRIPTION
Fix #2271 by doing the following:

  - Remove KOKKOS_ENABLE_PROFILING redundant #cmakedefine from
    Teuchos_config.h
  - Do not include Kokkos_Core.h in Teuchos_Time.cpp; use forward
    declarations for Kokkos::Profiling::{push, pop}Region instead, to
    improve build time


<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 
@vbrunini

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

