### PR TITLE
Tempus:  Fix Doxygen

### DIFF
--- a/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_decl.hpp
+++ b/packages/tempus/src/Tempus_AdjointSensitivityModelEvaluator_decl.hpp
@@ -28,7 +28,7 @@ namespace Tempus {
  * to a product vector formed by its columns.  This is the form of the adjoint
  * equations suitable for computing pseudotransientsensitivities of a response
  * function g(x(T),p) or adjoint sensitivities for a time-integrated response
- * function \int_0^T g(x(t),p).
+ * function int_0^T g(x(t),p).
  *
  * To compute adjoint sensitivities, the equations f(x_dot,x,p) = 0 are
  * integrated forward in time to some final time T, with the adjoint equations

--- a/packages/tempus/src/Tempus_SolutionState_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_impl.hpp
@@ -77,8 +77,8 @@ SolutionState<Scalar>::SolutionState(
   const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x,
   const Teuchos::RCP<Thyra::VectorBase<Scalar> >& xdot,
   const Teuchos::RCP<Thyra::VectorBase<Scalar> >& xdotdot,
-  const Teuchos::RCP<Tempus::StepperState<Scalar> >& stepperState,
-  const Teuchos::RCP<Tempus::PhysicsState<Scalar> >& physicsState)
+  const Teuchos::RCP<StepperState<Scalar> >& stepperState,
+  const Teuchos::RCP<PhysicsState<Scalar> >& physicsState)
   : metaData_       (metaData),
     metaData_nc_    (metaData),
     x_              (x),
@@ -108,8 +108,8 @@ SolutionState<Scalar>::SolutionState(
   const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& x,
   const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& xdot,
   const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& xdotdot,
-  const Teuchos::RCP<const Tempus::StepperState<Scalar> >& stepperState,
-  const Teuchos::RCP<const Tempus::PhysicsState<Scalar> >& physicsState)
+  const Teuchos::RCP<const StepperState<Scalar> >& stepperState,
+  const Teuchos::RCP<const PhysicsState<Scalar> >& physicsState)
   : metaData_       (metaData),
     metaData_nc_    (Teuchos::null),
     x_              (x),
@@ -148,14 +148,14 @@ SolutionState<Scalar>::SolutionState(
   const Status solutionStatus,
   const bool   output,
   const bool   outputScreen,
-  const bool   isInterpolated,
   const bool   isSynced,
+  const bool   isInterpolated,
   const Scalar accuracy,
   const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x,
   const Teuchos::RCP<Thyra::VectorBase<Scalar> >& xdot,
   const Teuchos::RCP<Thyra::VectorBase<Scalar> >& xdotdot,
-  const Teuchos::RCP<Tempus::StepperState<Scalar> >& stepperState,
-  const Teuchos::RCP<Tempus::PhysicsState<Scalar> >& physicsState)
+  const Teuchos::RCP<StepperState<Scalar> >& stepperState,
+  const Teuchos::RCP<PhysicsState<Scalar> >& physicsState)
   : x_              (x),
     x_nc_           (x),
     xdot_           (xdot),
@@ -209,14 +209,14 @@ SolutionState<Scalar>::SolutionState(
   const Status solutionStatus,
   const bool   output,
   const bool   outputScreen,
-  const bool   isInterpolated,
   const bool   isSynced,
+  const bool   isInterpolated,
   const Scalar accuracy,
   const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& x,
   const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& xdot,
   const Teuchos::RCP<const Thyra::VectorBase<Scalar> >& xdotdot,
-  const Teuchos::RCP<const Tempus::StepperState<Scalar> >& stepperState,
-  const Teuchos::RCP<const Tempus::PhysicsState<Scalar> >& physicsState)
+  const Teuchos::RCP<const StepperState<Scalar> >& stepperState,
+  const Teuchos::RCP<const PhysicsState<Scalar> >& physicsState)
   : x_              (x),
     x_nc_           (Teuchos::null),
     xdot_           (xdot),
@@ -259,8 +259,8 @@ SolutionState<Scalar>::SolutionState(
 template<class Scalar>
 SolutionState<Scalar>::SolutionState(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
-  const Teuchos::RCP<Tempus::StepperState<Scalar> >& stepperState,
-  const Teuchos::RCP<Tempus::PhysicsState<Scalar> >& physicsState)
+  const Teuchos::RCP<StepperState<Scalar> >& stepperState,
+  const Teuchos::RCP<PhysicsState<Scalar> >& physicsState)
 {
   typedef Thyra::ModelEvaluatorBase MEB;
   using Teuchos::rcp_const_cast;

--- a/packages/tempus/src/Tempus_TimeDerivative.hpp
+++ b/packages/tempus/src/Tempus_TimeDerivative.hpp
@@ -24,7 +24,7 @@ namespace Tempus {
  *  requires definition of the time derivatives during the iterations of
  *  the nonlinear solve. Note that if the Stepper solves for a time
  *  derivative, e.g., \f$\ddot{x}\f$ for the Newmark-\f$\beta\f$ methods,
- *  definitions for \f$x\f$ and \f$\dot{x} are required in the function
+ *  definitions for \f$x\f$ and \f$\dot{x}\f$ are required in the function
  *  compute().  This interface defines the calling function to compute
  *  those derivatives and/or state.
  */

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -31,22 +31,22 @@ namespace Tempus {
  * PID = Proportional-Integral-Derivative Controller
  * \f[
  *      (\Delta t)_{n+1} =
- *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p) \epsilon_{n-1}^{k_2 / p} \epsilon_{n-2}^{-k_3 / p} \right)
+ *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p} \epsilon_{n-1}^{k_2 / p} \epsilon_{n-2}^{-k_3 / p} \right)
  * \f]
  *
  * PI = Proportional-Integral Controller
  * \f[
  *      (\Delta t)_{n+1} =
- *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p) \epsilon_{n-1}^{k_2 / p} \right)
+ *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p} \epsilon_{n-1}^{k_2 / p} \right)
  * \f]
  *
  * I = Integral Controller
  * \f[
  *      (\Delta t)_{n+1} =
- *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p) \right)
+ *      (\Delta t)_n \left( \epsilon_n ^{-k_1 / p} \right)
  * \f]
  *
