### PR TITLE
Sacado: remove unreachable break statements

### DIFF
--- a/packages/sacado/src/Sacado_ScalarFlopCounter.cpp
+++ b/packages/sacado/src/Sacado_ScalarFlopCounter.cpp
@@ -145,7 +145,6 @@ Sacado::FlopCounterPack::FlopCounts::getSummaryType(Sacado::FlopCounterPack::Flo
   switch(ft) {
     case ASSIGN:
       return SUMMARY_ASSIGN;
-      break;
     case PLUS:
     case PLUS_ASSIGN:
     case UNARY_PLUS:
@@ -153,15 +152,12 @@ Sacado::FlopCounterPack::FlopCounts::getSummaryType(Sacado::FlopCounterPack::Flo
     case MINUS_ASSIGN:
     case UNARY_MINUS:
       return SUMMARY_PLUS_MINUS;
-      break;
     case MULTIPLY:
     case MULTIPLY_ASSIGN:
       return SUMMARY_MULTIPLY;
-      break;
     case DIVIDE:
     case DIVIDE_ASSIGN:
       return SUMMARY_DIVIDE;
-      break;
     case EXP:
     case LOG:
     case LOG10:
@@ -184,14 +180,12 @@ Sacado::FlopCounterPack::FlopCounts::getSummaryType(Sacado::FlopCounterPack::Flo
     case MAX:
     case MIN:
       return SUMMARY_NONLINEAR;
-      break;
     case GREATER_THAN:
     case GREATER_THAN_EQUAL:
     case LESS_THAN:
     case LESS_THAN_EQUAL:
     case EQUAL:
       return SUMMARY_COMPARISON;
-      break;
     default:
       assert(0);
   }


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/sacado

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
Remove break statements that immediately follow return statements.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
These were generating warnings in a CUDA 8 build with GCC 5.4.0
