### PR TITLE
KokkosKernels: Replace KOKKOS_INLINE_FUNCTION_DEFAULTED

### DIFF
--- a/packages/kokkos-kernels/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
+++ b/packages/kokkos-kernels/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
@@ -50,7 +50,7 @@ namespace KokkosBatched {
       struct Functor {
         UnmanagedViewType<ViewType> _a;
 
-        KOKKOS_INLINE_FUNCTION_DEFAULTED
+        KOKKOS_INLINE_FUNCTION
         Functor() = default;
 
         KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Replace with KOKKOS_INLINE_FUNCTION following Kokkos changes in PR #2393
Necessary to prevent compilation errors when perf_tests are built

## Description
<!--- Describe your changes in detail. -->
Replace KOKKOS_INLINE_FUNCTION_DEFAULTED with KOKKOS_INLINE_FUNCTION following PR #2393

## Related Issues
#2393 

