### PR TITLE
Teuchos: preserve name of PL during update

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -918,6 +918,9 @@ void updateParametersFromYamlFile(const std::string& yamlFileName,
   Teuchos::RCP<Teuchos::ParameterList> updated = YAMLParameterList::parseYamlFile(yamlFileName);
   //now update the original list (overwriting values with same key)
   paramList->setParameters(*updated);
+  if (paramList->name() == "ANONYMOUS") {
+    paramList->setName(updated->name());
+  }
 }
 
 void updateParametersFromYamlCString(const char* const data,
@@ -928,6 +931,9 @@ void updateParametersFromYamlCString(const char* const data,
   if(overwrite)
   {
     paramList->setParameters(*updated);
+    if (paramList->name() == "ANONYMOUS") {
+      paramList->setName(updated->name());
+    }
   }
   else
   {
@@ -944,6 +950,9 @@ void updateParametersFromYamlString(const std::string& yamlData,
   if(overwrite)
   {
     paramList->setParameters(*updated);
+    if (paramList->name() == "ANONYMOUS") {
+      paramList->setName(updated->name());
+    }
   }
   else
   {
@@ -1065,7 +1074,7 @@ void writeYamlStream(std::ostream& yaml, const Teuchos::ParameterList& pl)
     popFlags = true;
   }
   yaml << "%YAML 1.1\n---\n";
-  yaml << "ANONYMOUS:";         //original top-level list name is not stored by ParameterList
+  yaml << pl.name() << ':';
   if(pl.numParams() == 0)
   {
     yaml << " { }\n";

--- a/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
+++ b/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
@@ -257,5 +257,21 @@ namespace TeuchosTests
       Teuchos::ParserFail);
   }
 
+  TEUCHOS_UNIT_TEST(YAML, keep_top_name)
+  {
+    Teuchos::ParameterList pl;
+    char const * const cstr =
+      "%YAML 1.1\n"
+      "---\n"
+      "Albany:\n"
+      "  some param: 5\n"
+      "...\n";
+    Teuchos::updateParametersFromYamlCString(cstr, Teuchos::ptr(&pl), true);
+    std::stringstream ss;
+    Teuchos::writeParameterListToYamlOStream(pl, ss);
+    auto s = ss.str();
+    TEST_EQUALITY(s, cstr);
+  }
+
 } //namespace TeuchosTests
 


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
This keeps the top-level name given
to a ParameterList in the input YAML
file throughout the update process,
and eventually writes it to an output
YAML file if that is the workflow.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Right now if users read in a YAML file like:
```yaml
Albany:
  some param: 5
```
The resulting ParameterList is called `ANONYMOUS` instead of `Albany`, so if the PL is written to file it becomes:
```yaml
ANONYMOUS:
  some param: 5
```
These changes preserve the name throughout the process.
