### PR TITLE
Belos: Change all default parameters to be constexpr (#2483)

### DIFF
--- a/packages/belos/src/BelosBiCGStabSolMgr.hpp
+++ b/packages/belos/src/BelosBiCGStabSolMgr.hpp
@@ -271,16 +271,16 @@ namespace Belos {
     mutable Teuchos::RCP<const Teuchos::ParameterList> validParams_;
 
     // Default solver values.
-    static const MagnitudeType convtol_default_;
-    static const int maxIters_default_;
-    static const bool showMaxResNormOnly_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const int defQuorum_default_;
-    static const std::string resScale_default_;
-    static const std::string label_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr bool showMaxResNormOnly_default_ = false;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr int defQuorum_default_ = 1;
+    static constexpr const char * resScale_default_ = "Norm of Initial Residual";
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     // Current solver values.
     MagnitudeType convtol_,achievedTol_;
@@ -297,43 +297,11 @@ namespace Belos {
     bool isSet_;
   };
 
-
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename BiCGStabSolMgr<ScalarType,MV,OP>::MagnitudeType BiCGStabSolMgr<ScalarType,MV,OP>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const int BiCGStabSolMgr<ScalarType,MV,OP>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool BiCGStabSolMgr<ScalarType,MV,OP>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int BiCGStabSolMgr<ScalarType,MV,OP>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int BiCGStabSolMgr<ScalarType,MV,OP>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int BiCGStabSolMgr<ScalarType,MV,OP>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const int BiCGStabSolMgr<ScalarType,MV,OP>::defQuorum_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const std::string BiCGStabSolMgr<ScalarType,MV,OP>::resScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string BiCGStabSolMgr<ScalarType,MV,OP>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> BiCGStabSolMgr<ScalarType,MV,OP>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 BiCGStabSolMgr<ScalarType,MV,OP>::BiCGStabSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -352,8 +320,8 @@ BiCGStabSolMgr<ScalarType,MV,OP>::
 BiCGStabSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                      const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -478,7 +446,7 @@ void BiCGStabSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -597,41 +565,44 @@ BiCGStabSolMgr<ScalarType,MV,OP>::getValidParameters() const
   if (validParams_.is_null()) {
     // Set all the valid parameters and their default values.
     RCP<ParameterList> pl = parameterList ();
-    pl->set("Convergence Tolerance", convtol_default_,
+
+    // The static_cast is to resolve an issue with older clang versions which
+    // would cause the constexpr to link fail. With c++17 the problem is resolved.
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linera system to be declared converged.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Deflation Quorum", defQuorum_default_,
+    pl->set("Deflation Quorum", static_cast<int>(defQuorum_default_),
       "The number of linear systems that need to converge before\n"
       "they are deflated.  This number should be <= block size.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Implicit Residual Scaling", resScale_default_,
+    pl->set("Implicit Residual Scaling", static_cast<const char *>(resScale_default_),
       "The type of scaling used in the residual convergence test.");
     // We leave the old name as a valid parameter for backwards
     // compatibility (so that validateParametersAndSetDefaults()
     // doesn't raise an exception if it encounters "Residual
     // Scaling").  The new name was added for compatibility with other
     // solvers, none of which use "Residual Scaling".
-    pl->set("Residual Scaling", resScale_default_,
+    pl->set("Residual Scaling", static_cast<const char *>(resScale_default_),
             "The type of scaling used in the residual convergence test.  This "
             "name is deprecated; the new name is \"Implicit Residual Scaling\".");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     validParams_ = pl;
   }

--- a/packages/belos/src/BelosBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosBlockCGSolMgr.hpp
@@ -357,20 +357,20 @@ namespace Belos {
     //
     // Default solver parameters.
     //
-    static const MagnitudeType convtol_default_;
-    static const MagnitudeType orthoKappa_default_;
-    static const int maxIters_default_;
-    static const bool adaptiveBlockSize_default_;
-    static const bool showMaxResNormOnly_default_;
-    static const bool useSingleReduction_default_;
-    static const int blockSize_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const std::string resScale_default_;
-    static const std::string label_default_;
-    static const std::string orthoType_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr MagnitudeType orthoKappa_default_ = -1.0;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr bool adaptiveBlockSize_default_ = true;
+    static constexpr bool showMaxResNormOnly_default_ = false;
+    static constexpr bool useSingleReduction_default_ = false;
+    static constexpr int blockSize_default_ = 1;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr const char * resScale_default_ = "Norm of Initial Residual";
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr const char * orthoType_default_ = "DGKS";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     //
     // Current solver parameters and other values.
@@ -411,55 +411,11 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename BlockCGSolMgr<ScalarType,MV,OP,true>::MagnitudeType BlockCGSolMgr<ScalarType,MV,OP,true>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename BlockCGSolMgr<ScalarType,MV,OP,true>::MagnitudeType BlockCGSolMgr<ScalarType,MV,OP,true>::orthoKappa_default_ = -1.0;
-
-template<class ScalarType, class MV, class OP>
-const int BlockCGSolMgr<ScalarType,MV,OP,true>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockCGSolMgr<ScalarType,MV,OP,true>::adaptiveBlockSize_default_ = true;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockCGSolMgr<ScalarType,MV,OP,true>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockCGSolMgr<ScalarType,MV,OP,true>::useSingleReduction_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int BlockCGSolMgr<ScalarType,MV,OP,true>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int BlockCGSolMgr<ScalarType,MV,OP,true>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int BlockCGSolMgr<ScalarType,MV,OP,true>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int BlockCGSolMgr<ScalarType,MV,OP,true>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockCGSolMgr<ScalarType,MV,OP,true>::resScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockCGSolMgr<ScalarType,MV,OP,true>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockCGSolMgr<ScalarType,MV,OP,true>::orthoType_default_ = "DGKS";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> BlockCGSolMgr<ScalarType,MV,OP,true>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 BlockCGSolMgr<ScalarType,MV,OP,true>::BlockCGSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
@@ -484,8 +440,8 @@ BlockCGSolMgr<ScalarType,MV,OP,true>::
 BlockCGSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
               const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+    outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
@@ -678,7 +634,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -798,41 +754,41 @@ BlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", convtol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "The number of vectors in each block.");
-    pl->set("Adaptive Block Size", adaptiveBlockSize_default_,
+    pl->set("Adaptive Block Size", static_cast<bool>(adaptiveBlockSize_default_),
       "Whether the solver manager should adapt to the block size\n"
       "based on the number of RHS to solve.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Use Single Reduction", useSingleReduction_default_,
+    pl->set("Use Single Reduction", static_cast<bool>(useSingleReduction_default_),
       "Use single reduction iteration when the block size is one.");
     pl->set("Implicit Residual Scaling", resScale_default_,
       "The type of scaling used in the residual convergence test.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
-    pl->set("Orthogonalization", orthoType_default_,
+    pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, or IMGS.");
-    pl->set("Orthogonalization Constant",orthoKappa_default_,
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL = pl;

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -315,24 +315,24 @@ private:
   Teuchos::RCP<Teuchos::ParameterList> params_;
 
   // Default solver values.
-  static const MagnitudeType convtol_default_;
-  static const MagnitudeType orthoKappa_default_;
-  static const int maxRestarts_default_;
-  static const int maxIters_default_;
-  static const bool adaptiveBlockSize_default_;
-  static const bool showMaxResNormOnly_default_;
-  static const bool flexibleGmres_default_;
-  static const bool expResTest_default_;
-  static const int blockSize_default_;
-  static const int numBlocks_default_;
-  static const int verbosity_default_;
-  static const int outputStyle_default_;
-  static const int outputFreq_default_;
-  static const std::string impResScale_default_;
-  static const std::string expResScale_default_;
-  static const std::string label_default_;
-  static const std::string orthoType_default_;
-  static const Teuchos::RCP<std::ostream> outputStream_default_;
+  static constexpr MagnitudeType convTol_default_ = 1e-8;
+  static constexpr MagnitudeType orthoKappa_default_ = -1.0;
+  static constexpr int maxRestarts_default_ = 20;
+  static constexpr int maxIters_default_ = 1000;
+  static constexpr bool adaptiveBlockSize_default_ = true;
+  static constexpr bool showMaxResNormOnly_default_ = false;
+  static constexpr bool flexibleGmres_default_ = false;
+  static constexpr bool expResTest_default_ = false;
+  static constexpr int blockSize_default_ = 1;
+  static constexpr int numBlocks_default_ = 300;
+  static constexpr int verbosity_default_ = Belos::Errors;
+  static constexpr int outputStyle_default_ = Belos::General;
+  static constexpr int outputFreq_default_ = -1;
+  static constexpr const char * impResScale_default_ = "Norm of Preconditioned Initial Residual";
+  static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
+  static constexpr const char * label_default_ = "Belos";
+  static constexpr const char * orthoType_default_ = "DGKS";
+  static constexpr std::ostream * outputStream_default_ = &std::cout;
 
   // Current solver values.
   MagnitudeType convtol_, orthoKappa_, achievedTol_;
@@ -352,67 +352,11 @@ private:
 };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename BlockGmresSolMgr<ScalarType,MV,OP>::MagnitudeType BlockGmresSolMgr<ScalarType,MV,OP>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename BlockGmresSolMgr<ScalarType,MV,OP>::MagnitudeType BlockGmresSolMgr<ScalarType,MV,OP>::orthoKappa_default_ = -1.0;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::maxRestarts_default_ = 20;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockGmresSolMgr<ScalarType,MV,OP>::adaptiveBlockSize_default_ = true;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockGmresSolMgr<ScalarType,MV,OP>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockGmresSolMgr<ScalarType,MV,OP>::flexibleGmres_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const bool BlockGmresSolMgr<ScalarType,MV,OP>::expResTest_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::numBlocks_default_ = 300;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int BlockGmresSolMgr<ScalarType,MV,OP>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockGmresSolMgr<ScalarType,MV,OP>::impResScale_default_ = "Norm of Preconditioned Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockGmresSolMgr<ScalarType,MV,OP>::expResScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockGmresSolMgr<ScalarType,MV,OP>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const std::string BlockGmresSolMgr<ScalarType,MV,OP>::orthoType_default_ = "DGKS";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> BlockGmresSolMgr<ScalarType,MV,OP>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 BlockGmresSolMgr<ScalarType,MV,OP>::BlockGmresSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxRestarts_(maxRestarts_default_),
@@ -443,8 +387,8 @@ BlockGmresSolMgr<ScalarType,MV,OP>::
 BlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                   const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxRestarts_(maxRestarts_default_),
@@ -485,53 +429,56 @@ BlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
   if (is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", convtol_default_,
+
+    // The static_cast is to resolve an issue with older clang versions which
+    // would cause the constexpr to link fail. With c++17 the problem is resolved.
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged." );
-    pl->set("Maximum Restarts", maxRestarts_default_,
+    pl->set("Maximum Restarts", static_cast<int>(maxRestarts_default_),
       "The maximum number of restarts allowed for each\n"
       "set of RHS solved.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Num Blocks", numBlocks_default_,
+    pl->set("Num Blocks", static_cast<int>(numBlocks_default_),
       "The maximum number of blocks allowed in the Krylov subspace\n"
       "for each set of RHS solved.");
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "The number of vectors in each block.  This number times the\n"
       "number of blocks is the total Krylov subspace dimension.");
-    pl->set("Adaptive Block Size", adaptiveBlockSize_default_,
+    pl->set("Adaptive Block Size", static_cast<bool>(adaptiveBlockSize_default_),
       "Whether the solver manager should adapt the block size\n"
       "based on the number of RHS to solve.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Flexible Gmres", flexibleGmres_default_,
+    pl->set("Flexible Gmres", static_cast<bool>(flexibleGmres_default_),
       "Whether the solver manager should use the flexible variant\n"
       "of GMRES.");
-    pl->set("Explicit Residual Test", expResTest_default_,
+    pl->set("Explicit Residual Test", static_cast<bool>(expResTest_default_),
       "Whether the explicitly computed residual should be used in the convergence test.");
-    pl->set("Implicit Residual Scaling", impResScale_default_,
+    pl->set("Implicit Residual Scaling", static_cast<const char *>(impResScale_default_),
       "The type of scaling used in the implicit residual convergence test.");
-    pl->set("Explicit Residual Scaling", expResScale_default_,
+    pl->set("Explicit Residual Scaling", static_cast<const char *>(expResScale_default_),
       "The type of scaling used in the explicit residual convergence test.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
-    pl->set("Orthogonalization", orthoType_default_,
+    pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, or IMGS.");
-    pl->set("Orthogonalization Constant",orthoKappa_default_,
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL = pl;
@@ -726,7 +673,7 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);

--- a/packages/belos/src/BelosFixedPointSolMgr.hpp
+++ b/packages/belos/src/BelosFixedPointSolMgr.hpp
@@ -278,15 +278,15 @@ namespace Belos {
     //
     // Default solver parameters.
     //
-    static const MagnitudeType convtol_default_;
-    static const int maxIters_default_;
-    static const bool showMaxResNormOnly_default_;
-    static const int blockSize_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const std::string label_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr bool showMaxResNormOnly_default_ = false;
+    static constexpr int blockSize_default_ = 1;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     //
     // Current solver parameters and other values.
@@ -322,40 +322,11 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename FixedPointSolMgr<ScalarType,MV,OP>::MagnitudeType FixedPointSolMgr<ScalarType,MV,OP>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const int FixedPointSolMgr<ScalarType,MV,OP>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool FixedPointSolMgr<ScalarType,MV,OP>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int FixedPointSolMgr<ScalarType,MV,OP>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int FixedPointSolMgr<ScalarType,MV,OP>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int FixedPointSolMgr<ScalarType,MV,OP>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int FixedPointSolMgr<ScalarType,MV,OP>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string FixedPointSolMgr<ScalarType,MV,OP>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> FixedPointSolMgr<ScalarType,MV,OP>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 FixedPointSolMgr<ScalarType,MV,OP>::FixedPointSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -375,8 +346,8 @@ FixedPointSolMgr<ScalarType,MV,OP>::
 FixedPointSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 	      const Teuchos::RCP<Teuchos::ParameterList> &pl) : 
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -507,7 +478,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -572,30 +543,33 @@ FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", convtol_default_,
+
+    // The static_cast is to resolve an issue with older clang versions which
+    // would cause the constexpr to link fail. With c++17 the problem is resolved.
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "The number of vectors in each block.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");  
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     validPL = pl;
   }

--- a/packages/belos/src/BelosGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosGCRODRSolMgr.hpp
@@ -452,21 +452,21 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
     Teuchos::RCP<Teuchos::ParameterList> params_;
 
     // Default solver values.
-    static const MagnitudeType convTol_default_;
-    static const MagnitudeType orthoKappa_default_;
-    static const int maxRestarts_default_;
-    static const int maxIters_default_;
-    static const int numBlocks_default_;
-    static const int blockSize_default_;
-    static const int recycledBlocks_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const std::string impResScale_default_;
-    static const std::string expResScale_default_;
-    static const std::string label_default_;
-    static const std::string orthoType_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr MagnitudeType orthoKappa_default_ = 0.0;
+    static constexpr int maxRestarts_default_ = 100;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr int numBlocks_default_ = 50;
+    static constexpr int blockSize_default_ = 1;
+    static constexpr int recycledBlocks_default_ = 5;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr const char * impResScale_default_ = "Norm of Preconditioned Initial Residual";
+    static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr const char * orthoType_default_ = "DGKS";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     // Current solver values.
     MagnitudeType convTol_, orthoKappa_, achievedTol_;
@@ -520,56 +520,6 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename GCRODRSolMgr<ScalarType,MV,OP,true>::MagnitudeType
-GCRODRSolMgr<ScalarType,MV,OP,true>::convTol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename GCRODRSolMgr<ScalarType,MV,OP,true>::MagnitudeType
-GCRODRSolMgr<ScalarType,MV,OP,true>::orthoKappa_default_ = 0.0;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::maxRestarts_default_ = 100;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::maxIters_default_ = 5000;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::numBlocks_default_ = 50;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::recycledBlocks_default_ = 5;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int GCRODRSolMgr<ScalarType,MV,OP,true>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string GCRODRSolMgr<ScalarType,MV,OP,true>::impResScale_default_ = "Norm of Preconditioned Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string GCRODRSolMgr<ScalarType,MV,OP,true>::expResScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string GCRODRSolMgr<ScalarType,MV,OP,true>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const std::string GCRODRSolMgr<ScalarType,MV,OP,true>::orthoType_default_ = "DGKS";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream>
-GCRODRSolMgr<ScalarType,MV,OP,true>::outputStream_default_ = Teuchos::rcpFromRef (std::cout);
-
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 GCRODRSolMgr<ScalarType,MV,OP,true>::GCRODRSolMgr():
@@ -612,7 +562,7 @@ GCRODRSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >& problem,
 // Common instructions executed in all constructors
 template<class ScalarType, class MV, class OP>
 void GCRODRSolMgr<ScalarType,MV,OP,true>::init () {
-  outputStream_ = outputStream_default_;
+  outputStream_ = Teuchos::rcp(outputStream_default_,false);
   convTol_ = convTol_default_;
   orthoKappa_ = orthoKappa_default_;
   maxRestarts_ = maxRestarts_default_;
@@ -1155,46 +1105,46 @@ GCRODRSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
     RCP<ParameterList> pl = parameterList ();
 
     // Set all the valid parameters and their default values.
-    pl->set("Convergence Tolerance", convTol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Maximum Restarts", maxRestarts_default_,
+    pl->set("Maximum Restarts", static_cast<int>(maxRestarts_default_),
       "The maximum number of cycles allowed for each\n"
       "set of RHS solved.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of iterations allowed for each\n"
       "set of RHS solved.");
     // mfh 25 Oct 2010: "Block Size" must be 1 because GCRODR is
     // currently not a block method: i.e., it does not work on
     // multiple right-hand sides at once.
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "Block Size Parameter -- currently must be 1 for GCRODR");
-    pl->set("Num Blocks", numBlocks_default_,
+    pl->set("Num Blocks", static_cast<int>(numBlocks_default_),
       "The maximum number of vectors allowed in the Krylov subspace\n"
       "for each set of RHS solved.");
-    pl->set("Num Recycled Blocks", recycledBlocks_default_,
+    pl->set("Num Recycled Blocks", static_cast<int>(recycledBlocks_default_),
       "The maximum number of vectors in the recycled subspace." );
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Implicit Residual Scaling", impResScale_default_,
+    pl->set("Implicit Residual Scaling", static_cast<const char *>(impResScale_default_),
       "The type of scaling used in the implicit residual convergence test.");
-    pl->set("Explicit Residual Scaling", expResScale_default_,
+    pl->set("Explicit Residual Scaling", static_cast<const char *>(expResScale_default_),
       "The type of scaling used in the explicit residual convergence test.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     {
       OrthoManagerFactory<ScalarType, MV, OP> factory;
-      pl->set("Orthogonalization", orthoType_default_,
+      pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
               "The type of orthogonalization to use.  Valid options: " +
               factory.validNamesString());
       RCP<const ParameterList> orthoParams =
@@ -1202,7 +1152,7 @@ GCRODRSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
       pl->set ("Orthogonalization Parameters", *orthoParams,
                "Parameters specific to the type of orthogonalization used.");
     }
-    pl->set("Orthogonalization Constant", orthoKappa_default_,
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
             "When using DGKS orthogonalization: the \"depTol\" constant, used "
             "to determine whether another step of classical Gram-Schmidt is "
             "necessary.  Otherwise ignored.");

--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -320,24 +320,24 @@ private:
   Teuchos::RCP<Teuchos::ParameterList> params_;
 
   // Default solver values.
-  static const MagnitudeType polytol_default_;
-  static const MagnitudeType convtol_default_;
-  static const MagnitudeType orthoKappa_default_;
-  static const int maxDegree_default_;
-  static const int maxRestarts_default_;
-  static const int maxIters_default_;
-  static const bool strictConvTol_default_;
-  static const bool showMaxResNormOnly_default_;
-  static const int blockSize_default_;
-  static const int numBlocks_default_;
-  static const int verbosity_default_;
-  static const int outputStyle_default_;
-  static const int outputFreq_default_;
-  static const std::string impResScale_default_;
-  static const std::string expResScale_default_;
-  static const std::string label_default_;
-  static const std::string orthoType_default_;
-  static const Teuchos::RCP<std::ostream> outputStream_default_;
+  static constexpr MagnitudeType polytol_default_ = 1e-12;
+  static constexpr MagnitudeType convTol_default_ = 1e-8;
+  static constexpr MagnitudeType orthoKappa_default_ = -1.0;
+  static constexpr int maxDegree_default_ = 25;
+  static constexpr int maxRestarts_default_ = 20;
+  static constexpr int maxIters_default_ = 1000;
+  static constexpr bool strictConvTol_default_ = false;
+  static constexpr bool showMaxResNormOnly_default_ = false;
+  static constexpr int blockSize_default_ = 1;
+  static constexpr int numBlocks_default_ = 300;
+  static constexpr int verbosity_default_ = Belos::Errors;
+  static constexpr int outputStyle_default_ = Belos::General;
+  static constexpr int outputFreq_default_ = -1;
+  static constexpr const char * impResScale_default_ = "Norm of RHS";
+  static constexpr const char * expResScale_default_ = "Norm of RHS";
+  static constexpr const char * label_default_ = "Belos";
+  static constexpr const char * orthoType_default_ = "DGKS";
+  static constexpr std::ostream * outputStream_default_ = &std::cout;
 
   // Current solver values.
   MagnitudeType polytol_, convtol_, orthoKappa_;
@@ -367,72 +367,11 @@ private:
 };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename GmresPolySolMgr<ScalarType,MV,OP>::MagnitudeType
-GmresPolySolMgr<ScalarType,MV,OP>::polytol_default_ = 1e-12;
-
-template<class ScalarType, class MV, class OP>
-const typename GmresPolySolMgr<ScalarType,MV,OP>::MagnitudeType
-GmresPolySolMgr<ScalarType,MV,OP>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename GmresPolySolMgr<ScalarType,MV,OP>::MagnitudeType
-GmresPolySolMgr<ScalarType,MV,OP>::orthoKappa_default_ =
-  -Teuchos::ScalarTraits<MagnitudeType>::one();
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::maxDegree_default_ = 25;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::maxRestarts_default_ = 20;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool GmresPolySolMgr<ScalarType,MV,OP>::strictConvTol_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const bool GmresPolySolMgr<ScalarType,MV,OP>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::numBlocks_default_ = 300;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int GmresPolySolMgr<ScalarType,MV,OP>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string GmresPolySolMgr<ScalarType,MV,OP>::impResScale_default_ = "Norm of RHS";
-
-template<class ScalarType, class MV, class OP>
-const std::string GmresPolySolMgr<ScalarType,MV,OP>::expResScale_default_ = "Norm of RHS";
-
-template<class ScalarType, class MV, class OP>
-const std::string GmresPolySolMgr<ScalarType,MV,OP>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const std::string GmresPolySolMgr<ScalarType,MV,OP>::orthoType_default_ = "DGKS";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream>
-GmresPolySolMgr<ScalarType,MV,OP>::outputStream_default_ = Teuchos::rcpFromRef (std::cout);
-
-
 template<class ScalarType, class MV, class OP>
 GmresPolySolMgr<ScalarType,MV,OP>::GmresPolySolMgr () :
   outputStream_ (outputStream_default_),
   polytol_ (polytol_default_),
-  convtol_ (convtol_default_),
+  convtol_ (convTol_default_),
   orthoKappa_ (orthoKappa_default_),
   maxDegree_ (maxDegree_default_),
   maxRestarts_ (maxRestarts_default_),
@@ -465,7 +404,7 @@ GmresPolySolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
   problem_ (problem),
   outputStream_ (outputStream_default_),
   polytol_ (polytol_default_),
-  convtol_ (convtol_default_),
+  convtol_ (convTol_default_),
   orthoKappa_ (orthoKappa_default_),
   maxDegree_ (maxDegree_default_),
   maxRestarts_ (maxRestarts_default_),
@@ -509,52 +448,55 @@ GmresPolySolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   if (validPL_.is_null ()) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList ();
-    pl->set("Polynomial Tolerance", polytol_default_,
+
+    // The static_cast is to resolve an issue with older clang versions which
+    // would cause the constexpr to link fail. With c++17 the problem is resolved.
+    pl->set("Polynomial Tolerance", static_cast<MagnitudeType>(polytol_default_),
       "The relative residual tolerance that used to construct the GMRES polynomial.");
-    pl->set("Maximum Degree", maxDegree_default_,
+    pl->set("Maximum Degree", static_cast<int>(maxDegree_default_),
       "The maximum degree allowed for any GMRES polynomial.");
-    pl->set("Convergence Tolerance", convtol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged." );
-    pl->set("Maximum Restarts", maxRestarts_default_,
+    pl->set("Maximum Restarts", static_cast<int>(maxRestarts_default_),
       "The maximum number of restarts allowed for each\n"
       "set of RHS solved.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Num Blocks", numBlocks_default_,
+    pl->set("Num Blocks", static_cast<int>(numBlocks_default_),
       "The maximum number of blocks allowed in the Krylov subspace\n"
       "for each set of RHS solved.");
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "The number of vectors in each block.  This number times the\n"
       "number of blocks is the total Krylov subspace dimension.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Strict Convergence", strictConvTol_default_,
+    pl->set("Strict Convergence", static_cast<bool>(strictConvTol_default_),
       "After polynomial is applied, whether solver should try to achieve\n"
       "the relative residual tolerance.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Implicit Residual Scaling", impResScale_default_,
+    pl->set("Implicit Residual Scaling", static_cast<const char *>(impResScale_default_),
       "The type of scaling used in the implicit residual convergence test.");
-    pl->set("Explicit Residual Scaling", expResScale_default_,
+    pl->set("Explicit Residual Scaling", static_cast<const char *>(expResScale_default_),
       "The type of scaling used in the explicit residual convergence test.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
-    pl->set("Orthogonalization", orthoType_default_,
+    pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, or IMGS.");
-    pl->set("Orthogonalization Constant",orthoKappa_default_,
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL_ = pl;
@@ -754,7 +696,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -362,17 +362,17 @@ namespace Belos {
     Teuchos::RCP<Teuchos::ParameterList> params_;
 
     // Default solver values.
-    static const MagnitudeType convtol_default_;
-    static const MagnitudeType orthoKappa_default_;
-    static const int maxIters_default_;
-    static const int deflatedBlocks_default_;
-    static const int savedBlocks_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const std::string label_default_;
-    static const std::string orthoType_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr MagnitudeType orthoKappa_default_ = -1.0;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr int deflatedBlocks_default_ = 2;
+    static constexpr int savedBlocks_default_ = 16;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr const char * orthoType_default_ = "DGKS";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     //
     // Current solver values.
@@ -411,48 +411,11 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename PCPGSolMgr<ScalarType,MV,OP,true>::MagnitudeType
-PCPGSolMgr<ScalarType,MV,OP,true>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename PCPGSolMgr<ScalarType,MV,OP,true>::MagnitudeType
-PCPGSolMgr<ScalarType,MV,OP,true>::orthoKappa_default_ = -1.0;
-
-template<class ScalarType, class MV, class OP>
-const int PCPGSolMgr<ScalarType,MV,OP,true>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const int PCPGSolMgr<ScalarType,MV,OP,true>::deflatedBlocks_default_ = 2;
-
-template<class ScalarType, class MV, class OP>
-const int PCPGSolMgr<ScalarType,MV,OP,true>::savedBlocks_default_ = 16;
-
-template<class ScalarType, class MV, class OP>
-const int PCPGSolMgr<ScalarType,MV,OP,true>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int PCPGSolMgr<ScalarType,MV,OP,true>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int PCPGSolMgr<ScalarType,MV,OP,true>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string PCPGSolMgr<ScalarType,MV,OP,true>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const std::string PCPGSolMgr<ScalarType,MV,OP,true>::orthoType_default_ = "DGKS";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> PCPGSolMgr<ScalarType,MV,OP,true>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 PCPGSolMgr<ScalarType,MV,OP,true>::PCPGSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   numIters_(0),
@@ -475,8 +438,9 @@ PCPGSolMgr<ScalarType,MV,OP,true>::PCPGSolMgr(
                                              const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                              const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   numIters_(0),
@@ -547,7 +511,8 @@ void PCPGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teucho
                        "Belos::PCPGSolMgr: \"Num Deflated Blocks\" must be <= \"Num Saved Blocks\".");
 
     // Update parameter in our list.
-    params_->set("Num Deflated Blocks", deflatedBlocks_);
+    // The static_cast is for clang link issues with the constexpr before c++17
+    params_->set("Num Deflated Blocks", static_cast<int>(deflatedBlocks_));
   }
 
   // Check to see if the timer label changed.
@@ -669,7 +634,7 @@ void PCPGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teucho
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -743,33 +708,33 @@ PCPGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   if (is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     // Set all the valid parameters and their default values.
-    pl->set("Convergence Tolerance", convtol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Num Deflated Blocks", deflatedBlocks_default_,
+    pl->set("Num Deflated Blocks", static_cast<int>(deflatedBlocks_default_),
       "The maximum number of vectors in the seed subspace." );
-    pl->set("Num Saved Blocks", savedBlocks_default_,
+    pl->set("Num Saved Blocks", static_cast<int>(savedBlocks_default_),
       "The maximum number of vectors saved from old Krylov subspaces." );
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
-    pl->set("Orthogonalization", orthoType_default_,
+    pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, IMGS");
-    pl->set("Orthogonalization Constant",orthoKappa_default_,
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL = pl;

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -325,18 +325,18 @@ namespace Belos {
     mutable Teuchos::RCP<const Teuchos::ParameterList> validParams_;
 
     // Default solver values.
-    static const MagnitudeType convtol_default_;
-    static const int maxIters_default_;
-    static const bool assertPositiveDefiniteness_default_;
-    static const bool showMaxResNormOnly_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const int defQuorum_default_;
-    static const std::string resScale_default_;
-    static const std::string label_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
-    static const bool genCondEst_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr bool assertPositiveDefiniteness_default_ = true;
+    static constexpr bool showMaxResNormOnly_default_ = false;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr int defQuorum_default_ = 1;
+    static constexpr const char * resScale_default_ = "Norm of Initial Residual";
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
+    static constexpr bool genCondEst_default_ = false;
 
     // Current solver values.
     MagnitudeType convtol_,achievedTol_;
@@ -356,48 +356,11 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::MagnitudeType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::assertPositiveDefiniteness_default_ = true;
-
-template<class ScalarType, class MV, class OP>
-const bool PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::defQuorum_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::resScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
-template<class ScalarType, class MV, class OP>
-const bool PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::genCondEst_default_ = false;
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::PseudoBlockCGSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -419,8 +382,8 @@ PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::
 PseudoBlockCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                      const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -590,7 +553,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
   // Check for convergence tolerance
   if (params->isParameter ("Convergence Tolerance")) {
-    convtol_ = params->get ("Convergence Tolerance", convtol_default_);
+    convtol_ = params->get ("Convergence Tolerance", convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set ("Convergence Tolerance", convtol_);
@@ -715,36 +678,36 @@ PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   if (validParams_.is_null()) {
     // Set all the valid parameters and their default values.
     RCP<ParameterList> pl = parameterList ();
-    pl->set("Convergence Tolerance", convtol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linera system to be declared converged.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Assert Positive Definiteness", assertPositiveDefiniteness_default_,
+    pl->set("Assert Positive Definiteness", static_cast<bool>(assertPositiveDefiniteness_default_),
       "Whether or not to assert that the linear operator\n"
       "and the preconditioner are indeed positive definite.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Deflation Quorum", defQuorum_default_,
+    pl->set("Deflation Quorum", static_cast<int>(defQuorum_default_),
       "The number of linear systems that need to converge before\n"
       "they are deflated.  This number should be <= block size.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
     pl->set("Implicit Residual Scaling", resScale_default_,
       "The type of scaling used in the residual convergence test.");
-    pl->set("Estimate Condition Number", genCondEst_default_,
+    pl->set("Estimate Condition Number", static_cast<bool>(genCondEst_default_),
       "Whether or not to estimate the condition number of the preconditioned system.");
     // We leave the old name as a valid parameter for backwards
     // compatibility (so that validateParametersAndSetDefaults()
@@ -754,7 +717,7 @@ PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
     pl->set("Residual Scaling", resScale_default_,
             "The type of scaling used in the residual convergence test.  This "
             "name is deprecated; the new name is \"Implicit Residual Scaling\".");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     validParams_ = pl;
   }

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -485,23 +485,23 @@ namespace Belos {
     Teuchos::RCP<Teuchos::ParameterList> params_;
 
     // Default solver values.
-    static const MagnitudeType convtol_default_;
-    static const MagnitudeType orthoKappa_default_;
-    static const int maxRestarts_default_;
-    static const int maxIters_default_;
-    static const bool showMaxResNormOnly_default_;
-    static const int blockSize_default_;
-    static const int numBlocks_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const int defQuorum_default_;
-    static const std::string impResScale_default_;
-    static const std::string expResScale_default_;
-    static const MagnitudeType resScaleFactor_default_;
-    static const std::string label_default_;
-    static const std::string orthoType_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr MagnitudeType orthoKappa_default_ = -1.0;
+    static constexpr int maxRestarts_default_ = 20;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr bool showMaxResNormOnly_default_ = false;
+    static constexpr int blockSize_default_ = 1;
+    static constexpr int numBlocks_default_ = 300;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr int defQuorum_default_ = 1;
+    static constexpr const char * impResScale_default_ = "Norm of Preconditioned Initial Residual";
+    static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
+    static constexpr MagnitudeType resScaleFactor_default_ = 1.0;
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr const char * orthoType_default_ = "DGKS";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     // Current solver values.
     MagnitudeType convtol_, orthoKappa_, achievedTol_;
@@ -522,64 +522,12 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename PseudoBlockGmresSolMgr<ScalarType,MV,OP>::MagnitudeType PseudoBlockGmresSolMgr<ScalarType,MV,OP>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename PseudoBlockGmresSolMgr<ScalarType,MV,OP>::MagnitudeType PseudoBlockGmresSolMgr<ScalarType,MV,OP>::orthoKappa_default_ = -1.0;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::maxRestarts_default_ = 20;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool PseudoBlockGmresSolMgr<ScalarType,MV,OP>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::numBlocks_default_ = 300;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockGmresSolMgr<ScalarType,MV,OP>::defQuorum_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockGmresSolMgr<ScalarType,MV,OP>::impResScale_default_ = "Norm of Preconditioned Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockGmresSolMgr<ScalarType,MV,OP>::expResScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const typename PseudoBlockGmresSolMgr<ScalarType,MV,OP>::MagnitudeType PseudoBlockGmresSolMgr<ScalarType,MV,OP>::resScaleFactor_default_ = 1.0;
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockGmresSolMgr<ScalarType,MV,OP>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockGmresSolMgr<ScalarType,MV,OP>::orthoType_default_ = "DGKS";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> PseudoBlockGmresSolMgr<ScalarType,MV,OP>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 PseudoBlockGmresSolMgr<ScalarType,MV,OP>::PseudoBlockGmresSolMgr() :
-  outputStream_(outputStream_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
   taggedTests_(Teuchos::null),
-  convtol_(convtol_default_),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxRestarts_(maxRestarts_default_),
@@ -609,9 +557,9 @@ PseudoBlockGmresSolMgr<ScalarType,MV,OP>::
 PseudoBlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                         const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
-  outputStream_(outputStream_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
   taggedTests_(Teuchos::null),
-  convtol_(convtol_default_),
+  convtol_(convTol_default_),
   orthoKappa_(orthoKappa_default_),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxRestarts_(maxRestarts_default_),
@@ -871,7 +819,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
   // Check for convergence tolerance
   if (params->isParameter ("Convergence Tolerance")) {
-    convtol_ = params->get ("Convergence Tolerance", convtol_default_);
+    convtol_ = params->get ("Convergence Tolerance", convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set ("Convergence Tolerance", convtol_);
@@ -1123,49 +1071,52 @@ PseudoBlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
   if (is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  // Set all the valid parameters and their default values.
+    // Set all the valid parameters and their default values.
+
+    // The static_cast is to resolve an issue with older clang versions which
+    // would cause the constexpr to link fail. With c++17 the problem is resolved.
     pl= Teuchos::rcp( new Teuchos::ParameterList() );
-    pl->set("Convergence Tolerance", convtol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Maximum Restarts", maxRestarts_default_,
+    pl->set("Maximum Restarts", static_cast<int>(maxRestarts_default_),
       "The maximum number of restarts allowed for each\n"
       "set of RHS solved.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Num Blocks", numBlocks_default_,
+    pl->set("Num Blocks", static_cast<int>(numBlocks_default_),
       "The maximum number of vectors allowed in the Krylov subspace\n"
       "for each set of RHS solved.");
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "The number of RHS solved simultaneously.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Deflation Quorum", defQuorum_default_,
+    pl->set("Deflation Quorum", static_cast<int>(defQuorum_default_),
       "The number of linear systems that need to converge before\n"
       "they are deflated.  This number should be <= block size.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Implicit Residual Scaling", impResScale_default_,
+    pl->set("Implicit Residual Scaling", static_cast<const char *>(impResScale_default_),
       "The type of scaling used in the implicit residual convergence test.");
-    pl->set("Explicit Residual Scaling", expResScale_default_,
+    pl->set("Explicit Residual Scaling", static_cast<const char *>(expResScale_default_),
       "The type of scaling used in the explicit residual convergence test.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
-    pl->set("Orthogonalization", orthoType_default_,
+    pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, IMGS.");
-    pl->set("Orthogonalization Constant",orthoKappa_default_,
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     pl->sublist("User Status Tests");

--- a/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
@@ -269,18 +269,18 @@ namespace Belos {
     Teuchos::RCP<Teuchos::ParameterList> params_;
     
     // Default solver values.
-    static const MagnitudeType convtol_default_;
-    static const MagnitudeType impTolScale_default_;
-    static const int maxIters_default_;
-    static const bool expResTest_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const int defQuorum_default_;
-    static const std::string impResScale_default_; 
-    static const std::string expResScale_default_; 
-    static const std::string label_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr MagnitudeType impTolScale_default_ = 10.0;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr bool expResTest_default_ = false;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr int defQuorum_default_ = 1;
+    static constexpr const char * impResScale_default_ = "Norm of Preconditioned Initial Residual";
+    static constexpr const char * expResScale_default_ = "Norm of Initial Residual";
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     // Current solver values.
     MagnitudeType convtol_, impTolScale_, achievedTol_;
@@ -298,49 +298,11 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::MagnitudeType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const typename PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::MagnitudeType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::impTolScale_default_ = 10.0;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const bool PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::expResTest_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const int PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::defQuorum_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::impResScale_default_ = "Norm of Preconditioned Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::expResScale_default_ = "Norm of Initial Residual";
-
-template<class ScalarType, class MV, class OP>
-const std::string PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr() :
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   impTolScale_(impTolScale_default_),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxIters_(maxIters_default_),
@@ -364,8 +326,8 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr(
 					     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) : 
   problem_(problem),
-  outputStream_(outputStream_default_),
-  convtol_(convtol_default_),
+  outputStream_(Teuchos::rcp(outputStream_default_,false)),
+  convtol_(convTol_default_),
   impTolScale_(impTolScale_default_),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxIters_(maxIters_default_),
@@ -481,7 +443,7 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
   
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -625,36 +587,39 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", convtol_default_,
+
+    // The static_cast is to resolve an issue with older clang versions which
+    // would cause the constexpr to link fail. With c++17 the problem is resolved.
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Implicit Tolerance Scale Factor", impTolScale_default_,
+    pl->set("Implicit Tolerance Scale Factor", static_cast<MagnitudeType>(impTolScale_default_),
       "The scale factor used by the implicit residual test when explicit residual\n"
       "testing is used.  May enable faster convergence when TFQMR bound is too loose.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");  
-    pl->set("Deflation Quorum", defQuorum_default_,
+    pl->set("Deflation Quorum", static_cast<int>(defQuorum_default_),
       "The number of linear systems that need to converge before they are deflated.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Explicit Residual Test", expResTest_default_,
+    pl->set("Explicit Residual Test", static_cast<bool>(expResTest_default_),
       "Whether the explicitly computed residual should be used in the convergence test.");
-    pl->set("Implicit Residual Scaling", impResScale_default_,
+    pl->set("Implicit Residual Scaling", static_cast<const char *>(impResScale_default_),
       "The type of scaling used in the implicit residual convergence test.");
-    pl->set("Explicit Residual Scaling", expResScale_default_,
+    pl->set("Explicit Residual Scaling", static_cast<const char *>(expResScale_default_),
       "The type of scaling used in the explicit residual convergence test.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     validPL = pl;
   }

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -357,17 +357,17 @@ namespace Belos {
     Teuchos::RCP<Teuchos::ParameterList> params_;
 
     // Default solver values.
-    static const MagnitudeType convtol_default_;
-    static const int maxIters_default_;
-    static const int blockSize_default_;
-    static const int numBlocks_default_;
-    static const int recycleBlocks_default_;
-    static const bool showMaxResNormOnly_default_;
-    static const int verbosity_default_;
-    static const int outputStyle_default_;
-    static const int outputFreq_default_;
-    static const std::string label_default_;
-    static const Teuchos::RCP<std::ostream> outputStream_default_;
+    static constexpr MagnitudeType convTol_default_ = 1e-8;
+    static constexpr int maxIters_default_ = 1000;
+    static constexpr int blockSize_default_ = 1;
+    static constexpr int numBlocks_default_ = 25;
+    static constexpr int recycleBlocks_default_ = 3;
+    static constexpr bool showMaxResNormOnly_default_ = false;
+    static constexpr int verbosity_default_ = Belos::Errors;
+    static constexpr int outputStyle_default_ = Belos::General;
+    static constexpr int outputFreq_default_ = -1;
+    static constexpr const char * label_default_ = "Belos";
+    static constexpr std::ostream * outputStream_default_ = &std::cout;
 
     //
     // Current solver values.
@@ -464,41 +464,6 @@ namespace Belos {
   };
 
 
-// Default solver values.
-template<class ScalarType, class MV, class OP>
-const typename RCGSolMgr<ScalarType,MV,OP,true>::MagnitudeType
-RCGSolMgr<ScalarType,MV,OP,true>::convtol_default_ = 1e-8;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::maxIters_default_ = 1000;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::numBlocks_default_ = 25;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::blockSize_default_ = 1;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::recycleBlocks_default_ = 3;
-
-template<class ScalarType, class MV, class OP>
-const bool RCGSolMgr<ScalarType,MV,OP,true>::showMaxResNormOnly_default_ = false;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::verbosity_default_ = Belos::Errors;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::outputStyle_default_ = Belos::General;
-
-template<class ScalarType, class MV, class OP>
-const int RCGSolMgr<ScalarType,MV,OP,true>::outputFreq_default_ = -1;
-
-template<class ScalarType, class MV, class OP>
-const std::string RCGSolMgr<ScalarType,MV,OP,true>::label_default_ = "Belos";
-
-template<class ScalarType, class MV, class OP>
-const Teuchos::RCP<std::ostream> RCGSolMgr<ScalarType,MV,OP,true>::outputStream_default_ = Teuchos::rcp(&std::cout,false);
-
 // Empty Constructor
 template<class ScalarType, class MV, class OP>
 RCGSolMgr<ScalarType,MV,OP,true>::RCGSolMgr():
@@ -530,8 +495,8 @@ RCGSolMgr<ScalarType,MV,OP,true>::RCGSolMgr(
 template<class ScalarType, class MV, class OP>
 void RCGSolMgr<ScalarType,MV,OP,true>::init()
 {
-  outputStream_ = outputStream_default_;
-  convtol_ = convtol_default_;
+  outputStream_ = Teuchos::rcp(outputStream_default_,false);
+  convtol_ = convTol_default_;
   maxIters_ = maxIters_default_;
   numBlocks_ = numBlocks_default_;
   recycleBlocks_ = recycleBlocks_default_;
@@ -697,7 +662,7 @@ void RCGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teuchos
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convtol_default_);
+    convtol_ = params->get("Convergence Tolerance",convTol_default_);
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -761,34 +726,34 @@ RCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", convtol_default_,
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Maximum Iterations", maxIters_default_,
+    pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
-    pl->set("Block Size", blockSize_default_,
+    pl->set("Block Size", static_cast<int>(blockSize_default_),
       "Block Size Parameter -- currently must be 1 for RCG");
-    pl->set("Num Blocks", numBlocks_default_,
+    pl->set("Num Blocks", static_cast<int>(numBlocks_default_),
       "The length of a cycle (and this max number of search vectors kept)\n");
-    pl->set("Num Recycled Blocks", recycleBlocks_default_,
+    pl->set("Num Recycled Blocks", static_cast<int>(recycleBlocks_default_),
       "The number of vectors in the recycle subspace.");
-    pl->set("Verbosity", verbosity_default_,
+    pl->set("Verbosity", static_cast<int>(verbosity_default_),
       "What type(s) of solver information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Style", outputStyle_default_,
+    pl->set("Output Style", static_cast<int>(outputStyle_default_),
       "What style is used for the solver information outputted\n"
       "to the output stream.");
-    pl->set("Output Frequency", outputFreq_default_,
+    pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
       "to the output stream.");
-    pl->set("Output Stream", outputStream_default_,
+    pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
-    pl->set("Show Maximum Residual Norm Only", showMaxResNormOnly_default_,
+    pl->set("Show Maximum Residual Norm Only", static_cast<bool>(showMaxResNormOnly_default_),
       "When convergence information is printed, only show the maximum\n"
       "relative residual norm when the block size is greater than one.");
-    pl->set("Timer Label", label_default_,
+    pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     validPL = pl;
   }


### PR DESCRIPTION
Change all belos solver manager defaults from static const to static constexpr.
This prepares for PR #2483 to avoid static initialization order conflicts.


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Description
<!--- Please describe your changes in detail. -->
The purpose of these changes is to prepare for premain
registration for the new DII system. The statics were
causing some initialization order issues that could
sometimes seg fault the managers when they were constructed.

Some older clang versions fail on the linkage of
the constexpr when calling the set method for ParameterList.
Using a static_cast seems to work around this though
the cast is simply assignining the constexpr to their
original type. I'm anticipating that would be removed eventually.

Using c++17 resolves this.

Note this PR is being used to test #2483 now and seems to
resolve all the static linkage issues allowing for pre-main
registration of DII to work. So that PR will depend on this one.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
The  new DII belos system #PR 2483 will have pre-main registration which conflicts with these statics. Changing them to constexpr resolves the issue.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
Blocks #2483.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
SEMS, linux builds, and clang builds.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
