### PR TITLE
Ifpack2: fixing instantiation in BlockRelaxation valid parameter list

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -151,7 +151,10 @@ getValidParameters () const
 
   validParams->set("partitioner: line detection threshold",(double)0.0);
   validParams->set("partitioner: PDE equations",(int)1);
-  Teuchos::RCP<Tpetra::MultiVector<> > dummy;
+  Teuchos::RCP<Tpetra::MultiVector<typename MatrixType::scalar_type,
+                                   typename MatrixType::local_ordinal_type,
+                                   typename MatrixType::global_ordinal_type,
+                                   typename MatrixType::node_type> > dummy;
   validParams->set("partitioner: coordinates",dummy);
   
   return validParams;


### PR DESCRIPTION
the parameter "partitioner: coordinates" was not instantiated correctly in
 getValidParameters which then caused an issue if one uses a non default
build of Trilinos.
This should be fixed with the changes in this commit.

@trilinos/ifpack2 

## Description
Simply modifying the template parameters in ```Ifpack2::BlockRelaxation::getValidParameters()``` to have the coordinates multivector consistently templated with the matrix type

## Motivation and Context
This will allow MueLu users to interface properly with Ifpack2 line detection capabilities.

## How Has This Been Tested?
A new test is added in MueLu that uses this feature. The new test is now passing.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.