### PR TITLE
Added function to return the full vector of data in the indexer rathe…

### DIFF
--- a/packages/panzer/dof-mgr/src/Panzer_UniqueGlobalIndexer.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_UniqueGlobalIndexer.hpp
@@ -302,6 +302,11 @@ public:
   const Kokkos::View<const LocalOrdinalT*,Kokkos::LayoutRight,PHX::Device> getElementLIDs(LocalOrdinalT localElmtId) const
     { return Kokkos::subview(localIDs_k_, localElmtId, Kokkos::ALL() ); }
 
+  /** Return all the element LIDS for a given indexer
+   */
+  const Kokkos::View<const LocalOrdinalT**,Kokkos::LayoutRight,PHX::Device> getLIDs() const
+    {return localIDs_k_;}
+
    /** Access the local IDs for an element. The local ordering is according to
      * the <code>getOwnedAndGhostedIndices</code> method. Note
      */


### PR DESCRIPTION
Simple function to not have to get slice by slice of the index data, 
@rppawlo @eric-c-cyr any objections?