### PR TITLE
Revert "MueLu: printf data in xml-expert-mode (#2260)"

### DIFF
--- a/packages/muelu/doc/Tutorial/src/xml/s6_export.xml
+++ b/packages/muelu/doc/Tutorial/src/xml/s6_export.xml
@@ -15,9 +15,9 @@
     </ParameterList>
     
     <ParameterList name="DataToWrite">
-      <Parameter name="A" type="string" value="{0,1,2}"/>
-      <Parameter name="P" type="string" value="{1,2}"/>
-      <Parameter name="R" type="string" value="{1,2}"/>
+      <Parameter name="Matrices" type="string" value="{0,1,2}"/>
+      <Parameter name="Prolongators" type="string" value="{1,2}"/>
+      <Parameter name="Restrictors" type="string" value="{1,2}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1817,41 +1817,16 @@ namespace MueLu {
       if (hieraList.isSublist("DataToWrite")) {
         //TODO We should be able to specify any data.  If it exists, write it.
         //TODO This would requires something like std::set<dataName, Array<int> >
-
-        // Process sublist to find data that is supposed to be written to files
         ParameterList foo = hieraList.sublist("DataToWrite");
-        std::string dataName = "A";
+        std::string dataName = "Matrices";
         if (foo.isParameter(dataName))
           this->matricesToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        dataName = "P";
-        if (foo.isParameter(dataName))
-          this->prolongatorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        dataName = "R";
-        if (foo.isParameter(dataName))
-          this->restrictorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        dataName = "Nullspace";
-        if (foo.isParameter(dataName))
-          this->nullspaceToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        dataName = "Coordinates";
-        if (foo.isParameter(dataName))
-          this->coordinatesToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-
-        // Take care of some deprecated options
-        dataName = "Matrices";
-        if (foo.isParameter(dataName)) {
-          this->GetOStream(Warnings0) << "Parameter 'Matrices' in 'DataToWrite' deprecated. Use 'A' instead." << std::endl;
-          this->matricesToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        }
         dataName = "Prolongators";
-        if (foo.isParameter(dataName)) {
-          this->GetOStream(Warnings0) << "Parameter 'Prolongators' in 'DataToWrite' deprecated. Use 'P' instead." << std::endl;
+        if (foo.isParameter(dataName))
           this->prolongatorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        }
         dataName = "Restrictors";
-        if (foo.isParameter(dataName)) {
-          this->GetOStream(Warnings0) << "Parameter 'Restrictors' in 'DataToWrite' deprecated. Use 'R' instead." << std::endl;
+        if (foo.isParameter(dataName))
           this->restrictorsToPrint_ = Teuchos::getArrayFromStringParameter<int>(foo, dataName);
-        }
       }
 
       // Get level configuration


### PR DESCRIPTION
This reverts commit c8fee91b237732f38d8d87d6aa08691e535991d6.

## Description
The original fix was pre-mature. Since it cannot be fixed in reasonable time now, we better revert it.

## Related Issues
* Closes #2260 
* Follows #2261 

## How Has This Been Tested?
```ctest``` passes locally on my machine.
