### PR TITLE
Tpetra: Requested Updates to FEM Assembly

### DIFF
--- a/packages/tpetra/core/example/Finite-Element-Assembly/CMakeLists.txt
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/CMakeLists.txt
@@ -27,7 +27,7 @@ TRIBITS_ADD_EXECUTABLE(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME FEMAssembly_InsertGlobalIndicesDP
-  ARGS "--with-insert-global-indices-dp --num-elements-x=200 --num-elements-y=200"
+  ARGS "--with-insert-global-indices --with-DynamicProfile --num-elements-x=200 --num-elements-y=200"
   COMM serial mpi
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT
@@ -36,7 +36,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME FEMAssembly_LocalElementLoopDP
-  ARGS "--with-local-element-loop-dp --num-elements-x=200 --num-elements-y=200"
+  ARGS "--with-local-element-loop --with-DynamicProfile --num-elements-x=200 --num-elements-y=200"
   COMM serial mpi
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT
@@ -45,7 +45,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME FEMAssembly_TotalElementLoopDP
-  ARGS "--with-total-element-loop-dp --num-elements-x=200 --num-elements-y=200"
+  ARGS "--with-total-element-loop --with-DynamicProfile --num-elements-x=200 --num-elements-y=200"
   COMM serial mpi
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT
@@ -54,7 +54,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME FEMAssembly_TotalElementLoopSP
-  ARGS "--with-total-element-loop-sp --num-elements-x=200 --num-elements-y=200"
+  ARGS "--with-total-element-loop --with-StaticProfile --num-elements-x=200 --num-elements-y=200"
   COMM serial mpi
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_Element.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_Element.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_ELEMENT_HPP
-#define FEM_ASSEMBLY_ELEMENT_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_ELEMENT_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_ELEMENT_HPP
 
 #include <iomanip>
 #include "Kokkos_View.hpp"
@@ -113,4 +113,4 @@ void PrettyPrintQuad4(scalar_2d_array_t & elementMatrix)
 } // end of namespace TpetraExamples
 
 
-#endif  // FEM_ASSEMBLY_ELEMENT_HPP
+#endif  // TPETRAEXAMPLES_FEM_ASSEMBLY_ELEMENT_HPP

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
@@ -46,7 +46,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_INSERTGLOBALINDICES_DP_HPP
-#define FEM_ASSEMBLY_INSERTGLOBALINDICES_DP_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_INSERTGLOBALINDICES_DP_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_INSERTGLOBALINDICES_DP_HPP
 
 #include <cmath>
 #include <iostream>
@@ -51,7 +51,6 @@
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_FancyOStream.hpp>
 
 #include "fem_assembly_typedefs.hpp"
@@ -66,7 +65,7 @@ using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
 
-int executeInsertGlobalIndicesDP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeInsertGlobalIndicesDP(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -263,4 +262,4 @@ int executeInsertGlobalIndicesDP(comm_ptr_t& comm, const struct CmdLineOpts& opt
 
 } // namespace TpetraExamples
 
-#endif // FEM_ASSEMBLY_INSERTGLOBALINDICES_DP_HPP
+#endif // TPETRAEXAMPLES_FEM_ASSEMBLY_INSERTGLOBALINDICES_DP_HPP

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP
-#define FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP
 
 #include <cmath>
 #include <iostream>
@@ -50,7 +50,6 @@
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_FancyOStream.hpp>
 
 #include "fem_assembly_typedefs.hpp"
@@ -66,7 +65,7 @@ using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
 
-int executeLocalElementLoopDP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeLocalElementLoopDP(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -315,4 +314,4 @@ int executeLocalElementLoopDP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
 } // namespace TpetraExamples
 
 
-#endif // FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP
+#endif // TPETRAEXAMPLES_FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
@@ -46,7 +46,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_RCP.hpp>

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_MeshDatabase.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_MeshDatabase.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_MESHDATABASE_HPP
-#define FEM_ASSEMBLY_MESHDATABASE_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_MESHDATABASE_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_MESHDATABASE_HPP
 
 #include <iostream>
 #include <iterator>
@@ -400,6 +400,6 @@ void MeshDatabase::print(std::ostream & oss)
 
 } // end of namespace TpetraExamples
 
