### PR TITLE
Changes to Panzer in support of domains.

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.cpp
@@ -4,9 +4,12 @@
 
 namespace panzer {
 
-  DomainEvaluator::DomainEvaluator(int domain) : domain_(domain) {}
+  DomainEvaluator::DomainEvaluator(DomainEvaluator::DomainType domain) : domain_(domain) {}
 
-  void DomainEvaluator::setDomain(const int domain)
+  DomainEvaluator::DomainType DomainEvaluator::getDomain()
+  {return domain_;}
+  
+  void DomainEvaluator::setDomain(const DomainEvaluator::DomainType domain)
   {domain_=domain;}
 
   int DomainEvaluator::cellStartIndex(const panzer::Workset & workset) const

--- a/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.hpp
@@ -27,7 +27,7 @@ namespace panzer {
      *
      * \param[in] domain (optional) Cell domain to iterate over (defaults to ALL)
      */
-    DomainEvaluator(int domain=ALL);
+    DomainEvaluator(DomainType domain=ALL);
 
     /**
      * \brief Default destructor
@@ -39,7 +39,13 @@ namespace panzer {
      *
      * \param[in] domain Domain to set
      */
-    void setDomain(const int domain);
+    void setDomain(const DomainType domain);
+    
+    /**
+     * \brief Get the domain for the evaluator
+     *
+     */
+    DomainType getDomain();
 
     /**
      * \brief Returns the starting cell for the specified domain for a given workset
@@ -70,7 +76,7 @@ namespace panzer {
   private:
 
     /// Domain for this evaluator
-    int domain_;
+    DomainType domain_;
 
   };
 


### PR DESCRIPTION
@trilinos/panzer 

@rppawlo, would you please review this?

## Description
Added getDomain() to DomainEvaluator.  Made domain arguments and results have type of DomainType.

## Motivation and Context
Some subclasses of panzer::Evaluator_WithBaseImpl which will use the new domain support need to be able to query the domain; that's why we need getDomain().  Changing from int to the enum type when there are domain arguments provides richer semantics, allowing the compiler to complain when mistakes are made.
