### PR TITLE
Update NOX_Thyra_Eq test to clearly show why it passes or fails

### DIFF
--- a/packages/nox/test/epetra/Thyra/Thyra_Heq.C
+++ b/packages/nox/test/epetra/Thyra/Thyra_Heq.C
@@ -70,6 +70,8 @@
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_FancyOStream.hpp"
 #include "Teuchos_StandardCatchMacros.hpp"
+#include "Teuchos_VerboseObject.hpp"
+#include "Teuchos_TestingHelpers.hpp"
 
 #include "Stratimikos_DefaultLinearSolverBuilder.hpp"
 #include "Thyra_LinearOpWithSolveFactoryHelpers.hpp"
@@ -84,6 +86,8 @@ using namespace std;
 int main(int argc, char *argv[])
 {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  const Teuchos::RCP<Teuchos::FancyOStream> out =
+    Teuchos::VerboseObjectBase::getDefaultOStream();
 
   // Create a communicator for Epetra objects
 #ifdef HAVE_MPI
@@ -117,11 +121,9 @@ int main(int argc, char *argv[])
       return parse_return;
 
     if (verbose)
-      std::cout << "Verbosity Activated" << std::endl;
+      *out << "Verbosity Activated" << std::endl;
     else
-      std::cout << "Verbosity Disabled" << std::endl;
-
-    int status = 0;
+      *out << "Verbosity Disabled" << std::endl;
 
     const int num_elements = 400;
 
@@ -234,24 +236,30 @@ int main(int argc, char *argv[])
       }
     }
 
+    *out << "\nCheck for test pass/fail:\n";
+
+    bool loc_success = true;
+ 
     // 1. Convergence
-    if (solvStatus != NOX::StatusTest::Converged)
-      status = 1;
+    TEUCHOS_TEST_EQUALITY_CONST(solvStatus, NOX::StatusTest::Converged, *out, loc_success);
     // 2. Number of iterations
-    if (const_cast<Teuchos::ParameterList&>(solver->getList()).sublist("Output").get("Nonlinear Iterations", 0) != 18)
-      status = 2;
+    int numIterations = 0;
+    const int *numItersPtr = nullptr;
+    if (numItersPtr = Teuchos::getParameterPtr<int>(
+        solver->getList().sublist("Output"), "Nonlinear Iterations") ) 
+    {
+      numIterations = *numItersPtr;
+    } 
+    TEUCHOS_TEST_EQUALITY_CONST(numIterations, 18, *out, loc_success);
     // 3. Same reset solution
-    if (diff->norm() >= 1.0e-14)
-      status = 3;
+    TEUCHOS_TEST_COMPARE_CONST(diff->norm(), <=, 1.0e-14, *out, loc_success);
 
-    success = status==0;
+    success = loc_success;
 
-    if (Comm.MyPID() == 0) {
-      if (success)
-        std::cout << "Test passed!" << std::endl;
-      else
-        std::cout << "Test failed!" << std::endl;
-    }
+    if (success)
+      *out << "\nTest passed!" << std::endl;
+    else
+      *out << "\nTest failed!" << std::endl;
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
 

--- a/packages/teuchos/core/src/Teuchos_LocalTestingHelpers.hpp
+++ b/packages/teuchos/core/src/Teuchos_LocalTestingHelpers.hpp
@@ -153,6 +153,15 @@
   TEUCHOS_TEST_COMPARE( v1, comp, v2, out, success )
 
 
