### PR TITLE
Stokhos: Add Stokhos_MP_Vector_MaskTraits.hpp and its UnitTest

### DIFF
--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -483,6 +483,7 @@ IF (Stokhos_ENABLE_Sacado)
     INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/sacado/kokkos/vector)
     LIST(APPEND SACADO_HEADERS
       sacado/kokkos/vector/Stokhos_Sacado_Kokkos_MP_Vector.hpp
+      sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
       sacado/kokkos/vector/Sacado_MP_Vector.hpp
       sacado/kokkos/vector/Sacado_MP_VectorTraits.hpp
       sacado/kokkos/vector/Sacado_MP_ScalarTraitsImp.hpp

--- a/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
@@ -1,0 +1,447 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Stokhos Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Eric T. Phipps (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef STOKHOS_MP_VECTOR_MASKTRAITS_HPP
+#define STOKHOS_MP_VECTOR_MASKTRAITS_HPP
+
+#include "Sacado.hpp"
+#include "Stokhos_Tpetra_Utilities_MP_Vector.hpp"
+#include <iostream>
+
+template <typename T>
+struct EnsembleTraits_m {
+  static const int size = 1;
+  typedef T value_type;
+  static const value_type& coeff(const T& x, int i) { return x; }
+  static value_type& coeff(T& x, int i) { return x; }
+};
+
+template <typename S>
+struct EnsembleTraits_m< Sacado::MP::Vector<S> > {
+  static const int size = S::static_size;
+  typedef typename S::value_type value_type;
+  static const value_type& coeff(const Sacado::MP::Vector<S>& x, int i) {
+    return x.fastAccessCoeff(i);
+  }
+  static value_type& coeff(Sacado::MP::Vector<S>& x, int i) {
+    return x.fastAccessCoeff(i);
+  }
+};
+
+template<typename scalar> class Mask 
+{
+    private: 
+        static const int size = EnsembleTraits_m<scalar>::size;
+        bool data[size];
+
+    public:
+        Mask(){
+        }
+
+        Mask(bool a){
+            size = 1;
+            data = new bool[size]();
+            data[0]=a;
+        }
+
+        int getSize() const {return size;}
+
+        bool operator> (double v)
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+
+            return sum > v*size;
+        }
+
+        bool operator< (double v)
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+
+            return sum < v*size;
+        }
+
+        bool operator>= (double v)
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+            
+            return sum >= v*size;
+        }
+    
+        bool operator<= (double v)
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+            
+            return sum <= v*size;
+        }
+
+        bool operator== (double v)
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+
+            return sum == v*size;
+        } 
+
+        bool operator!= (double v)
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+
+            return sum != v*size;
+        }
+
+        Mask<scalar> operator&& (Mask<scalar> m2)
+        {
+            Mask<scalar> m3;
+            for(auto i=0; i<size; ++i)
+                m3.data[i] = (this->data[i] && m2.data[i]);
+
+            return m3;
+        } 
+
+        Mask<scalar> operator|| (Mask<scalar> m2)
+        {
+            Mask<scalar> m3;
+            for(auto i=0; i<size; ++i)
+                m3.data[i] = (this->data[i] || m2.data[i]);
+
+            return m3;
+        } 
+
+        Mask<scalar> operator+ (Mask<scalar> m2)
+        {
+            Mask<scalar> m3;
+            for(auto i=0; i<size; ++i)
+                m3.data[i] = (this->data[i] + m2.data[i]);
+
+            return m3;
+        } 
+
+        Mask<scalar> operator- (Mask<scalar> m2)
+        {
+            Mask<scalar> m3;
+            for(auto i=0; i<size; ++i)
+                m3.data[i] = (this->data[i] - m2.data[i]);
+
+            return m3;
+        }
+
+        scalar operator* (scalar v)       
+        {
+            typedef EnsembleTraits_m<scalar> ET; 
+            scalar v2;
+            for(auto i=0; i<size; ++i)
+                ET::coeff(v2,i) = ET::coeff(v,i)*this->data[i];
+
+            return v2;            
+        }
+
+        bool operator[] (int i) const
+        {
+            return this->data[i];
+        }
+
+        bool & operator[] (int i)
+        {
+            return this->data[i];
+        }
+
+        Mask<scalar> operator! ()
+        {
+            Mask<scalar> m2;
+            for(auto i=0; i<size; ++i)
+                m2.data[i] = !(this->data[i]);
+
+            return m2;            
+        }
+
+        operator bool() const
+        {
+            return this->data[0];                            
+        }   
+
+        operator double() const
+        {
+            double sum = 0;
+            for(auto i=0; i<size; ++i)
+                sum = sum + this->data[i];
+
+            return sum/size;    
+        }                               
+} ;
+
+template<typename scalar> std::ostream &operator<<(std::ostream &os, const Mask<scalar>& m) {
+    os << "[ ";
+    for(int i=0; i<m.getSize(); ++i)
+        os << m[i] << " ";
+    return os << "]";
+}
+
+template<typename S>  Sacado::MP::Vector<S> operator* (Sacado::MP::Vector<S> &a1, Mask<Sacado::MP::Vector<S>> m)
+{
+    Sacado::MP::Vector<S> mul;
+    mul = m*a1;
+    return mul;
+};
+
+template<typename S, typename S2>  Sacado::MP::Vector<S> operator* (S2 a1, Mask<Sacado::MP::Vector<S>> m)
+{
+    Sacado::MP::Vector<S> mul;
+    mul = m* (Sacado::MP::Vector<S>) a1;
+    return mul;
+};
+
+template<typename S, typename S2>  Sacado::MP::Vector<S> operator* (Mask<Sacado::MP::Vector<S>> m, S2 a1)
+{
+    Sacado::MP::Vector<S> mul;
+    mul = m* (Sacado::MP::Vector<S>) a1;
+    return mul;
+};
+
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator> (Sacado::MP::Vector<S> &a1, S2 a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) > a2;
+    return mask;
+};
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator>= (Sacado::MP::Vector<S> &a1, S2 a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) >= a2;
+    return mask;
+};
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator< (Sacado::MP::Vector<S> &a1, S2 a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) < a2;
+    return mask;
+};
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator<= (Sacado::MP::Vector<S> &a1, S2 a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) <= a2;
+    return mask;
+};
+
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator> (S2 a2, Sacado::MP::Vector<S> &a1)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = a2 > ET::coeff(a1,i);
+    return mask;
+};
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator>= (S2 a2, Sacado::MP::Vector<S> &a1)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = a2 >= ET::coeff(a1,i);
+    return mask;
+};
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator< (S2 a2, Sacado::MP::Vector<S> &a1)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = a2 < ET::coeff(a1,i);
+    return mask;
+};
+
+template<typename S, typename S2> Mask<Sacado::MP::Vector<S> > operator<= (S2 a2, Sacado::MP::Vector<S> &a1)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = a2 <= ET::coeff(a1,i);
+    return mask;
+};
+
+template<typename S> Mask<Sacado::MP::Vector<S> > operator> (Sacado::MP::Vector<S> &a1, Sacado::MP::Vector<S> &a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) > ET::coeff(a2,i);
+    return mask;
+};
+
+template<typename S> Mask<Sacado::MP::Vector<S> > operator>= (Sacado::MP::Vector<S> &a1, Sacado::MP::Vector<S> &a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) >= ET::coeff(a2,i);
+    return mask;
+};
+
+template<typename S> Mask<Sacado::MP::Vector<S> > operator< (Sacado::MP::Vector<S> &a1, Sacado::MP::Vector<S> &a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) < ET::coeff(a2,i);
+    return mask;
+};
+
+template<typename S> Mask<Sacado::MP::Vector<S> > operator<= (Sacado::MP::Vector<S> &a1, Sacado::MP::Vector<S> &a2)
+{
+    typedef EnsembleTraits_m<Sacado::MP::Vector<S> > ET;
+    
+    Mask<Sacado::MP::Vector<S> > mask;
+    for(auto i=0; i<ET::size; ++i)
+        mask[i] = ET::coeff(a1,i) <= ET::coeff(a2,i);
+    return mask;
+};
+
+
+
+namespace MaskLogic{
+
+class OR
+{
+private:
+    bool value;
+    
+public:
+    OR(){
+        value = false;
+    }
+
+    OR(bool value_){
+        value = value_;
+    }
+
+    template<typename T> OR(T m){
+        value = (((double) m)!=0.);
+    }
+    
+    operator bool() const
+    {
+        return value;
+    }
+};
+
+class XOR
+{
+private:
+    bool value;
+    
+public:
+    XOR(){
+        value = false;
+    }
+
+    XOR(bool value_){
+        value = value_;
+    }
+
+    template<typename T> XOR(T m){
+        value = (((double) m)==1./m.getSize());
+    }
+    
+    operator bool() const
+    {
+        return value;
+    }
+};
+
+class AND
+{
+private:
+    bool value;
+    
+public:
+    AND(){
+        value = false;
+    }
+
+    AND(bool value_){
+        value = value_;
+    }
+   
+    template<typename T> AND(T m){
+        value = (((double) m)==1.);
+    }
+    
+    operator bool() const
+    {
+        return value;
+    }
+};
+}
+#endif // STOKHOS_MP_VECTOR_MASKTRAITS_HPP

