### PR TITLE
MueLu adapters: Let NullspaceFactory build missing nullspaces

### DIFF
--- a/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
@@ -96,44 +96,16 @@ namespace MueLu {
       }
       userList.set<RCP<Xpetra::MultiVector<double,LO,GO,NO> > >("Coordinates", coordinates);
     }
-    RCP<MultiVector> nullspace = Teuchos::null;
+
     if (userList.isParameter("Nullspace")) {
+      RCP<MultiVector> nullspace = Teuchos::null;
       try {
         nullspace = TpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(userList.get<RCP<Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >("Nullspace"));
       } catch(Teuchos::Exceptions::InvalidParameterType) {
         nullspace = userList.get<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >("Nullspace");
       }
+      userList.set<RCP<MultiVector> >("Nullspace", nullspace);
     }
-    if(nullspace == Teuchos::null) {
-      int nPDE = MueLu::MasterList::getDefault<int>("number of equations");
-      if (inParamList.isSublist("Matrix")) {
-        // Factory style parameter list
-        const Teuchos::ParameterList& operatorList = inParamList.sublist("Matrix");
-        if (operatorList.isParameter("PDE equations"))
-          nPDE = operatorList.get<int>("PDE equations");
-
-      } else if (inParamList.isParameter("number of equations")) {
-        // Easy style parameter list
-        nPDE = inParamList.get<int>("number of equations");
-      }
-
-      nullspace = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(A->getDomainMap(), nPDE);
-      if (nPDE == 1) {
-        nullspace->putScalar(Teuchos::ScalarTraits<Scalar>::one());
-
-      } else {
-        for (int i = 0; i < nPDE; i++) {
-          Teuchos::ArrayRCP<Scalar> nsData = nullspace->getDataNonConst(i);
-          for (int j = 0; j < nsData.size(); j++) {
-            GlobalOrdinal GID = A->getDomainMap()->getGlobalElement(j) - A->getDomainMap()->getIndexBase();
-            if ((GID-i) % nPDE == 0)
-              nsData[j] = Teuchos::ScalarTraits<Scalar>::one();
-          }
-        }
-      }
-    }
-    if(nullspace == Teuchos::null) {std::cout << "The nullspace is still Teuchos::null as it is added to the Hierarchy!" << std::endl;}
-    userList.set<RCP<MultiVector> >("Nullspace", nullspace);
 
     RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,inParamList,inParamList);
     return rcp(new TpetraOperator<SC,LO,GO,NO>(H));

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_epetra.gold
@@ -40,6 +40,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
@@ -50,6 +50,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory)
    Striding info = {}   [default]
    Strided block id = -1   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
@@ -38,6 +38,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -48,6 +48,9 @@ Level 1
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
    
+   Nullspace factory (MueLu::NullspaceFactory_kokkos)
+   Fine level nullspace = Nullspace
+   
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    

--- a/packages/muelu/test/unit_tests/Adapters/testPDE.xml
+++ b/packages/muelu/test/unit_tests/Adapters/testPDE.xml
@@ -109,6 +109,11 @@
       <Parameter name="A"                                   type="string" value="myRAPFact"/>
     </ParameterList>
 
+    <ParameterList name="myNullFact">
+      <Parameter name="factory"                             type="string"   value="NullspaceFactory"/>
+      <Parameter name="Nullspace"                           type="string"   value="myRebalanceProlongatorFact"/>
+    </ParameterList>
+
 <!-- -->
 <!-- -->
 <!-- -->
@@ -176,7 +181,7 @@
       <Parameter name="startLevel"                          type="int"      value="0"/>
       <Parameter name="Smoother"                            type="string"   value="SymGaussSeidel"/>
       <Parameter name="Aggregates"                          type="string"   value="UncoupledAggregationFact"/>
-      <Parameter name="Nullspace"                           type="string"   value="myRebalanceProlongatorFact"/>
+      <Parameter name="Nullspace"                           type="string"   value="myNullFact"/>
       <Parameter name="Coordinates"                         type="string"   value="myRebalanceProlongatorFact"/>
       <Parameter name="Importer"                            type="string"   value="myRepartitionFact"/>
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>

--- a/packages/muelu/test/unit_tests/Adapters/testWithRebalance.xml
+++ b/packages/muelu/test/unit_tests/Adapters/testWithRebalance.xml
@@ -124,6 +124,12 @@
       <Parameter name="A"                                   type="string" value="myRAPFact"/>
     </ParameterList>
 
+    <ParameterList name="myNullFact">
+      <Parameter name="factory"                             type="string"   value="NullspaceFactory"/>
+      <Parameter name="Nullspace"                           type="string"   value="myRebalanceProlongatorFact"/>
+    </ParameterList>
+
+
 <!-- -->
 <!-- -->
 <!-- -->
@@ -191,7 +197,7 @@
       <Parameter name="startLevel"                          type="int"      value="0"/>
       <Parameter name="Smoother"                            type="string"   value="SymGaussSeidel"/>
       <Parameter name="Aggregates"                          type="string"   value="UncoupledAggregationFact"/>
-      <Parameter name="Nullspace"                           type="string"   value="myRebalanceProlongatorFact"/>
+      <Parameter name="Nullspace"                           type="string"   value="myNullFact"/>
       <Parameter name="Coordinates"                         type="string"   value="myRebalanceProlongatorFact"/>
       <Parameter name="Importer"                            type="string"   value="myRepartitionFact"/>
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>


### PR DESCRIPTION
@trilinos/muelu 


## Description
Currently, both `CreateTpetraPreconditioner` and `CreateXpetraPreconditioner` will create a default nullspace when none is specified. This task is better handled by the `NullspaceFactory`. This reduces code duplication, and might have a positive impact on performance, since a Kokkos version of `NullspaceFactory` is available. At the very least, we now see timings of the nullspace creation.

## Related Issues
* Related to #1848 
