### PR TITLE
Panzer:  Use CONTRIBUTES-Style Integrator_BasisTimesScalar

### DIFF
--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_MixedPoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_MixedPoissonEquationSet_impl.hpp
@@ -54,7 +54,6 @@
 #include "Panzer_BasisIRLayout.hpp"
 
 // include evaluators here
-#include "Panzer_Integrator_BasisTimesScalar.hpp"
 #include "Panzer_Integrator_GradBasisDotVector.hpp"
 #include "Panzer_Integrator_DivBasisTimesScalar.hpp"
 #include "Panzer_ScalarToVector.hpp"

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_PoissonEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_PoissonEquationSet_impl.hpp
@@ -135,29 +135,33 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 				      const panzer::FieldLibrary& /* fl */,
 				      const Teuchos::ParameterList& /* user_data */) const
 {
+  using panzer::BasisIRLayout;
+  using panzer::EvaluatorStyle;
+  using panzer::IntegrationRule;
+  using panzer::Integrator_BasisTimesScalar;
+  using panzer::Integrator_GradBasisDotVector;
+  using panzer::Traits;
+  using PHX::Evaluator;
+  using std::string;
   using Teuchos::ParameterList;
   using Teuchos::RCP;
   using Teuchos::rcp;
   
-  Teuchos::RCP<panzer::IntegrationRule> ir = this->getIntRuleForDOF("TEMPERATURE");
-  Teuchos::RCP<panzer::BasisIRLayout> basis = this->getBasisIRLayoutForDOF("TEMPERATURE"); 
+  RCP<IntegrationRule> ir = this->getIntRuleForDOF("TEMPERATURE");
+  RCP<BasisIRLayout> basis = this->getBasisIRLayoutForDOF("TEMPERATURE"); 
 
   // ********************
   // Energy Equation
   // ********************
 
   // Transient Operator: Assembles \int \dot{T} v
-  if (this->buildTransientSupport()) {
-    ParameterList p("Transient Residual");
-    p.set("Residual Name", "RESIDUAL_TEMPERATURE_TRANSIENT_OP"); // we are defining the name of this operator
-    p.set("Value Name", "DXDT_TEMPERATURE"); // this field is constructed by the panzer library
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", 1.0);
-
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-    
+  if (this->buildTransientSupport())
+  {
+    string resName("RESIDUAL_TEMPERATURE"), valName("DXDT_TEMPERATURE");
+    double multiplier(1);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+      resName, valName, *basis, *ir, multiplier));
     this->template registerEvaluator<EvalT>(fm, op);
   }
 
@@ -166,47 +170,28 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     double thermal_conductivity = 1.0;
 
     ParameterList p("Diffusion Residual");
-    p.set("Residual Name", "RESIDUAL_TEMPERATURE_DIFFUSION_OP");
+    p.set("Residual Name", "RESIDUAL_TEMPERATURE");
     p.set("Flux Name", "GRAD_TEMPERATURE"); // this field is constructed by the panzer library
     p.set("Basis", basis);
     p.set("IR", ir);
     p.set("Multiplier", thermal_conductivity);
     
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_GradBasisDotVector<EvalT,panzer::Traits>(p));
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_GradBasisDotVector<EvalT, Traits>(p));
 
     this->template registerEvaluator<EvalT>(fm, op);
   }
   
   // Source Operator
   {   
-    ParameterList p("Source Residual");
-    p.set("Residual Name", "RESIDUAL_TEMPERATURE_SOURCE_OP");
-    p.set("Value Name", "SOURCE_TEMPERATURE"); // this field must be provided by the closure model factory
-                                               // and specified by the user
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", -1.0);
-    
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-    
+    string resName("RESIDUAL_TEMPERATURE"),
+           valName("SOURCE_TEMPERATURE");
+    double multiplier(-1);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+      resName, valName, *basis, *ir, multiplier));
     this->template registerEvaluator<EvalT>(fm, op);
   }
