### PR TITLE
Fix running of tests on 'serrano' for ATDM Trilinos builds

### DIFF
--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp-panzer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export SRUN_CTEST_TIME_LIMIT_MINUTES=20
+export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:20:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh

--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-#export SRUN_CTEST_TIME_LIMIT_MINUTES=60
+#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh

--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export SRUN_CTEST_TIME_LIMIT_MINUTES=20
+export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:20:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh

--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-#export SRUN_CTEST_TIME_LIMIT_MINUTES=60
+#export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh

--- a/cmake/ctest/drivers/atdm/toss3/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/toss3/local-driver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
-if [ "${SRUN_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
-  SRUN_CTEST_TIME_LIMIT_MINUTES=90
+if [ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
+  SALLOC_CTEST_TIME_LIMIT_MINUTES=1:30:00
   # This is just running tests, not the entire build!
 fi
 
@@ -11,5 +11,5 @@ source $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver-config-build.
 
 set -x
 
-/usr/bin/srun -N 1 --time=${SRUN_CTEST_TIME_LIMIT_MINUTES} --account=fy150090 -J $JOB_NAME \
+salloc -N1 --time=${SALLOC_CTEST_TIME_LIMIT_MINUTES} --account=fy150090 -J $JOB_NAME \
   $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver-test.sh

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -259,12 +259,11 @@ $ srun ./checkin-test-sems.sh intel-opt-openmp \
 
 ### chama/serrano
 
-Once logged on to `chama`  or `serrano`, one can
-directly configure and build on the login node (being careful not to overload
-the node).  But to run the tests, one must run on the compute nodes using the
-`srun` command.  For example, to configure, build and run the tests for say
-`MueuLu` on `serrano` or `chama`, (after cloning Trilinos on the `develop` branch) one
-would do:
+Once logged on to `chama` or `serrano`, one can directly configure and build
+on the login node (being careful not to overload the node).  But to run the
+tests, one must run on the compute nodes using the `srun` command.  For
+example, to configure, build and run the tests for say `MueuLu` on `serrano`
+or `chama`, (after cloning Trilinos on the `develop` branch) one would do:
 
 
 ```
@@ -279,11 +278,26 @@ $ cmake \
 
 $ make -j16
 
-$ srun -N 1 --time=600 --account=<YOUR_WCID> -J $JOB_NAME ctest -j16
+$ salloc -N1 --time=0:20:00 --account=<YOUR_WCID> ctest -j16
 ```
 
-To get information on <YOUR_WCID> used above, there is a WC tool tab on computing.sandia.gov 
+To get information on <YOUR_WCID> used above, there is a WC tool tab on
+computing.sandia.gov
 
+To use the checkin-test-atdm.sh script, you must split running the tests from
+the configure and build as with:
+
+```
+$ cd <some_build_dir>/
+$ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-sems.sh .
+$ ./checkin-test-sems.sh intel-opt-openmp \
+  --enable-all-packages=off --no-enable-fwd-packages --enable-packages=MueLu \
+  --allow-no-pull --configure --build
+$ salloc -N1 --time=0:20:00 --account=<YOUR_WCID> \
+  ./checkin-test-sems.sh intel-opt-openmp \
+  --enable-all-packages=off --no-enable-fwd-packages --enable-packages=MueLu \
+  --test
+```
 
 ### SEMS rhel6 environment
 

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -67,7 +67,7 @@ export MPICC=`which mpicc`
 export MPICXX=`which mpicxx`
 export MPIF90=`which mpif90`
 
-export ATDM_CONFIG_MPI_POST_FLAG="-map-by;socket:PE=16;--oversubscribe"
+export ATDM_CONFIG_MPI_POST_FLAG="--bind-to;core;--npernode;36"
 
 # Set the default compilers
 export CC=mpicc


### PR DESCRIPTION
**CC:** @fryeguy52 

## Description

This appears to mostly fix the problems with running tests on 'serrano' as reported in #2699.  I changed the arguments passed to `mpiexec` and I changed from `srun` to `salloc`.   I basically followed the guidelines at:

* https://computing.sandia.gov/platforms/cts1/submitting_jobs

exactly as stated.

## How Has This Been Tested?

I ran the Jenkins driver locally for Panzer and it produced:

```
100% tests passed, 0 tests failed out of 156

Label Time Summary:
Panzer    = 1257.04 sec*proc (156 tests)

Total Test time (real) = 162.90 sec

Panzer: File '' does NOT exist so all tests passed!

Panzer: Skipping running memory checking tests due to CTEST_DO_MEMORY_TESTING='FALSE'!

Done with the incremental building and testing of Trilinos packages!

TRIBITS_CTEST_DRIVER_ERROR_QUEUE is empty. All is well.

See results for:
  Site: serrano
  Build Name: Trilinos-atdm-toss3-intel-opt-openmp-panzer
at:
  http://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project

TRIBITS_CTEST_DRIVER: OVERALL: ALL PASSSED
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
