### PR TITLE
Anasazi: Fix #2323

### DIFF
--- a/packages/anasazi/src/AnasaziMultiVecTraits.hpp
+++ b/packages/anasazi/src/AnasaziMultiVecTraits.hpp
@@ -198,7 +198,7 @@ namespace Anasazi {
     /// \param mv [in] Multivector to view (shallow const copy)
     /// \param index [in] Inclusive index range of columns of mv
     /// \return Reference-counted pointer to the const view of specified columns of mv
-    static Teuchos::RCP<MV> CloneView( MV& mv, const Teuchos::Range1D& index )
+    static Teuchos::RCP<const MV> CloneView( const MV& mv, const Teuchos::Range1D& index )
     { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
 
     //@}


### PR DESCRIPTION
Fix #2323.
@trilinos/anasazi

## Description

Fix the signature of the `Anasazi::MultiVecTraits::CloneView` overload that takes `Teuchos::Range1D`, to be consistent with the overload that takes `std::vector`.

## Motivation and Context

This does not actually affect the build, since the default implementation of `Anasazi::MultiVecTraits` intentionally cannot and should never be able to compile.  However, the default implementation documents the interface that traits class specializers must implement, so it is important to get right.

## Related Issues
* Closes #2323 

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