--- a/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Stokhos_MP_Vector_MaskTraits.hpp
@@ -42,8 +42,7 @@
 #ifndef STOKHOS_MP_VECTOR_MASKTRAITS_HPP
 #define STOKHOS_MP_VECTOR_MASKTRAITS_HPP
 
-#include "Sacado.hpp"
-#include "Stokhos_Tpetra_Utilities_MP_Vector.hpp"
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include <iostream>
 
 template <typename T>
@@ -77,9 +76,8 @@ template<typename scalar> class Mask
         }
 
         Mask(bool a){
-            size = 1;
-            data = new bool[size]();
-            data[0]=a;
+            for(auto i=0; i<size; ++i)
+                data[i]=a;
         }
 
         int getSize() const {return size;}

--- a/packages/stokhos/test/UnitTest/CMakeLists.txt
+++ b/packages/stokhos/test/UnitTest/CMakeLists.txt
@@ -564,6 +564,14 @@ IF(Stokhos_ENABLE_Sacado)
       )
 
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      SacadoMPVectorUnitTestMaskTraits
+      SOURCES Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
+      COMM serial mpi
+      STANDARD_PASS_OUTPUT
+      NUM_MPI_PROCS 1
+      )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoMPVectorSerializationTests
       SOURCES Stokhos_SacadoMPVectorSerializationTests.cpp ${UTILS_SOURCES}
       ARGS

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
@@ -1,0 +1,498 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Stokhos Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Eric T. Phipps (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_TestingHelpers.hpp"
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+
+#include "Stokhos_MP_Vector_MaskTraits.hpp"
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Create_8)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    std::cout << std::endl;
+    std::cout << a << std::endl;
+    std::cout << b << std::endl;
+    std::cout << m1 << std::endl;
+    TEST_EQUALITY( m1.getSize(), ensemble_size );
+    TEST_EQUALITY( m1[0], true );
+    TEST_EQUALITY( m1[1], false );
+    TEST_EQUALITY( m1[2], true );
+    for (auto i=3; i<ensemble_size; ++i)
+        TEST_EQUALITY( m1[i], false );
+    
+    TEST_EQUALITY( (double) m1, 2./ensemble_size );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Create_16)
+{
+    constexpr int ensemble_size = 16;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    std::cout << std::endl;
+    std::cout << a << std::endl;
+    std::cout << b << std::endl;
+    std::cout << m1 << std::endl;
+    TEST_EQUALITY( m1.getSize(), ensemble_size );
+    TEST_EQUALITY( m1[0], true );
+    TEST_EQUALITY( m1[1], false );
+    TEST_EQUALITY( m1[2], true );
+    for (auto i=3; i<ensemble_size; ++i)
+        TEST_EQUALITY( m1[i], false );
+    
+    TEST_EQUALITY( (double) m1, 2./ensemble_size );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Not_8)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = !m1;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    for (auto i=0; i<ensemble_size; ++i)
+        TEST_EQUALITY( m2[i], !m1[i] );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Multiplication_8)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    scalar mul = m1*a;
+    
+    scalar mul2 = m1*b;
+    scalar mul3 = b*m1;
+
+    scalar mul4 = m1*2;
+    scalar mul5 = 2*m1;
+    
+    std::cout << m1 << std::endl;
+    std::cout << mul << std::endl;
+    
+    std::cout << mul2 << std::endl;
+    std::cout << mul3 << std::endl;
+    std::cout << mul4 << std::endl;
+    std::cout << mul5 << std::endl;
+    
+    TEST_EQUALITY( mul[0], 2.5 );
+    TEST_EQUALITY( mul[1], 0. );
+    TEST_EQUALITY( mul[2], 2.5 );
+    for (auto i=3; i<ensemble_size; ++i)
+        TEST_EQUALITY( mul[i], 0. );
+    
+    TEST_EQUALITY( mul2, mul3 );
+    TEST_EQUALITY( mul2, mul4 );
+    TEST_EQUALITY( mul2, mul5 );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Multiplication_16)
+{
+    constexpr int ensemble_size = 16;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    scalar mul = m1*a;
+    std::cout << m1 << std::endl;
+    std::cout << mul << std::endl;
+    
+    TEST_EQUALITY( mul[0], 2.5 );
+    TEST_EQUALITY( mul[1], 0. );
+    TEST_EQUALITY( mul[2], 2.5 );
+    for (auto i=3; i<ensemble_size; ++i)
+        TEST_EQUALITY( mul[i], 0. );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mul_Add_8)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    scalar mul = m1*a + !m1*b;
+    scalar mul2 = a*m1 + !m1*b;
+    std::cout << m1 << std::endl;
+    std::cout << mul << std::endl;
+    std::cout << mul2 << std::endl;
+    
+    TEST_EQUALITY( mul[0], 2.5 );
+    TEST_EQUALITY( mul[1], 2. );
+    TEST_EQUALITY( mul[2], 2.5 );
+    for (auto i=3; i<ensemble_size; ++i)
+        TEST_EQUALITY( mul[i], 2. );
+    
+    TEST_EQUALITY( mul, mul2 );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_DEFAULT)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    using namespace MaskLogic;
+    
+    scalar a = (scalar) 1.;
+    a[1] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>(scalar) 0.;
+    auto m3 = a> 0.;
+    auto m4 = 0.<a;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    std::cout << m3<< std::endl;
+    std::cout << m4<< std::endl;
+    
+    if (m1)
+        {TEST_EQUALITY( true, false );}
+    else
+        {TEST_EQUALITY( true, true );}
+    
+    TEST_EQUALITY((bool) m1, false );
+    TEST_EQUALITY((bool) !m1, true );
+    
+    if (m2)
+        {TEST_EQUALITY( true, true );}
+    else
+        {TEST_EQUALITY( true, false );}
+    
+    TEST_EQUALITY((bool) m2, true );
+    TEST_EQUALITY((bool) !m2, false );
+    
+    TEST_EQUALITY( m2, m3 );
+    TEST_EQUALITY( m2, m4 );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_AND)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    using namespace MaskLogic;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+
+    
+    TEST_EQUALITY( (AND) true, true );
+    TEST_EQUALITY( (AND) false, false );
+    TEST_EQUALITY( (AND) m1, false );
+    TEST_EQUALITY( (AND) !m1, false );
+    TEST_EQUALITY( (AND) m2, true );
+    TEST_EQUALITY( (AND) !m2, false );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_OR)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    using namespace MaskLogic;
+    
+    scalar a = (scalar) 1.;
+    a[0] = 2.5;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    
+    
+    TEST_EQUALITY( (OR) true, true );
+    TEST_EQUALITY( (OR) false, false );
+    TEST_EQUALITY( (OR) m1, true );
+    TEST_EQUALITY( (OR) !m1, true );
+    TEST_EQUALITY( (OR) m2, true );
+    TEST_EQUALITY( (OR) !m2, false );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_XOR)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    using namespace MaskLogic;
+    
+    scalar a = (scalar) 1.;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    
+    
+    TEST_EQUALITY( (XOR) true, true );
+    TEST_EQUALITY( (XOR) false, false );
+    TEST_EQUALITY( (XOR) m1, true );
+    TEST_EQUALITY( (XOR) !m1, false );
+    TEST_EQUALITY( (XOR) m2, false );
+    TEST_EQUALITY( (XOR) !m2, false );
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_compared_to_double)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    
+    TEST_EQUALITY((double) m1,1./ensemble_size);
+    TEST_EQUALITY((double) m2,1.);
+
+    TEST_EQUALITY(m1==1.,false);
+    TEST_EQUALITY(m1!=1.,true);
+    TEST_EQUALITY(m1==0.,false);
+    TEST_EQUALITY(m1!=0.,true);
+    
+    TEST_EQUALITY(m1>=0.5,false);
+    TEST_EQUALITY(m1<=0.5,true);
+    TEST_EQUALITY(m1>0.5,false);
+    TEST_EQUALITY(m1<0.5,true);
+    
+    TEST_EQUALITY(m2==1.,true);
+    TEST_EQUALITY(m2!=1.,false);
+    TEST_EQUALITY(m2==0.,false);
+    TEST_EQUALITY(m2!=0.,true);
+    
+    TEST_EQUALITY(m2>=0.5,true);
+    TEST_EQUALITY(m2<=0.5,false);
+    TEST_EQUALITY(m2>0.5,true);
+    TEST_EQUALITY(m2<0.5,false);
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_AND_Mask)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    
+    auto m3 = m1 && m2;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    std::cout << m3 << std::endl;
+    TEST_EQUALITY(m3,m1);
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_OR_Mask)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    
+    auto m3 = m1 || m2;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    std::cout << m3 << std::endl;
+    TEST_EQUALITY(m3,m2);
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_ADD_Mask)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    std::cout << a << std::endl;
+    std::cout << b << std::endl;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    //std::cout << m1 << std::endl;
+    //std::cout << m2 << std::endl;
+    auto m3 = m1 + m2;
+
+    std::cout << m3 << std::endl;
+    TEST_EQUALITY(m3,m2);
+}
+
+TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_SUB_Mask)
+{
+    constexpr int ensemble_size = 8;
+    
+    typedef Kokkos::DefaultExecutionSpace execution_space;
+    typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
+    typedef Sacado::MP::Vector<storage_type> scalar;
+    
+    scalar a = (scalar) 1.;
+    a[2] = 2.5;
+    scalar b = (scalar) 2;
+    
+    auto m1 = a>b;
+    auto m2 = a>0.;
+    std::cout << m1 << std::endl;
+    std::cout << m2 << std::endl;
+    auto m3 = (a>0.) - (a>b);
+    std::cout << m3 << std::endl;
+    TEST_EQUALITY(m3,!m1);
+}
+
+
+int main( int argc, char* argv[] ) {
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  Kokkos::HostSpace::execution_space::initialize();
+  if (!Kokkos::DefaultExecutionSpace::is_initialized())
+    Kokkos::DefaultExecutionSpace::initialize();
+
+  int res = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+
+  Kokkos::HostSpace::execution_space::finalize();
+  if (Kokkos::DefaultExecutionSpace::is_initialized())
+    Kokkos::DefaultExecutionSpace::finalize();
+
+  return res;
+}


