### PR TITLE
Tpetra: Adding an additive Schwarz test

### DIFF
--- a/packages/tpetra/core/example/Additive-Schwarz-Halo/AdditiveSchwarzHalo.cpp
+++ b/packages/tpetra/core/example/Additive-Schwarz-Halo/AdditiveSchwarzHalo.cpp
@@ -1,0 +1,195 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+#include <cmath>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_FancyOStream.hpp>
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ScalarTraits.hpp>
+#include <Teuchos_OrdinalTraits.hpp>
+#include <Teuchos_DefaultComm.hpp>
+
+#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Version.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MultiVector.hpp>
+//#include <Tpetra_TestingUtilities.hpp>
+
+
+
+
+int main (int argc, char *argv[]) 
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::TimeMonitor;
+  using Teuchos::Array;
+  using Teuchos::tuple;
+
+  // MPI / Kokkos initialization 
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv, NULL);
+  Kokkos::initialize(argc, argv);
+  RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
+
+  int num_halo_expansions = 1;  
+  Teuchos::CommandLineProcessor clp;
+    clp.addOutputSetupOptions(true);
+    clp.setOption(
+        "halo-expansions", &num_halo_expansions ,
+        "Number of times to expand the halo for Additive Schwarz");
+  switch (clp.parse(argc, argv)) {
+    case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
+    case Teuchos::CommandLineProcessor::PARSE_ERROR:
+    case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
+    case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
+  }
+
+
+  typedef double Scalar;
+
+  // Get LocalOrdinal & GlobalOrdinal from Map defaults.
+  typedef Tpetra::Map<>::local_ordinal_type LocalOrdinal;
+  typedef Tpetra::Map<>::global_ordinal_type GlobalOrdinal;
+  typedef Tpetra::Map<>::node_type Node;
+  typedef LocalOrdinal LO;
+  typedef GlobalOrdinal GO;
+  typedef Teuchos::ScalarTraits<Scalar> ST;
+  typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> MAT;
+  typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> MV;
+  typedef Tpetra::Import<LocalOrdinal,GlobalOrdinal,Node> IMP;
+  
+  const GlobalOrdinal ONE = Teuchos::OrdinalTraits<GlobalOrdinal>::one();
+  const GlobalOrdinal GO_INVALID = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
+  
+  
+  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) Matrix Fill")));
+
+  const size_t numImages = comm->getSize();
+  const size_t myImageID = comm->getRank();
+
+   
+  if (numImages < 2) return -1;
+  // create a Map
+  RCP<const Tpetra::Map<LO,GO,Node> > map =
+    Tpetra::createContigMapWithNode<LO,GO,Node>(GO_INVALID,ONE,comm);
+  // create a multivector ones(n,1)
+  MV ones(map,ONE,false), threes(map,ONE,false);
+  ones.putScalar(ST::one());
+  /* create the following matrix:
+     [2 1           ]
+     [1 1 1         ]
+     [  1 1 1       ]
+     [   . . .      ]
+     [     . . .    ]
+     [       . . .  ]
+     [         1 1 1]
+     [           1 2]
+     this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
+  */
+  MAT A(map,3);
+  if (myImageID == 0) {
+    Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*ST::one(), ST::one()));
+    Array<GO> cols(tuple<GO>(myImageID, myImageID+1));
+    A.insertGlobalValues(myImageID,cols(),vals());
+  }
+  else if (myImageID == numImages-1) {
+    Array<Scalar> vals(tuple<Scalar>(ST::one(), static_cast<Scalar>(2)*ST::one()));
+    Array<GO> cols(tuple<GO>(myImageID-1,myImageID));
+    A.insertGlobalValues(myImageID,cols(),vals());
+  }
+  else {
+    Array<Scalar> vals(3,ST::one());
+    Array<GO> cols(tuple<GO>(myImageID-1, myImageID, myImageID+1));
+    A.insertGlobalValues(myImageID,cols(),vals());
+  }
+  A.fillComplete();
+  
+  
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("2) Halo Generation")));
+
+  RCP<MAT> Mold, Mnew;
+  Mold = rcp(&A,false);
+  Mnew = Mold;
+  
+  for (int i=0; i<num_halo_expansions; i++) {
+
+    // Get the importer    
+    RCP<const IMP> rowImporter = Mold->getGraph()->getImporter();
+    
+    // ImportAndFillComplete
+    Mnew = Tpetra::importAndFillCompleteCrsMatrix<MAT>(Mold,*rowImporter);
+
+    Mold = Mnew;
+  }
+  
+
+  tm = Teuchos::null;
+
+#if DEBUG_OUTPUT
+
+  int rank = comm->getRank();
+  {
+    std::ofstream ofs1( std::string("orig.") + std::to_string(rank) + std::string(".dat") );
+    auto out1 = Teuchos::getFancyOStream(Teuchos::rcpFromRef(ofs1));
+    A.describe(*out1,Teuchos::VERB_EXTREME);
+  }
+  {
+    std::ofstream ofs1( std::string("new.") + std::to_string(rank) + std::string(".dat") );
+    auto out1 = Teuchos::getFancyOStream(Teuchos::rcpFromRef(ofs1));
+    Mnew->describe(*out1,Teuchos::VERB_EXTREME);
+  }
+#endif
+  
+  // Finalize Kokkos
+  Kokkos::finalize();
+
+  // This tells the Trilinos test framework that the test passed.
+  if(0 == mpiSession.getRank())
+  {
+    std::cout << "End Result: TEST PASSED" << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}  // END main()

