### PR TITLE
Ifpack2: Fix #2520

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAmesos2solver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAmesos2solver.cpp
@@ -220,26 +220,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Amesos2Wrapper, Test1, Scalar, LocalOrd
 }
 
 #define UNIT_TEST_GROUP_SCALAR_ORDINAL(Scalar,LocalOrdinal,GlobalOrdinal) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Ifpack2Amesos2Wrapper, Test0, Scalar, LocalOrdinal,GlobalOrdinal) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Ifpack2Amesos2Wrapper, Test1, Scalar, LocalOrdinal,GlobalOrdinal)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Ifpack2Amesos2Wrapper, Test0, Scalar, LocalOrdinal, GlobalOrdinal) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Ifpack2Amesos2Wrapper, Test1, Scalar, LocalOrdinal, GlobalOrdinal)
 
-// mfh 21 Oct 2015: This class was only getting tested for Scalar =
-// double, LocalOrdinal = int, GlobalOrdinal = int, and the default
-// Node type.  As part of the fix for Bug 6358, I'm removing the
-// assumption that GlobalOrdinal = int exists.
+// FIXME (mfh 11 Apr 2018) We should test this at least for all
+// enabled real Scalar types, if not complex Scalar types as well.
 
 typedef Tpetra::MultiVector<>::scalar_type default_scalar_type;
 typedef Tpetra::MultiVector<>::local_ordinal_type default_local_ordinal_type;
 typedef Tpetra::MultiVector<>::global_ordinal_type default_global_ordinal_type;
 
 UNIT_TEST_GROUP_SCALAR_ORDINAL( default_scalar_type, default_local_ordinal_type, default_global_ordinal_type )
-
-// //typedef std::complex<double> ComplexDouble;
-// //UNIT_TEST_GROUP_SCALAR_ORDINAL(ComplexDouble, int, int)
-// UNIT_TEST_GROUP_SCALAR_ORDINAL(double, int, int)
-// #ifndef HAVE_IFPACK2_EXPLICIT_INSTANTIATION
-// UNIT_TEST_GROUP_SCALAR_ORDINAL(float, short, int)
-// #endif
 
 } // namespace (anonymous)
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -919,26 +919,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestUpperTriangularBlo
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Ifpack2BlockRelaxation, TestLowerTriangularBlockCrsMatrix, Scalar, LocalOrdinal,GlobalOrdinal) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Ifpack2BlockRelaxation, TestUpperTriangularBlockCrsMatrix, Scalar, LocalOrdinal,GlobalOrdinal)
 
-// FIXME (mfh 21 Oct 2015) This test exercises two different GO
-// (GlobalOrdinal) types: whatever GO is, and GO = LO (LocalOrdinal).
-// As such, given that LO = int is the only currently enabled LO type,
-// this test won't build if GO = int is disabled (Bug 6358).  We
-// disable building the test in that case.
-
-#ifdef HAVE_TPETRA_INST_INT_INT
-
-// mfh 21 Oct 2015: This class was only getting tested for Scalar =
-// double, LocalOrdinal = int, GlobalOrdinal = int, and the default
-// Node type.  As part of the fix for Bug 6358, I'm removing the
-// assumption that GlobalOrdinal = int exists.
+// FIXME (mfh 11 Apr 2018) Test for other Scalar types at least.
 
 typedef Tpetra::MultiVector<>::scalar_type default_scalar_type;
 typedef Tpetra::MultiVector<>::local_ordinal_type default_local_ordinal_type;
 typedef Tpetra::MultiVector<>::global_ordinal_type default_global_ordinal_type;
 
 UNIT_TEST_GROUP_SCALAR_ORDINAL(default_scalar_type, default_local_ordinal_type, default_global_ordinal_type)
-
-#endif // HAVE_TPETRA_INST_INT_INT
 
 } // namespace (anonymous)
 


### PR DESCRIPTION
@trilinos/ifpack2

## Description

Fix Ifpack2::BlockRelaxation's test instantiations for the case when `GlobalOrdinal=int` is disabled.
See comment here:
https://github.com/trilinos/Trilinos/pull/2515#issuecomment-379865709

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Related to #74, #2548

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

