### PR TITLE
Kokkos: disable failing CUDA+DEBUG test

### DIFF
--- a/packages/kokkos/core/unit_test/TestTeamVector.hpp
+++ b/packages/kokkos/core/unit_test/TestTeamVector.hpp
@@ -903,12 +903,12 @@ TEST_F( TEST_CATEGORY, triple_nested_parallelism )
 // With KOKKOS_DEBUG enabled, the functor uses too many registers to run
 // with a team size of 32 on GPUs, 16 is the max possible (at least on a K80 GPU)
 // See https://github.com/kokkos/kokkos/issues/1513
-#if defined(KOKKOS_DEBUG)
+#if defined(KOKKOS_DEBUG) && defined(KOKKOS_ENABLE_CUDA)
   if (!std::is_same<TEST_EXECSPACE, Kokkos::Cuda>::value) {
 #endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 32 );
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 16 );
-#if defined(KOKKOS_DEBUG)
+#if defined(KOKKOS_DEBUG) && defined(KOKKOS_ENABLE_CUDA)
   }
 #endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 16 );

--- a/packages/kokkos/core/unit_test/TestTeamVector.hpp
+++ b/packages/kokkos/core/unit_test/TestTeamVector.hpp
@@ -900,8 +900,17 @@ TEST_F( TEST_CATEGORY, team_vector )
 #ifndef SKIP_TEST
 TEST_F( TEST_CATEGORY, triple_nested_parallelism )
 {
+// With KOKKOS_DEBUG enabled, the functor uses too many registers to run
+// with a team size of 32 on GPUs, 16 is the max possible (at least on a K80 GPU)
+// See https://github.com/kokkos/kokkos/issues/1513
+#if defined(KOKKOS_DEBUG)
+  if (!std::is_same<TEST_EXECSPACE, Kokkos::Cuda>::value) {
+#endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 32 );
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 16 );
+#if defined(KOKKOS_DEBUG)
+  }
+#endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 16 );
 }
 #endif


### PR DESCRIPTION



<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos 
@trilinos/framework

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
Disable instances of a test which request a hardcoded number of
32 CUDA threads per warp, because with debugging
enabled the CUDA kernel uses too many registers
and can only run on 16 threads per warp max.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This test is failing in key ATDM build configurations

## Related Issues
kokkos/kokkos#1514, kokkos/kokkos#1513, #2471