### PR TITLE
MueLu structured aggregation simplify inputs

### DIFF
--- a/packages/muelu/test/interface/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/Output/aggregation4_epetra.gold
@@ -65,6 +65,7 @@ Level 1
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]
@@ -143,6 +144,7 @@ Level 2
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]

--- a/packages/muelu/test/interface/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/aggregation4_tpetra.gold
@@ -75,6 +75,7 @@ Level 1
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]
@@ -163,6 +164,7 @@ Level 2
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]

--- a/packages/muelu/test/interface/Output/aggregation5_epetra.gold
+++ b/packages/muelu/test/interface/Output/aggregation5_epetra.gold
@@ -55,6 +55,7 @@ Level 1
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]
@@ -123,6 +124,7 @@ Level 2
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]

--- a/packages/muelu/test/interface/Output/aggregation5_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/aggregation5_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]
@@ -123,6 +124,7 @@ Level 2
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]

--- a/packages/muelu/test/interface/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/aggregation5_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]
@@ -143,6 +144,7 @@ Level 2
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]

--- a/packages/muelu/test/interface/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/Output/aggregation5_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]
@@ -143,6 +144,7 @@ Level 2
  Computing Ac (MueLu::RAPFactory)
  Build (MueLu::CoordinatesTransferFactory)
  structured aggregation = 0   [default]
+ aggregation coupled = 0   [default]
  Geometric = 0   [default]
  write start = -1   [default]
  write end = -1   [default]

--- a/packages/muelu/test/interface/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_epetra.gold
@@ -1,14 +1,11 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -69,6 +66,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -112,16 +110,13 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -182,6 +177,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -225,16 +221,13 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -295,6 +288,7 @@ Level 3
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -360,11 +354,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_epetra.gold
@@ -1,11 +1,14 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -110,13 +113,16 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20   [unused]
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -221,13 +227,16 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20   [unused]
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -354,11 +363,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_np4_epetra.gold
@@ -1,14 +1,11 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -69,6 +66,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -127,11 +125,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_np4_epetra.gold
@@ -1,11 +1,14 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -125,11 +128,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_np4_tpetra.gold
@@ -1,22 +1,17 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -136,11 +131,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_np4_tpetra.gold
@@ -1,17 +1,22 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -72,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -130,11 +136,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_tpetra.gold
@@ -1,17 +1,22 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -72,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -115,19 +121,24 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -188,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -231,19 +243,24 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -304,6 +321,7 @@ Level 3
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -369,11 +387,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar1_tpetra.gold
@@ -1,22 +1,17 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -121,24 +116,19 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -243,24 +233,19 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -387,11 +372,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_epetra.gold
@@ -1,14 +1,11 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -69,6 +66,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -112,16 +110,13 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -182,6 +177,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -225,16 +221,13 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -295,6 +288,7 @@ Level 3
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -360,11 +354,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_epetra.gold
@@ -1,11 +1,14 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -110,13 +113,16 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20   [unused]
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -221,13 +227,16 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20   [unused]
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -354,11 +363,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_np4_epetra.gold
@@ -1,14 +1,11 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 2   [unused]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -69,6 +66,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -127,11 +125,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_np4_epetra.gold
@@ -1,11 +1,14 @@
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+ Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -125,11 +128,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = Chebyshev}
 
-Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
+Smoother (level 2) both : MueLu::IfpackSmoother{type = Chebyshev}
 
 Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_np4_tpetra.gold
@@ -1,22 +1,17 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -136,11 +131,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_np4_tpetra.gold
@@ -1,17 +1,22 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -72,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -130,11 +136,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_tpetra.gold
@@ -1,17 +1,22 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -72,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -115,19 +121,24 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -188,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -231,19 +243,24 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 2
+  relaxation: damping factor = 1   [default]
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -304,6 +321,7 @@ Level 3
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -369,11 +387,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/Output/driver_drekar2_tpetra.gold
@@ -1,22 +1,17 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 1
  Build (MueLu::RebalanceTransferFactory)
@@ -121,24 +116,19 @@ Level 1
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 2
  Build (MueLu::RebalanceTransferFactory)
@@ -243,24 +233,19 @@ Level 2
  Computing Ac (MueLu::RebalanceAcFactory)
  repartition: use subcommunicators = 1   [default]
  
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
+  chebyshev: degree = 2
+  chebyshev: ratio eigenvalue = 20
+  chebyshev: min eigenvalue = 1
+  chebyshev: zero starting solution = 1
+  chebyshev: eigenvalue max iterations = 10
+  chebyshev: boost factor = 1.1   [unused]
+  chebyshev: min diagonal value = 2.22045e-16   [default]
+  chebyshev: assume matrix does not change = 0   [default]
  
 Level 3
  Build (MueLu::RebalanceTransferFactory)
@@ -387,11 +372,11 @@ level  rows    nnz  nnz/row  c ratio  procs
   2    1111   3331     3.00     3.00      1
   3     371   1111     2.99     2.99      1
 
-Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
+Smoother (level 1) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
+Smoother (level 2) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [1111, 1111], Global nnz: 3331}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/Output/repartition1_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/repartition1_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/repartition1_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/repartition1_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/Output/repartition3_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/repartition3_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/repartition3_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/Output/repartition3_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/Output/repartition4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/repartition4_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/repartition4_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/repartition4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-1_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-1_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-1_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-1_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-2_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-2_np4_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-2_np4_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RAP-2_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RP-2_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -250,6 +252,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -288,6 +291,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RP-2_np4_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -243,6 +245,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -281,6 +284,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RP-2_np4_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -273,6 +275,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -321,6 +324,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-RP-2_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -280,6 +282,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -328,6 +331,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-S-1_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -318,6 +320,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -429,6 +432,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-S-1_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -311,6 +313,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -422,6 +425,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-S-1_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -341,6 +343,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -462,6 +465,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-S-1_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -348,6 +350,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -469,6 +472,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-full-1_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-full-1_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-full-1_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-full-1_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-none_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -318,6 +320,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -429,6 +432,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-none_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -311,6 +313,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -422,6 +425,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-none_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -341,6 +343,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -462,6 +465,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-none_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -348,6 +350,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -469,6 +472,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-1_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -308,6 +310,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -380,6 +383,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-1_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -301,6 +303,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -373,6 +376,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-1_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -331,6 +333,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -413,6 +416,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-1_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -338,6 +340,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -420,6 +423,7 @@ Level 2
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-2_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -305,6 +307,7 @@ Level 1
   Computing Ac (MueLu::RAPFactory)
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -387,6 +390,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-2_np4_epetra.gold
@@ -67,6 +67,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -178,6 +179,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -298,6 +300,7 @@ Level 1
   Computing Ac (MueLu::RAPFactory)
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -380,6 +383,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-2_np4_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -328,6 +330,7 @@ Level 1
   Computing Ac (MueLu::RAPFactory)
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -420,6 +423,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-2_tpetra.gold
@@ -77,6 +77,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -198,6 +199,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -335,6 +337,7 @@ Level 1
   Computing Ac (MueLu::RAPFactory)
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -427,6 +430,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-3_epetra.gold
@@ -55,6 +55,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -154,6 +155,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -262,6 +264,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -332,6 +335,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-3_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -154,6 +155,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -255,6 +257,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -325,6 +328,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-3_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -174,6 +175,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -285,6 +287,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -365,6 +368,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/Output/reuse-tP-3_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -174,6 +175,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -292,6 +294,7 @@ Level 1
    Reusing previous RAP data
   Build (MueLu::CoordinatesTransferFactory)
   structured aggregation = 0   [default]
+  aggregation coupled = 0   [default]
   Geometric = 0   [default]
   write start = -1   [default]
   write end = -1   [default]
@@ -372,6 +375,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/Output/transpose2_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/transpose2_np4_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/transpose2_np4_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/Output/transpose2_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/Output/transpose3_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/Output/transpose3_np4_epetra.gold
@@ -63,6 +63,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -162,6 +163,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/Output/transpose3_np4_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/muelu/test/interface/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/Output/transpose3_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]
@@ -182,6 +183,7 @@ Level 2
     
    Build (MueLu::CoordinatesTransferFactory)
    structured aggregation = 0   [default]
+   aggregation coupled = 0   [default]
    Geometric = 0   [default]
    write start = -1   [default]
    write end = -1   [default]

--- a/packages/trilinoscouplings/examples/scaling/StructuredIntrepidPoisson_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/StructuredIntrepidPoisson_Pamgen_Tpetra_main.cpp
@@ -308,7 +308,7 @@ main (int argc, char *argv[])
               const std::string userName = "user data";
               Teuchos::ParameterList& userParamList = mueluParams.sublist(userName);
               Teuchos::Array<GO> gNodesPerDim(3, -1);
-              userParamList.set<Teuchos::Array<GO> >("Array<GO> gNodesPerDim", gNodesPerDim);
+              // userParamList.set<Teuchos::Array<GO> >("Array<GO> gNodesPerDim", gNodesPerDim);
               userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
 	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams,mueluParams);
 	    } else {

--- a/packages/trilinoscouplings/examples/scaling/StructuredIntrepidPoisson_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/StructuredIntrepidPoisson_Pamgen_Tpetra_main.cpp
@@ -307,8 +307,6 @@ main (int argc, char *argv[])
 	      ParameterList mueluParams = inputList.sublist("MueLu");
               const std::string userName = "user data";
               Teuchos::ParameterList& userParamList = mueluParams.sublist(userName);
-              Teuchos::Array<GO> gNodesPerDim(3, -1);
-              // userParamList.set<Teuchos::Array<GO> >("Array<GO> gNodesPerDim", gNodesPerDim);
               userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
 	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams,mueluParams);
 	    } else {


### PR DESCRIPTION
This change removes an unecessary dependency on user input data in MueLu
 which will make the code interface simpler for users.

@trilinos/muelu 

## Description
This modification removes a data dependency in structured aggregation and coordinates transfer factories in the case of uncoupled aggregation. This will in turn simplify the code interface for application developers by requiring less input data.

## Motivation and Context
Some application developers need to pass minimal amount of data for performance and code cleanliness.


## How Has This Been Tested?
I am using the test in trilinoscouplings that exercises structured aggregation in uncoupled mode.