-
-  // Use a sum operator to form the overall residual for the equation
-  {
-    std::vector<std::string> sum_names;
-
-    // these are the names of the residual values to sum together
-    sum_names.push_back("RESIDUAL_TEMPERATURE_DIFFUSION_OP");
-    sum_names.push_back("RESIDUAL_TEMPERATURE_SOURCE_OP");
-    if (this->buildTransientSupport())
-      sum_names.push_back("RESIDUAL_TEMPERATURE_TRANSIENT_OP");
-
-    this->buildAndRegisterResidualSummationEvaluator(fm,"TEMPERATURE",sum_names);
-  }
-
 }
 
 // ***********************************************************************

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_NeumannMatch_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_NeumannMatch_impl.hpp
@@ -126,14 +126,14 @@ buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 
   if (this->getDetailsIndex() == 0) {
     { // add contribution to the residual 
-      ParameterList p("Neumann Match Residual");
-      p.set("Residual Name", residual_name);
-      p.set("Value Name", flux_name);
-      p.set("Basis", basis);
-      p.set("IR", ir);
-      p.set("Multiplier", 1.0);
-      const RCP< PHX::Evaluator<panzer::Traits> >
-        op = rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
+      using panzer::EvaluatorStyle;
+      using panzer::Integrator_BasisTimesScalar;
+      using panzer::Traits;
+      using PHX::Evaluator;
+      double multiplier(1);
+      const RCP<Evaluator<Traits>> op = rcp(new
+        Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::EVALUATES,
+        residual_name, flux_name, *basis, *ir, multiplier));
       this->template registerEvaluator<EvalT>(fm, op);
     }
   } else {

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_WeakDirichletMatch_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Interface_WeakDirichletMatch_impl.hpp
@@ -217,14 +217,14 @@ buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
         this->template registerEvaluator<EvalT>(fm, op);
       }
       {
-        ParameterList p("Weak Dirichlet Match And Cancel Neumann Residual");
-        p.set("Residual Name", residual_name);
-        p.set("Value Name", sum_contributions_name);
-        p.set("Basis", basis);
-        p.set("IR", ir);
-        p.set("Multiplier", 1.0);
-        const RCP< PHX::Evaluator<panzer::Traits> >
-          op = rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
+        using panzer::EvaluatorStyle;
+        using panzer::Integrator_BasisTimesScalar;
+        using panzer::Traits;
+        using PHX::Evaluator;
+        double multiplier(1);
+        const RCP<Evaluator<Traits>> op = rcp(new
+          Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::EVALUATES,
+          residual_name, sum_contributions_name, *basis, *ir, multiplier));
         this->template registerEvaluator<EvalT>(fm, op);
       }
     }

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Neumann_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_BCStrategy_Neumann_Constant_impl.hpp
@@ -136,16 +136,14 @@ using std::string;
 
   // add contribution to the residual 
   {
-    ParameterList p("Constant Neumann Residual");
-    p.set("Residual Name", residual_name);
-    p.set("Value Name", flux_name);
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", 1.0);
-    
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-    
+    using panzer::EvaluatorStyle;
+    using panzer::Integrator_BasisTimesScalar;
+    using panzer::Traits;
+    using PHX::Evaluator;
+    double multiplier(1);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::EVALUATES,
+      residual_name, flux_name, *basis, *ir, multiplier));
     this->template registerEvaluator<EvalT>(fm, op);
   }
 }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar.cpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar.cpp
@@ -41,14 +41,8 @@
 // @HEADER
 
 #include "PanzerDiscFE_config.hpp"
-
-#ifdef HAVE_PANZER_EXPLICIT_INSTANTIATION
-
 #include "Panzer_ExplicitTemplateInstantiation.hpp"
-
-#include "Panzer_Integrator_BasisTimesScalar_decl.hpp"
+#include "Panzer_Integrator_BasisTimesScalar.hpp"
 #include "Panzer_Integrator_BasisTimesScalar_impl.hpp"
 
 PANZER_INSTANTIATE_TEMPLATE_CLASS_TWO_T(panzer::Integrator_BasisTimesScalar)
