### PR TITLE
Loose error tol from 5e-14 to 5.5e-14 for gnu-opt-serial on hansen/shiller (#2475)

### DIFF
--- a/packages/teko/tests/unit_tests/tDiagonallyScaledPreconditioner.cpp
+++ b/packages/teko/tests/unit_tests/tDiagonallyScaledPreconditioner.cpp
@@ -294,7 +294,7 @@ TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, application_test_row_tpetra)
    bool result;
    Thyra::LinearOpTester<ST> tester;
    tester.show_all_tests(true);
-   tester.set_all_error_tol(5e-14);
+   tester.set_all_error_tol(5.5e-14);
 
    // build operators and factories
    RCP<Teko::InverseLibrary> invLib = Teko::InverseLibrary::buildFromStratimikos();


### PR DESCRIPTION
CC: @trilinos/teko 

This small increase in the error tolerance allows the
tDiagonallyScaledPreconditioner_application_test_row_tpetra_UnitTest unit test
to pass on the ATDM build Trilinos-atdm-hansen-shiller-gnu-opt-serial.  See #2475.
