### PR TITLE
2407 fix safe as check power8

### DIFF
--- a/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
+++ b/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
@@ -78,6 +78,19 @@ typedef long long long_long_type;
 typedef unsigned long long unsigned_long_long_type;
 #endif // HAVE_TEUCHOS_LONG_LONG_INT
 
+
+template <class T>
+std::string valToString(const T &val)
+{
+  const int precision = std::numeric_limits<T>::digits10 + 10; // Be super safe!
+  //std::cout << "precision = " << precision << "\n";
+  std::ostringstream os;
+  os.precision(precision);
+  os << val;
+  return os.str();
+}
+
+
 //
 // Tests for conversions between built-in floating-point types.
 //
@@ -308,12 +321,16 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   const long double minusOneLD = -1;
   const long double maxLD = std::numeric_limits<long double>::max ();
 
+  out << "minLD = " << minLD << "\n";
+  out << "minusOneLD = " << minusOneLD << "\n";
+  out << "maxLD = " << maxLD << "\n";
+
   float valF = 0;
   double valD = 0;
   long double valLD = 0;
 
   //
-  // Test string -> float conversions.
+  out << "Testing string -> float conversions ...\n";
   //
   {
     std::ostringstream os;
@@ -358,7 +375,7 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   }
 
   //
-  // Test string -> float conversions that should throw.
+  out << "Testing string -> float conversions that should throw ...\n";
   //
   {
     std::ostringstream os;
@@ -374,7 +391,7 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   }
 
   //
-  // Test string -> double conversions.
+  out << "Testing string -> double conversions ...\n";
   //
   {
     std::ostringstream os;
@@ -395,12 +412,9 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
     TEST_EQUALITY_CONST(valD, maxD);
   }
   {
-    std::ostringstream os;
-    os.precision (17);
-    os << minusOneD;
-    TEST_NOTHROW(valD = asSafe<double> (os.str ()));
+    TEST_NOTHROW(valD = asSafe<double> (valToString(minusOneD)));
     TEST_EQUALITY_CONST(valD, minusOneD);
-    TEST_NOTHROW(valD = as<double> (os.str ()));
+    TEST_NOTHROW(valD = as<double> (valToString(minusOneD)));
     TEST_EQUALITY_CONST(valD, minusOneD);
   }
 
@@ -409,22 +423,21 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   // if sizeof(long double) > sizeof(double).
   //
   if (sizeof (long double) > sizeof (double)) {
+    out << "Testing converting from 'long double' to 'double' that does not fit ...\n";
     {
-      std::ostringstream os;
-      os.precision (36);
-      os << minLD;
-      TEST_THROW(valD = asSafe<double> (os.str ()), std::range_error);
+      TEST_THROW(valD = asSafe<double>(valToString(minLD)), std::range_error);
+      out << "valD = " << valD << "\n";
     }
     {
       std::ostringstream os;
       os.precision (36);
-      os << maxLD;
-      TEST_THROW(valD = asSafe<double> (os.str ()), std::range_error);
+      TEST_THROW(valD = asSafe<double>(valToString(maxLD)), std::range_error);
+      out << "valD = " << valD << "\n";
     }
   }
 
   //
