### PR TITLE
Kokkos disable profiling if DLlib is disabled

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -23,7 +23,7 @@ IF (${Trilinos_ENABLE_Kokkos})
   endif()
   set(Kokkos_ENABLE_Profiling ${Kokkos_ENABLE_Profiling_DEFAULT}
     CACHE BOOL
-    "Enable bounds checking in Kokkos array classes.")
+    "Enable Kokkos profiling hooks.")
 
   # Basic initialization (Used in KOKKOS_SETTINGS)
   set(KOKKOS_SRC_PATH ${Kokkos_SOURCE_DIR})

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -14,6 +14,16 @@ IF (${Trilinos_ENABLE_Kokkos})
   set(Kokkos_ENABLE_Debug_Bounds_Check ${KOKKOS_ENABLE_DEBUG}
     CACHE BOOL
     "Enable bounds checking in Kokkos array classes.")
+  set(Kokkos_ENABLE_Profiling_DEFAULT ON)
+  if (DEFINED TPL_ENABLE_DLlib)
+    if (NOT TPL_ENABLE_DLlib)
+      message(STATUS  "Setting Kokkos_ENABLE_Profiling_DEFAULT=OFF because TPL_ENABLE_DLlib=${TPL_ENABLE_DLlib}")
+      set(Kokkos_ENABLE_Profiling_DEFAULT OFF)
+    endif()
+  endif()
+  set(Kokkos_ENABLE_Profiling ${Kokkos_ENABLE_Profiling_DEFAULT}
+    CACHE BOOL
+    "Enable bounds checking in Kokkos array classes.")
 
   # Basic initialization (Used in KOKKOS_SETTINGS)
   set(KOKKOS_SRC_PATH ${Kokkos_SOURCE_DIR})


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos 
@trilinos/framework 

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
Disable Kokkos profiling when the TPL `DLlib` is disabled.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Kokkos profiling requires `DLlib`, currently if one disables `DLlib` then there are link failures in Kokkos because profiling remains enabled.

## Related Issues
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
* Closes kokkos/kokkos#1422

## How Has This Been Tested?
Tested in a custom build that `-DTPL_ENABLE_DLlib:BOOL=OFF` causes Kokkos profiling to be disabled.