### PR TITLE
PyTrilinos: Set up CI scripts to run on Gaia

### DIFF
--- a/cmake/ctest/drivers/gaia/single_ci_iter.sh
+++ b/cmake/ctest/drivers/gaia/single_ci_iter.sh
@@ -5,7 +5,8 @@
 DRIVER_SCRIPT_DIR=`echo $0 | sed "s/\(.*\)\/.*\.sh/\1/g"`
 echo "DRIVER_SCRIPT_DIR = '$DRIVER_SCRIPT_DIR'"
 
-TRILINOS_DIR=`readlink -f ${DRIVER_SCRIPT_DIR}/../../../..`
+#TRILINOS_DIR=`readlink -f ${DRIVER_SCRIPT_DIR}/../../../..`
+TRILINOS_DIR=${DRIVER_SCRIPT_DIR}/../../../..
 echo "TRILINOS_DIR='${TRILINOS_DIR}'"
 
 source /etc/bashrc
@@ -15,7 +16,7 @@ source $TRILINOS_DIR/cmake/load_sems_dev_env.sh
 export CTEST_DASHBOARD_ROOT=$PWD
 
 # See if there are updated files:
-cd Trilinos/
+cd ${TRILINOS_DIR}
 ./cmake/tribits/python_utils/gitdist --dist-no-color fetch
 NEW_COMMITS=`./cmake/tribits/python_utils/gitdist --dist-no-color log --oneline @{u} ^HEAD | grep -v "\(Git Repo\|^$\)"`
 echo "NEW_COMMITS ='$NEW_COMMITS'"

--- a/cmake/ctest/drivers/gaia/trilinos_ci_sever.sh
+++ b/cmake/ctest/drivers/gaia/trilinos_ci_sever.sh
@@ -7,7 +7,8 @@
 DRIVER_SCRIPT_DIR=`echo $0 | sed "s/\(.*\)\/.*\.sh/\1/g"`
 echo "DRIVER_SCRIPT_DIR = '$DRIVER_SCRIPT_DIR'"
 
-TRILINOS_DIR=`readlink -f ${DRIVER_SCRIPT_DIR}/../../../..`
+#TRILINOS_DIR=`readlink -f ${DRIVER_SCRIPT_DIR}/../../../..`
+TRILINOS_DIR=${DRIVER_SCRIPT_DIR}/../../../..
 echo "TRILINOS_DIR='${TRILINOS_DIR}'"
 
 BASE_COMMAND=$DRIVER_SCRIPT_DIR/single_ci_iter.sh
@@ -25,7 +26,7 @@ echo "TODAY_RUN_TILL = '$TODAY_RUN_TILL'"
 echo "PAUSE_FILE = '$PAUSE_FILE'"
 
 #
-# Executate
+# Execute
 #
 
 # Have to source this or you don't even get the module command!


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/pytrilinos 

@bartlettroscoe 

## Description
I modified the gaia-specific scripts `single_ci_iter.sh` and `trilinos_ci_sever.sh` so that they would run on Gaia. There was an issue with the `readlink` command not supporting `-f` and not producing required output. My solution might be overly simplistic.

## Motivation and Context
This is the next step in getting Gaia set up as a CI server

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests: -->

## Related Issues

* Part of #891 

<!---
## How Has This Been Tested?
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->