### PR TITLE
2487 fix timemonitor unittests mpi 3

### DIFF
--- a/packages/teuchos/comm/test/Time/CMakeLists.txt
+++ b/packages/teuchos/comm/test/Time/CMakeLists.txt
@@ -19,7 +19,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TimeMonitor_UnitTests
   SOURCES
     TimeMonitor_UnitTests.cpp
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+    ${TEUCHOS_STD_PARALLEL_UNIT_TEST_MAIN}
   COMM serial mpi
   NUM_MPI_PROCS 3
   ARGS --teuchos-suppress-startup-banner


### PR DESCRIPTION
CC: @trilinos/teuchos 

This addresses #2487 and actually fixes the test on a bunch of platforms.  For more details, see https://github.com/trilinos/Trilinos/issues/2487#issuecomment-377648679 and the commit message logs.  It should be pretty clear from that.
