### PR TITLE
Shylu/Tacho - fix a problem due to disabled serial space

### DIFF
--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExamplePerfTest.cpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExamplePerfTest.cpp
@@ -74,10 +74,7 @@ int main (int argc, char *argv[]) {
   if (r_parse) return 0; 
 
   Kokkos::initialize(argc, argv);
-  if (std::is_same<Kokkos::DefaultHostExecutionSpace,Kokkos::Serial>::value)
-    std::cout << "Kokkos::Serial\n";
-  else
-    Kokkos::DefaultHostExecutionSpace::print_configuration(std::cout, false);
+  Kokkos::DefaultHostExecutionSpace::print_configuration(std::cout, false);
 
   int r_val = 0;
 

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Util.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Util.hpp
@@ -86,10 +86,7 @@ namespace Tacho {
                                std::logic_error,
                                "SpT is not Kokkos execution space.");
       std::cout << std::setw(16) << name << "::  ";
-      if (std::is_same<SpT,Kokkos::Serial>::value)
-        std::cout << "Kokkos::Serial " << std::endl;
-      else
-        SpT::print_configuration(std::cout, detail);
+      SpT::print_configuration(std::cout, detail);
     }
 
     ///


### PR DESCRIPTION
serial space can be disabled and it causes a compile error. this pr fixes the problem.