### PR TITLE
Tpetra: FEM Assembly - move code into functions

### DIFF
--- a/packages/tpetra/core/example/Finite-Element-Assembly/MeshDatabase.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/MeshDatabase.hpp
@@ -130,9 +130,6 @@ private:
     return myElementStart_[0] <= i && i < myElementStop_[0] && myElementStart_[1] <= j && myElementStop_[1];
   }
 
-  // TODO: Add elementIsOwned()  (useful for Type-3 Assembly)
-
-
   inline global_ordinal_t idx_from_ij(global_ordinal_t num_x, global_ordinal_t i, global_ordinal_t j) const {
     return j*num_x+i;
   }

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.cpp
@@ -58,8 +58,10 @@
 
 using namespace TpetraExamples;
 
+#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
 
-int main (int argc, char *argv[]) 
+
+int execute(COMM_T& comm)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -67,10 +69,6 @@ int main (int argc, char *argv[])
   const global_ordinal_t GO_INVALID = Teuchos::OrdinalTraits<global_ordinal_t>::invalid();
 
   auto out = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cout));
-  
-  // MPI boilerplate
-  Tpetra::initialize(&argc, &argv);
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Processor decomp (only works on perfect squares)
   int numProcs  = comm->getSize();
@@ -255,8 +253,28 @@ int main (int argc, char *argv[])
   //Tpetra::MatrixMarket::Writer<matrix_t>::writeSparse(ofs, crs_matrix);
   //ofs.close();
 
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[]) 
+{
+  int status=EXIT_SUCCESS;
+  
+  // MPI boilerplate
+  Tpetra::initialize(&argc, &argv);
+  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+
+  // Entry Point
+  if(execute(comm))
+  {
+    status=EXIT_FAILURE;
+  }
+
+
   // Print out timing results.
-  TimeMonitor::report(comm.ptr(), std::cout, "");
+  Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
 
   // Finalize
   Tpetra::finalize();
@@ -267,5 +285,5 @@ int main (int argc, char *argv[])
     std::cout << "End Result: TEST PASSED" << std::endl;
   }
 
-  return EXIT_SUCCESS;
+  return status;
 }  // END main()

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.cpp
@@ -58,10 +58,11 @@
 
 using namespace TpetraExamples;
 
-#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
+using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
-int execute(COMM_T& comm)
+
+int execute(comm_ptr_t& comm)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -264,7 +265,7 @@ int main (int argc, char *argv[])
   
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Entry Point
   if(execute(comm))
@@ -272,18 +273,17 @@ int main (int argc, char *argv[])
     status=EXIT_FAILURE;
   }
 
-
   // Print out timing results.
   Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
-
-  // Finalize
-  Tpetra::finalize();
 
   // This tells the Trilinos test framework that the test passed.
   if(0 == comm->getRank())
   {
     std::cout << "End Result: TEST PASSED" << std::endl;
   }
+
+  // Finalize
+  Tpetra::finalize();
 
   return status;
 }  // END main()

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.cpp
@@ -58,10 +58,11 @@
 
 using namespace TpetraExamples;
 
-#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
+using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
-int execute (COMM_T &comm)
+
+int execute (comm_ptr_t& comm)
 {
 
   using Teuchos::RCP;
@@ -304,7 +305,7 @@ int main (int argc, char *argv[])
   
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Entry point
   if(execute(comm))
@@ -315,14 +316,14 @@ int main (int argc, char *argv[])
   // Print out timing results.
   Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
 
-  // Finalize
-  Tpetra::finalize();
- 
   // This tells the Trilinos test framework that the test passed.
   if(0 == comm->getRank())
   {
     std::cout << "End Result: TEST PASSED" << std::endl;
   }
+
+  // Finalize
+  Tpetra::finalize();
 
   return 0;
 }  // END main()

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.cpp
@@ -58,20 +58,18 @@
 
 using namespace TpetraExamples;
 
+#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
 
 
-int main (int argc, char *argv[]) 
+int execute (COMM_T &comm)
 {
+
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
 
   const global_ordinal_t GO_INVALID = Teuchos::OrdinalTraits<global_ordinal_t>::invalid();
 
   auto out = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cout));
-  
-  // MPI boilerplate
-  Tpetra::initialize(&argc, &argv);
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Processor decomp (only works on perfect squares)
   int numProcs  = comm->getSize();
@@ -295,8 +293,27 @@ int main (int argc, char *argv[])
   //Tpetra::MatrixMarket::Writer<matrix_t>::writeSparse(ofs, crs_matrix_owned);
   //ofs.close();
 