-
-#endif

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar.hpp
@@ -40,8 +40,8 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef   __Panzer_Integrator_BasisTimesScalar_decl_hpp__
-#define   __Panzer_Integrator_BasisTimesScalar_decl_hpp__
+#ifndef   PANZER_INTEGRATOR_BASISTIMESSCALAR_HPP
+#define   PANZER_INTEGRATOR_BASISTIMESSCALAR_HPP
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -70,11 +70,11 @@ namespace panzer
    *
    *  Evaluates the integral
    *  \f[
-        Ma(x)b(x)\cdots\int s(x)\phi(x)\,dx,
-      \f]
+   *    Ma(x)b(x)\cdots\int s(x)\phi(x)\,dx,
+   *  \f]
    *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc., are
    *  some fields that depend on position, \f$ s \f$ is some scalar function,
-   *  and \f$ \phi \f$ is some basis.
+   *  and \f$ \phi \f$ is some scalar basis.
    */
   template<typename EvalT, typename Traits>
   class Integrator_BasisTimesScalar
@@ -89,11 +89,11 @@ namespace panzer
        *
        *  Creates an `Evaluator` to evaluate the integral
        *  \f[
-            Ma(x)b(x)\cdots\int s(x)\phi(x)\,dx,
-          \f]
+       *    Ma(x)b(x)\cdots\int s(x)\phi(x)\,dx,
+       *  \f]
        *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc.,
        *  are some fields that depend on position, \f$ s \f$ is some scalar
-       *  function, and \f$ \phi \f$ is some basis.
+       *  function, and \f$ \phi \f$ is some scalar basis.
        *
        *  \param[in] evalStyle  An `enum` declaring the behavior of this
        *                        `Evaluator`, which is to either:
@@ -103,8 +103,8 @@ namespace panzer
        *                        field, depending on `evalStyle`.
        *  \param[in] valName    The name of the scalar value being integrated
        *                        (\f$ s \f$).
-       *  \param[in] basis      The basis that you'd like to use (\f$ \phi
-                                \f$).
+       *  \param[in] basis      The scalar basis that you'd like to use (\f$
+       *                        \phi \f$).
        *  \param[in] ir         The integration rule that you'd like to use.
        *  \param[in] multiplier The scalar multiplier out in front of the
        *                        integral you're computing (\f$ M \f$).  If not
@@ -133,11 +133,11 @@ namespace panzer
        *
        *  Creates an `Evaluator` to evaluate the integral
        *  \f[
-            Ma(x)b(x)\cdots\int s(x)\phi(x)\,dx,
-          \f]
+       *    Ma(x)b(x)\cdots\int s(x)\phi(x)\,dx,
+       *  \f]
        *  where \f$ M \f$ is some constant, \f$ a(x) \f$, \f$ b(x) \f$, etc.,
        *  are some fields that depend on position, \f$ s \f$ is some scalar
-       *  function, and \f$ \phi \f$ is some basis.
+       *  function, and \f$ \phi \f$ is some scalar basis.
        *
        *  \note This constructor exists to preserve the older way of creating
        *        an `Evaluator` with a `ParameterList`; however, it is
@@ -161,8 +161,8 @@ namespace panzer
        *                 `Evaluator` is evaluating,
        *               - "Value Name" is the name of the scalar value being
        *                 integrated (\f$ s \f$),
-       *               - "Basis" is the basis that you'd like to use (\f$ \phi
-                         \f$),
+       *               - "Basis" is the scalar basis that you'd like to use
+       *                 (\f$ \phi \f$),
        *               - "IR" is the integration rule that you'd like to use,
        *               - "Multiplier" is the scalar multiplier out in front of
        *                 the integral you're computing (\f$ M \f$), and
@@ -217,7 +217,7 @@ namespace panzer
        *  Generally speaking, for a given cell in the `Workset`, this routine
        *  loops over quadrature points and bases to perform the integration,
        *  scaling the vector field to be integrated by the multiplier (\f$ M
-          \f$) and any field multipliers (\f$ a(x) \f$, \f$ b(x) \f$, etc.).
+       *  \f$) and any field multipliers (\f$ a(x) \f$, \f$ b(x) \f$, etc.).
        *
        *  \note Optimizations are made for the cases in which we have no field
        *        multipliers or only a single one.
