### PR TITLE
Revert commits breaking CUDA buld (#2420)

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -839,13 +839,6 @@ namespace MueLu {
 
     // If we switched the number of vectors, we'd need to reallocate here.
     // If the number of vectors is unchanged, this is a noop.
-    // NOTE: We need to check against B because the tests in AllocateLevelMultiVectors
-    // will fail on Stokhos Scalar types (due to the so-called 'hidden dimension')
-    const BlockedMultiVector * Bblocked = dynamic_cast<const BlockedMultiVector*>(&B);  
-    if(residual_.size() > startLevel &&
-       ( ( Bblocked && !Bblocked->isSameSize(*residual_[startLevel])) ||
-         (!Bblocked && !residual_[startLevel]->isSameSize(B))))
-      DeleteLevelMultiVectors();
     AllocateLevelMultiVectors(X.getNumVectors());
 
     // Print residual information before iterating
@@ -984,7 +977,6 @@ namespace MueLu {
         RCP<Operator> Ac = Coarse->Get< RCP<Operator> >("A");
         if (!Ac.is_null()) {
           RCP<const Map> origXMap = coarseX->getMap();
-          RCP<const Map> origRhsMap = coarseRhs->getMap();
 
           // Replace maps with maps with a subcommunicator
           coarseRhs->replaceMap(Ac->getRangeMap());
@@ -1002,7 +994,6 @@ namespace MueLu {
             iterateLevelTime = rcp(new TimeMonitor(*this, iterateLevelTimeLabel));  // restart timing this level
           }
           coarseX->replaceMap(origXMap);
-          coarseRhs->replaceMap(origRhsMap);
         }
 
         if (!doPRrebalance_ && !importer.is_null()) {
@@ -1019,6 +1010,7 @@ namespace MueLu {
         // Note that due to what may be round-off error accumulation, use of the fused kernel
         //    P->apply(*coarseX, X, Teuchos::NO_TRANS, one, one);
         // can in some cases result in slightly higher iteration counts.
+        //        RCP<MultiVector> correction = MultiVectorFactory::Build(X.getMap(), X.getNumVectors(),false);
         RCP<MultiVector> correction = correction_[startLevel];
         {
           // ============== PROLONGATION ==============
@@ -1434,16 +1426,13 @@ namespace MueLu {
     for(int i=0; i<N; i++) {
       RCP<Operator> A = Levels_[i]->template Get< RCP<Operator> >("A");
       if(!A.is_null()) {
-        // This dance is because we allow A to have a BlockedMap and X/B to have (compatible) non-blocked map
-        RCP<const BlockedCrsMatrix> A_as_blocked = Teuchos::rcp_dynamic_cast<const BlockedCrsMatrix>(A);
-        RCP<const Map> Arm = A->getRangeMap();
-        RCP<const Map> Adm = A->getDomainMap();
-        if(!A_as_blocked.is_null()) { 
-          Adm = A_as_blocked->getFullDomainMap();
-        }
+        // This is zero'd by default since it is filled via an operator apply
+        residual_[i] = MultiVectorFactory::Build(A->getRangeMap(), numvecs, true);
 
-        // This is zero'd by default since it is filled via an operator apply        
-        residual_[i] = MultiVectorFactory::Build(Arm, numvecs, true);
+        // This dance is because we allow A to have a BlockedMap and X to have (compatible) non-blocked map
+        RCP<const Map> Adm = A->getDomainMap();
+        RCP<const BlockedCrsMatrix> A_as_blocked = Teuchos::rcp_dynamic_cast<const BlockedCrsMatrix>(A);
+        if(!A_as_blocked.is_null()) Adm = A_as_blocked->getFullDomainMap();
         correction_[i] = MultiVectorFactory::Build(Adm, numvecs, false);
       }
 
@@ -1470,7 +1459,7 @@ namespace MueLu {
         }
       }
     }
-    sizeOfAllocatedLevelMultiVectors_ = numvecs;
+
   }
 
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2167,31 +2167,20 @@ namespace Tpetra {
 
     /// \brief Copy the contents of \c src into \c *this (deep copy).
     ///
-    /// \param src [in] Source MultiVector (input of the deep copy). 
+    /// \param src [in] Source MultiVector (input of the deep copy).
     ///
     /// \pre <tt> ! src.getMap ().is_null () && ! this->getMap ().is_null () </tt>
     /// \pre <tt> src.getMap ()->isCompatible (* (this->getMap ()) </tt>
     ///
     /// \post Any outstanding views of \c src or \c *this remain valid.
     ///
-   /// \note To implementers: The postcondition implies that the
+    /// \note To implementers: The postcondition implies that the
     ///   implementation must not reallocate any memory of \c *this,
     ///   or otherwise change its dimensions.  This is <i>not</i> an
     ///   assignment operator; it does not change anything in \c *this
     ///   other than the contents of storage.
     void
     assign (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& src);
-
-
-    // \brief Checks to see if the local length, number of vectors and size of Scalar type match
-    /// \param src [in] MultiVector 
-    ///
-    /// \pre <tt> ! vec.getMap ().is_null () && ! this->getMap ().is_null () </tt>
-    /// \pre <tt> vec.getMap ()->isCompatible (* (this->getMap ()) </tt>
-    ///
-    /// \post Any outstanding views of \c src or \c *this remain valid.
-    ///
-    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const;
 
   protected:
     template <class DS, class DL, class DG, class DN,

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -61,10 +61,7 @@
 #include "Tpetra_Details_lclDot.hpp"
 #include "Tpetra_Details_Profiling.hpp"
 #include "Tpetra_Details_reallocDualViewIfNeeded.hpp"
-#include "Tpetra_Details_PackTraits.hpp"
 #include "Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp"
-
-
 
 #include "KokkosCompat_View.hpp"
 #include "KokkosBlas.hpp"
@@ -5169,27 +5166,6 @@ namespace Tpetra {
       }
     }
   }
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  bool
-  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  isSameSize (const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const {
-    typedef impl_scalar_type ST;
-    typedef typename Kokkos::View<int*, device_type>::HostMirror::execution_space HES;
-    size_t l1 = this->getLocalLength();
-    size_t l2 = vec.getLocalLength();
-    if ((l1!=l2) || (this->getNumVectors() != vec.getNumVectors()))
-      return false;    
-    if(l1==0)  return true;
-     
-    auto v1 = this->template getLocalView<HES>();
-    auto v2 = vec.template getLocalView<HES>();
-    if(Details::PackTraits<ST,HES>::packValueCount(v1(0,0)) != Details::PackTraits<ST,HES>::packValueCount(v2(0,0)))
-      return false;
-
-    return true;
-  }
-
 
   template <class Scalar, class LO, class GO, class NT>
   Teuchos::RCP<MultiVector<Scalar, LO, GO, NT> >

--- a/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector.hpp
+++ b/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector.hpp
@@ -562,22 +562,6 @@ namespace Xpetra {
       return map_->getFullMap()->getGlobalNumElements();
     }
 
-    //! Local number of rows on the calling process.
-    virtual bool isSameSize(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const {
-      const BlockedMultiVector * Vb = dynamic_cast<const BlockedMultiVector *>(&vec);
-      if(!Vb) return false;
-      for (size_t r = 0; r < map_->getNumMaps(); ++r) {
-        RCP<const MultiVector> a = getMultiVector(r);
-        RCP<const MultiVector> b = Vb->getMultiVector(r);
-        if((a==Teuchos::null && b != Teuchos::null) || 
-           (a!=Teuchos::null && b == Teuchos::null)) 
-          return false;           
-        if(a!=Teuchos::null  && b !=Teuchos::null && !a->isSameSize(*b)) 
-          return false;        
-      }
-      return true;
-    }
-
     //@}
 
     //! @name Overridden from Teuchos::Describable

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector.hpp
@@ -421,12 +421,6 @@ namespace Xpetra {
       return this->getBlockedMap()->getFullMap()->getGlobalNumElements();
     }
 
-    //! Local number of rows on the calling process.
-    virtual bool isSameSize(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const {
-      throw Xpetra::Exceptions::RuntimeError("BlockedVector::isSameSize: routine not implemented. It has no value as one must iterate on the partial vectors.");
-      TEUCHOS_UNREACHABLE_RETURN(0);
-    }
-
     //@}
 
     //! @name Overridden from Teuchos::Describable

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
@@ -221,9 +221,6 @@ namespace Xpetra {
     //! Global number of rows in the multivector.
     global_size_t getGlobalLength() const { return 0; }
 
-    // \brief Checks to see if the local length, number of vectors and size of Scalar type match
-    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { return false; }
-
     //@}
 
     //! @name Overridden from Teuchos::Describable
@@ -521,13 +518,6 @@ namespace Xpetra {
     //! Global number of rows in the multivector.
     global_size_t getGlobalLength() const { XPETRA_MONITOR("EpetraMultiVectorT::getGlobalLength"); return vec_->GlobalLength64(); }
 
-    //! Checks to see if the local length, number of vectors and size of Scalar type match
-    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
-      XPETRA_MONITOR("EpetraMultiVectorT::isSameSize"); 
-      auto vv = toEpetra<GlobalOrdinal,Node>(vec); 
-      return ( (vec_->MyLength() == vv.MyLength()) && (vec_->NumVectors() == vv.NumVectors()));
-    }
-                          
     //@}
 
     //! @name Overridden from Teuchos::Describable
@@ -934,13 +924,6 @@ namespace Xpetra {
     //! Global number of rows in the multivector.
     global_size_t getGlobalLength() const { XPETRA_MONITOR("EpetraMultiVectorT::getGlobalLength"); return vec_->GlobalLength64(); }
 
-    //! Checks to see if the local length, number of vectors and size of Scalar type match
-    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
-      XPETRA_MONITOR("EpetraMultiVectorT::isSameSize"); 
-      auto vv = toEpetra<GlobalOrdinal,Node>(vec); 
-      return ( (vec_->MyLength() == vv.MyLength()) && (vec_->NumVectors() == vv.NumVectors()));
-    }
-         
     //@}
 
     //! @name Overridden from Teuchos::Describable

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVector.hpp
@@ -197,9 +197,6 @@ namespace Xpetra {
 
     //! Global number of rows in the multivector.
     virtual global_size_t getGlobalLength() const = 0;
-   
-    // \brief Checks to see if the local length, number of vectors and size of Scalar type match
-    virtual bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const =0;
 
     //@}
 
@@ -212,7 +209,7 @@ namespace Xpetra {
     //! Print the object with the given verbosity level to a FancyOStream.
     virtual void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const = 0;
 
-    virtual void replaceMap(const RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >& map) = 0;    
+    virtual void replaceMap(const RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >& map) = 0;
 
     //@}
 
@@ -242,8 +239,6 @@ namespace Xpetra {
             }
         }
     }
-
-
 
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
     typedef typename Kokkos::Details::ArithTraits<Scalar>::val_type impl_scalar_type;

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector.hpp
@@ -244,10 +244,6 @@ namespace Xpetra {
     //! Global number of rows in the multivector.
     global_size_t getGlobalLength() const { XPETRA_MONITOR("TpetraMultiVector::getGlobalLength"); return vec_->getGlobalLength(); }
 
-    // \brief Checks to see if the local length, number of vectors and size of Scalar type match
-    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { XPETRA_MONITOR("TpetraMultiVector::isSameSize"); return vec_->isSameSize(toTpetra(vec));}
-                          
-
     //@}
 
     //! @name Overridden from Teuchos::Describable

--- a/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.cpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.cpp
@@ -49,57 +49,30 @@
 
 namespace Xpetra {
 
-
-  // TODO: move that elsewhere
-  template<class GlobalOrdinal, class Node>
-  Epetra_IntVector & toEpetra(Vector<int, int, GlobalOrdinal,Node> &x) {
-    XPETRA_DYNAMIC_CAST(      EpetraIntVectorT<GlobalOrdinal XPETRA_COMMA Node>, x, tX, "toEpetra");
-    return *tX.getEpetra_IntVector();
-  }
-
-  template<class GlobalOrdinal, class Node>
-  const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &x) {
-    XPETRA_DYNAMIC_CAST(const EpetraIntVectorT<GlobalOrdinal XPETRA_COMMA Node>, x, tX, "toEpetra");
-    return *tX.getEpetra_IntVector();
-  }
-  //
-
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
 #ifdef HAVE_XPETRA_TPETRA
 #include "TpetraCore_config.h"
 #if ((defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_OPENMP)) || \
     (!defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_SERIAL)))
 template class EpetraIntVectorT<int, Xpetra::EpetraNode >;
-template Epetra_IntVector & toEpetra<int,Xpetra::EpetraNode >(Vector<int, int, int, Xpetra::EpetraNode> &);
-template const Epetra_IntVector & toEpetra<int, Xpetra::EpetraNode >(const Vector<int, int, int, Xpetra::EpetraNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_SERIAL
 template class EpetraIntVectorT<int, Kokkos::Compat::KokkosSerialWrapperNode >;
-template Epetra_IntVector & toEpetra<int,Kokkos::Compat::KokkosSerialWrapperNode >(Vector<int, int, int, Kokkos::Compat::KokkosSerialWrapperNode> &);
-template const Epetra_IntVector & toEpetra<int, Kokkos::Compat::KokkosSerialWrapperNode >(const Vector<int, int, int, Kokkos::Compat::KokkosSerialWrapperNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_PTHREAD
 template class EpetraIntVectorT<int, Kokkos::Compat::KokkosThreadsWrapperNode>;
-template Epetra_IntVector & toEpetra<int,Kokkos::Compat::KokkosThreadsWrapperNode >(Vector<int, int, int, Kokkos::Compat::KokkosThreadsWrapperNode> &);
-template const Epetra_IntVector & toEpetra<int, Kokkos::Compat::KokkosThreadsWrapperNode >(const Vector<int, int, int, Kokkos::Compat::KokkosThreadsWrapperNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_OPENMP
 template class EpetraIntVectorT<int, Kokkos::Compat::KokkosOpenMPWrapperNode >;
-template Epetra_IntVector & toEpetra<int,Kokkos::Compat::KokkosOpenMPWrapperNode >(Vector<int, int, int, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
-template const Epetra_IntVector & toEpetra<int, Kokkos::Compat::KokkosOpenMPWrapperNode >(const Vector<int, int, int, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
 template class EpetraIntVectorT<int, default_node_type >;
-template Epetra_IntVector & toEpetra<int,default_node_type >(Vector<int, int, int, default_node_type> &);
-template const Epetra_IntVector & toEpetra<int,default_node_type >(const Vector<int, int, int, default_node_type> &);
 #endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
 template class EpetraIntVectorT<int, default_node_type >;
-template Epetra_IntVector & toEpetra<int,default_node_type >(Vector<int, int, int, default_node_type> &);
-template const Epetra_IntVector & toEpetra<int,default_node_type >(const Vector<int, int, int, default_node_type> &);
 #endif // HAVE_XPETRA_TPETRA
 #endif
 
@@ -109,36 +82,24 @@ template const Epetra_IntVector & toEpetra<int,default_node_type >(const Vector<
 #if ((defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_OPENMP)) || \
     (!defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_SERIAL)))
 template class EpetraIntVectorT<long long, Xpetra::EpetraNode >;
-template Epetra_IntVector & toEpetra<long long,Xpetra::EpetraNode >(Vector<int, int, long long, Xpetra::EpetraNode> &);
-template const Epetra_IntVector & toEpetra<long long, Xpetra::EpetraNode >(const Vector<int, int, long long, Xpetra::EpetraNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_SERIAL
 template class EpetraIntVectorT<long long, Kokkos::Compat::KokkosSerialWrapperNode >;
-template Epetra_IntVector & toEpetra<long long,Kokkos::Compat::KokkosSerialWrapperNode >(Vector<int, int, long long, Kokkos::Compat::KokkosSerialWrapperNode> &);
-template const Epetra_IntVector & toEpetra<long long, Kokkos::Compat::KokkosSerialWrapperNode >(const Vector<int, int, long long, Kokkos::Compat::KokkosSerialWrapperNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_PTHREAD
 template class EpetraIntVectorT<long long, Kokkos::Compat::KokkosThreadsWrapperNode>;
-template Epetra_IntVector & toEpetra<long long,Kokkos::Compat::KokkosThreadsWrapperNode >(Vector<int, int, long long, Kokkos::Compat::KokkosThreadsWrapperNode> &);
-template const Epetra_IntVector & toEpetra<long long, Kokkos::Compat::KokkosThreadsWrapperNode >(const Vector<int, int, long long, Kokkos::Compat::KokkosThreadsWrapperNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_OPENMP
 template class EpetraIntVectorT<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >;
-template Epetra_IntVector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode >(Vector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
-template const Epetra_IntVector & toEpetra<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >(const Vector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
 #endif
 #ifdef HAVE_TPETRA_INST_CUDA
 typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
 template class EpetraIntVectorT<long long, default_node_type >;
-template Epetra_IntVector & toEpetra<long long,default_node_type >(Vector<int, int, long long, default_node_type> &);
-template const Epetra_IntVector & toEpetra<long long,default_node_type >(const Vector<int, int, long long, default_node_type> &);
 #endif
 #else
 // Tpetra is disabled and Kokkos not available: use dummy node type
 typedef Xpetra::EpetraNode default_node_type;
 template class EpetraIntVectorT<long long, default_node_type >;
-template Epetra_IntVector & toEpetra<long long,default_node_type >(Vector<int, int, long long, default_node_type> &);
-template const Epetra_IntVector & toEpetra<long long,default_node_type >(const Vector<int, int, long long, default_node_type> &);
 #endif // HAVE_XPETRA_TPETRA
 #endif
 

--- a/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
@@ -59,14 +59,6 @@
 
 namespace Xpetra {
 
-// TODO: move that elsewhere
-template<class GlobalOrdinal, class Node>
-Epetra_IntVector & toEpetra(Vector<int, int, GlobalOrdinal, Node> &);
-
-template<class GlobalOrdinal, class Node>
-const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &);
-//
-
   // stub implementation for EpetraIntVectorT
   template<class EpetraGlobalOrdinal, class Node>
   class EpetraIntVectorT
@@ -259,9 +251,6 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
 
     //! Returns the global vector length of vectors in the multi-vector.
     global_size_t getGlobalLength() const {  return 0; }
-   
-    //! Checks to see if the local length, number of vectors and size of Scalar type match
-    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { return false; }
 
     //@}
 
@@ -595,15 +584,6 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
 
       //! Returns the global vector length of vectors in the multi-vector.
       global_size_t getGlobalLength() const {  return vec_->GlobalLength64(); }
-
-      //! Checks to see if the local length, number of vectors and size of Scalar type match
-      bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
-        XPETRA_MONITOR("EpetraIntVectorT::isSameSize"); 
-        const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> *asvec = dynamic_cast<const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> *>(&vec);
-        if(!asvec) return false;
-        auto vv = toEpetra(*asvec); 
-        return ( (vec_->MyLength() == vv.MyLength()) && (getNumVectors() == vec.getNumVectors()));
-      }
 
       //@}
 
@@ -1035,15 +1015,6 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //! Returns the global vector length of vectors in the multi-vector.
       global_size_t getGlobalLength() const {  return vec_->GlobalLength64(); }
 
-
-      //! Checks to see if the local length, number of vectors and size of Scalar type match
-      bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
-        XPETRA_MONITOR("EpetraIntVectorT::isSameSize"); 
-        const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>  *asvec = dynamic_cast<const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>* >(&vec);
-        if(!asvec) return false;
-        auto vv = toEpetra(*asvec); 
-        return ( (vec_->MyLength() == vv.MyLength()) && (getNumVectors() == vec.getNumVectors()));
-      }
       //@}
 
       //! @name Overridden from Teuchos::Describable


### PR DESCRIPTION
This reverts the commits that are breaking the CUDA build of Trilinos (see #2420)

This commit is a squash of a bunch of revert commits that were part of a single push commit cd1628f8f081a7c977839a636574f6194b0a9a03.

I verified that this fixes the build of Xpetra with the CUDA build on 'shiller' using:

```
$ ./checkin-test-atdm.sh cuda-opt --make-options="-j16"  \
  --enable-packages=Xpetra  --allow-no-pull --configure --build
```

which returned:

```
PASSED (NOT READY TO PUSH): Trilinos: shiller01

Tue Mar 20 06:19:08 MDT 2018

Enabled Packages: Xpetra

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) cuda-opt => passed: build-only passed => Not ready to push! (6.50 min)


REQUESTED ACTIONS: PASSED
```
