### PR TITLE
Panzer:  Fix Compiler Warnings

### DIFF
--- a/packages/panzer/adapters-ioss/src/Panzer_IOSSConnManager_impl.hpp
+++ b/packages/panzer/adapters-ioss/src/Panzer_IOSSConnManager_impl.hpp
@@ -651,19 +651,22 @@ void IOSSConnManager<GO>::buildOffsetsAndIdCounts(const panzer::FieldPattern & f
   };
 
   // compute ID counts for each sub cell type
-  switch(patternDim) {
+  switch (patternDim)
+  {
     case 3:
-	  faceIdCnt = fp.getSubcellIndices(2,0).size();
-	case 2:
-	  edgeIdCnt = fp.getSubcellIndices(1,0).size();
-	case 1:
-	  nodeIdCnt = fp.getSubcellIndices(0,0).size();
-	  cellIdCnt = fp.getSubcellIndices(patternDim,0).size();
-	  break;
-	 case 0:
-	 default:
-	   TEUCHOS_ASSERT(false);
-	 };
+      faceIdCnt = fp.getSubcellIndices(2,0).size();
+      [[gnu::fallthrough]];
+    case 2:
+      edgeIdCnt = fp.getSubcellIndices(1,0).size();
+      [[gnu::fallthrough]];
+    case 1:
+      nodeIdCnt = fp.getSubcellIndices(0,0).size();
+      cellIdCnt = fp.getSubcellIndices(patternDim,0).size();
+      break;
+    case 0:
+    default:
+      TEUCHOS_ASSERT(false);
+  }
 
   // compute offsets for each sub cell type
   nodeOffset = 0;

--- a/packages/panzer/adapters-stk/src/Panzer_STKConnManager_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STKConnManager_impl.hpp
@@ -180,8 +180,10 @@ void STKConnManager<GO>::buildOffsetsAndIdCounts(const panzer::FieldPattern & fp
    switch(patternDim) {
    case 3:
      faceIdCnt = fp.getSubcellIndices(2,0).size();
+     [[gnu::fallthrough]];
    case 2:
      edgeIdCnt = fp.getSubcellIndices(1,0).size();
+     [[gnu::fallthrough]];
    case 1:
      nodeIdCnt = fp.getSubcellIndices(0,0).size();
      cellIdCnt = fp.getSubcellIndices(patternDim,0).size();

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked_impl.hpp
@@ -223,9 +223,11 @@ void ParameterListCallbackBlocked<LocalOrdinalT,GlobalOrdinalT,Node>::buildCoord
    case 3:
       zcoords_[field].resize(coordsVec_->getLocalLength()); 
       coordsVec_->getVector(2)->get1dCopy(Teuchos::arrayViewFromVector(zcoords_[field]));
+      [[gnu::fallthrough]];
    case 2:
       ycoords_[field].resize(coordsVec_->getLocalLength()); 
       coordsVec_->getVector(1)->get1dCopy(Teuchos::arrayViewFromVector(ycoords_[field]));
+      [[gnu::fallthrough]];
    case 1:
       xcoords_[field].resize(coordsVec_->getLocalLength()); 
       coordsVec_->getVector(0)->get1dCopy(Teuchos::arrayViewFromVector(xcoords_[field]));

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallback_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallback_impl.hpp
@@ -159,9 +159,11 @@ void ParameterListCallback<LocalOrdinalT,GlobalOrdinalT,Node>::buildCoordinates(
    case 3:
       zcoords_.resize(resultVec->getLocalLength()); 
       resultVec->getVector(2)->get1dCopy(Teuchos::arrayViewFromVector(zcoords_));
+      [[gnu::fallthrough]];
    case 2:
       ycoords_.resize(resultVec->getLocalLength()); 
       resultVec->getVector(1)->get1dCopy(Teuchos::arrayViewFromVector(ycoords_));
+      [[gnu::fallthrough]];
    case 1:
       xcoords_.resize(resultVec->getLocalLength()); 
       resultVec->getVector(0)->get1dCopy(Teuchos::arrayViewFromVector(xcoords_));

--- a/packages/panzer/adapters-stk/src/Panzer_STK_SetupLOWSFactory_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_SetupLOWSFactory_impl.hpp
@@ -303,9 +303,11 @@ namespace {
              case 3:
                 vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&zcoords[0])));
                 EpetraExt::VectorToMatrixMarketFile("zcoords.mm",*vec);
+                [[gnu::fallthrough]];
              case 2:
                 vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&ycoords[0])));
                 EpetraExt::VectorToMatrixMarketFile("ycoords.mm",*vec);
+                [[gnu::fallthrough]];
              case 1:
                 vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&xcoords[0])));
                 EpetraExt::VectorToMatrixMarketFile("xcoords.mm",*vec);
@@ -417,9 +419,11 @@ namespace {
             case 3:
                vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&zcoords[0])));
                EpetraExt::VectorToMatrixMarketFile((fieldName+"_zcoords.mm").c_str(),*vec);
+               [[gnu::fallthrough]];
             case 2:
                vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&ycoords[0])));
                EpetraExt::VectorToMatrixMarketFile((fieldName+"_ycoords.mm").c_str(),*vec);
+               [[gnu::fallthrough]];
             case 1:
                vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&xcoords[0])));
                EpetraExt::VectorToMatrixMarketFile((fieldName+"_xcoords.mm").c_str(),*vec);

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -1022,7 +1022,6 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
 
     // Apply the permutation to the cubature arrays.
     MDFieldArrayFactory af(prefix, alloc_arrays);
-    const size_type num_ip = dyn_cub_points.dimension(0);
     {
       const size_type num_cells = ip_coordinates.dimension(0), num_ip = ip_coordinates.dimension(1),
           num_dim = ip_coordinates.dimension(2);


### PR DESCRIPTION
@trilinos/panzer 

## Description
Remove compiler warnings:
* Unused variable (looked like a copy/paste error).
* Switch statement fallthrough was intentional but wasn't marked as such.

## Motivation and Context
In order to ensure that new changes don't add compiler warnings, we need to try our best to keep Panzer building warning-free.

## How Has This Been Tested?
Passes `ctest` on my RHEL7 machine.

## Checklist
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.