@@ -276,7 +276,7 @@ namespace panzer
 
       /**
        *  \brief The scalar multiplier out in front of the integral (\f$ M
-                 \f$).
+       *         \f$).
        */
       double multiplier_;
 
@@ -319,4 +319,4 @@ namespace panzer
 
 } // end of namespace panzer
 
-#endif // __Panzer_Integrator_BasisTimesScalar_decl_hpp__
+#endif // PANZER_INTEGRATOR_BASISTIMESSCALAR_HPP

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesScalar_impl.hpp
@@ -40,8 +40,8 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef   __Panzer_Integrator_BasisTimesScalar_impl_hpp__
-#define   __Panzer_Integrator_BasisTimesScalar_impl_hpp__
+#ifndef   PANZER_INTEGRATOR_BASISTIMESSCALAR_IMPL_HPP
+#define   PANZER_INTEGRATOR_BASISTIMESSCALAR_IMPL_HPP
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -127,10 +127,10 @@ namespace panzer
     // Set the name of this object.
     string n("Integrator_BasisTimesScalar (");
     if (evalStyle_ == EvaluatorStyle::CONTRIBUTES)
-      n += "Cont";
+      n += "CONTRIBUTES";
     else // if (evalStyle_ == EvaluatorStyle::EVALUATES)
-      n += "Eval";
-    n += ", " + typeAsString<EvalT>() + "):  " + field_.fieldTag().name();
+      n += "EVALUATES";
+    n += "):  " + field_.fieldTag().name();
     this->setName(n);
   } // end of Main Constructor
 
@@ -320,4 +320,4 @@ namespace panzer
 
 } // end of namespace panzer
 
-#endif // __Panzer_Integrator_BasisTimesScalar_impl_hpp__
+#endif // PANZER_INTEGRATOR_BASISTIMESSCALAR_IMPL_HPP

--- a/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_Energy_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_Energy_impl.hpp
@@ -66,10 +66,10 @@
 template <typename EvalT>
 user_app::EquationSet_Energy<EvalT>::
 EquationSet_Energy(const Teuchos::RCP<Teuchos::ParameterList>& params,
-		   const int& default_integration_order,
-		   const panzer::CellData& cell_data,
-		   const Teuchos::RCP<panzer::GlobalData>& global_data,
-		   const bool build_transient_support) :
+                   const int& default_integration_order,
+                   const panzer::CellData& cell_data,
+                   const Teuchos::RCP<panzer::GlobalData>& global_data,
+                   const bool build_transient_support) :
   panzer::EquationSet_DefaultImpl<EvalT>(params,default_integration_order,cell_data,global_data,build_transient_support )
 {
   // ********************
@@ -124,37 +124,41 @@ EquationSet_Energy(const Teuchos::RCP<Teuchos::ParameterList>& params,
 template <typename EvalT>
 void user_app::EquationSet_Energy<EvalT>::
 buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
-				      const panzer::FieldLibrary& /* fl */,
-				      const Teuchos::ParameterList& /* user_data */) const
+                                      const panzer::FieldLibrary& /* fl */,
+                                      const Teuchos::ParameterList& /* user_data */) const
 {
+  using panzer::BasisIRLayout;
+  using panzer::EvaluatorStyle;
+  using panzer::IntegrationRule;
+  using panzer::Integrator_BasisTimesScalar;
+  using panzer::Integrator_GradBasisDotVector;
+  using panzer::ScalarToVector;
+  using panzer::Traits;
+  using PHX::Evaluator;
+  using std::string;
+  using std::vector;
   using Teuchos::ParameterList;
   using Teuchos::RCP;
   using Teuchos::rcp;
+  using user_app::Convection;
   // ********************
   // Energy Equation
   // ********************
 
-  Teuchos::RCP<panzer::IntegrationRule> ir = this->getIntRuleForDOF(m_dof_name); 
-  Teuchos::RCP<panzer::BasisIRLayout> basis = this->getBasisIRLayoutForDOF(m_dof_name); 
+  RCP<IntegrationRule> ir = this->getIntRuleForDOF(m_dof_name); 
+  RCP<BasisIRLayout> basis = this->getBasisIRLayoutForDOF(m_dof_name); 
 
   // Transient Operator
-  if (this->buildTransientSupport()) {
-    ParameterList p("Transient Residual");
-    p.set("Residual Name", "RESIDUAL_"+m_prefix+"TEMPERATURE_TRANSIENT_OP");
-    p.set("Value Name", "DXDT_"+m_prefix+"TEMPERATURE");
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", 1.0);
-    Teuchos::RCP<std::vector<std::string> > fms = 
-      Teuchos::rcp(new std::vector<std::string>);
-    fms->push_back(m_prefix+"DENSITY");
-    fms->push_back(m_prefix+"HEAT_CAPACITY");
-    p.set< Teuchos::RCP<const std::vector<std::string> > >("Field Multipliers",fms);
-
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      // rcp(new panzer::Integrator_TransientBasisTimesScalar<EvalT,panzer::Traits>(p));
-      rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-    
+  if (this->buildTransientSupport())
+  {
+    string resName("RESIDUAL_" + m_dof_name),
+           valName("DXDT_" + m_prefix + "TEMPERATURE");
+    double multiplier(1);
+    vector<string> fieldMultipliers{m_prefix + "DENSITY",
+      m_prefix + "HEAT_CAPACITY"};
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+      resName, valName, *basis, *ir, multiplier, fieldMultipliers));
     this->template registerEvaluator<EvalT>(fm, op);
   }
 
