### PR TITLE
Resolve "Panzer:  Update Integrator_CurlBasisDotVector"

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector.hpp
@@ -40,92 +40,339 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef PANZER_EVALUATOR_CURLBASISDOTVECTOR_DECL_HPP
-#define PANZER_EVALUATOR_CURLBASISDOTVECTOR_DECL_HPP
+#ifndef   Panzer_Integrator_CurlBasisDotVector_hpp
+#define   Panzer_Integrator_CurlBasisDotVector_hpp
 
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Include Files
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// C++
 #include <string>
-#include "Panzer_Dimension.hpp"
-#include "Phalanx_Evaluator_Macros.hpp"
-#include "Phalanx_MDField.hpp"
+
+// Kokkos
 #include "Kokkos_DynRankView.hpp"
 
-#include "Panzer_Evaluator_Macros.hpp"
+// Panzer
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+#include "Panzer_EvaluatorStyle.hpp"
 
-namespace panzer {
-    
-/** In 3D this computes
-  * 
-  *  \f$\int \nabla\times \phi \cdot v \f$
-  *
-  * however the name can be misleading. The curl of a vector
-  * in 2D is simply a scalar, here the evaluators handles
-  * both cases.
-  */
-template<typename EvalT, typename Traits>
-class Integrator_CurlBasisDotVector
-  :
-  public panzer::EvaluatorWithBaseImpl<Traits>,
-  public PHX::EvaluatorDerived<EvalT, Traits>
+// Phalanx
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_MDField.hpp"
+
+namespace panzer
 {
-  public:
+  /**
+   *  \brief Computes \f$
+   *         Ma(x)b(x)\cdots\int\nabla\times\vec{\phi}\cdot\vec{v}\, dx \f$.
+   *
+   *  Evaluates the integral
+   *  \f[
+   *    Ma(x)b(x)\cdots\int\nabla\times\vec{\phi}\cdot\vec{v}\, dx,
+   *  \f]
+   *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc., are
+   *  some fields that depend on position, \f$ \vec{v} \f$ is some
+   *  vector-valued function, and \f$ \vec{\phi} \f$ is some vector basis.
+   *
+   *  \note The name can be misleading.  In contrast to 3-D, the curl of a
+   *        vector in 2-D is simply a scalar.  This `Evaluator` handles both
+   *        cases.
+   */
+  template<typename EvalT, typename Traits>
+  class Integrator_CurlBasisDotVector
+    :
+    public panzer::EvaluatorWithBaseImpl<Traits>,
+    public PHX::EvaluatorDerived<EvalT, Traits>
+  {
+    public:
 
-    Integrator_CurlBasisDotVector(
-      const Teuchos::ParameterList& p);
+      /**
+       *  \brief Main Constructor
+       *
+       *  Creates an `Evaluator` to evaluate the integral
+       *  \f[
+       *    Ma(x)b(x)\cdots\int\nabla\times\vec{\phi}\cdot\vec{v}\, dx,
+       *  \f]
+       *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc.,
+       *  are some fields that depend on position, \f$ \vec{v} \f$ is some
+       *  vector-valued function, and \f$ \vec{\phi} \f$ is some vector basis.
+       *
+       *  \param[in] evalStyle  An `enum` declaring the behavior of this
+       *                        `Evaluator`, which is to either:
+       *                        - compute and contribute (`CONTRIBUTES`), or
+       *                        - compute and store (`EVALUATES`).
+       *  \param[in] resName    The name of either the contributed or evaluated
+       *                        field, depending on `evalStyle`.
+       *  \param[in] valName    The name of the vector value being integrated
+       *                        (\f$ \vec{s} \f$).
+       *  \param[in] basis      The vector basis that you'd like to use (\f$
+                                \vec{\phi} \f$).
+       *  \param[in] ir         The integration rule that you'd like to use.
+       *  \param[in] multiplier The scalar multiplier out in front of the
+       *                        integral you're computing (\f$ M \f$).  If not
+       *                        specified, this defaults to 1.
+       *  \param[in] fmNames    A list of names of fields that are multipliers
+       *                        out in front of the integral you're computing
+       *                        (\f$ a(x) \f$, \f$ b(x) \f$, etc.).  If not
+       *                        specified, this defaults to an empty `vector`.
+       *
+       *  \throws std::invalid_argument If any of the inputs are invalid.
+       *  \throws std::logic_error      If the `basis` supplied is not a vector
+       *                                basis, or if it doesn't require
+       *                                orientations.
+       */
+      Integrator_CurlBasisDotVector(
+        const panzer::EvaluatorStyle&   evalStyle,
+        const std::string&              resName,
+        const std::string&              valName,
+        const panzer::BasisIRLayout&    basis,
+        const panzer::IntegrationRule&  ir,
+        const double&                   multiplier = 1,
+        const std::vector<std::string>& fmNames    =
+          std::vector<std::string>());
 
-    void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
+      /**
+       *  \brief `ParameterList` Constructor.
+       *
+       *  Creates an `Evaluator` to evaluate the integral
+       *  \f[
+       *    Ma(x)b(x)\cdots\int\nabla\times\vec{\phi}\cdot\vec{v}\, dx,
+       *  \f]
+       *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc.,
+       *  are some fields that depend on position, \f$ \vec{s} \f$ is some
+       *  vector-valued function, and \f$ \vec{\phi} \f$ is some vector basis.
+       *
+       *  \note This constructor exists to preserve the older way of creating
+       *        an `Evaluator` with a `ParameterList`; however, it is
+       *        _strongly_ advised that you _not_ use this `ParameterList`
+       *        Constructor, but rather that you favor the Main Constructor
+       *        with its compile-time argument checking instead.
+       *
+       *  \param[in] p A `ParameterList` of the form
+                       \code{.xml}
+                       <ParameterList>
+                         <Parameter name = "Residual Name"     type = "std::string"                         value = (required)    />
+                         <Parameter name = "Value Name"        type = "std::string"                         value = (required)    />
+                         <Parameter name = "Basis"             type = "RCP<panzer::BasisIRLayout>"          value = (required)    />
+                         <Parameter name = "IR"                type = "RCP<panzer::IntegrationRule>"        value = (required)    />
+                         <Parameter name = "Multiplier"        type = "double"                              value = (required)    />
+                         <Parameter name = "Field Multipliers" type = "RCP<const std::vector<std::string>>" value = null (default)/>
+                       </ParameterList>
+                       \endcode
+       *               where
+       *               - "Residual Name" is the name for the term this
+       *                 `Evaluator` is evaluating,
+       *               - "Value Name" is the name of the vector value being
+       *                 integrated (\f$ \vec{s} \f$),
+       *               - "Basis" is the vector basis that you'd like to use
+       *                 (\f$ \vec{\phi} \f$),
+       *               - "IR" is the integration rule that you'd like to use,
+       *               - "Multiplier" is the scalar multiplier out in front of
+       *                 the integral you're computing (\f$ M \f$), and
+       *               - "Field Multipliers" is an optional list of names of
+       *                 fields that are multipliers out in front of the
+       *                 integral you're computing (\f$ a(x) \f$, \f$ b(x) \f$,
+       *                 etc.).
+       */
+      Integrator_CurlBasisDotVector(
+        const Teuchos::ParameterList& p);
 
-    void
-    evaluateFields(
-      typename Traits::EvalData d);
+      /**
+       *  \brief `FieldTag` Constructor.
+       *
+       *  Creates an `Evaluator` to evaluate the integral
+       *  \f[
+       *    Ma(x)b(x)\cdots\int\nabla\times\vec{\phi}\cdot\vec{v}\, dx,
+       *  \f]
+       *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc.,
+       *  are some fields that depend on position, \f$ \vec{s} \f$ is some
+       *  vector-valued function, and \f$ \vec{\phi} \f$ is some vector basis.
+       *
+       *  \param[in] evalStyle   An `enum` declaring the behavior of this
+       *                         `Evaluator`, which is to either:
+       *                         - compute and contribute (`CONTRIBUTES`), or
+       *                         - compute and store (`EVALUATES`).
+       *  \param[in] resTag      The tag of either the contributed or evaluated
+       *                         field, depending on `evalStyle`.
+       *  \param[in] valTag      The tag of the vector value being integrated
+       *                         (\f$ \vec{s} \f$).
+       *  \param[in] bd          The vector basis descriptor that you'd like to
+       *                         use (\f$ \vec{\phi} \f$).
+       *  \param[in] id          The integration descriptor that you'd like to
+       *                         use.
+       *  \param[in] spaceDim    The spatial dimensionality of the problem.  If
+       *                         not specified, this defaults to 3.
+       *  \param[in] multiplier  The scalar multiplier out in front of the
+       *                         integral you're computing (\f$ M \f$).  If not
+       *                         specified, this defaults to 1.
+       *  \param[in] multipliers A list of tags of fields that are multipliers
+       *                         out in front of the integral you're computing
+       *                         (\f$ a(x) \f$, \f$ b(x) \f$, etc.).  If not
+       *                         specified, this defaults to an empty `vector`.
+       *
+       *  \throws std::invalid_argument If any of the inputs are invalid.
+       *  \throws std::logic_error      If the `basis` supplied is not a vector
+       *                                basis, or if it doesn't require
+       *                                orientations.
+       */
+      Integrator_CurlBasisDotVector(
+        const panzer::EvaluatorStyle&        evalStyle,
+        const PHX::FieldTag&                 resTag,
+        const PHX::FieldTag&                 valTag,
+        const panzer::BasisDescriptor&       bd,
+        const panzer::IntegrationDescriptor& id,
+        const int&                           spaceDim    = 3,
+        const double&                        multiplier  = 1,
+        const std::vector<PHX::FieldTag>&    multipliers =
+          std::vector<PHX::FieldTag>());
 
-  private:
+      /**
+       *  \brief Post-Registration Setup.
+       *
+       *  Sets the `Kokkos::View`s for all of the field multipliers, sets the
+       *  basis index, and sets up the field that will be used to build up the
+       *  result of the integration.
+       *
+       *  \param[in] sd Essentially a list of `Workset`s, which are collections
+       *                of cells (elements) that all live on a single process.
+       *  \param[in] fm The `FieldManager` used to create the field to build up
+       *                the result.
+       */
+      void
+      postRegistrationSetup(
+        typename Traits::SetupData sd,
+        PHX::FieldManager<Traits>& fm);
 
-    using ScalarT = typename EvalT::ScalarT;
-public:
+      /**
+       *  \brief Evaluate Fields.
+       *
+       *  This actually performs the integration using a handful of functors in
+       *  `Kokkos::parallel_for`s, looping over the cells in the `Workset`.
+       *
+       *  \param[in] workset The `Workset` on which you're going to do the
+       *                     integration.
+       */
+      void
+      evaluateFields(
+        typename Traits::EvalData d);
 
-  Integrator_CurlBasisDotVector(const PHX::FieldTag & input,
-                                const PHX::FieldTag & output,
-                                const std::vector<PHX::FieldTag> & multipliers,
-                                double multiplier,
-                                const panzer::BasisDescriptor & bd,
-                                const panzer::IntegrationDescriptor & id,
-                                int space_dim);
+    private:
 
-private:
-  bool use_descriptors_;
-  panzer::BasisDescriptor bd_;
-  panzer::IntegrationDescriptor id_;
-  
-  PHX::MDField<ScalarT,Cell,BASIS> residual;
-    
-  PHX::MDField<const ScalarT,Cell,IP>     flux_scalar; // note that this is used for scalar fields
-  PHX::MDField<const ScalarT,Cell,IP,Dim> flux_vector; // note that this is used for vector fields
-    
-  std::vector<PHX::MDField<const ScalarT,Cell,IP> > field_multipliers;
+      /**
+       *  \brief Get Valid Parameters.
+       *
+       *  Get all the parameters that we support such that the `ParameterList`
+       *  Constructor can do some validation of the input `ParameterList`.
+       *
+       *  \returns A `ParameterList` with all the valid parameters (keys) in
+       *           it.  The values tied to those keys are meaningless default
+       *           values.
+       */
+      Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
 
-  std::size_t num_nodes;
-  std::size_t num_qp;
-  std::size_t num_dim;
+      /**
+       *  \brief The scalar type.
+       */
+      using ScalarT = typename EvalT::ScalarT;
 
-  double multiplier;
+      /**
+       *  \brief An `enum` determining the behavior of this `Evaluator`.
+       *
+       *  This `Evaluator` will compute the result of its integration and then:
+       *  - CONTRIBUTES:  contribute it to a specified residual, not saving
+       *                  anything; or
+       *  - EVALUATES:    save it under a specified name for future use.
+       */
+      const panzer::EvaluatorStyle evalStyle_;
 
-  std::string basis_name;
-  std::size_t basis_index;
+      /**
+       *  \brief A flag indicating whether or not to use the descriptor
+       *         interface.
+       */
+      bool useDescriptors_;
 
-  bool useScalarField;
+      /**
+       *  \brief The `BasisDescriptor` for the basis to use.
+       */
+      panzer::BasisDescriptor bd_;
 
-  // scratch space
-  PHX::MDField<ScalarT,Cell,IP>     scratch_scalar;
-  PHX::MDField<ScalarT,Cell,IP,Dim> scratch_vector;
+      /**
+       *  \brief The `IntegrationDescriptor` for the quadrature to use.
+       */
+      panzer::IntegrationDescriptor id_;
 
-private:
-  Teuchos::RCP<Teuchos::ParameterList> getValidParameters() const;
-}; // end of class Integrator_CurlBasisDotVector
+      /**
+       *  \brief A field to which we'll contribute, or in which we'll store,
+       *         the result of computing this integral.
+       */
+      PHX::MDField<ScalarT, panzer::Cell, panzer::BASIS> field_;
 
+      /**
+       *  \brief A field representing the vector-valued function we're
+       *         integrating (\f$ \vec{s} \f$) in a two-dimensional problem.
+       */
+      PHX::MDField<const ScalarT, panzer::Cell, panzer::IP> vector2D_;
 
-}
+      /**
+       *  \brief A field representing the vector-valued function we're
+       *         integrating (\f$ \vec{s} \f$) in a three-dimensional problem.
+       */
+      PHX::MDField<const ScalarT, panzer::Cell, panzer::IP, panzer::Dim>
+      vector3D_;
 
-#endif
+      /**
+       *  \brief The scalar multiplier out in front of the integral (\f$ M
+       *         \f$).
+       */
+      double multiplier_;
+
+      /**
+       *  \brief The (possibly empty) list of fields that are multipliers out
+       *         in front of the integral (\f$ a(x) \f$, \f$ b(x) \f$, etc.).
+       */
+      std::vector<PHX::MDField<const ScalarT, panzer::Cell, panzer::IP>>
+      fieldMults_;
+
+      /**
+       *  \brief The `Kokkos::View` representation of the (possibly empty) list
+       *         of fields that are multipliers out in front of the integral
+       *         (\f$ a(x) \f$, \f$ b(x) \f$, etc.).
+       */
+      Kokkos::View<Kokkos::View<const ScalarT**>*> kokkosFieldMults_;
+
+      /**
+       *  \brief The name of the basis we're using.
+       */
+      std::string basisName_;
+
+      /**
+       *  \brief The index in the `Workset` bases for our particular
+       *         `BasisIRLayout` name.
+       */
+      std::size_t basisIndex_;
+
+      /**
+       *  \brief The spatial dimension of the vector-valued function we're
+       *         integrating, either 2 or 3.
+       */
+      int spaceDim_;
+
+      /**
+       *  \brief A field used to build up the result of this integral when
+       *         working on a two-dimensional vector field.
+       */
+      PHX::MDField<ScalarT, panzer::Cell, panzer::IP> result2D_;
+
+      /**
+       *  \brief A field used to build up the result of this integral when
+       *         working on a three-dimensional vector field.
+       */
+      PHX::MDField<ScalarT, panzer::Cell, panzer::IP, panzer::Dim> result3D_;
+  }; // end of class Integrator_CurlBasisDotVector
+
+} // end of namespace panzer
+
+#endif // Panzer_Integrator_CurlBasisDotVector_hpp

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector_impl.hpp
@@ -40,424 +40,769 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef PANZER_EVALUATOR_CURLBASISDOTVECTOR_IMPL_HPP
-#define PANZER_EVALUATOR_CURLBASISDOTVECTOR_IMPL_HPP
+#ifndef   Panzer_Integrator_CurlBasisDotVector_impl_hpp
+#define   Panzer_Integrator_CurlBasisDotVector_impl_hpp
 
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Include Files
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// Intrepid2
 #include "Intrepid2_FunctionSpaceTools.hpp"