+  return 0;
+}
+
+
+
+int main (int argc, char *argv[]) 
+{
+  int status = EXIT_SUCCESS;
+  
+  // MPI boilerplate
+  Tpetra::initialize(&argc, &argv);
+  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+
+  // Entry point
+  if(execute(comm))
+  {
+    status = EXIT_FAILURE;
+  }
+
   // Print out timing results.
-  TimeMonitor::report(comm.ptr(), std::cout, "");
+  Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
 
   // Finalize
   Tpetra::finalize();

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.cpp
@@ -58,11 +58,11 @@
 
 using namespace TpetraExamples;
 
-#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
+using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
 
-int execute( COMM_T& comm )
+int execute(comm_ptr_t& comm )
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -315,7 +315,7 @@ int main (int argc, char *argv[])
 
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Entry point
   if(execute(comm))
@@ -326,15 +326,15 @@ int main (int argc, char *argv[])
   // Print out timing results.
   Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
 
-  // Finalize
-  Tpetra::finalize();
-
   // This tells the Trilinos test framework that the test passed.
   if(0 == comm->getRank())
   {
     if(0 == status) std::cout << "End Result: TEST PASSED" << std::endl;
     else            std::cout << "End Result: TEST FAILED" << std::endl;
   }
+
+  // Finalize
+  Tpetra::finalize();
 
   return status;
 }  // END main()

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.cpp
@@ -58,11 +58,11 @@
 
 using namespace TpetraExamples;
 
-#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
+using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
 
-int execute (COMM_T& comm)
+int execute (comm_ptr_t& comm)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -316,7 +316,7 @@ int main (int argc, char *argv[])
   
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Entry point
   if(execute(comm))
@@ -327,15 +327,15 @@ int main (int argc, char *argv[])
   // Print out timing results.
   Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
 
-  // Finalize
-  Tpetra::finalize();
-
   // This tells the Trilinos test framework that the test passed.
   if(0 == comm->getRank())
   {
     if(0 == status) std::cout << "End Result: TEST PASSED" << std::endl;
     else            std::cout << "End Result: TEST FAILED" << std::endl;
   }
+
+  // Finalize
+  Tpetra::finalize();
 
   return status;
 }  // END main()

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.cpp
@@ -58,9 +58,11 @@
 
 using namespace TpetraExamples;
 
+#define COMM_T Teuchos::RCP<const Teuchos::Comm<int> >
 
 
-int main (int argc, char *argv[]) 
+
+int execute (COMM_T& comm)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -68,10 +70,6 @@ int main (int argc, char *argv[])
   const global_ordinal_t GO_INVALID = Teuchos::OrdinalTraits<global_ordinal_t>::invalid();
 
   auto out = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cout));
-  
-  // MPI boilerplate
-  Tpetra::initialize(&argc, &argv);
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
 
   // Processor decomp (only works on perfect squares)
   int numProcs  = comm->getSize();
@@ -308,8 +306,26 @@ int main (int argc, char *argv[])
   //Tpetra::MatrixMarket::Writer<matrix_t>::writeSparse(ofs, crs_matrix);
   //ofs.close();
 
+  return 0;
+}
+
+
+int main (int argc, char *argv[]) 
+{
+  int status = EXIT_SUCCESS;
+  
+  // MPI boilerplate
+  Tpetra::initialize(&argc, &argv);
+  COMM_T comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+
+  // Entry point
+  if(execute(comm))
+  {
+    status = EXIT_FAILURE;
+  }
+
   // Print out timing results.
-  TimeMonitor::report(comm.ptr(), std::cout, "");
+  Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");
 
   // Finalize
   Tpetra::finalize();
@@ -317,9 +333,10 @@ int main (int argc, char *argv[])
   // This tells the Trilinos test framework that the test passed.
   if(0 == comm->getRank())
   {
-    std::cout << "End Result: TEST PASSED" << std::endl;
+    if(0 == status) std::cout << "End Result: TEST PASSED" << std::endl;
+    else            std::cout << "End Result: TEST FAILED" << std::endl;
   }
 
-  return 0;
+  return status;
 }  // END main()
 

--- a/packages/tpetra/core/example/Finite-Element-Assembly/typedefs.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/typedefs.hpp
@@ -38,8 +38,6 @@
 //
 // ************************************************************************
 // @HEADER
-
-
 #ifndef TYPEDEFS_HPP
 #define TYPEDEFS_HPP
 
@@ -50,7 +48,7 @@
 #include <Tpetra_CrsGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
-namespace TpetraExamples {}
+namespace TpetraExamples {
 
 typedef double Scalar;
 
@@ -73,6 +71,7 @@ typedef Kokkos::View<local_ordinal_t*[4], execution_space_t>  local_ordinal_2d_a
 typedef Kokkos::View<global_ordinal_t*[4], execution_space_t> global_ordinal_2d_array_t;
 typedef Kokkos::View<Scalar*[4], execution_space_t>           scalar_2d_array_t;
 
-#endif
+}
 
+#endif
 


### PR DESCRIPTION
@trilinos/tpetra 
@mhoemmen 

## Description
Moving example code into functions to get rid of the error messages caused by the d'tor of `RCP<Tpetra::Map<...>>` being called after `Tpetra::finalize()`.  This was happening because they were both in the same scope.

## Solution
Fixed by moving the actual tasks into an `execute()` function.
- We might break this up later but that's a different issue ;)

@mhoemmen created issue #2372 to add a message to the d'tor if it's called after `finalize()` has been called to improve clarity.

## Related Issues
* Closes #2370
* Related to #2372

## How Has This Been Tested?
- Tested on local machine.
- Tested on White.