-  // Test string -> long double conversions.
+  out << "Testing string -> long double conversions ...\n";
   //
   {
     std::ostringstream os;

--- a/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
+++ b/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
@@ -422,7 +422,19 @@ TEUCHOS_UNIT_TEST( asSafe, stringToReal ) {
   // Test string -> double conversions that should throw,
   // if sizeof(long double) > sizeof(double).
   //
-  if (sizeof (long double) > sizeof (double)) {
+  const int sizeof_long_double = sizeof(long double);
+  const int sizeof_double = sizeof(double);
+  const int max_exponent10_long_double = std::numeric_limits<long double>::max_exponent10;
+  const int max_exponent10_double = std::numeric_limits<double>::max_exponent10;
+
+  out << "sizeof_long_double = " << sizeof_long_double << "\n";
+  out << "sizeof_double = " << sizeof_double << "\n";
+  out << "max_exponent10_long_double = " << max_exponent10_long_double << "\n";
+  out << "max_exponent10_double = " << max_exponent10_double << "\n";
+ 
+  if (sizeof_long_double > sizeof_double
+    && max_exponent10_long_double > max_exponent10_double)
+  {
     out << "Testing converting from 'long double' to 'double' that does not fit ...\n";
     {
       TEST_THROW(valD = asSafe<double>(valToString(minLD)), std::range_error);


### PR DESCRIPTION
**CC:** @trilinos/teuchos, @mhoemmen 

## Description

This PR branch improves the outputting of some of the Teuchos type conversion code unit tests and it fixes a problem with a safeAs() test on power8 systems.  This addresses issue #2407.

Now, building and running with:

```
./TeuchosCore_TypeConversions_UnitTest.exe --test=stringToReal --details=ALL
```

passes as shown below on two systems.

With this change, on my Linux machine crf450 the unit test output shows:

```
1. asSafe_stringToReal_UnitTest ... 
 minLD = -1.19e+4932
 minusOneLD = -1
 maxLD = 1.19e+4932
 ...
 sizeof_long_double = 16
 sizeof_double = 8
 max_exponent10_long_double = 4932
 max_exponent10_double = 308
 Testing converting from 'long double' to 'double' that does not fit ...
 Test that code {valD = asSafe<double>(valToString(minLD));} throws std::range_error: passed
 
 Exception message for expected exception:
 
  /ascldap/users/rabartl/Trilinos.base/Trilinos/packages/teuchos/core/src/Teuchos_as.hpp:558:
  
  Throw number = 3
  
  Throw test that evaluated to true: errno == ERANGE && (val != 0)
  
  Teuchos::ValueTypeConversionTraits<double, std::string>::convert: The value in the given string "-1.189731495357231765021263853e+4932" overflows double.
  
 valD = -1
 Test that code {valD = asSafe<double>(valToString(maxLD));} throws std::range_error: passed
 
 Exception message for expected exception:
 
  /ascldap/users/rabartl/Trilinos.base/Trilinos/packages/teuchos/core/src/Teuchos_as.hpp:558:
  
  Throw number = 4
  
  Throw test that evaluated to true: errno == ERANGE && (val != 0)
  
  Teuchos::ValueTypeConversionTraits<double, std::string>::convert: The value in the given string "1.189731495357231765021263853e+4932" overflows double.
  
 valD = -1
 Testing string -> long double conversions ...
 ...
 [Passed] (0.000535 sec)

Total Time: 0.000829 sec

Summary: total = 116, run = 1, passed = 1, failed = 0

End Result: TEST PASSED
```

So it runs the unit tests `Testing converting from 'long double' to 'double' that does not fit` gets run since both the sizeof() and max_exponent10 values for long double are larger than for double.  So these important tests run.

But when I run this unit test now on the power8 machine `ride` with the the `gnu-debug-openmp` build as shown above, it shows:

```
1. asSafe_stringToReal_UnitTest ... 
 minLD = -1.8e+308
 minusOneLD = -1
 maxLD = 1.8e+308
 ...
 sizeof_long_double = 16
 sizeof_double = 8
 max_exponent10_long_double = 308
 max_exponent10_double = 308
 Testing string -> long double conversions ...
  ...
 [Passed] (0.000418 sec)

Total Time: 0.000783 sec

Summary: total = 116, run = 1, passed = 1, failed = 0

End Result: TEST PASSED
```

See, that shows that on this machine `max_exponent10_long_double` = `max_exponent10_double` = `308` and the checks printed in the section `Testing converting from 'long double' to 'double' that does not fit` are skipped and instead it goes straight to `Testing string -> long double conversions`.

I think this is the right thing to do to fix these tests and it informs something about this system.
 