### PR TITLE
Enable Xpetra and MueLu Experimental in standard CI build (#2317, #2462)

### DIFF
--- a/cmake/std/BasicCiTestingSettings.cmake
+++ b/cmake/std/BasicCiTestingSettings.cmake
@@ -35,6 +35,10 @@ TRIL_SET_BOOL_CACHE_VAR_FOR_CI(TPL_ENABLE_SuperLU ON)
 # problems.
 TRIL_SET_BOOL_CACHE_VAR_FOR_CI(Trilinos_TRACE_ADD_TEST ON)
 
+# Enable experimental features in Trilinos used by ATDM (#2462)
+TRIL_SET_BOOL_CACHE_VAR_FOR_CI(Xpetra_ENABLE_Experimental ON)
+TRIL_SET_BOOL_CACHE_VAR_FOR_CI(MueLu_ENABLE_Experimental ON)
+
 # Disable long-failing Piro test until it can be fixed (#826)
 TRIL_SET_BOOL_CACHE_VAR_FOR_CI(Piro_EpetraSolver_MPI_4_DISABLE ON)
 


### PR DESCRIPTION
**CC:** @trilinos/xpetra, @trilinos/muelu, @mhoemmen, @trilihos/framework

## Description

Since the ATDM APPs enable these, so should the CI and auto PR builds.  When
that changes, we can remove this.  This is one of the parts of #2462.

I tested this with:

```
$ ./checkin-test-sems.sh --enable-all-packages=on --local-do-all
```

and it passed the full CI build and I verified that experimental Xpetra and MueLu code are enabled.  See details below.

<details>
<summary>
  <b>DETAILS</b> (chick to expand)
</summary>

I tested this branch locally with:

```
$ ./checkin-test-sems.sh --enable-all-packages=on --local-do-all
```

and it returned:

```
passed: Trilinos/MPI_RELEASE_DEBUG_SHARED_PT: passed=2587,notpassed=0

Tue Mar 27 22:04:18 MDT 2018

Enabled Packages: 
Disabled Packages: PyTrilinos,Claps,TriKota Enabled all Packages
Hostname: crf450.srn.sandia.gov
Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
Build Dir: /home/rabartl/Trilinos.base/BUILDS/CHECKIN/MPI_RELEASE_DEBUG_SHARED_PT

CMake Cache Varibles: -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=BASIC -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=300.0 -DBUILD_SHARED_LIBS=ON -DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON -DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/MpiReleaseDebugSharedPtSettings.cmake,cmake/std/BasicCiTestingSettings.cmake,cmake/std/sems/SEMSDevEnv.cmake -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=ON -DTrilinos_ENABLE_PyTrilinos:BOOL=OFF -DTrilinos_ENABLE_Claps:BOOL=OFF -DTrilinos_ENABLE_TriKota:BOOL=OFF
Make Options: -j16
CTest Options: -j16 

Pull: Not Performed
Configure: Passed (2.79 min)
Build: Passed (89.59 min)
Test: Passed (15.20 min)

100% tests passed, 0 tests failed out of 2587

Label Time Summary:
Amesos               =  19.76 sec (14 tests)
Amesos2              =  10.78 sec (9 tests)
Anasazi              = 103.01 sec (71 tests)
AztecOO              =  16.08 sec (17 tests)
Belos                =  99.77 sec (72 tests)
Domi                 = 146.42 sec (125 tests)
Epetra               =  40.70 sec (61 tests)
EpetraExt            =  14.38 sec (11 tests)
FEI                  =  41.48 sec (43 tests)
Galeri               =   4.07 sec (9 tests)
GlobiPack            =   0.78 sec (6 tests)
Ifpack               =  58.52 sec (53 tests)
Ifpack2              =  41.91 sec (35 tests)
Intrepid             = 151.68 sec (152 tests)
Intrepid2            =  47.41 sec (144 tests)
Isorropia            =   7.37 sec (6 tests)
Kokkos               =  41.18 sec (23 tests)
KokkosKernels        =  71.84 sec (4 tests)
ML                   =  44.19 sec (34 tests)
MiniTensor           =   0.26 sec (2 tests)
MueLu                = 312.97 sec (84 tests)
NOX                  = 150.28 sec (106 tests)
OptiPack             =   5.93 sec (5 tests)
Panzer               = 590.07 sec (154 tests)
Phalanx              =   5.49 sec (27 tests)
Pike                 =   2.03 sec (7 tests)
Piro                 =  26.75 sec (12 tests)
ROL                  = 754.01 sec (153 tests)
RTOp                 =   9.47 sec (24 tests)
Rythmos              = 160.11 sec (83 tests)
SEACAS               =   8.02 sec (14 tests)
STK                  =  25.99 sec (12 tests)
Sacado               =  35.00 sec (292 tests)
Shards               =   0.53 sec (4 tests)
ShyLU_Node           =   0.50 sec (3 tests)
Stokhos              =  95.44 sec (75 tests)
Stratimikos          =  33.33 sec (40 tests)
Teko                 =  79.98 sec (19 tests)
Tempus               = 2233.98 sec (36 tests)
Teuchos              =  39.37 sec (137 tests)
ThreadPool           =   7.34 sec (10 tests)
Thyra                =  60.26 sec (81 tests)
Tpetra               = 165.46 sec (162 tests)
TrilinosCouplings    =  58.24 sec (24 tests)
Triutils             =   2.32 sec (2 tests)
Xpetra               =  42.53 sec (18 tests)
Zoltan               = 198.33 sec (19 tests)
Zoltan2              = 134.63 sec (101 tests)

Total Test time (real) = 912.05 sec

Total time for MPI_RELEASE_DEBUG_SHARED_PT = 107.59 min
```

It looks like experimental code in Xpetra and MueLu was enabled from looking at:

```
$ grep Experimental MPI_RELEASE_DEBUG_SHARED_PT/CMakeCache.txt  | grep "\(Xpetra\|MueLu\)"
MueLu_ENABLE_Experimental:BOOL=ON
Xpetra_ENABLE_Experimental:BOOL=ON
```

and:

```
$ find MPI_RELEASE_DEBUG_SHARED_PT/packages/xpetra -name "*config*" -exec grep -nHi "experimental" {} \;
MPI_RELEASE_DEBUG_SHARED_PT/packages/xpetra/sup/Xpetra_config.hpp:24:#define HAVE_XPETRA_EXPERIMENTAL
MPI_RELEASE_DEBUG_SHARED_PT/packages/xpetra/src/Xpetra_config.hpp:24:#define HAVE_XPETRA_EXPERIMENTAL

$ find MPI_RELEASE_DEBUG_SHARED_PT/packages/muelu/ -name "*config*" -exec grep -nHi "experimental" {} \;
MPI_RELEASE_DEBUG_SHARED_PT/packages/muelu/src/MueLu_config.hpp:20:#define HAVE_MUELU_EXPERIMENTAL
MPI_RELEASE_DEBUG_SHARED_PT/packages/muelu/src/Interface/MueLu_config.hpp:20:#define HAVE_MUELU_EXPERIMENTAL
```

So that is good evidence that experimental code in Xpetra and MueLu actually did get enabled.

</details>