- * where \f$\epsilon_n \f$ is the error at time step \f$n$\f
+ * where \f$\epsilon_n \f$ is the error at time step \f$n\f$.
  *
  * Appropriate for Explicit Methods
  */

--- a/packages/tempus/src/Thyra_AdjointLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_AdjointLinearOpWithSolveFactory.hpp
@@ -61,10 +61,8 @@ public:
     const RCP<const LinearOpWithSolveFactoryBase<Scalar> > &lowsf
     );
 
-  /** \brief . */
   RCP<LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF();
 
-  /** \brief . */
   RCP<const LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF() const;
 
   //@}
@@ -72,7 +70,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const;
 
   //@}
@@ -80,15 +77,10 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList);
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList();
-  /** \brief . */
   RCP<ParameterList> unsetParameterList();
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const;
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const;
 
   //@}
@@ -115,28 +107,23 @@ public:
     std::string *precFactoryName
     );
 
-  /** \brief . */
   virtual bool isCompatible(
     const LinearOpSourceBase<Scalar> &fwdOpSrc
     ) const;
 
-  /** \brief . */
   virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const;
 
-  /** \brief . */
   virtual void initializeOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op,
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeAndReuseOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op
     ) const;
 
-  /** \brief . */
   virtual void uninitializeOp(
     LinearOpWithSolveBase<Scalar> *Op,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
@@ -145,12 +132,10 @@ public:
     ESupportSolveUse *supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual bool supportsPreconditionerInputType(
     const EPreconditionerInputType precOpType
     ) const;
 
-  /** \brief . */
   virtual void initializePreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const PreconditionerBase<Scalar> > &prec,
@@ -158,7 +143,6 @@ public:
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeApproxPreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
@@ -173,7 +157,6 @@ protected:
   /** \brief Overridden from Teuchos::VerboseObjectBase */
   //@{
 
-  /** \brief . */
   void informUpdatedVerbosityState() const;
 
   //@}
@@ -188,7 +171,7 @@ private:
 
 /** \brief Nonmember constructor.
  *
- * \releates AdjointLinearOpWithSolveFactory
+ * \relates AdjointLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<const AdjointLinearOpWithSolveFactory<Scalar> >
@@ -204,7 +187,7 @@ adjointLinearOpWithSolveFactory(
 
 /** \brief Nonmember constructor.
  *
- * \releates AdjointLinearOpWithSolveFactory
+ * \relates AdjointLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<AdjointLinearOpWithSolveFactory<Scalar> >

--- a/packages/tempus/src/Thyra_AdjointPreconditioner.hpp
+++ b/packages/tempus/src/Thyra_AdjointPreconditioner.hpp
@@ -29,29 +29,24 @@ public:
   /** \brief Construct to uninitialized. */
   AdjointPreconditioner() {}
 
-  /** \brief . */
   void nonconstInitialize(
     const RCP<PreconditionerBase<Scalar> > &prec) {
     validateInitialize(prec);
     prec_ = prec;
   }
 
-  /** \brief . */
   void initialize(
     const RCP<const PreconditionerBase<Scalar> > &prec) {
     validateInitialize(prec);
     prec_ = prec;
   }
 
-  /** \brief . */
   RCP<PreconditionerBase<Scalar> >
   getNonconstPreconditioner() { return prec_.getNonconstObj(); }
 
-  /** \brief . */
   RCP<const PreconditionerBase<Scalar> >
   getPreconditioner() const { return prec_.getConstObj(); }
 
-  /** \brief . */
   void uninitialize() {
     prec_.uninitialize();
   }
@@ -61,40 +56,31 @@ public:
   /** @name Overridden from PreconditionerBase */
   //@{
 
-  /** \brief . */
   bool isLeftPrecOpConst() const
   { return prec_.getConstObj()->isLeftPrecOpConst(); }
 
-  /** \brief . */
   Teuchos::RCP<LinearOpBase<Scalar> > getNonconstLeftPrecOp()
   { return nonconstAdjoint(prec_.getNonconstObj()->getNonconstLeftPrecOp()); }
 
-  /** \brief . */
   Teuchos::RCP<const LinearOpBase<Scalar> > getLeftPrecOp() const
   { return adjoint(prec_.getConstObj()->getLeftPrecOp()); }
 
-  /** \brief . */
   bool isRightPrecOpConst() const
   { return prec_.getConstObj()->isRightPrecOpConst(); }
 
-  /** \brief . */
   Teuchos::RCP<LinearOpBase<Scalar> > getNonconstRightPrecOp()
   { return nonconstAdjoint(prec_.getNonconstObj()->getNonconstRightPrecOp()); }
 
-  /** \brief . */
   Teuchos::RCP<const LinearOpBase<Scalar> > getRightPrecOp() const
   { return adjoint(prec_.getConstObj()->getRightPrecOp()); }
 
-  /** \brief . */
   bool isUnspecifiedPrecOpConst() const
   { return prec_.getConstObj()->isUnspecifiedPrecOpConst(); }
 
-  /** \brief . */
   Teuchos::RCP<LinearOpBase<Scalar> > getNonconstUnspecifiedPrecOp()
   { return nonconstAdjoint(
       prec_.getNonconstObj()->getNonconstUnspecifiedPrecOp()); }
 
-  /** \brief . */
   Teuchos::RCP<const LinearOpBase<Scalar> > getUnspecifiedPrecOp() const
   { return adjoint(prec_.getNonconstObj()->getUnspecifiedPrecOp()); }
 

--- a/packages/tempus/src/Thyra_AdjointPreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_AdjointPreconditionerFactory.hpp
@@ -31,29 +31,24 @@ public:
   /** \brief Construct to uninitialized. */
   AdjointPreconditionerFactory() {}
 
-  /** \brief . */
   void nonconstInitialize(
     const RCP<PreconditionerFactoryBase<Scalar> > &prec_fac) {
     validateInitialize(prec_fac);
     prec_fac_ = prec_fac;
   }
 
-  /** \brief . */
   void initialize(
     const RCP<const PreconditionerFactoryBase<Scalar> > &prec_fac) {
     validateInitialize(prec_fac);
     prec_fac_ = prec_fac;
   }
 
-  /** \brief . */
   RCP<PreconditionerFactoryBase<Scalar> >
   getNonconstPreconditionerFactory() { return prec_fac_.getNonconstObj(); }
 
-  /** \brief . */
   RCP<const PreconditionerFactoryBase<Scalar> >
   getPreconditionerFactory() const { return prec_fac_.getConstObj(); }
 
-  /** \brief . */
   void uninitialize() {
     prec_fac_.uninitialize();
   }
@@ -61,7 +56,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const
   {
     std::ostringstream oss;
@@ -81,31 +75,26 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList)
   {
     prec_fac_.getNonconstObj()->setParameterList(paramList);
   }
 
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList()
   {
     return prec_fac_.getNonconstObj()->getNonconstParameterList();
   }
 
-  /** \brief . */
   RCP<ParameterList> unsetParameterList()
   {
     return prec_fac_.getNonconstObj()->unsetParameterList();
   }
 
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const
   {
     return prec_fac_.getConstObj()->getParameterList();
   }
 
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const
   {
     return prec_fac_.getConstObj()->getValidParameters();
@@ -118,16 +107,13 @@ public:
   /** @name Overridden from PreconditionerFactoryBase */
   //@{
 
-  /** \brief . */
   bool isCompatible(const LinearOpSourceBase<Scalar> &fwdOpSrc) const
   { return prec_fac_.getConstObj()->isCompatible(fwdOpSrc); }
 
-  /** \brief . */
    RCP<PreconditionerBase<Scalar> > createPrec() const
   { return nonconstAdjointPreconditioner(
       prec_fac_.getConstObj()->createPrec()); }
 
-  /** \brief . */
   void initializePrec(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     PreconditionerBase<Scalar> *precOp,
@@ -148,7 +134,6 @@ public:
       supportSolveUse);
   }
 
-  /** \brief . */
   void uninitializePrec(
     PreconditionerBase<Scalar> *precOp,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc = NULL,

--- a/packages/tempus/src/Thyra_BlockedTriangularLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_BlockedTriangularLinearOpWithSolveFactory.hpp
@@ -95,10 +95,8 @@ public:
     const Array< RCP<const LinearOpWithSolveFactoryBase<Scalar> > > &lowsf
     );
 
-  /** \brief . */
   Array< RCP<LinearOpWithSolveFactoryBase<Scalar> > > getUnderlyingLOWSF();
 
-  /** \brief . */
   Array< RCP<const LinearOpWithSolveFactoryBase<Scalar> > > getUnderlyingLOWSF() const;
 
   //@}
@@ -106,7 +104,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const;
 
   //@}
@@ -114,15 +111,10 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList);
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList();
-  /** \brief . */
   RCP<ParameterList> unsetParameterList();
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const;
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const;
 
   //@}