-#include "Panzer_IntegrationRule.hpp"
+
+// Panzer
 #include "Panzer_BasisIRLayout.hpp"
-#include "Panzer_Workset_Utilities.hpp"
 #include "Panzer_CommonArrayFactories.hpp"
+#include "Panzer_IntegrationRule.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+
+// Phalanx
 #include "Phalanx_KokkosDeviceTypes.hpp"
 
-namespace panzer {
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-Integrator_CurlBasisDotVector<EvalT, Traits>::
-Integrator_CurlBasisDotVector(
-  const Teuchos::ParameterList& p) :
-  use_descriptors_(false),
-  residual( p.get<std::string>("Residual Name"), 
-	    p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
-  basis_name(p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->name())
+namespace panzer
 {
-  Teuchos::RCP<Teuchos::ParameterList> valid_params = this->getValidParameters();
-  p.validateParameters(*valid_params);
-
-  Teuchos::RCP<const PureBasis> basis 
-     = p.get< Teuchos::RCP<BasisIRLayout> >("Basis")->getBasis();
-
-  // Verify that this basis supports the curl operation
-  TEUCHOS_TEST_FOR_EXCEPTION(!basis->supportsCurl(),std::logic_error,
-                             "Integrator_CurlBasisDotVector: Basis of type \"" << basis->name() << "\" does not support CURL.");
-  TEUCHOS_TEST_FOR_EXCEPTION(!basis->requiresOrientations(),std::logic_error,
-                             "Integration_CurlBasisDotVector: Basis of type \"" << basis->name() << "\" should require orientations. So we are throwing.");
-  TEUCHOS_TEST_FOR_EXCEPTION(!(basis->dimension()==2 || basis->dimension()==3),std::logic_error,
-                             "Integrator_CurlBasisDotVector: Evaluator requires 2D or 3D basis types, the basis \"" << basis->name() << "\" is neither.");
-
-  // use a scalar field only if dimension is 2D
-  useScalarField = (basis->dimension()==2);
-  
-  // determine if using scalar field for curl or a vector field (2D versus 3D)
-  if(!useScalarField) {
-     flux_vector = PHX::MDField<const ScalarT,Cell,IP,Dim>( p.get<std::string>("Value Name"), 
-	                                  p.get< Teuchos::RCP<panzer::IntegrationRule> >("IR")->dl_vector );
-     this->addDependentField(flux_vector);
-  }
-  else {
-     flux_scalar = PHX::MDField<const ScalarT,Cell,IP>( p.get<std::string>("Value Name"), 
-   	                                  p.get< Teuchos::RCP<panzer::IntegrationRule> >("IR")->dl_scalar );
-     this->addDependentField(flux_scalar);
-  }
-
-  this->addEvaluatedField(residual);
-  
-  multiplier = p.get<double>("Multiplier");
-  if (p.isType<Teuchos::RCP<const std::vector<std::string> > >("Field Multipliers")) 
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  Main Constructor
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  Integrator_CurlBasisDotVector<EvalT, Traits>::
+  Integrator_CurlBasisDotVector(
+    const panzer::EvaluatorStyle&   evalStyle,
+    const std::string&              resName,
+    const std::string&              valName,
+    const panzer::BasisIRLayout&    basis,
+    const panzer::IntegrationRule&  ir,
+    const double&                   multiplier, /* = 1 */
+    const std::vector<std::string>& fmNames     /* =
+      std::vector<std::string>() */)
+    :
+    evalStyle_(evalStyle),
+    useDescriptors_(false),
+    multiplier_(multiplier),
+    basisName_(basis.name())
   {
-    const std::vector<std::string>& field_multiplier_names = 
-      *(p.get<Teuchos::RCP<const std::vector<std::string> > >("Field Multipliers"));
+    using Kokkos::View;
+    using panzer::BASIS;
+    using panzer::Cell;
+    using panzer::Dim;
+    using panzer::EvaluatorStyle;
+    using panzer::IP;
+    using panzer::PureBasis;
+    using PHX::MDField;
+    using std::invalid_argument;
+    using std::logic_error;
+    using std::string;
+    using Teuchos::RCP;
 
-    for (std::vector<std::string>::const_iterator name = field_multiplier_names.begin(); 
-      name != field_multiplier_names.end(); ++name) 
+    // Ensure the input makes sense.
+    TEUCHOS_TEST_FOR_EXCEPTION(resName == "", invalid_argument, "Error:  "    \
+      "Integrator_CurlBasisDotVector called with an empty residual name.")
+    TEUCHOS_TEST_FOR_EXCEPTION(valName == "", invalid_argument, "Error:  "    \
+      "Integrator_CurlBasisDotVector called with an empty value name.")
+    RCP<const PureBasis> tmpBasis = basis.getBasis();
+    TEUCHOS_TEST_FOR_EXCEPTION(not tmpBasis->isVectorBasis(), logic_error,
+      "Error:  Integrator_CurlBasisDotVector:  Basis of type \""
+      << tmpBasis->name() << "\" is not a vector basis.")
+    TEUCHOS_TEST_FOR_EXCEPTION(not tmpBasis->requiresOrientations(),
+      logic_error, "Error:  Integrator_CurlBasisDotVector:  Basis of type \""
+      << tmpBasis->name() << "\" does not require orientations, though it "   \
+      "should for its use in this Evaluator.")
+    TEUCHOS_TEST_FOR_EXCEPTION(not tmpBasis->supportsCurl(), logic_error,
+      "Error:  Integrator_CurlBasisDotVector:  Basis of type \""
+      << tmpBasis->name() << "\" does not support curl.")
+    TEUCHOS_TEST_FOR_EXCEPTION(not ((tmpBasis->dimension() == 2) or
+      (tmpBasis->dimension() == 3)), logic_error,
+      "Error:  Integrator_CurlBasisDotVector requires either a two- or "      \
+      "three-dimensional basis.  The basis \"" << tmpBasis->name()
+      << "\" is neither.")
+
+    // Use a scalar field only if we're dealing with a two-dimensional case.
+    spaceDim_ = tmpBasis->dimension();
+
+    // Create the field for the vector-values quantity we're integrating.
+    if (spaceDim_ == 2)
     {
-      PHX::MDField<const ScalarT,Cell,IP> tmp_field(*name, p.get< Teuchos::RCP<panzer::IntegrationRule> >("IR")->dl_scalar);
-      field_multipliers.push_back(tmp_field);
+      vector2D_ = MDField<const ScalarT, Cell, IP>(valName, ir.dl_scalar);
+      this->addDependentField(vector2D_);
     }
-  }
-
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->addDependentField(*field);
-
-  std::string n = 
-    "Integrator_CurlBasisDotVector: " + residual.fieldTag().name();
-
-  this->setName(n);
-}
-
-//**********************************************************************
-template<typename EvalT, typename TRAITS>                   
-Integrator_CurlBasisDotVector<EvalT, TRAITS>::
-Integrator_CurlBasisDotVector(const PHX::FieldTag & input,
-                              const PHX::FieldTag & output,
-                              const std::vector<PHX::FieldTag> & multipliers,
-                              double mult,
-                              const panzer::BasisDescriptor & bd,
-                              const panzer::IntegrationDescriptor & id,
-                              int space_dim)
-  : use_descriptors_(true)
-  , bd_(bd)
-  , id_(id)
-  , residual(output)
-  , multiplier(mult)
-{
-  TEUCHOS_TEST_FOR_EXCEPTION(bd_.getType()!="HCurl",std::logic_error,
-                             "Integrator_CurlBasisDotVector: Basis of type \"" << bd_.getType() << "\" does not support CURL.");
-  // use a scalar field only if dimension is 2D
-  useScalarField = (space_dim==2);
-
-  if(not useScalarField) {
-    flux_vector = input;
-    this->addDependentField(flux_vector);
-  }
-  else {
-    flux_scalar = input;
-    this->addDependentField(flux_scalar);
-  }
-
-  this->addEvaluatedField(residual);
-
-  // setup multipliers
-  for(std::size_t i=0;i<multipliers.size();i++) {
-    PHX::MDField<const ScalarT,Cell,IP> tmp_field = multipliers[i];
-    field_multipliers.push_back(tmp_field);
-  }
-
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->addDependentField(*field);
-
-  std::string n = 
-    "Integrator_CurlBasisDotVector: " + residual.fieldTag().name();
-
-  this->setName(n);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-Integrator_CurlBasisDotVector<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
-{
-  // setup the output field
-  this->utils.setFieldData(residual,fm);
-
-  // initialize the input field multiplier fields
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->utils.setFieldData(*field,fm);
-
-  // setup the input fields, mainly differentiate between 2D and 3D
-  MDFieldArrayFactory af("",fm.template getKokkosExtendedDataTypeDimensions<EvalT>(),true);
-  if(!useScalarField) {
-    this->utils.setFieldData(flux_vector,fm);
-
-    num_nodes = residual.dimension(1);
-    num_qp = flux_vector.dimension(1);
-    num_dim = 3;
-
-    if(not use_descriptors_)
-      basis_index = panzer::getBasisIndex(basis_name, (*sd.worksets_)[0], this->wda);
-
-    scratch_vector = af.buildStaticArray<ScalarT,Cell,IP,Dim>("btv_scratch",flux_vector.dimension(0),num_qp,num_dim);
-  }
-  else {
-    this->utils.setFieldData(flux_scalar,fm);
-
-    num_nodes = residual.dimension(1);
-    num_qp = flux_scalar.dimension(1);
-    num_dim = 2;
-
-    if(not use_descriptors_)
-      basis_index = panzer::getBasisIndex(basis_name, (*sd.worksets_)[0], this->wda);
-
-    scratch_scalar = af.buildStaticArray<ScalarT,Cell,IP>("btv_scratch",flux_scalar.dimension(0),num_qp);
-  }
-}
-
-namespace {
-
-template <typename ScalarT>
-class FillScratchVector {
-public:
-  typedef typename PHX::Device execution_space;
-
-  // Required for all functors
-  PHX::MDField<ScalarT,Cell,IP,Dim> scratch;
-
-  // Required for "Initialize" functor
-  double multiplier;
-  PHX::MDField<const ScalarT,Cell,IP,Dim> vectorField;
-
-  // Required for "FieldMultipliers" functor
-  PHX::MDField<const ScalarT,Cell,IP> field;
-
-  struct Initialize {};
-  struct FieldMultipliers {};
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const Initialize,const unsigned cell) const
-  {
-    for (std::size_t qp = 0; qp < scratch.dimension_1(); ++qp) 
-      for (std::size_t d = 0; d < scratch.dimension_2(); ++d)
-        scratch(cell,qp,d) = multiplier * vectorField(cell,qp,d);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const FieldMultipliers,const unsigned cell) const
-  {
-    for (std::size_t qp = 0; qp < scratch.dimension_1(); ++qp) 
-      for (std::size_t d = 0; d < scratch.dimension_2(); ++d)
-        scratch(cell,qp,d) *= field(cell,qp);
-  }
-};
-
-template <typename ScalarT>
-class FillScratchScalar {
-public:
-  typedef typename PHX::Device execution_space;
-
-  // Required for all functors
-  PHX::MDField<ScalarT,Cell,IP> scratch;
-
-  // Required for "Initialize" functor
-  double multiplier;
-  PHX::MDField<const ScalarT,Cell,IP> vectorField;
-
-  // Required for "FieldMultipliers" functor
-  PHX::MDField<const ScalarT,Cell,IP> field;
-
-  struct Initialize {};
-  struct FieldMultipliers {};
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const Initialize,const unsigned cell) const
-  {
-    for (std::size_t qp = 0; qp < scratch.dimension_1(); ++qp) 
-      scratch(cell,qp) = multiplier*vectorField(cell,qp);  
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const FieldMultipliers,const unsigned cell) const
-  {
-    for (std::size_t qp = 0; qp < scratch.dimension_1(); ++qp) 
-      scratch(cell,qp) *= field(cell,qp);
-  }
-};
-
-template <typename ScalarT,int spaceDim>
-class IntegrateValuesVector {
-public:
-  typedef typename PHX::Device execution_space;
-  PHX::MDField<ScalarT,Cell,IP,Dim> scratch;
-  PHX::MDField<ScalarT,Cell,BASIS> residual;
-  PHX::MDField<double,Cell,BASIS,IP,Dim> weighted_curl_basis;
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const unsigned cell) const
-  {
-    for (int lbf = 0; lbf < weighted_curl_basis.extent_int(1); lbf++) {
-      residual(cell,lbf) = 0.0;
-      for (int qp = 0; qp < weighted_curl_basis.extent_int(2); qp++) {
-        for (int d = 0; d < spaceDim; d++) {
-          residual(cell,lbf) += scratch(cell, qp, d)*weighted_curl_basis(cell, lbf, qp, d);
-        } // D-loop
-      } // P-loop
-    } // F-loop
-  }
-};
-
-template <typename ScalarT>
-class IntegrateValuesScalar {
-public:
-  typedef typename PHX::Device execution_space;
-  PHX::MDField<ScalarT,Cell,IP> scratch;
-  PHX::MDField<ScalarT,Cell,BASIS> residual;
-  PHX::MDField<double,Cell,BASIS,IP> weighted_curl_basis;
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const unsigned cell) const
-  {
-    for (int lbf = 0; lbf < weighted_curl_basis.extent_int(1); lbf++) {
-      residual(cell,lbf) = 0.0;
-      for (int qp = 0; qp < weighted_curl_basis.extent_int(2); qp++) {
-          residual(cell,lbf) += scratch(cell,qp)*weighted_curl_basis(cell,lbf,qp);
-      } // P-loop
-    } // F-loop
-  }
-};
-
-} // end internal namespace
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-Integrator_CurlBasisDotVector<EvalT, Traits>::
-evaluateFields(
-  typename Traits::EvalData workset)
-{ 
-  const panzer::BasisValues2<double> & bv = use_descriptors_ ?  this->wda(workset).getBasisValues(bd_,id_)
-                                                             : *this->wda(workset).bases[basis_index];
-
-  if(!useScalarField) {
-    typedef FillScratchVector<ScalarT> FillScratch;
-    FillScratch fillScratch;
-    fillScratch.scratch     = scratch_vector;
-    fillScratch.multiplier  = multiplier;
-    fillScratch.vectorField = flux_vector;
-
-    // initialize in first pass (basically a scaled copy)
-    Kokkos::parallel_for(Kokkos::RangePolicy<PHX::Device,typename FillScratch::Initialize>(0,workset.num_cells), fillScratch);
-
-    // multiply agains all the fields in the next one
-    for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-         field != field_multipliers.end(); ++field) {
-      fillScratch.field = *field;
-
-      Kokkos::parallel_for(Kokkos::RangePolicy<PHX::Device,typename FillScratch::FieldMultipliers>(0,workset.num_cells), fillScratch);
-    }
-
-    // Build integrate values functor (hard code spatial dimensions)
-    IntegrateValuesVector<ScalarT,3> intValues;
-    intValues.scratch     = scratch_vector;
-    intValues.residual    = residual;
-    intValues.weighted_curl_basis = bv.weighted_curl_basis_vector;
-    
-    Kokkos::parallel_for(workset.num_cells, intValues);
-  }
-  else {
-    typedef FillScratchScalar<ScalarT> FillScratch;
-    FillScratch fillScratch;
-    fillScratch.scratch     = scratch_scalar;
-    fillScratch.multiplier  = multiplier;
-    fillScratch.vectorField = flux_scalar;
-
-    // initialize in first pass (basically a scaled copy)
-    Kokkos::parallel_for(Kokkos::RangePolicy<PHX::Device,typename FillScratch::Initialize>(0,workset.num_cells), fillScratch);
-
-    // multiply agains all the fields in the next one
-    for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-         field != field_multipliers.end(); ++field) {
-      fillScratch.field = *field;
-
-      Kokkos::parallel_for(Kokkos::RangePolicy<PHX::Device,typename FillScratch::FieldMultipliers>(0,workset.num_cells), fillScratch);
-    }
-
-    // Build integrate values functor
-    IntegrateValuesScalar<ScalarT> intValues;
-    intValues.scratch     = scratch_scalar;
-    intValues.residual    = residual;
-    intValues.weighted_curl_basis = bv.weighted_curl_basis_scalar;
-
-    Kokkos::parallel_for(workset.num_cells, intValues);
-  }
-
-#if 0
-  residual.deep_copy(ScalarT(0.0));
-
-  for (index_t cell = 0; cell < workset.num_cells; ++cell)
-  {
-    for (std::size_t qp = 0; qp < num_qp; ++qp)
+    else // if (spaceDim_ == 3)
     {
-      ScalarT tmpVar = 1.0;
-      // for (typename std::vector<PHX::MDField<ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-      //      field != field_multipliers.end(); ++field)
-      for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-           field != field_multipliers.end(); ++field)
-        tmpVar = tmpVar * (*field)(cell,qp);  
+      vector3D_ = MDField<const ScalarT, Cell, IP, Dim>(valName, ir.dl_vector);
+      this->addDependentField(vector3D_);
+    } // end if spaceDim_ is 2 or 3
 
