### PR TITLE
Tpetra: Implementation of CrsGraph::transferAndFillComplete

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -386,5 +386,3 @@ SET_PROPERTY(
 # subdirectory.  That ensures that running "make" will also rerun
 # CMake in order to regenerate Makefiles.
 #
-# Here is another such change.
-#

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1368,6 +1368,196 @@ namespace Tpetra {
       }
     };
 
+  private:
+    // Friend declaration for nonmember function.
+    template<class CrsGraphType>
+    friend Teuchos::RCP<CrsGraphType>
+    importAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                    const Import<typename CrsGraphType::local_ordinal_type,
+                                                 typename CrsGraphType::global_ordinal_type,
+                                                 typename CrsGraphType::node_type>& importer,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& domainMap,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& rangeMap,
+                                    const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+    // Friend declaration for nonmember function.
+    template<class CrsGraphType>
+    friend Teuchos::RCP<CrsGraphType>
+    importAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                    const Import<typename CrsGraphType::local_ordinal_type,
+                                                 typename CrsGraphType::global_ordinal_type,
+                                                 typename CrsGraphType::node_type>& rowImporter,
+                                   const Import<typename CrsGraphType::local_ordinal_type,
+                                                typename CrsGraphType::global_ordinal_type,
+                                                typename CrsGraphType::node_type>& domainImporter,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& domainMap,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& rangeMap,
+                                    const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+
+    // Friend declaration for nonmember function.
+    template<class CrsGraphType>
+    friend Teuchos::RCP<CrsGraphType>
+    exportAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                    const Export<typename CrsGraphType::local_ordinal_type,
+                                                 typename CrsGraphType::global_ordinal_type,
+                                                 typename CrsGraphType::node_type>& exporter,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& domainMap,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& rangeMap,
+                                    const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+    // Friend declaration for nonmember function.
+    template<class CrsGraphType>
+    friend Teuchos::RCP<CrsGraphType>
+    exportAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                    const Export<typename CrsGraphType::local_ordinal_type,
+                                                 typename CrsGraphType::global_ordinal_type,
+                                                 typename CrsGraphType::node_type>& rowExporter,
+                                    const Export<typename CrsGraphType::local_ordinal_type,
+                                                 typename CrsGraphType::global_ordinal_type,
+                                                 typename CrsGraphType::node_type>& domainExporter,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& domainMap,
+                                    const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                                 typename CrsGraphType::global_ordinal_type,
+                                                                 typename CrsGraphType::node_type> >& rangeMap,
+                                    const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+  public:
+    /// \brief Import from <tt>this</tt> to the given destination
+    ///   graph, and make the result fill complete.
+    ///
+    /// If destGraph.is_null(), this creates a new graph as the
+    /// destination.  (This is why destGraph is passed in by nonconst
+    /// reference to RCP.)  Otherwise it checks for "pristine" status
+    /// and throws if that is not the case.  "Pristine" means that the
+    /// graph has no entries and is not fill complete.
+    ///
+    /// Use of the "non-member constructor" version of this method,
+    /// exportAndFillCompleteCrsGraph, is preferred for user
+    /// applications.
+    ///
+    /// \warning This method is intended for expert developer use
+    ///   only, and should never be called by user code.
+    void
+    importAndFillComplete (Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                           const import_type& importer,
+                           const Teuchos::RCP<const map_type>& domainMap,
+                           const Teuchos::RCP<const map_type>& rangeMap,
+                           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+    /// \brief Import from <tt>this</tt> to the given destination
+    ///   graph, and make the result fill complete.
+    ///
+    /// If destGraph.is_null(), this creates a new graph as the
+    /// destination.  (This is why destGraph is passed in by nonconst
+    /// reference to RCP.)  Otherwise it checks for "pristine" status
+    /// and throws if that is not the case.  "Pristine" means that the
+    /// graph has no entries and is not fill complete.
+    ///
+    /// Use of the "non-member constructor" version of this method,
+    /// exportAndFillCompleteCrsGraph, is preferred for user
+    /// applications.
+    ///
+    /// \warning This method is intended for expert developer use
+    ///   only, and should never be called by user code.
+    void
+    importAndFillComplete (Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                           const import_type& rowImporter,
+                           const import_type& domainImporter,
+                           const Teuchos::RCP<const map_type>& domainMap,
+                           const Teuchos::RCP<const map_type>& rangeMap,
+                           const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+
+
+    /// \brief Export from <tt>this</tt> to the given destination
+    ///   graph, and make the result fill complete.
+    ///
+    /// If destGraph.is_null(), this creates a new graph as the
+    /// destination.  (This is why destGraph is passed in by nonconst
+    /// reference to RCP.)  Otherwise it checks for "pristine" status
+    /// and throws if that is not the case.  "Pristine" means that the
+    /// graph has no entries and is not fill complete.
+    ///
+    /// Use of the "non-member constructor" version of this method,
+    /// exportAndFillCompleteCrsGraph, is preferred for user
+    /// applications.
+    ///
+    /// \warning This method is intended for expert developer use
+    ///   only, and should never be called by user code.
+    void
+    exportAndFillComplete (Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                           const export_type& exporter,
+                           const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
+                           const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
+                           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
+    /// \brief Export from <tt>this</tt> to the given destination
+    ///   graph, and make the result fill complete.
+    ///
+    /// If destGraph.is_null(), this creates a new graph as the
+    /// destination.  (This is why destGraph is passed in by nonconst
+    /// reference to RCP.)  Otherwise it checks for "pristine" status
+    /// and throws if that is not the case.  "Pristine" means that the
+    /// graph has no entries and is not fill complete.
+    ///
+    /// Use of the "non-member constructor" version of this method,
+    /// exportAndFillCompleteCrsGraph, is preferred for user
+    /// applications.
+    ///
+    /// \warning This method is intended for expert developer use
+    ///   only, and should never be called by user code.
+    void
+    exportAndFillComplete (Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                           const export_type& rowExporter,
+                           const export_type& domainExporter,
+                           const Teuchos::RCP<const map_type>& domainMap,
+                           const Teuchos::RCP<const map_type>& rangeMap,
+                           const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+
+
+  private:
+    /// \brief Transfer (e.g. Import/Export) from <tt>this</tt> to the
+    ///   given destination graph, and make the result fill complete.
+    ///
+    /// If destGraph.is_null(), this creates a new graph, otherwise it
+    /// checks for "pristine" status and throws if that is not the
+    /// case.  This method implements importAndFillComplete and
+    /// exportAndFillComplete, which in turn implemment the nonmember
+    /// "constructors" importAndFillCompleteCrsGraph and
+    /// exportAndFillCompleteCrsGraph.  It's convenient to put those
+    /// nonmember constructors' implementations inside the CrsGraph
+    /// class, so that we don't have to put much code in the _decl
+    /// header file.
+    ///
+    /// The point of this method is to fuse three tasks:
+    ///
+    ///   1. Create a destination graph (CrsGraph constructor)
+    ///   2. Import or Export this graph to the destination graph
+    ///   3. Call fillComplete on the destination graph
+    ///
+    /// Fusing these tasks can avoid some communication and work.
+    void
+    transferAndFillComplete (Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                             const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+                             const Teuchos::RCP<const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node> > & domainTransfer,
+                             const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
+                             const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
+                             const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
+
   protected:
     // these structs are conveniences, to cut down on the number of
     // arguments to some of the methods below.
@@ -2026,6 +2216,252 @@ namespace Tpetra {
     using Teuchos::rcp;
     typedef CrsGraph<LocalOrdinal, GlobalOrdinal, Node> graph_type;
     return rcp (new graph_type (map, maxNumEntriesPerRow, DynamicProfile, params));
+  }
+
+  /// \brief Nonmember CrsGraph constructor that fuses Import and fillComplete().
+  /// \relatesalso CrsGraph
+  /// \tparam CrsGraphType A specialization of CrsGraph.
+  ///
+  /// A common use case is to create an empty destination CrsGraph,
+  /// redistribute from a source CrsGraph (by an Import or Export
+  /// operation), then call fillComplete() on the destination
+  /// CrsGraph.  This constructor fuses these three cases, for an
+  /// Import redistribution.
+  ///
+  /// Fusing redistribution and fillComplete() exposes potential
+  /// optimizations.  For example, it may make constructing the column
+  /// Map faster, and it may avoid intermediate unoptimized storage in
+  /// the destination CrsGraph.
+  ///
+  /// The resulting graph is fill complete (in the sense of
+  /// isFillComplete()) and has optimized storage (in the sense of
+  /// isStorageOptimized()).  By default, its domain Map is the domain
+  /// Map of the source graph, and its range Map is the range Map of
+  /// the source graph.
+  ///
+  /// \warning If the target Map of the Import is a subset of the
+  ///   source Map of the Import, then you cannot use the default
+  ///   range Map.  You should instead construct a nonoverlapping
+  ///   version of the target Map and supply that as the nondefault
+  ///   value of the range Map.
+  ///
+  /// \param sourceGraph [in] The source graph from which to
+  ///   import.  The source of an Import must have a nonoverlapping
+  ///   distribution.
+  ///
+  /// \param importer [in] The Import instance containing a
+  ///   precomputed redistribution plan.  The source Map of the
+  ///   Import must be the same as the rowMap of sourceGraph unless
+  ///   the "Reverse Mode" option on the params list, in which case
+  ///   the targetMap of Import must match the rowMap of the sourceGraph
+  ///
+  /// \param domainMap [in] Domain Map of the returned graph.  If
+  ///   null, we use the default, which is the domain Map of the
+  ///   source graph.
+  ///
+  /// \param rangeMap [in] Range Map of the returned graph.  If
+  ///   null, we use the default, which is the range Map of the
+  ///   source graph.
+  ///
+  /// \param params [in/out] Optional list of parameters.  If not
+  ///   null, any missing parameters will be filled in with their
+  ///   default values.
+  template<class CrsGraphType>
+  Teuchos::RCP<CrsGraphType>
+  importAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                  const Import<typename CrsGraphType::local_ordinal_type,
+                                               typename CrsGraphType::global_ordinal_type,
+                                               typename CrsGraphType::node_type>& importer,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& domainMap = Teuchos::null,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& rangeMap = Teuchos::null,
+                                  const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
+  {
+    Teuchos::RCP<CrsGraphType> destGraph;
+    sourceGraph->importAndFillComplete (destGraph,importer,domainMap, rangeMap, params);
+    return destGraph;
+  }
+
+  /// \brief Nonmember CrsGraph constructor that fuses Import and fillComplete().
+  /// \relatesalso CrsGraph
+  /// \tparam CrsGraphType A specialization of CrsGraph.
+  ///
+  /// A common use case is to create an empty destination CrsGraph,
+  /// redistribute from a source CrsGraph (by an Import or Export
+  /// operation), then call fillComplete() on the destination
+  /// CrsGraph.  This constructor fuses these three cases, for an
+  /// Import redistribution.
+  ///
+  /// Fusing redistribution and fillComplete() exposes potential
+  /// optimizations.  For example, it may make constructing the column
+  /// Map faster, and it may avoid intermediate unoptimized storage in
+  /// the destination CrsGraph.
+  ///
+  /// The resulting graph is fill complete (in the sense of
+  /// isFillComplete()) and has optimized storage (in the sense of
+  /// isStorageOptimized()).  By default, its domain Map is the domain
+  /// Map of the source graph, and its range Map is the range Map of
+  /// the source graph.
+  ///
+  /// \warning If the target Map of the Import is a subset of the
+  ///   source Map of the Import, then you cannot use the default
+  ///   range Map.  You should instead construct a nonoverlapping
+  ///   version of the target Map and supply that as the nondefault
+  ///   value of the range Map.
+  ///
+  /// \param sourceGraph [in] The source graph from which to
+  ///   import.  The source of an Import must have a nonoverlapping
+  ///   distribution.
+  ///
+  /// \param rowImporter [in] The Import instance containing a
+  ///   precomputed redistribution plan.  The source Map of the
+  ///   Import must be the same as the rowMap of sourceGraph unless
+  ///   the "Reverse Mode" option on the params list, in which case
+  ///   the targetMap of Import must match the rowMap of the sourceGraph
+  ///
+  /// \param domainImporter [in] The Import instance containing a
+  ///   precomputed redistribution plan.  The source Map of the
+  ///   Import must be the same as the domainMap of sourceGraph unless
+  ///   the "Reverse Mode" option on the params list, in which case
+  ///   the targetMap of Import must match the domainMap of the sourceGraph
+  ///
+  /// \param domainMap [in] Domain Map of the returned graph.
+  ///
+  /// \param rangeMap [in] Range Map of the returned graph.
+  ///
+  /// \param params [in/out] Optional list of parameters.  If not
+  ///   null, any missing parameters will be filled in with their
+  ///   default values.
+  template<class CrsGraphType>
+  Teuchos::RCP<CrsGraphType>
+  importAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                  const Import<typename CrsGraphType::local_ordinal_type,
+                                               typename CrsGraphType::global_ordinal_type,
+                                               typename CrsGraphType::node_type>& rowImporter,
+                                  const Import<typename CrsGraphType::local_ordinal_type,
+                                              typename CrsGraphType::global_ordinal_type,
+                                              typename CrsGraphType::node_type>& domainImporter,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& domainMap,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& rangeMap,
+                                  const Teuchos::RCP<Teuchos::ParameterList>& params)
+  {
+    Teuchos::RCP<CrsGraphType> destGraph;
+    sourceGraph->importAndFillComplete (destGraph,rowImporter,domainImporter, domainMap, rangeMap, params);
+    return destGraph;
+  }
+
+  /// \brief Nonmember CrsGraph constructor that fuses Export and fillComplete().
+  /// \relatesalso CrsGraph
+  /// \tparam CrsGraphType A specialization of CrsGraph.
+  ///
+  /// For justification, see the documentation of
+  /// importAndFillCompleteCrsGraph() (which is the Import analog of
+  /// this function).
+  ///
+  /// The resulting graph is fill complete (in the sense of
+  /// isFillComplete()) and has optimized storage (in the sense of
+  /// isStorageOptimized()).  By default, its domain Map is the domain
+  /// Map of the source graph, and its range Map is the range Map of
+  /// the source graph.
+  ///
+  /// \param sourceGraph [in] The source graph from which to
+  ///   export.  Its row Map may be overlapping, since the source of
+  ///   an Export may be overlapping.
+  ///
+  /// \param exporter [in] The Export instance containing a
+  ///   precomputed redistribution plan.  The source Map of the
+  ///   Export must be the same as the row Map of sourceGraph.
+  ///
+  /// \param domainMap [in] Domain Map of the returned graph.  If
+  ///   null, we use the default, which is the domain Map of the
+  ///   source graph.
+  ///
+  /// \param rangeMap [in] Range Map of the returned graph.  If
+  ///   null, we use the default, which is the range Map of the
+  ///   source graph.
+  ///
+  /// \param params [in/out] Optional list of parameters.  If not
+  ///   null, any missing parameters will be filled in with their
+  ///   default values.
+  template<class CrsGraphType>
+  Teuchos::RCP<CrsGraphType>
+  exportAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                  const Export<typename CrsGraphType::local_ordinal_type,
+                                               typename CrsGraphType::global_ordinal_type,
+                                               typename CrsGraphType::node_type>& exporter,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& domainMap = Teuchos::null,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& rangeMap = Teuchos::null,
+                                  const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
+  {
+    Teuchos::RCP<CrsGraphType> destGraph;
+    sourceGraph->exportAndFillComplete (destGraph,exporter,domainMap, rangeMap, params);
+    return destGraph;
+  }
+
+  /// \brief Nonmember CrsGraph constructor that fuses Export and fillComplete().
+  /// \relatesalso CrsGraph
+  /// \tparam CrsGraphType A specialization of CrsGraph.
+  ///
+  /// For justification, see the documentation of
+  /// importAndFillCompleteCrsGraph() (which is the Import analog of
+  /// this function).
+  ///
+  /// The resulting graph is fill complete (in the sense of
+  /// isFillComplete()) and has optimized storage (in the sense of
+  /// isStorageOptimized()).  By default, its domain Map is the domain
+  /// Map of the source graph, and its range Map is the range Map of
+  /// the source graph.
+  ///
+  /// \param sourceGraph [in] The source graph from which to
+  ///   export.  Its row Map may be overlapping, since the source of
+  ///   an Export may be overlapping.
+  ///
+  /// \param rowExporter [in] The Export instance containing a
+  ///   precomputed redistribution plan.  The source Map of the
+  ///   Export must be the same as the row Map of sourceGraph.
+  ///
+  /// \param domainExporter [in] The Export instance containing a
+  ///   precomputed redistribution plan.  The source Map of the
+  ///   Export must be the same as the domain Map of sourceGraph.
+  ///
+  /// \param domainMap [in] Domain Map of the returned graph.
+  ///
+  /// \param rangeMap [in] Range Map of the returned graph.
+  ///
+  /// \param params [in/out] Optional list of parameters.  If not
+  ///   null, any missing parameters will be filled in with their
+  ///   default values.
+  template<class CrsGraphType>
+  Teuchos::RCP<CrsGraphType>
+  exportAndFillCompleteCrsGraph (const Teuchos::RCP<const CrsGraphType>& sourceGraph,
+                                  const Export<typename CrsGraphType::local_ordinal_type,
+                                               typename CrsGraphType::global_ordinal_type,
+                                               typename CrsGraphType::node_type>& rowExporter,
+                                  const Export<typename CrsGraphType::local_ordinal_type,
+                                               typename CrsGraphType::global_ordinal_type,
+                                               typename CrsGraphType::node_type>& domainExporter,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& domainMap,
+                                  const Teuchos::RCP<const Map<typename CrsGraphType::local_ordinal_type,
+                                                               typename CrsGraphType::global_ordinal_type,
+                                                               typename CrsGraphType::node_type> >& rangeMap,
+                                  const Teuchos::RCP<Teuchos::ParameterList>& params)
+  {
+    Teuchos::RCP<CrsGraphType> destGraph;
+    sourceGraph->exportAndFillComplete (destGraph,rowExporter,domainExporter,domainMap, rangeMap, params);
+    return destGraph;
   }
 
   namespace Details {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1,4 +1,4 @@
-// @HEADER
+// @HEADER 
 // ***********************************************************************
 //
 //          Tpetra: Templated Linear Algebra Services Package
@@ -60,6 +60,11 @@
 #include "Tpetra_Details_getEntryOnHost.hpp"
 #include "Tpetra_Distributor.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
+#include "Tpetra_Vector.hpp"
+#include "Tpetra_Import_Util.hpp"
+#include "Tpetra_Import_Util2.hpp"
+#include "Tpetra_Details_packCrsGraph.hpp"
+#include "Tpetra_Details_unpackCrsGraphAndCombine.hpp"
 #include <algorithm>
 #include <limits>
 #include <sstream>
@@ -2947,7 +2952,7 @@ namespace Tpetra {
       }
       if (! allInColMap) {
         std::ostringstream os;
-        os << "Tpetra::CrsMatrix::insertLocalIndices: You attempted to insert "
+        os << "Tpetra::CrsGraph::insertLocalIndices: You attempted to insert "
           "entries in owned row " << localRow << ", at the following column "
           "indices: " << toString (indices) << "." << endl;
         os << "Of those, the following indices are not in the column Map on "
@@ -6226,6 +6231,703 @@ namespace Tpetra {
     return true;
   }
 
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  transferAndFillComplete (Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                           const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& rowTransfer,
+                           const Teuchos::RCP<const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node> > & domainTransfer,
+                           const Teuchos::RCP<const map_type>& domainMap,
+                           const Teuchos::RCP<const map_type>& rangeMap,
+                           const Teuchos::RCP<Teuchos::ParameterList>& params) const
+  {
+    using Tpetra::Details::getArrayViewFromDualView;
+    using Tpetra::Details::packCrsGraphWithOwningPIDs;
+    using Tpetra::Details::unpackAndCombineWithOwningPIDsCount;
+    using Tpetra::Details::unpackAndCombineIntoCrsArrays;
+    using Teuchos::ArrayRCP;
+    using Teuchos::ArrayView;
+    using Teuchos::Comm;
+    using Teuchos::ParameterList;
+    using Teuchos::rcp;
+    using Teuchos::RCP;
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    using std::string;
+    using Teuchos::TimeMonitor;
+#endif
+
+    using LO = LocalOrdinal;
+    using GO = GlobalOrdinal;
+    using NT = node_type;
+    using this_type = CrsGraph<LO, GO, NT>;
+    using ivector_type = Vector<int, LO, GO, NT>;
+    using packet_type = typename this_type::packet_type;
+
+    const char* prefix = "Tpetra::CrsGraph::transferAndFillComplete: ";
+
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    string label;
+    if(!params.is_null()) label = params->get("Timer Label", label);
+    string prefix2 = string("Tpetra ")+ label + std::string(": CrsGraph TAFC ");
+    RCP<TimeMonitor> MM =
+      rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("Pack-1"))));
+#endif
+
+    // Make sure that the input argument rowTransfer is either an
+    // Import or an Export.  Import and Export are the only two
+    // subclasses of Transfer that we defined, but users might
+    // (unwisely, for now at least) decide to implement their own
+    // subclasses.  Exclude this possibility.
+    const import_type* xferAsImport = dynamic_cast<const import_type*>(&rowTransfer);
+    const export_type* xferAsExport = dynamic_cast<const export_type*>(&rowTransfer);
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      xferAsImport == NULL && xferAsExport == NULL, std::invalid_argument,
+      prefix << "The 'rowTransfer' input argument must be either an Import or "
+      "an Export, and its template parameters must match the corresponding "
+      "template parameters of the CrsGraph.");
+
+    // Make sure that the input argument domainTransfer is either an
+    // Import or an Export.  Import and Export are the only two
+    // subclasses of Transfer that we defined, but users might
+    // (unwisely, for now at least) decide to implement their own
+    // subclasses.  Exclude this possibility.
+    Teuchos::RCP<const import_type> xferDomainAsImport =
+      Teuchos::rcp_dynamic_cast<const import_type>(domainTransfer);
+    Teuchos::RCP<const export_type> xferDomainAsExport =
+      Teuchos::rcp_dynamic_cast<const export_type>(domainTransfer);
+
+    if(! domainTransfer.is_null()) {
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+         (xferDomainAsImport.is_null() && xferDomainAsExport.is_null()), std::invalid_argument,
+         prefix << "The 'domainTransfer' input argument must be either an "
+         "Import or an Export, and its template parameters must match the "
+         "corresponding template parameters of the CrsGraph.");
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+         ( xferAsImport != NULL || ! xferDomainAsImport.is_null() ) &&
+         (( xferAsImport != NULL &&   xferDomainAsImport.is_null() ) ||
+          ( xferAsImport == NULL && ! xferDomainAsImport.is_null() )), std::invalid_argument,
+         prefix << "The 'rowTransfer' and 'domainTransfer' input arguments "
+         "must be of the same type (either Import or Export).");
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+         ( xferAsExport != NULL || ! xferDomainAsExport.is_null() ) &&
+         (( xferAsExport != NULL &&   xferDomainAsExport.is_null() ) ||
+          ( xferAsExport == NULL && ! xferDomainAsExport.is_null() )), std::invalid_argument,
+         prefix << "The 'rowTransfer' and 'domainTransfer' input arguments "
+         "must be of the same type (either Import or Export).");
+
+    } // domainTransfer != null
+
+
+    // FIXME (mfh 15 May 2014) Wouldn't communication still be needed,
+    // if the source Map is not distributed but the target Map is?
+    const bool communication_needed = rowTransfer.getSourceMap()->isDistributed();
+
+    //
+    // Get the caller's parameters
+    //
+
+    bool reverseMode = false; // Are we in reverse mode?
+    bool restrictComm = false; // Do we need to restrict the communicator?
+    RCP<ParameterList> graphparams; // parameters for the destination graph
+    if (! params.is_null()) {
+      reverseMode = params->get("Reverse Mode", reverseMode);
+      restrictComm = params->get("Restrict Communicator", restrictComm);
+      graphparams = sublist(params, "CrsGraph");
+    }
+
+    // Get the new domain and range Maps.  We need some of them for error
+    // checking, now that we have the reverseMode parameter.
+    RCP<const map_type> MyRowMap = reverseMode ?
+      rowTransfer.getSourceMap() : rowTransfer.getTargetMap();
+    RCP<const map_type> MyColMap; // create this below
+    RCP<const map_type> MyDomainMap = ! domainMap.is_null() ? domainMap : getDomainMap();
+    RCP<const map_type> MyRangeMap = ! rangeMap.is_null() ? rangeMap : getRangeMap();
+    RCP<const map_type> BaseRowMap = MyRowMap;
+    RCP<const map_type> BaseDomainMap = MyDomainMap;
+
+    // If the user gave us a nonnull destGraph, then check whether it's
+    // "pristine."  That means that it has no entries.
+    //
+    // FIXME (mfh 15 May 2014) If this is not true on all processes,
+    // then this exception test may hang.  It would be better to
+    // forward an error flag to the next communication phase.
+    if (! destGraph.is_null()) {
+      // FIXME (mfh 15 May 2014): The Epetra idiom for checking
+      // whether a graph or matrix has no entries on the calling
+      // process, is that it is neither locally nor globally indexed.
+      // This may change eventually with the Kokkos refactor version
+      // of Tpetra, so it would be better just to check the quantity
+      // of interest directly.  Note that with the Kokkos refactor
+      // version of Tpetra, asking for the total number of entries in
+      // a graph or matrix that is not fill complete might require
+      // computation (kernel launch), since it is not thread scalable
+      // to update a count every time an entry is inserted.
+      const bool NewFlag =
+        ! destGraph->isLocallyIndexed() && ! destGraph->isGloballyIndexed();
+      TEUCHOS_TEST_FOR_EXCEPTION(! NewFlag, std::invalid_argument,
+        prefix << "The input argument 'destGraph' is only allowed to be nonnull, "
+        "if its graph is empty (neither locally nor globally indexed).");
+
+      // FIXME (mfh 15 May 2014) At some point, we want to change
+      // graphs and matrices so that their DistObject Map
+      // (this->getMap()) may differ from their row Map.  This will
+      // make redistribution for 2-D distributions more efficient.  I
+      // hesitate to change this check, because I'm not sure how much
+      // the code here depends on getMap() and getRowMap() being the
+      // same.
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        ! destGraph->getRowMap()->isSameAs(*MyRowMap), std::invalid_argument,
+        prefix << "The (row) Map of the input argument 'destGraph' is not the "
+        "same as the (row) Map specified by the input argument 'rowTransfer'.");
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        ! destGraph->checkSizes(*this), std::invalid_argument,
+        prefix << "You provided a nonnull destination graph, but checkSizes() "
+        "indicates that it is not a legal legal target for redistribution from "
+        "the source graph (*this).  This may mean that they do not have the "
+        "same dimensions.");
+    }
+
+    // If forward mode (the default), then *this's (row) Map must be
+    // the same as the source Map of the Transfer.  If reverse mode,
+    // then *this's (row) Map must be the same as the target Map of
+    // the Transfer.
+    //
+    // FIXME (mfh 15 May 2014) At some point, we want to change graphs
+    // and matrices so that their DistObject Map (this->getMap()) may
+    // differ from their row Map.  This will make redistribution for
+    // 2-D distributions more efficient.  I hesitate to change this
+    // check, because I'm not sure how much the code here depends on
+    // getMap() and getRowMap() being the same.
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      ! (reverseMode || getRowMap()->isSameAs(*rowTransfer.getSourceMap())),
+      std::invalid_argument, prefix <<
+      "rowTransfer->getSourceMap() must match this->getRowMap() in forward mode.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      ! (! reverseMode || getRowMap()->isSameAs(*rowTransfer.getTargetMap())),
+      std::invalid_argument, prefix <<
+      "rowTransfer->getTargetMap() must match this->getRowMap() in reverse mode.");
+
+    // checks for domainTransfer
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      ! xferDomainAsImport.is_null() && ! xferDomainAsImport->getTargetMap()->isSameAs(*domainMap),
+      std::invalid_argument,
+      prefix << "The target map of the 'domainTransfer' input argument must be "
+      "the same as the rebalanced domain map 'domainMap'");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      ! xferDomainAsExport.is_null() && ! xferDomainAsExport->getSourceMap()->isSameAs(*domainMap),
+      std::invalid_argument,
+      prefix << "The source map of the 'domainTransfer' input argument must be "
+      "the same as the rebalanced domain map 'domainMap'");
+
+    // The basic algorithm here is:
+    //
+    // 1. Call the moral equivalent of "distor.do" to handle the import.
+    // 2. Copy all the Imported and Copy/Permuted data into the raw
+    //    CrsGraph pointers, still using GIDs.
+    // 3. Call an optimized version of MakeColMap that avoids the
+    //    Directory lookups (since the importer knows who owns all the
+    //    GIDs) AND reindexes to LIDs.
+    // 4. Call expertStaticFillComplete()
+
+    // Get information from the Importer
+    const size_t NumSameIDs = rowTransfer.getNumSameIDs();
+    ArrayView<const LO> ExportLIDs = reverseMode ?
+      rowTransfer.getRemoteLIDs() : rowTransfer.getExportLIDs();
+    ArrayView<const LO> RemoteLIDs = reverseMode ?
+      rowTransfer.getExportLIDs() : rowTransfer.getRemoteLIDs();
+    ArrayView<const LO> PermuteToLIDs = reverseMode ?
+      rowTransfer.getPermuteFromLIDs() : rowTransfer.getPermuteToLIDs();
+    ArrayView<const LO> PermuteFromLIDs = reverseMode ?
+      rowTransfer.getPermuteToLIDs() : rowTransfer.getPermuteFromLIDs();
+    Distributor& Distor = rowTransfer.getDistributor();
+
+    // Owning PIDs
+    Teuchos::Array<int> SourcePids;
+    Teuchos::Array<int> TargetPids;
+    int MyPID = getComm()->getRank();
+
+    // Temp variables for sub-communicators
+    RCP<const map_type> ReducedRowMap, ReducedColMap,
+      ReducedDomainMap, ReducedRangeMap;
+    RCP<const Comm<int> > ReducedComm;
+
+    // If the user gave us a null destGraph, then construct the new
+    // destination graph.  We will replace its column Map later.
+    if (destGraph.is_null()) {
+      destGraph = rcp(new this_type(MyRowMap, 0, StaticProfile, graphparams));
+    }
+
+    /***************************************************/
+    /***** 1) First communicator restriction phase ****/
+    /***************************************************/
+    if (restrictComm) {
+      ReducedRowMap = MyRowMap->removeEmptyProcesses();
+      ReducedComm = ReducedRowMap.is_null() ?
+        Teuchos::null :
+        ReducedRowMap->getComm();
+      destGraph->removeEmptyProcessesInPlace(ReducedRowMap);
+
+      ReducedDomainMap = MyRowMap.getRawPtr() == MyDomainMap.getRawPtr() ?
+        ReducedRowMap :
+        MyDomainMap->replaceCommWithSubset(ReducedComm);
+      ReducedRangeMap = MyRowMap.getRawPtr() == MyRangeMap.getRawPtr() ?
+        ReducedRowMap :
+        MyRangeMap->replaceCommWithSubset(ReducedComm);
+
+      // Reset the "my" maps
+      MyRowMap    = ReducedRowMap;
+      MyDomainMap = ReducedDomainMap;
+      MyRangeMap  = ReducedRangeMap;
+
+      // Update my PID, if we've restricted the communicator
+      if (! ReducedComm.is_null()) {
+        MyPID = ReducedComm->getRank();
+      }
+      else {
+        MyPID = -2; // For debugging
+      }
+    }
+    else {
+      ReducedComm = MyRowMap->getComm();
+    }
+
+    /***************************************************/
+    /***** 2) From Tpera::DistObject::doTransfer() ****/
+    /***************************************************/
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("ImportSetup"))));
+#endif
+    // Get the owning PIDs
+    RCP<const import_type> MyImporter = getImporter();
+
+    // check whether domain maps of source graph and base domain map is the same
+    bool bSameDomainMap = BaseDomainMap->isSameAs(*getDomainMap());
+
+    if (! restrictComm && ! MyImporter.is_null() && bSameDomainMap ) {
+      // Same domain map as source graph
+      //
+      // NOTE: This won't work for restrictComm (because the Import
+      // doesn't know the restricted PIDs), though writing an
+      // optimized version for that case would be easy (Import an
+      // IntVector of the new PIDs).  Might want to add this later.
+      Import_Util::getPids(*MyImporter, SourcePids, false);
+    }
+    else if (restrictComm && ! MyImporter.is_null() && bSameDomainMap) {
+      // Same domain map as source graph (restricted communicator)
+      // We need one import from the domain to the column map
+      ivector_type SourceDomain_pids(getDomainMap(),true);
+      ivector_type SourceCol_pids(getColMap());
+      // SourceDomain_pids contains the restricted pids
+      SourceDomain_pids.putScalar(MyPID);
+
+      SourceCol_pids.doImport(SourceDomain_pids, *MyImporter, INSERT);
+      SourcePids.resize(getColMap()->getNodeNumElements());
+      SourceCol_pids.get1dCopy(SourcePids());
+    }
+    else if (MyImporter.is_null() && bSameDomainMap) {
+      // Graph has no off-process entries
+      SourcePids.resize(getColMap()->getNodeNumElements());
+      SourcePids.assign(getColMap()->getNodeNumElements(), MyPID);
+    }
+    else if ( ! MyImporter.is_null() &&
+              ! domainTransfer.is_null() ) {
+      // general implementation for rectangular matrices with
+      // domain map different than SourceGraph domain map.
+      // User has to provide a DomainTransfer object. We need
+      // to communications (import/export)
+
+      // TargetDomain_pids lives on the rebalanced new domain map
+      ivector_type TargetDomain_pids(domainMap);
+      TargetDomain_pids.putScalar(MyPID);
+
+      // SourceDomain_pids lives on the non-rebalanced old domain map
+      ivector_type SourceDomain_pids(getDomainMap());
+
+      // SourceCol_pids lives on the non-rebalanced old column map
+      ivector_type SourceCol_pids(getColMap());
+
+      if (! reverseMode && ! xferDomainAsImport.is_null() ) {
+        SourceDomain_pids.doExport(TargetDomain_pids, *xferDomainAsImport, INSERT);
+      }
+      else if (reverseMode && ! xferDomainAsExport.is_null() ) {
+        SourceDomain_pids.doExport(TargetDomain_pids, *xferDomainAsExport, INSERT);
+      }
+      else if (! reverseMode && ! xferDomainAsExport.is_null() ) {
+        SourceDomain_pids.doImport(TargetDomain_pids, *xferDomainAsExport, INSERT);
+      }
+      else if (reverseMode && ! xferDomainAsImport.is_null() ) {
+        SourceDomain_pids.doImport(TargetDomain_pids, *xferDomainAsImport, INSERT);
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          true, std::logic_error,
+          prefix << "Should never get here!  Please report this bug to a Tpetra developer.");
+      }
+      SourceCol_pids.doImport(SourceDomain_pids, *MyImporter, INSERT);
+      SourcePids.resize(getColMap()->getNodeNumElements());
+      SourceCol_pids.get1dCopy(SourcePids());
+    }
+    else if (BaseDomainMap->isSameAs(*BaseRowMap) &&
+             getDomainMap()->isSameAs(*getRowMap())) {
+      // We can use the rowTransfer + SourceGraph's Import to find out who owns what.
+      ivector_type TargetRow_pids(domainMap);
+      ivector_type SourceRow_pids(getRowMap());
+      ivector_type SourceCol_pids(getColMap());
+
+      TargetRow_pids.putScalar(MyPID);
+      if (! reverseMode && xferAsImport != NULL) {
+        SourceRow_pids.doExport(TargetRow_pids, *xferAsImport, INSERT);
+      }
+      else if (reverseMode && xferAsExport != NULL) {
+        SourceRow_pids.doExport(TargetRow_pids, *xferAsExport, INSERT);
+      }
+      else if (! reverseMode && xferAsExport != NULL) {
+        SourceRow_pids.doImport(TargetRow_pids, *xferAsExport, INSERT);
+      }
+      else if (reverseMode && xferAsImport != NULL) {
+        SourceRow_pids.doImport(TargetRow_pids, *xferAsImport, INSERT);
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          true, std::logic_error,
+          prefix << "Should never get here!  Please report this bug to a Tpetra developer.");
+      }
+      SourceCol_pids.doImport(SourceRow_pids, *MyImporter, INSERT);
+      SourcePids.resize(getColMap()->getNodeNumElements());
+      SourceCol_pids.get1dCopy(SourcePids());
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        true, std::invalid_argument,
+        prefix << "This method only allows either domainMap == getDomainMap(), "
+        "or (domainMap == rowTransfer.getTargetMap() and getDomainMap() == getRowMap()).");
+    }
+
+    // Tpetra-specific stuff
+    size_t constantNumPackets = destGraph->constantNumberOfPackets();
+    if (constantNumPackets == 0) {
+      destGraph->reallocArraysForNumPacketsPerLid(ExportLIDs.size(),
+                                                 RemoteLIDs.size());
+    }
+    else {
+      // There are a constant number of packets per element.  We
+      // already know (from the number of "remote" (incoming)
+      // elements) how many incoming elements we expect, so we can
+      // resize the buffer accordingly.
+      const size_t rbufLen = RemoteLIDs.size() * constantNumPackets;
+      destGraph->reallocImportsIfNeeded(rbufLen);
+    }
+
+    // packAndPrepare* methods modify numExportPacketsPerLID_.
+    destGraph->numExportPacketsPerLID_.template modify<Kokkos::HostSpace>();
+    Teuchos::ArrayView<size_t> numExportPacketsPerLID =
+      getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
+
+    // Pack & Prepare w/ owning PIDs
+    packCrsGraphWithOwningPIDs(*this, destGraph->exports_,
+                               numExportPacketsPerLID, ExportLIDs,
+                               SourcePids, constantNumPackets, Distor);
+
+    // Do the exchange of remote data.
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("Transfer"))));
+#endif
+
+    if (communication_needed) {
+      if (reverseMode) {
+        if (constantNumPackets == 0) { // variable number of packets per LID
+          // Make sure that host has the latest version, since we're
+          // using the version on host.  If host has the latest
+          // version, syncing to host does nothing.
+          destGraph->numExportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
+            getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
+          destGraph->numImportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<size_t> numImportPacketsPerLID =
+            getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
+          Distor.doReversePostsAndWaits(numExportPacketsPerLID, 1,
+                                         numImportPacketsPerLID);
+          size_t totalImportPackets = 0;
+          for (Array_size_type i = 0; i < numImportPacketsPerLID.size(); ++i) {
+            totalImportPackets += numImportPacketsPerLID[i];
+          }
+
+          // Reallocation MUST go before setting the modified flag,
+          // because it may clear out the flags.
+          destGraph->reallocImportsIfNeeded(totalImportPackets);
+          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          Teuchos::ArrayView<packet_type> hostImports =
+            getArrayViewFromDualView(destGraph->imports_);
+          // This is a legacy host pack/unpack path, so use the host
+          // version of exports_.
+          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<const packet_type> hostExports =
+            getArrayViewFromDualView(destGraph->exports_);
+          Distor.doReversePostsAndWaits(hostExports,
+                                         numExportPacketsPerLID,
+                                         hostImports,
+                                         numImportPacketsPerLID);
+        }
+        else { // constant number of packets per LI
+          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          Teuchos::ArrayView<packet_type> hostImports =
+            getArrayViewFromDualView(destGraph->imports_);
+          // This is a legacy host pack/unpack path, so use the host
+          // version of exports_.
+          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<const packet_type> hostExports =
+            getArrayViewFromDualView(destGraph->exports_);
+          Distor.doReversePostsAndWaits(hostExports,
+                                         constantNumPackets,
+                                         hostImports);
+        }
+      }
+      else { // forward mode (the default)
+        if (constantNumPackets == 0) { // variable number of packets per LID
+          // Make sure that host has the latest version, since we're
+          // using the version on host.  If host has the latest
+          // version, syncing to host does nothing.
+          destGraph->numExportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
+            getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
+          destGraph->numImportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<size_t> numImportPacketsPerLID =
+            getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
+          Distor.doPostsAndWaits(numExportPacketsPerLID, 1,
+                                  numImportPacketsPerLID);
+          size_t totalImportPackets = 0;
+          for (Array_size_type i = 0; i < numImportPacketsPerLID.size(); ++i) {
+            totalImportPackets += numImportPacketsPerLID[i];
+          }
+
+          // Reallocation MUST go before setting the modified flag,
+          // because it may clear out the flags.
+          destGraph->reallocImportsIfNeeded(totalImportPackets);
+          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          Teuchos::ArrayView<packet_type> hostImports =
+            getArrayViewFromDualView(destGraph->imports_);
+          // This is a legacy host pack/unpack path, so use the host
+          // version of exports_.
+          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<const packet_type> hostExports =
+            getArrayViewFromDualView(destGraph->exports_);
+          Distor.doPostsAndWaits(hostExports,
+                                  numExportPacketsPerLID,
+                                  hostImports,
+                                  numImportPacketsPerLID);
+        }
+        else { // constant number of packets per LID
+          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          Teuchos::ArrayView<packet_type> hostImports =
+            getArrayViewFromDualView(destGraph->imports_);
+          // This is a legacy host pack/unpack path, so use the host
+          // version of exports_.
+          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          Teuchos::ArrayView<const packet_type> hostExports =
+            getArrayViewFromDualView(destGraph->exports_);
+          Distor.doPostsAndWaits(hostExports,
+                                  constantNumPackets,
+                                  hostImports);
+        }
+      }
+    }
+
+    /*********************************************************************/
+    /**** 3) Copy all of the Same/Permute/Remote data into CSR_arrays ****/
+    /*********************************************************************/
+
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("Unpack-1"))));
+#endif
+
+    // Backwards compatibility measure.  We'll use this again below.
+    destGraph->numImportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+    Teuchos::ArrayView<const size_t> numImportPacketsPerLID =
+      getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
+    destGraph->imports_.template sync<Kokkos::HostSpace>();
+    Teuchos::ArrayView<const packet_type> hostImports =
+      getArrayViewFromDualView(destGraph->imports_);
+    size_t mynnz =
+      unpackAndCombineWithOwningPIDsCount(*this, RemoteLIDs, hostImports,
+                                           numImportPacketsPerLID,
+                                           constantNumPackets, Distor, INSERT,
+                                           NumSameIDs, PermuteToLIDs, PermuteFromLIDs);
+    size_t N = BaseRowMap->getNodeNumElements();
+
+    // Allocations
+    ArrayRCP<size_t> CSR_rowptr(N+1);
+    ArrayRCP<GO> CSR_colind_GID;
+    ArrayRCP<LO> CSR_colind_LID;
+    CSR_colind_GID.resize(mynnz);
+
+    // If LO and GO are the same, we can reuse memory when
+    // converting the column indices from global to local indices.
+    if (typeid(LO) == typeid(GO)) {
+      CSR_colind_LID = Teuchos::arcp_reinterpret_cast<LO>(CSR_colind_GID);
+    }
+    else {
+      CSR_colind_LID.resize(mynnz);
+    }
+
+    // FIXME (mfh 15 May 2014) Why can't we abstract this out as an
+    // unpackAndCombine method on a "CrsArrays" object?  This passing
+    // in a huge list of arrays is icky.  Can't we have a bit of an
+    // abstraction?  Implementing a concrete DistObject subclass only
+    // takes five methods.
+    unpackAndCombineIntoCrsArrays(*this, RemoteLIDs, hostImports,
+                                  numImportPacketsPerLID, constantNumPackets,
+                                  Distor, INSERT, NumSameIDs, PermuteToLIDs,
+                                  PermuteFromLIDs, N, mynnz, MyPID,
+                                  CSR_rowptr(), CSR_colind_GID(),
+                                  SourcePids(), TargetPids);
+
+    /**************************************************************/
+    /**** 4) Call Optimized MakeColMap w/ no Directory Lookups ****/
+    /**************************************************************/
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("Unpack-2"))));
+#endif
+    // Call an optimized version of makeColMap that avoids the
+    // Directory lookups (since the Import object knows who owns all
+    // the GIDs).
+    Teuchos::Array<int> RemotePids;
+    Import_Util::lowCommunicationMakeColMapAndReindex(CSR_rowptr(),
+                                                       CSR_colind_LID(),
+                                                       CSR_colind_GID(),
+                                                       BaseDomainMap,
+                                                       TargetPids, RemotePids,
+                                                       MyColMap);
+
+    /*******************************************************/
+    /**** 4) Second communicator restriction phase      ****/
+    /*******************************************************/
+    if (restrictComm) {
+      ReducedColMap = (MyRowMap.getRawPtr() == MyColMap.getRawPtr()) ?
+        ReducedRowMap :
+        MyColMap->replaceCommWithSubset(ReducedComm);
+      MyColMap = ReducedColMap; // Reset the "my" maps
+    }
+
+    // Replace the col map
+    destGraph->replaceColMap(MyColMap);
+
+    // Short circuit if the processor is no longer in the communicator
+    //
+    // NOTE: Epetra replaces modifies all "removed" processes so they
+    // have a dummy (serial) Map that doesn't touch the original
+    // communicator.  Duplicating that here might be a good idea.
+    if (ReducedComm.is_null()) {
+      return;
+    }
+
+    /***************************************************/
+    /**** 5) Sort                                   ****/
+    /***************************************************/
+    if ((! reverseMode && xferAsImport != NULL) ||
+        (reverseMode && xferAsExport != NULL)) {
+      Import_Util::sortCrsEntries(CSR_rowptr(),
+                                   CSR_colind_LID());
+    }
+    else if ((! reverseMode && xferAsExport != NULL) ||
+             (reverseMode && xferAsImport != NULL)) {
+      Import_Util::sortAndMergeCrsEntries(CSR_rowptr(),
+                                           CSR_colind_LID());
+      if (CSR_rowptr[N] != mynnz) {
+        CSR_colind_LID.resize(CSR_rowptr[N]);
+      }
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        true, std::logic_error,
+        prefix << "Should never get here!  Please report this bug to a Tpetra developer.");
+    }
+    /***************************************************/
+    /**** 6) Reset the colmap and the arrays        ****/
+    /***************************************************/
+
+    // Call constructor for the new graph (restricted as needed)
+    //
+    destGraph->setAllIndices(CSR_rowptr, CSR_colind_LID);
+
+    /***************************************************/
+    /**** 7) Build Importer & Call ESFC             ****/
+    /***************************************************/
+    // Pre-build the importer using the existing PIDs
+    Teuchos::ParameterList esfc_params;
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("CreateImporter"))));
+#endif
+    RCP<import_type> MyImport = rcp(new import_type(MyDomainMap, MyColMap, RemotePids));
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix2+string("ESFC"))));
+
+    esfc_params.set("Timer Label",prefix + std::string("TAFC"));
+#endif
+    if(!params.is_null())
+      esfc_params.set("compute global constants",params->get("compute global constants",true));
+
+    destGraph->expertStaticFillComplete(MyDomainMap, MyRangeMap,
+        MyImport, Teuchos::null, rcp(&esfc_params,false));
+
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  importAndFillComplete(Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                         const import_type& importer,
+                         const Teuchos::RCP<const map_type>& domainMap,
+                         const Teuchos::RCP<const map_type>& rangeMap,
+                         const Teuchos::RCP<Teuchos::ParameterList>& params) const
+  {
+    transferAndFillComplete(destGraph, importer, Teuchos::null, domainMap, rangeMap, params);
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  importAndFillComplete(Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                         const import_type& rowImporter,
+                         const import_type& domainImporter,
+                         const Teuchos::RCP<const map_type>& domainMap,
+                         const Teuchos::RCP<const map_type>& rangeMap,
+                         const Teuchos::RCP<Teuchos::ParameterList>& params) const
+  {
+    transferAndFillComplete(destGraph, rowImporter, Teuchos::rcpFromRef(domainImporter), domainMap, rangeMap, params);
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  exportAndFillComplete(Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                         const export_type& exporter,
+                         const Teuchos::RCP<const map_type>& domainMap,
+                         const Teuchos::RCP<const map_type>& rangeMap,
+                         const Teuchos::RCP<Teuchos::ParameterList>& params) const
+  {
+    transferAndFillComplete(destGraph, exporter, Teuchos::null, domainMap, rangeMap, params);
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  exportAndFillComplete(Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >& destGraph,
+                         const export_type& rowExporter,
+                         const export_type& domainExporter,
+                         const Teuchos::RCP<const map_type>& domainMap,
+                         const Teuchos::RCP<const map_type>& rangeMap,
+                         const Teuchos::RCP<Teuchos::ParameterList>& params) const
+  {
+    transferAndFillComplete(destGraph, rowExporter, Teuchos::rcpFromRef(domainExporter), domainMap, rangeMap, params);
+  }
+
+
 } // namespace Tpetra
 
 //
@@ -6234,6 +6936,74 @@ namespace Tpetra {
 // Must be expanded from within the Tpetra namespace!
 //
 #define TPETRA_CRSGRAPH_GRAPH_INSTANT(LO,GO,NODE) template class CrsGraph< LO , GO , NODE >;
+
+#define TPETRA_CRSGRAPH_IMPORT_AND_FILL_COMPLETE_INSTANT(LO,GO,NODE) \
+  template<>                                                                        \
+  Teuchos::RCP<CrsGraph<LO,GO,NODE> >                        \
+  importAndFillCompleteCrsGraph(const Teuchos::RCP<const CrsGraph<LO,GO,NODE> >& sourceGraph, \
+                                  const Import<CrsGraph<LO,GO,NODE>::local_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::node_type>& importer, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& domainMap, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& rangeMap,  \
+                                                               const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+#define TPETRA_CRSGRAPH_IMPORT_AND_FILL_COMPLETE_INSTANT_TWO(LO,GO,NODE) \
+  template<>                                                                        \
+  Teuchos::RCP<CrsGraph<LO,GO,NODE> >                        \
+  importAndFillCompleteCrsGraph(const Teuchos::RCP<const CrsGraph<LO,GO,NODE> >& sourceGraph, \
+                                  const Import<CrsGraph<LO,GO,NODE>::local_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::node_type>& rowImporter, \
+                                  const Import<CrsGraph<LO,GO,NODE>::local_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::node_type>& domainImporter, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& domainMap, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& rangeMap,  \
+                                                               const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+
+#define TPETRA_CRSGRAPH_EXPORT_AND_FILL_COMPLETE_INSTANT(LO,GO,NODE) \
+  template<>                                                                        \
+  Teuchos::RCP<CrsGraph<LO,GO,NODE> >                        \
+  exportAndFillCompleteCrsGraph(const Teuchos::RCP<const CrsGraph<LO,GO,NODE> >& sourceGraph, \
+                                  const Export<CrsGraph<LO,GO,NODE>::local_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::node_type>& exporter, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& domainMap, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& rangeMap,  \
+                                                               const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+#define TPETRA_CRSGRAPH_EXPORT_AND_FILL_COMPLETE_INSTANT_TWO(LO,GO,NODE) \
+  template<>                                                                        \
+  Teuchos::RCP<CrsGraph<LO,GO,NODE> >                        \
+  exportAndFillCompleteCrsGraph(const Teuchos::RCP<const CrsGraph<LO,GO,NODE> >& sourceGraph, \
+                                  const Export<CrsGraph<LO,GO,NODE>::local_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::node_type>& rowExporter, \
+                                  const Export<CrsGraph<LO,GO,NODE>::local_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,  \
+                                               CrsGraph<LO,GO,NODE>::node_type>& domainExporter, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& domainMap, \
+                                  const Teuchos::RCP<const Map<CrsGraph<LO,GO,NODE>::local_ordinal_type,      \
+                                                               CrsGraph<LO,GO,NODE>::global_ordinal_type,     \
+                                                               CrsGraph<LO,GO,NODE>::node_type> >& rangeMap,  \
+                                                               const Teuchos::RCP<Teuchos::ParameterList>& params);
+
 
 // WARNING: These macros exist only for backwards compatibility.
 // We will remove them at some point.
@@ -6246,6 +7016,11 @@ namespace Tpetra {
   TPETRA_CRSGRAPH_SORTROWINDICESANDVALUES_INSTANT(S,LO,GO,NODE)  \
   TPETRA_CRSGRAPH_MERGEROWINDICESANDVALUES_INSTANT(S,LO,GO,NODE) \
   TPETRA_CRSGRAPH_ALLOCATEVALUES1D_INSTANT(S,LO,GO,NODE)         \
-  TPETRA_CRSGRAPH_ALLOCATEVALUES2D_INSTANT(S,LO,GO,NODE)
+  TPETRA_CRSGRAPH_ALLOCATEVALUES2D_INSTANT(S,LO,GO,NODE)         \
+  TPETRA_CRSGRAPH_IMPORT_AND_FILL_COMPLETE_INSTANT(LO,GO,NODE)   \
+  TPETRA_CRSGRAPH_EXPORT_AND_FILL_COMPLETE_INSTANT(LO,GO,NODE)   \
+  TPETRA_CRSGRAPH_IMPORT_AND_FILL_COMPLETE_INSTANT_TWO(LO,GO,NODE) \
+  TPETRA_CRSGRAPH_EXPORT_AND_FILL_COMPLETE_INSTANT_TWO(LO,GO,NODE)
+
 
 #endif // TPETRA_CRSGRAPH_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph.cpp
@@ -1,0 +1,67 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "TpetraCore_config.h"
+
+#if defined(HAVE_TPETRA_EXPLICIT_INSTANTIATION)
+
+// We protect the contents of this file with macros, to assist
+// applications that circumvent Trilinos' build system.  (We do NOT
+// recommend this.)  That way, they can still build this file, but as
+// long as the macros have correct definitions, they won't build
+// anything that's not enabled.
+
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Tpetra_Details_packCrsGraph_decl.hpp"
+#include "Tpetra_Details_packCrsGraph_def.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+
+namespace Tpetra {
+
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_LGN( TPETRA_DETAILS_PACKCRSGRAPH_INSTANT )
+
+} // namespace Tpetra
+
+#endif // Whether we should build this specialization

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
@@ -1,0 +1,220 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_PACKCRSGRAPH_DECL_HPP
+#define TPETRA_DETAILS_PACKCRSGRAPH_DECL_HPP
+
+#include "TpetraCore_config.h"
+#include "Kokkos_DualView.hpp"
+#include "Tpetra_DistObject_decl.hpp"
+
+/// \file Tpetra_Details_packCrsGraph.hpp
+/// \brief Functions for packing the entries of a Tpetra::CrsGraph
+///   for communication, in the case where it is valid to go to the
+///   KokkosSparse::CrsGraph (local sparse graph data structure)
+///   directly.
+/// \warning This file, and its contents, are implementation details
+///   of Tpetra.  The file itself or its contents may disappear or
+///   change at any time.
+///
+/// Data (bytes) describing the row of the CRS graph are "packed"
+/// (concatenated) in to a (view of) packet_type* object in the following order:
+///
+///   1. number of entries (LocalOrdinal)
+///   2. global column indices (GlobalOrdinal)
+///   3. proces IDs (optional, int)
+///
+/// The functions in this file are companions to
+/// Tpetra_Details_unpackCrsGraph.hpp, i.e., Tpetra_Details_unpackCrsGraph.hpp
+/// implements the reverse of the packing order described above to ensure proper
+/// unpacking.
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace Teuchos {
+// Forward declaration of Array
+template<class T> class Array;
+// Forward declaration of ArrayView
+template<class T> class ArrayView;
+} // namespace Teuchos
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+namespace Tpetra {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Forward declaration of Distributor
+class Distributor;
+// Forward declaration of CrsGraph
+template<class LO, class GO, class NT>
+class CrsGraph;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+//
+// Users must never rely on anything in the Details namespace.
+//
+namespace Details {
+
+/// \brief Pack specified entries of the given local sparse graph for
+///   communication.
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceGraph [in] the CrsGraph source
+///
+/// \param exports [in/out] Output pack buffer; resized if needed.
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local graph.
+///
+/// \param exportLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// This is the public interface to the pack machinery
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsGraph migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<typename LO, typename GO, typename NT>
+void
+packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
+               Teuchos::Array<typename CrsGraph<LO,GO,NT>::packet_type>& exports,
+               const Teuchos::ArrayView<size_t>& numPacketsPerLID,
+               const Teuchos::ArrayView<const LO>& exportLIDs,
+               size_t& constantNumPackets,
+               Distributor& distor);
+
+/// \brief Pack specified entries of the given local sparse graph for
+///   communication, for "new" DistObject interface.
+///
+/// \tparam LO The type of local indices.  This must be the same as
+///   the LocalOrdinal template parameter of Tpetra::CrsGraph.
+/// \tparam GO The type of global indices.  This must be the same as
+///   the GlobalOrdinal template parameter of Tpetra::CrsGraph.
+/// \tparam NT The Node type.  This must be the same as the Node
+///   template parameter of Tpetra::CrsGraph.
+///
+/// \param sourceGraph [in] The "source" graph to pack.
+///
+/// \param exports [in/out] Output pack buffer; resized if needed.
+///
+/// \param numPacketsPerLID [out] On output,
+///   numPacketsPerLID.d_view[k] is the number of bytes packed for row
+///   exportLIDs.d_view[k] of the local graph.
+///
+/// \param exportLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Same as the constantNumPackets
+///   output argument of Tpetra::DistObject::packAndPrepareNew (which
+///   see).
+///
+/// \param distor [in] (Not used.)
+///
+/// This method implements CrsGraph::packNew, and thus
+/// CrsGraph::packAndPrepareNew, for the case where the graph to
+/// pack has a valid KokkosSparse::CrsGraph.
+template<typename LO, typename GO, typename NT>
+void
+packCrsGraphNew (const CrsGraph<LO, GO, NT>& sourceGraph,
+                 Kokkos::DualView<typename CrsGraph<LO,GO,NT>::packet_type*,
+                                  typename CrsGraph<LO,GO,NT>::buffer_device_type>&
+                                  exports,
+                 const Kokkos::DualView<size_t*,
+                                        typename CrsGraph<LO,GO,NT>::buffer_device_type>&
+                                        numPacketsPerLID,
+                 const Kokkos::DualView<const LO*, typename NT::device_type>& exportLIDs,
+                 size_t& constantNumPackets,
+                 Distributor& distor);
+
+/// \brief Pack specified entries of the given local sparse graph for
+///   communication.
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceGraph [in] the CrsGraph source
+///
+/// \param exports [in/out] Output pack buffer; resized if needed.
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local graph.
+///
+/// \param exportLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// This is the public interface to the pack machinery
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsGraph migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<typename LO, typename GO, typename NT>
+void
+packCrsGraphWithOwningPIDs (const CrsGraph<LO,GO,NT>& sourceGraph,
+                            Kokkos::DualView<typename CrsGraph<LO,GO,NT>::packet_type*,
+                                             typename CrsGraph<LO,GO,NT>::buffer_device_type>&
+                                             exports_dv,
+                            const Teuchos::ArrayView<size_t>& numPacketsPerLID,
+                            const Teuchos::ArrayView<const LO>& exportLIDs,
+                            const Teuchos::ArrayView<const int>& sourcePIDs,
+                            size_t& constantNumPackets,
+                            Distributor& distor);
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_PACKCRSGRAPH_DECL_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine.cpp
@@ -1,0 +1,67 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "TpetraCore_config.h"
+
+#if defined(HAVE_TPETRA_EXPLICIT_INSTANTIATION)
+
+// We protect the contents of this file with macros, to assist
+// applications that circumvent Trilinos' build system.  (We do NOT
+// recommend this.)  That way, they can still build this file, but as
+// long as the macros have correct definitions, they won't build
+// anything that's not enabled.
+
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp"
+#include "Tpetra_Details_unpackCrsGraphAndCombine_def.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+
+namespace Tpetra {
+
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_LGN( TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_INSTANT )
+
+} // namespace Tpetra
+
+#endif // Whether we should build this specialization

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
@@ -1,0 +1,262 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_DECL_HPP
+#define TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_DECL_HPP
+
+#include "TpetraCore_config.h"
+#include "Tpetra_CombineMode.hpp"
+#include "Kokkos_DualView.hpp"
+#include "Tpetra_DistObject_decl.hpp"
+
+/// \file Tpetra_Details_unpackCrsGraphAndCombine_decl.hpp
+/// \brief Declaration of functions for unpacking the entries of a
+///   Tpetra::CrsGraph for communication, in the case where it is
+///   valid to go to the KokkosSparse::CrsGraph (local sparse graph
+///   data structure) directly.
+/// \warning This file, and its contents, are implementation details
+///   of Tpetra.  The file itself or its contents may disappear or
+///   change at any time.
+///
+/// Data (bytes) describing the row of the CRS graph are "packed"
+/// (concatenated) in to a (view of) packet_type* object in the following order:
+///
+///   1. global column indices (GO)
+///   2. process IDs (optional, int)
+///
+/// The functions in this file are companions to
+/// Tpetra_Details_packCrsGraph.hpp, i.e., Tpetra_Details_packCrsGraph.hpp
+/// implements the packing order described above to ensure proper unpacking.
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace Teuchos {
+// Forward declaration of Array
+template<class T> class Array;
+// Forward declaration of ArrayView
+template<class T> class ArrayView;
+} // namespace Teuchos
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+namespace Tpetra {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Forward declaration of Distributor
+class Distributor;
+// Forward declaration of CrsGraph
+template<class LO, class GO, class NT>
+class CrsGraph;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+//
+// Users must never rely on anything in the Details namespace.
+//
+namespace Details {
+
+/// \brief Unpack the imported column indices and combine
+///   into graph.
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceGraph [in] the CrsGraph source
+///
+/// \param imports [in] Input pack buffer
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local graph.
+///
+/// \param importLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// \param combineMode [in] the mode to use for combining
+///
+/// \param atomic [in] whether or not do atomic adds/replaces in to the graph
+///
+/// \warning The allowed \c combineMode are:
+///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
+///
+/// This is the public interface to the unpack and combine machinery and
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsGraph migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<class LO, class GO, class NT>
+void
+unpackCrsGraphAndCombine(
+    const CrsGraph<LO, GO, NT>& sourceGraph,
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type>& imports,
+    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+    const Teuchos::ArrayView<const LO>& importLIDs,
+    size_t constantNumPackets,
+    Distributor & distor,
+    CombineMode combineMode,
+    const bool atomic);
+
+template<class LO, class GO, class NT>
+void
+unpackCrsGraphAndCombineNew(
+    const CrsGraph<LO, GO, NT>& sourceGraph,
+    const Kokkos::DualView<const typename CrsGraph<LO,GO,NT>::packet_type*,
+                           typename CrsGraph<LO,GO,NT>::buffer_device_type>&
+                           imports,
+    const Kokkos::DualView<const size_t*,
+                           typename CrsGraph<LO,GO,NT>::buffer_device_type>&
+                           numPacketsPerLID,
+    const Kokkos::DualView<const LO*, typename NT::device_type>& importLIDs,
+    const size_t constantNumPackets,
+    Distributor & distor,
+    const CombineMode combineMode,
+    const bool atomic);
+
+/// \brief Special version of Tpetra::Details::unpackCrsGraphAndCombine
+///   that also unpacks owning process ranks.
+///
+/// Perform the count for unpacking the imported column indices and pids,
+/// and combining them into graph.  Return (a ceiling on)
+/// the number of local stored entries ("nonzeros") in the graph.  If
+/// there are no shared rows in the sourceGraph this count is exact.
+///
+/// Note: This routine also counts the copyAndPermute nonzeros in
+/// addition to those that come in via import.
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam NT The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceGraph [in] the CrsGraph source
+///
+/// \param imports [in] Input pack buffer
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local graph.
+///
+/// \param importLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// \param combineMode [in] the mode to use for combining
+///
+/// \param numSameIds [in]
+///
+/// \param permuteToLIDs [in]
+///
+/// \param permuteFromLIDs [in]
+///
+/// \warning The allowed \c combineMode are:
+///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
+//
+/// \warning This method is intended for expert developer use
+///   only, and should never be called by user code.
+///
+/// Note: This is the public interface to the unpack and combine machinery and
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsGraph migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<class LO, class GO, class NT>
+size_t
+unpackAndCombineWithOwningPIDsCount(
+    const CrsGraph<LO, GO, NT> & sourceGraph,
+    const Teuchos::ArrayView<const LO> &importLIDs,
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type> &imports,
+    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+    size_t constantNumPackets,
+    Distributor &distor,
+    CombineMode combineMode,
+    size_t numSameIDs,
+    const Teuchos::ArrayView<const LO>& permuteToLIDs,
+    const Teuchos::ArrayView<const LO>& permuteFromLIDs);
+
+/// \brief unpackAndCombineIntoCrsArrays
+///
+/// \note You should call unpackAndCombineWithOwningPIDsCount first
+///   and allocate all arrays accordingly, before calling this
+///   function.
+///
+/// Note: The SourcePids vector (on input) should contain owning PIDs
+/// for each column in the (source) ColMap, as from
+/// Tpetra::Import_Util::getPids, with the "-1 for local" option being
+/// used.
+///
+/// Note: The TargetPids vector (on output) will contain owning PIDs
+/// for each entry in the graph, with the "-1 for local" for locally
+/// owned entries.
+template<class LO, class GO, class NT>
+void
+unpackAndCombineIntoCrsArrays(
+    const CrsGraph<LO, GO, NT> & sourceGraph,
+    const Teuchos::ArrayView<const LO>& importLIDs,
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type>& imports,
+    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+    const size_t constantNumPackets,
+    Distributor& distor,
+    const CombineMode combineMode,
+    const size_t numSameIDs,
+    const Teuchos::ArrayView<const LO>& permuteToLIDs,
+    const Teuchos::ArrayView<const LO>& permuteFromLIDs,
+    size_t TargetNumRows,
+    size_t TargetNumNonzeros,
+    const int MyTargetPID,
+    const Teuchos::ArrayView<size_t>& CRS_rowptr,
+    const Teuchos::ArrayView<GO>& CRS_colind,
+    const Teuchos::ArrayView<const int>& SourcePids,
+    Teuchos::Array<int>& TargetPids);
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_DECL_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -1,0 +1,1292 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_DEF_HPP
+#define TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_DEF_HPP
+
+#include "TpetraCore_config.h"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_ArrayView.hpp"
+#include "Tpetra_Details_castAwayConstDualView.hpp"
+#include "Tpetra_Details_computeOffsets.hpp"
+#include "Tpetra_Details_createMirrorView.hpp"
+#include "Tpetra_Details_OrdinalTraits.hpp"
+#include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_CrsGraph_decl.hpp"
+#include "Tpetra_Details_getEntryOnHost.hpp"
+#include "Kokkos_Core.hpp"
+#include <memory>
+#include <string>
+
+/// \file Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+/// \brief Definition of functions for unpacking the entries of a
+///   Tpetra::CrsGraph for communication, in the case where it is
+///   valid to go to the KokkosSparse::CrsGraph (local sparse graph
+///   data structure) directly.
+/// \warning This file, and its contents, are implementation details
+///   of Tpetra.  The file itself or its contents may disappear or
+///   change at any time.
+///
+/// Data (bytes) describing the row of the CRS graph are "packed"
+/// (concatenated) in to a (view of) Packet* object in the following order:
+///
+///   1. global column indices (GlobalOrdinal)
+///   2. proces IDs (optional, int)
+///
+/// The functions in this file are companions to
+/// Tpetra_Details_packCrsGraph.hpp, i.e., Tpetra_Details_packCrsGraph.hpp
+/// implements the packing order described above to ensure proper unpacking.
+
+namespace Tpetra {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Forward declaration of Distributor
+class Distributor;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+//
+// Users must never rely on anything in the Details namespace.
+//
+namespace Details {
+
+namespace UnpackAndCombineCrsGraphImpl {
+
+/// \brief Unpack a single row of a CrsGraph
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Device The Kokkos device type.  See the documentation of Map
+///   for requirements.
+/// \tparam BufferDevice The "buffer device type."
+template<class Packet, class GO, class Device, class BufferDevice>
+KOKKOS_FUNCTION int
+unpackRow(typename Kokkos::View<GO*,Device,Kokkos::MemoryUnmanaged>& gids_out,
+          typename Kokkos::View<int*,Device,Kokkos::MemoryUnmanaged>& pids_out,
+          const Kokkos::View<const Packet*,BufferDevice>& imports,
+          const size_t offset,
+          const size_t num_ent)
+{
+  typedef typename Kokkos::View<GO*,Device>::size_type size_type;
+
+  if (num_ent == 0) {
+    // Empty rows always take zero bytes, to ensure sparsity.
+    return 0;
+  }
+
+  // Unpack GIDs
+  for (size_type k=0; k<num_ent; k++)
+    gids_out(k) = imports(offset+k);
+
+  // Unpack PIDs
+  if (pids_out.size() > 0) {
+    for (size_type k=0; k<num_ent; k++)
+      pids_out(k) = static_cast<int>(imports(offset+num_ent+k));
+  }
+
+  return 0;
+}
+
+/// \brief Unpacks and combines a single row of the CrsGraph.
+///
+/// \tparam LocalGraph KokkosSparse::CrsGraph specialization.
+/// \tparam LocalMap Type of the "local" column map
+/// \tparam BufferDevice Type of the "buffer device type."
+///   See Trilinos GitHub Issue #1088 for details.
+///
+/// Data (bytes) describing the row of the CRS graph are "unpacked"
+/// from a single (concatenated) (view of) Packet* directly into the
+/// row of the graph.
+template<class Packet, class LocalGraph, class LocalMap, class BufferDevice>
+class UnpackAndCombineFunctor {
+
+  typedef Packet packet_type;
+  typedef LocalMap local_map_type;
+  typedef LocalGraph local_graph_type;
+  typedef BufferDevice buffer_device_type;
+
+  typedef typename local_map_type::local_ordinal_type LO;
+  typedef typename local_map_type::global_ordinal_type GO;
+  // Kokkos::parallel_reduce fails to compile if named device_type and typedef
+  // is public
+  typedef typename local_map_type::device_type device_type;
+  typedef typename device_type::execution_space execution_space;
+
+  typedef Kokkos::View<const size_t*, buffer_device_type> num_packets_per_lid_type;
+  typedef Kokkos::View<const size_t*, device_type> offsets_type;
+  typedef Kokkos::View<const packet_type*, buffer_device_type> input_buffer_type;
+  typedef Kokkos::View<const LO*, device_type> import_lids_type;
+
+  typedef Kokkos::View<LO*, device_type> lids_scratch_type;
+  typedef Kokkos::View<GO*, device_type> gids_scratch_type;
+  typedef Kokkos::View<int*,device_type> pids_scratch_type;
+
+  static_assert(std::is_same<LO, typename local_graph_type::data_type>::value,
+                "LocalMap::local_ordinal_type and "
+                "LocalGraph::data_type must be the same.");
+
+  local_graph_type local_graph;
+  local_map_type local_col_map;
+  input_buffer_type imports;
+  num_packets_per_lid_type num_packets_per_lid;
+  import_lids_type import_lids;
+  offsets_type offsets;
+  Tpetra::CombineMode combine_mode;
+  size_t max_num_ent;
+  bool unpack_pids;
+  bool atomic;
+  Kokkos::Experimental::UniqueToken<execution_space,
+                                    Kokkos::Experimental::UniqueTokenScope::Global> tokens;
+  lids_scratch_type lids_scratch;
+  gids_scratch_type gids_scratch;
+  pids_scratch_type pids_scratch;
+
+ public:
+  typedef Kokkos::pair<int, LO> value_type;
+
+  UnpackAndCombineFunctor(
+      const local_graph_type& local_graph_in,
+      const local_map_type& local_col_map_in,
+      const input_buffer_type& imports_in,
+      const num_packets_per_lid_type& num_packets_per_lid_in,
+      const import_lids_type& import_lids_in,
+      const offsets_type& offsets_in,
+      const Tpetra::CombineMode combine_mode_in,
+      const size_t max_num_ent_in,
+      const bool unpack_pids_in,
+      const bool atomic_in) :
+    local_graph(local_graph_in),
+    local_col_map(local_col_map_in),
+    imports(imports_in),
+    num_packets_per_lid(num_packets_per_lid_in),
+    import_lids(import_lids_in),
+    offsets(offsets_in),
+    combine_mode(combine_mode_in),
+    max_num_ent(max_num_ent_in),
+    unpack_pids(unpack_pids_in),
+    atomic(atomic_in),
+    tokens(execution_space()),
+    lids_scratch("pids_scratch", tokens.size() * max_num_ent),
+    gids_scratch("gids_scratch", tokens.size() * max_num_ent),
+    pids_scratch("lids_scratch", tokens.size() * max_num_ent)
+  {}
+
+  KOKKOS_INLINE_FUNCTION void init(value_type& dst) const
+  {
+    using Tpetra::Details::OrdinalTraits;
+    dst = Kokkos::make_pair(0, OrdinalTraits<LO>::invalid());
+  }
+
+  KOKKOS_INLINE_FUNCTION void
+  join(volatile value_type& dst, const volatile value_type& src) const
+  {
+    // `dst` should reflect the first (least) bad index and
+    // all other associated error codes and data.  Thus, we need only
+    // check if the `src` object shows an error and if its associated
+    // bad index is less than `dst`'s bad index.
+    using Tpetra::Details::OrdinalTraits;
+    if (src.second != OrdinalTraits<LO>::invalid()) {
+      // An error in the src; check if
+      //   1. `dst` shows errors
+      //   2. If `dst` does show errors, if src's bad index is less than
+      //      *this' bad index
+      if (dst.second == OrdinalTraits<LO>::invalid() ||
+          src.second < dst.second) {
+        dst = src;
+      }
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const LO i, value_type& dst) const
+  {
+    using Kokkos::View;
+    using Kokkos::subview;
+    using Kokkos::MemoryUnmanaged;
+    typedef typename execution_space::size_type size_type;
+    typedef typename Kokkos::pair<size_type, size_type> slice;
+
+    typedef View<LO*, device_type, MemoryUnmanaged> lids_out_type;
+    typedef View<int*,device_type, MemoryUnmanaged> pids_out_type;
+    typedef View<GO*, device_type, MemoryUnmanaged> gids_out_type;
+
+    const size_t num_packets_this_lid = num_packets_per_lid(i);
+    const size_t num_ent = (unpack_pids) ? num_packets_this_lid/2
+                                         : num_packets_this_lid;
+    if (unpack_pids && num_packets_this_lid%2 != 0) {
+      // Attempting to unpack PIDs, but num_packets_this_lid is not even; this
+      // should never
+      dst = Kokkos::make_pair(1, i);
+      return;
+    }
+
+    // Only unpack data if there is a nonzero number to unpack
+    if (num_ent == 0) {
+      return;
+    }
+
+    // there is actually something in the row
+    const size_t buf_size = imports.size();
+    const size_t offset = offsets(i);
+
+    if (offset > buf_size || offset + num_packets_this_lid > buf_size) {
+      dst = Kokkos::make_pair(2, i); // out of bounds
+      return;
+    }
+
+    // Get subviews in to the scratch arrays.  The token returned from acquire
+    // is an integer in [0, tokens.size()).  It is used to grab a unique (to
+    // this thread) subview of the scratch arrays.
+    const size_type token = tokens.acquire();
+    const size_t a = static_cast<size_t>(token) * max_num_ent;
+    const size_t b = a + num_ent;
+    lids_out_type lids_out = subview(lids_scratch, slice(a, b));
+    gids_out_type gids_out = subview(gids_scratch, slice(a, b));
+    pids_out_type pids_out = subview(pids_scratch, slice(a, (unpack_pids ? b : a)));
+
+    // Unpack this row!
+    int err = unpackRow<packet_type,GO,device_type,buffer_device_type>(
+        gids_out, pids_out, imports, offset, num_ent);
+
+    if (err != 0) {
+      dst = Kokkos::make_pair(3, i);
+      return;
+    }
+
+    // Column indices come in as global indices, in case the
+    // source object's column Map differs from the target object's
+    // (this's) column Map, and must be converted local index values
+    for (size_t k = 0; k < num_ent; ++k) {
+      lids_out(k) = local_col_map.getLocalElement(gids_out(k));
+    }
+
+    tokens.release(token);
+  }
+};
+
+/// \brief Perform the unpack operation for the graph
+///
+/// \tparam LocalGraph the specialization of the KokkosSparse::CrsGraph
+///   local graph
+/// \tparam LocalMap the type of the local column map
+///
+/// This is a higher level interface to the UnpackAndCombineFunctor
+template<class Packet, class LocalGraph, class LocalMap, class BufferDevice>
+void
+unpackAndCombine(
+    const LocalGraph& local_graph,
+    const LocalMap& local_map,
+    const Kokkos::View<const Packet*, BufferDevice, Kokkos::MemoryUnmanaged>& imports,
+    const Kokkos::View<const size_t*, BufferDevice, Kokkos::MemoryUnmanaged>& num_packets_per_lid,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& import_lids,
+    const Tpetra::CombineMode combine_mode,
+    const bool unpack_pids,
+    const bool atomic)
+{
+
+  TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+      "unpackAndCombine[New] should not (yet) be called, the method is "
+      "incomplete.  To complete, indices need to be inserted (unpacked) in to "
+      "the destination graph.  The local graph, a Kokkos::StaticCrsGraph, does "
+      "not support insertion of indices");
+
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename LocalMap::device_type device_type;
+  typedef typename device_type::execution_space execution_space;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LO> > range_policy;
+  typedef UnpackAndCombineFunctor<Packet,LocalGraph,LocalMap,BufferDevice> unpack_functor_type;
+
+  const char prefix[] =
+    "Tpetra::Details::UnpackAndCombineCrsGraphImpl::unpackAndCombine: ";
+
+  const size_t num_import_lids = static_cast<size_t>(import_lids.dimension_0());
+  if (num_import_lids == 0) {
+    // Nothing to unpack
+    return;
+  }
+
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION(combine_mode == INSERT,
+        std::invalid_argument,
+        prefix << "INSERT combine mode is not allowed if the graph has a static graph "
+        "(i.e., was constructed with the CrsGraph constructor that takes a "
+        "const CrsGraph pointer).");
+
+    // Unknown combine mode!
+    TEUCHOS_TEST_FOR_EXCEPTION(combine_mode != REPLACE,
+        std::invalid_argument,
+        prefix << "Invalid combine mode; should never get "
+        "here!  Please report this bug to the Tpetra developers.");
+
+    // Check that sizes of input objects are consistent.
+    bool bad_num_import_lids =
+      num_import_lids != static_cast<size_t>(num_packets_per_lid.dimension_0());
+    TEUCHOS_TEST_FOR_EXCEPTION(bad_num_import_lids,
+        std::invalid_argument,
+        prefix << "importLIDs.size() (" << num_import_lids << ") != "
+        "numPacketsPerLID.size() (" << num_packets_per_lid.dimension_0() << ").");
+  } // end QA error checking
+
+  // Get the offsets
+  Kokkos::View<size_t*, device_type> offsets("offsets", num_import_lids+1);
+  computeOffsetsFromCounts(offsets, num_packets_per_lid);
+
+  // Determine the maximum number of entries in any row in the graph.  The
+  // maximum number of entries is needed to allocate unpack buffers on the
+  // device.
+  size_t max_num_ent;
+  Kokkos::parallel_reduce("MaxReduce",
+    num_packets_per_lid.size(),
+    KOKKOS_LAMBDA(const int& i, size_t& running_max_num_ent) {
+      size_t num_packets_this_lid = num_packets_per_lid(i);
+      size_t num_ent = (unpack_pids) ? num_packets_this_lid/2
+                                     : num_packets_this_lid;
+      if (num_ent > running_max_num_ent) running_max_num_ent = num_ent;
+    }, Kokkos::Experimental::Max<size_t>(max_num_ent));
+
+  // Now do the actual unpack!
+  unpack_functor_type f(local_graph, local_map,
+      imports, num_packets_per_lid, import_lids, offsets, combine_mode,
+      max_num_ent, unpack_pids, atomic);
+
+  typename unpack_functor_type::value_type x;
+  Kokkos::parallel_reduce(range_policy(0, static_cast<LO>(num_import_lids)), f, x);
+  auto x_h = x.to_std_pair();
+  TEUCHOS_TEST_FOR_EXCEPTION(x_h.first != 0, std::runtime_error,
+      prefix << "UnpackAndCombineFunctor reported error code "
+             << x_h.first << " for the first bad row " << x_h.second);
+
+  return;
+}
+
+template<class Packet, class LocalGraph, class BufferDevice>
+size_t
+unpackAndCombineWithOwningPIDsCount(
+  const LocalGraph& local_graph,
+  const Kokkos::View<const typename LocalGraph::data_type*,
+                     typename LocalGraph::device_type,
+                     Kokkos::MemoryUnmanaged> permute_from_lids,
+  const Kokkos::View<const Packet*, BufferDevice>& imports,
+  const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid,
+  const size_t num_same_ids)
+{
+  using Kokkos::parallel_reduce;
+  typedef LocalGraph local_graph_type;
+  typedef typename local_graph_type::data_type LO;
+  typedef typename local_graph_type::device_type device_type;
+  typedef typename device_type::execution_space execution_space;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LO> > range_policy;
+
+  size_t count = 0;
+  LO num_items;
+
+  // Number of graph entries to unpack (returned by this function).
+  num_items = static_cast<LO>(num_same_ids);
+  if (num_items) {
+    size_t kcnt = 0;
+    parallel_reduce(
+      range_policy(0, num_items),
+      KOKKOS_LAMBDA(const LO lid, size_t& update) {
+        update += static_cast<size_t>(local_graph.row_map[lid+1]
+                                     -local_graph.row_map[lid]);
+      }, kcnt);
+    count += kcnt;
+  }
+
+  // Count entries copied directly from the source graph with permuting.
+  num_items = static_cast<LO>(permute_from_lids.dimension_0());
+  if (num_items) {
+    size_t kcnt = 0;
+    parallel_reduce(
+      range_policy(0, num_items),
+      KOKKOS_LAMBDA(const LO i, size_t& update) {
+        const LO lid = permute_from_lids(i);
+        update += static_cast<size_t>(local_graph.row_map[lid+1]
+                                     - local_graph.row_map[lid]);
+      }, kcnt);
+    count += kcnt;
+  }
+
+  {
+    // Count entries received from other MPI processes.
+    size_t tot_num_ent = 0;
+    Kokkos::parallel_reduce("SumReduce",
+        num_packets_per_lid.size(),
+        KOKKOS_LAMBDA(const int& i, size_t& lsum) {
+          lsum += num_packets_per_lid(i) / 2;
+        }, Kokkos::Experimental::Sum<size_t>(tot_num_ent));
+    count += tot_num_ent;
+  }
+
+  return count;
+}
+
+/// \brief Setup row pointers for remotes
+template<class Packet, class LO, class Device, class BufferDevice>
+void
+setupRowPointersForRemotes(
+  const Kokkos::View<size_t*, Device>& tgt_rowptr,
+  const Kokkos::View<const LO*, Device>& import_lids,
+  const Kokkos::View<const Packet*, BufferDevice>& imports,
+  const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid)
+{
+  using Kokkos::parallel_reduce;
+  typedef Device device_type;
+  typedef typename device_type::execution_space execution_space;
+  typedef typename Kokkos::View<size_t*,device_type>::size_type size_type;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
+
+  const size_type N = num_packets_per_lid.dimension_0();
+  parallel_for("Setup row pointers for remotes",
+    range_policy(0, N),
+    KOKKOS_LAMBDA(const size_t i){
+      typedef typename std::remove_reference<decltype(tgt_rowptr(0))>::type atomic_incr_type;
+      const size_t num_packets_this_lid = num_packets_per_lid(i);
+      const size_t num_ent = num_packets_this_lid / 2;
+      Kokkos::atomic_fetch_add(&tgt_rowptr(import_lids(i)), atomic_incr_type(num_ent));
+    });
+}
+
+// Convert array of row lengths to a CRS pointer array
+template<class Device>
+void
+makeCrsRowPtrFromLengths(
+    const Kokkos::View<size_t*,Device,Kokkos::MemoryUnmanaged>& tgt_rowptr,
+    const Kokkos::View<size_t*,Device>& new_start_row)
+{
+  using Kokkos::parallel_scan;
+  typedef Device device_type;
+  typedef typename device_type::execution_space execution_space;
+  typedef typename Kokkos::View<size_t*,device_type>::size_type size_type;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
+  const size_type N = new_start_row.dimension_0();
+  parallel_scan(
+    range_policy(0, N),
+    KOKKOS_LAMBDA(const size_t& i, size_t& update, const bool& final) {
+      auto cur_val = tgt_rowptr(i);
+      if (final) {
+        tgt_rowptr(i) = update;
+        new_start_row(i) = tgt_rowptr(i);
+      }
+      update += cur_val;
+    }
+  );
+}
+
+template<class LocalGraph, class LocalMap>
+void
+copyDataFromSameIDs(
+    const Kokkos::View<typename LocalMap::global_ordinal_type*,
+                       typename LocalMap::device_type>& tgt_colind,
+    const Kokkos::View<int*, typename LocalMap::device_type>& tgt_pids,
+    const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
+    const Kokkos::View<size_t*, typename LocalMap::device_type>& tgt_rowptr,
+    const Kokkos::View<const int*, typename LocalMap::device_type>& src_pids,
+    const LocalGraph& local_graph,
+    const LocalMap& local_col_map,
+    const size_t num_same_ids,
+    const int my_pid)
+{
+  using Kokkos::parallel_for;
+  typedef typename LocalMap::device_type device_type;
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename device_type::execution_space execution_space;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_t> > range_policy;
+
+  parallel_for(
+    range_policy(0, num_same_ids),
+    KOKKOS_LAMBDA(const size_t i) {
+      typedef typename std::remove_reference<decltype(new_start_row(0))>::type atomic_incr_type;
+
+      const LO src_lid    = static_cast<LO>(i);
+      size_t src_row = local_graph.row_map(src_lid);
+
+      const LO tgt_lid      = static_cast<LO>(i);
+      const size_t tgt_row = tgt_rowptr(tgt_lid);
+
+      const size_t nsr = local_graph.row_map(src_lid+1)
+                       - local_graph.row_map(src_lid);
+      Kokkos::atomic_fetch_add(&new_start_row(tgt_lid), atomic_incr_type(nsr));
+
+      for (size_t j=local_graph.row_map(src_lid);
+                  j<local_graph.row_map(src_lid+1); ++j) {
+        LO src_col = local_graph.entries(j);
+        tgt_colind(tgt_row + j - src_row) = local_col_map.getGlobalElement(src_col);
+        tgt_pids(tgt_row + j - src_row) = (src_pids(src_col) != my_pid) ? src_pids(src_col) : -1;
+      }
+    }
+  );
+}
+
+template<class LocalGraph, class LocalMap>
+void
+copyDataFromPermuteIDs(
+    const Kokkos::View<typename LocalMap::global_ordinal_type*,
+                       typename LocalMap::device_type>& tgt_colind,
+    const Kokkos::View<int*,
+                       typename LocalMap::device_type>& tgt_pids,
+    const Kokkos::View<size_t*,
+                       typename LocalMap::device_type>& new_start_row,
+    const Kokkos::View<size_t*,
+                       typename LocalMap::device_type>& tgt_rowptr,
+    const Kokkos::View<const int*,
+                       typename LocalMap::device_type>& src_pids,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*,
+                       typename LocalMap::device_type>& permute_to_lids,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*,
+                       typename LocalMap::device_type>& permute_from_lids,
+    const LocalGraph& local_graph,
+    const LocalMap& local_col_map,
+    const int my_pid)
+{
+  using Kokkos::parallel_for;
+  typedef typename LocalMap::device_type device_type;
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename device_type::execution_space execution_space;
+  typedef typename Kokkos::View<LO*,device_type>::size_type size_type;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
+
+  const size_type num_permute_to_lids = permute_to_lids.dimension_0();
+
+  parallel_for(
+    range_policy(0, num_permute_to_lids),
+    KOKKOS_LAMBDA(const size_t i) {
+      typedef typename std::remove_reference<decltype(new_start_row(0)) >::type atomic_incr_type;
+
+      const LO src_lid = permute_from_lids(i);
+      const size_t src_row = local_graph.row_map(src_lid);
+
+      const LO tgt_lid = permute_to_lids(i);
+      const size_t tgt_row = tgt_rowptr(tgt_lid);
+
+      size_t nsr = local_graph.row_map(src_lid+1)
+                 - local_graph.row_map(src_lid);
+      Kokkos::atomic_fetch_add(&new_start_row(tgt_lid), atomic_incr_type(nsr));
+
+      for (size_t j=local_graph.row_map(src_lid);
+                  j<local_graph.row_map(src_lid+1); ++j) {
+        LO src_col = local_graph.entries(j);
+        tgt_colind(tgt_row + j - src_row) = local_col_map.getGlobalElement(src_col);
+        tgt_pids(tgt_row + j - src_row) = (src_pids(src_col) != my_pid) ? src_pids(src_col) : -1;
+      }
+    }
+  );
+}
+
+template<class Packet, class LocalGraph, class LocalMap, class BufferDevice>
+void
+unpackAndCombineIntoCrsArrays2(
+    const Kokkos::View<typename LocalMap::global_ordinal_type*, typename LocalMap::device_type>& tgt_colind,
+    const Kokkos::View<int*, typename LocalMap::device_type>& tgt_pids,
+    const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
+    const Kokkos::View<const size_t*, typename LocalMap::device_type>& offsets,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*, typename LocalMap::device_type>& import_lids,
+    const Kokkos::View<const Packet*, BufferDevice>& imports,
+    const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid,
+    const LocalGraph& local_graph,
+    const LocalMap /*& local_col_map*/,
+    const int my_pid)
+{
+  using Kokkos::View;
+  using Kokkos::subview;
+  using Kokkos::MemoryUnmanaged;
+  using Kokkos::parallel_reduce;
+  using Kokkos::atomic_fetch_add;
+
+  typedef Packet packet_type;
+  typedef BufferDevice buffer_device_type;
+  typedef typename LocalMap::device_type device_type;
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename LocalMap::global_ordinal_type GO;
+  typedef typename device_type::execution_space execution_space;
+  typedef typename Kokkos::View<LO*, device_type>::size_type size_type;
+  typedef typename Kokkos::pair<size_type, size_type> slice;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
+
+  typedef View<int*,device_type, MemoryUnmanaged> pids_out_type;
+  typedef View<GO*, device_type, MemoryUnmanaged> gids_out_type;
+
+  const size_type num_import_lids = import_lids.size();
+  const char prefix[] = "UnpackAndCombineCrsGraphImpl::unpackAndCombineIntoCrsArrays2: ";
+
+  // RemoteIDs: Loop structure following UnpackAndCombine
+  int gbl_err_count;
+  parallel_reduce("Unpack and combine into CRS",
+    range_policy(0, num_import_lids),
+    KOKKOS_LAMBDA(const size_t i, int& err) {
+      typedef typename std::remove_reference< decltype( new_start_row(0) ) >::type atomic_incr_type;
+      const size_t num_packets_this_lid = num_packets_per_lid(i);
+      const size_t num_ent = num_packets_this_lid / 2;
+      const size_t offset = offsets(i);
+      const LO lcl_row = import_lids(i);
+      const size_t start_row = atomic_fetch_add(&new_start_row(lcl_row), atomic_incr_type(num_ent));
+      const size_t end_row = start_row + num_ent;
+
+      gids_out_type gids_out = subview(tgt_colind, slice(start_row, end_row));
+      pids_out_type pids_out = subview(tgt_pids, slice(start_row, end_row));
+
+      err += unpackRow<packet_type,GO,device_type,buffer_device_type>(
+          gids_out, pids_out, imports, offset, num_ent);
+
+      // Correct target PIDs.
+      for (size_t j = 0; j < static_cast<size_t>(num_ent); ++j) {
+        const int pid = pids_out(j);
+        pids_out(j) = (pid != my_pid) ? pid : -1;
+      }
+    }, gbl_err_count);
+
+  TEUCHOS_TEST_FOR_EXCEPTION(gbl_err_count != 0,
+      std::invalid_argument, prefix <<
+      "Attempting to unpack PIDs, but num_ent is not even; this should never "
+      "happen!  Please report this bug to the Tpetra developers.");
+
+  return;
+}
+
+template<class Packet, class LocalGraph, class LocalMap, class BufferDevice>
+void
+unpackAndCombineIntoCrsArrays(
+    const LocalGraph & local_graph,
+    const LocalMap & local_col_map,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& import_lids,
+    const Kokkos::View<const Packet*, BufferDevice>& imports,
+    const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& permute_to_lids,
+    const Kokkos::View<const typename LocalMap::local_ordinal_type*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& permute_from_lids,
+    const Kokkos::View<size_t*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& tgt_rowptr,
+    const Kokkos::View<typename LocalMap::global_ordinal_type*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& tgt_colind,
+    const Kokkos::View<const int*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& src_pids,
+    const Kokkos::View<int*,
+                       typename LocalMap::device_type,
+                       Kokkos::MemoryUnmanaged>& tgt_pids,
+    const size_t num_same_ids,
+    const size_t tgt_num_rows,
+    const size_t tgt_num_nonzeros,
+    const int my_tgt_pid)
+{
+  using Kokkos::View;
+  using Kokkos::subview;
+  using Kokkos::parallel_for;
+  using Kokkos::MemoryUnmanaged;
+  typedef Packet packet_type;
+  typedef LocalMap local_map_type;
+  typedef LocalGraph local_graph_type;
+  typedef BufferDevice buffer_device_type;
+  typedef typename LocalMap::device_type device_type;
+  typedef typename LocalMap::local_ordinal_type LO;
+  typedef typename device_type::execution_space execution_space;
+  typedef typename Kokkos::View<LO*, device_type>::size_type size_type;
+  typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_t> > range_policy;
+
+  const char prefix[] = "UnpackAndCombineCrsGraphImpl::unpackAndCombineIntoCrsArrays: ";
+
+  const size_t N = tgt_num_rows;
+  const size_t mynnz = tgt_num_nonzeros;
+
+  // In the case of reduced communicators, the sourceGraph won't have
+  // the right "my_pid", so thus we have to supply it.
+  const int my_pid = my_tgt_pid;
+
+  // Zero the rowptr
+  parallel_for(
+    range_policy(0, N+1),
+    KOKKOS_LAMBDA(const size_t i) {
+      tgt_rowptr(i) = 0;
+    }
+  );
+
+  // same IDs: Always first, always in the same place
+  parallel_for(
+    range_policy(0, num_same_ids),
+    KOKKOS_LAMBDA(const size_t i) {
+      const LO tgt_lid = static_cast<LO>(i);
+      const LO src_lid = static_cast<LO>(i);
+      tgt_rowptr(tgt_lid) = local_graph.row_map(src_lid+1)
+                          - local_graph.row_map(src_lid);
+    }
+  );
+
+  // Permute IDs: Still local, but reordered
+  const size_type num_permute_to_lids = permute_to_lids.dimension_0();
+  parallel_for(
+    range_policy(0, num_permute_to_lids),
+    KOKKOS_LAMBDA(const size_t i) {
+      const LO tgt_lid = permute_to_lids(i);
+      const LO src_lid = permute_from_lids(i);
+      tgt_rowptr(tgt_lid) = local_graph.row_map(src_lid+1)
+                          - local_graph.row_map(src_lid);
+    }
+  );
+
+  // Get the offsets from the number of packets per LID
+  const size_type num_import_lids = import_lids.dimension_0();
+  View<size_t*, device_type> offsets("offsets", num_import_lids+1);
+  computeOffsetsFromCounts(offsets, num_packets_per_lid);
+
+#ifdef HAVE_TPETRA_DEBUG
+  {
+    auto nth_offset_h = getEntryOnHost(offsets, num_import_lids);
+    const bool condition =
+      nth_offset_h != static_cast<size_t>(imports.dimension_0());
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (condition, std::logic_error, prefix
+       << "The final offset in bytes " << nth_offset_h
+       << " != imports.size() = " << imports.dimension_0()
+       << ".  Please report this bug to the Tpetra developers.");
+  }
+#endif // HAVE_TPETRA_DEBUG
+
+  // Setup row pointers for remotes
+  setupRowPointersForRemotes<packet_type,LO,device_type,buffer_device_type>(
+      tgt_rowptr, import_lids, imports, num_packets_per_lid);
+
+  // If multiple processes contribute to the same row, we may need to
+  // update row offsets.  This tracks that.
+  View<size_t*, device_type> new_start_row("new_start_row", N+1);
+
+  // Turn row length into a real CRS row pointer
+  makeCrsRowPtrFromLengths(tgt_rowptr, new_start_row);
+  {
+    auto nth_tgt_rowptr_h = getEntryOnHost(tgt_rowptr, N);
+    bool condition = nth_tgt_rowptr_h != mynnz;
+    TEUCHOS_TEST_FOR_EXCEPTION(condition, std::invalid_argument,
+      prefix << "CRS_rowptr[last] = " <<
+      nth_tgt_rowptr_h << "!= mynnz = " << mynnz << ".");
+  }
+
+  // SameIDs: Copy the data over
+  copyDataFromSameIDs(tgt_colind, tgt_pids, new_start_row,
+      tgt_rowptr, src_pids, local_graph, local_col_map, num_same_ids, my_pid);
+
+  copyDataFromPermuteIDs(tgt_colind, tgt_pids, new_start_row,
+      tgt_rowptr, src_pids, permute_to_lids, permute_from_lids,
+      local_graph, local_col_map, my_pid);
+
+  if (imports.dimension_0() <= 0) {
+    return;
+  }
+
+  unpackAndCombineIntoCrsArrays2<
+    packet_type,local_graph_type,local_map_type,buffer_device_type>(
+        tgt_colind, tgt_pids, new_start_row, offsets, import_lids, imports,
+        num_packets_per_lid, local_graph, local_col_map, my_pid);
+
+  return;
+}
+
+} // namespace UnpackAndCombineCrsGraphImpl
+
+/// \brief Unpack the imported column indices and combine into graph.
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Node The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceGraph [in] the CrsGraph source
+///
+/// \param imports [in] Input pack buffer
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local graph.
+///
+/// \param importLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// \param combineMode [in] the mode to use for combining indices
+///
+/// \param atomic [in] whether or not do atomic adds/replaces in to the graph
+///
+/// \warning The allowed \c combineMode are:
+///   REPLACE. INSERT is not allowed.
+///
+/// This is the public interface to the unpack and combine machinery and
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsGraph migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<class LO, class GO, class Node>
+void
+unpackCrsGraphAndCombine(
+    const CrsGraph<LO, GO, Node>& sourceGraph,
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,Node>::packet_type>& imports,
+    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+    const Teuchos::ArrayView<const LO>& importLIDs,
+    size_t constantNumPackets,
+    Distributor & distor,
+    CombineMode combineMode,
+    const bool atomic)
+{
+  using Kokkos::View;
+  typedef typename Node::device_type device_type;
+  typedef typename CrsGraph<LO,GO,Node>::packet_type packet_type;
+  typedef typename CrsGraph<LO, GO, Node>::local_graph_type local_graph_type;
+  typedef typename CrsGraph<LO, GO, Node>::buffer_device_type buffer_device_type;
+  static_assert(std::is_same<device_type, typename local_graph_type::device_type>::value,
+                 "Node::device_type and LocalGraph::device_type must be the same.");
+
+  typedef typename device_type::execution_space execution_space;
+  typename execution_space::device_type outputDevice;
+
+  typedef typename buffer_device_type::execution_space buffer_execution_space;
+  typename buffer_execution_space::device_type bufferOutputDevice;
+
+  // Convert all Teuchos::Array to Kokkos::View.
+
+  // numPacketsPerLID, importLIDs, and imports are input, so we have to copy
+  // them to device.  Since unpacking is done directly in to the local graph
+  // (lclGraph), no copying needs to be performed after unpacking.
+  auto imports_d =
+    create_mirror_view_from_raw_host_array(bufferOutputDevice,
+        imports.getRawPtr(), imports.size(),
+        true, "imports");
+
+  auto num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array(bufferOutputDevice,
+        numPacketsPerLID.getRawPtr(), numPacketsPerLID.size(),
+        true, "num_packets_per_lid");
+
+  auto import_lids_d =
+    create_mirror_view_from_raw_host_array(outputDevice,
+        importLIDs.getRawPtr(), importLIDs.size(),
+        true, "import_lids");
+
+  auto local_graph = sourceGraph.getLocalGraph();
+  auto local_col_map = sourceGraph.getColMap()->getLocalMap();
+
+  // Now do the actual unpack!
+  typedef decltype(local_col_map) local_map_type;
+  UnpackAndCombineCrsGraphImpl::unpackAndCombine<
+    packet_type,local_graph_type,local_map_type,buffer_device_type>(
+        local_graph, local_col_map, imports_d, num_packets_per_lid_d,
+        import_lids_d, combineMode, false, atomic);
+
+  return;
+}
+
+template<class LO, class GO, class Node>
+void
+unpackCrsGraphAndCombineNew(
+    const CrsGraph<LO, GO, Node>& sourceGraph,
+    const Kokkos::DualView<const typename CrsGraph<LO,GO,Node>::packet_type*,
+                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& imports,
+    const Kokkos::DualView<const size_t*,
+                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& numPacketsPerLID,
+    const Kokkos::DualView<const LO*, typename Node::device_type>& importLIDs,
+    const size_t constantNumPackets,
+    Distributor& distor,
+    const CombineMode combineMode,
+    const bool atomic)
+{
+  using Tpetra::Details::castAwayConstDualView;
+  using Kokkos::View;
+  typedef typename Node::device_type device_type;
+  typedef CrsGraph<LO, GO, Node> crs_graph_type;
+  typedef typename crs_graph_type::packet_type packet_type;
+  typedef typename crs_graph_type::local_graph_type local_graph_type;
+  typedef typename crs_graph_type::buffer_device_type buffer_device_type;
+  typedef typename buffer_device_type::memory_space buffer_memory_space;
+  typedef typename device_type::memory_space memory_space;
+
+  static_assert(std::is_same<device_type, typename local_graph_type::device_type>::value,
+                "Node::device_type and LocalGraph::device_type must be "
+                "the same.");
+
+  {
+    auto numPacketsPerLID_nc = castAwayConstDualView(numPacketsPerLID);
+    numPacketsPerLID_nc.template sync<buffer_memory_space>();
+  }
+  auto num_packets_per_lid_d = numPacketsPerLID.template view<buffer_memory_space>();
+
+  {
+    auto importLIDs_nc = castAwayConstDualView(importLIDs);
+    importLIDs_nc.template sync<memory_space>();
+  }
+  auto import_lids_d = importLIDs.template view<memory_space>();
+
+  {
+    auto imports_nc = castAwayConstDualView(imports);
+    imports_nc.template sync<buffer_memory_space>();
+  }
+  auto imports_d = imports.template view<buffer_memory_space>();
+
+  auto local_graph = sourceGraph.getLocalGraph();
+  auto local_col_map = sourceGraph.getColMap()->getLocalMap();
+  typedef decltype(local_col_map) local_map_type;
+
+  // Now do the actual unpack!
+  UnpackAndCombineCrsGraphImpl::unpackAndCombine<
+    packet_type,local_graph_type,local_map_type,buffer_device_type>(
+      local_graph, local_col_map, imports_d, num_packets_per_lid_d,
+      import_lids_d, combineMode, false, atomic);
+}
+
+/// \brief Special version of Tpetra::Details::unpackCrsGraphAndCombine
+///   that also unpacks owning process ranks.
+///
+/// Perform the count for unpacking the imported column indices and pids,
+/// and combining them into graph.  Return (a ceiling on)
+/// the number of local stored entries ("nonzeros") in the graph.  If
+/// there are no shared rows in the sourceGraph this count is exact.
+///
+/// Note: This routine also counts the copyAndPermute nonzeros in
+/// addition to those that come in via import.
+///
+/// \tparam LO The type of local indices.  See the
+///   documentation of Map for requirements.
+/// \tparam GO The type of global indices.  See the
+///   documentation of Map for requirements.
+/// \tparam Node The Kokkos Node type.  See the documentation of Map
+///   for requirements.
+///
+/// \param sourceGraph [in] the CrsGraph source
+///
+/// \param imports [in] Input pack buffer
+///
+/// \param numPacketsPerLID [out] Entry k gives the number of bytes
+///   packed for row exportLIDs[k] of the local graph.
+///
+/// \param importLIDs [in] Local indices of the rows to pack.
+///
+/// \param constantNumPackets [out] Setting this to zero tells the caller
+///   to expect a possibly /// different ("nonconstant") number of packets per local index
+///   (i.e., a possibly different number of entries per row).
+///
+/// \param distor [in] The distributor (not used)
+///
+/// \param combineMode [in] the mode to use for combining
+///
+/// \param numSameIds [in]
+///
+/// \param permuteToLIDs [in]
+///
+/// \param permuteFromLIDs [in]
+///
+/// \warning The allowed \c combineMode are:
+///   ADD, REPLACE, and ABSMAX. INSERT is not allowed.
+//
+/// \warning This method is intended for expert developer use
+///   only, and should never be called by user code.
+///
+/// Note: This is the public interface to the unpack and combine machinery and
+/// converts passed Teuchos::ArrayView objects to Kokkos::View objects (and
+/// copies back in to the Teuchos::ArrayView objects, if needed).  When
+/// CrsGraph migrates fully to adopting Kokkos::DualView objects for its storage
+/// of data, this procedure could be bypassed.
+template<class LocalOrdinal, class GlobalOrdinal, class Node>
+size_t
+unpackAndCombineWithOwningPIDsCount(
+    const CrsGraph<LocalOrdinal, GlobalOrdinal, Node> & sourceGraph,
+    const Teuchos::ArrayView<const LocalOrdinal> &importLIDs,
+    const Teuchos::ArrayView<const typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type> &imports,
+    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+    size_t constantNumPackets,
+    Distributor &distor,
+    CombineMode combineMode,
+    size_t numSameIDs,
+    const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
+    const Teuchos::ArrayView<const LocalOrdinal>& permuteFromLIDs)
+{
+  using Kokkos::MemoryUnmanaged;
+  using Kokkos::View;
+  typedef typename Node::device_type device_type;
+  typedef typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type packet_type;
+  typedef typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::local_graph_type local_graph_type;
+  typedef typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::buffer_device_type buffer_device_type;
+  const char prefix[] = "unpackAndCombineWithOwningPIDsCount: ";
+
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (permuteToLIDs.size() != permuteFromLIDs.size(), std::invalid_argument,
+     prefix << "permuteToLIDs.size() = " << permuteToLIDs.size() << " != "
+     "permuteFromLIDs.size() = " << permuteFromLIDs.size() << ".");
+  // FIXME (mfh 26 Jan 2015) If there are no entries on the calling
+  // process, then the graph is neither locally nor globally indexed.
+  const bool locallyIndexed = sourceGraph.isLocallyIndexed();
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (! locallyIndexed, std::invalid_argument, prefix << "The input "
+    "CrsGraph 'sourceGraph' must be locally indexed.");
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (importLIDs.size() != numPacketsPerLID.size(), std::invalid_argument,
+     prefix << "importLIDs.size() = " << importLIDs.size() << " != "
+     "numPacketsPerLID.size() = " << numPacketsPerLID.size() << ".");
+
+  auto local_graph = sourceGraph.getLocalGraph();
+  auto permute_from_lids_d =
+    create_mirror_view_from_raw_host_array(device_type(),
+                                           permuteFromLIDs.getRawPtr(),
+                                           permuteFromLIDs.size(), true,
+                                           "permute_from_lids");
+  auto imports_d =
+    create_mirror_view_from_raw_host_array(buffer_device_type(),
+                                           imports.getRawPtr(),
+                                           imports.size(), true,
+                                           "imports");
+  auto num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array(buffer_device_type(),
+                                           numPacketsPerLID.getRawPtr(),
+                                           numPacketsPerLID.size(), true,
+                                           "num_packets_per_lid");
+
+  return UnpackAndCombineCrsGraphImpl::unpackAndCombineWithOwningPIDsCount<
+    packet_type,local_graph_type,buffer_device_type>(
+      local_graph, permute_from_lids_d, imports_d, num_packets_per_lid_d, numSameIDs);
+}
+
+/// \brief unpackAndCombineIntoCrsArrays
+///
+/// \note You should call unpackAndCombineWithOwningPIDsCount first
+///   and allocate all arrays accordingly, before calling this
+///   function.
+///
+/// Note: The SourcePids vector (on input) should contain owning PIDs
+/// for each column in the (source) ColMap, as from
+/// Tpetra::Import_Util::getPids, with the "-1 for local" option being
+/// used.
+///
+/// Note: The TargetPids vector (on output) will contain owning PIDs
+/// for each entry in the graph, with the "-1 for local" for locally
+/// owned entries.
+template<class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+unpackAndCombineIntoCrsArrays(
+    const CrsGraph<LocalOrdinal, GlobalOrdinal, Node> & sourceGraph,
+    const Teuchos::ArrayView<const LocalOrdinal>& importLIDs,
+    const Teuchos::ArrayView<const typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type>& imports,
+    const Teuchos::ArrayView<const size_t>& numPacketsPerLID,
+    const size_t constantNumPackets,
+    Distributor& distor,
+    const CombineMode combineMode,
+    const size_t numSameIDs,
+    const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
+    const Teuchos::ArrayView<const LocalOrdinal>& permuteFromLIDs,
+    size_t TargetNumRows,
+    size_t TargetNumNonzeros,
+    const int MyTargetPID,
+    const Teuchos::ArrayView<size_t>& CRS_rowptr,
+    const Teuchos::ArrayView<GlobalOrdinal>& CRS_colind,
+    const Teuchos::ArrayView<const int>& SourcePids,
+    Teuchos::Array<int>& TargetPids)
+{
+  using Kokkos::View;
+  using Kokkos::deep_copy;
+  using Teuchos::ArrayView;
+  using Teuchos::outArg;
+  using Teuchos::REDUCE_MAX;
+  using Teuchos::reduceAll;
+  typedef LocalOrdinal LO;
+  typedef typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type packet_type;
+  typedef typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::local_graph_type local_graph_type;
+  typedef typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::buffer_device_type buffer_device_type;
+  typedef typename Node::device_type device_type;
+  typedef typename device_type::execution_space execution_space;
+  typedef typename buffer_device_type::execution_space buffer_execution_space;
+  typedef typename ArrayView<const LO>::size_type size_type;
+
+  const char prefix[] = "Tpetra::Details::unpackAndCombineIntoCrsArrays: ";
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    TargetNumRows + 1 != static_cast<size_t>(CRS_rowptr.size()),
+    std::invalid_argument, prefix << "CRS_rowptr.size() = " <<
+    CRS_rowptr.size() << "!= TargetNumRows+1 = " << TargetNumRows+1 << ".");
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    permuteToLIDs.size() != permuteFromLIDs.size(), std::invalid_argument,
+    prefix << "permuteToLIDs.size() = " << permuteToLIDs.size()
+    << "!= permuteFromLIDs.size() = " << permuteFromLIDs.size() << ".");
+  const size_type numImportLIDs = importLIDs.size();
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    numImportLIDs != numPacketsPerLID.size(), std::invalid_argument,
+    prefix << "importLIDs.size() = " << numImportLIDs << " != "
+    "numPacketsPerLID.size() = " << numPacketsPerLID.size() << ".");
+
+  // Preseed TargetPids with -1 for local
+  if (static_cast<size_t>(TargetPids.size()) != TargetNumNonzeros) {
+    TargetPids.resize(TargetNumNonzeros);
+  }
+  TargetPids.assign(TargetNumNonzeros, -1);
+
+  // Grab pointers for sourceGraph
+  auto local_graph = sourceGraph.getLocalGraph();
+  auto local_col_map = sourceGraph.getColMap()->getLocalMap();
+
+  // Convert input arrays to Kokkos::View
+  typename execution_space::device_type outputDevice;
+  typename buffer_execution_space::device_type bufferOutputDevice;
+
+  auto import_lids_d = create_mirror_view_from_raw_host_array(outputDevice,
+        importLIDs.getRawPtr(), importLIDs.size(),
+        true, "import_lids");
+
+  auto imports_d = create_mirror_view_from_raw_host_array(bufferOutputDevice,
+        imports.getRawPtr(), imports.size(),
+        true, "imports");
+
+  auto num_packets_per_lid_d = create_mirror_view_from_raw_host_array(bufferOutputDevice,
+      numPacketsPerLID.getRawPtr(), numPacketsPerLID.size(),
+      true, "num_packets_per_lid");
+
+  auto permute_from_lids_d = create_mirror_view_from_raw_host_array(outputDevice,
+      permuteFromLIDs.getRawPtr(), permuteFromLIDs.size(),
+      true, "permute_from_lids");
+
+  auto permute_to_lids_d = create_mirror_view_from_raw_host_array(outputDevice,
+      permuteToLIDs.getRawPtr(), permuteToLIDs.size(),
+      true, "permute_to_lids");
+
+  auto crs_rowptr_d = create_mirror_view_from_raw_host_array(outputDevice,
+      CRS_rowptr.getRawPtr(), CRS_rowptr.size(),
+      true, "crs_rowptr");
+
+  auto crs_colind_d = create_mirror_view_from_raw_host_array(outputDevice,
+      CRS_colind.getRawPtr(), CRS_colind.size(),
+      true, "crs_colidx");
+
+  auto src_pids_d = create_mirror_view_from_raw_host_array(outputDevice,
+      SourcePids.getRawPtr(), SourcePids.size(),
+      true, "src_pids");
+
+  auto tgt_pids_d = create_mirror_view_from_raw_host_array(outputDevice,
+      TargetPids.getRawPtr(), TargetPids.size(),
+      true, "tgt_pids");
+
+  typedef decltype(local_col_map) local_map_type;
+  UnpackAndCombineCrsGraphImpl::unpackAndCombineIntoCrsArrays<
+    packet_type,local_graph_type,local_map_type,buffer_device_type>(
+      local_graph, local_col_map, import_lids_d, imports_d, num_packets_per_lid_d,
+      permute_to_lids_d, permute_from_lids_d, crs_rowptr_d, crs_colind_d, src_pids_d,
+      tgt_pids_d, numSameIDs, TargetNumRows, TargetNumNonzeros, MyTargetPID);
+
+  // Copy outputs back to host
+  typename decltype(crs_rowptr_d)::HostMirror crs_rowptr_h(
+      CRS_rowptr.getRawPtr(), CRS_rowptr.size());
+  deep_copy(crs_rowptr_h, crs_rowptr_d);
+
+  typename decltype(crs_colind_d)::HostMirror crs_colind_h(
+      CRS_colind.getRawPtr(), CRS_colind.size());
+  deep_copy(crs_colind_h, crs_colind_d);
+
+  typename decltype(tgt_pids_d)::HostMirror tgt_pids_h(
+      TargetPids.getRawPtr(), TargetPids.size());
+  deep_copy(tgt_pids_h, tgt_pids_d);
+
+}
+
+} // namespace Details
+} // namespace Tpetra
+
+#define TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_INSTANT( LO, GO, NT ) \
+  template void \
+  Details::unpackCrsGraphAndCombine<LO, GO, NT>( \
+    const CrsGraph<LO, GO, NT>&, \
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type>&, \
+    const Teuchos::ArrayView<const size_t>&, \
+    const Teuchos::ArrayView<const LO>&, \
+    size_t, \
+    Distributor&, \
+    CombineMode, \
+    const bool); \
+  template void \
+  Details::unpackCrsGraphAndCombineNew<LO, GO, NT>( \
+    const CrsGraph<LO, GO, NT>&, \
+    const Kokkos::DualView<const typename CrsGraph<LO,GO,NT>::packet_type*, \
+                           typename CrsGraph<LO, GO, NT>::buffer_device_type>&, \
+    const Kokkos::DualView<const size_t*, typename CrsGraph<LO, GO, NT>::buffer_device_type>&, \
+    const Kokkos::DualView<const LO*, NT::device_type>&, \
+    const size_t, \
+    Distributor&, \
+    const CombineMode, \
+    const bool); \
+  template void \
+  Details::unpackAndCombineIntoCrsArrays<LO, GO, NT>( \
+    const CrsGraph<LO, GO, NT> &, \
+    const Teuchos::ArrayView<const LO>&, \
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type>&, \
+    const Teuchos::ArrayView<const size_t>&, \
+    const size_t, \
+    Distributor&, \
+    const CombineMode, \
+    const size_t, \
+    const Teuchos::ArrayView<const LO>&, \
+    const Teuchos::ArrayView<const LO>&, \
+    size_t, \
+    size_t, \
+    const int, \
+    const Teuchos::ArrayView<size_t>&, \
+    const Teuchos::ArrayView<GO>&, \
+    const Teuchos::ArrayView<const int>&, \
+    Teuchos::Array<int>&); \
+  template size_t \
+  Details::unpackAndCombineWithOwningPIDsCount<LO, GO, NT>( \
+    const CrsGraph<LO, GO, NT> &, \
+    const Teuchos::ArrayView<const LO> &, \
+    const Teuchos::ArrayView<const typename CrsGraph<LO,GO,NT>::packet_type> &, \
+    const Teuchos::ArrayView<const size_t>&, \
+    size_t, \
+    Distributor &, \
+    CombineMode, \
+    size_t, \
+    const Teuchos::ArrayView<const LO>&, \
+    const Teuchos::ArrayView<const LO>&);
+
+#endif // TPETRA_DETAILS_UNPACKCRSGRAPHANDCOMBINE_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -808,10 +808,10 @@ unpackAndCombineIntoCrsArrays(
   }
 
   // SameIDs: Copy the data over
-  copyDataFromSameIDs(tgt_colind, tgt_pids, new_start_row,
+  copyDataFromSameIDs<LocalGraph,LocalMap>(tgt_colind, tgt_pids, new_start_row,
       tgt_rowptr, src_pids, local_graph, local_col_map, num_same_ids, my_pid);
 
-  copyDataFromPermuteIDs(tgt_colind, tgt_pids, new_start_row,
+  copyDataFromPermuteIDs<LocalGraph,LocalMap>(tgt_colind, tgt_pids, new_start_row,
       tgt_rowptr, src_pids, permute_to_lids, permute_from_lids,
       local_graph, local_col_map, my_pid);
 
@@ -1098,8 +1098,7 @@ unpackAndCombineWithOwningPIDsCount(
 ///   and allocate all arrays accordingly, before calling this
 ///   function.
 ///
-/// Note: The SourcePids vector (on input) should contain owning PIDs
-/// for each column in the (source) ColMap, as from
+/// Note: The SourcePids vector (on input) should contam
 /// Tpetra::Import_Util::getPids, with the "-1 for local" option being
 /// used.
 ///

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -89,6 +89,8 @@ class Distributor;
 //
 namespace Details {
 
+namespace UnpackAndCombineCrsMatrixImpl {
+
 /// \brief Unpack a single row of a CrsMatrix
 ///
 /// \tparam ST The type of the numerical entries of the matrix.
@@ -103,14 +105,14 @@ namespace Details {
 /// \tparam BDT The "buffer device type."
 template<class ST, class LO, class GO, class DT, class BDT>
 KOKKOS_FUNCTION int
-unpack_crs_matrix_row (typename PackTraits<GO, DT>::output_array_type& gids_out,
-                       typename PackTraits<int, DT>::output_array_type& pids_out,
-                       typename PackTraits<ST, DT>::output_array_type& vals_out,
-                       const Kokkos::View<const char*, BDT>& imports,
-                       const size_t offset,
-                       const size_t num_bytes,
-                       const size_t num_ent,
-                       const size_t num_bytes_per_value)
+unpackRow(typename PackTraits<GO, DT>::output_array_type& gids_out,
+          typename PackTraits<int, DT>::output_array_type& pids_out,
+          typename PackTraits<ST, DT>::output_array_type& vals_out,
+          const Kokkos::View<const char*, BDT>& imports,
+          const size_t offset,
+          const size_t num_bytes,
+          const size_t num_ent,
+          const size_t num_bytes_per_value)
 {
   if (num_ent == 0) {
     // Empty rows always take zero bytes, to ensure sparsity.
@@ -353,9 +355,9 @@ struct UnpackCrsMatrixAndCombineFunctor {
 
     // Unpack this row!
     int unpack_err =
-      unpack_crs_matrix_row<ST,LO,GO,DT,BDT> (gids_out, pids_out, vals_out,
-                                              imports, offset, num_bytes,
-                                              num_ent, num_bytes_per_value);
+      unpackRow<ST,LO,GO,DT,BDT>(gids_out, pids_out, vals_out,
+                                 imports, offset, num_bytes,
+                                 num_ent, num_bytes_per_value);
     if (unpack_err != 0) {
       dst = Kokkos::make_pair (unpack_err, i); // unpack error
       tokens.release (token);
@@ -530,7 +532,7 @@ compute_total_num_entries (
 /// This is a higher level interface to the UnpackCrsMatrixAndCombineFunctor
 template<class LocalMatrix, class LocalMap, class BufferDeviceType>
 void
-do_unpack_and_combine_into_crs_matrix(
+unpackAndCombineIntoCrsMatrix(
     const LocalMatrix& local_matrix,
     const LocalMap& local_map,
     const Kokkos::View<const char*, BufferDeviceType>& imports,
@@ -547,7 +549,8 @@ do_unpack_and_combine_into_crs_matrix(
   typedef Kokkos::RangePolicy<XS, Kokkos::IndexType<LO> > range_policy;
   typedef UnpackCrsMatrixAndCombineFunctor<LocalMatrix, LocalMap, BufferDeviceType> unpack_functor_type;
 
-  const char prefix[] = "Tpetra::Details::do_unpack_and_combine_into_crs_matrix: ";
+  const char prefix[] =
+    "Tpetra::Details::UnpackAndCombineCrsMatrixImpl::unpackAndCombineIntoCrsMatrix: ";
 
   const size_t num_import_lids = static_cast<size_t>(import_lids.dimension_0());
   if (num_import_lids == 0) {
@@ -615,7 +618,7 @@ do_unpack_and_combine_into_crs_matrix(
 
 template<class LocalMatrix, class BufferDeviceType>
 size_t
-unpackAndCombineWithOwningPIDsCountImpl (
+unpackAndCombineWithOwningPIDsCount(
   const LocalMatrix& local_matrix,
   const typename PackTraits<typename LocalMatrix::ordinal_type, typename LocalMatrix::device_type>::input_array_type permute_from_lids,
   const Kokkos::View<const char*, BufferDeviceType>& imports,
@@ -674,9 +677,9 @@ unpackAndCombineWithOwningPIDsCountImpl (
 template<class LO, class DT, class BDT>
 KOKKOS_INLINE_FUNCTION
 size_t
-unpack_crs_matrix_row_count (const Kokkos::View<const char*, BDT>& imports,
-                             const size_t offset,
-                             const size_t num_bytes)
+unpackRowCount(const Kokkos::View<const char*, BDT>& imports,
+               const size_t offset,
+               const size_t num_bytes)
 {
   LO num_ent_LO = 0;
   if (num_bytes > 0) {
@@ -693,7 +696,7 @@ unpack_crs_matrix_row_count (const Kokkos::View<const char*, BDT>& imports,
 /// \brief Setup row pointers for remotes
 template<class LO, class DT, class BDT>
 int
-setup_row_pointers_for_remotes(
+setupRowPointersForRemotes(
   const typename PackTraits<size_t, DT>::output_array_type& tgt_rowptr,
   const typename PackTraits<LO, DT>::input_array_type& import_lids,
   const Kokkos::View<const char*, BDT>& imports,
@@ -715,7 +718,7 @@ setup_row_pointers_for_remotes(
       typedef typename std::remove_reference< decltype( tgt_rowptr(0) ) >::type atomic_incr_type;
       const size_t num_bytes = num_packets_per_lid(i);
       const size_t offset = offsets(i);
-      const size_t num_ent = unpack_crs_matrix_row_count<LO, DT, BDT> (imports, offset, num_bytes);
+      const size_t num_ent = unpackRowCount<LO, DT, BDT> (imports, offset, num_bytes);
       if (num_ent == InvalidNum) {
         k_error += 1;
       }
@@ -727,7 +730,7 @@ setup_row_pointers_for_remotes(
 // Convert array of row lengths to a CRS pointer array
 template<class DT>
 void
-make_crs_row_pointer_from_lengths(
+makeCrsRowPtrFromLengths(
     const typename PackTraits<size_t,DT>::output_array_type& tgt_rowptr,
     const Kokkos::View<size_t*,DT>& new_start_row)
 {
@@ -750,7 +753,7 @@ make_crs_row_pointer_from_lengths(
 
 template<class LocalMatrix, class LocalMap>
 void
-copy_data_from_same_ids(
+copyDataFromSameIDs(
     const typename PackTraits<typename LocalMap::global_ordinal_type, typename LocalMap::device_type>::output_array_type& tgt_colind,
     const typename PackTraits<int, typename LocalMap::device_type>::output_array_type& tgt_pids,
     const typename PackTraits<typename LocalMatrix::value_type, typename LocalMap::device_type>::output_array_type& tgt_vals,
@@ -795,7 +798,7 @@ copy_data_from_same_ids(
 
 template<class LocalMatrix, class LocalMap>
 void
-copy_data_from_permute_ids(
+copyDataFromPermuteIDs(
     const typename PackTraits<typename LocalMap::global_ordinal_type, typename LocalMap::device_type>::output_array_type& tgt_colind,
     const typename PackTraits<int, typename LocalMap::device_type>::output_array_type& tgt_pids,
     const typename PackTraits<typename LocalMatrix::value_type, typename LocalMap::device_type>::output_array_type& tgt_vals,
@@ -844,7 +847,7 @@ copy_data_from_permute_ids(
 
 template<typename LocalMatrix, typename LocalMap, typename BufferDeviceType>
 int
-do_unpack_and_combine_into_crs_arrays(
+unpackAndCombineIntoCrsArrays2(
     const typename PackTraits<typename LocalMap::global_ordinal_type, typename LocalMap::device_type>::output_array_type& tgt_colind,
     const typename PackTraits<int, typename LocalMap::device_type>::output_array_type& tgt_pids,
     const typename PackTraits<typename LocalMatrix::value_type, typename LocalMap::device_type>::output_array_type& tgt_vals,
@@ -894,7 +897,7 @@ do_unpack_and_combine_into_crs_arrays(
         // Empty buffer means that the row is empty.
         return;
       }
-      size_t num_ent = unpack_crs_matrix_row_count<LO,DT,BDT>(imports, offset, num_bytes);
+      size_t num_ent = unpackRowCount<LO,DT,BDT>(imports, offset, num_bytes);
       if (num_ent == InvalidNum) {
         k_error += 1;
         return;
@@ -907,9 +910,9 @@ do_unpack_and_combine_into_crs_arrays(
       vals_out_type vals_out = subview(tgt_vals, slice(start_row, end_row));
       pids_out_type pids_out = subview(tgt_pids, slice(start_row, end_row));
 
-      k_error += unpack_crs_matrix_row<ST, LO, GO, DT, BDT> (gids_out, pids_out, vals_out,
-                                                             imports, offset, num_bytes,
-                                                             num_ent, num_bytes_per_value);
+      k_error += unpackRow<ST,LO,GO,DT,BDT>(gids_out, pids_out, vals_out,
+                                            imports, offset, num_bytes,
+                                            num_ent, num_bytes_per_value);
 
       // Correct target PIDs.
       for (size_t j = 0; j < static_cast<size_t>(num_ent); ++j) {
@@ -923,7 +926,7 @@ do_unpack_and_combine_into_crs_arrays(
 
 template<typename LocalMatrix, typename LocalMap, typename BufferDeviceType>
 void
-unpackAndCombineIntoCrsArraysImpl(
+unpackAndCombineIntoCrsArrays(
     const LocalMatrix & local_matrix,
     const LocalMap & local_col_map,
     const typename PackTraits<typename LocalMap::local_ordinal_type, typename LocalMap::device_type>::input_array_type& import_lids,
@@ -954,7 +957,7 @@ unpackAndCombineIntoCrsArraysImpl(
   typedef Kokkos::RangePolicy<XS, Kokkos::IndexType<size_t> > range_policy;
   typedef BufferDeviceType BDT;
 
-  const char prefix[] = "unpackAndCombineIntoCrsArraysImpl: ";
+  const char prefix[] = "unpackAndCombineIntoCrsArrays: ";
 
   const size_t N = tgt_num_rows;
   const size_t mynnz = tgt_num_nonzeros;
@@ -1011,7 +1014,7 @@ unpackAndCombineIntoCrsArraysImpl(
 
   // Setup row pointers for remotes
   int k_error =
-    setup_row_pointers_for_remotes<LO,DT,BDT> (tgt_rowptr,
+    setupRowPointersForRemotes<LO,DT,BDT>(tgt_rowptr,
       import_lids, imports, num_packets_per_lid, offsets);
   TEUCHOS_TEST_FOR_EXCEPTION(k_error != 0, std::logic_error, prefix
     << " Error transferring data to target row pointers.  "
@@ -1022,7 +1025,7 @@ unpackAndCombineIntoCrsArraysImpl(
   View<size_t*, DT> new_start_row ("new_start_row", N+1);
 
   // Turn row length into a real CRS row pointer
-  make_crs_row_pointer_from_lengths (tgt_rowptr, new_start_row);
+  makeCrsRowPtrFromLengths(tgt_rowptr, new_start_row);
   {
     auto nth_tgt_rowptr_h = getEntryOnHost(tgt_rowptr, N);
     bool condition = nth_tgt_rowptr_h != mynnz;
@@ -1032,10 +1035,10 @@ unpackAndCombineIntoCrsArraysImpl(
   }
 
   // SameIDs: Copy the data over
-  copy_data_from_same_ids(tgt_colind, tgt_pids, tgt_vals, new_start_row,
+  copyDataFromSameIDs(tgt_colind, tgt_pids, tgt_vals, new_start_row,
       tgt_rowptr, src_pids, local_matrix, local_col_map, num_same_ids, my_pid);
 
-  copy_data_from_permute_ids(tgt_colind, tgt_pids, tgt_vals, new_start_row,
+  copyDataFromPermuteIDs(tgt_colind, tgt_pids, tgt_vals, new_start_row,
       tgt_rowptr, src_pids, permute_to_lids, permute_from_lids,
       local_matrix, local_col_map, my_pid);
 
@@ -1043,7 +1046,7 @@ unpackAndCombineIntoCrsArraysImpl(
     return;
   }
 
-  int unpack_err = do_unpack_and_combine_into_crs_arrays(tgt_colind, tgt_pids,
+  int unpack_err = unpackAndCombineIntoCrsArrays2(tgt_colind, tgt_pids,
       tgt_vals, new_start_row, offsets, import_lids, imports, num_packets_per_lid,
       local_matrix, local_col_map, my_pid, num_bytes_per_value);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -1052,6 +1055,8 @@ unpackAndCombineIntoCrsArraysImpl(
 
   return;
 }
+
+} // namespace UnpackAndCombineCrsMatrixImpl
 
 /// \brief Unpack the imported column indices and values, and combine into matrix.
 ///
@@ -1135,8 +1140,9 @@ unpackCrsMatrixAndCombine(
   auto local_col_map = sourceMatrix.getColMap()->getLocalMap();
 
   // Now do the actual unpack!
-  do_unpack_and_combine_into_crs_matrix(local_matrix, local_col_map, imports_d,
-      num_packets_per_lid_d, import_lids_d, combineMode, false, atomic);
+  UnpackAndCombineCrsMatrixImpl::unpackAndCombineIntoCrsMatrix(
+      local_matrix, local_col_map, imports_d, num_packets_per_lid_d,
+      import_lids_d, combineMode, false, atomic);
 
   return;
 }
@@ -1190,7 +1196,7 @@ unpackCrsMatrixAndCombineNew (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   typedef decltype (local_col_map) local_map_type;
 
   // Now do the actual unpack!
-  do_unpack_and_combine_into_crs_matrix<
+  UnpackAndCombineCrsMatrixImpl::unpackAndCombineIntoCrsMatrix<
       local_matrix_type,
       local_map_type,
       buffer_device_type
@@ -1305,11 +1311,9 @@ unpackAndCombineWithOwningPIDsCount (
                                             numPacketsPerLID.size (), true,
                                             "num_packets_per_lid");
 
-  return unpackAndCombineWithOwningPIDsCountImpl (local_matrix,
-                                                  permute_from_lids_d,
-                                                  imports_d,
-                                                  num_packets_per_lid_d,
-                                                  numSameIDs);
+  return UnpackAndCombineCrsMatrixImpl::unpackAndCombineWithOwningPIDsCount(
+      local_matrix, permute_from_lids_d, imports_d,
+      num_packets_per_lid_d, numSameIDs);
 }
 
 /// \brief unpackAndCombineIntoCrsArrays
@@ -1493,10 +1497,11 @@ unpackAndCombineIntoCrsArrays (
     "never happen, since std::complex does not work in Kokkos::View objects.");
 #endif // HAVE_TPETRA_INST_COMPLEX_DOUBLE
 
-  unpackAndCombineIntoCrsArraysImpl(local_matrix, local_col_map,
-      import_lids_d, imports_d, num_packets_per_lid_d, permute_to_lids_d,
-      permute_from_lids_d, crs_rowptr_d, crs_colind_d, crs_vals_d, src_pids_d,
-      tgt_pids_d, numSameIDs, TargetNumRows, TargetNumNonzeros, MyTargetPID,
+  UnpackAndCombineCrsMatrixImpl::unpackAndCombineIntoCrsArrays(
+      local_matrix, local_col_map, import_lids_d, imports_d,
+      num_packets_per_lid_d, permute_to_lids_d, permute_from_lids_d,
+      crs_rowptr_d, crs_colind_d, crs_vals_d, src_pids_d, tgt_pids_d,
+      numSameIDs, TargetNumRows, TargetNumNonzeros, MyTargetPID,
       num_bytes_per_value);
 
   // Copy outputs back to host

--- a/packages/tpetra/core/test/CrsGraph/CMakeLists.txt
+++ b/packages/tpetra/core/test/CrsGraph/CMakeLists.txt
@@ -61,3 +61,23 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 2
   STANDARD_PASS_OUTPUT
   )
+
+# I want this test to _build_ in either MPI or non-MPI ("serial"),
+# but I only want it to _run_ in an MPI build with exactly 1 MPI
+# process.
+TRIBITS_ADD_EXECUTABLE(
+  CrsGraph_PackUnpack
+  SOURCES
+    CrsGraph_PackUnpack.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+)
+
+TRIBITS_ADD_TEST(
+  CrsGraph_PackUnpack
+  NAME CrsGraph_PackUnpack_MPI_1
+  ARGS ""
+  COMM mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_PackUnpack.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_PackUnpack.cpp
@@ -1,0 +1,419 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "Tpetra_TestingUtilities.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Tpetra_CrsGraph.hpp"
+#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Distributor.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_Details_gathervPrint.hpp"
+#include "Tpetra_Details_packCrsGraph.hpp"
+#include "Tpetra_Details_unpackCrsGraphAndCombine.hpp"
+#include "Teuchos_CommHelpers.hpp"
+#include "Kokkos_ArithTraits.hpp"
+#include <random>
+#include <set>
+
+namespace { // anonymous
+
+#define NUM_ROW_PER_PROC 4
+#define NUM_NZ_COLS 100
+
+using Tpetra::TestingUtilities::getDefaultComm;
+using Teuchos::rcp;
+using Teuchos::RCP;
+using Teuchos::Array;
+using Teuchos::ArrayView;
+using Teuchos::Comm;
+using Teuchos::outArg;
+using Tpetra::Details::gathervPrint;
+using Tpetra::Details::packCrsGraph;
+using Tpetra::Details::unpackCrsGraphAndCombine;
+using std::endl;
+
+template<class T>
+bool
+essentially_equal(T a, T b) {
+  typedef Kokkos::ArithTraits<T> KAT;
+  const auto eps = KAT::eps();
+  return KAT::abs(a - b) <= ( (KAT::abs(a) > KAT::abs(b) ? KAT::abs(b) : KAT::abs(a)) * eps);
+}
+
+template<class CrsGraphType>
+Teuchos::RCP<CrsGraphType>
+generate_test_graph(const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
+{
+  typedef CrsGraphType crs_graph_type;
+  typedef typename crs_graph_type::local_ordinal_type LO;
+  typedef typename crs_graph_type::global_ordinal_type GO;
+  typedef typename crs_graph_type::node_type NT;
+  typedef Tpetra::Map<LO, GO, NT> MapType;
+
+  const int world_rank = comm->getRank();
+
+  const LO num_row_per_proc = NUM_ROW_PER_PROC; // 4;
+  Array<GO> row_gids(num_row_per_proc);
+
+  GO start = static_cast<GO>(num_row_per_proc * world_rank);
+  for (LO i=0; i<num_row_per_proc; ++i) {
+    row_gids[i] = static_cast<GO>(start+i);
+  }
+
+  // Create random, unique column GIDs.
+  const LO max_num_ent_per_row = NUM_NZ_COLS; //100;
+  std::random_device rand_dev;
+  std::mt19937 generator(rand_dev());
+  std::uniform_int_distribution<GO>  distr(1, 2000);
+  std::set<GO> col_gids_set;
+  typedef typename std::set<GO>::size_type SGO;
+  SGO num_gids_in_set = static_cast<SGO>(max_num_ent_per_row);
+  col_gids_set.insert(0);
+  int num_passes = 0;
+  while (col_gids_set.size() < num_gids_in_set && num_passes <= 2000) {
+    col_gids_set.insert(distr(generator));
+    num_passes += 1;
+  }
+  TEUCHOS_TEST_FOR_EXCEPTION(col_gids_set.size() != num_gids_in_set,
+      std::runtime_error, "Random column IDs not generated");
+
+  Array<GO> col_gids(col_gids_set.begin(), col_gids_set.end());
+
+  const GO INVALID = Teuchos::OrdinalTraits<GO>::invalid();
+  RCP<const MapType> row_map = rcp(new MapType(INVALID, row_gids(), 0, comm));
+  RCP<const MapType> col_map = rcp(new MapType(INVALID, col_gids(), 0, comm));
+
+  auto A = rcp(new crs_graph_type(row_map, col_map, max_num_ent_per_row));
+
+  Array<LO> columns(max_num_ent_per_row);
+  for (LO j=0; j<max_num_ent_per_row; ++j) columns[j] = j;
+  for (LO i=0; i<num_row_per_proc; ++i) {
+    //LO lcl_row = static_cast<LO>(start + i); // unused
+    A->insertLocalIndices(i, columns());
+  }
+  A->fillComplete(col_map, row_map);
+
+  return A;
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT)
+{
+  typedef Tpetra::CrsGraph<LO, GO, NT> crs_graph_type;
+  typedef typename crs_graph_type::packet_type packet_type;
+  typedef typename NT::device_type device_type;
+  typedef typename device_type::execution_space execution_space;
+
+  int lclSuccess = 1; // to be revised below
+  int gblSuccess = 0; // output argument
+
+  RCP<const Comm<int> > comm = getDefaultComm();
+  const int world_rank = comm->getRank();
+
+  out << "Creating graph" << endl;
+
+  auto A = generate_test_graph<crs_graph_type> (comm);
+  auto col_map = A->getColMap();
+  auto row_map = A->getRowMap();
+
+  out << "Preparing arguments for packCrsGraph" << endl;
+
+  LO num_loc_rows = static_cast<LO>(A->getNodeNumRows());
+  Array<LO> exportLIDs (num_loc_rows); // input argument
+  for (LO i=0; i < num_loc_rows; ++i) {
+    exportLIDs[i] = static_cast<LO>(i); // pack all the rows
+  }
+  Array<packet_type> exports; // output argument; to be realloc'd
+  Array<size_t> numPacketsPerLID (num_loc_rows, 0); // output argument
+  size_t constantNumPackets; // output argument
+  Tpetra::Distributor distor (comm); // argument required, but not used
+
+  out << "Calling packCrsGraph" << endl;
+
+  {
+    int local_op_ok;
+    std::ostringstream msg;
+    try {
+      packCrsGraph<LO,GO,NT>(*A, exports, numPacketsPerLID(), exportLIDs(),
+          constantNumPackets, distor);
+      local_op_ok = 1;
+    } catch (std::exception& e) {
+      local_op_ok = 0;
+      msg << e.what();
+    }
+    TEST_ASSERT(local_op_ok == 1);
+    lclSuccess = success ? 1 : 0;
+    Teuchos::reduceAll<int, int> (*comm, Teuchos::REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    TEST_EQUALITY_CONST( gblSuccess, 1 );
+    if (gblSuccess != 1) {
+      if (world_rank == 0) {
+        out << "packCrsGraph reported an error!" << endl;
+      }
+      gathervPrint (out, msg.str(), *comm);
+      out << endl << "Abandoning test; no point in continuing." << endl;
+      return;
+    }
+  }
+
+  // Now make sure that the pack is correct by creating an empty graph and
+  // unpacking in to it.  The graph should end up being the same as the above graph.
+  out << "Building second graph" << endl;
+  RCP<crs_graph_type> B = rcp(new crs_graph_type(row_map, col_map, A->getNodeNumEntries()));
+
+#ifdef KOKKOS_HAVE_SERIAL
+  const bool atomic_updates = ! std::is_same<execution_space, Kokkos::Serial>::value;
+#else
+  const bool atomic_updates = true;
+#endif // KOKKOS_HAVE_SERIAL
+
+  out << "Calling unpackCrsGraphAndCombine with "
+      << "CombineMode=Tpetra::REPLACE" << endl;
+
+  {
+    int local_op_ok;
+    std::ostringstream msg;
+    try {
+      unpackCrsGraphAndCombine<LO,GO,NT>(*B, exports, numPacketsPerLID(),
+          exportLIDs(), constantNumPackets, distor, Tpetra::REPLACE, atomic_updates);
+      local_op_ok = 0;
+    } catch (std::exception& e) {
+      // This method should throw because it is not finished!
+      local_op_ok = 1;
+    }
+
+    TEST_ASSERT(local_op_ok == 1);
+    lclSuccess = success ? 1 : 0;
+    Teuchos::reduceAll<int, int> (*comm, Teuchos::REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    TEST_EQUALITY_CONST( gblSuccess, 1 );
+    if (gblSuccess != 1) {
+      if (world_rank == 0) {
+        out << "unpackCrsGraphAndCombine reported an error!" << endl;
+      }
+      gathervPrint(out, msg.str(), *comm);
+      return; // no point in continuing
+    }
+  }
+
+  // The test below uses the host Tpetra::CrsGraph interface to
+  // compare graph values.  Thus, we need to do a fence before
+  // comparing graph values, in order to ensure that changes made on
+  // device are visible on host.
+  execution_space::fence ();
+
+  int lclNumErrors = 0;
+
+  out << "Comparing graphs after unpackCrsGraphAndCombine "
+    "with CombineMode=REPLACE" << endl;
+  {
+    std::ostringstream errStrm;
+    for (LO lclRow=0; lclRow<num_loc_rows; ++lclRow) {
+      ArrayView<const LO> A_indices;
+      A->getLocalRowView(lclRow, A_indices);
+
+      ArrayView<const LO> B_indices;
+      B->getLocalRowView(lclRow, B_indices);
+
+      continue;
+      /*
+       * Test to be uncommented when unpackCrsGraphAndCombine is finished.
+       *
+      TEST_EQUALITY( A_indices.size (), B_indices.size () );
+
+      int curNumErrors = 0;
+      LO num_indices = static_cast<LO>(A_indices.size());
+      for (LO i=0; i<num_indices; i++) {
+        if (A_indices[i] != B_indices[i]) {
+          errStrm << "ERROR: Proc " << world_rank << ", row " << lclRow
+                  << ", A[" << i << "]=" << A_indices[i] << ", but "
+                  <<   "B[" << i << "]=" << B_indices[i] << "!\n";
+          ++curNumErrors;
+        }
+      }
+      lclNumErrors += curNumErrors;
+      */
+    }
+    TEST_ASSERT( lclNumErrors == 0 );
+
+    int gblNumErrors = 0;
+    Teuchos::reduceAll<int, int> (*comm, Teuchos::REDUCE_SUM, lclNumErrors, outArg (gblNumErrors));
+    TEST_EQUALITY_CONST( gblNumErrors, 0 );
+    if (gblNumErrors != 0) {
+      if (world_rank == 0) {
+        out << "unpackCrsGraphAndCombine comparison found " << gblNumErrors
+            << " error" << (gblNumErrors != 1 ? "s" : "") << "!" << endl;
+      }
+      gathervPrint (out, errStrm.str (), *comm);
+      return; // no point in continuing
+    }
+
+    lclSuccess = success ? 1 : 0;
+    Teuchos::reduceAll<int, int> (*comm, Teuchos::REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    TEST_EQUALITY_CONST( gblSuccess, 1 );
+    if (gblSuccess != 1) {
+      if (world_rank == 0) {
+        out << "unpackCrsGraphAndCombine comparison claims zero errors, "
+          "but success is false on at least one process!" << endl;
+      }
+      gathervPrint (out, errStrm.str (), *comm);
+      return; // no point in continuing
+    }
+  }
+
+}
+
+// PackWithError sends intentionally bad inputs to pack/unpack to make sure
+// that CrsGraph will detect the bad inputs and return the correct
+// error diagnostics.
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, PackWithError, LO, GO, NT)
+{
+
+  typedef Tpetra::CrsGraph<LO, GO, NT> crs_graph_type;
+  typedef typename crs_graph_type::packet_type packet_type;
+
+  RCP<const Comm<int> > comm = getDefaultComm();
+  const int world_rank = comm->getRank();
+
+  out << "Creating graph" << endl;
+
+  auto A = generate_test_graph<crs_graph_type>(comm);
+  auto col_map = A->getColMap();
+  auto row_map = A->getRowMap();
+
+  out << "Calling packCrsGraph" << endl;
+
+  // Prepare arguments for pack.  This test is similar to the
+  // PackThenUnpackAndCombine test,
+  // but incorrect exportLIDs are sent in to induce a packing error.
+  int lclSuccess = success ? 1 : 0;
+  int gblSuccess = 0; // output argument
+  std::ostringstream errStrm; // for error string local to each process
+
+  {
+    LO num_loc_rows = static_cast<LO>(A->getNodeNumRows());
+    Array<LO> exportLIDs(num_loc_rows);
+    // exportLIDs[i] should equal i, but we set it to i+2
+    for (LO i=0; i<num_loc_rows; i++) {
+      exportLIDs[i] = i + 2;
+    }
+
+    Array<packet_type> exports;
+    Array<size_t> numPacketsPerLID(num_loc_rows, 0);
+    size_t constantNumPackets;
+    Tpetra::Distributor distor(comm);
+    {
+      int local_op_ok;
+      std::ostringstream msg;
+      try {
+        packCrsGraph<LO,GO,NT>(*A, exports, numPacketsPerLID(), exportLIDs(),
+            constantNumPackets, distor);
+        local_op_ok = 1;
+      } catch (std::exception& e) {
+        local_op_ok = 0;
+        msg << e.what();
+      }
+      if (local_op_ok == 1) {
+        // Local pack should not be OK!  We requested bad local IDs be exported!
+        errStrm << "Proc " << world_rank
+                << ": packCrsGraph returned OK, but bad local IDs were requested!"
+                << endl;
+        lclSuccess = 0;
+      }
+    }
+  }
+
+  Teuchos::reduceAll<int, int> (*comm, Teuchos::REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+  TEST_EQUALITY( gblSuccess, 1 );
+  if (gblSuccess != 1) {
+    out << "packCrsGraph failed to notice bad export IDs on some process!" << endl;
+    gathervPrint (out, errStrm.str (), *comm);
+  }
+
+  {
+    // Let's try this again, but send in the wrong number of exportLIDs
+    LO num_loc_rows = static_cast<LO>(A->getNodeNumRows());
+    // Note the -1!
+    out << "Allocating ids... ";
+    Array<LO> exportLIDs(num_loc_rows-1);
+    for (LO i=0; i < num_loc_rows-1; ++i) {
+      exportLIDs[i] = i;
+    }
+    out << "done" << endl;
+
+    Array<packet_type> exports;
+    Array<size_t> numPacketsPerLID(num_loc_rows, 0);
+    size_t constantNumPackets;
+    Tpetra::Distributor distor(comm);
+    out << "Calling packCrsGraph" << endl;
+    {
+      int local_op_ok;
+      std::ostringstream msg;
+      try {
+        packCrsGraph<LO,GO,NT>(*A, exports, numPacketsPerLID(), exportLIDs(),
+            constantNumPackets, distor);
+        local_op_ok = 1;
+      } catch (std::exception& e) {
+        local_op_ok = 0;
+        msg << e.what();
+      }
+      if (local_op_ok == 1) {
+        // Local pack should not be OK!  We requested too few local IDs be exported!
+        errStrm << "Proc " << world_rank
+                << ": packCrsGraph returned OK, but too few IDs "
+                << "were requested to be exported!"
+                << endl;
+        lclSuccess = 0;
+      }
+    }
+    Teuchos::reduceAll<int, int> (*comm, Teuchos::REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    TEST_EQUALITY( gblSuccess, 1 );
+  }
+}
+
+#define UNIT_TEST_GROUP( LO, GO, NT ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(CrsGraph, PackThenUnpackAndCombine, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(CrsGraph, PackWithError, LO, GO, NT)
+
+TPETRA_ETI_MANGLING_TYPEDEFS()
+
+TPETRA_INSTANTIATE_LGN(UNIT_TEST_GROUP)
+
+} // namespace (anonymous)

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -697,6 +697,76 @@ namespace {
   }
 
 
+template<class Graph>
+bool graphs_are_same(const RCP<Graph>& G1, const RCP<const Graph>& G2)
+{
+  typedef typename Graph::local_ordinal_type LO;
+
+  int my_rank = G1->getRowMap()->getComm()->getRank();
+
+  // Make sure each graph is fill complete before checking other properties
+  if (! G1->isFillComplete()) {
+    if (my_rank == 0)
+      cerr << "***Error: Graph 1 is not fill complete!" << endl;
+    return false;
+  }
+  if (! G2->isFillComplete()) {
+    if (my_rank == 0)
+      cerr << "***Error: Graph 2 is not fill complete!" << endl;
+    return false;
+  }
+
+  int errors = 0;
+
+  if (! G1->getRowMap()->isSameAs(*G2->getRowMap())) {
+    if (my_rank == 0)
+      cerr << "***Error: Graph 1's row map is different than Graph 2's" << endl;
+    errors++;
+  }
+  if (! G1->getDomainMap()->isSameAs(*G2->getDomainMap())) {
+    if (my_rank == 0)
+      cerr << "***Error: Graph 1's domain map is different than Graph 2's" << endl;
+    errors++;
+  }
+  if (! G1->getRangeMap()->isSameAs(*G2->getRangeMap())) {
+    if (my_rank == 0)
+      cerr << "***Error: Graph 1's range map is different than Graph 2's" << endl;
+    errors++;
+  }
+  if (G1->getNodeNumEntries() != G2->getNodeNumEntries()) {
+    cerr << "***Error: Graph 1 does not have the same number of entries as Graph 2 on Process "
+         << my_rank << endl;
+    errors++;
+  }
+
+  if (errors != 0) return false;
+
+  for (LO i=0; i<static_cast<LO>(G1->getNodeNumRows()); i++) {
+    ArrayView<const LO> V1, V2;
+    G1->getLocalRowView(i, V1);
+    G2->getLocalRowView(i, V2);
+    if (V1.size() != V2.size()) {
+      cerr << "***Error: Graph 1 and Graph 2 have different number of entries in local row "
+           << i << " on Process " << my_rank << endl;
+      errors++;
+      continue;
+    }
+    int jerr = 0;
+    for (LO j=0; static_cast<LO>(j<V1.size()); j++) {
+      if (V1[j] != V2[j])
+        jerr++;
+    }
+    if (jerr != 0) {
+      cerr << "***Error: One or more entries in row " << i << " on Process " << my_rank
+           << " Graphs 1 and 2 are not the same" << endl;
+      errors++;
+      continue;
+    }
+  }
+
+  return (errors == 0);
+
+}
 
 // All the fused Import/export test stuff
 // ===============================================================================
@@ -1158,6 +1228,7 @@ build_remote_only_map (const Teuchos::RCP<const ImportType>& Import,
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
 {
+  typedef Tpetra::CrsGraph<LO, GO> Graph;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
   typedef Tpetra::Map<LO, GO> MapType;
   typedef Tpetra::Import<LO, GO> ImportType;
@@ -1172,6 +1243,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
   RCP<const Comm<int> > Comm = getDefaultComm();
 
   RCP<CrsMatrixType> A, B, C;
+  RCP<Graph> Bg;
   RCP<const MapType> Map1, Map2;
   RCP<MapType> Map3;
 
@@ -1194,6 +1266,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
         << e.what () << endl;
     lclErr = 1;
   }
+  auto Ag = A->getCrsGraph();
 
   reduceAll<int, int> (*Comm, REDUCE_MAX, lclErr, outArg (gblErr));
   // The test fails if any (MPI) process had trouble.
@@ -1224,6 +1297,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+    // Test the graph version
+    Import1 = rcp(new ImportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedImport: CrsGraph test #1 FAILED." << endl;
+      total_err--;
+    }
 
     // Execute fused export
     Export1 = rcp(new ExportType(A->getRowMap(),Map1));
@@ -1234,6 +1314,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
         cerr << "FusedExport: Test #1 FAILED with norm diff = " << diff
              << "." << endl;
       }
+      total_err--;
+    }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #1 FAILED." << endl;
       total_err--;
     }
 
@@ -1275,6 +1363,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       total_err--;
     }
 
+    // Test the graph version
+    Import1 = rcp(new ImportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedImport: CrsGraph test #2 FAILED." << endl;
+      total_err--;
+    }
+
     // Execute fused export
     Export1 = rcp(new ExportType(A->getRowMap(),Map1));
     B = Tpetra::exportAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Export1);
@@ -1286,6 +1382,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #2 FAILED." << endl;
+      total_err--;
+    }
+
   } catch (std::exception& e) {
     err << "Process " << MyPID << " threw an exception: " << e.what ();
     lclErr = 1;
@@ -1339,6 +1444,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       total_err--;
     }
 
+    // Test the graph version
+    Import1 = rcp(new ImportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedImport: CrsGraph test #4 FAILED." << endl;
+      total_err--;
+    }
+
     // Execute fused export
     Export1 = rcp(new ExportType(A->getRowMap(),Map1));
     B = Tpetra::exportAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Export1);
@@ -1350,6 +1463,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #4 FAILED." << endl;
+      total_err--;
+    }
+
   } catch (std::exception& e) {
     err << "Process " << MyPID << " threw an exception: " << e.what () << endl;
     lclErr = 1;
@@ -1381,6 +1503,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+    // Test the graph version
+    Import1 = rcp(new ImportType(Ag->getRowMap(),Map3));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1,Map3,Map3);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedImport: CrsGraph test #5 FAILED." << endl;
+      total_err--;
+    }
 
     // Execute fused export
     Export1 = rcp(new ExportType(A->getRowMap(),Map3));
@@ -1393,6 +1522,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Ag->getRowMap(),Map3));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1,Map3,Map3);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #5 FAILED." << endl;
+      total_err--;
+    }
+
   } catch (std::exception& e) {
     err << "Process " << MyPID << " threw an exception: " << e.what () << endl;
     lclErr = 1;
@@ -1420,7 +1558,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     // Execute fused import constructor
     Import1 = rcp(new ImportType(A->getRowMap(),Map3));
     B = Tpetra::importAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Import1,Map3,Map3,rcp(&params,false));
-
     diff=test_with_matvec_reduced_maps<CrsMatrixType,MapType>(*A,*B,*Map3);
     if(diff > diff_tol){
       if(MyPID==0) {
@@ -1430,10 +1567,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       total_err--;
     }
 
+    // Test the graph version
+    Import1 = rcp(new ImportType(Ag->getRowMap(),Map3));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1,Map3,Map3,rcp(&params,false));
+    if (Map3->getNodeNumElements() > 0) {
+      if (!graphs_are_same(Bg, B->getCrsGraph())) {
+        if (MyPID == 0) cerr << "FusedImport: CrsGraph test #6 FAILED." << endl;
+        total_err--;
+      }
+    }
+
     // Execute fused export constructor
     Export1 = rcp(new ExportType(A->getRowMap(),Map3));
     B = Tpetra::exportAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Export1,Map3,Map3,rcp(&params,false));
-
     diff=test_with_matvec_reduced_maps<CrsMatrixType,MapType>(*A,*B,*Map3);
     if(diff > diff_tol){
       if(MyPID==0) {
@@ -1442,6 +1588,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Ag->getRowMap(),Map3));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1,Map3,Map3,rcp(&params,false));
+    if (Map3->getNodeNumElements() > 0) {
+      if (!graphs_are_same(Bg, B->getCrsGraph())) {
+        if (MyPID == 0) cerr << "FusedExport: CrsGraph test #6 FAILED." << endl;
+        total_err--;
+      }
+    }
+
   } catch (std::exception& e) {
     err << "Process " << MyPID << " threw an exception: " << e.what () << endl;
     lclErr = 1;
@@ -1472,7 +1629,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     // Execute fused import constructor
     Import1 = rcp(new ImportType(Map1,A->getRowMap()));
     B = Tpetra::importAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Import1,Map1,Map1,rcp(&params,false));
-
     diff=test_with_matvec<CrsMatrixType>(*A,*B);
     if(diff > diff_tol){
       if(MyPID==0) {
@@ -1482,10 +1638,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       total_err--;
     }
 
+    // Test the graph version
+    Import1 = rcp(new ImportType(Map1,Ag->getRowMap()));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1,Map1,Map1,rcp(&params,false));
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedImport: CrsGraph test #7 FAILED." << endl;
+      total_err--;
+    }
+
     // Execute fused export constructor
     Export1 = rcp(new ExportType(Map1,A->getRowMap()));
     B = Tpetra::exportAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Export1,Map1,Map1,rcp(&params,false));
-
     diff=test_with_matvec<CrsMatrixType>(*A,*B);
     if(diff > diff_tol){
       if(MyPID==0) {
@@ -1494,6 +1657,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Map1,Ag->getRowMap()));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1,Map1,Map1,rcp(&params,false));
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #1 FAILED." << endl;
+      total_err--;
+    }
+
   } catch (std::exception& e) {
     err << "Process " << MyPID << " threw an exception: " << e.what () << endl;
     lclErr = 1;
@@ -1512,6 +1684,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
   try {
     OSTab tab2 (out);
     build_test_matrix_with_row_overlap<CrsMatrixType>(Comm,A);
+    Ag = A->getCrsGraph();
 
     Teuchos::ArrayRCP<const size_t> rowptr;
     Teuchos::ArrayRCP<const LO> colind;
@@ -1524,13 +1697,20 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     params.set("Reverse Mode",true);
     Import1 = rcp(new ImportType(Map1,A->getRowMap()));
     B = Tpetra::importAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Import1,Map1,Map1,rcp(&params,false));
-
     diff=test_with_matvec<CrsMatrixType>(*B,*A);
     if(diff > diff_tol){
       if(MyPID==0) {
         cerr << "FusedImport: Test #8 FAILED with norm diff = " << diff
              << "." << endl;
       }
+      total_err--;
+    }
+
+    // Test the graph version
+    Import1 = rcp(new ImportType(Map1,Ag->getRowMap()));
+    Bg = Tpetra::importAndFillCompleteCrsGraph<Graph>(Ag,*Import1,Map1,Map1,rcp(&params,false));
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedImport: CrsGraph test #8 FAILED." << endl;
       total_err--;
     }
 
@@ -1545,6 +1725,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
       }
       total_err--;
     }
+
+    // Test the graph version
+    Export1 = rcp(new ExportType(Ag->getRowMap(),Map1));
+    Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1,Map1,Map1);
+    if (!graphs_are_same(Bg, B->getCrsGraph())) {
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #1 FAILED." << endl;
+      total_err--;
+    }
+
   } catch (std::exception& e) {
     err << "Process " << MyPID << " threw an exception: " << e.what () << endl;
     lclErr = 1;

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -1662,7 +1662,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     Export1 = rcp(new ExportType(Map1,Ag->getRowMap()));
     Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1,Map1,Map1,rcp(&params,false));
     if (!graphs_are_same(Bg, B->getCrsGraph())) {
-      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #1 FAILED." << endl;
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #7 FAILED." << endl;
       total_err--;
     }
 
@@ -1730,7 +1730,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     Export1 = rcp(new ExportType(Ag->getRowMap(),Map1));
     Bg = Tpetra::exportAndFillCompleteCrsGraph<Graph>(Ag,*Export1,Map1,Map1);
     if (!graphs_are_same(Bg, B->getCrsGraph())) {
-      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #1 FAILED." << endl;
+      if (MyPID == 0) cerr << "FusedExport: CrsGraph test #8 FAILED." << endl;
       total_err--;
     }
 


### PR DESCRIPTION
CrsGraph::transferAndFillComplete is new, independent code.  However, there were
some function name clashes in packCrsMatrix and packCrsGraph.  So, I moved implementation
details of each to a new namespace so that they could have consistent naming.  The
same goes for unpackAndCombineCrsMatrix and unpackAndCombineCrsGraph.

@trilinos/tpetra 

## Related Issues

* Part of #2267 


## How Has This Been Tested?
Tpetra tests pass with GCC 6.4, openmpi 3.0.0, openmp

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.