### PR TITLE
Tpetra: Fix for #2574

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxationPerf.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxationPerf.cpp
@@ -18,7 +18,7 @@
 #include "ml_MultiLevelPreconditioner.h"
 
 #include <Tpetra_DefaultPlatform.hpp>
-#include <Tpetra_CrsMatrix_def.hpp>
+#include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_MultiVector_def.hpp>
 #include <Tpetra_Vector_def.hpp>
 #include <Tpetra_RowMatrix_def.hpp>

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -6624,15 +6624,17 @@ namespace Tpetra {
       destGraph->reallocImportsIfNeeded(rbufLen);
     }
 
-    // packAndPrepare* methods modify numExportPacketsPerLID_.
-    destGraph->numExportPacketsPerLID_.template modify<Kokkos::HostSpace>();
-    Teuchos::ArrayView<size_t> numExportPacketsPerLID =
-      getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
+    {
+      // packAndPrepare* methods modify numExportPacketsPerLID_.
+      destGraph->numExportPacketsPerLID_.template modify<Kokkos::HostSpace>();
+      Teuchos::ArrayView<size_t> numExportPacketsPerLID =
+        getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
 
-    // Pack & Prepare w/ owning PIDs
-    packCrsGraphWithOwningPIDs(*this, destGraph->exports_,
-                               numExportPacketsPerLID, ExportLIDs,
-                               SourcePids, constantNumPackets, Distor);
+      // Pack & Prepare w/ owning PIDs
+      packCrsGraphWithOwningPIDs(*this, destGraph->exports_,
+                                 numExportPacketsPerLID, ExportLIDs,
+                                 SourcePids, constantNumPackets, Distor);
+    }
 
     // Do the exchange of remote data.
 #ifdef HAVE_TPETRA_MMM_TIMINGS

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -875,8 +875,8 @@ packCrsGraphNew(const CrsGraph<LO, GO, NT>& sourceGraph,
   // mfh 23 Aug 2017: Fix for #1088 requires pack / unpack buffers to
   // have a possibly different memory space (CudaSpace) than the
   // default CUDA memory space (currently CudaUVMSpace).
-  typedef typename device_type::execution_space buffer_exec_space;
 #ifdef KOKKOS_HAVE_CUDA
+  typedef typename device_type::execution_space buffer_exec_space;
   typedef typename std::conditional<
       std::is_same<
         buffer_exec_space, Kokkos::Cuda
@@ -887,8 +887,6 @@ packCrsGraphNew(const CrsGraph<LO, GO, NT>& sourceGraph,
 #else
   typedef typename device_type::memory_space buffer_memory_space;
 #endif // KOKKOS_HAVE_CUDA
-  // @MFH: why not use CrsGraph<LO,GO,NT>::buffer_device_type???
-  typedef Kokkos::Device<buffer_exec_space, buffer_memory_space> buffer_device_type;
 
   // Create an empty array of PIDs, since the interface needs it.
   Kokkos::View<int*, device_type> exportPIDs_d ("exportPIDs", 0);

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -54,15 +54,10 @@
 #include "Tpetra_Util.hpp"
 #include "Tpetra_Distributor.hpp"
 #include "Tpetra_Details_reallocDualViewIfNeeded.hpp"
+#include "Tpetra_Vector.hpp"
 #include "Kokkos_DualView.hpp"
 #include <Teuchos_Array.hpp>
 #include <utility>
-
-// Tpetra::CrsMatrix uses the functions below in its implementation.
-// To avoid a circular include issue, only include the declarations
-// for CrsMatrix.  We will include the definition after the functions
-// here have been defined.
-#include "Tpetra_CrsMatrix_decl.hpp"
 
 namespace Tpetra {
 namespace Import_Util {
@@ -333,7 +328,7 @@ sortCrsEntries (const rowptr_array_type& CRS_rowptr,
 {
   // Generate dummy values array
   typedef typename colind_array_type::execution_space execution_space;
-  typedef typename CrsMatrix<>::impl_scalar_type scalar_type;
+  typedef Tpetra::Details::DefaultTypes::scalar_type scalar_type;
   typedef typename Kokkos::View<scalar_type*, execution_space> scalar_view_type;
   scalar_view_type CRS_vals;
   sortCrsEntries<rowptr_array_type, colind_array_type,
@@ -728,10 +723,5 @@ void getTwoTransferOwnershipVector(const ::Tpetra::Details::Transfer<LocalOrdina
 
 } // namespace Import_Util
 } // namespace Tpetra
-
-// We can include the definitions for Tpetra::CrsMatrix now that the above
-// functions have been defined.  For ETI, this isn't necessary, so we just
-// including the generated hpp
-#include "Tpetra_CrsMatrix.hpp"
 
 #endif // TPETRA_IMPORT_UTIL_HPP


### PR DESCRIPTION
Albany builds (compiled without ETI) exposed some circular dependencies
associated with `Tpetra_Import_Util2.hpp` that surfaced with 47e569d.
My previous local testing did not show the failure.  On completely wiping my
build directory and using some Albany configure files, I was able to reproduce
the build error.

The fix involved removing an include of Tpetra_CrsMatrix_decl.hpp
and Tpetra_CrsMatrix.hpp from Tpetra_Import_Util2.hpp and then cleaning up some
downstream code that inadvertently included `Tpetra_CrsMatrix.hpp` through
`Tpetra_Import_Util2.hpp`.

@trilinos/tpetra 

Related to: #2574, 47e569d

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
