### PR TITLE
Provide better error message when compiler is not supported (TRIL-200)

### DIFF
--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -47,7 +47,10 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
     export ATDM_CONFIG_LAPACK_LIB="-mkl"
     export ATDM_CONFIG_BLAS_LIB="-mkl"
 else
-    echo "No valid compiler found"
+    echo
+    echo "***"
+    echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
+    echo "***"
     return
 fi
 


### PR DESCRIPTION
Provides a more verbose error message when you select a non-supported compiler for the `toss3` system.  For example:

```
. cmake/std/atdm/load-env.sh gnu
Hostname 'serrano-login2' matches known ATDM host 'serrano' and system 'toss3'
ATDM_CONFIG_TRILNOS_DIR = /home/rabartl/Trilinos.base/Trilinos
Setting default compiler and build options for JOB_NAME='gnu'
Using chama compiler stack GNU to build DEBUG code with Kokkos node type SERIAL

***
*** ERROR: COMPILER=GNU is not supported on this system!
***

***
*** ERROR: Environment setup was not successful, see above errors!
***
````

Hopefully this will help users see the problem sooner.


