### PR TITLE
Ifpack2 coordinates scalar template

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -151,7 +151,7 @@ getValidParameters () const
 
   validParams->set("partitioner: line detection threshold",(double)0.0);
   validParams->set("partitioner: PDE equations",(int)1);
-  Teuchos::RCP<Tpetra::MultiVector<typename MatrixType::scalar_type,
+  Teuchos::RCP<Tpetra::MultiVector<double,
                                    typename MatrixType::local_ordinal_type,
                                    typename MatrixType::global_ordinal_type,
                                    typename MatrixType::node_type> > dummy;

--- a/packages/ifpack2/src/Ifpack2_LinePartitioner_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LinePartitioner_decl.hpp
@@ -67,7 +67,7 @@ This implementation is derived from the related routine in ML.
 Supported parameters:
   <ul>
     <li> \c "partitioner: line detection threshold": if \f$||x_j - x_i||^2 < thresh * \max_k||x_k - x_i||^2\f$, then the points are close enough to line smooth <Scalar>
-    <li> \c "partitioner: coordinates"  : coordinates of local nodes  < Teuchos::MultiVector<Scalar> >
+    <li> \c "partitioner: coordinates"  : coordinates of local nodes  < Teuchos::MultiVector<double> >
     <li> \c "partitioner: PDE equations": number of equations per node <int>
   </ul>
 */
@@ -80,8 +80,8 @@ public:
   typedef typename GraphType::global_ordinal_type global_ordinal_type;
   typedef typename GraphType::node_type node_type;
   typedef Tpetra::RowGraph<local_ordinal_type, global_ordinal_type, node_type>  row_graph_type;
-  typedef Tpetra::MultiVector<Scalar,local_ordinal_type, global_ordinal_type, node_type>  multivector_type;
-  typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MT;
+  typedef Tpetra::MultiVector<double,local_ordinal_type, global_ordinal_type, node_type>  multivector_type;
+  typedef typename Teuchos::ScalarTraits<double>::magnitudeType MT;
 
 
   //! Constructor.

--- a/packages/ifpack2/src/Ifpack2_LinePartitioner_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LinePartitioner_decl.hpp
@@ -81,7 +81,6 @@ public:
   typedef typename GraphType::node_type node_type;
   typedef Tpetra::RowGraph<local_ordinal_type, global_ordinal_type, node_type>  row_graph_type;
   typedef Tpetra::MultiVector<double,local_ordinal_type, global_ordinal_type, node_type>  multivector_type;
-  typedef typename Teuchos::ScalarTraits<double>::magnitudeType MT;
 
 
   //! Constructor.
@@ -99,14 +98,14 @@ public:
 private:
     // Useful functions
   int Compute_Blocks_AutoLine(Teuchos::ArrayView<local_ordinal_type> blockIndices) const;
-  void local_automatic_line_search(int NumEqns, Teuchos::ArrayView <local_ordinal_type> blockIndices, local_ordinal_type last, local_ordinal_type next, local_ordinal_type LineID, MT tol, Teuchos::Array<local_ordinal_type> itemp, Teuchos::Array<MT> dtemp) const;
+  void local_automatic_line_search(int NumEqns, Teuchos::ArrayView <local_ordinal_type> blockIndices, local_ordinal_type last, local_ordinal_type next, local_ordinal_type LineID, double tol, Teuchos::Array<local_ordinal_type> itemp, Teuchos::Array<double> dtemp) const;
 
 
 
   // User data
   int NumEqns_;
   Teuchos::RCP<multivector_type> coord_;
-  MT threshold_;
+  double threshold_;
 
 };
 