@@ -149,28 +141,23 @@ public:
     std::string *precFactoryName
     );
 
-  /** \brief . */
   virtual bool isCompatible(
     const LinearOpSourceBase<Scalar> &fwdOpSrc
     ) const;
 
-  /** \brief . */
   virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const;
 
-  /** \brief . */
   virtual void initializeOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op,
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeAndReuseOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op
     ) const;
 
-  /** \brief . */
   virtual void uninitializeOp(
     LinearOpWithSolveBase<Scalar> *Op,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
@@ -179,12 +166,10 @@ public:
     ESupportSolveUse *supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual bool supportsPreconditionerInputType(
     const EPreconditionerInputType precOpType
     ) const;
 
-  /** \brief . */
   virtual void initializePreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const PreconditionerBase<Scalar> > &prec,
@@ -192,7 +177,6 @@ public:
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeApproxPreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
@@ -207,7 +191,6 @@ protected:
   /** \brief Overridden from Teuchos::VerboseObjectBase */
   //@{
 
-  /** \brief . */
   void informUpdatedVerbosityState() const;
 
   //@}
@@ -226,7 +209,7 @@ private:
 
 /** \brief Nonmember constructor.
  *
- * \releates BlockedTriangularLinearOpWithSolveFactory
+ * \relates BlockedTriangularLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<BlockedTriangularLinearOpWithSolveFactory<Scalar> >
@@ -242,7 +225,7 @@ blockedTriangularLinearOpWithSolveFactory(
 
 /** \brief Nonmember constructor.
  *
- * \releates BlockedTriangularLinearOpWithSolveFactory
+ * \relates BlockedTriangularLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<BlockedTriangularLinearOpWithSolveFactory<Scalar> >

--- a/packages/tempus/src/Thyra_MultiVectorLinearOp.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorLinearOp.hpp
@@ -38,7 +38,6 @@ public:
   /** \brief Construct to uninitialized. */
   MultiVectorLinearOp() {}
 
-  /** \brief . */
   void nonconstInitialize(
     const RCP<LinearOpBase<Scalar> > &op,
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
@@ -50,7 +49,6 @@ public:
     multiVecDomain_ = multiVecDomain;
   }
 
-  /** \brief . */
   void initialize(
     const RCP<const LinearOpBase<Scalar> > &op,
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
@@ -62,15 +60,12 @@ public:
     multiVecDomain_ = multiVecDomain;
   }
 
-  /** \brief . */
   RCP<LinearOpBase<Scalar> >
   getNonconstLinearOp() { return op_.getNonconstObj(); }
 
-  /** \brief . */
   RCP<const LinearOpBase<Scalar> >
   getLinearOp() const { return op_.getConstObj(); }
 
-  /** \brief . */
   void uninitialize() {
     op_.uninitialize();
     multiVecRange_ = Teuchos::null;
@@ -82,13 +77,10 @@ public:
   /** @name Overridden from LinearOpBase */
   //@{
 
-  /** \brief . */
   RCP< const VectorSpaceBase<Scalar> > range() const { return multiVecRange_; }
 
-  /** \brief . */
   RCP< const VectorSpaceBase<Scalar> > domain() const { return multiVecDomain_; }
 
-  /** \brief . */
   RCP<const LinearOpBase<Scalar> > clone() const { return Teuchos::null; // ToDo: Implement if needed ???
   }
   //@}
@@ -97,12 +89,10 @@ protected:
 
   /** @name Overridden from LinearOpBase */
   //@{
-  /** \brief . */
   bool opSupportedImpl(EOpTransp M_trans) const {
     return Thyra::opSupported(*op_.getConstObj(),M_trans);
   }
 
-  /** \brief . */
   void applyImpl(
     const EOpTransp M_trans,
     const MultiVectorBase<Scalar> &XX,
@@ -144,7 +134,7 @@ protected:
 
   /** \brief Get some statistics about a supported row.
    *
-   * \precondition <tt>this->rowStatIsSupported(rowStat)==true</tt>
+   * \pre <tt>this->rowStatIsSupported(rowStat)==true</tt>
    */
   void getRowStatImpl(
     const RowStatLinearOpBaseUtils::ERowStat rowStat,
@@ -177,19 +167,16 @@ protected:
   /** @name Overridden from ScaledLinearOpBase */
   //@{
 
-  /** \brief . */
   virtual bool supportsScaleLeftImpl() const {
     using Teuchos::rcp_dynamic_cast;
     return rcp_dynamic_cast<const ScaledLinearOpBase<Scalar> >(op_.getConstObj())->supportsScaleLeft();
   }
 
-  /** \brief . */
   virtual bool supportsScaleRightImpl() const {
     using Teuchos::rcp_dynamic_cast;
     return rcp_dynamic_cast<const ScaledLinearOpBase<Scalar> >(op_.getConstObj())->supportsScaleRight();
   }
 
-  /** \brief . */
   virtual void scaleLeftImpl(const VectorBase<Scalar> &row_scaling) {
     TEUCHOS_ASSERT(this->supportsScaleLeft());
 
@@ -207,7 +194,6 @@ protected:
     //row_scaling.describe(std::cout, Teuchos::VERB_EXTREME);
   }
 
-  /** \brief . */
   virtual void scaleRightImpl(const VectorBase<Scalar> &col_scaling) {
     TEUCHOS_ASSERT(this->supportsScaleRight());
 

--- a/packages/tempus/src/Thyra_MultiVectorLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorLinearOpWithSolveFactory.hpp
@@ -37,6 +37,8 @@ public:
    *
    * \param lowsf [in,persisting] The LOWSFB object that will be used to
    * create the LOWSB object for the diagonal blocks.
+   * \param multiVecRange [?] Description.
+   * \param multiVecDomain [?] Description.
    *
    * <b>Preconditions:</b><ul>
    * <li><tt>!is_null(lowsf)</tt>
@@ -54,6 +56,8 @@ public:
    *
    * \param lowsf [in,persisting] The LOWSFB object that will be used to
    * create the LOWSB object for the diagonal blocks.
+   * \param multiVecRange [?] Description.
+   * \param multiVecDomain [?] Description.
    *
    * <b>Preconditions:</b><ul>
    * <li><tt>!is_null(lowsf)</tt>
@@ -66,10 +70,8 @@ public:
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecDomain
     );
 
-  /** \brief . */
   RCP<LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF();
 
-  /** \brief . */
   RCP<const LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF() const;
 
   //@}
@@ -77,7 +79,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const;
 
   //@}
@@ -85,15 +86,10 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList);
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList();
-  /** \brief . */
   RCP<ParameterList> unsetParameterList();
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const;
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const;
 
   //@}
@@ -120,28 +116,23 @@ public:
     std::string *precFactoryName
     );
 
-  /** \brief . */
   virtual bool isCompatible(
     const LinearOpSourceBase<Scalar> &fwdOpSrc
     ) const;
 
-  /** \brief . */
   virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const;
 
-  /** \brief . */
   virtual void initializeOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op,
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeAndReuseOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op
     ) const;
 
-  /** \brief . */
   virtual void uninitializeOp(
     LinearOpWithSolveBase<Scalar> *Op,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
@@ -150,12 +141,10 @@ public:
     ESupportSolveUse *supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual bool supportsPreconditionerInputType(
     const EPreconditionerInputType precOpType
     ) const;
 
-  /** \brief . */
   virtual void initializePreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const PreconditionerBase<Scalar> > &prec,
@@ -163,7 +152,6 @@ public:
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeApproxPreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
@@ -178,7 +166,6 @@ protected:
   /** \brief Overridden from Teuchos::VerboseObjectBase */
   //@{
 
-  /** \brief . */
   void informUpdatedVerbosityState() const;
 
   //@}
@@ -195,7 +182,7 @@ private:
 
 /** \brief Nonmember constructor.
  *
- * \releates MultiVectorLinearOpWithSolveFactory
+ * \relates MultiVectorLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
@@ -213,7 +200,7 @@ nonconstMultiVectorLinearOpWithSolveFactory(
 
 /** \brief Nonmember constructor.
  *
- * \releates MultiVectorLinearOpWithSolveFactory
+ * \relates MultiVectorLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
@@ -232,7 +219,7 @@ nonconstMultiVectorLinearOpWithSolveFactory(
 
 /** \brief Nonmember constructor.
  *
- * \releates MultiVectorLinearOpWithSolveFactory
+ * \relates MultiVectorLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >
@@ -250,7 +237,7 @@ multiVectorLinearOpWithSolveFactory(
 
 /** \brief Nonmember constructor.
  *
- * \releates MultiVectorLinearOpWithSolveFactory
+ * \relates MultiVectorLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<MultiVectorLinearOpWithSolveFactory<Scalar> >

--- a/packages/tempus/src/Thyra_MultiVectorPreconditioner.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorPreconditioner.hpp
@@ -30,7 +30,6 @@ public:
   /** \brief Construct to uninitialized. */
   MultiVectorPreconditioner() {}
 
-  /** \brief . */
   void nonconstInitialize(
     const RCP<PreconditionerBase<Scalar> > &prec,
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
@@ -42,7 +41,6 @@ public:
     multiVecDomain_ = multiVecDomain;
   }
 
-  /** \brief . */
   void initialize(
     const RCP<const PreconditionerBase<Scalar> > &prec,
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
@@ -53,15 +51,12 @@ public:
     multiVecDomain_ = multiVecDomain;
   }
 
-  /** \brief . */
   RCP<PreconditionerBase<Scalar> >
   getNonconstPreconditioner() { return prec_.getNonconstObj(); }
 
-  /** \brief . */
   RCP<const PreconditionerBase<Scalar> >
   getPreconditioner() const { return prec_.getConstObj(); }
 
-  /** \brief . */
   void uninitialize() {
     prec_.uninitialize();
     multiVecRange_ = Teuchos::null;
@@ -73,54 +68,45 @@ public:
   /** @name Overridden from PreconditionerBase */
   //@{
 
-  /** \brief . */
   bool isLeftPrecOpConst() const
   { return prec_.getConstObj()->isLeftPrecOpConst(); }
 
-  /** \brief . */
   Teuchos::RCP<LinearOpBase<Scalar> > getNonconstLeftPrecOp()
   { return nonconstMultiVectorLinearOp(
       prec_.getNonconstObj()->getNonconstLeftPrecOp(),
       multiVecRange_,
       multiVecDomain_); }
 
-  /** \brief . */
   Teuchos::RCP<const LinearOpBase<Scalar> > getLeftPrecOp() const
   { return multiVectorLinearOp(
       prec_.getConstObj()->getLeftPrecOp(),
       multiVecRange_,
       multiVecDomain_); }
 
-  /** \brief . */
   bool isRightPrecOpConst() const
   { return prec_.getConstObj()->isRightPrecOpConst(); }
 
-  /** \brief . */
   Teuchos::RCP<LinearOpBase<Scalar> > getNonconstRightPrecOp()
   { return nonconstMultiVectorLinearOp(
       prec_.getNonconstObj()->getNonconstRightPrecOp(),
       multiVecRange_,
       multiVecDomain_); }
 
-  /** \brief . */
   Teuchos::RCP<const LinearOpBase<Scalar> > getRightPrecOp() const
   { return multiVectorLinearOp(
       prec_.getConstObj()->getRightPrecOp(),
       multiVecRange_,
       multiVecDomain_); }
 
-  /** \brief . */
   bool isUnspecifiedPrecOpConst() const
   { return prec_.getConstObj()->isUnspecifiedPrecOpConst(); }
 
-  /** \brief . */
   Teuchos::RCP<LinearOpBase<Scalar> > getNonconstUnspecifiedPrecOp()
   { return nonconstMultiVectorLinearOp(
       prec_.getNonconstObj()->getNonconstUnspecifiedPrecOp(),
       multiVecRange_,
       multiVecDomain_); }
 
-  /** \brief . */
   Teuchos::RCP<const LinearOpBase<Scalar> > getUnspecifiedPrecOp() const
   { return multiVectorLinearOp(
       prec_.getNonconstObj()->getUnspecifiedPrecOp(),

--- a/packages/tempus/src/Thyra_MultiVectorPreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorPreconditionerFactory.hpp
@@ -32,7 +32,6 @@ public:
   /** \brief Construct to uninitialized. */
   MultiVectorPreconditionerFactory() {}
 
-  /** \brief . */
   void nonconstInitialize(
     const RCP<PreconditionerFactoryBase<Scalar> > &prec_fac,
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
@@ -44,7 +43,6 @@ public:
     multiVecDomain_ = multiVecDomain;
   }
 
-  /** \brief . */
   void initialize(
     const RCP<const PreconditionerFactoryBase<Scalar> > &prec_fac,
     const RCP<const DefaultMultiVectorProductVectorSpace<Scalar> > &multiVecRange,
@@ -55,15 +53,12 @@ public:
     multiVecDomain_ = multiVecDomain;
   }
 
-  /** \brief . */
   RCP<PreconditionerFactoryBase<Scalar> >
   getNonconstPreconditionerFactory() { return prec_fac_.getNonconstObj(); }
 
-  /** \brief . */
   RCP<const PreconditionerFactoryBase<Scalar> >
   getPreconditionerFactory() const { return prec_fac_.getConstObj(); }
 
-  /** \brief . */
   void uninitialize() {
     prec_fac_.uninitialize();
     multiVecRange_ = Teuchos::null;
@@ -73,7 +68,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const
   {
     std::ostringstream oss;
@@ -93,31 +87,26 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList)
   {
     prec_fac_.getNonconstObj()->setParameterList(paramList);
   }
 
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList()
   {
     return prec_fac_.getNonconstObj()->getNonconstParameterList();
   }
 
-  /** \brief . */
   RCP<ParameterList> unsetParameterList()
   {
     return prec_fac_.getNonconstObj()->unsetParameterList();
   }
 
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const
   {
     return prec_fac_.getConstObj()->getParameterList();
   }
 
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const
   {
     return prec_fac_.getConstObj()->getValidParameters();
@@ -130,18 +119,15 @@ public:
   /** @name Overridden from PreconditionerFactoryBase */
   //@{
 
-  /** \brief . */
   bool isCompatible(const LinearOpSourceBase<Scalar> &fwdOpSrc) const
   { return prec_fac_.getConstObj()->isCompatible(fwdOpSrc); }
 
-  /** \brief . */
    RCP<PreconditionerBase<Scalar> > createPrec() const
   { return nonconstMultiVectorPreconditioner(
       prec_fac_.getConstObj()->createPrec(),
       multiVecRange_,
       multiVecDomain_); }
 
-  /** \brief . */
   void initializePrec(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     PreconditionerBase<Scalar> *precOp,
@@ -162,7 +148,6 @@ public:
       supportSolveUse);
   }
 
-  /** \brief . */
   void uninitializePrec(
     PreconditionerBase<Scalar> *precOp,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc = NULL,

--- a/packages/tempus/src/Thyra_ReuseLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_ReuseLinearOpWithSolveFactory.hpp
@@ -33,6 +33,7 @@ public:
    *
    * \param lowsf [in,persisting] The LOWSFB object that will be used to
    * create the LOWSB object for the diagonal blocks.
+   * \param prec [?] Description.
    *
    * <b>Preconditions:</b><ul>
    * <li><tt>!is_null(lowsf)</tt>
@@ -49,6 +50,7 @@ public:
    *
    * \param lowsf [in,persisting] The LOWSFB object that will be used to
    * create the LOWSB object for the diagonal blocks.
+   * \param prec [?] Description.
    *
    * <b>Preconditions:</b><ul>
    * <li><tt>!is_null(lowsf)</tt>
@@ -60,16 +62,12 @@ public:
     const RCP<PreconditionerBase<Scalar> > &prec
     );
 
-  /** \brief . */
   RCP<LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF();
 
-  /** \brief . */
   RCP<const LinearOpWithSolveFactoryBase<Scalar> > getUnderlyingLOWSF() const;
 
-  /** \brief . */
   RCP<PreconditionerBase<Scalar> > getUnderlyingPreconditioner();
 
-  /** \brief . */
   RCP<const PreconditionerBase<Scalar> > getUnderlyingPreconditioner() const;
 
   //@}
@@ -77,7 +75,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const;
 
   //@}
@@ -85,15 +82,10 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList);
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList();
-  /** \brief . */
   RCP<ParameterList> unsetParameterList();
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const;
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const;
 
   //@}
@@ -120,28 +112,23 @@ public:
     std::string *precFactoryName
     );
 
-  /** \brief . */
   virtual bool isCompatible(
     const LinearOpSourceBase<Scalar> &fwdOpSrc
     ) const;
 
-  /** \brief . */
   virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const;
 
-  /** \brief . */
   virtual void initializeOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op,
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeAndReuseOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op
     ) const;
 
-  /** \brief . */
   virtual void uninitializeOp(
     LinearOpWithSolveBase<Scalar> *Op,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
@@ -150,12 +137,10 @@ public:
     ESupportSolveUse *supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual bool supportsPreconditionerInputType(
     const EPreconditionerInputType precOpType
     ) const;
 
-  /** \brief . */
   virtual void initializePreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const PreconditionerBase<Scalar> > &prec,
@@ -163,7 +148,6 @@ public:
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeApproxPreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
@@ -178,7 +162,6 @@ protected:
   /** \brief Overridden from Teuchos::VerboseObjectBase */
   //@{
 
-  /** \brief . */
   void informUpdatedVerbosityState() const;
 
   //@}
@@ -194,7 +177,7 @@ private:
 
 /** \brief Nonmember constructor.
  *
- * \releates ReuseLinearOpWithSolveFactory
+ * \relates ReuseLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<ReuseLinearOpWithSolveFactory<Scalar> >
@@ -211,7 +194,7 @@ nonconstReuseLinearOpWithSolveFactory(
 
 /** \brief Nonmember constructor.
  *
- * \releates ReuseLinearOpWithSolveFactory
+ * \relates ReuseLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<ReuseLinearOpWithSolveFactory<Scalar> >

--- a/packages/tempus/src/Thyra_ReusePreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_ReusePreconditionerFactory.hpp
@@ -28,7 +28,6 @@ public:
   /** \brief Construct to uninitialized. */
   ReusePreconditionerFactory() {}
 
-  /** \brief . */
   void initialize(
     const RCP<PreconditionerBase<Scalar> > &prec
     ) {
@@ -38,15 +37,12 @@ public:
     prec_ = prec;
   }
 
-  /** \brief . */
   RCP<PreconditionerBase<Scalar> >
   getNonconstPreconditioner() { return prec_; }
 
-  /** \brief . */
   RCP<const PreconditionerBase<Scalar> >
   getPreconditioner() const { return prec_; }
 
-  /** \brief . */
   void uninitialize() {
     prec_ = Teuchos::null;
   }
@@ -54,7 +50,6 @@ public:
   /** \name Overridden from Teuchos::Describable. */
   //@{
 
-  /** \brief . */
   std::string description() const
   {
     std::ostringstream oss;
@@ -74,30 +69,25 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList)
   {
   }
 
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList()
   {
     return Teuchos::null;
   }
 
-  /** \brief . */
   RCP<ParameterList> unsetParameterList()
   {
     return Teuchos::null;
   }
 
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const
   {
     return Teuchos::null;
   }
 
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const
   {
     return rcp(new ParameterList);
@@ -110,15 +100,12 @@ public:
   /** @name Overridden from PreconditionerFactoryBase */
   //@{
 
-  /** \brief . */
   bool isCompatible(const LinearOpSourceBase<Scalar> &fwdOpSrc) const
   { return false; }
 
-  /** \brief . */
    RCP<PreconditionerBase<Scalar> > createPrec() const
   { return prec_; }
 
-  /** \brief . */
   void initializePrec(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     PreconditionerBase<Scalar> *precOp,
@@ -127,7 +114,6 @@ public:
   {
   }
 
-  /** \brief . */
   void uninitializePrec(
     PreconditionerBase<Scalar> *precOp,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc = NULL,

--- a/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolve.hpp
+++ b/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolve.hpp
@@ -30,7 +30,6 @@ public:
   /** \brief Construct to uninitialized. */
   ScaledIdentityLinearOpWithSolve() {}
 
-  /** \brief . */
   void initialize(const RCP<const VectorSpaceBase<Scalar> >& space,
                   const Scalar& s)
   {
@@ -39,7 +38,6 @@ public:
     s_ = s;
   }
 
-  /** \brief . */
   void uninitialize()
   {
     space_ = Teuchos::null;
@@ -54,13 +52,10 @@ public:
   /** @name Overridden from LinearOpBase */
   //@{
 
-  /** \brief . */
   RCP< const VectorSpaceBase<Scalar> > range() const { return space_; }
 
-  /** \brief . */
   RCP< const VectorSpaceBase<Scalar> > domain() const { return space_; }
 
-  /** \brief . */
   RCP<const LinearOpBase<Scalar> > clone() const
   {
     RCP<ScaledIdentityLinearOpWithSolve<Scalar> > op =
@@ -74,10 +69,8 @@ protected:
 
   /** @name Overridden from LinearOpBase */
   //@{
-  /** \brief . */
   bool opSupportedImpl(EOpTransp M_trans) const { return true; }
 
-  /** \brief . */
   void applyImpl(const EOpTransp M_trans,
                  const MultiVectorBase<Scalar>& X,
                  const Ptr<MultiVectorBase<Scalar> >& Y,
@@ -95,22 +88,18 @@ protected:
 
   /** @name Overridden from LinearOpWithSolveBase */
   //@{
-  /** \brief . */
   bool solveSupportsImpl(EOpTransp M_trans) const { return true; }
 
-  /** \brief . */
   bool solveSupportsNewImpl(
     EOpTransp M_trans,
     const Ptr< const SolveCriteria< Scalar > > solveCriteria) const
   { return true; }
 
-  /** \brief . */
   bool solveSupportsSolveMeasureTypeImpl(
     EOpTransp M_trans,
      const SolveMeasureType &solveMeasureType) const
   { return true; }
 
-  /** \brief . */
   SolveStatus< Scalar > solveImpl(
     const EOpTransp M_trans,
     const MultiVectorBase<Scalar>& B,

--- a/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolveFactory.hpp
@@ -47,15 +47,10 @@ public:
   /** @name Overridden from ParameterListAcceptor */
   //@{
 
-  /** \brief . */
   void setParameterList(RCP<ParameterList> const& paramList) {}
-  /** \brief . */
   RCP<ParameterList> getNonconstParameterList() { return Teuchos::parameterList(); }
-  /** \brief . */
   RCP<ParameterList> unsetParameterList() { return Teuchos::parameterList(); }
-  /** \brief . */
   RCP<const ParameterList> getParameterList() const { return Teuchos::parameterList(); }
-  /** \brief . */
   RCP<const ParameterList> getValidParameters() const { return Teuchos::parameterList(); }
 
   //@}
@@ -82,7 +77,6 @@ public:
     std::string *precFactoryName
     ) {}
 
-  /** \brief . */
   virtual bool isCompatible(
     const LinearOpSourceBase<Scalar> &fwdOpSrc
     ) const
@@ -91,18 +85,15 @@ public:
       Teuchos::rcp_dynamic_cast<const ScaledIdentityLinearOpWithSolve<Scalar> >(fwdOpSrc.getOp()));
   }
 
-  /** \brief . */
   virtual RCP<LinearOpWithSolveBase<Scalar> > createOp() const
   { return scaledIdentity(space_, s_); }
 
-  /** \brief . */
   virtual void initializeOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op,
     const ESupportSolveUse supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual void initializeAndReuseOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     LinearOpWithSolveBase<Scalar> *Op
@@ -111,7 +102,6 @@ public:
       initializeOp(fwdOpSrc, Op, SUPPORT_SOLVE_UNSPECIFIED);
     }
 
-  /** \brief . */
   virtual void uninitializeOp(
     LinearOpWithSolveBase<Scalar> *Op,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
@@ -120,12 +110,10 @@ public:
     ESupportSolveUse *supportSolveUse
     ) const;
 
-  /** \brief . */
   virtual bool supportsPreconditionerInputType(
     const EPreconditionerInputType precOpType
     ) const { return false; }
 
-  /** \brief . */
   virtual void initializePreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const PreconditionerBase<Scalar> > &prec,
@@ -133,7 +121,6 @@ public:
     const ESupportSolveUse supportSolveUse
     ) const {}
 
-  /** \brief . */
   virtual void initializeApproxPreconditionedOp(
     const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
     const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
@@ -148,7 +135,6 @@ protected:
   /** \brief Overridden from Teuchos::VerboseObjectBase */
   //@{
 
-  /** \brief . */
   void informUpdatedVerbosityState() const {}
 
   //@}
@@ -162,7 +148,7 @@ private:
 
 /** \brief Nonmember constructor.
  *
- * \releates ScaledIdentityLinearOpWithSolveFactory
+ * \relates ScaledIdentityLinearOpWithSolveFactory
  */
 template<class Scalar>
 RCP<ScaledIdentityLinearOpWithSolveFactory<Scalar> >


### PR DESCRIPTION
## Description

Deal with a number of Tempus doxygen warnings:
*  Equation errors.
*  End of list marker without any list.
*  Disconnects between _decl and _impl files.
*  Etc.

@trilinos/tempus

## Motivation and Context
Email from @ccober6:

> Hi all,
> 
> I have doxygen warnings that I can not track down, and wondered if you had any thoughts.  I get many of the following type warnings:
> 
> /Users/ccober/myOffice/Trilinos/packages/tempus/src/Thyra_AdjointLinearOpWithSolveFactory.hpp:88: warning: End of list marker found without any preceding list items
> 
> Here is what I know so far
>  * They only occur in Thyra_* files (Thats why I am asking Eric about this.)
>  * They occur on /** \brief . */
>  * Adding a short text to the brief fixes it.
>  * Removing the dot “.” fixes it.
>  * A dot “.” ends the brief.
> 
> Is this "brief ." important?
> 
> Thanks,
> 
> Curt

## How Has This Been Tested?
Tempus documentation builds without errors with doxygen-1.8.14.  No code changes, so no need to run `ctest`.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.