### PR TITLE
Panzer Warnings-As-Errors Cleanup

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_LocalPartitioningUtilities.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_LocalPartitioningUtilities.cpp
@@ -91,7 +91,7 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
   const int num_parent_total_cells = parent_info.num_owned_cells + parent_info.num_ghstd_cells + parent_info.num_virtual_cells;
 
   // Just as a precaution, make sure the parent_info is setup properly
-  TEUCHOS_ASSERT(parent_info.cell_to_faces.dimension_0() == num_parent_total_cells);
+  TEUCHOS_ASSERT(static_cast<int>(parent_info.cell_to_faces.extent(0)) == num_parent_total_cells);
   const int num_faces_per_cell = parent_info.cell_to_faces.dimension_1();
 
   // The first thing to do is construct a vector containing the parent cell indexes of all
@@ -175,9 +175,9 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
   // We now have the indexing order for our sub_info
 
   // Just as a precaution, make sure the parent_info is setup properly
-  TEUCHOS_ASSERT(parent_info.cell_vertices.dimension_0() == num_parent_total_cells);
-  TEUCHOS_ASSERT(parent_info.local_cells.dimension_0() == num_parent_total_cells);
-  TEUCHOS_ASSERT(parent_info.global_cells.dimension_0() == num_parent_total_cells);
+  TEUCHOS_ASSERT(static_cast<int>(parent_info.cell_vertices.extent(0)) == num_parent_total_cells);
+  TEUCHOS_ASSERT(static_cast<int>(parent_info.local_cells.extent(0)) == num_parent_total_cells);
+  TEUCHOS_ASSERT(static_cast<int>(parent_info.global_cells.extent(0)) == num_parent_total_cells);
 
   const int num_vertices_per_cell = parent_info.cell_vertices.dimension_1();
   const int num_dims = parent_info.cell_vertices.dimension_2();

--- a/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_SubcellConnectivity.cpp
@@ -79,7 +79,7 @@ subcellForCell(const int cell, const int local_subcell_index) const
 #endif
   const int index = _cell_to_subcells_adj(cell)+local_subcell_index;
   return _cell_to_subcells(index);
-};
+}
 
 int
 SubcellConnectivity::
@@ -91,7 +91,7 @@ cellForSubcell(const int subcell, const int local_cell_index) const
 #endif
   const int index = _subcell_to_cells_adj(subcell)+local_cell_index;
   return _subcell_to_cells(index);
-};
+}
 
 int
 SubcellConnectivity::
@@ -103,7 +103,7 @@ localSubcellForSubcell(const int subcell, const int local_cell_index) const
 #endif
   const int index = _subcell_to_cells_adj(subcell)+local_cell_index;
   return _subcell_to_local_subcells(index);
-};
+}
 
 // ========================================================================
 


### PR DESCRIPTION
@trilinos/panzer

## Description
#2279 pointed out [these warnings-as-errors failures on CDash](https://testing.sandia.gov/cdash/viewBuildError.php?buildid=3400850).  This PR should clean those up.  Specifically there were
*  extraneous semicolons, and
*  signed vs unsigned comparisons.

## Motivation and Context
Some applications apparently depend on those warnings-as-errors builds being clean.

## Related Issues
* Closes #2282
* Part of #2279

## How Has This Been Tested?
It hasn't yet&mdash;using the @trilinos-autotester.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.