### PR TITLE
2330 fix kokkos arch list

### DIFF
--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -126,7 +126,7 @@ perforamnt code and for C++ software that uses Kokkos.
 ============================    ======================================
 Functionality                   CMake Cache Varaible
 ============================    ======================================
-Specify architecture            ``KOKKOS_HOST_ARCH``
+Specify architecture            ``KOKKOS_ARCH``
 Debug builds                    ``KOKKOS_DEBUG``
 Device options:
 * Enable Cuda                   ``TPL_ENABLE_CUDA``
@@ -150,14 +150,26 @@ CUDA Options:
 * Enable CUDA LAMBDA            ``KOKKOS_ENABLE_CUDA_LAMBDA``
 ============================    ======================================
 
-If the cache var ``KOKKOS_HOST_ARCH`` is not set (or is set to ``None``) then
+If the cache var ``KOKKOS_ARCH`` is not set (or is set to ``None``) then
 the Kokkos settings are not used and the default Trilinos CMake configuration
 is used as described below.
 
-If ``KOKKOS_HOST_ARCH != None`` is set, then the correct compiler flags for
+If ``KOKKOS_ARCH != None`` is set, then the correct compiler flags for
 C++11 and OpenMP are selected by the Kokkos system and the values of the cache
 vars ``Trilinos_CXX11_FLAGS`` and ``OpenMP_CXX_FLAGS`` set by the user will be
 ignored.
+
+``KOKKOS_ARCH`` can be set to a list of entries using semi-colons as::
+
+  -DKOKKOS_ARCH="<arch0>;<arch1>"
+
+or as a list of etries using comas as::
+
+  -DKOKKOS_ARCH=<arch0>,<arch1>
+
+Using commas is more robust since it will not get accidentally interepreted as
+a shell command sperator or with differnet CMake logic that is trying to
+handle an array of entries which include one being `${KOKKOS_ARCH}`.
 
 To see more documentation for each of these options, run a configure with
 ``-DTrilinos_ENABLE_Kokkos=ON`` and then look in the CMakeCache.txt file (as

--- a/packages/kokkos/cmake/kokkos_settings.cmake
+++ b/packages/kokkos/cmake/kokkos_settings.cmake
@@ -14,6 +14,7 @@
 #-------------------------------------------------------------------------------
 
 # Ensure that KOKKOS_ARCH is in the ARCH_LIST
+string(REPLACE "," ";" KOKKOS_ARCH "${KOKKOS_ARCH}")  # Interpret as as CMake array
 foreach(arch ${KOKKOS_ARCH})
   list(FIND KOKKOS_ARCH_LIST ${arch} indx)
   if (indx EQUAL -1)
@@ -22,9 +23,8 @@ foreach(arch ${KOKKOS_ARCH})
   endif ()
 endforeach()
 
-# KOKKOS_SETTINGS uses KOKKOS_ARCH
+# KOKKOS_SETTINGS uses KOKKOS_ARCH (with commas, not semi-colons)
 string(REPLACE ";" "," KOKKOS_ARCH "${KOKKOS_ARCH}")
-set(KOKKOS_ARCH ${KOKKOS_ARCH})
 
 # From Makefile.kokkos: Options: yes,no
 if(${KOKKOS_ENABLE_DEBUG})


### PR DESCRIPTION
This fixes the problem with KOKKOS_ARCH described in #2230.

This is an update to Kokkos itself under Trilinos which gets shapshotted in to Trilinos.  But I will create a PR on the kokkos/kokkos git repo itself so that the snapshot does not overwrite this change.