### PR TITLE
Remove '#line 1' as workaround for Ninja + CUDA rebuilds (#2359)

### DIFF
--- a/packages/seacas/libraries/aprepro_lib/apr_scanner.cc
+++ b/packages/seacas/libraries/aprepro_lib/apr_scanner.cc
@@ -971,7 +971,6 @@ static yyconst flex_int16_t yy_rule_linenum[102] = {
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-#line 1 "/scratch/gdsjaar/seacas/packages/seacas/libraries/aprepro_lib/aprepro.ll"
 /* -*- Mode: c++ -*- */
 #line 39 "/scratch/gdsjaar/seacas/packages/seacas/libraries/aprepro_lib/aprepro.ll"
 


### PR DESCRIPTION
This really needs to be fixed in SEACAS proper but this is a quick workaround
that will get us going with Nina + CUDA for ATDM builds of Trilinos.

This addresses #2359.

