### PR TITLE
MueLu: fix 2664 by using appropriate type for coordinate multi-vector

### DIFF
--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -724,17 +724,17 @@ namespace MueLuTests {
   TEST_EQUALITY(bOp->getGlobalNumEntries(), 2392);
 
   // coordinates
-  RCP<MultiVector> coord = MultiVectorFactory::Build(bOp->getFullRangeMap(),1);
+  RCP<Xpetra::MultiVector<double,LO,GO,NO> > coord = Xpetra::MultiVectorFactory<double,LO,GO,NO>::Build(bOp->getFullRangeMap(),1);
   int PID = comm->getRank();
-  Teuchos::ArrayRCP<Scalar> data = coord->getDataNonConst(0);
-  for(size_t i=0; i<(size_t)data.size(); i++)
-    data[i] = PID + (double)i / data.size();
+  Teuchos::ArrayRCP<double> coordData = coord->getDataNonConst(0);
+  for(size_t i = 0; i < (size_t) coordData.size(); ++i)
+    coordData[i] = PID + (double)i / coordData.size();
 
   // nullspace
   RCP<MultiVector> nullspace = MultiVectorFactory::Build(bOp->getFullRangeMap(),1);
-  data = nullspace->getDataNonConst(0);
-  for(size_t i=0; i<(size_t)data.size(); i++)
-    data[i] = 1.0;
+  Teuchos::ArrayRCP<SC> nspData = nullspace->getDataNonConst(0);
+  for(size_t i=0; i<(size_t)nspData.size(); i++)
+    nspData[i] = 1.0;
 
   // Grab sub-blocks for the Tobias-style goodies
   RCP<MultiVector> nullspace1 = mapExtractor->ExtractVector(nullspace,0);


### PR DESCRIPTION
@trilinos/muelu 
@csiefer2 @jhux2 

## Description
In unit test BlockedRAPFactoryWithDiagonal a multivector holding coordinates is created as RCP<MultiVector>, this has been modified to RCP<MultiVector<double,LO,GO,NO> > in order to avoid bad cast when the multivector is extracted from MueLu levels.

## Motivation and Context
We need to fix this unit test.

## Related Issues

* Closes 2664

## How Has This Been Tested?
I configured locally on of the builds that fails on the dashboard, compiled and ran the MueLu unit tests. They all passed including `BlockedRAPFactoryWithDiagonal`

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.