### PR TITLE
Framework: handle special Clang CUDA flags

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -71,19 +71,25 @@ IF (${Trilinos_ENABLE_Kokkos})
     # cannot be passed to the link line, so we sneak these into the lesser-used
     # add_compile_options() function, which only affects the compile line and not the link line
     foreach(opt ${KOKKOS_CXX_FLAGS})
-      if (opt MATCHES "--cuda-gpu-arch")
-        # Furthermore, add_compile_options normally affects all languages, so
-        # we need a generator expression to prevent CUDA flags being passed to C or Fortran
-        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${opt}>)
+      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        if (opt MATCHES "--cuda-gpu-arch")
+          # Furthermore, add_compile_options normally affects all languages, so
+          # we need a generator expression to prevent CUDA flags being passed to C or Fortran
+          add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${opt}>)
+        else()
+          set(KOKKOS_CXX_FLAGS_str "${KOKKOS_CXX_FLAGS_str} ${opt}")
+        endif()
       else()
         set(KOKKOS_CXX_FLAGS_str "${KOKKOS_CXX_FLAGS_str} ${opt}")
       endif()
     endforeach()
-    # Since "-x cuda" shows up as two arguments, its easier to filter out here:
-    if (KOKKOS_CXX_FLAGS_str MATCHES "-x cuda")
-      string(REPLACE "-x cuda" "" KOKKOS_CXX_FLAGS_str "${KOKKOS_CXX_FLAGS_str}")
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-x>)
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:cuda>)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      # Since "-x cuda" shows up as two arguments, its easier to filter out here:
+      if (KOKKOS_CXX_FLAGS_str MATCHES "-x cuda")
+        string(REPLACE "-x cuda" "" KOKKOS_CXX_FLAGS_str "${KOKKOS_CXX_FLAGS_str}")
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-x>)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:cuda>)
+      endif()
     endif()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KOKKOS_CXX_FLAGS_str}")

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -65,13 +65,28 @@ IF (${Trilinos_ENABLE_Kokkos})
 
   IF (NOT KOKKOS_ARCH STREQUAL "None")
 
-    # Convert CMakeList into string for CXX_FLAGS
-    set(CMAKE_CXX_FLAGSl "")
+    # Convert KOKKOS_CXX_FLAGS, which is a CMake list, into a string for CXX_FLAGS
+    set(KOKKOS_CXX_FLAGS_str "")
+    # When compiling CUDA with Clang, the flags "-x cuda" and "--cuda-gpu-arch=sm_??"
+    # cannot be passed to the link line, so we sneak these into the lesser-used
+    # add_compile_options() function, which only affects the compile line and not the link line
     foreach(opt ${KOKKOS_CXX_FLAGS})
-      set(CMAKE_CXX_FLAGSl "${CMAKE_CXX_FLAGSl} ${opt}")
+      if (opt MATCHES "--cuda-gpu-arch")
+        # Furthermore, add_compile_options normally affects all languages, so
+        # we need a generator expression to prevent CUDA flags being passed to C or Fortran
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${opt}>)
+      else()
+        set(KOKKOS_CXX_FLAGS_str "${KOKKOS_CXX_FLAGS_str} ${opt}")
+      endif()
     endforeach()
-  
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGSl}")
+    # Since "-x cuda" shows up as two arguments, its easier to filter out here:
+    if (KOKKOS_CXX_FLAGS_str MATCHES "-x cuda")
+      string(REPLACE "-x cuda" "" KOKKOS_CXX_FLAGS_str "${KOKKOS_CXX_FLAGS_str}")
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-x>)
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:cuda>)
+    endif()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KOKKOS_CXX_FLAGS_str}")
   
     # TODO -- need to remove the -lkokkos.  Check on LDFlags
     #set(KOKKOS_LINK_DEPENDS libkokkos.a CACHE STRING "")


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos 
@trilinos/framework

## Description
<!--- Please describe your changes in detail. -->

Move "-x cuda" and friends
over to add_compile_options() instead of
CMAKE_CXX_FLAGS.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
The flag "-x cuda" will break linkage if passed to the linker, and the
other one will cause warnings.
This happens if one tries to compile Trilinos in CUDA mode using Clang's
built-in CUDA compilation.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
A custom Clang-CUDA build of Kokkos and Teuchos passes tests.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->