@@ -163,14 +167,14 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     double thermal_conductivity = 1.0;
 
     ParameterList p("Diffusion Residual");
-    p.set("Residual Name", "RESIDUAL_"+m_prefix+"TEMPERATURE_DIFFUSION_OP");
+    p.set("Residual Name", "RESIDUAL_"+m_dof_name);
     p.set("Flux Name", "GRAD_"+m_prefix+"TEMPERATURE");
     p.set("Basis", basis);
     p.set("IR", ir);
     p.set("Multiplier", thermal_conductivity);
     
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_GradBasisDotVector<EvalT,panzer::Traits>(p));
+    RCP< Evaluator<Traits> > op = 
+      rcp(new Integrator_GradBasisDotVector<EvalT,Traits>(p));
 
     this->template registerEvaluator<EvalT>(fm, op);
   }
@@ -181,16 +185,16 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     // Combine scalar velocities into a velocity vector
     {
       ParameterList p("Velocity: ScalarToVector");
-      RCP<std::vector<std::string> > scalar_names = rcp(new std::vector<std::string>);
+      RCP<vector<string> > scalar_names = rcp(new vector<string>);
       scalar_names->push_back(m_prefix+"UX");
       scalar_names->push_back(m_prefix+"UY");
-      p.set<RCP<const std::vector<std::string> > >("Scalar Names", scalar_names);
+      p.set<RCP<const vector<string> > >("Scalar Names", scalar_names);
       p.set("Vector Name", m_prefix+"U");
       p.set("Data Layout Scalar",ir->dl_scalar);
       p.set("Data Layout Vector",ir->dl_vector);
 
-      RCP< PHX::Evaluator<panzer::Traits> > op = 
-	rcp(new panzer::ScalarToVector<EvalT,panzer::Traits>(p));
+      RCP< Evaluator<Traits> > op = 
+        rcp(new ScalarToVector<EvalT,Traits>(p));
       
       this->template registerEvaluator<EvalT>(fm, op);
     }
@@ -204,64 +208,36 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
       p.set("Gradient Name", "GRAD_"+m_prefix+"TEMPERATURE");
       p.set("Multiplier", 1.0);
 
