### PR TITLE
MueLu: adding #ifdef HAVE_MPI in MueLu_FactoryFactory to avoid link error

### DIFF
--- a/packages/muelu/src/Interface/MueLu_FactoryFactory_decl.hpp
+++ b/packages/muelu/src/Interface/MueLu_FactoryFactory_decl.hpp
@@ -303,7 +303,9 @@ namespace MueLu {
       if (factoryName == "RebalanceBlockRestrictionFactory")return BuildBlockedFactory<RebalanceBlockRestrictionFactory>(paramList, factoryMapIn, factoryManagersIn);
       if (factoryName == "RebalanceBlockAcFactory")         return BuildBlockedFactory<RebalanceBlockAcFactory>(paramList, factoryMapIn, factoryManagersIn);
       if (factoryName == "RebalanceBlockInterpolationFactory") return BuildBlockedFactory<RebalanceBlockInterpolationFactory>(paramList, factoryMapIn, factoryManagersIn);
+#ifdef HAVE_MPI
       if (factoryName == "RepartitionBlockDiagonalFactory")    return Build2<RepartitionBlockDiagonalFactory>    (paramList, factoryMapIn, factoryManagersIn);
+#endif
 #ifdef HAVE_MUELU_TEKO
       if (factoryName == "TekoSmoother")                    return BuildTekoSmoother(paramList, factoryMapIn, factoryManagersIn);
 #endif


### PR DESCRIPTION
@trilinos/muelu 
@csiefer2 

## Description
This guard is added to avoid trying to link against the repationblockdiagonal
factory when a serial build is requested.

## Motivation and Context
This will fix a clean build on the dashboard

## Related Issues

* Closes #2664 

## How Has This Been Tested?
Local build links correctly using the same configuration as the one on [ascic144](https://testing.sandia.gov/cdash/buildSummary.php?buildid=3541596)

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.