### PR TITLE
Resolves "Panzer:  Use CONTRIBUTES-Style Integrator_CurlBasisDotVector"

### DIFF
--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_ClosureModel_Factory_impl.hpp
@@ -49,8 +49,6 @@
 
 #include "Panzer_IntegrationRule.hpp"
 #include "Panzer_BasisIRLayout.hpp"
-#include "Panzer_Integrator_CurlBasisDotVector.hpp"
-#include "Panzer_Integrator_BasisTimesVector.hpp"
 #include "Panzer_ScalarToVector.hpp"
 #include "Panzer_String_Utilities.hpp"
 #include "Panzer_Sum.hpp"

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
@@ -54,8 +54,8 @@
 #include "Panzer_BasisIRLayout.hpp"
 
 // include evaluators here
-#include "Panzer_Integrator_BasisTimesScalar.hpp"
-#include "Panzer_Integrator_GradBasisDotVector.hpp"
+#include "Panzer_Integrator_BasisTimesVector.hpp"
+#include "Panzer_Integrator_CurlBasisDotVector.hpp"
 #include "Panzer_ScalarToVector.hpp"
 #include "Panzer_Sum.hpp"
 #include "Panzer_Constant.hpp"
@@ -164,19 +164,16 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
   // Diffusion Operator: Assembles \int \nabla T \cdot \nabla v
   {
-    double thermal_conductivity = 1.0;
-
-    ParameterList p("Diffusion Residual");
-    p.set("Residual Name", "RESIDUAL_EFIELD_DIFFUSION_OP");
-    p.set("Value Name", "CURL_EFIELD"); // this field is constructed by the panzer library
-    p.set("Test Field Name", "EFIELD"); 
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", -thermal_conductivity);
-    
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_CurlBasisDotVector<EvalT,panzer::Traits>(p));
-
+    using panzer::EvaluatorStyle;
+    using panzer::Integrator_CurlBasisDotVector;
+    using panzer::Traits;
+    using PHX::Evaluator;
+    using std::string;
+    string resName("RESIDUAL_EFIELD"), valName("CURL_EFIELD");
+    double thermalConductivity(1.0), multiplier(-thermalConductivity);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_CurlBasisDotVector<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+      resName, valName, *basis, *ir, multiplier));
     this->template registerEvaluator<EvalT>(fm, op);
   }
 
@@ -218,7 +215,6 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     std::vector<std::string> sum_names;
     
     // these are the names of the residual values to sum together
-    sum_names.push_back("RESIDUAL_EFIELD_DIFFUSION_OP");
     sum_names.push_back("RESIDUAL_EFIELD_MASS_OP");
     sum_names.push_back("RESIDUAL_EFIELD_SOURCE_OP");
     if (this->buildTransientSupport())

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_ClosureModel_Factory_impl.hpp
@@ -49,8 +49,6 @@
 
 #include "Panzer_IntegrationRule.hpp"
 #include "Panzer_BasisIRLayout.hpp"
-#include "Panzer_Integrator_CurlBasisDotVector.hpp"
-#include "Panzer_Integrator_BasisTimesVector.hpp"
 #include "Panzer_ScalarToVector.hpp"
 #include "Panzer_String_Utilities.hpp"
 #include "Panzer_Sum.hpp"

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_CurlBasisDotVector_impl.hpp
@@ -792,7 +792,6 @@ namespace panzer
     RCP<ParameterList> p = rcp(new ParameterList);
     p->set<string>("Residual Name", "?");
     p->set<string>("Value Name", "?");
-    p->set<string>("Test Field Name", "?");
     RCP<BasisIRLayout> basis;
     p->set("Basis", basis);
     RCP<IntegrationRule> ir;

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell_impl.hpp
@@ -120,18 +120,19 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
       residual_operator_names.push_back(resid);
     }
     {
-      std::string resid="RESIDUAL_"+m_Efield_dof_name+"_CURLB_OP";
-      ParameterList p("Curl B"+m_Efield_dof_name);
-      p.set("Residual Name", resid);
-      p.set("Value Name", m_Bfield_dof_name);
-      p.set("Basis", basis);
-      p.set("IR", ir);
-      p.set("Multiplier", -1.0/mu);
-      RCP< PHX::Evaluator<panzer::Traits> > op =
-          rcp(new panzer::Integrator_CurlBasisDotVector<EvalT,panzer::Traits>(p));
-
+      using panzer::EvaluatorStyle;
+      using panzer::Integrator_CurlBasisDotVector;
+      using panzer::Traits;
+      using PHX::Evaluator;
+      using std::string;
+      string resName("RESIDUAL_" + m_Efield_dof_name),
+             valName(m_Bfield_dof_name);
+      double multiplier(-1.0 / mu);
+      RCP<Evaluator<Traits>> op = rcp(new
+        Integrator_CurlBasisDotVector<EvalT, Traits>(
+        EvaluatorStyle::CONTRIBUTES, resName, valName, *basis, *ir,
+        multiplier));
       this->template registerEvaluator<EvalT>(fm, op);
-      residual_operator_names.push_back(resid);
     }
     {
       std::string resid="RESIDUAL_"+m_Efield_dof_name+"_CURRENT_SOURCE";


### PR DESCRIPTION
@trilinos/panzer

## Description
This switches all uses of `panzer::Integrator_CurlBasisDotVector` from the `EVALUATES` style (which is the default when using the `ParameterList` constructor) to the `CONTRIBUTES` style.

## Motivation and Context
We'll save the memory that was previously needed to store the result of the integral before summing it into another `Evaluator`.

## Related Issues
* Closes #2527 
* Follows #1890 
* Part of #1575 

## How Has This Been Tested?
Passes `ctest` on my RHEL7 machine.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.