### PR TITLE
TrilinosCouplings/FENL:  Update FENL/UQ::PCE to use scalar mean-based prec

### DIFF
--- a/packages/trilinoscouplings/examples/fenl/BelosSolve.hpp
+++ b/packages/trilinoscouplings/examples/fenl/BelosSolve.hpp
@@ -164,16 +164,11 @@ belos_solve(
 
     RCP<ParameterList> mueluParams = Teuchos::sublist(fenlParams, "MueLu");
     if (use_mean_based) {
-      preconditioner =
-        Teuchos::rcp(new MeanBasedPreconditioner<SM, LO, GO, N>());
-      precOp = preconditioner->setupPreconditioner(rcpFromRef(A), mueluParams,
-                                                   coords);
+      precOp = build_mean_based_muelu_preconditioner(rcpFromRef(A), mueluParams,
+                                                     coords);
     }
     else {
-      preconditioner =
-        Teuchos::rcp(new MueLuPreconditioner<SM, LO, GO, N>());
-      precOp = preconditioner->setupPreconditioner(rcpFromRef(A), mueluParams,
-                                                   coords);
+      precOp = build_muelu_preconditioner(rcpFromRef(A), mueluParams, coords);
     }
   }
 

--- a/packages/trilinoscouplings/examples/fenl/MueLuPreconditioner.hpp
+++ b/packages/trilinoscouplings/examples/fenl/MueLuPreconditioner.hpp
@@ -43,7 +43,6 @@
 #define STOKHOS_MUELU_PRECONDITIONER_HPP
 
 #include "Teuchos_RCP.hpp"
-#include "SGPreconditioner.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "MueLu_CreateTpetraPreconditioner.hpp"
@@ -52,44 +51,19 @@ namespace Kokkos {
 namespace Example {
 
   template<class S, class LO, class GO, class N>
-  class MueLuPreconditioner :
-    public SGPreconditioner<S, LO, GO, N> {
-
-  public:
-
-    //! Constructor
-    MueLuPreconditioner() {}
-
-    //! Destructor
-    virtual ~MueLuPreconditioner() {}
-
-    //! Setup preconditioner
-    virtual
-    Teuchos::RCP<Tpetra::Operator<S,LO,GO,N> >
-    setupPreconditioner(
-      const Teuchos::RCP<Tpetra::CrsMatrix<S,LO,GO,N> >& A,
-      const Teuchos::RCP<Teuchos::ParameterList>& mueluParams,
-      const Teuchos::RCP<Tpetra::MultiVector<double,LO,GO,N> >& coords)
-    {
-      typedef Tpetra::Operator<S,LO,GO,N> OperatorType;
-      typedef MueLu::TpetraOperator<S,LO,GO,N> PreconditionerType;
-      Teuchos::RCP<OperatorType> A_op = A;
-      Teuchos::RCP<PreconditionerType> mueluPreconditioner;
-      mueluPreconditioner =
-        MueLu::CreateTpetraPreconditioner(A_op,*mueluParams,coords);
-      return mueluPreconditioner;
-    }
-
-  private:
-
-    //! Private to prohibit copying
-    MueLuPreconditioner(const MueLuPreconditioner&);
-
-    //! Private to prohibit copying
-    MueLuPreconditioner& operator=(const MueLuPreconditioner&);
-
-
-  }; // class MeanBasedPreconditioner
+  Teuchos::RCP<Tpetra::Operator<S,LO,GO,N> >
+  build_muelu_preconditioner(
+    const Teuchos::RCP<Tpetra::CrsMatrix<S,LO,GO,N> >& A,
+    const Teuchos::RCP<Teuchos::ParameterList>& mueluParams,
+    const Teuchos::RCP<Tpetra::MultiVector<double,LO,GO,N> >& coords)
+  {
+    typedef Tpetra::Operator<S,LO,GO,N> OperatorType;
+    typedef MueLu::TpetraOperator<S,LO,GO,N> PreconditionerType;
+    Teuchos::RCP<OperatorType> A_op = A;
+    Teuchos::RCP<PreconditionerType> mueluPreconditioner =
+      MueLu::CreateTpetraPreconditioner(A_op,*mueluParams,coords);
+    return mueluPreconditioner;
+  }
 
 }
 }

--- a/packages/trilinoscouplings/examples/fenl/fenl_ensemble.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_ensemble.hpp
@@ -143,45 +143,7 @@ struct CreateDeviceConfigs< Sacado::MP::Vector<StorageType> > {
 
 } /* namespace FENL */
 
-#if defined(HAVE_TRILINOSCOUPLINGS_BELOS) && defined(HAVE_TRILINOSCOUPLINGS_MUELU)
-  //! Get mean values matrix for mean-based preconditioning
-  /*! Specialization for Sacado::MP::Vector
-   */
-  template <class Storage, class ... P>
-  class GetMeanValsFunc< Kokkos::View< Sacado::MP::Vector<Storage>*,
-                                       P... > > {
-  public:
-    typedef Sacado::MP::Vector<Storage> Scalar;
-    typedef Kokkos::View< Scalar*, P... > ViewType;
-    typedef ViewType MeanViewType;
-    typedef typename ViewType::execution_space execution_space;
-    typedef typename ViewType::size_type size_type;
-
-    GetMeanValsFunc(const ViewType& vals_) :
-      vals(vals_), vec_size(Kokkos::dimension_scalar(vals))
-    {
-      const size_type nnz = vals.dimension_0();
-      mean_vals = ViewType("mean-values", nnz, 1);
-      Kokkos::parallel_for( nnz, *this );
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    void operator() (const size_type i) const
-    {
-      typename Scalar::value_type s = 0.0;
-      for (size_type j=0; j<vec_size; ++j)
-        s += vals(i).fastAccessCoeff(j);
-      mean_vals(i) = s;
-    }
-
-    MeanViewType getMeanValues() const { return mean_vals; }
-
-  private:
-    MeanViewType mean_vals;
-    ViewType vals;
-    const size_type vec_size;
-  };
-
+#if defined(HAVE_TRILINOSCOUPLINGS_BELOS)
 template <typename S, typename V, typename O>
 struct ExtractEnsembleIts;
 


### PR DESCRIPTION
Mirrors recent changes in Stokhos and gets mean-based preconditioner with MueLu working with UQ::PCE scalar type again on OpenMP and Cuda.
