### PR TITLE
Sacado:  Add explicit include for Cuda/Vectorization.hpp

### DIFF
--- a/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
+++ b/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
@@ -37,6 +37,9 @@
 #include "Sacado_Traits.hpp"
 #if defined(HAVE_SACADO_KOKKOSCORE)
 #include "Kokkos_Core.hpp"
+#if defined(KOKKOS_HAVE_CUDA)
+#include "Cuda/Kokkos_Cuda_Vectorization.hpp"
+#endif
 #if !defined(SACADO_DISABLE_CUDA_IN_KOKKOS)
 #include "Kokkos_MemoryPool.hpp"
 #endif
@@ -139,7 +142,7 @@ namespace Sacado {
 
 #endif
 
-#if !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDACC__)
+#if !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(KOKKOS_HAVE_CUDA) && defined(__CUDACC__)
 
   namespace Impl {
 


### PR DESCRIPTION
There have been build failures for Sacado with Cuda on showing up on the
dashboard, e.g.,

https://testing.sandia.gov/cdash/viewBuildError.php?buildid=3483315

where Kokkos::shfl_*() functions aren't being found.  I can't reproduce
this on my machine, so I am trying to see if adding an explicit include
for the Kokkos header that defines them fixes it.