### PR TITLE
Improve test output to better pin-point failing code (#2407)

### DIFF
--- a/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
+++ b/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
@@ -78,6 +78,19 @@ typedef long long long_long_type;
 typedef unsigned long long unsigned_long_long_type;
 #endif // HAVE_TEUCHOS_LONG_LONG_INT
 
+
+template <class T>
+std::string valToString(const T &val)
+{
+  const int precision = std::numeric_limits<T>::digits10 + 10; // Be super safe!
+  //std::cout << "precision = " << precision << "\n";
+  std::ostringstream os;
+  os.precision(precision);
+  os << val;
+  return os.str();
+}
+
+
 //
 // Tests for conversions between built-in floating-point types.
 //
@@ -308,12 +321,16 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   const long double minusOneLD = -1;
   const long double maxLD = std::numeric_limits<long double>::max ();
 
+  out << "minLD = " << minLD << "\n";
+  out << "minusOneLD = " << minusOneLD << "\n";
+  out << "maxLD = " << maxLD << "\n";
+
   float valF = 0;
   double valD = 0;
   long double valLD = 0;
 
   //
-  // Test string -> float conversions.
+  out << "Testing string -> float conversions ...\n";
   //
   {
     std::ostringstream os;
@@ -358,7 +375,7 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   }
 
   //
-  // Test string -> float conversions that should throw.
+  out << "Testing string -> float conversions that should throw ...\n";
   //
   {
     std::ostringstream os;
@@ -374,7 +391,7 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   }
 
   //
-  // Test string -> double conversions.
+  out << "Testing string -> double conversions ...\n";
   //
   {
     std::ostringstream os;
@@ -395,12 +412,9 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
     TEST_EQUALITY_CONST(valD, maxD);
   }
   {
-    std::ostringstream os;
-    os.precision (17);
-    os << minusOneD;
-    TEST_NOTHROW(valD = asSafe<double> (os.str ()));
+    TEST_NOTHROW(valD = asSafe<double> (valToString(minusOneD)));
     TEST_EQUALITY_CONST(valD, minusOneD);
-    TEST_NOTHROW(valD = as<double> (os.str ()));
+    TEST_NOTHROW(valD = as<double> (valToString(minusOneD)));
     TEST_EQUALITY_CONST(valD, minusOneD);
   }
 
@@ -409,22 +423,21 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   // if sizeof(long double) > sizeof(double).
   //
   if (sizeof (long double) > sizeof (double)) {
+    out << "Testing converting from 'long double' to 'double' that does not fit ...\n";
     {
-      std::ostringstream os;
-      os.precision (36);
-      os << minLD;
-      TEST_THROW(valD = asSafe<double> (os.str ()), std::range_error);
+      TEST_THROW(valD = asSafe<double>(valToString(minLD)), std::range_error);
+      out << "valD = " << valD << "\n";
     }
     {
       std::ostringstream os;
       os.precision (36);
-      os << maxLD;
-      TEST_THROW(valD = asSafe<double> (os.str ()), std::range_error);
+      TEST_THROW(valD = asSafe<double>(valToString(maxLD)), std::range_error);
+      out << "valD = " << valD << "\n";
     }
   }
 
   //
-  // Test string -> long double conversions.
+  out << "Testing string -> long double conversions ...\n";
   //
   {
     std::ostringstream os;

--- a/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
+++ b/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
@@ -422,7 +422,19 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   // Test string -> double conversions that should throw,
   // if sizeof(long double) > sizeof(double).
   //
-  if (sizeof (long double) > sizeof (double)) {
+  const int sizeof_long_double = sizeof(long double);
+  const int sizeof_double = sizeof(double);
+  const int max_exponent10_long_double = std::numeric_limits<long double>::max_exponent10;
+  const int max_exponent10_double = std::numeric_limits<double>::max_exponent10;
+
+  out << "sizeof_long_double = " << sizeof_long_double << "\n";
+  out << "sizeof_double = " << sizeof_double << "\n";
+  out << "max_exponent10_long_double = " << max_exponent10_long_double << "\n";
+  out << "max_exponent10_double = " << max_exponent10_double << "\n";
+ 
+  if (sizeof_long_double > sizeof_double
+    && max_exponent10_long_double > max_exponent10_double)
+  {
     out << "Testing converting from 'long double' to 'double' that does not fit ...\n";
     {
       TEST_THROW(valD = asSafe<double>(valToString(minLD)), std::range_error);


### PR DESCRIPTION
**CC:** @trilinos/teuchos, @mhoemmen 

## Description

This makes it easier to see which code is failing in the type conversion from
long double as string to double (see #2407).

This now shows which unit test code is failing and why on `ride` build `gnu-debug-openmp`:

```
1. asSafe_stringToReal_UnitTest ... 
 minLD = -1.79769e+308
 minusOneLD = -1
 maxLD = 1.79769e+308
 Testing string -> float conversions ...
 Test that code {valF = asSafe<float> (os.str ());} does not throw : passes
 valF = -3.40282347e+38 == -3.40282347e+38 : passed
 Test that code {valF = as<float> (os.str ());} does not throw : passes
 valF = -3.40282347e+38 == -3.40282347e+38 : passed
 Test that code {valF = asSafe<float> (os.str ());} does not throw : passes
 valF = 3.40282347e+38 == 3.40282347e+38 : passed
 Test that code {valF = as<float> (os.str ());} does not throw : passes
 valF = 3.40282347e+38 == 3.40282347e+38 : passed
 Test that code {valF = asSafe<float> (os.str ());} does not throw : passes
 valF = -1.00000000e+00 == -1.00000000e+00 : passed
 Test that code {valF = as<float> (os.str ());} does not throw : passes
 valF = -1.00000000e+00 == -1.00000000e+00 : passed
 Test that code {valF = asSafe<float> (os.str ());} does not throw : passes
 valF = -1.00000000e+00 == -1.00000000e+00 : passed
 Test that code {valF = as<float> (os.str ());} does not throw : passes
 valF = -1.00000000e+00 == -1.00000000e+00 : passed
 Testing string -> float conversions that should throw ...
 Test that code {valF = asSafe<float> (os.str ());} throws std::range_error: passed
 
 Exception message for expected exception:
 
  /home/rabartl/Trilinos.base/Trilinos/packages/teuchos/core/src/Teuchos_as.hpp:558:
  
  Throw number = 1
  
  Throw test that evaluated to true: errno == ERANGE && (val != 0)
  
  Teuchos::ValueTypeConversionTraits<float, std::string>::convert: The value in the given string "-1.79769313e+308" overflows float.
  
 Test that code {valF = asSafe<float> (os.str ());} throws std::range_error: passed
 
 Exception message for expected exception:
 
  /home/rabartl/Trilinos.base/Trilinos/packages/teuchos/core/src/Teuchos_as.hpp:558:
  
  Throw number = 2
  
  Throw test that evaluated to true: errno == ERANGE && (val != 0)
  
  Teuchos::ValueTypeConversionTraits<float, std::string>::convert: The value in the given string "1.79769313e+308" overflows float.
  
 Testing string -> double conversions ...
 Test that code {valD = asSafe<double> (os.str ());} does not throw : passed
 valD = -1.79769313486231571e+308 == -1.79769313486231571e+308 : passed
 Test that code {valD = as<double> (os.str ());} does not throw : passed
 valD = -1.79769313486231571e+308 == -1.79769313486231571e+308 : passed
 Test that code {valD = asSafe<double> (os.str ());} does not throw : passed
 valD = 1.79769313486231571e+308 == 1.79769313486231571e+308 : passed
 Test that code {valD = as<double> (os.str ());} does not throw : passed
 valD = 1.79769313486231571e+308 == 1.79769313486231571e+308 : passed
 Test that code {valD = asSafe<double> (valToString(minusOneD));} does not throw : passed
 valD = -1.00000000000000000e+00 == -1.00000000000000000e+00 : passed
 Test that code {valD = as<double> (valToString(minusOneD));} does not throw : passed
 valD = -1.00000000000000000e+00 == -1.00000000000000000e+00 : passed
 Testing converting from 'long double' to 'double' that does not fit ...
 Test that code {valD = asSafe<double>(valToString(minLD));} throws std::range_error: failed (code did not throw an exception at all)
 valD = -1.79769e+308
 Test that code {valD = asSafe<double>(valToString(maxLD));} throws std::range_error: failed (code did not throw an exception at all)
 valD = 1.79769e+308
 Testing string -> long double conversions ...
 Test that code {valLD = asSafe<long double> (os.str ());} does not throw : passed
 valLD = -1.79769e+308 == -1.79769e+308 : passed
 Test that code {valLD = as<long double> (os.str ());} does not throw : passed
 valLD = -1.79769e+308 == -1.79769e+308 : passed
 Test that code {valLD = asSafe<long double> (os.str ());} does not throw : passed
 valLD = 1.79769e+308 == 1.79769e+308 : passed
 Test that code {valLD = as<long double> (os.str ());} does not throw : passed
 valLD = 1.79769e+308 == 1.79769e+308 : passed
 Test that code {valLD = asSafe<long double> (os.str ());} does not throw : passed
 valLD = -1 == -1 : passed
 Test that code {valLD = as<long double> (os.str ());} does not throw : passed
 valLD = -1 == -1 : passed
 [FAILED]  (0.00042 sec) asSafe_stringToReal_UnitTest
 Location: /home/rabartl/Trilinos.base/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:287
 

The following tests FAILED:
    1. asSafe_stringToReal_UnitTest ... 
```
