### PR TITLE
Zoltan2: FindTPLParMETIS - look for metis header and library

### DIFF
--- a/cmake/TPLs/FindTPLParMETIS.cmake
+++ b/cmake/TPLs/FindTPLParMETIS.cmake
@@ -55,7 +55,7 @@
 
 
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( ParMETIS
-  REQUIRED_HEADERS parmetis.h
+  REQUIRED_HEADERS "parmetis.h;metis.h"
   REQUIRED_LIBS_NAMES "parmetis;metis"
   )
 


### PR DESCRIPTION

@trilinos/zoltan2 

## Description

`FindTPLParMETIS` to look for metis header and library.  Previously, it looked only for the library.

## Motivation and Context

spack installs packages in isolated prefixes; `FindTPLParMETIS` finds the library, but not the header in this case.  

## Related Issues

* Closes #2199 