-      if(!useScalarField) {
-        // for vector fields loop over dimension
-        for (std::size_t dim = 0; dim < num_dim; ++dim)
-          scratch_vector(cell,qp,dim) = multiplier * tmpVar * flux_vector(cell,qp,dim);
-      }
-      else {
-        // no dimension to loop over for scalar fields
-        scratch_scalar(cell,qp) = multiplier * tmpVar * flux_scalar(cell,qp);
-      }
+    // Create the field that we're either contributing to or evaluating
+    // (storing).
+    field_ = MDField<ScalarT, Cell, BASIS>(resName, basis.functional);
+    if (evalStyle == EvaluatorStyle::CONTRIBUTES)
+      this->addContributedField(field_);
+    else // if (evalStyle == EvaluatorStyle::EVALUATES)
+      this->addEvaluatedField(field_);
+
+    // Add the dependent field multipliers, if there are any.
+    int i(0);
+    fieldMults_.resize(fmNames.size());
+    kokkosFieldMults_ = View<View<const ScalarT**>*>(
+      "CurlBasisDotVector::KokkosFieldMultipliers", fmNames.size());
+    for (const auto& name : fmNames)
+    {
+      fieldMults_[i++] = MDField<const ScalarT, Cell, IP>(name, ir.dl_scalar);
+      this->addDependentField(fieldMults_[i - 1]);
+    } // end loop over the field multipliers
+
+    // Set the name of this object.
+    string n("Integrator_CurlBasisDotVector (");
+    if (evalStyle == EvaluatorStyle::CONTRIBUTES)
+      n += "CONTRIBUTES";
+    else // if (evalStyle == EvaluatorStyle::EVALUATES)
+      n += "EVALUATES";
+    n += "):  " + field_.fieldTag().name();
+    this->setName(n);
+  } // end of Main Constructor
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  ParameterList Constructor
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  Integrator_CurlBasisDotVector<EvalT, Traits>::
+  Integrator_CurlBasisDotVector(
+    const Teuchos::ParameterList& p)
+    :
+    Integrator_CurlBasisDotVector(
+      panzer::EvaluatorStyle::EVALUATES,
+      p.get<std::string>("Residual Name"),
+      p.get<std::string>("Value Name"),
+      (*p.get<Teuchos::RCP<panzer::BasisIRLayout>>("Basis")),
+      (*p.get<Teuchos::RCP<panzer::IntegrationRule>>("IR")),
+      p.get<double>("Multiplier"),
+      p.isType<Teuchos::RCP<const std::vector<std::string>>>
+        ("Field Multipliers") ?
+        (*p.get<Teuchos::RCP<const std::vector<std::string>>>
+        ("Field Multipliers")) : std::vector<std::string>())
+  {
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+
+    // Ensure that the input ParameterList didn't contain any bogus entries.
+    RCP<ParameterList> validParams = this->getValidParameters();
+    p.validateParameters(*validParams);
+  } // end of ParameterList Constructor
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  FieldTag Constructor
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename TRAITS>
+  Integrator_CurlBasisDotVector<EvalT, TRAITS>::
+  Integrator_CurlBasisDotVector(
+    const panzer::EvaluatorStyle&        evalStyle,
+    const PHX::FieldTag&                 resTag,
+    const PHX::FieldTag&                 valTag,
+    const panzer::BasisDescriptor&       bd,
+    const panzer::IntegrationDescriptor& id,
+    const int&                           spaceDim,   /* = 3 */
+    const double&                        multiplier, /* = 1 */
+    const std::vector<PHX::FieldTag>&    multipliers /* =
+      std::vector<PHX::FieldTag>() */)
+    :
+    evalStyle_(evalStyle),
+    useDescriptors_(true),
+    bd_(bd),
+    id_(id),
+    multiplier_(multiplier),
+    spaceDim_(spaceDim)
+  {
+    using Kokkos::View;
+    using panzer::EvaluatorStyle;
+    using std::logic_error;
+    using std::string;
+
+    // Ensure the input makes sense.
+    TEUCHOS_TEST_FOR_EXCEPTION(bd_.getType() != "HCurl", logic_error,
+      "Error:  Integrator_CurlBasisDotVector:  Basis of type \""
+      << bd_.getType() << "\" does not support curl.")
+    TEUCHOS_TEST_FOR_EXCEPTION(not ((spaceDim == 2) or (spaceDim == 3)),
+      logic_error, "Error:  Integrator_CurlBasisDotVector works on either " \
+      "two- or three-dimensional problems.  You've provided spaceDim = "
+      << spaceDim << ".")
+
+    // Create the field for the vector-valued quantity we're integrating.
+    if (spaceDim_ == 2)
+    {
+      vector2D_ = valTag;
+      this->addDependentField(vector2D_);
     }
-  }
+    else // if (spaceDim_ == 3)
+    {
+      vector3D_ = valTag;
+      this->addDependentField(vector3D_);
+    } // end if spaceDim_ is 2 or 3
 