### PR DESCRIPTION
@trilinos/stokhos
@etphipp 

## Description
Add Mask class for ensemble type class. 
The class allows masked operations on ensemble values and allows boolean reduction such as AND, OR, and XOR.
The pull request includes a UnitTest cpp file that tests the functionalities of the class.

## Motivation and Context
It allows the writing of comparisons for ensemble type in a way which is consistent with usual scalar types.
It allows the writing of if-else statement based on masked operations such that it is still consistent with usual scalar types. 

## Related Issues
None

## How Has This Been Tested?
It has been tested using Teuchos UnitTest and

```
ctest -R Stokhos_SacadoMPVectorUnitTestMaskTraits_MPI_1

Test project /Users/kimliegeois/dev/TrilinosB
    Start 49: Stokhos_SacadoMPVectorUnitTestMaskTraits_MPI_1
1/1 Test #49: Stokhos_SacadoMPVectorUnitTestMaskTraits_MPI_1 ...   Passed    1.09 sec

100% tests passed, 0 tests failed out of 1

Subproject Time Summary:
Stokhos    =   1.09 sec*proc (1 test)

Total Test time (real) =   1.11 sec
```

Tested on a MacBook Pro with icpc (ICC) 18.0.1 20171018.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.


## Additional Information
It is my first pull request to the Trilinos project. Let me know if I can improve anything for the next ones. 
