### PR TITLE
Use netlib BLAS and LAPACK instead of OpenBLAS 1.2.19 on white/ride (#2454)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -27,15 +27,17 @@ fi
 if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
     export ATDM_CONFIG_KOKKOS_ARCH=Power8
     module load devpack/openmpi/1.10.4/gcc/5.4.0/cuda/8.0.44
+    module swap openblas/0.2.19/gcc/5.4.0 netlib/3.8.0/gcc/5.4.0
     export OMPI_CXX=`which g++`
     export OMPI_CC=`which gcc`
     export OMPI_FC=`which gfortran`
     export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
-    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp"
+    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
 elif [ "$ATDM_CONFIG_COMPILER" == "CUDA" ]; then
     export ATDM_CONFIG_KOKKOS_ARCH=Kepler37
     export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
     module load devpack/openmpi/1.10.4/gcc/5.4.0/cuda/8.0.44
+    module swap openblas/0.2.19/gcc/5.4.0 netlib/3.8.0/gcc/5.4.0
     export OMPI_CXX=$ATDM_CONFIG_TRILNOS_DIR/packages/kokkos/bin/nvcc_wrapper
     if [ ! -x "$OMPI_CXX" ]; then
         echo "No nvcc_wrapper found"
@@ -44,7 +46,7 @@ elif [ "$ATDM_CONFIG_COMPILER" == "CUDA" ]; then
     export OMPI_CC=`which gcc`
     export OMPI_FC=`which gfortran`
     export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
-    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp"
+    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
     export ATDM_CONFIG_USE_CUDA=ON
     export CUDA_LAUNCH_BLOCKING=1
     export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1


### PR DESCRIPTION
**CC:** @trilinos/belos , @trilinos/anasazi, @etphipp

## Description

This appears to fix almost all of the failing Belos and Anaszzi tests on 'white' (see #2454 2454)

## How Has This Been Tested?

I tested this one 'white' using:

```
$ cd ~/Trilinos.base/BUILD/WHITE/CHECKIN/
$  bsub -x -I -q rhel7F -n 16 \
   ./checkin-test-atdm.sh all --enable-packages=Belos,Anasazi --local-do-all
```

This returned:

```
Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) gnu-debug-openmp => passed: passed=145,notpassed=0 (4.31 min)
2) gnu-opt-openmp => passed: passed=146,notpassed=0 (6.30 min)
3) cuda-debug => passed: passed=145,notpassed=0 (10.72 min)
4) cuda-opt => FAILED: passed=145,notpassed=1 => Not ready to push! (13.36 min)
```

The only failing test was the 'cuda-opt' test:

```
  	 27 - Belos_pseudo_pcg_hb_0_MPI_4 (Failed)
```

That test was already failing so this is not a regression.  We will fix that test next.

The detailed test results are shown below.

<details>
<summary>
  <b>Detailed checkin-test-atdm.sh results:</b> (click to expand)
</summary>

```
FAILED (NOT READY TO PUSH): Trilinos: white24

Wed May  2 18:40:48 MDT 2018

Enabled Packages: Belos, Anasazi

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) gnu-debug-openmp => passed: passed=145,notpassed=0 (4.31 min)
2) gnu-opt-openmp => passed: passed=146,notpassed=0 (6.30 min)
3) cuda-debug => passed: passed=145,notpassed=0 (10.72 min)
4) cuda-opt => FAILED: passed=145,notpassed=1 => Not ready to push! (13.36 min)

*** Commits for repo :

1) gnu-debug-openmp Results:
----------------------------

  passed: Trilinos/gnu-debug-openmp: passed=145,notpassed=0
  
  Wed May  2 18:10:00 MDT 2018
  
  Enabled Packages: Belos, Anasazi
  Hostname: white24
  Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /home/rabartl/Trilinos.base/BUILD/WHITE/CHECKIN/gnu-debug-openmp
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=BASIC -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=600.0 -GNinja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_TRACE_ADD_TEST=ON -DTrilinos_ENABLE_Belos:BOOL=ON -DTrilinos_ENABLE_Anasazi:BOOL=ON -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF
  Make Options: -j 128
  CTest Options: -j 16
  
  Pull: Not Performed
  Configure: Passed (0.76 min)
  Build: Passed (2.75 min)
  Test: Passed (0.81 min)
  
  100% tests passed, 0 tests failed out of 145
  
  Subproject Time Summary:
  Anasazi    = 329.01 sec*proc (74 tests)
  Belos      = 363.76 sec*proc (71 tests)
  
  Total Test time (real) =  48.36 sec
  
  Total time for gnu-debug-openmp = 4.31 min


2) gnu-opt-openmp Results:
--------------------------

  passed: Trilinos/gnu-opt-openmp: passed=146,notpassed=0
  
  Wed May  2 18:16:25 MDT 2018
  
  Enabled Packages: Belos, Anasazi
  Hostname: white24
  Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /home/rabartl/Trilinos.base/BUILD/WHITE/CHECKIN/gnu-opt-openmp
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=BASIC -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=600.0 -GNinja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_TRACE_ADD_TEST=ON -DTrilinos_ENABLE_Belos:BOOL=ON -DTrilinos_ENABLE_Anasazi:BOOL=ON -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF
  Make Options: -j 128
  CTest Options: -j 16
  
  Pull: Not Performed
  Configure: Passed (0.71 min)
  Build: Passed (4.86 min)
  Test: Passed (0.73 min)
  
  100% tests passed, 0 tests failed out of 146
  
  Subproject Time Summary:
  Anasazi    = 314.23 sec*proc (74 tests)
  Belos      = 316.64 sec*proc (72 tests)
  
  Total Test time (real) =  43.52 sec
  
  Total time for gnu-opt-openmp = 6.30 min


3) cuda-debug Results:
----------------------

  passed: Trilinos/cuda-debug: passed=145,notpassed=0
  
  Wed May  2 18:27:15 MDT 2018
  
  Enabled Packages: Belos, Anasazi
  Hostname: white24
  Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /home/rabartl/Trilinos.base/BUILD/WHITE/CHECKIN/cuda-debug
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=BASIC -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=600.0 -GNinja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_TRACE_ADD_TEST=ON -DTrilinos_ENABLE_Belos:BOOL=ON -DTrilinos_ENABLE_Anasazi:BOOL=ON -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF
  Make Options: -j 128
  CTest Options: -j 8
  
  Pull: Not Performed
  Configure: Passed (1.30 min)
  Build: Passed (7.57 min)
  Test: Passed (1.84 min)
  
  100% tests passed, 0 tests failed out of 145
  
  Subproject Time Summary:
  Anasazi    = 435.97 sec*proc (74 tests)
  Belos      = 400.05 sec*proc (71 tests)
  
  Total Test time (real) = 110.43 sec
  
  Total time for cuda-debug = 10.72 min


4) cuda-opt Results:
--------------------

  FAILED: Trilinos/cuda-opt: passed=145,notpassed=1
  
  Wed May  2 18:40:43 MDT 2018
  
  Enabled Packages: Belos, Anasazi
  Hostname: white24
  Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /home/rabartl/Trilinos.base/BUILD/WHITE/CHECKIN/cuda-opt
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=BASIC -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=600.0 -GNinja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_TRACE_ADD_TEST=ON -DTrilinos_ENABLE_Belos:BOOL=ON -DTrilinos_ENABLE_Anasazi:BOOL=ON -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF
  Make Options: -j 128
  CTest Options: -j 8
  
  Pull: Not Performed
  Configure: Passed (1.29 min)
  Build: Passed (10.33 min)
  Test: FAILED (1.74 min)
  
  99% tests passed, 1 tests failed out of 146
  
  Subproject Time Summary:
  Anasazi    = 421.83 sec*proc (74 tests)
  Belos      = 368.36 sec*proc (72 tests)
  
  Total Test time (real) = 104.25 sec
  
  The following tests FAILED:
  	 27 - Belos_pseudo_pcg_hb_0_MPI_4 (Failed)
  Errors while running CTest
  
  Total time for cuda-opt = 13.36 min
```

</details>

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] All new and existing tests passed.