-  if(!useScalarField) {
-    auto weighted_curl_basis_vector = bv.weighted_curl_basis_vector;
+    // Create the field that we're either contributing to or evaluating
+    // (storing).
+    field_ = resTag;
+    if (evalStyle == EvaluatorStyle::CONTRIBUTES)
+      this->addContributedField(field_);
+    else // if (evalStyle == EvaluatorStyle::EVALUATES)
+      this->addEvaluatedField(field_);
 
-    for (index_t cell = 0; cell < workset.num_cells; ++cell)
-      for (std::size_t basis = 0; basis < num_nodes; ++basis) {
-        residual(cell,basis) = 0.0;
-        for (std::size_t qp = 0; qp < num_qp; ++qp)
-          for (std::size_t dim = 0; dim < num_dim; ++dim)
-            // residual(cell,basis) += scratch_vector(cell,qp,dim)*weighted_curl_basis_vector(cell,basis,qp,dim);
-            residual(cell,basis) += multiplier*flux_vector(cell,qp,dim)*weighted_curl_basis_vector(cell,basis,qp,dim);
-      }
-  }
-  else { // useScalarField
-    auto weighted_curl_basis_scalar = bv.weighted_curl_basis_scalar;
+    // Add the dependent field multipliers, if there are any.
+    int i(0);
+    fieldMults_.resize(multipliers.size());
+    kokkosFieldMults_ = View<View<const ScalarT**>*>(
+      "CurlBasisDotVector::KokkosFieldMultipliers", multipliers.size());
+    for (const auto& fm : multipliers)
+    {
+      fieldMults_[i++] = fm;
+      this->addDependentField(fieldMults_[i - 1]);
+    } // end loop over the field multipliers
 
-    for (index_t cell = 0; cell < workset.num_cells; ++cell)
-      for (std::size_t basis = 0; basis < num_nodes; ++basis) {
-       residual(cell,basis) = 0.0;
-        for (std::size_t qp = 0; qp < num_qp; ++qp)
-          // residual(cell,basis) += scratch_scalar(cell,qp)*weighted_curl_basis_scalar(cell,basis,qp);
-          residual(cell,basis) += multiplier*flux_scalar(cell,qp)*weighted_curl_basis_scalar(cell,basis,qp);
-      }
-  }
-#endif
-}
+    // Set the name of this object.
+    string n("Integrator_CurlBasisDotVector (");
+    if (evalStyle == EvaluatorStyle::CONTRIBUTES)
+      n += "CONTRIBUTES";
+    else // if (evalStyle == EvaluatorStyle::EVALUATES)
+      n += "EVALUATES";
+    n += "):  " + field_.fieldTag().name();
+    this->setName(n);
+  } // end of Other Constructor
 
