### PR TITLE
Panzer:  Fix Compiler Warnings

### DIFF
--- a/packages/panzer/adapters-ioss/src/Panzer_IOSSConnManager_impl.hpp
+++ b/packages/panzer/adapters-ioss/src/Panzer_IOSSConnManager_impl.hpp
@@ -655,10 +655,10 @@ void IOSSConnManager<GO>::buildOffsetsAndIdCounts(const panzer::FieldPattern & f
   {
     case 3:
       faceIdCnt = fp.getSubcellIndices(2,0).size();
-      [[gnu::fallthrough]];
+      // Intentional fall-through.
     case 2:
       edgeIdCnt = fp.getSubcellIndices(1,0).size();
-      [[gnu::fallthrough]];
+      // Intentional fall-through.
     case 1:
       nodeIdCnt = fp.getSubcellIndices(0,0).size();
       cellIdCnt = fp.getSubcellIndices(patternDim,0).size();

--- a/packages/panzer/adapters-stk/src/Panzer_STKConnManager_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STKConnManager_impl.hpp
@@ -180,10 +180,10 @@ void STKConnManager<GO>::buildOffsetsAndIdCounts(const panzer::FieldPattern & fp
    switch(patternDim) {
    case 3:
      faceIdCnt = fp.getSubcellIndices(2,0).size();
-     [[gnu::fallthrough]];
+     // Intentional fall-through.
    case 2:
      edgeIdCnt = fp.getSubcellIndices(1,0).size();
-     [[gnu::fallthrough]];
+     // Intentional fall-through.
    case 1:
      nodeIdCnt = fp.getSubcellIndices(0,0).size();
      cellIdCnt = fp.getSubcellIndices(patternDim,0).size();

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallbackBlocked_impl.hpp
@@ -223,11 +223,11 @@ void ParameterListCallbackBlocked<LocalOrdinalT,GlobalOrdinalT,Node>::buildCoord
    case 3:
       zcoords_[field].resize(coordsVec_->getLocalLength()); 
       coordsVec_->getVector(2)->get1dCopy(Teuchos::arrayViewFromVector(zcoords_[field]));
-      [[gnu::fallthrough]];
+      // Intentional fall-through.
    case 2:
       ycoords_[field].resize(coordsVec_->getLocalLength()); 
       coordsVec_->getVector(1)->get1dCopy(Teuchos::arrayViewFromVector(ycoords_[field]));
-      [[gnu::fallthrough]];
+      // Intentional fall-through.
    case 1:
       xcoords_[field].resize(coordsVec_->getLocalLength()); 
       coordsVec_->getVector(0)->get1dCopy(Teuchos::arrayViewFromVector(xcoords_[field]));

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallback_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ParameterListCallback_impl.hpp
@@ -159,11 +159,11 @@ void ParameterListCallback<LocalOrdinalT,GlobalOrdinalT,Node>::buildCoordinates(
    case 3:
       zcoords_.resize(resultVec->getLocalLength()); 
       resultVec->getVector(2)->get1dCopy(Teuchos::arrayViewFromVector(zcoords_));
-      [[gnu::fallthrough]];
+      // Intentional fall-through.
    case 2:
       ycoords_.resize(resultVec->getLocalLength()); 
       resultVec->getVector(1)->get1dCopy(Teuchos::arrayViewFromVector(ycoords_));
-      [[gnu::fallthrough]];
+      // Intentional fall-through.
    case 1:
       xcoords_.resize(resultVec->getLocalLength()); 
       resultVec->getVector(0)->get1dCopy(Teuchos::arrayViewFromVector(xcoords_));

--- a/packages/panzer/adapters-stk/src/Panzer_STK_SetupLOWSFactory_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_SetupLOWSFactory_impl.hpp
@@ -303,11 +303,11 @@ namespace {
              case 3:
                 vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&zcoords[0])));
                 EpetraExt::VectorToMatrixMarketFile("zcoords.mm",*vec);
-                [[gnu::fallthrough]];
+                // Intentional fall-through.
              case 2:
                 vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&ycoords[0])));
                 EpetraExt::VectorToMatrixMarketFile("ycoords.mm",*vec);
-                [[gnu::fallthrough]];
+                // Intentional fall-through.
              case 1:
                 vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&xcoords[0])));
                 EpetraExt::VectorToMatrixMarketFile("xcoords.mm",*vec);
@@ -419,11 +419,11 @@ namespace {
             case 3:
                vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&zcoords[0])));
                EpetraExt::VectorToMatrixMarketFile((fieldName+"_zcoords.mm").c_str(),*vec);
-               [[gnu::fallthrough]];
+               // Intentional fall-through.
             case 2:
                vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&ycoords[0])));
                EpetraExt::VectorToMatrixMarketFile((fieldName+"_ycoords.mm").c_str(),*vec);
-               [[gnu::fallthrough]];
+               // Intentional fall-through.
             case 1:
                vec = rcp(new Epetra_Vector(Copy,map,const_cast<double *>(&xcoords[0])));
                EpetraExt::VectorToMatrixMarketFile((fieldName+"_xcoords.mm").c_str(),*vec);


### PR DESCRIPTION
@trilinos/panzer 

## Description
PR #2541 apparently cleaned up warnings for gcc-7.3, but created warnings for gcc-4.x&mdash;go figure.  Hopefully this fix takes care of both.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.