### PR TITLE
Panzer:  Typo Fix

### DIFF
--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
@@ -224,7 +224,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     if (this->buildTransientSupport())
       sum_names.push_back("RESIDUAL_EFIELD_TRANSIENT_OP");
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,"EFIELD",sum_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,"EFIELD",sum_names);
   }
 
 }

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_MixedPoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_MixedPoissonEquationSet_impl.hpp
@@ -224,7 +224,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     sum_names.push_back("RESIDUAL_GRADPHI_FIELD_DIFFUSION_OP");
     sum_names.push_back("RESIDUAL_GRADPHI_FIELD_MASS_OP");
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,"GRADPHI_FIELD",sum_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,"GRADPHI_FIELD",sum_names);
   }
 
   // Use a sum operator to form the overall residual for the equation
@@ -235,7 +235,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     sum_names.push_back("RESIDUAL_PHI_DIFFUSION_OP");
     sum_names.push_back("RESIDUAL_PHI_MASS_OP");
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,"PHI",sum_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,"PHI",sum_names);
   }
 
 }

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_PoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_PoissonEquationSet_impl.hpp
@@ -204,7 +204,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     if (this->buildTransientSupport())
       sum_names.push_back("RESIDUAL_TEMPERATURE_TRANSIENT_OP");
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,"TEMPERATURE",sum_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,"TEMPERATURE",sum_names);
   }
 
 }

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_PoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_PoissonEquationSet_impl.hpp
@@ -206,7 +206,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     if (this->buildTransientSupport())
       sum_names.push_back("RESIDUAL_" + dof_name + "_TRANSIENT_OP");
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,dof_name,sum_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,dof_name,sum_names);
   }
 
 }

--- a/packages/panzer/adapters-stk/tutorial/siamCse17/myEquationSetImpl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/siamCse17/myEquationSetImpl.hpp
@@ -195,7 +195,7 @@ buildAndRegisterEquationSetEvaluators(
   {
     vector<string> residualOperatorNames{laplacianName, helmholtzName,
       sourceName};
-    this->buildAndRegisterResidualSummationEvalautor(fm, dofName_,
+    this->buildAndRegisterResidualSummationEvaluator(fm, dofName_,
       residualOperatorNames);
   }
 } // end of buildAndRegisterEquationSetEvaluators()

--- a/packages/panzer/adapters-stk/tutorial/step01/Step01_EquationSet_Projection_impl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step01/Step01_EquationSet_Projection_impl.hpp
@@ -167,7 +167,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     residual_operator_names.push_back(residual_projection_src_term);
 
     // build a sum evaluator
-    this->buildAndRegisterResidualSummationEvalautor(fm,dof_name_,residual_operator_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,dof_name_,residual_operator_names);
   }
 
 }

--- a/packages/panzer/adapters-stk/tutorial/step02/Step02_EquationSet_Projection_impl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step02/Step02_EquationSet_Projection_impl.hpp
@@ -167,7 +167,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     residual_operator_names.push_back(residual_projection_src_term);
 
     // build a sum evaluator
-    this->buildAndRegisterResidualSummationEvalautor(fm,dof_name_,residual_operator_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,dof_name_,residual_operator_names);
   }
 
 }