-      RCP< PHX::Evaluator<panzer::Traits> > op = 
-	rcp(new user_app::Convection<EvalT,panzer::Traits>(p));
+      RCP< Evaluator<Traits> > op = 
+        rcp(new Convection<EvalT,Traits>(p));
       
       this->template registerEvaluator<EvalT>(fm, op);
     }
 
     // Integration operator (could sum this into source for efficiency)
     {
-      ParameterList p("Convection Residual");
-      p.set("Residual Name","RESIDUAL_"+m_prefix+"TEMPERATURE_CONVECTION_OP");
-      p.set("Value Name", m_prefix+"TEMPERATURE_CONVECTION_OP");
-      p.set("Basis", basis);
-      p.set("IR", ir);
-      p.set("Multiplier", 1.0);
-      Teuchos::RCP<std::vector<std::string> > fms = 
-	Teuchos::rcp(new std::vector<std::string>);
-      fms->push_back(m_prefix+"DENSITY");
-      fms->push_back(m_prefix+"HEAT_CAPACITY");
-      p.set< Teuchos::RCP<const std::vector<std::string> > >("Field Multipliers",fms);
-      
-      RCP< PHX::Evaluator<panzer::Traits> > op = 
-	rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-      
+      string resName("RESIDUAL_" + m_dof_name),
+             valName(m_prefix + "TEMPERATURE_CONVECTION_OP");
+      double multiplier(1);
+      vector<string> fieldMultipliers{m_prefix + "DENSITY",
+        m_prefix + "HEAT_CAPACITY"};
+      RCP<Evaluator<Traits>> op = rcp(new
+        Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+        resName, valName, *basis, *ir, multiplier, fieldMultipliers));
       this->template registerEvaluator<EvalT>(fm, op);
     }
   }
 
   // Source Operator
   {   
-    ParameterList p("Source Residual");
-    p.set("Residual Name", "RESIDUAL_"+m_prefix+"TEMPERATURE_SOURCE_OP");
-    p.set("Value Name", "SOURCE_"+m_prefix+"TEMPERATURE");
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", -1.0);
-    
-    RCP< PHX::Evaluator<panzer::Traits> > op = 
-      rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-    
+    string resName("RESIDUAL_" + m_dof_name),
+           valName("SOURCE_" + m_prefix + "TEMPERATURE");
+    double multiplier(-1);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+      resName, valName, *basis, *ir, multiplier));
     this->template registerEvaluator<EvalT>(fm, op);
   }
-
-  // Use a sum operator to form the overall residual for the equation
-  // - this way we avoid loading each operator separately into the
-  // global residual and Jacobian
-  {
-    std::vector<std::string> residual_operator_names;
-
-    residual_operator_names.push_back("RESIDUAL_"+m_prefix+"TEMPERATURE_DIFFUSION_OP");
-    residual_operator_names.push_back("RESIDUAL_"+m_prefix+"TEMPERATURE_SOURCE_OP");
-    if (m_do_convection == "ON")
-      residual_operator_names.push_back("RESIDUAL_"+m_prefix+"TEMPERATURE_CONVECTION_OP");
-    if (this->buildTransientSupport())
-      residual_operator_names.push_back("RESIDUAL_"+m_prefix+"TEMPERATURE_TRANSIENT_OP");
-
-    this->buildAndRegisterResidualSummationEvaluator(fm,m_dof_name,residual_operator_names);
-  }
-
 }
 
 // ***********************************************************************

