### PR TITLE
Use GCC 4.9.3 headers with Intel 17.0.1 (#2463, #2317)

### DIFF
--- a/cmake/load_sems_dev_env.sh
+++ b/cmake/load_sems_dev_env.sh
@@ -100,8 +100,6 @@ if [ "$sems_cmake_and_version_load" == "" ] || [ "$sems_cmake_and_version_load" 
 fi
 #echo "sems_cmake_and_version_load = $sems_cmake_and_version_load"
 
-TRILINOS_SEMS_DEV_ENV_TO_LOAD="$sems_compiler_and_version_load $sems_mpi_and_version_load $sems_cmake_and_version_load"
-
 #
 # B) Purge the current set of modules
 #
@@ -121,7 +119,9 @@ module load $sems_git_and_version_default
 # until this is fixed, the workaround is below.
 # Please see https://github.com/trilinos/Trilinos/issues/2142
 # for updates regarding the right solution.
-if [[ $sems_compiler_and_version_load == "sems-intel/"* ]]; then
+if [[ $sems_compiler_and_version_load == "sems-intel/17.0.1" ]]; then
+  module load sems-gcc/4.9.3
+elif [[ $sems_compiler_and_version_load == "sems-intel/"* ]]; then
   module load sems-gcc/4.8.4
 fi
 


### PR DESCRIPTION
@trilinos/framework, @fryeguy52 

## Description

It was requested that we use GCC 4.9.3 headers instead of GCC 4.8.4 headers with Intel 17.0.1 builds of
Trilinos (see #2317 and #2463).

## How Has This Been Tested?

I tested it locally.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
