### PR TITLE
Replace Panzer Evaluator Macros

### DIFF
--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_decl.hpp
@@ -70,7 +70,29 @@ namespace panzer_stk {
   * "IR" of type <code>Teuchos::RCP<panzer::IntegrationRule></code> and
   * "Mesh" of type <code>Teuchos::RCP<const panzer_stk::STK_Interface></code>.
   */
-PANZER_EVALUATOR_CLASS(ScatterCellAvgQuantity)
+template<typename EvalT, typename Traits>
+class ScatterCellAvgQuantity
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ScatterCellAvgQuantity(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   typedef panzer_stk::STK_Interface::SolutionFieldType VariableField; // this is weird, but the correct thing
 
   std::size_t numValues_;
@@ -80,7 +102,8 @@ PANZER_EVALUATOR_CLASS(ScatterCellAvgQuantity)
 
   std::vector<VariableField*> stkFields_;
  
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ScatterCellAvgQuantity
+
 
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
@@ -59,7 +59,10 @@
 
 namespace panzer_stk {
 
-PHX_EVALUATOR_CTOR(ScatterCellAvgQuantity,p) :
+template<typename EvalT, typename Traits>
+ScatterCellAvgQuantity<EvalT, Traits>::
+ScatterCellAvgQuantity(
+  const Teuchos::ParameterList& p) :
    mesh_(p.get<Teuchos::RCP<STK_Interface> >("Mesh"))
 {
   using panzer::Cell;
@@ -89,7 +92,12 @@ PHX_EVALUATOR_CTOR(ScatterCellAvgQuantity,p) :
   this->setName(scatterName+": STK-Scatter Cell Fields");
 }
 
-PHX_POST_REGISTRATION_SETUP(ScatterCellAvgQuantity, /* d */, fm)
+template<typename EvalT, typename Traits>
+void
+ScatterCellAvgQuantity<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* d */,
+  PHX::FieldManager<Traits>&  fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
     std::string fieldName = scatterFields_[fd].fieldTag().name();
@@ -101,7 +109,11 @@ PHX_POST_REGISTRATION_SETUP(ScatterCellAvgQuantity, /* d */, fm)
   }
 }
 
-PHX_EVALUATE_FIELDS(ScatterCellAvgQuantity,workset)
+template<typename EvalT, typename Traits>
+void
+ScatterCellAvgQuantity<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 {
    panzer::MDFieldArrayFactory af("",true);
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_decl.hpp
@@ -70,7 +70,29 @@ namespace panzer_stk {
   * "IR" of type <code>Teuchos::RCP<panzer::IntegrationRule></code> and
   * "Mesh" of type <code>Teuchos::RCP<const panzer_stk::STK_Interface></code>.
   */
-PANZER_EVALUATOR_CLASS(ScatterCellAvgVector)
+template<typename EvalT, typename Traits>
+class ScatterCellAvgVector
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ScatterCellAvgVector(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   // typedef panzer_stk::STK_Interface::SolutionFieldType VariableField; // this is weird, but the correct thing
   typedef panzer_stk::STK_Interface::VectorFieldType VariableField;
@@ -82,7 +104,8 @@ PANZER_EVALUATOR_CLASS(ScatterCellAvgVector)
 
   std::vector<VariableField*> stkFields_;
  
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ScatterCellAvgVector
+
 
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
@@ -59,7 +59,10 @@
 
 namespace panzer_stk {
 
-PHX_EVALUATOR_CTOR(ScatterCellAvgVector,p) :
+template<typename EvalT, typename Traits>
+ScatterCellAvgVector<EvalT, Traits>::
+ScatterCellAvgVector(
+  const Teuchos::ParameterList& p) :
    mesh_(p.get<Teuchos::RCP<STK_Interface> >("Mesh"))
 {
   using panzer::Cell;
@@ -91,7 +94,12 @@ PHX_EVALUATOR_CTOR(ScatterCellAvgVector,p) :
 }
 
 
-PHX_POST_REGISTRATION_SETUP(ScatterCellAvgVector, /* d */, fm)
+template<typename EvalT, typename Traits>
+void
+ScatterCellAvgVector<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* d */,
+  PHX::FieldManager<Traits>&  fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) 
   {
@@ -105,7 +113,11 @@ PHX_POST_REGISTRATION_SETUP(ScatterCellAvgVector, /* d */, fm)
 }
 
 
-PHX_EVALUATE_FIELDS(ScatterCellAvgVector,workset)
+template<typename EvalT, typename Traits>
+void
+ScatterCellAvgVector<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 {
   panzer::MDFieldArrayFactory af("",true);
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_decl.hpp
@@ -69,11 +69,34 @@ namespace panzer_stk {
   * "Workset Size" of type <code>int</code>
   * "Mesh" of type <code>Teuchos::RCP<const panzer_stk::STK_Interface></code>.
   */
-PANZER_EVALUATOR_CLASS(ScatterCellQuantity)
+template<typename EvalT, typename Traits>
+class ScatterCellQuantity
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ScatterCellQuantity(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   std::vector< PHX::MDField<const ScalarT,panzer::Cell> > scatterFields_;
   Teuchos::RCP<STK_Interface> mesh_;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ScatterCellQuantity
+
 
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_impl.hpp
@@ -59,7 +59,10 @@
 
 namespace panzer_stk {
 
-PHX_EVALUATOR_CTOR(ScatterCellQuantity,p) :
+template<typename EvalT, typename Traits>
+ScatterCellQuantity<EvalT, Traits>::
+ScatterCellQuantity(
+  const Teuchos::ParameterList& p) :
    mesh_(p.get<Teuchos::RCP<STK_Interface> >("Mesh"))
 {
   using panzer::Cell;
@@ -87,7 +90,12 @@ PHX_EVALUATOR_CTOR(ScatterCellQuantity,p) :
   this->setName(scatterName+": STK-Scatter Cell Quantity Fields");
 }
 
-PHX_POST_REGISTRATION_SETUP(ScatterCellQuantity, /* d */, fm)
+template<typename EvalT, typename Traits>
+void
+ScatterCellQuantity<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* d */,
+  PHX::FieldManager<Traits>&  fm)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
     std::string fieldName = scatterFields_[fd].fieldTag().name();
@@ -97,7 +105,11 @@ PHX_POST_REGISTRATION_SETUP(ScatterCellQuantity, /* d */, fm)
   }
 }
 
-PHX_EVALUATE_FIELDS(ScatterCellQuantity,workset)
+template<typename EvalT, typename Traits>
+void
+ScatterCellQuantity<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 {
    panzer::MDFieldArrayFactory af("",true);
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_decl.hpp
@@ -68,7 +68,29 @@ namespace panzer_stk {
   * "Basis" of type <code>Teuchos::RCP<panzer::BasisIRLayout></code> and
   * "Mesh" of type <code>Teuchos::RCP<const panzer_stk::STK_Interface></code>.
   */
-PANZER_EVALUATOR_CLASS(ScatterVectorFields)
+template<typename EvalT, typename Traits>
+class ScatterVectorFields
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ScatterVectorFields(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   typedef panzer_stk::STK_Interface::SolutionFieldType VariableField;
 
   std::vector<std::string> names_;
@@ -87,7 +109,8 @@ public:
                       const std::vector<std::string> & names,
                       const std::vector<double> & scaling = std::vector<double>());
  
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ScatterVectorFields
+
 
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_impl.hpp
@@ -58,7 +58,10 @@
 
 namespace panzer_stk {
 
-PHX_EVALUATOR_CTOR(ScatterVectorFields,p) :
+template<typename EvalT, typename Traits>
+ScatterVectorFields<EvalT, Traits>::
+ScatterVectorFields(
+  const Teuchos::ParameterList& p) :
    mesh_(p.get<Teuchos::RCP<STK_Interface> >("Mesh"))
 {
    TEUCHOS_ASSERT(false);
@@ -99,7 +102,12 @@ ScatterVectorFields(const std::string & scatterName,
   this->setName(scatterName+": STK-Scatter Vector Fields");
 }
 
-PHX_POST_REGISTRATION_SETUP(ScatterVectorFields, /* d */, fm)
+template<typename EvalT, typename Traits>
+void
+ScatterVectorFields<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* d */,
+  PHX::FieldManager<Traits>&  fm)
 {
   // this->utils.setFieldData(pointField_,fm);
 
@@ -109,7 +117,11 @@ PHX_POST_REGISTRATION_SETUP(ScatterVectorFields, /* d */, fm)
   }
 }
 
-PHX_EVALUATE_FIELDS(ScatterVectorFields, /* workset */)
+template<typename EvalT, typename Traits>
+void
+ScatterVectorFields<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 {
    TEUCHOS_ASSERT(false);
 }

--- a/packages/panzer/adapters-stk/test/evaluator_tests/PointEvaluator.hpp
+++ b/packages/panzer/adapters-stk/test/evaluator_tests/PointEvaluator.hpp
@@ -58,7 +58,29 @@ public:
                                   PHX::MDField<ScalarT> & field) const = 0;
 };
 
-PANZER_EVALUATOR_CLASS(PointEvaluator)
+template<typename EvalT, typename Traits>
+class PointEvaluator
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    PointEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   PHX::MDField<ScalarT> scalar;
   PHX::MDField<ScalarT> vectorField;
@@ -67,10 +89,14 @@ PANZER_EVALUATOR_CLASS(PointEvaluator)
   int quad_order;
   int quad_index;
   Teuchos::RCP<const PointEvaluation<ScalarT> > function;
-PANZER_EVALUATOR_CLASS_END
+}; // end of class PointEvaluator
+
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(PointEvaluator,p)
+template<typename EvalT, typename Traits>
+PointEvaluator<EvalT, Traits>::
+PointEvaluator(
+  const Teuchos::ParameterList& p)
 {
   // Read from parameters
   const std::string name = p.get<std::string>("Name");
@@ -97,7 +123,12 @@ PHX_EVALUATOR_CTOR(PointEvaluator,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(PointEvaluator,sd,fm)
+template<typename EvalT, typename Traits>
+void
+PointEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   if(isVector)
      this->utils.setFieldData(vectorField,fm);
@@ -108,7 +139,11 @@ PHX_POST_REGISTRATION_SETUP(PointEvaluator,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(PointEvaluator,workset)
+template<typename EvalT, typename Traits>
+void
+PointEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 {
    if(isVector)
       function->evaluateContainer(this->wda(workset).int_rules[quad_index]->ip_coordinates,vectorField);

--- a/packages/panzer/adapters-stk/test/evaluator_tests/RandomFieldEvaluator.hpp
+++ b/packages/panzer/adapters-stk/test/evaluator_tests/RandomFieldEvaluator.hpp
@@ -56,7 +56,29 @@ public:
                                   PHX::MDField<ScalarT> & field) const = 0;
 };
 
-PHX_EVALUATOR_CLASS(RandomFieldEvaluator)
+template<typename EvalT, typename Traits>
+class RandomFieldEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    RandomFieldEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   PHX::MDField<ScalarT> field;
 
@@ -64,22 +86,35 @@ public:
   RandomFieldEvaluator(const std::string & name,
                        const Teuchos::RCP<PHX::DataLayout> & dl)
      : field(name,dl) { this->addEvaluatedField(field); }
-PHX_EVALUATOR_CLASS_END
+}; // end of class RandomFieldEvaluator
+
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(RandomFieldEvaluator,p)
+template<typename EvalT, typename Traits>
+RandomFieldEvaluator<EvalT, Traits>::
+RandomFieldEvaluator(
+  const Teuchos::ParameterList& p)
 {
    TEUCHOS_ASSERT(false); // don't do this
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(RandomFieldEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+RandomFieldEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(field,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(RandomFieldEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+RandomFieldEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 {
    for(int i=0;i<static_cast<int>(field.size());i++)
       field[i] = double(std::rand())/double(RAND_MAX);

--- a/packages/panzer/adapters-stk/test/gather_scatter_evaluators/scatter_field_evaluator.cpp
+++ b/packages/panzer/adapters-stk/test/gather_scatter_evaluators/scatter_field_evaluator.cpp
@@ -89,12 +89,38 @@ namespace panzer {
   Teuchos::RCP<panzer::PureBasis> linBasis;
 
   //! Interpolates basis DOF values to IP DOF values
-  PANZER_EVALUATOR_CLASS(XCoordinate)
+  template<typename EvalT, typename Traits>
+  class XCoordinate
+    :
+    public panzer::EvaluatorWithBaseImpl<Traits>,
+    public PHX::EvaluatorDerived<EvalT, Traits>
+  {
+    public:
+
+      XCoordinate(
+        const Teuchos::ParameterList& p);
+
+      void
+      postRegistrationSetup(
+        typename Traits::SetupData d,
+        PHX::FieldManager<Traits>& fm);
+
+      void
+      evaluateFields(
+        typename Traits::EvalData d);
+
+    private:
+
+      using ScalarT = typename EvalT::ScalarT;
      PHX::MDField<ScalarT,Cell,NODE> xcoord;
      int nodes;
-  PANZER_EVALUATOR_CLASS_END
+  }; // end of class XCoordinate
 
-  PHX_EVALUATOR_CTOR(XCoordinate,p)
+
+  template<typename EvalT, typename Traits>
+  XCoordinate<EvalT, Traits>::
+  XCoordinate(
+    const Teuchos::ParameterList& p)
   {
      nodes = 4;
      if(p.isType<int>("Nodes"))
@@ -104,10 +130,19 @@ namespace panzer {
      this->addEvaluatedField(xcoord);
   }
 
-  PHX_POST_REGISTRATION_SETUP(XCoordinate, /* sd */, fm)
+  template<typename EvalT, typename Traits>
+  void
+  XCoordinate<EvalT, Traits>::
+  postRegistrationSetup(
+    typename Traits::SetupData  /* sd */,
+    PHX::FieldManager<Traits>&  fm)
   { this->utils.setFieldData(xcoord,fm); }
 
-  PHX_EVALUATE_FIELDS(XCoordinate,workset)
+  template<typename EvalT, typename Traits>
+  void
+  XCoordinate<EvalT, Traits>::
+  evaluateFields(
+    typename Traits::EvalData workset)
   { 
      std::size_t numcells = workset.num_cells;
 

--- a/packages/panzer/adapters-stk/test/response_library/TestEvaluators.hpp
+++ b/packages/panzer/adapters-stk/test/response_library/TestEvaluators.hpp
@@ -51,15 +51,41 @@
 
 namespace panzer {
 
-PANZER_EVALUATOR_CLASS(TestEvaluator)
+template<typename EvalT, typename Traits>
+class TestEvaluator
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    TestEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   PHX::MDField<ScalarT,Cell> dogValues;
   PHX::MDField<ScalarT,Cell> hrsValues;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class TestEvaluator
+
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(TestEvaluator,p)
+template<typename EvalT, typename Traits>
+TestEvaluator<EvalT, Traits>::
+TestEvaluator(
+  const Teuchos::ParameterList& p)
 {
   // Read from parameters
   int worksetSize = p.get<int>("Workset Size");
@@ -77,14 +103,23 @@ PHX_EVALUATOR_CTOR(TestEvaluator,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(TestEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+TestEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(dogValues,fm);
   this->utils.setFieldData(hrsValues,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(TestEvaluator,workset)
+template<typename EvalT, typename Traits>
+void
+TestEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
    double extra = 0.0;
    if(this->wda(workset).block_id=="block_1")

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_decl.hpp
@@ -54,7 +54,29 @@
 namespace panzer {
     
 //! Interpolates basis DOF values to IP DOF values
-PANZER_EVALUATOR_CLASS(BasisValues_Evaluator)
+template<typename EvalT, typename Traits>
+class BasisValues_Evaluator
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    BasisValues_Evaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
  
   Teuchos::RCP<const panzer::PureBasis> basis;
   
@@ -80,7 +102,8 @@ public:
                         const Teuchos::RCP<const panzer::PureBasis> & basis,
                         bool derivativesRequired);
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class BasisValues_Evaluator
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_impl.hpp
@@ -50,7 +50,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(BasisValues_Evaluator,p)
+template<typename EvalT, typename Traits>
+BasisValues_Evaluator<EvalT, Traits>::
+BasisValues_Evaluator(
+  const Teuchos::ParameterList& p)
   : derivativesRequired_(true)
 {
   Teuchos::RCP<const panzer::PointRule> pointRule 
@@ -155,7 +158,12 @@ void BasisValues_Evaluator<EvalT,TRAITST>::initialize(const Teuchos::RCP<const p
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(BasisValues_Evaluator, sd, fm)
+template<typename EvalT, typename Traits>
+void
+BasisValues_Evaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  sd,
+  PHX::FieldManager<Traits>&  fm)
 {
   int space_dim = basis->dimension();
 
@@ -208,7 +216,11 @@ PHX_POST_REGISTRATION_SETUP(BasisValues_Evaluator, sd, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(BasisValues_Evaluator, workset)
+template<typename EvalT, typename Traits>
+void
+BasisValues_Evaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  workset)
 { 
   // evaluate the point values (construct jacobians etc...)
   basisValues->evaluateValues(pointValues.coords_ref,

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CellAverage.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CellAverage.hpp
@@ -66,7 +66,29 @@ namespace panzer {
     </ParameterList>
   \endverbatim
   */
-PANZER_EVALUATOR_CLASS(CellAverage)
+template<typename EvalT, typename Traits>
+class CellAverage
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    CellAverage(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell> average;  // result
     
@@ -87,7 +109,8 @@ public:
 private:
   Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class CellAverage
+
 
 /** This is a function constructor for an evaluator
   * that builds scalars from a single vector field. The user specifies

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CellAverage_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CellAverage_impl.hpp
@@ -53,7 +53,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(CellAverage,p) : quad_index(-1)
+template<typename EvalT, typename Traits>
+CellAverage<EvalT, Traits>::
+CellAverage(
+  const Teuchos::ParameterList& p) : quad_index(-1)
 {
   Teuchos::RCP<Teuchos::ParameterList> valid_params = this->getValidParameters();
   p.validateParameters(*valid_params);
@@ -93,7 +96,12 @@ PHX_EVALUATOR_CTOR(CellAverage,p) : quad_index(-1)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(CellAverage,sd,fm)
+template<typename EvalT, typename Traits>
+void
+CellAverage<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(average,fm);
   this->utils.setFieldData(scalar,fm);
@@ -108,7 +116,11 @@ PHX_POST_REGISTRATION_SETUP(CellAverage,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(CellAverage,workset)
+template<typename EvalT, typename Traits>
+void
+CellAverage<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   for (index_t cell = 0; cell < workset.num_cells; ++cell) {
     

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CellExtreme.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CellExtreme.hpp
@@ -67,7 +67,29 @@ namespace panzer {
     </ParameterList>
   \endverbatim
   */
-PANZER_EVALUATOR_CLASS(CellExtreme)
+template<typename EvalT, typename Traits>
+class CellExtreme
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    CellExtreme(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> extreme;  // result
     
@@ -90,7 +112,8 @@ public:
 private:
   Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class CellExtreme
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CellExtreme_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CellExtreme_impl.hpp
@@ -53,7 +53,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(CellExtreme,p) : quad_index(-1)
+template<typename EvalT, typename Traits>
+CellExtreme<EvalT, Traits>::
+CellExtreme(
+  const Teuchos::ParameterList& p) : quad_index(-1)
 {
   Teuchos::RCP<Teuchos::ParameterList> valid_params = this->getValidParameters();
   p.validateParameters(*valid_params);
@@ -98,7 +101,12 @@ PHX_EVALUATOR_CTOR(CellExtreme,p) : quad_index(-1)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(CellExtreme,sd,fm)
+template<typename EvalT, typename Traits>
+void
+CellExtreme<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(extreme,fm);
   this->utils.setFieldData(scalar,fm);
@@ -113,7 +121,11 @@ PHX_POST_REGISTRATION_SETUP(CellExtreme,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(CellExtreme,workset)
+template<typename EvalT, typename Traits>
+void
+CellExtreme<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   for (index_t cell = 0; cell < workset.num_cells; ++cell) {
     

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantFlux_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantFlux_decl.hpp
@@ -52,13 +52,36 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(ConstantFlux)
+template<typename EvalT, typename Traits>
+class ConstantFlux
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ConstantFlux(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   std::vector<ScalarT> values;
   
   PHX::MDField<ScalarT> flux;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ConstantFlux
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantFlux_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantFlux_impl.hpp
@@ -46,7 +46,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(ConstantFlux,p) :
+template<typename EvalT, typename Traits>
+ConstantFlux<EvalT, Traits>::
+ConstantFlux(
+  const Teuchos::ParameterList& p) :
   flux( p.get<std::string>("Flux Field Name"), 
 	p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout") )
 {
@@ -62,7 +65,12 @@ PHX_EVALUATOR_CTOR(ConstantFlux,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(ConstantFlux, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+ConstantFlux<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   using namespace PHX;
   this->utils.setFieldData(flux,fm);
@@ -76,7 +84,11 @@ PHX_POST_REGISTRATION_SETUP(ConstantFlux, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(ConstantFlux, /* d */)
+template<typename EvalT, typename Traits>
+void
+ConstantFlux<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* d */)
 { }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantVector.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantVector.hpp
@@ -52,13 +52,36 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(ConstantVector)
+template<typename EvalT, typename Traits>
+class ConstantVector
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ConstantVector(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   ScalarT vals[3]; // 3 dimensional vector
   
   PHX::MDField<ScalarT> vector;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ConstantVector
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ConstantVector_impl.hpp
@@ -46,7 +46,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(ConstantVector,p) :
+template<typename EvalT, typename Traits>
+ConstantVector<EvalT, Traits>::
+ConstantVector(
+  const Teuchos::ParameterList& p) :
   vector(p.get<std::string>("Name"), 
          p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout") )
 {
@@ -65,14 +68,23 @@ PHX_EVALUATOR_CTOR(ConstantVector,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(ConstantVector, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+ConstantVector<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   using namespace PHX;
   this->utils.setFieldData(vector,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(ConstantVector, /* d */)
+template<typename EvalT, typename Traits>
+void
+ConstantVector<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* d */)
 { 
   for(int c=0;c<vector.extent_int(0);c++)
     for(int p=0;p<vector.extent_int(1);p++)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Constant_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Constant_decl.hpp
@@ -60,13 +60,36 @@ namespace panzer {
     </ParameterList>
     \endverbatim
   */
-PANZER_EVALUATOR_CLASS(Constant)
+template<typename EvalT, typename Traits>
+class Constant
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Constant(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   ScalarT value;
   
   PHX::MDField<ScalarT> constant;
   
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Constant
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Constant_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Constant_impl.hpp
@@ -46,7 +46,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Constant,p) :
+template<typename EvalT, typename Traits>
+Constant<EvalT, Traits>::
+Constant(
+  const Teuchos::ParameterList& p) :
   value( p.get<double>("Value") ),
   constant( p.get<std::string>("Name"), 
 	    p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout") )
@@ -58,7 +61,12 @@ PHX_EVALUATOR_CTOR(Constant,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Constant, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+Constant<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   using namespace PHX;
   this->utils.setFieldData(constant,fm);
@@ -67,7 +75,11 @@ PHX_POST_REGISTRATION_SETUP(Constant, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Constant, /* d */)
+template<typename EvalT, typename Traits>
+void
+Constant<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* d */)
 { }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator.hpp
@@ -52,13 +52,36 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(CoordinatesEvaluator)
+template<typename EvalT, typename Traits>
+class CoordinatesEvaluator
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    CoordinatesEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   int dimension;
   
   PHX::MDField<ScalarT,Cell,BASIS> coordinate;
   
-PANZER_EVALUATOR_CLASS_END
+}; // end of class CoordinatesEvaluator
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator_impl.hpp
@@ -46,7 +46,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(CoordinatesEvaluator,p) :
+template<typename EvalT, typename Traits>
+CoordinatesEvaluator<EvalT, Traits>::
+CoordinatesEvaluator(
+  const Teuchos::ParameterList& p) :
   dimension(p.get<int>("Dimension")),
   coordinate( p.get<std::string>("Field Name"), 
 	      p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout") )
@@ -58,14 +61,23 @@ PHX_EVALUATOR_CTOR(CoordinatesEvaluator,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(CoordinatesEvaluator, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+CoordinatesEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   using namespace PHX;
   this->utils.setFieldData(coordinate,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(CoordinatesEvaluator,d)
+template<typename EvalT, typename Traits>
+void
+CoordinatesEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData d)
 { 
   PHX::MDField<double,Cell,NODE,Dim> coords = this->wda(d).cell_vertex_coordinates;
   // const Kokkos::DynRankView<double,PHX::Device> & coords = this->wda(d).cell_vertex_coordinates;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_decl.hpp
@@ -61,12 +61,35 @@ namespace panzer {
     <ParameterList/>
     \endverbatim
   */
-PANZER_EVALUATOR_CLASS(Copy)
+template<typename EvalT, typename Traits>
+class Copy
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Copy(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<const ScalarT> input;
   PHX::MDField<ScalarT> output;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Copy
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_impl.hpp
@@ -50,7 +50,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Copy,p)
+template<typename EvalT, typename Traits>
+Copy<EvalT, Traits>::
+Copy(
+  const Teuchos::ParameterList& p)
 {
   std::string input_name = p.get<std::string>("Source Name");
   std::string output_name = p.get<std::string>("Destination Name");
@@ -67,7 +70,12 @@ PHX_EVALUATOR_CTOR(Copy,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Copy, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+Copy<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(input,fm);
   this->utils.setFieldData(output,fm);
@@ -76,7 +84,11 @@ PHX_POST_REGISTRATION_SETUP(Copy, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Copy, /* workset */)
+template<typename EvalT, typename Traits>
+void
+Copy<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   output.deep_copy(input);
 }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct.hpp
@@ -59,7 +59,29 @@ namespace panzer {
     <Parameter name="Vector A Name" type="string" value="<vector a name>"/>
     <Parameter name="Vector B Name" type="string" value="<vector b name>"/>
   */
-PANZER_EVALUATOR_CLASS(CrossProduct)
+template<typename EvalT, typename Traits>
+class CrossProduct
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    CrossProduct(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> vec_a_cross_vec_b;
   PHX::MDField<const ScalarT> vec_a, vec_b;
@@ -69,7 +91,8 @@ PANZER_EVALUATOR_CLASS(CrossProduct)
   int num_pts;
   int num_dim;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class CrossProduct
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct_impl.hpp
@@ -53,7 +53,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(CrossProduct,p)
+template<typename EvalT, typename Traits>
+CrossProduct<EvalT, Traits>::
+CrossProduct(
+  const Teuchos::ParameterList& p)
 {
   std::string result_name = p.get<std::string>("Result Name");
   std::string vec_a_name = p.get<std::string>("Vector A Name");
@@ -82,7 +85,12 @@ PHX_EVALUATOR_CTOR(CrossProduct,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(CrossProduct, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+CrossProduct<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(vec_a_cross_vec_b,fm);
   this->utils.setFieldData(vec_a,fm);
@@ -96,7 +104,11 @@ PHX_POST_REGISTRATION_SETUP(CrossProduct, /* sd */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(CrossProduct,workset)
+template<typename EvalT, typename Traits>
+void
+CrossProduct<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   if(useScalarField) {
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFGradient_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFGradient_impl.hpp
@@ -85,7 +85,10 @@ struct evaluateGrad_withSens {
 }
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(DOFGradient,p) :
+template<typename EvalT, typename Traits>
+DOFGradient<EvalT, Traits>::
+DOFGradient(
+  const Teuchos::ParameterList& p) :
   use_descriptors_(false),
   dof_value( p.get<std::string>("Name"), 
 	     p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
@@ -132,7 +135,12 @@ DOFGradient(const PHX::FieldTag & input,
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DOFGradient,sd,fm)
+template<typename EvalT, typename Traits>
+void
+DOFGradient<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(dof_value,fm);
   this->utils.setFieldData(dof_gradient,fm);
@@ -142,7 +150,11 @@ PHX_POST_REGISTRATION_SETUP(DOFGradient,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(DOFGradient,workset)
+template<typename EvalT, typename Traits>
+void
+DOFGradient<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   if (workset.num_cells == 0 )
     return;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis.hpp
@@ -64,7 +64,29 @@ namespace panzer {
   * at a set of points defined by a point rule. Note that this assumes
   * a vector basis is used.
   */
-PANZER_EVALUATOR_CLASS(DirichletResidual_EdgeBasis)
+template<typename EvalT, typename Traits>
+class DirichletResidual_EdgeBasis
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    DirichletResidual_EdgeBasis(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell,BASIS> residual;
   PHX::MDField<const ScalarT,Cell,Point,Dim> dof;
@@ -79,7 +101,8 @@ PANZER_EVALUATOR_CLASS(DirichletResidual_EdgeBasis)
 
   Teuchos::RCP<const std::vector<Intrepid2::Orientation> > orientations;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class DirichletResidual_EdgeBasis
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
@@ -59,7 +59,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(DirichletResidual_EdgeBasis,p)
+template<typename EvalT, typename Traits>
+DirichletResidual_EdgeBasis<EvalT, Traits>::
+DirichletResidual_EdgeBasis(
+  const Teuchos::ParameterList& p)
 {
   std::string residual_name = p.get<std::string>("Residual Name");
 
@@ -106,7 +109,12 @@ PHX_EVALUATOR_CTOR(DirichletResidual_EdgeBasis,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DirichletResidual_EdgeBasis,sd,fm)
+template<typename EvalT, typename Traits>
+void
+DirichletResidual_EdgeBasis<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   orientations = sd.orientations_;
 
@@ -117,7 +125,11 @@ PHX_POST_REGISTRATION_SETUP(DirichletResidual_EdgeBasis,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(DirichletResidual_EdgeBasis,workset)
+template<typename EvalT, typename Traits>
+void
+DirichletResidual_EdgeBasis<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   const int numCells = workset.num_cells;
   if(numCells <= 0)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis.hpp
@@ -64,7 +64,29 @@ namespace panzer {
   * at a set of points defined by a point rule. Note that this assumes
   * a vector basis is used.
   */
-PANZER_EVALUATOR_CLASS(DirichletResidual_FaceBasis)
+template<typename EvalT, typename Traits>
+class DirichletResidual_FaceBasis
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    DirichletResidual_FaceBasis(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell,BASIS> residual;
   PHX::MDField<const ScalarT,Cell,Point,Dim> dof;
@@ -81,7 +103,8 @@ PANZER_EVALUATOR_CLASS(DirichletResidual_FaceBasis)
 
   Teuchos::RCP<const std::vector<Intrepid2::Orientation> > orientations;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class DirichletResidual_FaceBasis
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
@@ -54,7 +54,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(DirichletResidual_FaceBasis,p)
+template<typename EvalT, typename Traits>
+DirichletResidual_FaceBasis<EvalT, Traits>::
+DirichletResidual_FaceBasis(
+  const Teuchos::ParameterList& p)
 {
   std::string residual_name = p.get<std::string>("Residual Name");
 
@@ -100,7 +103,12 @@ PHX_EVALUATOR_CTOR(DirichletResidual_FaceBasis,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DirichletResidual_FaceBasis,sd,fm)
+template<typename EvalT, typename Traits>
+void
+DirichletResidual_FaceBasis<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   orientations = sd.orientations_;
 
@@ -113,7 +121,11 @@ PHX_POST_REGISTRATION_SETUP(DirichletResidual_FaceBasis,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(DirichletResidual_FaceBasis,workset)
+template<typename EvalT, typename Traits>
+void
+DirichletResidual_FaceBasis<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   // basic cell topology data
   const shards::CellTopology & parentCell = *basis->getCellTopology();

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_decl.hpp
@@ -51,7 +51,29 @@
 namespace panzer {
     
 //! Evaluates a Dirichlet BC residual corresponding to a field value
-PANZER_EVALUATOR_CLASS(DirichletResidual)
+template<typename EvalT, typename Traits>
+class DirichletResidual
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    DirichletResidual(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> residual;
   PHX::MDField<const ScalarT> dof;
@@ -59,7 +81,8 @@ PANZER_EVALUATOR_CLASS(DirichletResidual)
 
   std::size_t cell_data_size;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class DirichletResidual
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_impl.hpp
@@ -50,7 +50,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(DirichletResidual,p)
+template<typename EvalT, typename Traits>
+DirichletResidual<EvalT, Traits>::
+DirichletResidual(
+  const Teuchos::ParameterList& p)
 {
   std::string residual_name = p.get<std::string>("Residual Name");
   std::string dof_name = p.get<std::string>("DOF Name"); 
@@ -72,7 +75,12 @@ PHX_EVALUATOR_CTOR(DirichletResidual,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DirichletResidual, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+DirichletResidual<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(dof,fm);
@@ -82,7 +90,11 @@ PHX_POST_REGISTRATION_SETUP(DirichletResidual, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(DirichletResidual,workset)
+template<typename EvalT, typename Traits>
+void
+DirichletResidual<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   for (index_t i = 0; i < workset.num_cells; ++i)
     for (std::size_t j = 0; j < cell_data_size; ++j)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_decl.hpp
@@ -61,7 +61,29 @@ namespace panzer {
   <Parameter name="Multiplier" type="double" value="Multiplier value"/>
   <Parameter name="Field Multiplier" type="string" value="Multiplier name"/>
 */
-PANZER_EVALUATOR_CLASS(DotProduct)
+template<typename EvalT, typename Traits>
+class DotProduct
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    DotProduct(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> vec_a_dot_vec_b;
   PHX::MDField<const ScalarT> vec_a, vec_b;
@@ -72,7 +94,8 @@ PANZER_EVALUATOR_CLASS(DotProduct)
 
   bool multiplier_field_on;
   double multiplier_value;
-PANZER_EVALUATOR_CLASS_END
+}; // end of class DotProduct
+
 
 /** \brief Build a dot product evaluator. Evaluates dot product at a set of points
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_impl.hpp
@@ -73,7 +73,10 @@ buildEvaluator_DotProduct(const std::string & resultName,
 }
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(DotProduct,p)
+template<typename EvalT, typename Traits>
+DotProduct<EvalT, Traits>::
+DotProduct(
+  const Teuchos::ParameterList& p)
   : multiplier_field_on(false)
 {
   std::string result_name = p.get<std::string>("Result Name");
@@ -110,7 +113,12 @@ PHX_EVALUATOR_CTOR(DotProduct,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(DotProduct, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+DotProduct<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(vec_a_dot_vec_b,fm);
   this->utils.setFieldData(vec_a,fm);
@@ -127,7 +135,11 @@ PHX_POST_REGISTRATION_SETUP(DotProduct, /* sd */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(DotProduct,workset)
+template<typename EvalT, typename Traits>
+void
+DotProduct<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   for (index_t cell = 0; cell < workset.num_cells; ++cell) {
     for (int p = 0; p < num_pts; ++p) {

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_decl.hpp
@@ -57,7 +57,37 @@ namespace panzer {
 
 struct GlobalData;
     
-PANZER_EVALUATOR_CLASS_PP(GlobalStatistics)
+template<typename EvalT, typename Traits>
+class GlobalStatistics
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    GlobalStatistics(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+    void
+    preEvaluate(
+      typename Traits::PreEvalData d);
+
+    void
+    postEvaluate(
+      typename Traits::PostEvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell> volumes;
     
@@ -88,7 +118,8 @@ PANZER_EVALUATOR_CLASS_PP(GlobalStatistics)
 public:
   const PHX::FieldTag& getRequiredFieldTag();
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class GlobalStatistics
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_impl.hpp
@@ -57,7 +57,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(GlobalStatistics,p)
+template<typename EvalT, typename Traits>
+GlobalStatistics<EvalT, Traits>::
+GlobalStatistics(
+  const Teuchos::ParameterList& p)
 {
   comm = p.get< Teuchos::RCP<const Teuchos::Comm<int> > >("Comm");
 
@@ -104,7 +107,12 @@ PHX_EVALUATOR_CTOR(GlobalStatistics,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(GlobalStatistics,sd,fm)
+template<typename EvalT, typename Traits>
+void
+GlobalStatistics<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(volumes,fm);
   this->utils.setFieldData(tmp,fm);
@@ -122,7 +130,11 @@ PHX_POST_REGISTRATION_SETUP(GlobalStatistics,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(GlobalStatistics,workset)
+template<typename EvalT, typename Traits>
+void
+GlobalStatistics<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   if (workset.num_cells == 0)
     return;
@@ -155,7 +167,11 @@ PHX_EVALUATE_FIELDS(GlobalStatistics,workset)
 }
 
 //**********************************************************************
-PHX_PRE_EVALUATE_FIELDS(GlobalStatistics, /* data */)
+template<typename EvalT, typename Traits>
+void
+GlobalStatistics<EvalT, Traits>::
+preEvaluate(
+  typename Traits::PreEvalData  /* data */)
 {
   total_volume = Teuchos::ScalarTraits<ScalarT>::zero();
 
@@ -170,7 +186,11 @@ PHX_PRE_EVALUATE_FIELDS(GlobalStatistics, /* data */)
 }
 
 //**********************************************************************
-PHX_POST_EVALUATE_FIELDS(GlobalStatistics, /* data */)
+template<typename EvalT, typename Traits>
+void
+GlobalStatistics<EvalT, Traits>::
+postEvaluate(
+  typename Traits::PostEvalData  /* data */)
 {
   this->postprocess(*(global_data->os));
 }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector.hpp
@@ -61,7 +61,29 @@ namespace panzer {
   * in 2D is simply a scalar, here the evaluators handles
   * both cases.
   */
-PANZER_EVALUATOR_CLASS(Integrator_CurlBasisDotVector)
+template<typename EvalT, typename Traits>
+class Integrator_CurlBasisDotVector
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Integrator_CurlBasisDotVector(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 public:
 
   Integrator_CurlBasisDotVector(const PHX::FieldTag & input,
@@ -101,7 +123,8 @@ private:
 
 private:
   Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Integrator_CurlBasisDotVector
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector_impl.hpp
@@ -53,7 +53,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Integrator_CurlBasisDotVector,p) :
+template<typename EvalT, typename Traits>
+Integrator_CurlBasisDotVector<EvalT, Traits>::
+Integrator_CurlBasisDotVector(
+  const Teuchos::ParameterList& p) :
   use_descriptors_(false),
   residual( p.get<std::string>("Residual Name"), 
 	    p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
@@ -163,7 +166,12 @@ Integrator_CurlBasisDotVector(const PHX::FieldTag & input,
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Integrator_CurlBasisDotVector,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Integrator_CurlBasisDotVector<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   // setup the output field
   this->utils.setFieldData(residual,fm);
@@ -314,7 +322,11 @@ public:
 } // end internal namespace
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Integrator_CurlBasisDotVector,workset)
+template<typename EvalT, typename Traits>
+void
+Integrator_CurlBasisDotVector<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   const panzer::BasisValues2<double> & bv = use_descriptors_ ?  this->wda(workset).getBasisValues(bd_,id_)
                                                              : *this->wda(workset).bases[basis_index];

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar.hpp
@@ -59,7 +59,29 @@ namespace panzer {
   *
   * where \f$\phi\f$ is a vector HDIV basis.
   */
-PANZER_EVALUATOR_CLASS(Integrator_DivBasisTimesScalar)
+template<typename EvalT, typename Traits>
+class Integrator_DivBasisTimesScalar
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Integrator_DivBasisTimesScalar(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell,BASIS> residual;
   PHX::MDField<const ScalarT,Cell,IP> scalar;
@@ -80,7 +102,8 @@ PANZER_EVALUATOR_CLASS(Integrator_DivBasisTimesScalar)
 
 private:
   Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Integrator_DivBasisTimesScalar
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar_impl.hpp
@@ -53,7 +53,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Integrator_DivBasisTimesScalar,p) :
+template<typename EvalT, typename Traits>
+Integrator_DivBasisTimesScalar<EvalT, Traits>::
+Integrator_DivBasisTimesScalar(
+  const Teuchos::ParameterList& p) :
   residual( p.get<std::string>("Residual Name"), 
 	    p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
   basis_name(p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->name())
@@ -98,7 +101,12 @@ PHX_EVALUATOR_CTOR(Integrator_DivBasisTimesScalar,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Integrator_DivBasisTimesScalar,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Integrator_DivBasisTimesScalar<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(scalar,fm);
@@ -115,7 +123,11 @@ PHX_POST_REGISTRATION_SETUP(Integrator_DivBasisTimesScalar,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Integrator_DivBasisTimesScalar,workset)
+template<typename EvalT, typename Traits>
+void
+Integrator_DivBasisTimesScalar<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   // zero the reisdual
   residual.deep_copy(ScalarT(0.0));

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisCrossVector_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisCrossVector_decl.hpp
@@ -53,7 +53,29 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(Integrator_GradBasisCrossVector)
+template<typename EvalT, typename Traits>
+class Integrator_GradBasisCrossVector
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Integrator_GradBasisCrossVector(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   std::vector<PHX::MDField<ScalarT,Cell,BASIS> > _residuals;
     
@@ -84,7 +106,8 @@ PANZER_EVALUATOR_CLASS(Integrator_GradBasisCrossVector)
   // Temporary variable to store tmp = multipliers * vector
   Kokkos::DynRankView<ScalarT,PHX::Device> _tmp;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Integrator_GradBasisCrossVector
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisCrossVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisCrossVector_impl.hpp
@@ -52,7 +52,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Integrator_GradBasisCrossVector,p):
+template<typename EvalT, typename Traits>
+Integrator_GradBasisCrossVector<EvalT, Traits>::
+Integrator_GradBasisCrossVector(
+  const Teuchos::ParameterList& p):
   _num_basis_nodes(0),
   _num_quadrature_points(0),
   _basis_index(-1)
@@ -119,7 +122,12 @@ PHX_EVALUATOR_CTOR(Integrator_GradBasisCrossVector,p):
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Integrator_GradBasisCrossVector,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Integrator_GradBasisCrossVector<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
 
   for (auto & residual : _residuals){
@@ -142,7 +150,11 @@ PHX_POST_REGISTRATION_SETUP(Integrator_GradBasisCrossVector,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Integrator_GradBasisCrossVector,workset)
+template<typename EvalT, typename Traits>
+void
+Integrator_GradBasisCrossVector<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
 
   // Zero the residuals

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisTimesScalar_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisTimesScalar_decl.hpp
@@ -53,7 +53,29 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(Integrator_GradBasisTimesScalar)
+template<typename EvalT, typename Traits>
+class Integrator_GradBasisTimesScalar
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Integrator_GradBasisTimesScalar(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   std::vector<PHX::MDField<ScalarT,Cell,BASIS> > _residuals;
     
@@ -81,7 +103,8 @@ PANZER_EVALUATOR_CLASS(Integrator_GradBasisTimesScalar)
   // Temporary variable to store tmp = multipliers * vector
   Kokkos::DynRankView<ScalarT,PHX::Device> _tmp;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Integrator_GradBasisTimesScalar
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisTimesScalar_impl.hpp
@@ -52,7 +52,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Integrator_GradBasisTimesScalar,p):
+template<typename EvalT, typename Traits>
+Integrator_GradBasisTimesScalar<EvalT, Traits>::
+Integrator_GradBasisTimesScalar(
+  const Teuchos::ParameterList& p):
   _num_basis_nodes(0),
   _num_quadrature_points(0),
   _basis_index(-1)
@@ -112,7 +115,12 @@ PHX_EVALUATOR_CTOR(Integrator_GradBasisTimesScalar,p):
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Integrator_GradBasisTimesScalar,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Integrator_GradBasisTimesScalar<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
 
   for (auto & residual : _residuals){
@@ -135,7 +143,11 @@ PHX_POST_REGISTRATION_SETUP(Integrator_GradBasisTimesScalar,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Integrator_GradBasisTimesScalar,workset)
+template<typename EvalT, typename Traits>
+void
+Integrator_GradBasisTimesScalar<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
 
   // Zero the residuals

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_Scalar_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_Scalar_decl.hpp
@@ -66,7 +66,29 @@ namespace panzer {
     </ParameterList>
   \endverbatim
   */
-PANZER_EVALUATOR_CLASS(Integrator_Scalar)
+template<typename EvalT, typename Traits>
+class Integrator_Scalar
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Integrator_Scalar(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> integral;  // result
     
@@ -90,7 +112,8 @@ public:
 private:
   Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Integrator_Scalar
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_Scalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_Scalar_impl.hpp
@@ -52,7 +52,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Integrator_Scalar,p) : quad_index(-1)
+template<typename EvalT, typename Traits>
+Integrator_Scalar<EvalT, Traits>::
+Integrator_Scalar(
+  const Teuchos::ParameterList& p) : quad_index(-1)
 {
   Teuchos::RCP<Teuchos::ParameterList> valid_params = this->getValidParameters();
   p.validateParameters(*valid_params);
@@ -92,7 +95,12 @@ PHX_EVALUATOR_CTOR(Integrator_Scalar,p) : quad_index(-1)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Integrator_Scalar,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Integrator_Scalar<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(integral,fm);
   this->utils.setFieldData(scalar,fm);
@@ -109,7 +117,11 @@ PHX_POST_REGISTRATION_SETUP(Integrator_Scalar,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Integrator_Scalar,workset)
+template<typename EvalT, typename Traits>
+void
+Integrator_Scalar<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
 /*
   for (index_t cell = 0; cell < workset.num_cells; ++cell)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_TransientBasisTimesScalar_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_TransientBasisTimesScalar_decl.hpp
@@ -53,7 +53,29 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(Integrator_TransientBasisTimesScalar)
+template<typename EvalT, typename Traits>
+class Integrator_TransientBasisTimesScalar
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Integrator_TransientBasisTimesScalar(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell,BASIS> residual;
     
@@ -75,7 +97,8 @@ PANZER_EVALUATOR_CLASS(Integrator_TransientBasisTimesScalar)
 private:
   Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Integrator_TransientBasisTimesScalar
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_TransientBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_TransientBasisTimesScalar_impl.hpp
@@ -52,7 +52,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Integrator_TransientBasisTimesScalar,p) :
+template<typename EvalT, typename Traits>
+Integrator_TransientBasisTimesScalar<EvalT, Traits>::
+Integrator_TransientBasisTimesScalar(
+  const Teuchos::ParameterList& p) :
   residual( p.get<std::string>("Residual Name"), 
 	    p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
   scalar( p.get<std::string>("Value Name"), 
@@ -97,7 +100,12 @@ PHX_EVALUATOR_CTOR(Integrator_TransientBasisTimesScalar,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Integrator_TransientBasisTimesScalar,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Integrator_TransientBasisTimesScalar<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(scalar,fm);
@@ -115,7 +123,11 @@ PHX_POST_REGISTRATION_SETUP(Integrator_TransientBasisTimesScalar,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Integrator_TransientBasisTimesScalar,workset)
+template<typename EvalT, typename Traits>
+void
+Integrator_TransientBasisTimesScalar<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   if (workset.evaluate_transient_terms) {
     

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Interface_Residual_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Interface_Residual_decl.hpp
@@ -57,7 +57,29 @@ namespace panzer {
 
       int(n \cdot (flux * phi) )
   */
-PANZER_EVALUATOR_CLASS(InterfaceResidual)
+template<typename EvalT, typename Traits>
+class InterfaceResidual
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    InterfaceResidual(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> residual;
   PHX::MDField<ScalarT> normal_dot_flux;
@@ -69,7 +91,8 @@ PANZER_EVALUATOR_CLASS(InterfaceResidual)
   std::size_t num_ip;
   std::size_t num_dim;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class InterfaceResidual
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Interface_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Interface_Residual_impl.hpp
@@ -54,7 +54,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(InterfaceResidual,p)
+template<typename EvalT, typename Traits>
+InterfaceResidual<EvalT, Traits>::
+InterfaceResidual(
+  const Teuchos::ParameterList& p)
 {
   std::string residual_name = p.get<std::string>("Residual Name");
   std::string flux_name = p.get<std::string>("Flux Name");
@@ -85,7 +88,12 @@ PHX_EVALUATOR_CTOR(InterfaceResidual,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(InterfaceResidual,sd,fm)
+template<typename EvalT, typename Traits>
+void
+InterfaceResidual<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(normal_dot_flux,fm);
@@ -102,7 +110,11 @@ PHX_POST_REGISTRATION_SETUP(InterfaceResidual,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(InterfaceResidual,workset)
+template<typename EvalT, typename Traits>
+void
+InterfaceResidual<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   residual.deep_copy(ScalarT(0.0));
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Neumann_Residual_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Neumann_Residual_decl.hpp
@@ -57,7 +57,29 @@ namespace panzer {
 
       int(n \cdot (flux * phi) )
   */
-PANZER_EVALUATOR_CLASS(NeumannResidual)
+template<typename EvalT, typename Traits>
+class NeumannResidual
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    NeumannResidual(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> residual;
   PHX::MDField<ScalarT> normal_dot_flux;
@@ -69,7 +91,8 @@ PANZER_EVALUATOR_CLASS(NeumannResidual)
   std::size_t num_ip;
   std::size_t num_dim;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class NeumannResidual
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Neumann_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Neumann_Residual_impl.hpp
@@ -54,7 +54,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(NeumannResidual,p)
+template<typename EvalT, typename Traits>
+NeumannResidual<EvalT, Traits>::
+NeumannResidual(
+  const Teuchos::ParameterList& p)
 {
   std::string residual_name = p.get<std::string>("Residual Name");
   std::string flux_name = p.get<std::string>("Flux Name");
@@ -85,7 +88,12 @@ PHX_EVALUATOR_CTOR(NeumannResidual,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(NeumannResidual,sd,fm)
+template<typename EvalT, typename Traits>
+void
+NeumannResidual<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(normal_dot_flux,fm);
@@ -102,7 +110,11 @@ PHX_POST_REGISTRATION_SETUP(NeumannResidual,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(NeumannResidual,workset)
+template<typename EvalT, typename Traits>
+void
+NeumannResidual<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   residual.deep_copy(ScalarT(0.0));
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Normals_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Normals_decl.hpp
@@ -67,7 +67,29 @@ namespace panzer {
   * the determinant of the side jacobian built in thus they correspond to a
   * differential on the side.
   */
-PANZER_EVALUATOR_CLASS(Normals)
+template<typename EvalT, typename Traits>
+class Normals
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Normals(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   int side_id;
   int quad_order, quad_index;
@@ -82,7 +104,8 @@ public:
   const PHX::FieldTag & getFieldTag() const 
   { return normals.fieldTag(); }
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Normals
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Normals_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Normals_impl.hpp
@@ -52,7 +52,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Normals,p)
+template<typename EvalT, typename Traits>
+Normals<EvalT, Traits>::
+Normals(
+  const Teuchos::ParameterList& p)
    : normalize(true)
 {
   // Read from parameters
@@ -76,7 +79,12 @@ PHX_EVALUATOR_CTOR(Normals,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Normals,sd,fm)
+template<typename EvalT, typename Traits>
+void
+Normals<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(normals,fm);
 
@@ -87,7 +95,11 @@ PHX_POST_REGISTRATION_SETUP(Normals,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Normals,workset)
+template<typename EvalT, typename Traits>
+void
+Normals<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   // ECC Fix: Get Physical Side Normals
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_PointValues_Evaluator_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_PointValues_Evaluator_decl.hpp
@@ -52,7 +52,29 @@
 namespace panzer {
     
 //! Interpolates basis DOF values to IP DOF values
-PANZER_EVALUATOR_CLASS(PointValues_Evaluator)
+template<typename EvalT, typename Traits>
+class PointValues_Evaluator
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    PointValues_Evaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   // is anything other than ScalarT really needed here?
   PointValues2<ScalarT> pointValues;
@@ -81,7 +103,8 @@ public:
   PointValues_Evaluator(const Teuchos::RCP<const panzer::PointRule> & pointRule,
                         const Teuchos::RCP<const panzer::PureBasis> & pureBasis);
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class PointValues_Evaluator
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_PointValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_PointValues_Evaluator_impl.hpp
@@ -51,7 +51,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(PointValues_Evaluator,p)
+template<typename EvalT, typename Traits>
+PointValues_Evaluator<EvalT, Traits>::
+PointValues_Evaluator(
+  const Teuchos::ParameterList& p)
 {
   basis_index = 0;
 
@@ -141,7 +144,12 @@ void PointValues_Evaluator<EvalT,TRAITST>::initialize(const Teuchos::RCP<const p
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(PointValues_Evaluator,sd,fm)
+template<typename EvalT, typename Traits>
+void
+PointValues_Evaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   // setup the pointers for evaluation
   this->utils.setFieldData(pointValues.coords_ref,fm);
@@ -161,7 +169,11 @@ PHX_POST_REGISTRATION_SETUP(PointValues_Evaluator,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(PointValues_Evaluator,workset)
+template<typename EvalT, typename Traits>
+void
+PointValues_Evaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   if(useBasisValuesRefArray) {
     panzer::BasisValues2<double> & basisValues = *this->wda(workset).bases[basis_index];

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Product_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Product_decl.hpp
@@ -61,13 +61,36 @@ namespace panzer {
     </ParameterList>
     \endverbatim
   */
-PANZER_EVALUATOR_CLASS(Product)
+template<typename EvalT, typename Traits>
+class Product
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Product(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   double scaling;
   PHX::MDField<ScalarT> product;
   std::vector< PHX::MDField<const ScalarT> > values;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Product
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Product_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Product_impl.hpp
@@ -50,7 +50,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Product,p)
+template<typename EvalT, typename Traits>
+Product<EvalT, Traits>::
+Product(
+  const Teuchos::ParameterList& p)
   : scaling(1.0)
 {
   std::string product_name = p.get<std::string>("Product Name");
@@ -77,7 +80,12 @@ PHX_EVALUATOR_CTOR(Product,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Product, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+Product<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(product,fm);
   for (std::size_t i=0; i < values.size(); ++i)
@@ -85,7 +93,11 @@ PHX_POST_REGISTRATION_SETUP(Product, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Product, /* workset */)
+template<typename EvalT, typename Traits>
+void
+Product<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
     product.deep_copy(ScalarT(scaling));
     for (std::size_t j = 0; j < values.size(); ++j)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_decl.hpp
@@ -51,7 +51,29 @@
 namespace panzer {
     
 //! Interpolates basis DOF values to IP DOF values
-PANZER_EVALUATOR_CLASS(ScalarToVector)
+template<typename EvalT, typename Traits>
+class ScalarToVector
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ScalarToVector(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   std::vector< PHX::MDField<const ScalarT,Cell,Point> > scalar_fields;
   PHX::MDField<ScalarT,Cell,Point,Dim> vector_field;
 
@@ -67,7 +89,8 @@ public:
   ScalarToVector(const std::vector<PHX::Tag<ScalarT>> & input,
                  const PHX::FieldTag & output);
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class ScalarToVector
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScalarToVector_impl.hpp
@@ -48,7 +48,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(ScalarToVector,p)
+template<typename EvalT, typename Traits>
+ScalarToVector<EvalT, Traits>::
+ScalarToVector(
+  const Teuchos::ParameterList& p)
 {
   Teuchos::RCP<PHX::DataLayout> scalar_dl = 
     p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout Scalar");
@@ -103,7 +106,12 @@ ScalarToVector(const std::vector<PHX::Tag<ScalarT>> & input,
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(ScalarToVector, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+ScalarToVector<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   internal_scalar_fields = Kokkos::View<KokkosScalarFields_t*>("ScalarToVector::internal_scalar_fields", scalar_fields.size());
   for (std::size_t i=0; i < scalar_fields.size(); ++i) {
@@ -131,7 +139,11 @@ void ScalarToVector<EvalT, TRAITS>::operator()(const size_t &cell) const {
 
 }
 //**********************************************************************
-PHX_EVALUATE_FIELDS(ScalarToVector,workset)
+template<typename EvalT, typename Traits>
+void
+ScalarToVector<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
 
   // Loop over cells

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_decl.hpp
@@ -77,7 +77,29 @@ namespace panzer {
     </ParameterList>
   \endverbatim
   */
-PANZER_EVALUATOR_CLASS(SubcellSum)
+template<typename EvalT, typename Traits>
+class SubcellSum
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    SubcellSum(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT,Cell> outField;  // result
     
@@ -99,7 +121,8 @@ private:
   // evalaute on the "closure" of the indicated sub-cells
   bool evaluateOnClosure_;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class SubcellSum
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_impl.hpp
@@ -52,7 +52,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(SubcellSum,p) 
+template<typename EvalT, typename Traits>
+SubcellSum<EvalT, Traits>::
+SubcellSum(
+  const Teuchos::ParameterList& p) 
   : evaluateOnClosure_(false)
 {
   Teuchos::RCP<Teuchos::ParameterList> valid_params = this->getValidParameters();
@@ -79,14 +82,23 @@ PHX_EVALUATOR_CTOR(SubcellSum,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(SubcellSum, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+SubcellSum<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(inField,fm);
   this->utils.setFieldData(outField,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(SubcellSum,workset)
+template<typename EvalT, typename Traits>
+void
+SubcellSum<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   std::vector<int> indices;
  

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Sum.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Sum.hpp
@@ -63,7 +63,29 @@ namespace panzer {
     </ParameterList>
     \endverbatim
   */
-PANZER_EVALUATOR_CLASS(Sum)
+template<typename EvalT, typename Traits>
+class Sum
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Sum(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   static const int MAX_VALUES=20;
   
   PHX::MDField<ScalarT> sum;
@@ -81,7 +103,8 @@ public:
   template<unsigned int RANK>
   void operator() (PanzerSumTag<RANK>, const int &i) const;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Sum
+
 
 /** A template version of Sum that specializes on the
   * rank type. This must be done at run time.

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
@@ -55,7 +55,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Sum,p)
+template<typename EvalT, typename Traits>
+Sum<EvalT, Traits>::
+Sum(
+  const Teuchos::ParameterList& p)
 {
   std::string sum_name = p.get<std::string>("Sum Name");
   Teuchos::RCP<std::vector<std::string> > value_names = 
@@ -104,7 +107,12 @@ PHX_EVALUATOR_CTOR(Sum,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Sum, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+Sum<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(sum,fm);
   for (std::size_t i=0; i < scalars.dimension_0(); ++i)
@@ -175,7 +183,11 @@ void Sum<EvalT, TRAITS>::operator() (PanzerSumTag<RANK>, const int &i) const{
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Sum, /* workset */)
+template<typename EvalT, typename Traits>
+void
+Sum<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 {   
 
   sum.deep_copy(ScalarT(0.0));

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_decl.hpp
@@ -61,7 +61,29 @@ namespace panzer {
  *
  *  \author mayr.mt \date 09/2015
  */
-PHX_EVALUATOR_CLASS(TensorToStdVector)
+template<typename EvalT, typename Traits>
+class TensorToStdVector
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    TensorToStdVector(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
     //! Tensor (to be distributed to vector)
     PHX::MDField<const ScalarT,Cell,Point,Dim,Dim> tensor_field;
@@ -69,7 +91,8 @@ PHX_EVALUATOR_CLASS(TensorToStdVector)
     //! Vector (to be filled)
     std::vector<PHX::MDField<ScalarT,Cell,Point,Dim> > vector_fields;
 
-PHX_EVALUATOR_CLASS_END
+}; // end of class TensorToStdVector
+
 
 /** This is a function constructor for an evaluator
   * that builds vectors from a single tensor field. The user specifies

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_impl.hpp
@@ -48,7 +48,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(TensorToStdVector, p)
+template<typename EvalT, typename Traits>
+TensorToStdVector<EvalT, Traits>::
+TensorToStdVector(
+  const Teuchos::ParameterList&  p)
 {
   Teuchos::RCP<PHX::DataLayout> vector_dl = 
     p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout Vector");
@@ -78,7 +81,12 @@ PHX_EVALUATOR_CTOR(TensorToStdVector, p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(TensorToStdVector, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+TensorToStdVector<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   for (std::size_t i=0; i < vector_fields.size(); ++i)
     this->utils.setFieldData(vector_fields[i], fm);
@@ -87,7 +95,11 @@ PHX_POST_REGISTRATION_SETUP(TensorToStdVector, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(TensorToStdVector, workset)
+template<typename EvalT, typename Traits>
+void
+TensorToStdVector<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  workset)
 { 
 
   typedef typename PHX::MDField<ScalarT,Cell,Point,Dim>::size_type size_type;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_decl.hpp
@@ -50,14 +50,37 @@
 
 namespace panzer {
 
-PANZER_EVALUATOR_CLASS(TestScatter)
+template<typename EvalT, typename Traits>
+class TestScatter
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    TestScatter(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   PHX::MDField<ScalarT,Cell,NODE> scatter_value;
   PHX::MDField<const ScalarT,Cell,NODE> value;
   int localOffset;
 
   std::size_t num_nodes;
   static int offset;
-PANZER_EVALUATOR_CLASS_END
+}; // end of class TestScatter
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_impl.hpp
@@ -48,7 +48,10 @@ namespace panzer {
 template <typename EvalT,typename TRAITS>
 int panzer::TestScatter<EvalT, TRAITS>::offset = 0;
 
-PHX_EVALUATOR_CTOR(TestScatter,p)
+template<typename EvalT, typename Traits>
+TestScatter<EvalT, Traits>::
+TestScatter(
+  const Teuchos::ParameterList& p)
 {
   std::string test_name     = p.get<std::string>("Test Name");
   std::string test_name_res = p.get<std::string>("Test Name Residual");
@@ -68,7 +71,12 @@ PHX_EVALUATOR_CTOR(TestScatter,p)
   this->setName(n);
 }
 
-PHX_POST_REGISTRATION_SETUP(TestScatter, /* setupData */, fm)
+template<typename EvalT, typename Traits>
+void
+TestScatter<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* setupData */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(scatter_value,fm);
   this->utils.setFieldData(value,fm);
@@ -76,7 +84,11 @@ PHX_POST_REGISTRATION_SETUP(TestScatter, /* setupData */, fm)
   num_nodes = scatter_value.dimension(1);
 }
 
-PHX_EVALUATE_FIELDS(TestScatter,workset)
+template<typename EvalT, typename Traits>
+void
+TestScatter<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
  // for (int i=0; i < scatter_value.size(); ++i)
  //   scatter_value[i] = 0.0;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_decl.hpp
@@ -51,7 +51,29 @@
 
 namespace panzer {
     
-PANZER_EVALUATOR_CLASS(VectorToScalar)
+template<typename EvalT, typename Traits>
+class VectorToScalar
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    VectorToScalar(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   std::vector< PHX::MDField<ScalarT,Cell,Point> > scalar_fields;
   PHX::MDField<const ScalarT,Cell,Point,Dim> vector_field;
@@ -64,7 +86,8 @@ public:
   VectorToScalar(const PHX::FieldTag & input,
                  const std::vector<PHX::Tag<ScalarT>> & output);
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class VectorToScalar
+
 
 /** This is a function constructor for an evaluator
   * that builds scalars from a single vector field. The user specifies

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_VectorToScalar_impl.hpp
@@ -48,7 +48,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(VectorToScalar,p)
+template<typename EvalT, typename Traits>
+VectorToScalar<EvalT, Traits>::
+VectorToScalar(
+  const Teuchos::ParameterList& p)
 {
   Teuchos::RCP<PHX::DataLayout> scalar_dl = 
     p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout Scalar");
@@ -103,7 +106,12 @@ VectorToScalar(const PHX::FieldTag & input,
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(VectorToScalar, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+VectorToScalar<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   for (std::size_t i=0; i < scalar_fields.size(); ++i)
     this->utils.setFieldData(scalar_fields[i],fm);
@@ -112,7 +120,11 @@ PHX_POST_REGISTRATION_SETUP(VectorToScalar, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(VectorToScalar,workset)
+template<typename EvalT, typename Traits>
+void
+VectorToScalar<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
 
   typedef typename PHX::MDField<ScalarT,Cell,Point>::size_type size_type;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_WeakDirichlet_Residual_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_WeakDirichlet_Residual_decl.hpp
@@ -58,7 +58,29 @@ namespace panzer {
       int(n \cdot flux * phi) + int(\sigma (u-g) * phi)
       
   */
-PANZER_EVALUATOR_CLASS(WeakDirichletResidual)
+template<typename EvalT, typename Traits>
+class WeakDirichletResidual
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    WeakDirichletResidual(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   PHX::MDField<ScalarT> residual;
   PHX::MDField<ScalarT> normal_dot_flux_plus_pen;
@@ -73,7 +95,8 @@ PANZER_EVALUATOR_CLASS(WeakDirichletResidual)
   std::size_t num_ip;
   std::size_t num_dim;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class WeakDirichletResidual
+
 
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_WeakDirichlet_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_WeakDirichlet_Residual_impl.hpp
@@ -54,7 +54,10 @@
 namespace panzer {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(WeakDirichletResidual,p)
+template<typename EvalT, typename Traits>
+WeakDirichletResidual<EvalT, Traits>::
+WeakDirichletResidual(
+  const Teuchos::ParameterList& p)
 {
   std::string residual_name = p.get<std::string>("Residual Name");
   std::string flux_name = p.get<std::string>("Flux Name");
@@ -94,7 +97,12 @@ PHX_EVALUATOR_CTOR(WeakDirichletResidual,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(WeakDirichletResidual,sd,fm)
+template<typename EvalT, typename Traits>
+void
+WeakDirichletResidual<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData sd,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(normal_dot_flux_plus_pen,fm);
@@ -114,7 +122,11 @@ PHX_POST_REGISTRATION_SETUP(WeakDirichletResidual,sd,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(WeakDirichletResidual,workset)
+template<typename EvalT, typename Traits>
+void
+WeakDirichletResidual<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   for (index_t cell = 0; cell < workset.num_cells; ++cell) {
     for (std::size_t ip = 0; ip < num_ip; ++ip) {

--- a/packages/panzer/disc-fe/test/closure_model/user_app_ConstantModel.hpp
+++ b/packages/panzer/disc-fe/test/closure_model/user_app_ConstantModel.hpp
@@ -48,13 +48,36 @@
 
 namespace user_app {
     
-PHX_EVALUATOR_CLASS(ConstantModel)
+template<typename EvalT, typename Traits>
+class ConstantModel
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    ConstantModel(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   
   ScalarT value;
   
   PHX::MDField<ScalarT> constant;
   
-PHX_EVALUATOR_CLASS_END
+}; // end of class ConstantModel
+
 
 }
 

--- a/packages/panzer/disc-fe/test/closure_model/user_app_ConstantModel_impl.hpp
+++ b/packages/panzer/disc-fe/test/closure_model/user_app_ConstantModel_impl.hpp
@@ -44,7 +44,10 @@
 #define USER_APP_CONSTANT_MODEL_T_HPP
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR_NAMESPACE(user_app,ConstantModel,p) :
+template<typename EvalT, typename Traits>
+user_app::ConstantModel<EvalT, Traits>::
+ConstantModel(
+  const Teuchos::ParameterList& p) :
   value( p.get<double>("Value") ),
   constant( p.get<std::string>("Name"), 
 	    p.get< Teuchos::RCP<PHX::DataLayout> >("Data Layout") )
@@ -56,7 +59,12 @@ PHX_EVALUATOR_CTOR_NAMESPACE(user_app,ConstantModel,p) :
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(user_app::ConstantModel,worksets,fm)
+template<typename EvalT, typename Traits>
+void
+user_app::ConstantModel<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData worksets,
+  PHX::FieldManager<Traits>& fm)
 {
   using namespace PHX;
   this->utils.setFieldData(constant,fm);
@@ -67,7 +75,11 @@ PHX_POST_REGISTRATION_SETUP(user_app::ConstantModel,worksets,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(user_app::ConstantModel,d)
+template<typename EvalT, typename Traits>
+void
+user_app::ConstantModel<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData d)
 { }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/test/equation_set/user_app_Convection.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_Convection.hpp
@@ -56,7 +56,29 @@ using panzer::Dim;
 namespace user_app {
     
   //! Convection: conv = multiplier * a \cdot \nabla x
-PANZER_EVALUATOR_CLASS(Convection)
+template<typename EvalT, typename Traits>
+class Convection
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Convection(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   PHX::MDField<ScalarT,Cell,Point> conv;
     
@@ -66,7 +88,8 @@ PANZER_EVALUATOR_CLASS(Convection)
     
   double multiplier;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Convection
+
 
 }
 

--- a/packages/panzer/disc-fe/test/equation_set/user_app_Convection_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_Convection_impl.hpp
@@ -49,7 +49,10 @@
 namespace user_app {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Convection,p)
+template<typename EvalT, typename Traits>
+Convection<EvalT, Traits>::
+Convection(
+  const Teuchos::ParameterList& p)
 {
   using std::string;
   using Teuchos::RCP;
@@ -81,7 +84,12 @@ PHX_EVALUATOR_CTOR(Convection,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Convection, /* worksets */, fm)
+template<typename EvalT, typename Traits>
+void
+Convection<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* worksets */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(conv,fm);
   this->utils.setFieldData(a,fm);
@@ -89,7 +97,11 @@ PHX_POST_REGISTRATION_SETUP(Convection, /* worksets */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Convection,workset)
+template<typename EvalT, typename Traits>
+void
+Convection<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   typedef typename PHX::MDField<ScalarT,Cell,Point>::size_type size_type;
   

--- a/packages/panzer/disc-fe/test/evaluator_tests/UnitValueEvaluator.hpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/UnitValueEvaluator.hpp
@@ -50,14 +50,40 @@
 
 namespace panzer {
 
-PHX_EVALUATOR_CLASS(UnitValueEvaluator)
+template<typename EvalT, typename Traits>
+class UnitValueEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    UnitValueEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   PHX::MDField<ScalarT,Cell,panzer::IP> unitValue;
 
-PHX_EVALUATOR_CLASS_END
+}; // end of class UnitValueEvaluator
+
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(UnitValueEvaluator,p)
+template<typename EvalT, typename Traits>
+UnitValueEvaluator<EvalT, Traits>::
+UnitValueEvaluator(
+  const Teuchos::ParameterList& p)
 {
   // Read from parameters
   const std::string name = p.get<std::string>("Name");
@@ -74,13 +100,22 @@ PHX_EVALUATOR_CTOR(UnitValueEvaluator,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(UnitValueEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+UnitValueEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(unitValue,fm);
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(UnitValueEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+UnitValueEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   for(int cell=0;cell<unitValue.extent_int(0);++cell)
     for(int ip=0;ip<unitValue.extent_int(1);++ip)

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
@@ -84,10 +84,36 @@ namespace panzer {
 typedef Kokkos::DynRankView<double,PHX::Device> FieldArray;
 
 //**********************************************************************
-PHX_EVALUATOR_CLASS(DummyFieldEvaluator)
+template<typename EvalT, typename Traits>
+class DummyFieldEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    DummyFieldEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   PHX::MDField<ScalarT,Cell,panzer::BASIS> fieldValue;
-PHX_EVALUATOR_CLASS_END
-PHX_EVALUATOR_CTOR(DummyFieldEvaluator,p)
+}; // end of class DummyFieldEvaluator
+
+template<typename EvalT, typename Traits>
+DummyFieldEvaluator<EvalT, Traits>::
+DummyFieldEvaluator(
+  const Teuchos::ParameterList& p)
 {
   // Read from parameters
   const std::string name = p.get<std::string>("Name");
@@ -102,14 +128,23 @@ PHX_EVALUATOR_CTOR(DummyFieldEvaluator,p)
   std::string n = "DummyFieldEvaluator: " + name;
   this->setName(n);
 }
-PHX_POST_REGISTRATION_SETUP(DummyFieldEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+DummyFieldEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(fieldValue,fm);
 
   
 }
 
-PHX_EVALUATE_FIELDS(DummyFieldEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+DummyFieldEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   fieldValue(0,0) = 1.0;
   fieldValue(0,1) = 2.0;

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_pointfield.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_pointfield.cpp
@@ -84,10 +84,36 @@ namespace panzer {
 typedef Kokkos::DynRankView<double,PHX::Device> FieldArray;
 
 //**********************************************************************
-PHX_EVALUATOR_CLASS(DummyFieldEvaluator)
+template<typename EvalT, typename Traits>
+class DummyFieldEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    DummyFieldEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   PHX::MDField<ScalarT,Cell,panzer::BASIS> fieldValue;
-PHX_EVALUATOR_CLASS_END
-PHX_EVALUATOR_CTOR(DummyFieldEvaluator,p)
+}; // end of class DummyFieldEvaluator
+
+template<typename EvalT, typename Traits>
+DummyFieldEvaluator<EvalT, Traits>::
+DummyFieldEvaluator(
+  const Teuchos::ParameterList& p)
 {
   // Read from parameters
   const std::string name = p.get<std::string>("Name");
@@ -102,9 +128,18 @@ PHX_EVALUATOR_CTOR(DummyFieldEvaluator,p)
   std::string n = "DummyFieldEvaluator: " + name;
   this->setName(n);
 }
-PHX_POST_REGISTRATION_SETUP(DummyFieldEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+DummyFieldEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 { this->utils.setFieldData(fieldValue,fm); }
-PHX_EVALUATE_FIELDS(DummyFieldEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+DummyFieldEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   int i = 0;
   for(int cell=0;cell<fieldValue.extent_int(0);cell++) {
@@ -115,13 +150,39 @@ PHX_EVALUATE_FIELDS(DummyFieldEvaluator, /* workset */)
   }
 }
 //**********************************************************************
-PHX_EVALUATOR_CLASS(RefCoordEvaluator)
+template<typename EvalT, typename Traits>
+class RefCoordEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    RefCoordEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
   PHX::MDField<ScalarT,panzer::Point,panzer::Dim> fieldValue;
   Teuchos::RCP<panzer::IntegrationValues2<double> > quadValues;
 public:
   Teuchos::RCP<PHX::DataLayout> coordsLayout;
-PHX_EVALUATOR_CLASS_END
-PHX_EVALUATOR_CTOR(RefCoordEvaluator,p)
+}; // end of class RefCoordEvaluator
+
+template<typename EvalT, typename Traits>
+RefCoordEvaluator<EvalT, Traits>::
+RefCoordEvaluator(
+  const Teuchos::ParameterList& p)
 {
   // Read from parameters
   const std::string name = p.get<std::string>("Name");
@@ -137,9 +198,18 @@ PHX_EVALUATOR_CTOR(RefCoordEvaluator,p)
   std::string n = "RefCoordEvaluator: " + name;
   this->setName(n);
 }
-PHX_POST_REGISTRATION_SETUP(RefCoordEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+RefCoordEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 { this->utils.setFieldData(fieldValue,fm); }
-PHX_EVALUATE_FIELDS(RefCoordEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+RefCoordEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   for(int cell=0;cell<fieldValue.extent_int(0);cell++)
     for(int pt=0;pt<fieldValue.extent_int(1);pt++)

--- a/packages/panzer/disc-fe/test/evaluator_tests/hessian_test.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/hessian_test.cpp
@@ -95,7 +95,29 @@ inline panzer::Traits::HessianType seed_second_deriv(int num_vars, int index, do
 }
 
 //**********************************************************************
-PHX_EVALUATOR_CLASS(InputConditionsEvaluator)
+template<typename EvalT, typename Traits>
+class InputConditionsEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    InputConditionsEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
 public:
   PHX::MDField<ScalarT,panzer::IP> x;
@@ -103,10 +125,14 @@ public:
   PHX::MDField<ScalarT,panzer::IP> dx;
   PHX::MDField<ScalarT,panzer::IP> dy;
 
-PHX_EVALUATOR_CLASS_END
+}; // end of class InputConditionsEvaluator
+
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(InputConditionsEvaluator, /* p */)
+template<typename EvalT, typename Traits>
+InputConditionsEvaluator<EvalT, Traits>::
+InputConditionsEvaluator(
+  const Teuchos::ParameterList&  /* p */)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -134,7 +160,12 @@ PHX_EVALUATOR_CTOR(InputConditionsEvaluator, /* p */)
 
 //**********************************************************************
 
-PHX_POST_REGISTRATION_SETUP(InputConditionsEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+InputConditionsEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(x,fm);
   this->utils.setFieldData(y,fm);
@@ -143,7 +174,11 @@ PHX_POST_REGISTRATION_SETUP(InputConditionsEvaluator, /* sd */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(InputConditionsEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+InputConditionsEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   double x_val = 0.25;
   double y_val = 0.5;
@@ -159,17 +194,43 @@ PHX_EVALUATE_FIELDS(InputConditionsEvaluator, /* workset */)
 }
 
 //**********************************************************************
-PHX_EVALUATOR_CLASS(HessianTestEvaluator)
+template<typename EvalT, typename Traits>
+class HessianTestEvaluator
+  :
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    HessianTestEvaluator(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
 public:
   PHX::MDField<const ScalarT,panzer::IP> x;
   PHX::MDField<const ScalarT,panzer::IP> y;
   PHX::MDField<ScalarT,panzer::IP> result;
 
-PHX_EVALUATOR_CLASS_END
+}; // end of class HessianTestEvaluator
+
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(HessianTestEvaluator, /* p */)
+template<typename EvalT, typename Traits>
+HessianTestEvaluator<EvalT, Traits>::
+HessianTestEvaluator(
+  const Teuchos::ParameterList&  /* p */)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -196,7 +257,12 @@ PHX_EVALUATOR_CTOR(HessianTestEvaluator, /* p */)
 
 //**********************************************************************
 
-PHX_POST_REGISTRATION_SETUP(HessianTestEvaluator, /* sd */, fm)
+template<typename EvalT, typename Traits>
+void
+HessianTestEvaluator<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData  /* sd */,
+  PHX::FieldManager<Traits>&  fm)
 {
   this->utils.setFieldData(x,fm);
   this->utils.setFieldData(y,fm);
@@ -204,7 +270,11 @@ PHX_POST_REGISTRATION_SETUP(HessianTestEvaluator, /* sd */, fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(HessianTestEvaluator, /* workset */)
+template<typename EvalT, typename Traits>
+void
+HessianTestEvaluator<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData  /* workset */)
 { 
   // Grad = y * std::cos(x*y)
   //      = x * std::cos(x*y)-0.25*std::sin(y)

--- a/packages/panzer/disc-fe/test/ugi_rig/user_app_Convection.hpp
+++ b/packages/panzer/disc-fe/test/ugi_rig/user_app_Convection.hpp
@@ -56,7 +56,29 @@ using panzer::Dim;
 namespace user_app {
     
   //! Convection: conv = multiplier * a \cdot \nabla x
-PANZER_EVALUATOR_CLASS(Convection)
+template<typename EvalT, typename Traits>
+class Convection
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+  public:
+
+    Convection(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;
 
   PHX::MDField<ScalarT,Cell,Point> conv;
     
@@ -66,7 +88,8 @@ PANZER_EVALUATOR_CLASS(Convection)
     
   double multiplier;
 
-PANZER_EVALUATOR_CLASS_END
+}; // end of class Convection
+
 
 }
 

--- a/packages/panzer/disc-fe/test/ugi_rig/user_app_Convection_impl.hpp
+++ b/packages/panzer/disc-fe/test/ugi_rig/user_app_Convection_impl.hpp
@@ -49,7 +49,10 @@
 namespace user_app {
 
 //**********************************************************************
-PHX_EVALUATOR_CTOR(Convection,p)
+template<typename EvalT, typename Traits>
+Convection<EvalT, Traits>::
+Convection(
+  const Teuchos::ParameterList& p)
 {
   using std::string;
   using Teuchos::RCP;
@@ -81,7 +84,12 @@ PHX_EVALUATOR_CTOR(Convection,p)
 }
 
 //**********************************************************************
-PHX_POST_REGISTRATION_SETUP(Convection,worksets,fm)
+template<typename EvalT, typename Traits>
+void
+Convection<EvalT, Traits>::
+postRegistrationSetup(
+  typename Traits::SetupData worksets,
+  PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(conv,fm);
   this->utils.setFieldData(a,fm);
@@ -89,7 +97,11 @@ PHX_POST_REGISTRATION_SETUP(Convection,worksets,fm)
 }
 
 //**********************************************************************
-PHX_EVALUATE_FIELDS(Convection,workset)
+template<typename EvalT, typename Traits>
+void
+Convection<EvalT, Traits>::
+evaluateFields(
+  typename Traits::EvalData workset)
 { 
   typedef typename PHX::MDField<ScalarT,Cell,Point>::size_type size_type;
   

--- a/packages/panzer/maintenance/replacePanzerEvaluatorMacros.py
+++ b/packages/panzer/maintenance/replacePanzerEvaluatorMacros.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# This script will read a file and replace any Panzer Evaluator macros it
+# finds with their contents.
+import re
+import sys
+import textwrap
+
+
+class MacroReplacer:
+    """Replace Panzer Evaluator macros."""
+
+    def __init__(self):
+        """Initialize the object.
+
+        Create the variables used to pass data around between members, along
+        with the various replacement rules that will be used.
+        """
+        self.filename = ""
+        self.name = ""
+        self.line = ""
+        self.output = []
+        header = """template<typename EvalT, typename Traits>
+class {0}
+  :
+  public panzer::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{{"""
+        public = """
+  public:
+
+    {0}(
+      const Teuchos::ParameterList& p);
+
+    void
+    postRegistrationSetup(
+      typename Traits::SetupData d,
+      PHX::FieldManager<Traits>& fm);
+
+    void
+    evaluateFields(
+      typename Traits::EvalData d);
+"""
+        prePost = """
+    void
+    preEvaluate(
+      typename Traits::PreEvalData d);
+
+    void
+    postEvaluate(
+      typename Traits::PostEvalData d);
+"""
+        private = """
+  private:
+
+    using ScalarT = typename EvalT::ScalarT;"""
+        self.replacements = {}
+        self.replacements["PANZER_EVALUATOR_CLASS\((.*)\)"] = (
+            header + public + private)
+        self.replacements["PANZER_EVALUATOR_CLASS_PP\((.*)\)"] = (
+            header + public + prePost + private)
+        self.replacements["PANZER_EVALUATOR_CLASS_END"] = (
+            """}}; // end of class {0}
+""")
+
+    def replaceText(self, regex, text):
+        """Replace a regular expression with its corresponding text."""
+        indent = self.line.find(regex[:10])
+        if indent >= 0:
+            match = re.search(regex, self.line)
+            if match:
+                args = list(match.groups())
+                if len(args) > 0:
+                    self.name = args[0]
+                    replacement = text.format(*args)
+                else:
+                    replacement = text.format(self.name)
+                replacement = textwrap.indent(replacement, " " * indent)
+                replacement = replacement[indent:]
+                replacement = re.sub(regex, replacement, self.line)
+                for i in replacement.splitlines(True):
+                    self.output.append(i)
+                return True
+        return False
+
+    def replaceInFile(self, filename):
+        """Make all the necessary replacements in the given file."""
+        self.filename = filename
+        with open(filename) as f:
+            for line in f:
+                self.line = line
+                foundIt = False
+                for (regex, text) in self.replacements.items():
+                    foundIt = foundIt or self.replaceText(regex, text)
+                if not foundIt:
+                    self.output.append(line)
+
+    def writeOutput(self):
+        """Overwrite the original file with the modified output."""
+        with open(self.filename, 'w') as f:
+            for line in self.output:
+                f.write(line)
+
+
+if __name__ == "__main__":
+    r = MacroReplacer()
+    r.replaceInFile(sys.argv[1])
+    r.writeOutput()


### PR DESCRIPTION
@trilinos/panzer 

## Description
This PR adds a script to replace the various Panzer `Evaluator` macros with their respective contents.  This script is analogous to the Phalanx one in #2361.  Both scripts were run against the Panzer code to remove the `Evaluator` macros.

## Motivation and Context
Originally we thought the macros were a great idea to help users build up `Evaluators` quickly and easily.  Eventually we realized they perhaps hid too much.

## Related Issues
* Related to #2361 

## How Has This Been Tested?
Ran the script on Panzer, Drekar, and Charon, and all our tests still pass.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.