### PR TITLE
Tpetra: Fix #2498

### DIFF
--- a/packages/tpetra/core/test/inout/ReadTriples.cpp
+++ b/packages/tpetra/core/test/inout/ReadTriples.cpp
@@ -42,6 +42,7 @@
 #include "Tpetra_TestingUtilities.hpp"
 #include "Tpetra_Details_ReadTriples.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
+#include "Tpetra_Map.hpp"
 #include "Teuchos_CommHelpers.hpp"
 #ifdef HAVE_TPETRACORE_MPI
 #  include "Teuchos_DefaultMpiComm.hpp"
@@ -55,7 +56,7 @@ using Teuchos::Comm;
 using Teuchos::RCP;
 using Teuchos::rcp;
 using std::endl;
-typedef long long GO;
+typedef ::Tpetra::Map<>::global_ordinal_type GO;
 
 // Type of each (row index, column index) pair in the std::map we use
 //   in this test for representing a sparse matrix.


### PR DESCRIPTION
Fix Tpetra test build by avoiding use of `long long` when `Teuchos_ENABLE_LONG_LONG_INT` is `OFF`.  The latter should never be `OFF` anyway, since Teuchos now requires C++11 and `long long` comes with C++11, but some users have that option `OFF` in their scripts for legacy reasons.  It takes less time to fix the build issue than to tell several users to read the configure script output.

@trilinos/tpetra 

## Related Issues
* Closes #2498 
* Related to #2495 #2496 

## How Has This Been Tested?

I set `Teuchos_ENABLE_LONG_LONG_INT:BOOL=OFF`, enabled OpenMP, and disabled Serial (in both Kokkos and Tpetra).  I then tested with GCC 4.9.3 in both debug and release modes (dynamic shared libraries and ETI enabled for both).

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

