### PR TITLE
Tpetra: Fix #2372

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -386,3 +386,5 @@ SET_PROPERTY(
 # subdirectory.  That ensures that running "make" will also rerun
 # CMake in order to regenerate Makefiles.
 #
+# Here is another such change.
+#

--- a/packages/tpetra/core/src/Tpetra_Core.cpp
+++ b/packages/tpetra/core/src/Tpetra_Core.cpp
@@ -209,9 +209,14 @@ namespace Tpetra {
   void initialize (int* argc, char*** argv, MPI_Comm comm)
   {
     initialize (argc, argv);
-    // Set the default communicator.  What if users have already
-    // called initialize() before, but with a different default
-    // communicator?  There are two possible things we could do here:
+    // Set the default communicator.  We set it here, after the above
+    // initialize() call, just in case users have not yet initialized
+    // MPI.  (This is legal if users pass in a predefined
+    // communicator, like MPI_COMM_WORLD or MPI_COMM_SELF.)
+    //
+    // What if users have already called initialize() before, but with
+    // a different default communicator?  There are two possible
+    // things we could do here:
     //
     //   1. Test via MPI_Comm_compare whether comm differs from the
     //      raw MPI communicator in wrappedDefaultComm_ (if indeed it
@@ -235,23 +240,8 @@ namespace Tpetra {
               const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
   {
     initialize (argc, argv);
-    // Set the default communicator.  What if users have already
-    // called initialize() before, but with a different default
-    // communicator?  There are two possible things we could do here:
-    //
-    //   1. Test via MPI_Comm_compare whether comm differs from the
-    //      raw MPI communicator in wrappedDefaultComm_ (if indeed it
-    //      is an MpiComm).
-    //   2. Accept that the user might want to change the default
-    //      communicator, and let them do it.
-    //
-    // I prefer #2.  Perhaps it would be sensible to print a warning
-    // here, but on which process?  Would we use the old or the new
-    // communicator to find that process' rank?  We don't want to use
-    // MPI_COMM_WORLD's Process 0, since neither communicator might
-    // include that process.  Furthermore, in some environments, only
-    // Process 0 in MPI_COMM_WORLD is allowed to do I/O.  Thus, we
-    // just let the change go without a warning.
+    // See notes above on why we set the default communicator after
+    // calling two-argument initialize().
     wrappedDefaultComm_ = comm;
   }
 

--- a/packages/tpetra/core/src/Tpetra_Core.cpp
+++ b/packages/tpetra/core/src/Tpetra_Core.cpp
@@ -44,9 +44,8 @@
 
 #ifdef HAVE_TPETRACORE_MPI
 #  include <Teuchos_DefaultMpiComm.hpp> // this includes mpi.h too
-#else
-#  include <Teuchos_DefaultSerialComm.hpp>
 #endif // HAVE_TPETRACORE_MPI
+#include <Teuchos_DefaultSerialComm.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -74,6 +73,45 @@ namespace Tpetra {
       Teuchos::oblackholestream blackHole_;
     };
 
+#if defined(HAVE_TPETRACORE_MPI)
+    bool mpiIsInitializedAndNotFinalized ()
+    {
+      int isInitialized = 0;
+      int isFinalized = 0;
+      // Not sure if MPI_Initialized or MPI_Finalized meet the strong
+      // exception guarantee.
+      try {
+	(void) MPI_Initialized (&isInitialized);
+      }
+      catch (...) {
+	isInitialized = 0;
+      }
+      try {
+	(void) MPI_Finalized (&isFinalized);
+      }
+      catch (...) {
+	isFinalized = 0;
+      }
+      return isInitialized != 0 && isFinalized == 0;
+    }
+
+    int getRankHarmlessly (MPI_Comm comm)
+    {
+      int myRank = 0;      
+      if (mpiIsInitializedAndNotFinalized ()) {
+	try {
+	  (void) MPI_Comm_rank (comm, &myRank);
+	}
+	catch (...) {
+	  // Not sure if MPI_Comm_rank meets strong exception guarantee
+	  myRank = 0;
+	}
+      }
+      return myRank;
+    }
+#endif // defined(HAVE_TPETRACORE_MPI)
+    
+
     // Whether one of the Tpetra::initialize() functions has been called before.
     bool tpetraIsInitialized_ = false;
 
@@ -94,9 +132,8 @@ namespace Tpetra {
     // After Tpetra::finalize() is called, this GOES AWAY (is set to null).
     Teuchos::RCP<const Teuchos::Comm<int> > wrappedDefaultComm_;
 
-    // Initialize Kokkos, if it needs initialization.
     // This takes the same arguments as (the first two of) initialize().
-    void initKokkos (int* argc, char*** argv)
+    void initKokkosIfNeeded (int* argc, char*** argv, const int myRank)
     {
       if (! tpetraInitializedKokkos_) {
         // Kokkos doesn't have a global is_initialized().  However,
@@ -105,13 +142,6 @@ namespace Tpetra {
         const bool kokkosIsInitialized =
           Kokkos::DefaultExecutionSpace::is_initialized ();
         if (! kokkosIsInitialized) {
-          int myRank = 0;
-          const bool mpiHasBeenInitialized = Details::mpiIsInitialized ();
-          if (mpiHasBeenInitialized) { // always false if not built with MPI
-            auto comm = getDefaultComm ();
-            myRank = comm->getRank ();
-          }
-
           HideOutputExceptOnProcess0 hideCerr (std::cerr, myRank);
           HideOutputExceptOnProcess0 hideCout (std::cout, myRank);
 
@@ -124,19 +154,26 @@ namespace Tpetra {
       const bool kokkosIsInitialized =
         Kokkos::DefaultExecutionSpace::is_initialized ();
       TEUCHOS_TEST_FOR_EXCEPTION
-        (! kokkosIsInitialized, std::logic_error, "At the end of initKokkos, "
-         "Kokkos is not initialized.  Please report this bug to the Tpetra "
-         "developers.");
+        (! kokkosIsInitialized, std::logic_error, "At the end of "
+	 "initKokkosIfNeeded, Kokkos is not initialized.  "
+	 "Please report this bug to the Tpetra developers.");
     }
 
 #ifdef HAVE_TPETRACORE_MPI
-    // Initialize MPI, if needed, and check for errors.  This takes
-    // the same arguments as MPI_Init and the first two arguments of
-    // initialize().
-    void initMpi (int* argc, char*** argv)
+    // This takes the same arguments as MPI_Init and the first two
+    // arguments of initialize().
+    void initMpiIfNeeded (int* argc, char*** argv)
     {
-      const bool mpiAlreadyInitialized = Details::mpiIsInitialized ();
-      if (! mpiAlreadyInitialized) {
+      // Both MPI_Initialized and MPI_Finalized report true after
+      // MPI_Finalize has been called.  It's not legal to call
+      // MPI_Init after MPI_Finalize has been called (see MPI 3.0
+      // Standard, Section 8.7).  It would be unusual for users to
+      // want to use Tpetra after MPI_Finalize has been called, but
+      // there's no reason why we should forbid it.  It just means
+      // that Tpetra will need to run without MPI.
+
+      const bool mpiReady = mpiIsInitializedAndNotFinalized ();
+      if (! mpiReady) {
 	// Tpetra doesn't currently need to call MPI_Init_thread,
 	// since with Tpetra, only one thread ever calls MPI
 	// functions.  If we ever want to explore
@@ -153,8 +190,6 @@ namespace Tpetra {
         tpetraInitializedMpi_ = true;
       }
     }
-#else
-    void initMpi (int* /* argc */, char*** /* argv */) {}
 #endif // HAVE_TPETRACORE_MPI
 
   } // namespace (anonymous)
@@ -165,29 +200,25 @@ namespace Tpetra {
 
   Teuchos::RCP<const Teuchos::Comm<int> > getDefaultComm ()
   {
-    // It's OK to call this function if Tpetra::initialize hasn't been
-    // called.  Users aren't obligated to call Tpetra::initialize, as
-    // long as they take responsibility for initializing Kokkos and
-    // MPI.  However, MPI must be initialized.  (Kokkos need not be
-    // initialized for this method to be called.)
-
-#ifdef HAVE_TPETRACORE_MPI
-    const bool mpiInitd = Details::mpiIsInitialized ();
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (! mpiInitd, std::runtime_error,
-       "Tpetra::getDefaultComm: MPI has not been initialized.  Before "
-       "calling this method, you must either initialize MPI (by calling "
-       "MPI_Init), or you must call Tpetra::initialize (which initializes "
-       "MPI, if it has not yet been initialized).");
-#endif // HAVE_TPETRACORE_MPI
-
-    // This serves as lazy initialization.  Thus, the various
-    // Tpetra::initialize functions do not need to set up
-    // wrappedDefaultComm_.
+    // It's technically not correct to call this function if Tpetra
+    // has not yet been initialized, but requiring that may break some
+    // downstream tests.
+    //
+    // This function initializes wrappedDefaultComm_ lazily.
+    // Tpetra::initialize should not set it up.
     if (wrappedDefaultComm_.is_null ()) {
       Teuchos::RCP<const Teuchos::Comm<int> > comm;
 #ifdef HAVE_TPETRACORE_MPI
-      comm = Teuchos::rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+      // Teuchos::MpiComm's constructor used to invoke MPI collectives.
+      // It still reserves the right to do so.  This means MPI must be
+      // initialized and not finalized.
+      const bool mpiReady = mpiIsInitializedAndNotFinalized ();
+      if (mpiReady) {
+	comm = Teuchos::rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+      }
+      else {
+	comm = Teuchos::rcp (new Teuchos::SerialComm<int> ());
+      }
 #else
       comm = Teuchos::rcp (new Teuchos::SerialComm<int> ());
 #endif // HAVE_TPETRACORE_MPI
@@ -195,12 +226,20 @@ namespace Tpetra {
     }
     return wrappedDefaultComm_;
   }
-
+  
   void initialize (int* argc, char*** argv)
   {
     if (! tpetraIsInitialized_) {
-      initMpi (argc, argv); // initialize MPI, if needed
-      initKokkos (argc, argv); // initialize Kokkos, if needed
+#if defined(HAVE_TPETRACORE_MPI)      
+      initMpiIfNeeded (argc, argv);
+      // It's technically legal to initialize Tpetra after
+      // MPI_Finalize has been called.  This means that we can't call
+      // MPI_Comm_rank without first checking MPI_Finalized.
+      const int myRank = getRankHarmlessly (MPI_COMM_WORLD);
+#else
+      const int myRank = 0;
+#endif // defined(HAVE_TPETRACORE_MPI)      
+      initKokkosIfNeeded (argc, argv, myRank);
     }
     tpetraIsInitialized_ = true;
   }
@@ -208,7 +247,20 @@ namespace Tpetra {
 #ifdef HAVE_TPETRACORE_MPI
   void initialize (int* argc, char*** argv, MPI_Comm comm)
   {
-    initialize (argc, argv);
+    if (! tpetraIsInitialized_) {
+#if defined(HAVE_TPETRACORE_MPI)      
+      initMpiIfNeeded (argc, argv);
+      // It's technically legal to initialize Tpetra after
+      // MPI_Finalize has been called.  This means that we can't call
+      // MPI_Comm_rank without first checking MPI_Finalized.
+      const int myRank = getRankHarmlessly (comm); 
+#else
+      const int myRank = 0;
+#endif // defined(HAVE_TPETRACORE_MPI)      
+      initKokkosIfNeeded (argc, argv, myRank);
+    }
+    tpetraIsInitialized_ = true;
+    
     // Set the default communicator.  We set it here, after the above
     // initialize() call, just in case users have not yet initialized
     // MPI.  (This is legal if users pass in a predefined
@@ -239,9 +291,17 @@ namespace Tpetra {
   initialize (int* argc, char*** argv,
               const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
   {
-    initialize (argc, argv);
-    // See notes above on why we set the default communicator after
-    // calling two-argument initialize().
+    if (! tpetraIsInitialized_) {
+#if defined(HAVE_TPETRACORE_MPI)   
+      initMpiIfNeeded (argc, argv);
+#endif // defined(HAVE_TPETRACORE_MPI)
+      // It's technically legal to initialize Tpetra after
+      // MPI_Finalize has been called.  This means that we can't call
+      // MPI_Comm_rank without first checking MPI_Finalized.
+      const int myRank = comm->getRank ();
+      initKokkosIfNeeded (argc, argv, myRank);
+    }
+    tpetraIsInitialized_ = true;
     wrappedDefaultComm_ = comm;
   }
 

--- a/packages/tpetra/core/src/Tpetra_Details_mpiIsInitialized.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_mpiIsInitialized.cpp
@@ -1,0 +1,65 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Tpetra_Details_mpiIsInitialized.hpp"
+#ifdef HAVE_TPETRACORE_MPI
+#  include "mpi.h"
+#  include <iostream>
+#endif // HAVE_TPETRACORE_MPI
+
+namespace Tpetra {
+  namespace Details {
+    
+    bool mpiIsInitialized ()
+    {
+#ifdef HAVE_TPETRACORE_MPI
+      int isInitialized = 0;
+      const int errCode = MPI_Initialized (&isInitialized);
+      // If the call failed, then assume MPI wasn't implemented
+      // correctly and return false.
+      return errCode == MPI_SUCCESS && (isInitialized != 0);
+#else
+      return false; // Tpetra was not built with MPI support
+#endif // HAVE_TPETRACORE_MPI
+    }
+    
+  } // namespace Details
+} // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Details_mpiIsInitialized.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_mpiIsInitialized.hpp
@@ -1,0 +1,69 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_MPIISINITIALIZED
+#define TPETRA_DETAILS_MPIISINITIALIZED
+
+#include "TpetraCore_config.h"
+
+namespace Tpetra {
+  namespace Details {
+
+    /// \brief Has MPI_Init been called (on this process)?
+    ///
+    /// If Tpetra was built with MPI support, then this wraps
+    /// MPI_Initialized.  If Tpetra was not built with MPI support,
+    /// then this always returns false, regardless of whether the user
+    /// has built with MPI.
+    ///
+    /// MPI (at least 3.0) only permits MPI to be initialized once.
+    /// After MPI_Init has been called on a process, MPI_Initialized
+    /// always returns true on that process, regardless of whether
+    /// MPI_Finalize has been called.
+    ///
+    /// If you want to know whether MPI_Finalize has been called on
+    /// this process, use MPI_Finalized.
+    bool mpiIsInitialized ();
+
+  } // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_MPIISINITIALIZED

--- a/packages/tpetra/core/src/Tpetra_Details_printOnce.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_printOnce.cpp
@@ -1,0 +1,121 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Tpetra_Details_printOnce.hpp"
+
+#if defined(HAVE_TPETRACORE_MPI)
+#  include "Teuchos_DefaultMpiComm.hpp"
+#else
+#  include "Teuchos_Comm.hpp"
+#endif // defined(HAVE_TPETRACORE_MPI)
+
+namespace { // (anonymous)
+  bool mpiIsInitialized ()
+  {
+#if defined(HAVE_TPETRACORE_MPI)
+    int isInitialized = 0;
+    try {
+      (void) MPI_Initialized (&isInitialized);
+    }
+    catch (...) {
+      // Not sure if MPI_Initialized meets strong exception guarantee
+      isInitialized = 0;
+    }
+    return isInitialized != 0;
+#else
+    return false;
+#endif // defined(HAVE_TPETRACORE_MPI)
+  }
+
+  bool mpiIsFinalized ()
+  {
+#if defined(HAVE_TPETRACORE_MPI)
+    int isFinalized = 0;
+    try {
+      (void) MPI_Finalized (&isFinalized);
+    }
+    catch (...) {
+      // Not sure if MPI_Initialized meets strong exception guarantee
+      isFinalized = 0;
+    }
+    return isFinalized != 0;
+#else
+    return false;
+#endif // defined(HAVE_TPETRACORE_MPI)
+  }
+
+#if defined(HAVE_TPETRACORE_MPI)  
+  bool isMpiComm (const Teuchos::Comm<int>& comm)
+  {
+    using mpi_comm_type = Teuchos::MpiComm<int>;
+    return dynamic_cast<const mpi_comm_type* > (&comm) != nullptr;
+  }
+#else
+  bool isMpiComm (const Teuchos::Comm<int>& /* comm */ )
+  {
+    return false;
+  }
+#endif // defined(HAVE_TPETRACORE_MPI)    
+  
+  int getRankHarmlessly (const Teuchos::Comm<int>& comm)
+  {
+    if (mpiIsInitialized () && ! mpiIsFinalized () && isMpiComm (comm)) {
+      return comm.getRank ();
+    }
+    else {
+      return 0;
+    }
+  }
+} // namespace (anonymous)  
+
+namespace Tpetra {
+  namespace Details {
+    void
+    printOnce (std::ostream& out,
+	       const std::string& s,
+	       const Teuchos::Comm<int>* comm)
+    {
+      if (comm == nullptr || getRankHarmlessly (*comm) == 0) {
+      	out << s;
+      }
+    }
+  } // namespace Details
+} // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Details_printOnce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_printOnce.hpp
@@ -1,0 +1,82 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/// \file Tpetra_Details_printOnce.hpp
+/// \brief Declaration of Tpetra::Details::printOnce.
+
+#ifndef TPETRA_DETAILS_PRINTONCE_HPP
+#define TPETRA_DETAILS_PRINTONCE_HPP
+
+#include "TpetraCore_config.h"
+#include <ostream>
+#include <string>
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace Teuchos {
+// Forward declaration of Comm.
+template <class OrdinalType> class Comm;
+} // namespace Teuchos
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+namespace Tpetra {
+namespace Details {
+  
+/// \brief Print on one process of the given communicator, or at least
+///   try to do so (if MPI is not initialized).
+///
+/// \param out [out] Output stream to which to print.  If MPI is
+///   initialized, then it need only be valid on Process 0 of the
+///   given communicator.  Otherwise, it must be valid on all
+///   processes of the given communicator.
+///
+/// \param s [in] String to print.
+///
+/// \param comm [in] Communicator; if nullptr, print on all processes,
+///   else, print based on above rule.
+void
+printOnce (std::ostream& out,
+	   const std::string& s,
+	   const Teuchos::Comm<int>* comm);
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_PRINTONCE_HPP

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -50,6 +50,8 @@
 #include "Tpetra_Directory.hpp" // must include for implicit instantiation to work
 #include "Tpetra_Details_FixedHashTable.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
+#include "Tpetra_Details_printOnce.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Util.hpp"
 #include "Teuchos_as.hpp"
 #include "Teuchos_TypeNameTraits.hpp"
@@ -1047,7 +1049,18 @@ namespace Tpetra {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Map<LocalOrdinal,GlobalOrdinal,Node>::~Map ()
-  {}
+  {
+    if (! Tpetra::isInitialized ()) {
+      std::ostringstream os;
+      os << "WARNING: Tpetra::Map destructor (~Map()) is being called after "
+	"Tpetra::finalize() has been called.  This is user error!  This may "
+	"happen if you create a Tpetra::Map (or RCP or shared_ptr of a "
+	"Tpetra::Map) at the same scope in main() as Tpetra::finalize().  "
+	"Don't do that.  Please refer to GitHib Issue #2372." << std::endl;
+      ::Tpetra::Details::printOnce (std::cerr, os.str (),
+				    this->getComm ().getRawPtr ());
+    }
+  }
 
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/test/CMakeLists.txt
+++ b/packages/tpetra/core/test/CMakeLists.txt
@@ -9,6 +9,7 @@ ADD_SUBDIRECTORIES(
   Block
   BugTests
   Comm
+  Core  
   CrsGraph
   CrsMatrix
   Directory

--- a/packages/tpetra/core/test/Core/CMakeLists.txt
+++ b/packages/tpetra/core/test/Core/CMakeLists.txt
@@ -13,3 +13,50 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM mpi
   STANDARD_PASS_OUTPUT
   )
+
+# This test does an MPI_Comm_split,
+# so it needs at least 2 processes.
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_user_initializes_mpi_and_provides_comm
+  SOURCES
+    initialize_user_inits_mpi_and_provides_comm
+  COMM mpi
+  NUM_MPI_PROCS 2-4
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_tpetra_initializes_kokkos
+  SOURCES
+    initialize_tpetra_inits_kokkos
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_user_initializes_kokkos
+  SOURCES
+    initialize_user_inits_kokkos
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_tpetra_initializes_mpi_and_user_initializes_kokkos
+  SOURCES
+    initialize_tpetra_inits_mpi_user_inits_kokkos
+  COMM mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_user_initializes_mpi_and_tpetra_initializes_kokkos
+  SOURCES
+    initialize_user_inits_mpi_tpetra_inits_kokkos
+  COMM mpi
+  NUM_MPI_PROCS 2  
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/Core/CMakeLists.txt
+++ b/packages/tpetra/core/test/Core/CMakeLists.txt
@@ -1,0 +1,15 @@
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_tpetra_initializes_mpi
+  SOURCES
+    initialize_tpetra_inits_mpi
+  COMM mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_initialize_where_user_initializes_mpi
+  SOURCES
+    initialize_user_inits_mpi
+  COMM mpi
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/Core/initialize_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_tpetra_inits_kokkos.cpp
@@ -1,0 +1,110 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+namespace { // (anonymous)
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  // In this example, Tpetra::initialize is responsible for calling
+  // Kokkos::initialize and Kokkos::finalize.
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "before Tpetra::initialize was called." << endl;
+    return;
+  }
+  Tpetra::initialize (&argc, &argv);
+
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "after Tpetra::initialize was called." << endl;
+  }
+  if (! Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Tpetra::isInitialized() is false, "
+      "even after Tpetra::initialize was called." << endl;
+  }
+
+  auto comm = Tpetra::getDefaultComm ();
+  if (comm.is_null ()) {
+    success = false;
+    cout << "Tpetra::getDefaultComm() is null." << endl;
+  }
+
+  cout << "About to call Tpetra::finalize." << endl;
+  Tpetra::finalize ();
+  cout << "Called Tpetra::finalize." << endl;
+
+  // Kokkos is like Tpetra; Kokkos::is_initialized() means "was
+  // initialized and was not finalized."  That differs from MPI, where
+  // MPI_Initialized only refers to MPI_Init and MPI_Finalized only
+  // refers to MPI_Finalize.
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Tpetra::finalize did not call Kokkos::finalize." << endl;
+    return;
+  }
+
+  // MPI is no longer initialized, so we can't all-reduce on this.
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Tpetra::isInitialized() is true, "
+      "even after Tpetra::finalize has been called" << endl;
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {  
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)  
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+ 
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+  
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/initialize_tpetra_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/initialize_tpetra_inits_mpi.cpp
@@ -1,0 +1,198 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+bool isMpiFinalized ()
+{
+  int mpiFinalizedInt = 0;
+  (void) MPI_Finalized (&mpiFinalizedInt);
+  return mpiFinalizedInt != 0;
+}
+  
+int getRankInCommWorld ()
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
+  return myRank;
+}
+
+bool allTrueInCommWorld (const bool lclTruth)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1, MPI_INT,
+		 MPI_MIN, MPI_COMM_WORLD);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (MPI_COMM_WORLD, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup on the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+  
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  // In this example, Tpetra::initialize is responsible for calling
+  // MPI_Init and MPI_Finalize.
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is initialized, "
+      "before Tpetra::initialize was called." << endl;
+    return;
+  }
+  Tpetra::initialize (&argc, &argv);
+
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is not initialized, "
+      "even after MPI_Init and Tpetra::initialize were called." << endl;
+    Tpetra::finalize (); // just for completeness
+    return;
+  }
+  const int myRank = getRankInCommWorld ();
+
+  // MPI is initialized, so we can check whether all processes report
+  // Tpetra as initialized.
+  const bool tpetraIsNowInitialized =
+    allTrueInCommWorld (Tpetra::isInitialized ());
+  if (! tpetraIsNowInitialized) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() is false on at least one process, "
+	"even after Tpetra::initialize() has been called." << endl;
+    }
+    MPI_Finalize (); // just for completeness
+    return;
+  }
+
+  auto comm = Tpetra::getDefaultComm ();
+  const bool tpetraCommGloballyValid =
+    allTrueInCommWorld (tpetraCommIsLocallyLegit (comm.get ()));
+  if (! tpetraCommGloballyValid) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::getDefaultComm() returns an invalid comm "
+	"on at least one process." << endl;
+    }
+  }
+
+  const int myTpetraRank = comm->getRank ();
+  const bool ranksSame = allTrueInCommWorld (myRank == myTpetraRank);
+  if (! ranksSame) {
+    success = false;
+    if (myRank == 0) {
+      cout << "MPI rank does not match Tpetra rank "
+	"on at least one process" << endl;
+    }
+  }
+
+  if (myRank == 0) {
+    cout << "About to call Tpetra::finalize" << endl;
+  }
+  Tpetra::finalize ();
+  if (myRank == 0) {
+    cout << "Called Tpetra::finalize" << endl;
+  }
+  // Since Tpetra is responsible for calling MPI_Finalize,
+  // Tpetra::finalize MUST have called MPI_Finalize.
+  if (! isMpiFinalized ()) {
+    success = false;
+    cout << "Tpetra::finalize() did not call MPI_Finalize." << endl;
+  }
+
+  // MPI is no longer initialized, so we can't all-reduce on this.
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() returns true, "
+	"even after Tpetra::finalize() has been called" << endl;
+    }
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {  
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)  
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+ 
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+  
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/initialize_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_kokkos.cpp
@@ -1,0 +1,120 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+namespace { // (anonymous)
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "even before Kokkos::initialize was called." << endl;
+    return;
+  }
+  Kokkos::initialize (argc, argv);
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "even after Kokkos::initialize was called." << endl;
+    return;
+  }
+
+  // In this example, the "user" has called Kokkos::initialize before
+  // Tpetra::initialize is called.  Tpetra::initialize must not try to
+  // call it again.
+  Tpetra::initialize (&argc, &argv);
+  if (! Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Tpetra::isInitialized() is false, "
+      "even after Tpetra::initialize was called."
+      << endl;
+    return;
+  }
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "even after Kokkos::initialize and Tpetra::initialize were called."
+      << endl;
+    // Let the program keep going, so MPI (if applicable) gets finalized.
+  }
+
+  cout << "About to call Tpetra::finalize" << endl;
+  Tpetra::finalize ();
+  cout << "Called Tpetra::finalize" << endl;
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Tpetra::isInitialized() is true, "
+      "even after Tpetra::finalize was called."
+      << endl;
+    // Let the program keep going, so Kokkos gets finalized.
+  }
+
+  // Since the "user" is responsible for calling Kokkos::finalize,
+  // Tpetra::finalize should NOT have called Kokkos::finalize.
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "after Tpetra::initialize was called." << endl;
+  }
+  Kokkos::finalize ();
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "even after Kokkos::initialize was called." << endl;
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {  
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)  
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+ 
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+  
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/initialize_user_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_mpi.cpp
@@ -1,0 +1,208 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+int getRankInCommWorld ()
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
+  return myRank;
+}
+
+bool allTrueInCommWorld (const bool lclTruth)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1, MPI_INT,
+		 MPI_MIN, MPI_COMM_WORLD);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (MPI_COMM_WORLD, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup on the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+  
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is initialized, "
+      "before MPI_Init was called" << endl;
+    return;
+  }
+  (void) MPI_Init (&argc, &argv);
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is not initialized, "
+      "even after MPI_Init was called" << endl;
+    return;
+  }
+  const int myRank = getRankInCommWorld ();
+
+  // In this example, the "user" has called MPI_Init before
+  // Tpetra::initialize is called.  Tpetra::initialize must not try to
+  // call it again.
+  Tpetra::initialize (&argc, &argv);
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "Hm, MPI_Initialized claims MPI is not initialized, "
+      "even after MPI_Init and Tpetra::initialize were called" << endl;
+    Tpetra::finalize (); // just for completeness
+    return;
+  }
+
+  // MPI is initialized, so we can check whether all processes report
+  // Tpetra as initialized.
+  const bool tpetraIsNowInitialized =
+    allTrueInCommWorld (Tpetra::isInitialized ());
+  if (! tpetraIsNowInitialized) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() is false on at least one process, "
+	"even after Tpetra::initialize() has been called." << endl;
+    }
+    (void) MPI_Finalize (); // just for completeness
+    return;
+  }
+
+  auto comm = Tpetra::getDefaultComm ();
+  const bool tpetraCommGloballyValid =
+    allTrueInCommWorld (tpetraCommIsLocallyLegit (comm.get ()));
+  if (! tpetraCommGloballyValid) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::getDefaultComm() returns an invalid comm "
+	"on at least one process." << endl;
+    }
+  }
+
+  const int myTpetraRank = comm->getRank ();
+  const bool ranksSame = allTrueInCommWorld (myRank == myTpetraRank);
+  if (! ranksSame) {
+    success = false;
+    if (myRank == 0) {
+      cout << "MPI rank does not match Tpetra rank "
+	"on at least one process" << endl;
+    }
+  }
+
+  if (myRank == 0) {
+    cout << "About to call Tpetra::finalize" << endl;
+  }
+  Tpetra::finalize ();
+  if (myRank == 0) {
+    cout << "Called Tpetra::finalize" << endl;
+  }
+  // Since the "user" is responsible for calling MPI_Finalize,
+  // Tpetra::finalize should NOT have called MPI_Finalize.
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "Tpetra::finalize() seems to have called MPI_Finalize, "
+      "even though the user was responsible for initializing and "
+      "finalizing MPI." << endl;
+    return;
+  }
+
+  // MPI is still initialized, so we can check whether processes are
+  // consistent.
+  const bool tpetraGloballyFinalized =
+    allTrueInCommWorld (! Tpetra::isInitialized ());
+  if (! tpetraGloballyFinalized) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() returns true on some process, "
+	"even after Tpetra::finalize() has been called" << endl;
+    }
+    return;
+  }
+
+  (void) MPI_Finalize ();
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {  
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)  
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+ 
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+  
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Map/CMakeLists.txt
+++ b/packages/tpetra/core/test/Map/CMakeLists.txt
@@ -200,3 +200,19 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1-4
   STANDARD_PASS_OUTPUT
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Map_warn_on_post_finalize_destruction_issue_2372
+  SOURCES
+    Map_warn_on_post_finalize_destruction
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Map_no_warn_on_pre_finalize_destruction_issue_2372
+  SOURCES
+    Map_no_warn_on_pre_finalize_destruction
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/Map/Map_no_warn_on_pre_finalize_destruction.cpp
+++ b/packages/tpetra/core/test/Map/Map_no_warn_on_pre_finalize_destruction.cpp
@@ -1,0 +1,106 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+
+namespace { // (anonymous)
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;  
+
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Hm, Tpetra::isInitialized() returns true "
+      "even before Tpetra::initialize() has been called." << endl;
+    return;
+  }
+  
+  Tpetra::initialize (&argc, &argv);
+
+  auto comm = Tpetra::getDefaultComm ();
+  const int myRank = comm->getRank ();
+  const int numProcs = comm->getSize ();
+
+  if (myRank == 0) {
+    cout << "Tpetra::initialize has been called; about to create Map" << endl;
+  }
+
+  {
+    Tpetra::Map<> map (numProcs, 0, comm);
+    if (myRank == 0) {
+      // Print so that the compiler doesn't try eliding Map (it
+      // shouldn't, since the constructor may have side effects).
+      cout << "Map's global number of indices: " << map.getGlobalNumElements ()
+	   << endl;
+    }
+  } // Map's destructor gets called here
+
+  if (myRank == 0) {
+    cout << "Created and destroyed Map; about to call Tpetra::finalize" << endl;
+  }
+
+  Tpetra::finalize ();
+  if (myRank == 0) {
+    cout << "Called Tpetra::finalize" << endl;
+  }
+
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Hm, Tpetra::isInitialized() returns true "
+	"even after Tpetra::finalize() has been called" << endl;
+    }
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)  
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Map's destructor
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is not empty!" << endl;
+    }
+  }
+  
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Map/Map_warn_on_post_finalize_destruction.cpp
+++ b/packages/tpetra/core/test/Map/Map_warn_on_post_finalize_destruction.cpp
@@ -1,0 +1,104 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+
+namespace { // (anonymous)
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Hm, Tpetra::isInitialized() returns true "
+      "even before Tpetra::initialize() has been called" << endl;
+    return;
+  }
+  
+  Tpetra::initialize (&argc, &argv);
+
+  auto comm = Tpetra::getDefaultComm ();
+  const int myRank = comm->getRank ();
+  const int numProcs = comm->getSize ();
+
+  if (myRank == 0) {
+    cout << "Tpetra::initialize has been called; about to create Map" << endl;
+  }
+
+  // NOTE: This is INCORRECT BEHAVIOR, because the Map outlives
+  // Tpetra::finalize.  DO NOT WRITE CODE LIKE THIS!  The point is to
+  // test whether Map's destructor prints an error message per GitHub
+  // Issue #2372.  Map's destructor must print to std::cerr in this
+  // case; the code that calls testMain will capture std::cerr output
+  // in order to check correct behavior.
+  Tpetra::Map<> map (numProcs, 0, comm);
+
+  if (myRank == 0) {
+    cout << "Created Map; about to call Tpetra::finalize" << endl;
+  }
+
+  Tpetra::finalize ();
+  if (myRank == 0) {
+    cout << "Called Tpetra::finalize" << endl;
+  }
+
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Hm, Tpetra::isInitialized() returns true "
+	"even after Tpetra::finalize() has been called" << endl;
+    }
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {  
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)  
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+ 
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Map's destructor
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () == 0) {
+      success = false; // SHOULD have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+  
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Platform/issue_434_already_initialized.cpp
+++ b/packages/tpetra/core/test/Platform/issue_434_already_initialized.cpp
@@ -209,7 +209,7 @@ main (int argc, char* argv[])
       goto EndOfTest;
     }
     else {
-      if (mpiIsFinalized == 0) {
+      if (mpiIsFinalized == 1) {
         err << "*** MPI_Finalized says MPI was finalized" << endl;
         success = false;
         goto EndOfTest; // MPI is finalized, so this is safe to do


### PR DESCRIPTION
Make `Tpetra::Map`'s destructor print a useful warning, on Process 0 of the Map's communicator only, if users finalized Kokkos before Map's destructor was called.  This fixes #2372.  Also fix an issue with `Tpetra::initialize` when the user called `MPI_Init` before `Tpetra::initialize` was called.

@trilinos/tpetra 

This PR supersedes #2403 and #2412.

NOTE TO REVIEWERS: This looks like a lot to review, but most of the changes are new tests.  The tests declare the invariants for `Tpetra::initialize`, `Tpetra::finalize`, and `Tpetra::getDefaultComm`, with respect to MPI and Kokkos initialization and finalization.  Reading the tests will make those invariants clear.

## Motivation and Context

See #2372 discussion.  Make error messages less cryptic and help users avoid incorrect behavior.

## Related Issues
* Closes #2372 

## How Has This Been Tested?

I tested locally, both with and without MPI enabled.  Testing without MPI enabled is critical, because the pull request tester does not exercise that case, and because this pull request has some MPI-specific code (protected by the appropriate macros).

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.