### PR TITLE
Zoltan2: MJ migration: fix ArrayView construction

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6947,6 +6947,7 @@ void Zoltan2_AlgMJ<Adapter>::partition(
     }
 
     // Reorder results so that they match the order of the input
+
 #if defined(__cplusplus) && __cplusplus >= 201103L
     std::unordered_map<mj_gno_t, mj_lno_t> localGidToLid;
     localGidToLid.reserve(result_num_local_coords);
@@ -7000,8 +7001,7 @@ void Zoltan2_AlgMJ<Adapter>::partition(
         distributor.doPostsAndWaits<mj_gno_t>(sent_gnos, 1, received_gnos());
       }
       {
-
-        ArrayView<mj_part_t> sent_partnos(partId.getRawPtr(), result_num_local_coords);
+        ArrayView<mj_part_t> sent_partnos(partId());
         distributor.doPostsAndWaits<mj_part_t>(sent_partnos, 1, received_partids());
       }
       partId = arcp(new mj_part_t[this->num_local_coords],


### PR DESCRIPTION
Change how an ArrayView of an ArrayRCP is created in multijagged
migration.  For whatever reason, the previous way it was being
built was causing a MueLu unit test to fail.  See issue #2536.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

The Zoltan2 and MueLu unit tests pass locally with this change.

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

## Screenshots
<!--- Not obligatory, but is there anything pertinent that we should see? -->

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

## Additional Information
<!--- Anything else we need to know in evaluating this merge request? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/2537)
<!-- Reviewable:end -->
