### PR TITLE
Teuchos: allow getting all MathExpr symbols

### DIFF
--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -123,6 +123,15 @@ std::set<std::string> get_variables_used(std::string const& expr) {
   return reader.variable_names;
 }
 
+std::set<std::string> get_symbols_used(std::string const& expr) {
+  SymbolSetReader reader;
+  any result;
+  reader.read_string(result, expr, "get_variables_used");
+  auto set = std::move(reader.variable_names);
+  set.insert(reader.function_names.begin(), reader.function_names.end());
+  return set;
+}
+
 }  // end namespace MathExpr
 
 }  // end namespace Teuchos

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -126,7 +126,7 @@ std::set<std::string> get_variables_used(std::string const& expr) {
 std::set<std::string> get_symbols_used(std::string const& expr) {
   SymbolSetReader reader;
   any result;
-  reader.read_string(result, expr, "get_variables_used");
+  reader.read_string(result, expr, "get_symbols_used");
   auto set = std::move(reader.variable_names);
   set.insert(reader.function_names.begin(), reader.function_names.end());
   return set;

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.hpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.hpp
@@ -100,6 +100,7 @@ class SymbolSetReader : public Reader {
 };
 
 std::set<std::string> get_variables_used(std::string const& expr);
+std::set<std::string> get_symbols_used(std::string const& expr);
 
 }  // end namespace MathExpr
 

--- a/packages/teuchos/parser/test/unit_tests.cpp
+++ b/packages/teuchos/parser/test/unit_tests.cpp
@@ -504,4 +504,13 @@ TEUCHOS_UNIT_TEST( Parser, mathexpr_reader ) {
   test_mathexpr_reader("x = 2; y = 5; x^2 + y^2");
 }
 
+TEUCHOS_UNIT_TEST( Parser, mathexpr_symbols ) {
+  auto vars = Teuchos::MathExpr::get_variables_used("sin(pi * x)");
+  std::set<std::string> expect_vars = {"pi", "x"};
+  TEUCHOS_ASSERT(vars == expect_vars);
+  auto symbols = Teuchos::MathExpr::get_symbols_used("sin(pi * x)");
+  std::set<std::string> expect_symbols = {"sin", "pi", "x"};
+  TEUCHOS_ASSERT(symbols == expect_symbols);
+}
+
 } // anonymous namespace


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.
-->

<!---
Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".
-->

<!---
Note that anything between these delimiters is a comment that will not appear
in the pull request description once created.
-->

<!---
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

<!---
Reviewers:  If you know someone who is knowledgeable about what you are
changing, or perhaps someone who should be, and you would like them to review
your changes before they are accepted, select them from the Reviewers drop-down
on the right.
-->

<!---
Assignees:  If you know anyone who should likely handle bringing this pull
request to completion, select them from the Assignees drop-down on the right.
If you have write-access to Trilinos, this should likely be you.
-->

<!---
Lables:  Choose any applicable package names from the Labels drop-down on the
right.  Additionally, choose a label to indicate the type of issue, for
instance, bug, build, documentation, enhancement, etc.
-->

## Description
<!--- Describe your changes in detail. -->
Add a function to return all symbols in a MathExpr string, including those that are only acted on by the call operator.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Previously, symbols which were only acted on by the call operator were not retrievable, and users need a way to get them too.