-//**********************************************************************
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  postRegistrationSetup()
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  void
+  Integrator_CurlBasisDotVector<EvalT, Traits>::
+  postRegistrationSetup(
+    typename Traits::SetupData sd,
+    PHX::FieldManager<Traits>& fm)
+  {
+    using panzer::getBasisIndex;
+    using PHX::MDField;
+    using std::vector;
 
-template<typename EvalT, typename TRAITS>
-Teuchos::RCP<Teuchos::ParameterList> 
-Integrator_CurlBasisDotVector<EvalT, TRAITS>::getValidParameters() const
-{
-  Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::rcp(new Teuchos::ParameterList);
-  p->set<std::string>("Residual Name", "?");
-  p->set<std::string>("Value Name", "?");
-  p->set<std::string>("Test Field Name", "?");
-  Teuchos::RCP<panzer::BasisIRLayout> basis;
-  p->set("Basis", basis);
-  Teuchos::RCP<panzer::IntegrationRule> ir;
-  p->set("IR", ir);
-  p->set<double>("Multiplier", 1.0);
-  Teuchos::RCP<const std::vector<std::string> > fms;
-  p->set("Field Multipliers", fms);
-  return p;
-}
+    // Get the Kokkos::Views of the field multipliers.
+    for (size_t i(0); i < fieldMults_.size(); ++i)
+      kokkosFieldMults_(i) = fieldMults_[i].get_static_view();
 
-//**********************************************************************
+    // Determine the index in the Workset bases for our particular basis
+    // name.
+    if (not useDescriptors_)
+      basisIndex_ = getBasisIndex(basisName_, (*sd.worksets_)[0], this->wda);
 
-}
+    // Set up the field that will be used to build of the result of this
+    // integration.
+    MDFieldArrayFactory af("",
+      fm.template getKokkosExtendedDataTypeDimensions<EvalT>(), true);
+    if (spaceDim_ == 2)
+      result2D_ = af.buildStaticArray<ScalarT, Cell, IP>(
+        "Integrator_CurlBasisDotVector:  2-D Result", vector2D_.extent(0),
+        vector2D_.extent(1));
+    else // if (spaceDim_ == 3)
+      result3D_ = af.buildStaticArray<ScalarT, Cell, IP, Dim>(
+        "Integrator_CurlBasisDotVector:  3-D Result", vector3D_.extent(0),
+        vector3D_.extent(1), 3);
+  } // end of postRegistrationSetup()
 
