### PR TITLE
Disable 3 Anasazi tests that randomly fail in debug builds on white/ride (#2473)

### DIFF
--- a/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
@@ -6,4 +6,9 @@ ATDM_SET_ENABLE(TeuchosNumerics_LAPACK_test_MPI_1_DISABLE ON)
 # This test segfaults in the 'debug' builds on this system (#2466)
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
 
+# These tests randomly fail (see #2473)
+ATDM_SET_ENABLE(Anasazi_Epetra_ModalSolversTester_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_1_MPI_4_DISABLE ON)
+
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/ride/tweaks/GNU-DEBUG-OPENMP.cmake
+++ b/cmake/std/atdm/ride/tweaks/GNU-DEBUG-OPENMP.cmake
@@ -8,3 +8,8 @@ ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISAB
 
 # This test segfaults in the 'debug' builds on this system (#2466)
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
+
+# These tests randomly fail (see #2473)
+ATDM_SET_ENABLE(Anasazi_Epetra_ModalSolversTester_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_1_MPI_4_DISABLE ON)


### PR DESCRIPTION
These tests randomly fail with massive diffs.  Very strange behavior.  See #2473 for history and more details.
