### PR TITLE
Revert "Merge pull request #2501 from bartlettroscoe/2473-disable-random-failing-anasazi-tests" (#2473)

### DIFF
--- a/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
@@ -6,9 +6,4 @@ ATDM_SET_ENABLE(TeuchosNumerics_LAPACK_test_MPI_1_DISABLE ON)
 # This test segfaults in the 'debug' builds on this system (#2466)
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
 
-# These tests randomly fail (see #2473)
-ATDM_SET_ENABLE(Anasazi_Epetra_ModalSolversTester_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_1_MPI_4_DISABLE ON)
-
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/ride/tweaks/GNU-DEBUG-OPENMP.cmake
+++ b/cmake/std/atdm/ride/tweaks/GNU-DEBUG-OPENMP.cmake
@@ -8,8 +8,3 @@ ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISAB
 
 # This test segfaults in the 'debug' builds on this system (#2466)
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
-
-# These tests randomly fail (see #2473)
-ATDM_SET_ENABLE(Anasazi_Epetra_ModalSolversTester_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(Anasazi_Epetra_OrthoManagerGenTester_1_MPI_4_DISABLE ON)


### PR DESCRIPTION
**CC:** @fryeguy52, @trilinos/anasazi 

## Description

This reverts commit 2e9da0c931e8c11c60d194e8a64d13e6e8697213, reversing
changes made to c828f5ad7f9ccef1d148839aaf65d6236ca172d5.

The merge branch in PR #2517 should allow these tests to pass now.

This should resolve #2473.  We will just need to to observe these tests passing.

Note that this just impacts the tests that run in the ATDM Trilinos builds and does not impact any actual code in Trilinos at all or any of the auto PR builds.

## How this was tested

I tested this on white with:

```
$ bsub -x -I -q rhel7F -n 16 \
  ./checkin-test-atdm.sh cuda-debug gnu-debug-openmp \
  --enable-all-packages=off --no-enable-fwd-packages \
  --enable-packages=Anasazi --local-do-all

...

PASSED (NOT READY TO PUSH): Trilinos: white24

Mon Apr 23 11:55:40 MDT 2018

Enabled Packages: Anasazi

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) cuda-debug => passed: passed=74,notpassed=0 (14.77 min)
2) gnu-debug-openmp => passed: passed=74,notpassed=0 (3.84 min)

```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
