### PR TITLE
Tpetra: Add "Error 127" CUDA build work-around to FAQ

### DIFF
--- a/packages/tpetra/doc/FAQ.txt
+++ b/packages/tpetra/doc/FAQ.txt
@@ -289,7 +289,7 @@ might see a link error with the mysterious "Error 127" message.
 
 Short answer: Try setting the following CMake option:
 #+BEGIN_EXAMPLE
-CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON
+-D CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON
 #+END_EXAMPLE
 
 For details, see the following GitHub issue:
@@ -297,6 +297,12 @@ For details, see the following GitHub issue:
 https://github.com/trilinos/Trilinos/issues/2141
 
 and the following instructions:
+
+http://trilinos.org/docs/files/TrilinosBuildReference.html#enabling-the-usage-of-resource-files-to-reduce-length-of-build-lines
+
+If you have trouble seeing the above trilinos.org link, due to web
+page certificate issues, please refer to the following tribits.org
+link instead:
 
 https://tribits.org/doc/TribitsBuildReference.html#enabling-the-usage-of-resource-files-to-reduce-length-of-build-lines
 

--- a/packages/tpetra/doc/FAQ.txt
+++ b/packages/tpetra/doc/FAQ.txt
@@ -281,6 +281,25 @@ by adding the following to your CMake invocation line:
 -D CMAKE_CXX_FLAGS_DEBUG:STRING="-g -Os"
 #+END_EXAMPLE
 
+** "Error 127" link error in CUDA builds
+
+In a CUDA build of kokkos-kernels (upstream of Tpetra) with complex
+arithmetic and explicit template instantiation (ETI) enabled, one
+might see a link error with the mysterious "Error 127" message.
+
+Short answer: Try setting the following CMake option:
+#+BEGIN_EXAMPLE
+CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON
+#+END_EXAMPLE
+
+For details, see the following GitHub issue:
+
+https://github.com/trilinos/Trilinos/issues/2141
+
+and the following instructions:
+
+https://tribits.org/doc/TribitsBuildReference.html#enabling-the-usage-of-resource-files-to-reduce-length-of-build-lines
+
 * Thread safety
 ** Weak and strong thread safety
 


### PR DESCRIPTION
Add work-around for "Error 127" kokkos-kernels CUDA build link error to Tpetra's FAQ.
See Trilinos/packages/tpetra/doc/FAQ.txt.
This pull request ONLY affects Tpetra's documentation.
It does not touch source code files.

@trilinos/tpetra

See the following GitHub issue:

https://github.com/trilinos/Trilinos/issues/2141

and the following detailed instructions:

https://tribits.org/doc/TribitsBuildReference.html#enabling-the-usage-of-resource-files-to-reduce-length-of-build-lines

Thanks to @bartlettroscoe for the instructions!