### PR TITLE
Panzer: add (optional) prefix to response field name

### DIFF
--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_ExtremeValue.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_ExtremeValue.hpp
@@ -70,10 +70,12 @@ public:
                                const std::string & quadPointField="",
                                const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > & linearObjFactory=Teuchos::null,
                                const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > & globalIndexer=Teuchos::null,
-                               bool applyDirichletToDerivative=false)
+                               bool applyDirichletToDerivative=false,
+                               std::string in_prefix="")
      : comm_(comm), cubatureDegree_(cubatureDegree), requiresCellExtreme_(requiresCellReduction), useMax_(useMax)
      , quadPointField_(quadPointField), linearObjFactory_(linearObjFactory), globalIndexer_(globalIndexer)
      , applyDirichletToDerivative_(applyDirichletToDerivative)
+     , prefix_(in_prefix)
    {
      TEUCHOS_ASSERT((linearObjFactory==Teuchos::null && globalIndexer==Teuchos::null) ||
                     (linearObjFactory!=Teuchos::null && globalIndexer!=Teuchos::null));
@@ -134,6 +136,7 @@ private:
    Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > linearObjFactory_;
    Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> > globalIndexer_;
    bool applyDirichletToDerivative_;
+   std::string prefix_;
 };
 
 template <typename LO,typename GO> 