--- a/packages/ifpack2/src/Ifpack2_LinePartitioner_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LinePartitioner_def.hpp
@@ -58,7 +58,7 @@ inline typename Teuchos::ScalarTraits<T>::magnitudeType square(T x) {
 template<class GraphType,class Scalar>
 LinePartitioner<GraphType,Scalar>::
 LinePartitioner (const Teuchos::RCP<const row_graph_type>& graph) :
-  OverlappingPartitioner<GraphType> (graph), NumEqns_(1), threshold_(Teuchos::ScalarTraits<MT>::zero())
+  OverlappingPartitioner<GraphType> (graph), NumEqns_(1), threshold_(0.0)
 {}
 
 
@@ -71,7 +71,7 @@ void
 LinePartitioner<GraphType,Scalar>::
 setPartitionParameters(Teuchos::ParameterList& List) {
   threshold_ = List.get("partitioner: line detection threshold",threshold_);
-  TEUCHOS_TEST_FOR_EXCEPTION(threshold_ < Teuchos::ScalarTraits<MT>::zero() || threshold_ > Teuchos::ScalarTraits<MT>::one(),
+  TEUCHOS_TEST_FOR_EXCEPTION(threshold_ < 0.0 || threshold_ > 1.0,
                              std::runtime_error,"Ifpack2::LinePartitioner: threshold not valid");
 
   NumEqns_   = List.get("partitioner: PDE equations",NumEqns_);
@@ -111,7 +111,6 @@ int LinePartitioner<GraphType,Scalar>::Compute_Blocks_AutoLine(Teuchos::ArrayVie
   typedef local_ordinal_type LO;
   const LO invalid  = Teuchos::OrdinalTraits<LO>::invalid();
   const double zero = Teuchos::ScalarTraits<double>::zero();
-  const MT mzero    = Teuchos::ScalarTraits<MT>::zero();
 
   Teuchos::ArrayRCP<const double>  xvalsRCP, yvalsRCP, zvalsRCP;
   Teuchos::ArrayView<const double> xvals, yvals, zvals;
@@ -119,16 +118,16 @@ int LinePartitioner<GraphType,Scalar>::Compute_Blocks_AutoLine(Teuchos::ArrayVie
   if(coord_->getNumVectors() > 1) { yvalsRCP = coord_->getData(1); yvals = yvalsRCP(); }
   if(coord_->getNumVectors() > 2) { zvalsRCP = coord_->getData(2); zvals = zvalsRCP(); }
 
-  MT tol                 = threshold_;
+  double tol             = threshold_;
   size_t N               = this->Graph_->getNodeNumRows();
   size_t allocated_space = this->Graph_->getNodeMaxNumRowEntries();
 
-  Teuchos::Array<LO> cols(allocated_space);
-  Teuchos::Array<LO> indices(allocated_space);
-  Teuchos::Array<MT> dist(allocated_space);
+  Teuchos::Array<LO>     cols(allocated_space);
+  Teuchos::Array<LO>     indices(allocated_space);
+  Teuchos::Array<double> dist(allocated_space);
 
-  Teuchos::Array<LO> itemp(2*allocated_space);
-  Teuchos::Array<MT> dtemp(allocated_space);
+  Teuchos::Array<LO>     itemp(2*allocated_space);
+  Teuchos::Array<double> dtemp(allocated_space);
 
   LO num_lines = 0;
 
@@ -145,18 +144,18 @@ int LinePartitioner<GraphType,Scalar>::Compute_Blocks_AutoLine(Teuchos::ArrayVie
 
     LO neighbor_len=0;
     for(size_t j=0; j<nz; j+=NumEqns_) {
-      MT mydist = mzero;
+      double mydist = zero;
       LO nn = cols[j] / NumEqns_;
       if(cols[j] >=(LO)N) continue; // Check for off-proc entries
       if(!xvals.is_null()) mydist += square<double>(x0 - xvals[nn]);
       if(!yvals.is_null()) mydist += square<double>(y0 - yvals[nn]);
       if(!zvals.is_null()) mydist += square<double>(z0 - zvals[nn]);
-      dist[neighbor_len] = Teuchos::ScalarTraits<MT>::squareroot(mydist);
+      dist[neighbor_len] = Teuchos::ScalarTraits<double>::squareroot(mydist);
       indices[neighbor_len]=cols[j];
       neighbor_len++;
     }
 
-    Teuchos::ArrayView<MT> dist_view = dist(0,neighbor_len);
+    Teuchos::ArrayView<double> dist_view = dist(0,neighbor_len);
     Tpetra::sort2(dist_view.begin(),dist_view.end(),indices.begin());
 
     // Number myself
@@ -178,11 +177,10 @@ int LinePartitioner<GraphType,Scalar>::Compute_Blocks_AutoLine(Teuchos::ArrayVie
 }
 // ============================================================================
 template<class GraphType,class Scalar>
-void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns, Teuchos::ArrayView <local_ordinal_type> blockIndices, local_ordinal_type last, local_ordinal_type next,  local_ordinal_type LineID, MT tol,  Teuchos::Array<local_ordinal_type> itemp, Teuchos::Array<MT> dtemp) const {
+void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns, Teuchos::ArrayView <local_ordinal_type> blockIndices, local_ordinal_type last, local_ordinal_type next,  local_ordinal_type LineID, double tol,  Teuchos::Array<local_ordinal_type> itemp, Teuchos::Array<double> dtemp) const {
   typedef local_ordinal_type LO;
   const LO invalid  = Teuchos::OrdinalTraits<LO>::invalid();
   const double zero = Teuchos::ScalarTraits<double>::zero();
-  const MT mzero    = Teuchos::ScalarTraits<MT>::zero();
 
   Teuchos::ArrayRCP<const double>  xvalsRCP, yvalsRCP, zvalsRCP;
   Teuchos::ArrayView<const double> xvals, yvals, zvals;
@@ -192,9 +190,9 @@ void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns,
 
   size_t N               = this->Graph_->getNodeNumRows();
   size_t allocated_space = this->Graph_->getNodeMaxNumRowEntries();
-  Teuchos::ArrayView<LO> cols    = itemp();
-  Teuchos::ArrayView<LO> indices = itemp.view(allocated_space,allocated_space);
-  Teuchos::ArrayView<MT> dist= dtemp();
+  Teuchos::ArrayView<LO>     cols    = itemp();
+  Teuchos::ArrayView<LO>     indices = itemp.view(allocated_space,allocated_space);
+  Teuchos::ArrayView<double> dist= dtemp();
 
   while (blockIndices[next] == invalid) {
     // Get the next row
@@ -209,14 +207,14 @@ void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns,
     // Calculate neighbor distances & sort
     LO neighbor_len=0;
     for(size_t i=0; i<nz; i+=NumEqns) {
-      MT mydist = mzero;
+      double mydist = zero;
       if(cols[i] >=(LO)N) continue; // Check for off-proc entries
       LO nn = cols[i] / NumEqns;
       if(blockIndices[nn]==LineID) neighbors_in_line++;
       if(!xvals.is_null()) mydist += square<double>(x0 - xvals[nn]);
       if(!yvals.is_null()) mydist += square<double>(y0 - yvals[nn]);
       if(!zvals.is_null()) mydist += square<double>(z0 - zvals[nn]);
-      dist[neighbor_len] = Teuchos::ScalarTraits<MT>::squareroot(mydist);
+      dist[neighbor_len] = Teuchos::ScalarTraits<double>::squareroot(mydist);
       indices[neighbor_len]=cols[i];
       neighbor_len++;
     }
@@ -229,7 +227,7 @@ void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns,
       blockIndices[next + k] = LineID;
 
     // Try to find the next guy in the line (only check the closest two that aren't element 0 (diagonal))
-    Teuchos::ArrayView<MT> dist_view = dist(0,neighbor_len);
+    Teuchos::ArrayView<double> dist_view = dist(0,neighbor_len);
     Tpetra::sort2(dist_view.begin(),dist_view.end(),indices.begin());
 
     if(neighbor_len > 2 && indices[1] != last && blockIndices[indices[1]] == -1 && dist[1]/dist[neighbor_len-1] < tol) {

--- a/packages/ifpack2/src/Ifpack2_LinePartitioner_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LinePartitioner_def.hpp
@@ -110,11 +110,11 @@ template<class GraphType,class Scalar>
 int LinePartitioner<GraphType,Scalar>::Compute_Blocks_AutoLine(Teuchos::ArrayView<local_ordinal_type> blockIndices) const {
   typedef local_ordinal_type LO;
   const LO invalid  = Teuchos::OrdinalTraits<LO>::invalid();
-  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+  const double zero = Teuchos::ScalarTraits<double>::zero();
   const MT mzero    = Teuchos::ScalarTraits<MT>::zero();
 
-  Teuchos::ArrayRCP<const Scalar>  xvalsRCP, yvalsRCP, zvalsRCP;
-  Teuchos::ArrayView<const Scalar> xvals, yvals, zvals;
+  Teuchos::ArrayRCP<const double>  xvalsRCP, yvalsRCP, zvalsRCP;
+  Teuchos::ArrayView<const double> xvals, yvals, zvals;
   xvalsRCP = coord_->getData(0); xvals = xvalsRCP();
   if(coord_->getNumVectors() > 1) { yvalsRCP = coord_->getData(1); yvals = yvalsRCP(); }
   if(coord_->getNumVectors() > 2) { zvalsRCP = coord_->getData(2); zvals = zvalsRCP(); }
@@ -139,18 +139,18 @@ int LinePartitioner<GraphType,Scalar>::Compute_Blocks_AutoLine(Teuchos::ArrayVie
 
     // Get neighbors and sort by distance
     this->Graph_->getLocalRowCopy(i,cols(),nz);
-    Scalar x0 = (!xvals.is_null()) ? xvals[i/NumEqns_] : zero;
-    Scalar y0 = (!yvals.is_null()) ? yvals[i/NumEqns_] : zero;
-    Scalar z0 = (!zvals.is_null()) ? zvals[i/NumEqns_] : zero;
+    double x0 = (!xvals.is_null()) ? xvals[i/NumEqns_] : zero;
+    double y0 = (!yvals.is_null()) ? yvals[i/NumEqns_] : zero;
+    double z0 = (!zvals.is_null()) ? zvals[i/NumEqns_] : zero;
 
     LO neighbor_len=0;
     for(size_t j=0; j<nz; j+=NumEqns_) {
       MT mydist = mzero;
       LO nn = cols[j] / NumEqns_;
       if(cols[j] >=(LO)N) continue; // Check for off-proc entries
-      if(!xvals.is_null()) mydist += square<Scalar>(x0 - xvals[nn]);
-      if(!yvals.is_null()) mydist += square<Scalar>(y0 - yvals[nn]);
-      if(!zvals.is_null()) mydist += square<Scalar>(z0 - zvals[nn]);
+      if(!xvals.is_null()) mydist += square<double>(x0 - xvals[nn]);
+      if(!yvals.is_null()) mydist += square<double>(y0 - yvals[nn]);
+      if(!zvals.is_null()) mydist += square<double>(z0 - zvals[nn]);
       dist[neighbor_len] = Teuchos::ScalarTraits<MT>::squareroot(mydist);
       indices[neighbor_len]=cols[j];
       neighbor_len++;
@@ -181,11 +181,11 @@ template<class GraphType,class Scalar>
 void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns, Teuchos::ArrayView <local_ordinal_type> blockIndices, local_ordinal_type last, local_ordinal_type next,  local_ordinal_type LineID, MT tol,  Teuchos::Array<local_ordinal_type> itemp, Teuchos::Array<MT> dtemp) const {
   typedef local_ordinal_type LO;
   const LO invalid  = Teuchos::OrdinalTraits<LO>::invalid();
-  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+  const double zero = Teuchos::ScalarTraits<double>::zero();
   const MT mzero    = Teuchos::ScalarTraits<MT>::zero();
 
-  Teuchos::ArrayRCP<const Scalar>  xvalsRCP, yvalsRCP, zvalsRCP;
-  Teuchos::ArrayView<const Scalar> xvals, yvals, zvals;
+  Teuchos::ArrayRCP<const double>  xvalsRCP, yvalsRCP, zvalsRCP;
+  Teuchos::ArrayView<const double> xvals, yvals, zvals;
   xvalsRCP = coord_->getData(0); xvals = xvalsRCP();
   if(coord_->getNumVectors() > 1) { yvalsRCP = coord_->getData(1); yvals = yvalsRCP(); }
   if(coord_->getNumVectors() > 2) { zvalsRCP = coord_->getData(2); zvals = zvalsRCP(); }
@@ -202,9 +202,9 @@ void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns,
     LO neighbors_in_line=0;
 
     this->Graph_->getLocalRowCopy(next,cols(),nz);
-    Scalar x0 = (!xvals.is_null()) ? xvals[next/NumEqns_] : zero;
-    Scalar y0 = (!yvals.is_null()) ? yvals[next/NumEqns_] : zero;
-    Scalar z0 = (!zvals.is_null()) ? zvals[next/NumEqns_] : zero;
+    double x0 = (!xvals.is_null()) ? xvals[next/NumEqns_] : zero;
+    double y0 = (!yvals.is_null()) ? yvals[next/NumEqns_] : zero;
+    double z0 = (!zvals.is_null()) ? zvals[next/NumEqns_] : zero;
 
     // Calculate neighbor distances & sort
     LO neighbor_len=0;
@@ -213,9 +213,9 @@ void LinePartitioner<GraphType,Scalar>::local_automatic_line_search(int NumEqns,
       if(cols[i] >=(LO)N) continue; // Check for off-proc entries
       LO nn = cols[i] / NumEqns;
       if(blockIndices[nn]==LineID) neighbors_in_line++;
-      if(!xvals.is_null()) mydist += square<Scalar>(x0 - xvals[nn]);
-      if(!yvals.is_null()) mydist += square<Scalar>(y0 - yvals[nn]);
-      if(!zvals.is_null()) mydist += square<Scalar>(z0 - zvals[nn]);
+      if(!xvals.is_null()) mydist += square<double>(x0 - xvals[nn]);
+      if(!yvals.is_null()) mydist += square<double>(y0 - yvals[nn]);
+      if(!zvals.is_null()) mydist += square<double>(z0 - zvals[nn]);
       dist[neighbor_len] = Teuchos::ScalarTraits<MT>::squareroot(mydist);
       indices[neighbor_len]=cols[i];
       neighbor_len++;

--- a/packages/muelu/test/scaling/sa_with_Ifpack2_line_detection.xml
+++ b/packages/muelu/test/scaling/sa_with_Ifpack2_line_detection.xml
@@ -30,7 +30,6 @@
     <ParameterList name="smoother: params">
       <Parameter name="relaxation: type"                  type="string" value="Jacobi"/>
       <Parameter name="relaxation: sweeps"                type="int"    value="1"/>
-      <Parameter name="relaxation: damping factor"        type="double" value="0.8"/>
       <Parameter name="partitioner: type"                 type="string" value="line"/>
     </ParameterList>
 


### PR DESCRIPTION
@trilinos/ifpack2 

## Description
This pull request is fixing a templating issue for the multivector of coordinates passed to Ifpack2 when the line partitioner is being used.

## Motivation and Context
This will allow MueLu users to access the line detection algorithm implemented for Block Relaxation in Ifpack2. This is useful as a smoother in certain situations. 

## Related Issues
* Closes #2551 
* Follows #2520 #2523 

## How Has This Been Tested?
A unite test in MueLu is using this capability and now passes for both double and std::complex<double>

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