--- a/packages/panzer/disc-fe/src/Panzer_EquationSet_DefaultImpl_decl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_EquationSet_DefaultImpl_decl.hpp
@@ -305,7 +305,7 @@ namespace panzer {
      * \param[in] residual_contributions Vector of field names that will be summed to produce the residual contributions
      * \param[in] residualfield_name Name of the evalauted residual field.  This is optional and will use a default value if the string is empty.
      */ 
-    void buildAndRegisterResidualSummationEvalautor(PHX::FieldManager<panzer::Traits>& fm,
+    void buildAndRegisterResidualSummationEvaluator(PHX::FieldManager<panzer::Traits>& fm,
                                                     const std::string dof_name,
                                                     const std::vector<std::string>& residual_contributions,
                                                     const std::string residual_field_name = "") const;
@@ -325,7 +325,7 @@ namespace panzer {
      * \param[in] scale_contributions Vector of scalars for each term in the residual contributions.
      * \param[in] residualfield_name Name of the evalauted residual field.  This is optional and will use a default value if the string is empty.
      */ 
-    void buildAndRegisterResidualSummationEvalautor(PHX::FieldManager<panzer::Traits>& fm,
+    void buildAndRegisterResidualSummationEvaluator(PHX::FieldManager<panzer::Traits>& fm,
                                                     const std::string dof_name,
                                                     const std::vector<std::string>& residual_contributions,
                                                     const std::vector<double>& scale_contributions,

--- a/packages/panzer/disc-fe/src/Panzer_EquationSet_DefaultImpl_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_EquationSet_DefaultImpl_impl.hpp
@@ -1061,7 +1061,7 @@ panzer::EquationSet_DefaultImpl<EvalT>::getBasisIRLayoutForDOF(const std::string
 // ***********************************************************************
 template <typename EvalT>
 void panzer::EquationSet_DefaultImpl<EvalT>::
-buildAndRegisterResidualSummationEvalautor(PHX::FieldManager<panzer::Traits>& fm,
+buildAndRegisterResidualSummationEvaluator(PHX::FieldManager<panzer::Traits>& fm,
                                            const std::string dof_name,
                                            const std::vector<std::string>& residual_contributions,
                                            const std::string residual_field_name) const
@@ -1094,7 +1094,7 @@ buildAndRegisterResidualSummationEvalautor(PHX::FieldManager<panzer::Traits>& fm
 // ***********************************************************************
 template <typename EvalT>
 void panzer::EquationSet_DefaultImpl<EvalT>::
-buildAndRegisterResidualSummationEvalautor(PHX::FieldManager<panzer::Traits>& fm,
+buildAndRegisterResidualSummationEvaluator(PHX::FieldManager<panzer::Traits>& fm,
                                            const std::string dof_name,
                                            const std::vector<std::string>& residual_contributions,
                                            const std::vector<double>& scale_contributions,

--- a/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_Energy_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_Energy_impl.hpp
@@ -259,7 +259,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     if (this->buildTransientSupport())
       residual_operator_names.push_back("RESIDUAL_"+m_prefix+"TEMPERATURE_TRANSIENT_OP");
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,m_dof_name,residual_operator_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,m_dof_name,residual_operator_names);
   }
 
 }

--- a/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_MeshCoords_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_MeshCoords_impl.hpp
@@ -180,7 +180,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
       residual_operator_names.push_back("RESIDUAL_"+dof_names[i]+"_TRANSIENT_OP");
       residual_operator_names.push_back("RESIDUAL_"+dof_names[i]+"_SOURCE_OP");
 
-      this->buildAndRegisterResidualSummationEvalautor(fm,dof_names[i],residual_operator_names);
+      this->buildAndRegisterResidualSummationEvaluator(fm,dof_names[i],residual_operator_names);
     }
   }
 }

--- a/packages/panzer/disc-fe/test/ugi_rig/user_app_EquationSet_Energy_impl.hpp
+++ b/packages/panzer/disc-fe/test/ugi_rig/user_app_EquationSet_Energy_impl.hpp
@@ -260,7 +260,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     if (this->buildTransientSupport())
       residual_operator_names.push_back("RESIDUAL_"+m_prefix+"TEMPERATURE_TRANSIENT_OP");*/
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,m_dof_name,residual_operator_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,m_dof_name,residual_operator_names);
   }
 
 }

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell_impl.hpp
@@ -149,7 +149,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
       residual_operator_names.push_back(resid);
     }
 
-    this->buildAndRegisterResidualSummationEvalautor(fm,m_Efield_dof_name,residual_operator_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,m_Efield_dof_name,residual_operator_names);
   }
   {
     //Build the B Field equation
@@ -192,7 +192,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
       this->template registerEvaluator<EvalT>(fm, op);
       residual_operator_names.push_back(resid);
     }
-    this->buildAndRegisterResidualSummationEvalautor(fm,m_Bfield_dof_name,residual_operator_names);
+    this->buildAndRegisterResidualSummationEvaluator(fm,m_Bfield_dof_name,residual_operator_names);
   }
 
 


### PR DESCRIPTION
`Evaluator` was misspelled in `buildAndRegisterResidualSummationEvalautor`.