--- a/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_MeshCoords_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_EquationSet_MeshCoords_impl.hpp
@@ -123,6 +123,14 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
 				      const panzer::FieldLibrary& /* fl */,
 				      const Teuchos::ParameterList& /* user_data */) const
 {
+  using panzer::BasisIRLayout;
+  using panzer::EvaluatorStyle;
+  using panzer::IntegrationRule;
+  using panzer::Integrator_BasisTimesScalar;
+  using panzer::Traits;
+  using PHX::Evaluator;
+  using std::string;
+  using std::vector;
   using Teuchos::ParameterList;
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -130,58 +138,40 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
   // MeshCoords Equation
   // ********************
 
-  std::string coord_names[3] = {"X","Y","Z"};
-  std::string dof_names[3] = {"COORDX","COORDY","COORDZ"};
+  string coord_names[3] = {"X","Y","Z"};
+  string dof_names[3] = {"COORDX","COORDY","COORDZ"};
 
-  Teuchos::RCP<panzer::IntegrationRule> ir = this->getIntRuleForDOF(dof_names[0]); 
-  Teuchos::RCP<panzer::BasisIRLayout> basis = this->getBasisIRLayoutForDOF(dof_names[0]); 
+  RCP<IntegrationRule> ir = this->getIntRuleForDOF(dof_names[0]); 
+  RCP<BasisIRLayout> basis = this->getBasisIRLayoutForDOF(dof_names[0]); 
 
   // Transient Operator
-  if (this->buildTransientSupport()) {
-    for(int i=0;i<dimension_;i++) {
-      ParameterList p("Transient Residual");
-      p.set("Residual Name", "RESIDUAL_"+dof_names[i]+"_TRANSIENT_OP");
-      p.set("Value Name", "DXDT_"+dof_names[i]);
-      p.set("Basis", basis);
-      p.set("IR", ir);
-      p.set("Multiplier", 1.0);
-  
-      RCP< PHX::Evaluator<panzer::Traits> > op = 
-        rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-      
+  if (this->buildTransientSupport())
+  {
+    for (int i(0); i < dimension_; ++i)
+    {
+      string resName("RESIDUAL_" + dof_names[i]),
+             valName("DXDT_" + dof_names[i]);
+      double multiplier(1);
+      RCP<Evaluator<Traits>> op = rcp(new
+        Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+        resName, valName, *basis, *ir, multiplier));
       this->template registerEvaluator<EvalT>(fm, op);
     }
   }
-  else {
+  else
+  {
     TEUCHOS_ASSERT(false); // what does this even mean?
   }
 
-  for(int i=0;i<dimension_;i++) {
-    ParameterList p("Momentum Source Residual");
-    p.set("Residual Name", "RESIDUAL_"+dof_names[i]+"_SOURCE_OP");
-    p.set("Value Name", "NODE_VELOCITY_"+coord_names[i]);
-    p.set("Basis", basis);
-    p.set("IR", ir);
-    p.set("Multiplier", -1.0);
-
-    RCP< PHX::Evaluator<panzer::Traits> > op =
-      rcp(new panzer::Integrator_BasisTimesScalar<EvalT,panzer::Traits>(p));
-
-    this->template registerEvaluator<EvalT>(fm, op);
-  }
-
-  // Use a sum operator to form the overall residual for the equation
-  // - this way we avoid loading each operator separately into the
-  // global residual and Jacobian
+  for (int i(0); i < dimension_; ++i)
   {
-    for(int i=0;i<dimension_;i++) {
-      std::vector<std::string> residual_operator_names;
-
-      residual_operator_names.push_back("RESIDUAL_"+dof_names[i]+"_TRANSIENT_OP");
-      residual_operator_names.push_back("RESIDUAL_"+dof_names[i]+"_SOURCE_OP");
-
-      this->buildAndRegisterResidualSummationEvaluator(fm,dof_names[i],residual_operator_names);
-    }
+    string resName("RESIDUAL_" + dof_names[i]),
+           valName("NODE_VELOCITY_" + coord_names[i]);
+    double multiplier(-1);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(EvaluatorStyle::EVALUATES,
+      resName, valName, *basis, *ir, multiplier));
+    this->template registerEvaluator<EvalT>(fm, op);
   }
 }
 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_WeakGradient_impl.hpp
@@ -13,7 +13,6 @@
 #include "Panzer_BasisIRLayout.hpp"
 
 // include evaluators here
-#include "Panzer_Integrator_BasisTimesScalar.hpp"
 #include "Panzer_Integrator_BasisTimesVector.hpp"
 #include "Panzer_Integrator_GradBasisDotVector.hpp"
 #include "Panzer_ScalarToVector.hpp"


### PR DESCRIPTION
@trilinos/panzer 

## Description
Analogous to #2527.  `Integrator_BasisTimesScalar` was refactored as part of #1575.  This changes any uses of the class to use the new compile-time checked constructor, and anywhere possible the objects were switched from the `EVALUATES` to the `CONTRIBUTES` style.

## Motivation and Context
Decreased memory usage.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Related to #2535, #2526, #2527
* Part of #1575 

## How Has This Been Tested?
`ctest` "passes" on my RHEL7 machine.  There are a number of Drekar failures, but they were present on `develop` as well, so they probably don't have anything to do with these changes.

## Checklist
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.