-#endif // FEM_ASSEMBLY_MESH_DATABASE
+#endif // TPETRAEXAMPLES_FEM_ASSEMBLY_MESH_DATABASE
 
 

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_TOTALELEMENTLOOP_DP_HPP
-#define FEM_ASSEMBLY_TOTALELEMENTLOOP_DP_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_TOTALELEMENTLOOP_DP_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_TOTALELEMENTLOOP_DP_HPP
 
 #include <cmath>
 #include <iostream>
@@ -50,7 +50,6 @@
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_FancyOStream.hpp>
 
 #include "fem_assembly_typedefs.hpp"
@@ -66,7 +65,7 @@ using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
 
-int executeTotalElementLoopDP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeTotalElementLoopDP(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -317,4 +316,4 @@ int executeTotalElementLoopDP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
 } // namespace TpetraExamples
 
 
-#endif // FEM_ASSEMBLY_TOTALELEMENTLOOP_DP_HPP
+#endif // TPETRAEXAMPLES_FEM_ASSEMBLY_TOTALELEMENTLOOP_DP_HPP

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
@@ -46,7 +46,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_RCP.hpp>

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
@@ -46,7 +46,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_TOTALELEMENTLOOP_SP_HPP
-#define FEM_ASSEMBLY_TOTALELEMENTLOOP_SP_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_TOTALELEMENTLOOP_SP_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_TOTALELEMENTLOOP_SP_HPP
 
 #include <cmath>
 #include <iostream>
@@ -51,7 +51,6 @@
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_FancyOStream.hpp>
 
 #include "fem_assembly_typedefs.hpp"
@@ -67,7 +66,7 @@ using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
 
 
-int executeTotalElementLoopSP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeTotalElementLoopSP(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;
@@ -318,4 +317,4 @@ int executeTotalElementLoopSP(comm_ptr_t& comm, const struct CmdLineOpts& opts)
 
 } // namespace TpetraExamples
 
-#endif // FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP
+#endif // TPETRAEXAMPLES_FEM_ASSEMBLY_LOCALELEMENTLOOP_DP_HPP

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
@@ -83,9 +83,18 @@ int main (int argc, char *argv[])
   // Read command-line options into the 'opts' struct.
   struct CmdLineOpts opts;
 
-  status = readCmdLineOpts(out, opts, argc, argv);
+  try
+  {
+    status = readCmdLineOpts(out, opts, argc, argv);
+  }
+  catch(...)
+  {
+    status = EXIT_FAILURE;
+  }
+
   if(EXIT_SUCCESS != status)
   {
+    Tpetra::finalize();
     return status;
   }
 

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
@@ -44,7 +44,6 @@
 #include <sstream>
 
 #include <Tpetra_Core.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_RCP.hpp>
@@ -75,7 +74,7 @@ int main (int argc, char *argv[])
   
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  comm_ptr_t comm = Tpetra::getDefaultComm();
 
   // The output stream 'out' will ignore any output not from Process 0.
   RCP<Teuchos::FancyOStream> pOut = getOutputStream(*comm);

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
@@ -43,11 +43,11 @@
 #include <iomanip>
 #include <sstream>
 
+#include <Tpetra_Core.hpp>
 #include <Tpetra_DefaultPlatform.hpp>
 #include <Tpetra_Version.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_FancyOStream.hpp>
 
 #include "fem_assembly_commandLineOpts.hpp"
@@ -75,7 +75,7 @@ int main (int argc, char *argv[])
   
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm();
+  comm_ptr_t comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
 
   // The output stream 'out' will ignore any output not from Process 0.
   RCP<Teuchos::FancyOStream> pOut = getOutputStream(*comm);
@@ -91,10 +91,16 @@ int main (int argc, char *argv[])
   }
 
   // Entry point
