### PR TITLE
Kokkos: fix defaulted functions with CUDA 9

### DIFF
--- a/packages/kokkos/Makefile.kokkos
+++ b/packages/kokkos/Makefile.kokkos
@@ -510,6 +510,14 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
     KOKKOS_LDFLAGS += --relocatable-device-code=true
   endif
 
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_NVCC), 1)
+    ifeq ($(shell test $(KOKKOS_INTERNAL_COMPILER_NVCC_VERSION) -ge 90; echo $$?),0)
+      # This diagnostic is just plain wrong in CUDA 9
+      # See https://github.com/kokkos/kokkos/issues/1470
+      KOKKOS_CXXFLAGS += -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+    endif
+  endif
+
   ifeq ($(KOKKOS_INTERNAL_CUDA_USE_LAMBDA), 1)
     ifeq ($(KOKKOS_INTERNAL_COMPILER_NVCC), 1)
       ifeq ($(shell test $(KOKKOS_INTERNAL_COMPILER_NVCC_VERSION) -gt 70; echo $$?),0)

--- a/packages/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/packages/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -73,17 +73,47 @@ public:
   KOKKOS_INLINE_FUNCTION
   UniqueToken() : m_buffer(0), m_count(0) {}
 
-  KOKKOS_FUNCTION_DEFAULTED
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION
+  UniqueToken( const UniqueToken & rhs )
+  : m_buffer(rhs.m_buffer)
+  , m_count(rhs.m_count)
+  {
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  UniqueToken( UniqueToken && rhs )
+  : m_buffer(std::move(rhs.m_buffer))
+  , m_count(std::move(rhs.m_count))
+  {
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  UniqueToken & operator=( const UniqueToken & rhs ) {
+    m_buffer = rhs.m_buffer;
+    m_count = rhs.m_count;
+    return *this;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  UniqueToken & operator=( UniqueToken && rhs ) {
+    m_buffer = std::move(rhs.m_buffer);
+    m_count = std::move(rhs.m_count);
+    return *this;
+  }
+#else
+  KOKKOS_INLINE_FUNCTION
   UniqueToken( const UniqueToken & ) = default;
 
-  KOKKOS_FUNCTION_DEFAULTED
+  KOKKOS_INLINE_FUNCTION
   UniqueToken( UniqueToken && )      = default;
 
-  KOKKOS_FUNCTION_DEFAULTED
+  KOKKOS_INLINE_FUNCTION
   UniqueToken & operator=( const UniqueToken & ) = default ;
 
-  KOKKOS_FUNCTION_DEFAULTED
+  KOKKOS_INLINE_FUNCTION
   UniqueToken & operator=( UniqueToken && ) = default ;
+#endif
 
   /// \brief upper bound for acquired values, i.e. 0 <= value < size()
   KOKKOS_INLINE_FUNCTION

--- a/packages/kokkos/core/src/Kokkos_Array.hpp
+++ b/packages/kokkos/core/src/Kokkos_Array.hpp
@@ -152,10 +152,17 @@ public:
   KOKKOS_INLINE_FUNCTION pointer       data()       { return pointer(0) ; }
   KOKKOS_INLINE_FUNCTION const_pointer data() const { return const_pointer(0); }
 
-  KOKKOS_FUNCTION_DEFAULTED ~Array() = default ;
-  KOKKOS_FUNCTION_DEFAULTED Array() = default ;
-  KOKKOS_FUNCTION_DEFAULTED Array( const Array & ) = default ;
-  KOKKOS_FUNCTION_DEFAULTED Array & operator = ( const Array & ) = default ;
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION ~Array() {}
+  KOKKOS_INLINE_FUNCTION Array() {}
+  KOKKOS_INLINE_FUNCTION Array( const Array & ) {}
+  KOKKOS_INLINE_FUNCTION Array & operator = ( const Array & ) {}
+#else
+  KOKKOS_INLINE_FUNCTION ~Array() = default;
+  KOKKOS_INLINE_FUNCTION Array() = default;
+  KOKKOS_INLINE_FUNCTION Array( const Array & ) = default;
+  KOKKOS_INLINE_FUNCTION Array & operator = ( const Array & ) = default;
+#endif
 
   // Some supported compilers are not sufficiently C++11 compliant
   // for default move constructor and move assignment operator.
@@ -209,7 +216,11 @@ public:
   KOKKOS_INLINE_FUNCTION pointer       data()       { return m_elem ; }
   KOKKOS_INLINE_FUNCTION const_pointer data() const { return m_elem ; }
 
-  KOKKOS_FUNCTION_DEFAULTED ~Array() = default ;
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION ~Array() {}
+#else
+  KOKKOS_INLINE_FUNCTION ~Array() = default;
+#endif
   Array() = delete ;
   Array( const Array & rhs ) = delete ;
 
@@ -278,7 +289,11 @@ public:
   KOKKOS_INLINE_FUNCTION pointer       data()       { return m_elem ; }
   KOKKOS_INLINE_FUNCTION const_pointer data() const { return m_elem ; }
 
-  KOKKOS_FUNCTION_DEFAULTED ~Array() = default ;
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION ~Array() {}
+#else
+  KOKKOS_INLINE_FUNCTION ~Array() = default;
+#endif
   Array()  = delete ;
   Array( const Array & ) = delete ;
 

--- a/packages/kokkos/core/src/Kokkos_Macros.hpp
+++ b/packages/kokkos/core/src/Kokkos_Macros.hpp
@@ -164,6 +164,12 @@
   #else // !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
     #undef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
   #endif // !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
+
+  #if ( 9000 <= CUDA_VERSION ) && ( CUDA_VERSION < 10000 )
+    // CUDA 9 introduced an incorrect warning,
+    // see https://github.com/kokkos/kokkos/issues/1470
+    #define KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  #endif
 #endif // #if defined( KOKKOS_ENABLE_CUDA ) && defined( __CUDACC__ )
 
 //----------------------------------------------------------------------------
@@ -175,10 +181,6 @@
   #define KOKKOS_FORCEINLINE_FUNCTION  __device__  __host__  __forceinline__
   #define KOKKOS_INLINE_FUNCTION       __device__  __host__  inline
   #define KOKKOS_FUNCTION              __device__  __host__
-  #ifdef KOKKOS_COMPILER_CLANG
-  #define KOKKOS_INLINE_FUNCTION_DEFAULTED KOKKOS_INLINE_FUNCTION
-  #define KOKKOS_FUNCTION_DEFAULTED KOKKOS_FUNCTION
-  #endif
 #endif // #if defined( __CUDA_ARCH__ )
 
 #if defined( KOKKOS_ENABLE_ROCM ) && defined( __HCC__ )
@@ -187,8 +189,6 @@
   #define KOKKOS_INLINE_FUNCTION       __attribute__((amp,cpu)) inline
   #define KOKKOS_FUNCTION              __attribute__((amp,cpu))
   #define KOKKOS_LAMBDA                [=] __attribute__((amp,cpu))
-  #define KOKKOS_INLINE_FUNCTION_DEFAULTED KOKKOS_INLINE_FUNCTION
-  #define KOKKOS_FUNCTION_DEFAULTED    KOKKOS_FUNCTION
 #endif
 
 #if defined( _OPENMP )
@@ -421,11 +421,6 @@
 
 #if !defined( KOKKOS_FUNCTION )
   #define KOKKOS_FUNCTION /**/
-#endif
-
-#if !defined( KOKKOS_FUNCTION_DEFAULTED )
-  #define KOKKOS_INLINE_FUNCTION_DEFAULTED inline
-  #define KOKKOS_FUNCTION_DEFAULTED /**/
 #endif
 
 //----------------------------------------------------------------------------

--- a/packages/kokkos/core/src/Kokkos_MemoryPool.hpp
+++ b/packages/kokkos/core/src/Kokkos_MemoryPool.hpp
@@ -258,10 +258,63 @@ public:
 
   //--------------------------------------------------------------------------
 
-  KOKKOS_INLINE_FUNCTION_DEFAULTED MemoryPool( MemoryPool && ) = default ;
-  KOKKOS_INLINE_FUNCTION_DEFAULTED MemoryPool( const MemoryPool & ) = default ;
-  KOKKOS_INLINE_FUNCTION_DEFAULTED MemoryPool & operator = ( MemoryPool && ) = default ;
-  KOKKOS_INLINE_FUNCTION_DEFAULTED MemoryPool & operator = ( const MemoryPool & ) = default ;
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION MemoryPool( MemoryPool && rhs )
+    : m_tracker(std::move(rhs.m_tracker))
+    , m_sb_state_array(std::move(rhs.m_sb_state_array))
+    , m_sb_state_size(std::move(rhs.m_sb_state_size))
+    , m_sb_size_lg2(std::move(rhs.m_sb_size_lg2))
+    , m_max_block_size_lg2(std::move(rhs.m_max_block_size_lg2))
+    , m_min_block_size_lg2(std::move(rhs.m_min_block_size_lg2))
+    , m_sb_count(std::move(rhs.m_sb_count))
+    , m_hint_offset(std::move(rhs.m_hint_offset))
+    , m_data_offset(std::move(rhs.m_data_offset))
+  {
+  }
+  KOKKOS_INLINE_FUNCTION MemoryPool( const MemoryPool & rhs )
+    : m_tracker(rhs.m_tracker)
+    , m_sb_state_array(rhs.m_sb_state_array)
+    , m_sb_state_size(rhs.m_sb_state_size)
+    , m_sb_size_lg2(rhs.m_sb_size_lg2)
+    , m_max_block_size_lg2(rhs.m_max_block_size_lg2)
+    , m_min_block_size_lg2(rhs.m_min_block_size_lg2)
+    , m_sb_count(rhs.m_sb_count)
+    , m_hint_offset(rhs.m_hint_offset)
+    , m_data_offset(rhs.m_data_offset)
+  {
+  }
+  KOKKOS_INLINE_FUNCTION MemoryPool & operator = ( MemoryPool && rhs )
+  {
+    m_tracker = std::move(rhs.m_tracker);
+    m_sb_state_array = std::move(rhs.m_sb_state_array);
+    m_sb_state_size = std::move(rhs.m_sb_state_size);
+    m_sb_size_lg2 = std::move(rhs.m_sb_size_lg2);
+    m_max_block_size_lg2 = std::move(rhs.m_max_block_size_lg2);
+    m_min_block_size_lg2 = std::move(rhs.m_min_block_size_lg2);
+    m_sb_count = std::move(rhs.m_sb_count);
+    m_hint_offset = std::move(rhs.m_hint_offset);
+    m_data_offset = std::move(rhs.m_data_offset);
+    return *this;
+  }
+  KOKKOS_INLINE_FUNCTION MemoryPool & operator = ( const MemoryPool & rhs )
+  {
+    m_tracker = rhs.m_tracker;
+    m_sb_state_array = rhs.m_sb_state_array;
+    m_sb_state_size = rhs.m_sb_state_size;
+    m_sb_size_lg2 = rhs.m_sb_size_lg2;
+    m_max_block_size_lg2 = rhs.m_max_block_size_lg2;
+    m_min_block_size_lg2 = rhs.m_min_block_size_lg2;
+    m_sb_count = rhs.m_sb_count;
+    m_hint_offset = rhs.m_hint_offset;
+    m_data_offset = rhs.m_data_offset;
+    return *this;
+  }
+#else
+  KOKKOS_INLINE_FUNCTION MemoryPool( MemoryPool && ) = default ;
+  KOKKOS_INLINE_FUNCTION MemoryPool( const MemoryPool & ) = default ;
+  KOKKOS_INLINE_FUNCTION MemoryPool & operator = ( MemoryPool && ) = default ;
+  KOKKOS_INLINE_FUNCTION MemoryPool & operator = ( const MemoryPool & ) = default ;
+#endif
 
   KOKKOS_INLINE_FUNCTION MemoryPool()
     : m_tracker()

--- a/packages/kokkos/core/src/Kokkos_Pair.hpp
+++ b/packages/kokkos/core/src/Kokkos_Pair.hpp
@@ -78,8 +78,12 @@ struct pair
   /// This calls the default constructors of T1 and T2.  It won't
   /// compile if those default constructors are not defined and
   /// public.
-  KOKKOS_FUNCTION_DEFAULTED constexpr
-  pair() = default ;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  pair() : first(), second() {}
+#else
+  pair() = default;
+#endif
 
   /// \brief Constructor that takes both elements of the pair.
   ///
@@ -458,8 +462,12 @@ struct pair<T1,void>
   first_type  first;
   enum { second = 0 };
 
-  KOKKOS_FUNCTION_DEFAULTED constexpr
-  pair() = default ;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  pair() : first() {}
+#else
+  pair() = default;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr
   pair(const first_type & f)

--- a/packages/kokkos/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_TaskQueue.hpp
@@ -180,7 +180,11 @@ public:
   TaskBase & operator = ( TaskBase && ) = delete ;
   TaskBase & operator = ( const TaskBase & ) = delete ;
 
-  KOKKOS_INLINE_FUNCTION_DEFAULTED ~TaskBase() = default ;
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION ~TaskBase() {};
+#else
+  KOKKOS_INLINE_FUNCTION ~TaskBase() = default;
+#endif
 
   KOKKOS_INLINE_FUNCTION constexpr
   TaskBase()

--- a/packages/kokkos/core/src/impl/Kokkos_ViewTile.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_ViewTile.hpp
@@ -143,10 +143,25 @@ public:
 
   //----------------------------------------
 
-  KOKKOS_FUNCTION_DEFAULTED ~ViewOffset() = default ;
-  KOKKOS_FUNCTION_DEFAULTED ViewOffset() = default ;
-  KOKKOS_FUNCTION_DEFAULTED ViewOffset( const ViewOffset & ) = default ;
-  KOKKOS_FUNCTION_DEFAULTED ViewOffset & operator = ( const ViewOffset & ) = default ;
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION ~ViewOffset() {}
+  KOKKOS_INLINE_FUNCTION ViewOffset() {}
+  KOKKOS_INLINE_FUNCTION ViewOffset( const ViewOffset & rhs )
+  : m_dim(rhs.m_dim)
+  , m_tile_N0(rhs.m_tile_N0)
+  {
+  }
+  KOKKOS_INLINE_FUNCTION ViewOffset & operator = ( const ViewOffset & rhs ) {
+    m_dim = rhs.m_dim;
+    m_tile_N0 = rhs.m_tile_N0;
+    return *this;
+  }
+#else
+  KOKKOS_INLINE_FUNCTION ~ViewOffset() = default;
+  KOKKOS_INLINE_FUNCTION ViewOffset() = default;
+  KOKKOS_INLINE_FUNCTION ViewOffset( const ViewOffset & ) = default;
+  KOKKOS_INLINE_FUNCTION ViewOffset & operator = ( const ViewOffset & ) = default;
+#endif
 
   template< unsigned TrivialScalarSize >
   KOKKOS_INLINE_FUNCTION

--- a/packages/kokkos/core/unit_test/TestTaskScheduler.hpp
+++ b/packages/kokkos/core/unit_test/TestTaskScheduler.hpp
@@ -177,53 +177,6 @@ struct TestFib
 namespace TestTaskScheduler {
 
 template< class Space >
-struct TestTaskSpawn {
-  typedef Kokkos::TaskScheduler< Space >  sched_type;
-  typedef Kokkos::Future< Space >         future_type;
-  typedef void                            value_type;
-
-  sched_type   m_sched ;
-  future_type  m_future ;
-
-  KOKKOS_INLINE_FUNCTION
-  TestTaskSpawn( const sched_type & arg_sched
-               , const future_type & arg_future
-               )
-    : m_sched( arg_sched )
-    , m_future( arg_future )
-    {}
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()( typename sched_type::member_type & )
-  {
-    if ( ! m_future.is_null() ) {
-      Kokkos::task_spawn( Kokkos::TaskSingle( m_sched ) , TestTaskSpawn( m_sched , future_type() ) );
-    }
-  }
-
-  static void run()
-  {
-    typedef typename sched_type::memory_space memory_space;
-
-    enum { MemoryCapacity = 16000 };
-    enum { MinBlockSize   =   64 };
-    enum { MaxBlockSize   = 1024 };
-    enum { SuperBlockSize = 4096 };
-
-    sched_type sched( memory_space()
-                    , MemoryCapacity
-                    , MinBlockSize
-                    , MaxBlockSize
-                    , SuperBlockSize );
-
-    auto f = Kokkos::host_spawn( Kokkos::TaskSingle( sched ), TestTaskSpawn( sched, future_type() ) );
-    Kokkos::host_spawn( Kokkos::TaskSingle( f ), TestTaskSpawn( sched, f ) );
-
-    Kokkos::wait( sched );
-  }
-};
-
-template< class Space >
 struct TestTaskDependence {
   typedef Kokkos::TaskScheduler< Space >  sched_type;
   typedef Kokkos::Future< Space >         future_type;
@@ -637,6 +590,63 @@ struct TestTaskTeamValue {
 
 } // namespace TestTaskScheduler
 
+//----------------------------------------------------------------------------
+
+namespace TestTaskScheduler {
+
+template< class Space >
+struct TestTaskSpawnWithPool {
+  typedef Kokkos::TaskScheduler< Space >  sched_type;
+  typedef Kokkos::Future< Space >         future_type;
+  typedef void                            value_type;
+
+  sched_type   m_sched ;
+  int  m_count ;
+  Kokkos::MemoryPool<Space> m_pool ;
+
+  KOKKOS_INLINE_FUNCTION
+  TestTaskSpawnWithPool( const sched_type & arg_sched
+               , const int & arg_count
+               , const Kokkos::MemoryPool<Space> & arg_pool
+               )
+    : m_sched( arg_sched )
+    , m_count( arg_count )
+    , m_pool( arg_pool )
+    {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()( typename sched_type::member_type & )
+  {
+    if ( m_count ) {
+      Kokkos::task_spawn( Kokkos::TaskSingle( m_sched ) , TestTaskSpawnWithPool( m_sched , m_count - 1, m_pool ) );
+    }
+  }
+
+  static void run()
+  {
+    typedef typename sched_type::memory_space memory_space;
+
+    enum { MemoryCapacity = 16000 };
+    enum { MinBlockSize   =   64 };
+    enum { MaxBlockSize   = 1024 };
+    enum { SuperBlockSize = 4096 };
+
+    sched_type sched( memory_space()
+                    , MemoryCapacity
+                    , MinBlockSize
+                    , MaxBlockSize
+                    , SuperBlockSize );
+
+    using other_memory_space = typename Space::memory_space;
+    Kokkos::MemoryPool<Space> pool(other_memory_space(), 10000, 100, 200, 1000);
+    auto f = Kokkos::host_spawn( Kokkos::TaskSingle( sched ), TestTaskSpawnWithPool( sched, 3, pool ) );
+
+    Kokkos::wait( sched );
+  }
+};
+
+}
+
 namespace Test {
 
 TEST_F( TEST_CATEGORY, task_fib )
@@ -658,6 +668,11 @@ TEST_F( TEST_CATEGORY, task_team )
 {
   TestTaskScheduler::TestTaskTeam< TEST_EXECSPACE >::run( 1000 );
   //TestTaskScheduler::TestTaskTeamValue< TEST_EXECSPACE >::run( 1000 ); // Put back after testing.
+}
+
+TEST_F( TEST_CATEGORY, task_with_mempool )
+{
+  TestTaskScheduler::TestTaskSpawnWithPool< TEST_EXECSPACE >::run();
 }
 
 }


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos 
@trilinos/sacado 
@etphipp 
@rppawlo 
@bathmatt 
@crtrott 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
CUDA 9 emits an incorrect warning for
defaulted device functions.
This warning mislead Kokkos into marking
them wrong, causing code crashes.
This change introduces a workaround
(only under CUDA 9) which ensures correct
behavior and prevents warnings.
Makefile.kokkos will now add a warning
suppression flag to KOKKOS_CXX_FLAGS
when compiling with CUDA 9, so that Kokkos
users can do the right thing with defaulted
functions and not get warnings.
This means Trilinos users who use KOKKOS_ARCH
will have that flag automatically added
to their build.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Currently ShyLU/Tacho crashes because `Kokkos::MemoryPool` is marked wrong for CUDA, and Sacado code emits lots of warnings under CUDA 9. This change should fix both things.

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Passed Kokkos-only spot check as part of kokkos/kokkos#1471