-#endif
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  Anonymous namespace containing classes for performing the integration.
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  namespace
+  {
+    /**
+     *  \brief Multiply the integrand by the scalar multiplier (\f$ M \f$) and
+     *         any field multipliers (\f$ a(x) \f$, \f$ b(x) \f$, etc.) out in
+     *         front of the integral.
+     *
+     *  This must happen before the integration itself is performed by
+     *  `Integrate2D`.
+     *
+     *  \note This class is used when integrating a two-dimensional problem.
+     *        Three-dimensional problems use the `PreMultiply3D` class.
+     */
+    template<typename ScalarT>
+    class PreMultiply2D
+    {
+      public:
+
+        /**
+         *  \brief The Kokkos dispatch tag to pre-multiply the integrand by the
+         *         scalar multiplier.
+         */
+        struct ScalarMultiplierTag
+        {
+        }; // end of struct ScalarMultiplierTag
+
+        /**
+         *  \brief The Kokkos dispatch tag to pre-multiply the integrand by a
+         *         field multiplier.
+         */
+        struct FieldMultiplierTag
+        {
+        }; // end of struct FieldMultiplierTag
+
+        /**
+         *  \brief Multiply the integrand by the scalar multiplier (\f$ M \f$)
+         *         out in front of the integral.
+         *
+         *  Loop over the quadrature points and scale the integrand by the
+         *  scalar multiplier.
+         *
+         *  \note This must be called before the `FieldMultiplierTag`
+         *        `operator()()` routine, as this initializes the resulting
+         *        field.
+         */
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const ScalarMultiplierTag, const unsigned cell) const
+        {
+          int numQP(result.extent(1));
+          for (int qp(0); qp < numQP; ++qp)
+            result(cell, qp) = multiplier * vectorField(cell, qp);
+        } // end of ScalarMultiplierTag operator()()
+
+        /**
+         *  \brief Multiply the integrand by one of the field multipliers
+         *         (\f$ a(x) \f$, \f$ b(x) \f$, etc.) out in front of the
+         *         integral.
+         *
+         *  Loop over the quadrature points and scale the integrand by the
+         *  field multiplier.
+         *
+         *  \note This must be called after the `ScalarMultiplierTag`
+         *        `operator()()` routine, as that one initializes the resulting
+         *        field.
+         */
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const FieldMultiplierTag, const unsigned cell) const
+        {
+          int numQP(result.extent(1));
+          for (int qp(0); qp < numQP; ++qp)
+            result(cell, qp) *= fieldMult(cell, qp);
+        } // end of FieldMultiplierTag operator()()
+
+        /**
+         *  \brief This tells Kokkos to only execute this functor in the
+         *         `PHX::Device` execution space.
+         */
+        using execution_space = PHX::Device;
+
+        /**
+         *  \brief A field that will be used to build up the result of the
+         *         integral we're performing.
+         */
+        PHX::MDField<ScalarT, panzer::Cell, panzer::IP> result;
+
+        /**
+         *  \brief The scalar multiplier out in front of the integral (\f$ M
+         *         \f$).
+         */
+        double multiplier;
+
+        /**
+         *  \brief A field representing the vector-valued function we're
+         *         integrating (\f$ \vec{s} \f$).
+         */
+        PHX::MDField<const ScalarT, panzer::Cell, panzer::IP> vectorField;
+
+        /**
+         *  \brief One of the field multipliers (\f$ a(x) \f$, \f$ b(x) \f$,
+         *         etc.) out in front of the integral.
+         */
+        PHX::MDField<const ScalarT, panzer::Cell, panzer::IP> fieldMult;
+    }; // end of class PreMultiply2D
+
+    /**
+     *  \brief Multiply the integrand by the scalar multiplier (\f$ M \f$) and
+     *         any field multipliers (\f$ a(x) \f$, \f$ b(x) \f$, etc.) out in
+     *         front of the integral.
+     *
+     *  This must happen before the integration itself is performed by
+     *  `Integrate3D`.
+     *
+     *  \note This class is used when integrating a three-dimensional problem.
+     *        Two-dimensional problems use the `PreMultiply2D` class.
+     */
+    template<typename ScalarT>
+    class PreMultiply3D
+    {
+      public:
+
+        /**
+         *  \brief The Kokkos dispatch tag to pre-multiply the integrand by the
+         *         scalar multiplier.
+         */
+        struct ScalarMultiplierTag
+        {
+        }; // end of struct ScalarMultiplierTag
+
+        /**
+         *  \brief The Kokkos dispatch tag to pre-multiply the integrand by a
+         *         field multiplier.
+         */
+        struct FieldMultiplierTag
+        {
+        }; // end of struct FieldMultiplierTag
+
+        /**
+         *  \brief Multiply the integrand by the scalar multiplier (\f$ M \f$)
+         *         out in front of the integral.
+         *
+         *  Loop over the quadrature points and dimensions of our vector field
+         *  and scale the integrand by the scalar multiplier.
+         *
+         *  \note This must be called before the `FieldMultiplierTag`
+         *        `operator()()` routine, as this initializes the resulting
+         *        field.
+         */
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const ScalarMultiplierTag, const unsigned cell) const
+        {
+          int numQP(result.extent(1)), numDim(result.extent(2));
+          for (int qp(0); qp < numQP; ++qp)
+            for (int dim(0); dim < numDim; ++dim)
+              result(cell, qp, dim) = multiplier * vectorField(cell, qp, dim);
+        } // end of ScalarMultiplierTag operator()()
+
+        /**
+         *  \brief Multiply the integrand by one of the field multipliers
+         *         (\f$ a(x) \f$, \f$ b(x) \f$, etc.) out in front of the
+         *         integral.
+         *
+         *  Loop over the quadrature points and dimensions of our vector field
+         *  and scale the integrand by the field multiplier.
+         *
+         *  \note This must be called after the `ScalarMultiplierTag`
+         *        `operator()()` routine, as that one initializes the resulting
+         *        field.
+         */
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const FieldMultiplierTag, const unsigned cell) const
+        {
+          int numQP(result.extent(1)), numDim(result.extent(2));
+          for (int qp(0); qp < numQP; ++qp)
+            for (int dim(0); dim < numDim; ++dim)
+              result(cell, qp, dim) *= fieldMult(cell, qp);
+        } // end of FieldMultiplierTag operator()()
+
+        /**
+         *  \brief This tells Kokkos to only execute this functor in the
+         *         `PHX::Device` execution space.
+         */
+        using execution_space = PHX::Device;
+
+        /**
+         *  \brief A field that will be used to build up the result of the
+         *         integral we're performing.
+         */
+        PHX::MDField<ScalarT, panzer::Cell, panzer::IP, panzer::Dim> result;
+
+        /**
+         *  \brief The scalar multiplier out in front of the integral (\f$ M
+         *         \f$).
+         */
+        double multiplier;
+
+        /**
+         *  \brief A field representing the vector-valued function we're
+         *         integrating (\f$ \vec{s} \f$).
+         */
+        PHX::MDField<const ScalarT, panzer::Cell, panzer::IP, panzer::Dim>
+        vectorField;
+
+        /**
+         *  \brief One of the field multipliers (\f$ a(x) \f$, \f$ b(x) \f$,
+         *         etc.) out in front of the integral.
+         */
+        PHX::MDField<const ScalarT, panzer::Cell, panzer::IP> fieldMult;
+    }; // end of class PreMultiply3D
+
+    /**
+     *  \brief Perform the actual integration, looping over the bases,
+     *         quadrature points, and dimensions of our vector field.
+     *
+     *  This must happen after the integrand has already been pre-multiplied
+     *  by the scalar multiplier (\f$ M \f$) and any field multipliers
+     *  (\f$ a(x) \f$, \f$ b(x) \f$, etc.) out in front of the integral.
+     *
+     *  \note This class is used when integrating a three-dimensional problem.
+     *        Two-dimensional problems use the `Integrate2D` class.
+     */
+    template<typename ScalarT, int spaceDim>
+    class Integrate3D
+    {
+      public:
+
+        /**
+         *  \brief Perform the actual integration.
+         *
+         *  Loop over the bases, quadrature points, and dimensions in our
+         *  vector field, summing up the integrand times the appropriate basis
+         *  information.
+         *
+         *  \note If this is a `EVALUATES` style `Evaluator`, the field will be
+         *        initialized to zero.  If it's a `CONTRIBUTES` style one
+         *        instead, the field will not be initialized, as that's assumed
+         *        to have happened in some other `Evaluator`.
+         */
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const unsigned cell) const
+        {
+          using panzer::EvaluatorStyle;
+          int numBases(weightedCurlBasis.extent(1)),
+            numQP(weightedCurlBasis.extent(2));
+          for (int basis(0); basis < numBases; ++basis)
+          {
+            if (evalStyle == EvaluatorStyle::EVALUATES)
+              field(cell, basis) = 0.0;
+            for (int qp(0); qp < numQP; ++qp)
+              for (int dim(0); dim < spaceDim; ++dim)
+                field(cell, basis) += result(cell, qp, dim) *
+                  weightedCurlBasis(cell, basis, qp, dim);
+          } // end loop over the basis functions
+        } // end of operator()
+
+        /**
+         *  \brief This tells Kokkos to only execute this functor in the
+         *         `PHX::Device` execution space.
+         */
+        using execution_space = PHX::Device;
+
+        /**
+         *  \brief A field representing the result of this integration.
+         */
+        PHX::MDField<ScalarT, panzer::Cell, panzer::IP, panzer::Dim> result;
+
+        /**
+         *  \brief A field to which we'll contribute, or in which we'll store,
+         *         the result of computing this integral.
+         */
+        PHX::MDField<ScalarT, panzer::Cell, panzer::BASIS> field;
+
+        /**
+         *  \brief The vector basis information necessary for integration.
+         */
+        PHX::MDField<double, panzer::Cell, panzer::BASIS, panzer::IP,
+          panzer::Dim> weightedCurlBasis;
+
+        /**
+         *  \brief The `EvaluatorStyle` of the parent
+         *         `Integrator_CurlBasisDotVector` object.
+         */
+        panzer::EvaluatorStyle evalStyle;
+    }; // end of class Integrate3D
+
+    /**
+     *  \brief Perform the actual integration, looping over the bases,
+     *         quadrature points, and dimensions of our vector field.
+     *
+     *  This must happen after the integrand has already been pre-multiplied
+     *  by the scalar multiplier (\f$ M \f$) and any field multipliers
+     *  (\f$ a(x) \f$, \f$ b(x) \f$, etc.) out in front of the integral.
+     *
+     *  \note This class is used when integrating a two-dimensional problem.
+     *        Three-dimensional problems use the `Integrate3D` class.
+     */
+    template<typename ScalarT>
+    class Integrate2D
+    {
+      public:
+
+        /**
+         *  \brief Perform the actual integration.
+         *
+         *  Loop over the bases, quadrature points, summing up the integrand
+         *  times the appropriate basis information.
+         *
+         *  \note If this is a `EVALUATES` style `Evaluator`, the field will be
+         *        initialized to zero.  If it's a `CONTRIBUTES` style one
+         *        instead, the field will not be initialized, as that's assumed
+         *        to have happened in some other `Evaluator`.
+         */
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const unsigned cell) const
+        {
+          using panzer::EvaluatorStyle;
+          int numBases(weightedCurlBasis.extent(1)),
+            numQP(weightedCurlBasis.extent(2));
+          for (int basis(0); basis < numBases; ++basis)
+          {
+            if (evalStyle == EvaluatorStyle::EVALUATES)
+              field(cell, basis) = 0.0;
+            for (int qp(0); qp < numQP; ++qp)
+              field(cell, basis) += result(cell, qp) *
+                weightedCurlBasis(cell, basis, qp);
+          } // end loop over the basis functions
+        } // end of operator()
+
+        /**
+         *  \brief This tells Kokkos to only execute this functor in the
+         *         `PHX::Device` execution space.
+         */
+        using execution_space = PHX::Device;
+
+        /**
+         *  \brief A field representing the result of this integration.
+         */
+        PHX::MDField<ScalarT, panzer::Cell, panzer::IP> result;
+
+        /**
+         *  \brief A field to which we'll contribute, or in which we'll store,
+         *         the result of computing this integral.
+         */
+        PHX::MDField<ScalarT, panzer::Cell, panzer::BASIS> field;
+
+        /**
+         *  \brief The vector basis information necessary for integration.
+         */
+        PHX::MDField<double, panzer::Cell, panzer::BASIS, panzer::IP>
+        weightedCurlBasis;
+
+        /**
+         *  \brief The `EvaluatorStyle` of the parent
+         *         `Integrator_CurlBasisDotVector` object.
+         */
+        panzer::EvaluatorStyle evalStyle;
+    }; // end of class Integrate2D
+
+  } // end of anonymous namespace
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  evaluateFields()
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  void
+  Integrator_CurlBasisDotVector<EvalT, Traits>::
+  evaluateFields(
+    typename Traits::EvalData workset)
+  {
+    using Kokkos::parallel_for;
+    using Kokkos::RangePolicy;
+    using panzer::BasisValues2;
+    using PHX::Device;
+    using PHX::MDField;
+    using std::vector;
+
+    // Grab the basis information.
+    const BasisValues2<double>& bv = useDescriptors_ ?
+      this->wda(workset).getBasisValues(bd_, id_) :
+      *this->wda(workset).bases[basisIndex_];
+
+    // If we're dealing with a two- or three-dimensional problem...
+    if (spaceDim_ == 2)
+    {
+      // Create an object to multiply the integrand by the scalar multiplier
+      // and any field multipliers out in front of the integral.
+      using PreMultiply         = PreMultiply2D<ScalarT>;
+      using ScalarMultiplierTag = typename PreMultiply::ScalarMultiplierTag;
+      using FieldMultiplierTag  = typename PreMultiply::FieldMultiplierTag;
+      PreMultiply preMultiply;
+      preMultiply.result      = result2D_;
+      preMultiply.multiplier  = multiplier_;
+      preMultiply.vectorField = vector2D_;
+
+      // Multiply the integrand by the scalar multiplier out in front of the
+      // integral.
+      parallel_for(RangePolicy<Device, ScalarMultiplierTag>(0,
+        workset.num_cells), preMultiply);
+
+      // Multiply the integrand by any field multipliers out in front of the
+      // integral.
+      for (const auto& field : fieldMults_)
+      {
+        preMultiply.fieldMult = field;
+        parallel_for(RangePolicy<Device, FieldMultiplierTag>(0,
+          workset.num_cells), preMultiply);
+      } // end loop over the field multipliers
+
+      // Create an object to do the actual integration and then do it.
+      Integrate2D<ScalarT> integrate;
+      integrate.result            = result2D_;
+      integrate.field             = field_;
+      integrate.weightedCurlBasis = bv.weighted_curl_basis_scalar;
+      integrate.evalStyle         = evalStyle_;
+      parallel_for(workset.num_cells, integrate);
+    }
+    else // if (spaceDim_ == 3)
+    {
+      // Create an object to multiply the integrand by the scalar multiplier
+      // and any field multipliers out in front of the integral.
+      using PreMultiply         = PreMultiply3D<ScalarT>;
+      using ScalarMultiplierTag = typename PreMultiply::ScalarMultiplierTag;
+      using FieldMultiplierTag  = typename PreMultiply::FieldMultiplierTag;
+      PreMultiply preMultiply;
+      preMultiply.result      = result3D_;
+      preMultiply.multiplier  = multiplier_;
+      preMultiply.vectorField = vector3D_;
+
+      // Multiply the integrand by the scalar multiplier out in front of the
+      // integral.
+      parallel_for(RangePolicy<Device, ScalarMultiplierTag>(0,
+        workset.num_cells), preMultiply);
+
+      // Multiply the integrand by any field multipliers out in front of the
+      // integral.
+      for (const auto& field : fieldMults_)
+      {
+        preMultiply.fieldMult = field;
+        parallel_for(RangePolicy<Device, FieldMultiplierTag>(0,
+          workset.num_cells), preMultiply);
+      } // end loop over the field multipliers
+
+      // Create an object to do the actual integration and then do it.
+      Integrate3D<ScalarT, 3> integrate;
+      integrate.result            = result3D_;
+      integrate.field             = field_;
+      integrate.weightedCurlBasis = bv.weighted_curl_basis_vector;
+      integrate.evalStyle         = evalStyle_;
+      parallel_for(workset.num_cells, integrate);
+    } // end if spaceDim_ is 2 or 3
+  } // end of evaluateFields()
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  getValidParameters()
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename TRAITS>
+  Teuchos::RCP<Teuchos::ParameterList>
+  Integrator_CurlBasisDotVector<EvalT, TRAITS>::
+  getValidParameters() const
+  {
+    using panzer::BasisIRLayout;
+    using panzer::IntegrationRule;
+    using std::string;
+    using std::vector;
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+
+    RCP<ParameterList> p = rcp(new ParameterList);
+    p->set<string>("Residual Name", "?");
+    p->set<string>("Value Name", "?");
+    p->set<string>("Test Field Name", "?");
+    RCP<BasisIRLayout> basis;
+    p->set("Basis", basis);
+    RCP<IntegrationRule> ir;
+    p->set("IR", ir);
+    p->set<double>("Multiplier", 1.0);
+    RCP<const vector<string>> fms;
+    p->set("Field Multipliers", fms);
+    return p;
+  } // end of getValidParameters()
+
+} // end of namespace panzer
+
+#endif // Panzer_Integrator_CurlBasisDotVector_impl_hpp


### PR DESCRIPTION
@trilinos/panzer 

## Description
Updated Panzer's `Integrator_CurlBasisDotVector` `Evaluator` such that it can `CONTRIBUTE` to some other `Evaluator`.  Compile time argument checking is enforced through the main constructor, but backward compatibility is maintained via a `ParameterList` constructor that defaults to the `EVALUATES` style and delegates to the main constructor.

## Motivation and Context
This should allow us to refactor things such that these `Evaluator`s contribute the result of the integration to some other `Evaluator`, rather than storing the result such that it'll later be used in a `Sum`, for instance.

## Related Issues
* Closes #1890

## How Has This Been Tested?
Passes Panzer/Drekar/Charon tests on my RHEL7 machine.  Passes Panzer tests on ride/cuda/opt (didn't test Drekar/Charon there).

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.