+/** \brief Assert that v1 comp v2 (where comp = '==', '>=", "!=", etc) where
+ * the second object v2 is printed as value.
+ *
+ * \ingroup Teuchos_UnitTestAssertMacros_grp
+ */
+#define TEST_COMPARE_CONST( v1, comp, v2 ) \
+  TEUCHOS_TEST_COMPARE_CONST( v1, comp, v2, out, success )
+
+
 /** \brief Assert that a1.size()==a2.size() and a[i]==b[i], i=0....
  *
  * Works for any object types that support a1[i], a1.size(), a2[j], and

--- a/packages/teuchos/core/src/Teuchos_TestingHelpers.hpp
+++ b/packages/teuchos/core/src/Teuchos_TestingHelpers.hpp
@@ -451,6 +451,25 @@ bool compareFloatingArrays(
   }
 
 
+/** \brief Compare an object and a constant using an input comparsion
+ * operator.
+ *
+ * The test succeeds (passes) if and only if "(v1) comp (v2)".
+ * For example, TEUCHOS_TEST_COMPARE( 2, <, 3, out, success )
+ * succeeds, but TEUCHOS_TEST_COMPARE( 2, >, 3, out, success )
+ * and TEUCHOS_TEST_COMPARE( 3, <, 2, out, success ) both fail.
+ *
+ * \ingroup teuchos_testing_grp
+ */
+#define TEUCHOS_TEST_COMPARE_CONST( v1, comp, v2, out, success ) \
+  { \
+    out << #v1" = "<<(v1)<<" "#comp" "<<(v2)<<" : "; \
+    const bool l_result = (v1) comp (v2); \
+    if (!l_result) (success) = false; \
+    (out) << TEUCHOS_PASS_FAIL(l_result) << "\n"; \
+  }
+
+
 /** \brief Test that the chunk of code 'code' throws an expected exception.
  *
  * 'code' is a chunk of code to execute.  It will be executed exactly

--- a/packages/teuchos/core/test/UnitTest/vector_UnitTests.cpp
+++ b/packages/teuchos/core/test/UnitTest/vector_UnitTests.cpp
@@ -92,6 +92,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( vector, sizedConstruct, T )
   TEST_EQUALITY( as<int>(a.size()), n );
   TEST_COMPARE( a.max_size(), >=, as<size_type>(n) );
   TEST_COMPARE( as<int>(a.capacity()), >=, n );
+  TEST_COMPARE_CONST( as<int>(a.capacity()), >=, n );
 }
 
 


### PR DESCRIPTION
**CC:** @trilinos/nox, @fryeguy52

This updates the test NOX_Thyra_Heq so that it clearly shows why the test passes or fails.  This currently still fails for the Intel 17.4 compiler but at least now we can see how this test is behaving on differnet platforms.

Before, the test just showed:

```
************************************************************************
-- Nonlinear Solver Step 16 -- 
||F|| = 6.500e-08  step = 1.000e+00 (Converged!)
************************************************************************

************************************************************************
-- Final Status Test Results --
Converged....OR Combination -> 
  **...........Finite Number Check (Two-Norm F) = Finite
  Converged....AND Combination -> 
    Converged....F-Norm = 6.749e-09 < 1.000e-08
                 (Length-Scaled Two-Norm, Absolute Tolerance)
    Converged....WRMS-Norm = 5.011e-05 < 1
  ??...........Number of Iterations = -1 < 100
************************************************************************
Test failed!
```

which makes no sense because it says it converged!

But there was a silent check that it must solve in 18 iterations.  But with Intel 17.4, it converges in 16 iterations (assuming due to better rounding with this Intel compiler).  Yea! 

This updates the test to print the real pass/fail criteria and I updated the criteria to all allow num interations between (14, 18) and it now prints:

```
************************************************************************
-- Nonlinear Solver Step 16 -- 
||F|| = 6.500e-08  step = 1.000e+00 (Converged!)
************************************************************************

************************************************************************
-- Final Status Test Results --
Converged....OR Combination -> 
  **...........Finite Number Check (Two-Norm F) = Finite
  Converged....AND Combination -> 
    Converged....F-Norm = 3.250e-09 < 1.000e-08
                 (Length-Scaled Two-Norm, Absolute Tolerance)
    Converged....WRMS-Norm = 2.810e-05 < 1
  ??...........Number of Iterations = -1 < 100
************************************************************************

Check for test pass/fail:
solvStatus = Converged.... == Converged.... : passed
numIterations = 16 == 18 : FAILED
diff->norm() = 1.4614e-07 <= 1e-14 : FAILED

Test failed!
```

I also improve the outputting by using` Teuchos::VerboseObjectBase::getDefaultOStream()` so you don't need to bother checking what proc you are on when you print.