@@ -146,6 +149,7 @@ struct ExtremeValueResponse_Builder : public ResponseMESupportBuilderBase {
   bool applyDirichletToDerivative; // if this is set to true, then the dirichlet values will be zerod out in
                                    // the DgDx vector
 
+  std::string prefix;
   ExtremeValueResponse_Builder() : applyDirichletToDerivative(false) {}
 
   virtual ~ExtremeValueResponse_Builder() {}
@@ -171,7 +175,7 @@ struct ExtremeValueResponse_Builder : public ResponseMESupportBuilderBase {
   template <typename T>
   Teuchos::RCP<panzer::ResponseEvaluatorFactoryBase> build() const
   { return Teuchos::rcp(new ResponseEvaluatorFactory_ExtremeValue<T,LO,GO>(comm,cubatureDegree,requiresCellExtreme,useMax,quadPointField,
-                                                                         linearObjFactory,globalIndexer,applyDirichletToDerivative)); }
+                                                                         linearObjFactory,globalIndexer,applyDirichletToDerivative,prefix)); }
 
   virtual Teuchos::RCP<panzer::ResponseEvaluatorFactoryBase> buildValueFactory() const
   { return build<panzer::Traits::Residual>(); }

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_ExtremeValue_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_ExtremeValue_impl.hpp
@@ -84,7 +84,8 @@ buildAndRegisterEvaluators(const std::string & responseName,
      RCP<IntegrationRule> ir = rcp(new IntegrationRule(cubatureDegree_,physicsBlock.cellData()));
 
      Teuchos::ParameterList pl;
-     pl.set("Extreme Name",field);
+     // add prefix_ to help identify
+     pl.set("Extreme Name",prefix_+field);
      pl.set("Field Name",field);
      pl.set("IR",ir);
      pl.set("Use Max",useMax_);
@@ -101,6 +102,7 @@ buildAndRegisterEvaluators(const std::string & responseName,
      Teuchos::RCP<ExtremeValueScatterBase> scatterObj =
          (globalIndexer_!=Teuchos::null) ?  Teuchos::rcp(new ExtremeValueScatter<LO,GO>(globalIndexer_)) : Teuchos::null;
      std::string field = (quadPointField_=="" ? responseName : quadPointField_);
+     field = prefix_+field; // add prefix to help identify
 
      // build useful evaluator
      Teuchos::RCP<PHX::Evaluator<panzer::Traits> > eval 

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_Functional_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseEvaluatorFactory_Functional_impl.hpp
@@ -86,7 +86,7 @@ buildAndRegisterEvaluators(const std::string & responseName,
      RCP<IntegrationRule> ir = rcp(new IntegrationRule(cubatureDegree_,physicsBlock.cellData()));
 
      Teuchos::ParameterList pl;
-     pl.set("Integral Name",field);
+     pl.set("Integral Name", field);
      pl.set("Integrand Name",field);
      pl.set("IR",ir);
 

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue_impl.hpp
@@ -89,7 +89,7 @@ ResponseScatterEvaluator_ExtremeValue(const std::string & name,
   cellExtremeValue_ = PHX::MDField<const ScalarT,panzer::Cell>(name,dl_cell);
   this->addDependentField(cellExtremeValue_);
 
-  std::string n = "Functional Response Scatter: " + name;
+  std::string n = "Extreme Value Response Scatter: " + name;
   this->setName(n);
 }
 
@@ -119,7 +119,7 @@ ResponseScatterEvaluator_ExtremeValue(const std::string & integrandName,
   cellExtremeValue_ = PHX::MDField<const ScalarT,panzer::Cell>(integrandName,dl_cell);
   this->addDependentField(cellExtremeValue_);
 
-  std::string n = "Functional Response Scatter: " + responseName;
+  std::string n = "Extreme Value Response Scatter: " + responseName;
   this->setName(n);
 }
 


### PR DESCRIPTION
To help identify the response type on the evaluated field to help
prevent a bug when `Functional` and `ExtremeValue` responses are use at
the same time on the same field.

Before, a single node was shared and depending on the order the response
sublist for two types were added, the result would be different (correct
for the first response but wrong for the second one).

This should help fix that.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description

In Drekar, when using the `Functional` response type and `Max Value`/`Min Value` on the same field name, e.g `TEMPERATURE`, it turned out that the ordering mattered. Later, it was discovered that both response types just used the field name so they would just end up sharing the same node on the DAG.



- Here, the `Max Value`/`Min Value` response sublists are added first to compute the maximum/minimum temperature, followed by the `Functional` response to compute the integrated temperature. All 3 responses are sharing the same node:

![maxtemperature_integratedtemperature_output](https://user-images.githubusercontent.com/1556219/37106913-35cddd5a-21f0-11e8-9f95-b3536cfecdcf.png)

Since the maximum/minimum temperature response were added first, these quantities are similar to the values provided by the `Global Statistics`. Yet, the `integrated temperature` is wrong.

[MaxTemperature_integratedTemperature_log.txt](https://github.com/trilinos/Trilinos/files/1790124/MaxTemperature_integratedTemperature_log.txt)



- Here, the `Max Value`/`Min Value` response sublists are added last to compute the maximum/minimum temperature. The `Functional` response to compute the integrated temperature is added first. Again all 3 responses are sharing the same node:

![integratedtemperature_maxtemperature_output](https://user-images.githubusercontent.com/1556219/37107152-d6dded7a-21f0-11e8-979b-4120e42ea4a3.png)

Now since the `integrated temperature` response was added first, this value is correct. But the `max/min temperature` are different from the values provided by the `Global Statistics`.
[integratedTemperature_MaxTemperature_log.txt](https://github.com/trilinos/Trilinos/files/1790143/integratedTemperature_MaxTemperature_log.txt)

### New Change

All I did was to add `Functional ` and `Extreme Value ` prefix to the evaluated field name by the `Functional` and `ExtremeValue` responses respectively. This way, the `min/max temperatures` will share a single node while the `integrated temperature` will now have a different node.

![changes_to_response](https://user-images.githubusercontent.com/1556219/37107352-5b118700-21f1-11e8-8e51-71dcd0b18a9c.png)

Now the order the response sublists are defined no longer matters.

[changes_to_response_log.txt](https://github.com/trilinos/Trilinos/files/1790172/changes_to_response_log.txt)


## How Has This Been Tested?

All existing trilinos tests are passing.
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--
## Screenshots
 Not obligatory, but is there anything pertinent that we should see? -->

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

## Additional Information
<!--- Anything else we need to know in evaluating this merge request? -->