--- a/packages/tpetra/core/example/Additive-Schwarz-Halo/CMakeLists.txt
+++ b/packages/tpetra/core/example/Additive-Schwarz-Halo/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+# This example works whether or not MPI is enabled.
+# It does not refer to MPI explicitly.
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  AdditiveSchwarzHalo
+  SOURCES AdditiveSchwarzHalo.cpp
+  ARGS 
+  COMM  mpi
+  STANDARD_PASS_OUTPUT
+)
+

--- a/packages/tpetra/core/example/CMakeLists.txt
+++ b/packages/tpetra/core/example/CMakeLists.txt
@@ -12,6 +12,7 @@ ADD_SUBDIRECTORY(Lesson06-Custom-Operator)
 ADD_SUBDIRECTORY(Lesson07-Kokkos-Fill)
 
 ADD_SUBDIRECTORY(Finite-Element-Assembly)
+ADD_SUBDIRECTORY(Additive-Schwarz-Halo)
 ADD_SUBDIRECTORY(BlockCrs)
 
 ADD_SUBDIRECTORY(utilities)


### PR DESCRIPTION
This adds an additive Schwarz test to Tpetra

@trilinos/tpetra 

# Testing:

All tests done with Trilinos/sampleScripts/Sandia-SEMS/test_tpetra_sandia

### Shepard
```
Running on machine: shepard
Repository Status:  b91ac77ae4d4d0e0da116748a28146933d07c028 Tpetra: Adding an additive Schwarz test

Configure-Only: [ False ] Build-Only: [ False ] Report-To-CDash: [ False ]
Shepard
Calling: /ascldap/users/crtrott/Trilinos/sampleScripts/Sandia-SEMS/configure-testbeds-tpetra-jenkins &> configure.out
Calling: make -j 32 &> build.out
Calling: ctest &> test.out


*********************************
Build:
   Warnings:  0
   Errors:    0
Test:
   Failed:    0
   Timeout:   0
   Not Run:   0
*********************************
Result: PASSED
*********************************
```

### White

```
Running on machine: white
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? kokkos

Repository Status:  b91ac77ae4d4d0e0da116748a28146933d07c028 Tpetra: Adding an additive Schwarz test


Configure-Only: [ False ] Build-Only: [ False ] Report-To-CDash: [ False ]
Calling: /ascldap/users/crtrott/Trilinos/sampleScripts/Sandia-SEMS/configure-testbeds-tpetra-jenkins &> configure.out
Calling: make -j 32 &> build.out
Calling: ctest &> test.out


*********************************
Build:
   Warnings:  250
   Errors:    0
Test:
   Failed:    0
   Timeout:   0
   Not Run:   0
*********************************
Result: PASSED
*********************************
```
