### PR TITLE
MueLu: fix #2664 for std::complex using a cast in parameter list

### DIFF
--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -868,7 +868,7 @@ namespace MueLuTests {
   // Smoothers
   RCP<BlockedGaussSeidelSmoother> smootherPrototype     = rcp( new BlockedGaussSeidelSmoother() );
   smootherPrototype->SetParameter("Sweeps", Teuchos::ParameterEntry(2));
-  smootherPrototype->SetParameter("Damping factor", Teuchos::ParameterEntry(1.0));
+  smootherPrototype->SetParameter("Damping factor", Teuchos::ParameterEntry((SC) 1.0));
   smootherPrototype->AddFactoryManager(M11,0);
   smootherPrototype->AddFactoryManager(M22,1);
   RCP<SmootherFactory>   smootherFact          = rcp( new SmootherFactory(smootherPrototype) );

--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -868,7 +868,7 @@ namespace MueLuTests {
   // Smoothers
   RCP<BlockedGaussSeidelSmoother> smootherPrototype     = rcp( new BlockedGaussSeidelSmoother() );
   smootherPrototype->SetParameter("Sweeps", Teuchos::ParameterEntry(2));
-  smootherPrototype->SetParameter("Damping factor", Teuchos::ParameterEntry((SC) 1.0));
+  smootherPrototype->SetParameter("Damping factor", Teuchos::ParameterEntry(Teuchos::as<SC>(1.0)));
   smootherPrototype->AddFactoryManager(M11,0);
   smootherPrototype->AddFactoryManager(M22,1);
   RCP<SmootherFactory>   smootherFact          = rcp( new SmootherFactory(smootherPrototype) );


### PR DESCRIPTION
This commit provides a simple fix to the error in the BlockedRepartition
unit test when std::complex is on. This should remove the last error on the
dashboard related to PR #2561 

@trilinos/muelu 

## Description
Simple cast of value in parameter list from `double` to `SC` ensuring proper type for `std::complex` builds

## Motivation and Context
This fixes a failing test

## Related Issues

* Closes #2664 

## How Has This Been Tested?
The test suite of `MueLu` was run with `-D Trilinos_ENABLE_COMPLEX:BOOL=ON` to make sure that the test now passes for complex builds

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.