-  if(opts.execInsertGlobalIndicesDP && executeInsertGlobalIndicesDP(comm, opts))  status = EXIT_FAILURE;
-  if(opts.execLocalElementLoopDP    && executeLocalElementLoopDP(comm, opts))     status = EXIT_FAILURE;
-  if(opts.execTotalElementLoopDP    && executeTotalElementLoopDP(comm, opts))     status = EXIT_FAILURE;
-  if(opts.execTotalElementLoopSP    && executeTotalElementLoopSP(comm, opts))     status = EXIT_FAILURE;
+  if(opts.useStaticProfile)
+  {
+    if(opts.execTotalElementLoop && executeTotalElementLoopSP(comm, opts))        status = EXIT_FAILURE;
+  }
+  else
+  {
+    if(opts.execInsertGlobalIndices && executeInsertGlobalIndicesDP(comm, opts))  status = EXIT_FAILURE;
+    if(opts.execLocalElementLoop    && executeLocalElementLoopDP(comm, opts))     status = EXIT_FAILURE;
+    if(opts.execTotalElementLoop    && executeTotalElementLoopDP(comm, opts))     status = EXIT_FAILURE;
+  }
 
   // Print out timing results.
   if(opts.timing) Teuchos::TimeMonitor::report(comm.ptr(), std::cout, "");

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_typedefs.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_typedefs.hpp
@@ -42,7 +42,6 @@
 #define TPETRAEXAMPLES_FEM_ASSEMBLY_TYPEDEFS_HPP
 
 #include <Kokkos_View.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
 #include <Tpetra_Export.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_CrsGraph.hpp>

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_typedefs.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_typedefs.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_TYPEDEFS_HPP
-#define FEM_ASSEMBLY_TYPEDEFS_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_TYPEDEFS_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_TYPEDEFS_HPP
 
 #include <Kokkos_View.hpp>
 #include <Tpetra_DefaultPlatform.hpp>
@@ -73,5 +73,5 @@ typedef Kokkos::View<Scalar*[4], execution_space_t>           scalar_2d_array_t;
 
 }
 
-#endif  // FEM_ASSEMBLY_TYPEDEFS_HPP
+#endif  // TPETRAEXAMPLES_FEM_ASSEMBLY_TYPEDEFS_HPP
 

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_utility.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_utility.hpp
@@ -44,7 +44,6 @@
 #include <iostream>
 
 #include <Teuchos_FancyOStream.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_RCP.hpp>
 
 

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_utility.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_utility.hpp
@@ -38,8 +38,8 @@
 //
 // ************************************************************************
 // @HEADER
-#ifndef FEM_ASSEMBLY_UTILITY_HPP
-#define FEM_ASSEMBLY_UTILITY_HPP
+#ifndef TPETRAEXAMPLES_FEM_ASSEMBLY_UTILITY_HPP
+#define TPETRAEXAMPLES_FEM_ASSEMBLY_UTILITY_HPP
 
 #include <iostream>
 
@@ -78,5 +78,5 @@ getOutputStream(const Teuchos::Comm<int>& comm)
 
 } // namespace TpetraExamples
 
-#endif  // FEM_ASSEMBLY_UTILITY_HPP
+#endif  // TPETRAEXAMPLES_FEM_ASSEMBLY_UTILITY_HPP
 


### PR DESCRIPTION
@trilinos/tpetra

## Description
Addressing requested updates to FEM Assembly from @mhoemmen from PR #2443.

## Motivation and Context

- [x] Command line parameters: split dynamic profile from the assembly mode
  - Algorithm Types (**one** is required):
    - --with-insert-global-indices
    - --with-local-element-loop
    - --with-total-element-loop
  - Static/Dynamic Profile Selector
    - --with-StaticProfile (DEFAULT) 
    - --with-DynamicProfile
- [x] Nuance header guard macros, add `TPETRAEXAMPLES_` prefix.
- [x] Teuchos_GlobalMPISession.hpp --> Tpetra_Core.hpp
- [x] Allow only one 'type' to run at a time to keep the timings from getting confused.
- [x] InsertGlobalIndices_DP (and others) --> Use `const comm_ptr_t&` rather than non-const.
- [x] Tpetra::DefaultPlatform --> Tpetra::getDefaultComm()
- [x] Change parameters to `const comm_ptr_t&` in parameters to executors for each type
rather than non-const version.
- [x] Remove `Tpetra_getDefaultPlatform` from includes
- [x] Replace `Tpetra::DefaultPlatform::getDefaultPlatform().getComm()` with `Tpetra::getDefaultComm()` in `fem_assembly_main.cpp`

## Related Issues
* Closes #2453 

## How Has This Been Tested?
* PR Testing
* GPU on White
* Local workstation

