### PR TITLE
Tpetra: Fix #2705 (don't use deprecated Kokkos::View methods)

### DIFF
--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
@@ -162,7 +162,7 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // View, so we take a subview.
     auto x_1d = Kokkos::subview (x_2d, Kokkos::ALL (), 0);
 
-    // x_data.dimension_0 () may be longer than the number of local
+    // x_data.extent (0) may be longer than the number of local
     // rows in the Vector, so be sure to ask the Vector for its
     // dimensions, rather than the ArrayRCP.
     const size_t localLength = x.getLocalLength ();
@@ -210,7 +210,7 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     x.modify<Kokkos::HostSpace> ();
 
     // Use local indices to access the entries of x_data.
-    // x_data.dimension_0 () may be longer than the number of local
+    // x_data.extent (0) may be longer than the number of local
     // rows in the Vector, so be sure to ask the Vector for its
     // dimensions.
     const size_t localLength = x.getLocalLength ();

--- a/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
@@ -136,7 +136,7 @@ localApplyBlockNoTrans (Tpetra::Experimental::BlockCrsMatrix<Scalar, LO, GO, Nod
         const LO meshCol = indHost[absBlkOff];
 
         auto A_cur_1d = Kokkos::subview (val, absBlkOff * blockSize * blockSize);
-        little_blk_type A_cur (A_cur_1d.ptr_on_device (), blockSize, blockSize);
+        little_blk_type A_cur (A_cur_1d.data (), blockSize, blockSize);
         auto X_cur = X.getLocalBlock (meshCol, j);
 
         GEMV (alpha, A_cur, X_cur, Y_lcl); // Y_lcl += alpha*A_cur*X_cur
@@ -555,7 +555,7 @@ getTpetraBlockCrsMatrix (Teuchos::FancyOStream& out,
   block_type curBlk ("curBlk", blkSize, blkSize);
   // We only use this if filling with random values.
   Kokkos::View<SC*, Kokkos::LayoutRight, host_device_type,
-    Kokkos::MemoryUnmanaged> curBlk_1d (curBlk.ptr_on_device (),
+    Kokkos::MemoryUnmanaged> curBlk_1d (curBlk.data (),
                                         blkSize * blkSize);
   if (! opts.runTest) {
     // For benchmarks, we don't care so much about the values; we just
@@ -582,7 +582,7 @@ getTpetraBlockCrsMatrix (Teuchos::FancyOStream& out,
       }
       const LO lclColInd = lclColInds[k];
       const LO err =
-        A->replaceLocalValues (lclRow, &lclColInd, curBlk.ptr_on_device (), 1);
+        A->replaceLocalValues (lclRow, &lclColInd, curBlk.data (), 1);
       TEUCHOS_TEST_FOR_EXCEPTION(err != 1, std::logic_error, "Bug");
     }
   }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -534,7 +534,7 @@ makeColMapAndConvertGids(GlobalOrdinal ncols,
   typedef global_col_inds_array GView;
   typedef col_inds_array LView;
   //Functors (explained in the procedural code below)
-  auto nentries = gids.dimension_0();
+  auto nentries = gids.extent(0);
   //each entry of entryUnion is 0 unless there is a local entry in that column (then it is 1)
   ByteView entryUnion("entry union", ncols);
   UnionEntries<ByteView, GView> ue(entryUnion, gids);
@@ -544,13 +544,13 @@ makeColMapAndConvertGids(GlobalOrdinal ncols,
   ::Tpetra::Details::computeOffsetsFromCounts<decltype(gtol), decltype(entryUnion)>(gtol, entryUnion);
   //convert gids to local ids and put them in lids (implicitly sorted as long as input gids is sorted per row)
   ConvertGlobalToLocal<LView, GView> cgtl(gtol, gids, lids);
-  Kokkos::parallel_for("Tpetra_MatrixMatrix_convertGlobalToLocal", range_type(0, gids.dimension_0()), cgtl);
+  Kokkos::parallel_for("Tpetra_MatrixMatrix_convertGlobalToLocal", range_type(0, gids.extent(0)), cgtl);
   //build local set of GIDs for constructing column map - the last entry in gtol is the total number of local cols
   execution_space::fence();
   GView colmap("column map", gtol(ncols));
   size_t localIter = 0;
   execution_space::fence();
-  for(size_t i = 0; i < entryUnion.dimension_0(); i++)
+  for(size_t i = 0; i < entryUnion.extent(0); i++)
   {
     if(entryUnion(i) != 0)
     {
@@ -758,7 +758,7 @@ add (const Scalar& alpha,
     AddKern::convertToGlobalAndAdd(
       Aprime->getLocalMatrix(), alpha, Bprime->getLocalMatrix(), beta, Acolmap, Bcolmap,
       CRangeMap->getMinGlobalIndex(), Aprime->getGlobalNumCols(), vals, rowptrs, globalColinds);
-    colinds = col_inds_array("C colinds", globalColinds.dimension_0());
+    colinds = col_inds_array("C colinds", globalColinds.extent(0));
     if (debug) {
       std::ostringstream os;
       os << "Proc " << A.getMap ()->getComm ()->getRank () << ": "
@@ -819,7 +819,7 @@ add (const Scalar& alpha,
 #ifdef HAVE_TPETRA_MMM_TIMINGS
       MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("Tpetra::Crs constructor"))));
 #endif
-      //      C = rcp(new crs_matrix_type(CrowMap, CcolMap, rowptrs, colinds, vals, params));      
+      //      C = rcp(new crs_matrix_type(CrowMap, CcolMap, rowptrs, colinds, vals, params));
       C.replaceColMap(CcolMap);
       C.setAllValues(rowptrs,colinds,vals);
 #ifdef HAVE_TPETRA_MMM_TIMINGS
@@ -1191,8 +1191,8 @@ addSorted(
   typename AddDetails::AddKernels<SC, LO, GO, NO>::col_inds_array& Ccolinds)
 {
   using Teuchos::TimeMonitor;
-  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.dimension_0() != Browptrs.dimension_0(), std::runtime_error, "Can't add matrices with different numbers of rows.");
-  auto nrows = Arowptrs.dimension_0() - 1;
+  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.extent(0) != Browptrs.extent(0), std::runtime_error, "Can't add matrices with different numbers of rows.");
+  auto nrows = Arowptrs.extent(0) - 1;
   Crowptrs = row_ptrs_array("C row ptrs", nrows + 1);
   typedef KokkosKernels::Experimental::KokkosKernelsHandle<typename col_inds_array::size_type, LO, impl_scalar_type,
               execution_space, memory_space, memory_space> KKH;
@@ -1236,8 +1236,8 @@ addUnsorted(
   typename AddDetails::AddKernels<SC, LO, GO, NO>::col_inds_array& Ccolinds)
 {
   using Teuchos::TimeMonitor;
-  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.dimension_0() != Browptrs.dimension_0(), std::runtime_error, "Can't add matrices with different numbers of rows.");
-  auto nrows = Arowptrs.dimension_0() - 1;
+  TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.extent(0) != Browptrs.extent(0), std::runtime_error, "Can't add matrices with different numbers of rows.");
+  auto nrows = Arowptrs.extent(0) - 1;
   Crowptrs = row_ptrs_array("C row ptrs", nrows + 1);
   typedef AddDetails::AddKernels<SC, LO, GO, NO> AddKern;
   typedef KokkosKernels::Experimental::KokkosKernelsHandle<typename col_inds_array::size_type, LO, AddKern::impl_scalar_type,
@@ -1314,15 +1314,15 @@ convertToGlobalAndAdd(
   const col_inds_array& Bcolinds = B.graph.entries;
   auto Arowptrs = A.graph.row_map;
   auto Browptrs = B.graph.row_map;
-  global_col_inds_array AcolindsConverted("A colinds (converted)", Acolinds.dimension_0());
-  global_col_inds_array BcolindsConverted("B colinds (converted)", Bcolinds.dimension_0());
+  global_col_inds_array AcolindsConverted("A colinds (converted)", Acolinds.extent(0));
+  global_col_inds_array BcolindsConverted("B colinds (converted)", Bcolinds.extent(0));
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   auto MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() diff col map kernel: " + std::string("column map conversion"))));
 #endif
   ConvertColIndsFunctor<GO, col_inds_array, global_col_inds_array, local_map_type> convertA(minGlobalCol, Acolinds, AcolindsConverted, AcolMap);
-  Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsA", range_type(0, Acolinds.dimension_0()), convertA);
+  Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsA", range_type(0, Acolinds.extent(0)), convertA);
   ConvertColIndsFunctor<GO, col_inds_array, global_col_inds_array, local_map_type> convertB(minGlobalCol, Bcolinds, BcolindsConverted, BcolMap);
-  Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsB", range_type(0, Bcolinds.dimension_0()), convertB);
+  Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsB", range_type(0, Bcolinds.extent(0)), convertB);
   typedef KokkosKernels::Experimental::KokkosKernelsHandle<typename col_inds_array::size_type, GO, impl_scalar_type,
               execution_space, memory_space, memory_space> KKH;
   KKH handle;
@@ -1331,7 +1331,7 @@ convertToGlobalAndAdd(
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("TpetraExt::MatrixMatrix::add() diff col map kernel: unsorted symbolic")));
 #endif
-  auto nrows = Arowptrs.dimension_0() - 1;
+  auto nrows = Arowptrs.extent(0) - 1;
   Crowptrs = row_ptrs_array("C row ptrs", nrows + 1);
   KokkosSparse::Experimental::spadd_symbolic
     <KKH, typename row_ptrs_array::const_type, typename global_col_inds_array::const_type, typename row_ptrs_array::const_type, typename global_col_inds_array::const_type, row_ptrs_array, global_col_inds_array>
@@ -1868,7 +1868,7 @@ void mult_A_B_newmatrix(
       });
 
   }
-  
+
   // Replace the column map
   //
   // mfh 27 Sep 2016: We do this because C was originally created
@@ -1904,7 +1904,7 @@ void mult_A_B_newmatrix(
         LO I_LID = Irowmap_local.getLocalElement(aidx);
         targetMapToOrigRow(i)   = LO_INVALID;
         targetMapToImportRow(i) = I_LID;
-        
+
       }
     });
 
@@ -2199,11 +2199,11 @@ void mult_A_B_reuse(
     Kokkos::parallel_for(range_type(0,Bview.origMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
         Bcol2Ccol(i) = Ccolmap_local.getLocalElement(Bcolmap_local.getGlobalElement(i));
       });
-    
+
     if (!Bview.importMatrix.is_null()) {
       TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Bview.origMatrix->getDomainMap()),
                                  std::runtime_error, "Tpetra::MMM: Import setUnion messed with the DomainMap in an unfortunate way");
-      
+
       Kokkos::resize(Icol2Ccol,Bview.importMatrix->getColMap()->getNodeNumElements());
       Kokkos::parallel_for(range_type(0,Bview.importMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
           Icol2Ccol(i) = Ccolmap_local.getLocalElement(Icolmap_local.getGlobalElement(i));
@@ -2224,7 +2224,7 @@ void mult_A_B_reuse(
         LO I_LID = Irowmap_local.getLocalElement(aidx);
         targetMapToOrigRow(i)   = LO_INVALID;
         targetMapToImportRow(i) = I_LID;
-        
+
       }
     });
 
@@ -2371,7 +2371,7 @@ void KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Node,LocalOrdinalViewType>
   }
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM2= Teuchos::null; 
+  MM2= Teuchos::null;
   MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Reuse ESFC"))));
 #endif
 
@@ -2531,7 +2531,7 @@ void jacobi_A_B_newmatrix(
         LO I_LID = Irowmap_local.getLocalElement(aidx);
         targetMapToOrigRow(i)   = LO_INVALID;
         targetMapToImportRow(i) = I_LID;
-        
+
       }
     });
 
@@ -2845,11 +2845,11 @@ void jacobi_A_B_reuse(
     Kokkos::parallel_for(range_type(0,Bview.origMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
         Bcol2Ccol(i) = Ccolmap_local.getLocalElement(Bcolmap_local.getGlobalElement(i));
       });
-    
+
     if (!Bview.importMatrix.is_null()) {
       TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Bview.origMatrix->getDomainMap()),
                                  std::runtime_error, "Tpetra::Jacobi: Import setUnion messed with the DomainMap in an unfortunate way");
-      
+
       Kokkos::resize(Icol2Ccol,Bview.importMatrix->getColMap()->getNodeNumElements());
       Kokkos::parallel_for(range_type(0,Bview.importMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
           Icol2Ccol(i) = Ccolmap_local.getLocalElement(Icolmap_local.getGlobalElement(i));
@@ -2870,7 +2870,7 @@ void jacobi_A_B_reuse(
         LO I_LID = Irowmap_local.getLocalElement(aidx);
         targetMapToOrigRow(i)   = LO_INVALID;
         targetMapToImportRow(i) = I_LID;
-        
+
       }
     });
 
@@ -3036,7 +3036,7 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Node,LocalOrdinalViewType
   }
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM2= Teuchos::null; 
+  MM2= Teuchos::null;
   MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("Jacobi Reuse ESFC"))));
 #endif
 
@@ -3226,7 +3226,7 @@ merge_matrices(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview
                     const LocalOrdinalViewType & Acol2Brow,
                     const LocalOrdinalViewType & Acol2Irow,
                     const LocalOrdinalViewType & Bcol2Ccol,
-                    const LocalOrdinalViewType & Icol2Ccol,   
+                    const LocalOrdinalViewType & Icol2Ccol,
                     const size_t mergedNodeNumCols) {
 
   using Teuchos::RCP;
@@ -3251,13 +3251,13 @@ merge_matrices(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview
     if(Ik!=0) Iks = *Ik;
     size_t merge_numrows =  Ak.numCols();
     lno_view_t Mrowptr("Mrowptr", merge_numrows + 1);
-    
+
     const LocalOrdinal LO_INVALID =Teuchos::OrdinalTraits<LocalOrdinal>::invalid();
-    
+
     // Use a Kokkos::parallel_scan to build the rowptr
     typedef typename Node::execution_space execution_space;
     typedef Kokkos::RangePolicy<execution_space, size_t> range_type;
-    Kokkos::parallel_scan ("Tpetra_MatrixMatrix_merge_matrices_buildRowptr", range_type (0, merge_numrows), 
+    Kokkos::parallel_scan ("Tpetra_MatrixMatrix_merge_matrices_buildRowptr", range_type (0, merge_numrows),
       KOKKOS_LAMBDA(const size_t i, size_t& update, const bool final) {
         if(final) Mrowptr(i) = update;
         // Get the row count
@@ -3267,16 +3267,16 @@ merge_matrices(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview
         else
           ct = Iks.graph.row_map(Acol2Irow(i)+1) - Iks.graph.row_map(Acol2Irow(i));
         update+=ct;
-        
+
         if(final && i+1==merge_numrows)
           Mrowptr(i+1)=update;
       });
-    
+
     // Allocate nnz
     size_t merge_nnz = ::Tpetra::Details::getEntryOnHost(Mrowptr,merge_numrows);
     lno_nnz_view_t Mcolind("Mcolind",merge_nnz);
     scalar_view_t Mvalues("Mvals",merge_nnz);
-    
+
     // Use a Kokkos::parallel_for to fill the rowptr/colind arrays
     typedef Kokkos::RangePolicy<execution_space, size_t> range_type;
     Kokkos::parallel_for ("Tpetra_MatrixMatrix_merg_matrices_buildColindValues", range_type (0, merge_numrows),KOKKOS_LAMBDA(const size_t i) {
@@ -3297,14 +3297,14 @@ merge_matrices(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview
           }
         }
       });
-    
+
     KCRS newmat("CrsMatrix",merge_numrows,mergedNodeNumCols,merge_nnz,Mvalues,Mrowptr,Mcolind);
     return newmat;
   }
   else {
     // We don't have a Bimport (the easy case)
     return Bk;
-  }   
+  }
 }//end merge_matrices
 
 
@@ -3319,7 +3319,7 @@ merge_matrices(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview
 //
 // Must be expanded from within the Tpetra namespace!
 //
-namespace Tpetra { 
+namespace Tpetra {
 
 #define TPETRA_MATRIXMATRIX_INSTANT(SCALAR,LO,GO,NODE) \
   template \

--- a/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
+++ b/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
@@ -691,8 +691,8 @@ public:
 
     std::vector<std::size_t> rowOffsetsSV;
     this->impl_.buildCrs (rowOffsetsSV,
-                          gblColInds_h.ptr_on_device (),
-                          vals_h.ptr_on_device ());
+                          gblColInds_h.data (),
+                          vals_h.data ());
     rowOffsets =
       View<OffsetType*, device_type> ("rowOffsets", rowOffsetsSV.size ());
     typename View<OffsetType*, device_type>::HostMirror
@@ -1030,12 +1030,12 @@ protected:
     }
 
     const size_t numPermuteIDs =
-      static_cast<size_t> (permuteToLIDs.dimension_0 ());
-    if (numPermuteIDs != static_cast<size_t> (permuteFromLIDs.dimension_0 ())) {
+      static_cast<size_t> (permuteToLIDs.extent (0));
+    if (numPermuteIDs != static_cast<size_t> (permuteFromLIDs.extent (0))) {
       std::ostream& err = this->markLocalErrorAndGetStream ();
-      err << prefix << "permuteToLIDs.dimension_0() = "
-          << numPermuteIDs << " != permuteFromLIDs.dimension_0() = "
-          << permuteFromLIDs.dimension_0 () << "." << endl;
+      err << prefix << "permuteToLIDs.extent(0) = "
+          << numPermuteIDs << " != permuteFromLIDs.extent(0) = "
+          << permuteFromLIDs.extent (0) << "." << endl;
       return;
     }
     if (sizeof (int) <= sizeof (size_t) &&
@@ -1256,7 +1256,7 @@ protected:
 
     // TODO (mfh 28 Jan 2017) pack source object's data, NOT *this's data!
 
-    const size_t numExports = exportLIDs.dimension_0 ();
+    const size_t numExports = exportLIDs.extent (0);
     if (numExports == 0) {
       Details::reallocDualViewIfNeeded (exports, 0, exports.h_view.label ());
       return; // nothing to send
@@ -1384,7 +1384,7 @@ protected:
     std::vector<SC> vals;
 
     int outBufCurPos = 0;
-    packet_type* outBuf = exports.h_view.ptr_on_device ();
+    packet_type* outBuf = exports.h_view.data ();
     for (size_t k = 0; k < numExports; ++k) {
       const LO lclRow = exportLIDs.h_view[k];
       // We're packing the source object's data, so we need to use the
@@ -1426,11 +1426,11 @@ protected:
     const char suffix[] = "  This should never happen.  "
       "Please report this bug to the Tpetra developers.";
 
-    const std::size_t numImports = importLIDs.dimension_0 ();
+    const std::size_t numImports = importLIDs.extent (0);
     if (numImports == 0) {
       return; // nothing to receive
     }
-    else if (imports.dimension_0 () == 0) {
+    else if (imports.extent (0) == 0) {
       std::ostream& err = this->markLocalErrorAndGetStream ();
       typename Kokkos::DualView<const LO*, device_type>::t_host importLIDs_h;
       {
@@ -1439,7 +1439,7 @@ protected:
           // It's forbidden to sync a DualView<const T>, so we must copy.
           auto importLIDs_d = importLIDs.template view<DMS> ();
           typedef typename decltype (importLIDs_h)::non_const_type HVNC;
-          HVNC importLIDs_h_nc (importLIDs_d.label (), importLIDs.dimension_0 ());
+          HVNC importLIDs_h_nc (importLIDs_d.label (), importLIDs.extent (0));
           Kokkos::deep_copy (importLIDs_h_nc, importLIDs_d);
           importLIDs_h = importLIDs_h_nc;
         }
@@ -1447,8 +1447,8 @@ protected:
           importLIDs_h = importLIDs.h_view; // importLIDs.template view<HMS> ();
         }
       }
-      err << prefix << "importLIDs.dimension_0() = " << numImports << " != 0, "
-          << "but imports.dimension_0() = 0.  This doesn't make sense, because "
+      err << prefix << "importLIDs.extent(0) = " << numImports << " != 0, "
+          << "but imports.extent(0) = 0.  This doesn't make sense, because "
           << "for every incoming LID, CooMatrix packs at least the count of "
           << "triples associated with that LID, even if the count is zero.  "
           << "importLIDs = [";
@@ -1481,14 +1481,14 @@ protected:
 
     // Make sure that the length of 'imports' fits in int.
     // This is ultimately an MPI restriction.
-    if (static_cast<size_t> (imports.dimension_0 ()) >
+    if (static_cast<size_t> (imports.extent (0)) >
         static_cast<size_t> (std::numeric_limits<int>::max ())) {
       std::ostream& err = this->markLocalErrorAndGetStream ();
-      err << prefix << "imports.dimension_0() = "
-          << imports.dimension_0 () << " does not fit in int." << endl;
+      err << prefix << "imports.extent(0) = "
+          << imports.extent (0) << " does not fit in int." << endl;
       return;
     }
-    const int inBufSize = static_cast<int> (imports.dimension_0 ());
+    const int inBufSize = static_cast<int> (imports.extent (0));
 
     // It's forbidden to sync a DualView<const T>, so if the input
     // DualView are not in sync on host, we must make copies.
@@ -1502,7 +1502,7 @@ protected:
         auto importLIDs_d = importLIDs.template view<DMS> ();
         typedef typename decltype (importLIDs_h)::non_const_type HVNC;
         HVNC importLIDs_h_nc (importLIDs_d.label (),
-                              importLIDs.dimension_0 ());
+                              importLIDs.extent (0));
         Kokkos::deep_copy (importLIDs_h_nc, importLIDs_d);
         importLIDs_h = importLIDs_h_nc;
       }
@@ -1515,7 +1515,7 @@ protected:
         auto imports_d = imports.template view<CDMS> ();
         typedef typename decltype (imports_h)::non_const_type HVNC;
         HVNC imports_h_nc (imports_d.label (),
-                           imports.dimension_0 ());
+                           imports.extent (0));
         Kokkos::deep_copy (imports_h_nc, imports_d);
         imports_h = imports_h_nc;
       }
@@ -1528,7 +1528,7 @@ protected:
         auto numPacketsPerLID_d = numPacketsPerLID.template view<CDMS> ();
         typedef typename decltype (numPacketsPerLID_h)::non_const_type HVNC;
         HVNC numPacketsPerLID_h_nc (numPacketsPerLID_d.label (),
-                                    numPacketsPerLID.dimension_0 ());
+                                    numPacketsPerLID.extent (0));
         Kokkos::deep_copy (numPacketsPerLID_h_nc, numPacketsPerLID_d);
         numPacketsPerLID_h = numPacketsPerLID_h_nc;
       }
@@ -1543,7 +1543,7 @@ protected:
     std::vector<GO> gblColInds;
     std::vector<SC> vals;
 
-    const packet_type* inBuf = imports_h.ptr_on_device ();
+    const packet_type* inBuf = imports_h.data ();
     int inBufCurPos = 0;
     size_t numInvalidRowInds = 0;
     int errCode = 0;

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1181,7 +1181,7 @@ namespace Tpetra {
     /// \pre The graph must have a column Map.
     /// \pre All diagonal entries of the graph must be populated on
     ///   this process.  Results are undefined otherwise.
-    /// \pre <tt>offsets.dimension_0() >= this->getNodeNumRows()</tt>
+    /// \pre <tt>offsets.extent(0) >= this->getNodeNumRows()</tt>
     ///
     /// \param offsets [out] Output array of offsets.  This method
     ///   does NOT allocate the array; the caller must allocate.  Must

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -123,8 +123,8 @@ namespace Tpetra {
           typedef ::Kokkos::RangePolicy<typename DT::execution_space, LO> range_type;
           typedef ConvertColumnIndicesFromGlobalToLocal<LO, GO, DT, OffsetType, NumEntType> functor_type;
 
-          const LO lclNumRows = ptr.dimension_0 () == 0 ?
-            static_cast<LO> (0) : static_cast<LO> (ptr.dimension_0 () - 1);
+          const LO lclNumRows = ptr.extent (0) == 0 ?
+            static_cast<LO> (0) : static_cast<LO> (ptr.extent (0) - 1);
           OffsetType numBad = 0;
           // Count of "bad" column indices is a reduction over rows.
           ::Kokkos::parallel_reduce (range_type (0, lclNumRows),
@@ -416,9 +416,9 @@ namespace Tpetra {
     const size_t lclNumRows = rowMap.is_null () ?
       static_cast<size_t> (0) : rowMap->getNodeNumElements ();
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      static_cast<size_t> (numEntPerRow.dimension_0 ()) != lclNumRows,
+      static_cast<size_t> (numEntPerRow.extent (0)) != lclNumRows,
       std::invalid_argument, "numEntPerRow has length " <<
-      numEntPerRow.dimension_0 () << " != the local number of rows " <<
+      numEntPerRow.extent (0) << " != the local number of rows " <<
       lclNumRows << " as specified by " "the input row Map.");
 
     const bool debug = ::Tpetra::Details::Behavior::debug ();
@@ -477,9 +477,9 @@ namespace Tpetra {
     const size_t lclNumRows = rowMap.is_null () ?
       static_cast<size_t> (0) : rowMap->getNodeNumElements ();
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      static_cast<size_t> (numEntPerRow.dimension_0 ()) != lclNumRows,
+      static_cast<size_t> (numEntPerRow.extent (0)) != lclNumRows,
       std::invalid_argument, "numEntPerRow has length " <<
-      numEntPerRow.dimension_0 () << " != the local number of rows " <<
+      numEntPerRow.extent (0) << " != the local number of rows " <<
       lclNumRows << " as specified by " "the input row Map.");
 
     const bool debug = ::Tpetra::Details::Behavior::debug ();
@@ -714,7 +714,7 @@ namespace Tpetra {
     //   "number of rows.  The row Map claims " << getNodeNumRows () << " row(s), "
     //   "but the local graph claims " << k_local_graph_.numRows () << " row(s).");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      k_lclInds1D_.dimension_0 () != 0 || k_gblInds1D_.dimension_0 () != 0, std::logic_error,
+      k_lclInds1D_.extent (0) != 0 || k_gblInds1D_.extent (0) != 0, std::logic_error,
       ": cannot have 1D data structures allocated.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       ! lclInds2D_.is_null () || ! gblInds2D_.is_null (), std::logic_error,
@@ -949,7 +949,7 @@ namespace Tpetra {
     // getNodeNumRows() is zero?
 
     const bool isOpt = indicesAreAllocated_ &&
-      k_numRowEntries_.dimension_0 () == 0 &&
+      k_numRowEntries_.extent (0) == 0 &&
       getNodeNumRows () > 0;
 
     const char tfecfFuncName[] = "isStorageOptimized: ";
@@ -1002,9 +1002,9 @@ namespace Tpetra {
       else {
         // Avoid the "*this capture" issue by creating a local Kokkos::View.
         auto numEntPerRow = this->k_numRowEntries_;
-        const LO numNumEntPerRow = numEntPerRow.dimension_0 ();
+        const LO numNumEntPerRow = numEntPerRow.extent (0);
         if (numNumEntPerRow == 0) {
-          if (static_cast<LO> (this->lclGraph_.row_map.dimension_0 ()) <
+          if (static_cast<LO> (this->lclGraph_.row_map.extent (0)) <
               static_cast<LO> (lclNumRows + 1)) {
             return static_cast<size_t> (0);
           }
@@ -1133,7 +1133,7 @@ namespace Tpetra {
         return static_cast<size_t> (0);
       }
       else if (this->storageStatus_ == Details::STORAGE_1D_PACKED) {
-        if (static_cast<LO> (this->lclGraph_.row_map.dimension_0 ()) <
+        if (static_cast<LO> (this->lclGraph_.row_map.extent (0)) <
             static_cast<LO> (lclNumRows + 1)) {
           return static_cast<size_t> (0);
         }
@@ -1142,7 +1142,7 @@ namespace Tpetra {
         }
       }
       else if (this->storageStatus_ == Details::STORAGE_1D_UNPACKED) {
-        if (this->k_rowPtrs_.dimension_0 () == 0) {
+        if (this->k_rowPtrs_.extent (0) == 0) {
           return static_cast<size_t> (0);
         }
         else {
@@ -1280,15 +1280,15 @@ namespace Tpetra {
       //
       non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
 
-      if (this->k_numAllocPerRow_.dimension_0 () != 0) {
+      if (this->k_numAllocPerRow_.extent (0) != 0) {
         // It's OK to throw std::invalid_argument here, because we
         // haven't incurred any side effects yet.  Throwing that
         // exception (and not, say, std::logic_error) implies that the
         // instance can recover.
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (this->k_numAllocPerRow_.dimension_0 () != numRows,
+          (this->k_numAllocPerRow_.extent (0) != numRows,
            std::invalid_argument, "k_numAllocPerRow_ is allocated, that is, "
-           "has nonzero length " << this->k_numAllocPerRow_.dimension_0 ()
+           "has nonzero length " << this->k_numAllocPerRow_.extent (0)
            << ", but its length != numRows = " << numRows << ".");
 
         // k_numAllocPerRow_ is a host View, but k_rowPtrs (the thing
@@ -1336,7 +1336,7 @@ namespace Tpetra {
       //  DYNAMIC ALLOCATION PROFILE
       //
       const bool useNumAllocPerRow =
-        (this->k_numAllocPerRow_.dimension_0 () != 0);
+        (this->k_numAllocPerRow_.extent (0) != 0);
 
       if (lg == LocalIndices) {
         this->lclInds2D_ = arcp<Array<LocalOrdinal> > (numRows);
@@ -1419,7 +1419,7 @@ namespace Tpetra {
       return Teuchos::ArrayView<const LO> ();
     }
     else { // nothing in the row to view
-      if (k_lclInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (k_lclInds1D_.extent (0) != 0) { // 1-D storage
         const size_t start = rowinfo.offset1D;
         const size_t len = rowinfo.allocSize;
         const std::pair<size_t, size_t> rng (start, start + len);
@@ -1429,7 +1429,7 @@ namespace Tpetra {
         // that.  That touches the reference count, which costs
         // performance in a measurable way.
         row_view_type rowView = subview (row_view_type (k_lclInds1D_), rng);
-        const LO* const rowViewRaw = (len == 0) ? NULL : rowView.ptr_on_device ();
+        const LO* const rowViewRaw = (len == 0) ? NULL : rowView.data ();
         return Teuchos::ArrayView<const LO> (rowViewRaw, len, Teuchos::RCP_DISABLE_NODE_LOOKUP);
       }
       else if (! lclInds2D_[rowinfo.localRow].empty ()) { // 2-D storage
@@ -1452,10 +1452,10 @@ namespace Tpetra {
     capacity = 0;
 
     if (rowInfo.allocSize != 0) {
-      if (k_lclInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (k_lclInds1D_.extent (0) != 0) { // 1-D storage
 #ifdef HAVE_TPETRA_DEBUG
         if (rowInfo.offset1D + rowInfo.allocSize >
-            static_cast<size_t> (k_lclInds1D_.dimension_0 ())) {
+            static_cast<size_t> (k_lclInds1D_.extent (0))) {
           return static_cast<LocalOrdinal> (-1);
         }
 #endif // HAVE_TPETRA_DEBUG
@@ -1494,7 +1494,7 @@ namespace Tpetra {
       return Teuchos::ArrayView<LO> ();
     }
     else {
-      if (k_lclInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (k_lclInds1D_.extent (0) != 0) { // 1-D storage
         const size_t start = rowinfo.offset1D;
         const size_t len = rowinfo.allocSize;
         const std::pair<size_t, size_t> rng (start, start + len);
@@ -1504,7 +1504,7 @@ namespace Tpetra {
         // that.  That touches the reference count, which costs
         // performance in a measurable way.
         row_view_type rowView = subview (row_view_type (k_lclInds1D_), rng);
-        LO* const rowViewRaw = (len == 0) ? NULL : rowView.ptr_on_device ();
+        LO* const rowViewRaw = (len == 0) ? NULL : rowView.data ();
         return Teuchos::ArrayView<LO> (rowViewRaw, len, Teuchos::RCP_DISABLE_NODE_LOOKUP);
       }
       else if (! lclInds2D_[rowinfo.localRow].empty ()) { // 2-D storage
@@ -1532,7 +1532,7 @@ namespace Tpetra {
       return row_view_type ();
     }
     else { // nothing in the row to view
-      if (k_lclInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (k_lclInds1D_.extent (0) != 0) { // 1-D storage
         const size_t start = rowInfo.offset1D;
         const size_t len = rowInfo.allocSize;
         const std::pair<size_t, size_t> rng (start, start + len);
@@ -1575,7 +1575,7 @@ namespace Tpetra {
       return row_view_type ();
     }
     else { // nothing in the row to view
-      if (k_lclInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (k_lclInds1D_.extent (0) != 0) { // 1-D storage
         const size_t start = rowInfo.offset1D;
         const size_t len = rowInfo.allocSize;
         const std::pair<size_t, size_t> rng (start, start + len);
@@ -1619,7 +1619,7 @@ namespace Tpetra {
       return row_view_type ();
     }
     else { // nothing in the row to view
-      if (this->k_gblInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (this->k_gblInds1D_.extent (0) != 0) { // 1-D storage
         const size_t start = rowinfo.offset1D;
         const size_t len = rowinfo.allocSize;
         const std::pair<size_t, size_t> rng (start, start + len);
@@ -1654,7 +1654,7 @@ namespace Tpetra {
   {
     Teuchos::ArrayView<const GlobalOrdinal> view;
     if (rowinfo.allocSize > 0) {
-      if (k_gblInds1D_.dimension_0 () != 0) {
+      if (k_gblInds1D_.extent (0) != 0) {
         auto rng = std::make_pair (rowinfo.offset1D,
                                    rowinfo.offset1D + rowinfo.allocSize);
         // mfh 23 Nov 2015: Don't just create a subview of
@@ -1685,10 +1685,10 @@ namespace Tpetra {
     capacity = 0;
 
     if (rowInfo.allocSize != 0) {
-      if (k_gblInds1D_.dimension_0 () != 0) { // 1-D storage
+      if (k_gblInds1D_.extent (0) != 0) { // 1-D storage
 #ifdef HAVE_TPETRA_DEBUG
         if (rowInfo.offset1D + rowInfo.allocSize >
-            static_cast<size_t> (k_gblInds1D_.dimension_0 ())) {
+            static_cast<size_t> (k_gblInds1D_.extent (0))) {
           return static_cast<LocalOrdinal> (-1);
         }
 #endif // HAVE_TPETRA_DEBUG
@@ -1719,7 +1719,7 @@ namespace Tpetra {
   {
     Teuchos::ArrayView<GlobalOrdinal> view;
     if (rowinfo.allocSize > 0) {
-      if (k_gblInds1D_.dimension_0 () != 0) {
+      if (k_gblInds1D_.extent (0) != 0) {
         auto rng = std::make_pair (rowinfo.offset1D,
                                    rowinfo.offset1D + rowinfo.allocSize);
         // mfh 23 Nov 2015: Don't just create a subview of
@@ -1758,7 +1758,7 @@ namespace Tpetra {
     if (this->indicesAreAllocated ()) {
       if (this->getProfileType () == StaticProfile) {
         // Offsets tell us the allocation size in this case.
-        if (this->k_rowPtrs_.dimension_0 () == 0) {
+        if (this->k_rowPtrs_.extent (0) == 0) {
           ret.offset1D  = 0;
           ret.allocSize = 0;
         }
@@ -1767,7 +1767,7 @@ namespace Tpetra {
           ret.allocSize = this->k_rowPtrs_(myRow+1) - this->k_rowPtrs_(myRow);
         }
 
-        ret.numEntries = (this->k_numRowEntries_.dimension_0 () == 0) ?
+        ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
           ret.allocSize :
           this->k_numRowEntries_(myRow);
       }
@@ -1787,7 +1787,7 @@ namespace Tpetra {
           ret.allocSize = 0;
         }
 
-        ret.numEntries = (this->k_numRowEntries_.dimension_0 () == 0) ?
+        ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
           size_t (0) :
           this->k_numRowEntries_(myRow);
       }
@@ -1796,7 +1796,7 @@ namespace Tpetra {
       // FIXME (mfh 07 Aug 2014) We want graph's constructors to
       // allocate, rather than doing lazy allocation at first insert.
       // This will make k_numAllocPerRow_ obsolete.
-      ret.allocSize = (this->k_numAllocPerRow_.dimension_0 () != 0) ?
+      ret.allocSize = (this->k_numAllocPerRow_.extent (0) != 0) ?
         this->k_numAllocPerRow_(myRow) : // this is a host View
         this->numAllocForAllRows_;
       ret.numEntries = 0;
@@ -1836,7 +1836,7 @@ namespace Tpetra {
       //
       // if static graph, offsets tell us the allocation size
       if (this->getProfileType() == StaticProfile) {
-        if (this->k_rowPtrs_.dimension_0 () == 0) {
+        if (this->k_rowPtrs_.extent (0) == 0) {
           ret.offset1D  = 0;
           ret.allocSize = 0;
         }
@@ -1845,7 +1845,7 @@ namespace Tpetra {
           ret.allocSize = this->k_rowPtrs_(myRow+1) - this->k_rowPtrs_(myRow);
         }
 
-        ret.numEntries = (this->k_numRowEntries_.dimension_0 () == 0) ?
+        ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
           ret.allocSize :
           this->k_numRowEntries_(myRow);
       }
@@ -1862,7 +1862,7 @@ namespace Tpetra {
             this->gblInds2D_[myRow].size ();
         }
 
-        ret.numEntries = (this->k_numRowEntries_.dimension_0 () == 0) ?
+        ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
           size_t (0) :
           this->k_numRowEntries_(myRow);
       }
@@ -1871,7 +1871,7 @@ namespace Tpetra {
       // FIXME (mfh 07 Aug 2014) We want graph's constructors to
       // allocate, rather than doing lazy allocation at first insert.
       // This will make k_numAllocPerRow_ obsolete.
-      ret.allocSize = (this->k_numAllocPerRow_.dimension_0 () != 0) ?
+      ret.allocSize = (this->k_numAllocPerRow_.extent (0) != 0) ?
         this->k_numAllocPerRow_(myRow) : // this is a host View
         this->numAllocForAllRows_;
       ret.numEntries = 0;
@@ -2073,19 +2073,19 @@ namespace Tpetra {
            << ".  Please report this bug to the Tpetra developers.");
 
         size_t dupCount = 0;
-        if (k_gblInds1D_.dimension_0 () != 0) {
+        if (k_gblInds1D_.extent (0) != 0) {
           const size_t curOffset = rowInfo.offset1D;
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (k_gblInds1D_.dimension_0 ()) < curOffset,
-             std::logic_error, "k_gblInds1D_.dimension_0() = "
-             << this->k_gblInds1D_.dimension_0 ()
+            (static_cast<size_t> (k_gblInds1D_.extent (0)) < curOffset,
+             std::logic_error, "k_gblInds1D_.extent(0) = "
+             << this->k_gblInds1D_.extent (0)
              << " < offset1D = " << curOffset << ".  "
              "Please report this bug to the Tpetra developers.");
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (k_gblInds1D_.dimension_0 ()) <
+            (static_cast<size_t> (k_gblInds1D_.extent (0)) <
              curOffset + rowInfo.numEntries,
-             std::logic_error, "k_gblInds1D_.dimension_0() = "
-             << this->k_gblInds1D_.dimension_0 ()
+             std::logic_error, "k_gblInds1D_.extent(0) = "
+             << this->k_gblInds1D_.extent (0)
              << " < offset1D (= " << curOffset << ") + rowInfo.numEntries (= "
              << rowInfo.numEntries << ").  "
              "Please report this bug to the Tpetra developers.");
@@ -2094,9 +2094,9 @@ namespace Tpetra {
 
           auto gblIndsCur = subview (this->k_gblInds1D_, range);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (gblIndsCur.dimension_0 ()) !=
+            (static_cast<size_t> (gblIndsCur.extent (0)) !=
              rowInfo.numEntries, std::logic_error,
-             "gblIndsCur.dimension_0() = " << gblIndsCur.dimension_0 ()
+             "gblIndsCur.extent(0) = " << gblIndsCur.extent (0)
              << " != rowInfo.numEntries = " << rowInfo.numEntries
              << ".  Please report this bug to the Tpetra developers.");
 
@@ -2166,7 +2166,7 @@ namespace Tpetra {
            "either fix the upper bound on the number of entries in this row, "
            "or switch from StaticProfile to DynamicProfile.");
 
-        if (k_gblInds1D_.dimension_0 () != 0) { // global 1-D indexing
+        if (k_gblInds1D_.extent (0) != 0) { // global 1-D indexing
           const size_t curOffset = rowInfo.offset1D;
           auto gblIndsCur =
             subview (k_gblInds1D_, range_type (curOffset,
@@ -2259,7 +2259,7 @@ namespace Tpetra {
     } // newNumEntries > rowInfo.allocSize
 
     // Copy new indices at end of global index array
-    if (k_gblInds1D_.dimension_0 () != 0) {
+    if (k_gblInds1D_.extent (0) != 0) {
       const size_t offset = rowInfo.offset1D + rowInfo.numEntries;
       for (size_t k = 0; k < numInputInds; ++k) {
         this->k_gblInds1D_[offset + k] = inputGblColInds[k];
@@ -2320,7 +2320,7 @@ namespace Tpetra {
     }
 
     // Store the new indices at the end of row myRow.
-    if (this->k_lclInds1D_.dimension_0 () != 0) {
+    if (this->k_lclInds1D_.extent (0) != 0) {
       typedef View<const LO*, execution_space, MemoryUnmanaged> input_view_type;
       typedef View<LO*, execution_space, MemoryUnmanaged> row_view_type;
 
@@ -2544,7 +2544,7 @@ namespace Tpetra {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->indicesAreAllocated () &&
          (this->numAllocForAllRows_ != 0 ||
-          this->k_numAllocPerRow_.dimension_0 () != 0),
+          this->k_numAllocPerRow_.extent (0) != 0),
          std::logic_error, "The graph claims that its indices are allocated, but "
          "either numAllocForAllRows_ (= " << this->numAllocForAllRows_ << ") is "
          "nonzero, or k_numAllocPerRow_ has nonzero dimension.  In other words, "
@@ -2556,22 +2556,22 @@ namespace Tpetra {
          "Storage is optimized, but graph is not StaticProfile." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->isGloballyIndexed () &&
-         this->k_rowPtrs_.dimension_0 () != 0 &&
-         (static_cast<size_t> (this->k_rowPtrs_.dimension_0 ()) != static_cast<size_t> (lclNumRows + 1) ||
-          this->k_rowPtrs_(lclNumRows) != static_cast<size_t> (this->k_gblInds1D_.dimension_0 ())),
+         this->k_rowPtrs_.extent (0) != 0 &&
+         (static_cast<size_t> (this->k_rowPtrs_.extent (0)) != static_cast<size_t> (lclNumRows + 1) ||
+          this->k_rowPtrs_(lclNumRows) != static_cast<size_t> (this->k_gblInds1D_.extent (0))),
          std::logic_error, "If k_rowPtrs_ has nonzero size and "
          "the graph is globally indexed, then "
          "k_rowPtrs_ must have N+1 rows, and "
-         "k_rowPtrs_(N) must equal k_gblInds1D_.dimension_0()." << suffix);
+         "k_rowPtrs_(N) must equal k_gblInds1D_.extent(0)." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->isLocallyIndexed () &&
-         this->k_rowPtrs_.dimension_0 () != 0 &&
-         (static_cast<size_t> (k_rowPtrs_.dimension_0 ()) != static_cast<size_t> (lclNumRows + 1) ||
-          this->k_rowPtrs_(lclNumRows) != static_cast<size_t> (this->k_lclInds1D_.dimension_0 ())),
+         this->k_rowPtrs_.extent (0) != 0 &&
+         (static_cast<size_t> (k_rowPtrs_.extent (0)) != static_cast<size_t> (lclNumRows + 1) ||
+          this->k_rowPtrs_(lclNumRows) != static_cast<size_t> (this->k_lclInds1D_.extent (0))),
          std::logic_error, "If k_rowPtrs_ has nonzero size and "
          "the graph is locally indexed, then "
          "k_rowPtrs_ must have N+1 rows, and "
-         "k_rowPtrs_(N) must equal k_lclInds1D_.dimension_0()." << suffix);
+         "k_rowPtrs_(N) must equal k_lclInds1D_.extent(0)." << suffix);
 
       if (this->pftype_ == DynamicProfile) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -2585,17 +2585,17 @@ namespace Tpetra {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->indicesAreAllocated () &&
            this->getNodeNumRows () > 0 &&
-           this->k_numRowEntries_.dimension_0 () == 0,
+           this->k_numRowEntries_.extent (0) == 0,
            std::logic_error, "Graph has DynamicProfile, indices are allocated, and "
            "the calling process has nonzero rows, but k_numRowEntries_ is not "
            "present." << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (this->k_lclInds1D_.dimension_0 () != 0 ||
-           this->k_gblInds1D_.dimension_0 () != 0,
+          (this->k_lclInds1D_.extent (0) != 0 ||
+           this->k_gblInds1D_.extent (0) != 0,
            std::logic_error, "Graph has DynamicProfile, but "
            "1-D allocations are present." << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (this->k_rowPtrs_.dimension_0 () != 0,
+          (this->k_rowPtrs_.extent (0) != 0,
            std::logic_error, "Graph has DynamicProfile, but "
            "row offsets are present." << suffix);
       }
@@ -2603,8 +2603,8 @@ namespace Tpetra {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->indicesAreAllocated () &&
            nodeAllocSize > 0 &&
-           this->k_lclInds1D_.dimension_0 () == 0 &&
-           this->k_gblInds1D_.dimension_0 () == 0,
+           this->k_lclInds1D_.extent (0) == 0 &&
+           this->k_gblInds1D_.extent (0) == 0,
            std::logic_error, "Graph has StaticProfile and is allocated "
            "nonnontrivally, but 1-D allocations are not present." << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -2615,11 +2615,11 @@ namespace Tpetra {
 
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (! this->indicesAreAllocated () &&
-         ((this->k_rowPtrs_.dimension_0 () != 0 ||
-           this->k_numRowEntries_.dimension_0 () != 0) ||
-          this->k_lclInds1D_.dimension_0 () != 0 ||
+         ((this->k_rowPtrs_.extent (0) != 0 ||
+           this->k_numRowEntries_.extent (0) != 0) ||
+          this->k_lclInds1D_.extent (0) != 0 ||
           this->lclInds2D_ != Teuchos::null ||
-          this->k_gblInds1D_.dimension_0 () != 0 ||
+          this->k_gblInds1D_.extent (0) != 0 ||
           this->gblInds2D_ != Teuchos::null),
          std::logic_error, "If indices are not allocated, "
          "then none of the buffers should be." << suffix);
@@ -2636,67 +2636,67 @@ namespace Tpetra {
          std::logic_error, "Indices may not be both local and global." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->indicesAreLocal_ &&
-         (this->k_gblInds1D_.dimension_0 () != 0 || ! this->gblInds2D_.is_null ()),
+         (this->k_gblInds1D_.extent (0) != 0 || ! this->gblInds2D_.is_null ()),
          std::logic_error, "Indices are local, but either "
-         "k_gblInds1D_.dimension_0() (= "
-         << this->k_gblInds1D_.dimension_0 () << ") != 0, or "
+         "k_gblInds1D_.extent(0) (= "
+         << this->k_gblInds1D_.extent (0) << ") != 0, or "
          "gblInds2D_ is not null.  In other words, if indices are local, "
          "then global allocations should not be present." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->indicesAreGlobal_ &&
-         (this->k_lclInds1D_.dimension_0 () != 0 ||
+         (this->k_lclInds1D_.extent (0) != 0 ||
           ! this->lclInds2D_.is_null ()),
          std::logic_error, "Indices are global, but either "
-         "k_lclInds1D_.dimension_0() (= "
-         << this->k_lclInds1D_.dimension_0 () << ") != 0, or "
+         "k_lclInds1D_.extent(0) (= "
+         << this->k_lclInds1D_.extent (0) << ") != 0, or "
          "lclInds2D_ is not null.  In other words, if indices are global, "
          "then local allocations should not be present." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->indicesAreLocal_ &&
          nodeAllocSize > 0 &&
-         this->k_lclInds1D_.dimension_0 () == 0 &&
+         this->k_lclInds1D_.extent (0) == 0 &&
          this->getNodeNumRows () > 0 &&
          this->lclInds2D_.is_null (),
          std::logic_error, "Indices are local, getNodeAllocationSize() = "
-         << nodeAllocSize << " > 0, k_lclInds1D_.dimension_0() = 0, "
+         << nodeAllocSize << " > 0, k_lclInds1D_.extent(0) = 0, "
          "getNodeNumRows() = " << this->getNodeNumRows () << " > 0, and "
          "lclInds2D_ is null." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (this->indicesAreGlobal_ &&
          nodeAllocSize > 0 &&
-         this->k_gblInds1D_.dimension_0 () == 0 &&
+         this->k_gblInds1D_.extent (0) == 0 &&
          this->getNodeNumRows () > 0 &&
          this->gblInds2D_.is_null (),
          std::logic_error, "Indices are global, getNodeAllocationSize() = "
-         << nodeAllocSize << " > 0, k_gblInds1D_.dimension_0() = 0, "
+         << nodeAllocSize << " > 0, k_gblInds1D_.extent(0) = 0, "
          "getNodeNumRows() = " << this->getNodeNumRows () << " > 0, and "
          "gblInds2D_ is null." << suffix);
       // check the actual allocations
       if (this->indicesAreAllocated () &&
           this->pftype_ == StaticProfile &&
-          this->k_rowPtrs_.dimension_0 () != 0) {
+          this->k_rowPtrs_.extent (0) != 0) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (this->k_rowPtrs_.dimension_0 ()) !=
+          (static_cast<size_t> (this->k_rowPtrs_.extent (0)) !=
            this->getNodeNumRows () + 1,
            std::logic_error, "Graph is StaticProfile, indices are allocated, and "
-           "k_rowPtrs_ has nonzero length, but k_rowPtrs_.dimension_0() = "
-           << this->k_rowPtrs_.dimension_0 () << " != getNodeNumRows()+1 = "
+           "k_rowPtrs_ has nonzero length, but k_rowPtrs_.extent(0) = "
+           << this->k_rowPtrs_.extent (0) << " != getNodeNumRows()+1 = "
            << (this->getNodeNumRows () + 1) << "." << suffix);
         const size_t actualNumAllocated =
           Details::getEntryOnHost (this->k_rowPtrs_, this->getNodeNumRows ());
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->isLocallyIndexed () &&
-           static_cast<size_t> (this->k_lclInds1D_.dimension_0 ()) != actualNumAllocated,
+           static_cast<size_t> (this->k_lclInds1D_.extent (0)) != actualNumAllocated,
            std::logic_error, "Graph is StaticProfile and locally indexed, "
            "indices are allocated, and k_rowPtrs_ has nonzero length, but "
-           "k_lclInds1D_.dimension_0() = " << this->k_lclInds1D_.dimension_0 ()
+           "k_lclInds1D_.extent(0) = " << this->k_lclInds1D_.extent (0)
            << " != actualNumAllocated = " << actualNumAllocated << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->isGloballyIndexed () &&
-           static_cast<size_t> (this->k_gblInds1D_.dimension_0 ()) != actualNumAllocated,
+           static_cast<size_t> (this->k_gblInds1D_.extent (0)) != actualNumAllocated,
            std::logic_error, "Graph is StaticProfile and globally indexed, "
            "indices are allocated, and k_rowPtrs_ has nonzero length, but "
-           "k_gblInds1D_.dimension_0() = " << this->k_gblInds1D_.dimension_0 ()
+           "k_gblInds1D_.extent(0) = " << this->k_gblInds1D_.extent (0)
            << " != actualNumAllocated = " << actualNumAllocated << suffix);
       }
     }
@@ -2777,7 +2777,7 @@ namespace Tpetra {
     const char prefix[] = "Tpetra::CrsGraph::getNodeRowPtrs: ";
     const char suffix[] = "  Please report this bug to the Tpetra developers.";
 #endif // HAVE_TPETRA_DEBUG
-    const size_t size = k_rowPtrs_.dimension_0 ();
+    const size_t size = k_rowPtrs_.extent (0);
     const bool same = Kokkos::Impl::is_same<size_t, row_offset_type>::value;
 
     if (size == 0) {
@@ -2794,18 +2794,18 @@ namespace Tpetra {
       Kokkos::deep_copy (ptr_h, k_rowPtrs_);
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION(
-        ptr_h.dimension_0 () != k_rowPtrs_.dimension_0 (), std::logic_error,
-        prefix << "size_t == row_offset_type, but ptr_h.dimension_0() = "
-        << ptr_h.dimension_0 () << " != k_rowPtrs_.dimension_0() = "
-        << k_rowPtrs_.dimension_0 () << ".");
+        ptr_h.extent (0) != k_rowPtrs_.extent (0), std::logic_error,
+        prefix << "size_t == row_offset_type, but ptr_h.extent(0) = "
+        << ptr_h.extent (0) << " != k_rowPtrs_.extent(0) = "
+        << k_rowPtrs_.extent (0) << ".");
       TEUCHOS_TEST_FOR_EXCEPTION(
-        same && size != 0 && k_rowPtrs_.ptr_on_device () == NULL, std::logic_error,
-        prefix << "size_t == row_offset_type and k_rowPtrs_.dimension_0() = "
-        << size << " != 0, but k_rowPtrs_.ptr_on_device() == NULL." << suffix);
+        same && size != 0 && k_rowPtrs_.data () == NULL, std::logic_error,
+        prefix << "size_t == row_offset_type and k_rowPtrs_.extent(0) = "
+        << size << " != 0, but k_rowPtrs_.data() == NULL." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION(
-        same && size != 0 && ptr_h.ptr_on_device () == NULL, std::logic_error,
-        prefix << "size_t == row_offset_type and k_rowPtrs_.dimension_0() = "
-        << size << " != 0, but create_mirror_view(k_rowPtrs_).ptr_on_device() "
+        same && size != 0 && ptr_h.data () == NULL, std::logic_error,
+        prefix << "size_t == row_offset_type and k_rowPtrs_.extent(0) = "
+        << size << " != 0, but create_mirror_view(k_rowPtrs_).data() "
         "== NULL." << suffix);
 #endif // HAVE_TPETRA_DEBUG
       ptr_rot = Kokkos::Compat::persistingView (ptr_h);
@@ -3287,7 +3287,7 @@ namespace Tpetra {
     // all processes?
     clearGlobalConstants ();
 
-    if (k_numRowEntries_.dimension_0 () != 0) {
+    if (k_numRowEntries_.extent (0) != 0) {
       this->k_numRowEntries_(lrow) = 0;
     }
 #ifdef HAVE_TPETRA_DEBUG
@@ -3320,8 +3320,8 @@ namespace Tpetra {
     // since the future model will be allocation at construction, not
     // lazy allocation on first insert.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (this->k_lclInds1D_.dimension_0 () != 0 ||
-       this->k_gblInds1D_.dimension_0 () != 0,
+      (this->k_lclInds1D_.extent (0) != 0 ||
+       this->k_gblInds1D_.extent (0) != 0,
        std::runtime_error, "You may not call this method if 1-D data "
        "structures are already allocated.");
 
@@ -3442,7 +3442,7 @@ namespace Tpetra {
            "The graph is not StaticProfile, but storage appears to be optimized."
            << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (numRows != 0 && k_rowPtrs_.dimension_0 () == 0, std::logic_error,
+          (numRows != 0 && k_rowPtrs_.extent (0) == 0, std::logic_error,
            "The graph has " << numRows << " (> 0) row" << (numRows != 1 ? "s" : "")
            << " on the calling process, but the k_rowPtrs_ array has zero entries."
            << suffix);
@@ -3473,7 +3473,7 @@ namespace Tpetra {
           allRowsSame = false; // conservatively; we don't check the array
         }
       }
-      else if (k_numRowEntries_.dimension_0 () != 0) {
+      else if (k_numRowEntries_.extent (0) != 0) {
         // This is a shallow copy; the ArrayRCP wraps the View in a
         // custom destructor, which ensures correct deallocation if
         // that is the only reference to the View.  Furthermore, this
@@ -3487,7 +3487,7 @@ namespace Tpetra {
       }
     }
     else { // indices not allocated
-      if (k_numAllocPerRow_.dimension_0 () != 0) {
+      if (k_numAllocPerRow_.extent (0) != 0) {
         // This is a shallow copy; the ArrayRCP wraps the View in a
         // custom destructor, which ensures correct deallocation if
         // that is the only reference to the View.  Furthermore, this
@@ -3933,14 +3933,14 @@ namespace Tpetra {
       isFillComplete () || ! hasColMap (), std::runtime_error, "You may not "
       "call this method unless the graph has a column Map.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      getNodeNumRows () > 0 && k_rowPtrs_.dimension_0 () == 0,
+      getNodeNumRows () > 0 && k_rowPtrs_.extent (0) == 0,
       std::runtime_error, "The calling process has getNodeNumRows() = "
       << getNodeNumRows () << " > 0 rows, but the row offsets array has not "
       "been set.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      static_cast<size_t> (k_rowPtrs_.dimension_0 ()) != getNodeNumRows () + 1,
+      static_cast<size_t> (k_rowPtrs_.extent (0)) != getNodeNumRows () + 1,
       std::runtime_error, "The row offsets array has length " <<
-      k_rowPtrs_.dimension_0 () << " != getNodeNumRows()+1 = " <<
+      k_rowPtrs_.extent (0) << " != getNodeNumRows()+1 = " <<
       (getNodeNumRows () + 1) << ".");
 
     // Note: We don't need to do the following things which are normally done in fillComplete:
@@ -4080,9 +4080,9 @@ namespace Tpetra {
       // storage (ind_d).
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (this->k_numRowEntries_.dimension_0 ()) !=
+        (static_cast<size_t> (this->k_numRowEntries_.extent (0)) !=
          lclNumRows, std::logic_error, "(DynamicProfile branch) "
-         "k_numRowEntries_.dimension_0() = " << k_numRowEntries_.dimension_0 ()
+         "k_numRowEntries_.extent(0) = " << k_numRowEntries_.extent (0)
          << " != getNodeNumRows() = " << lclNumRows << "");
 #endif // HAVE_TPETRA_DEBUG
 
@@ -4105,9 +4105,9 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (ptr_d.dimension_0 ()) != lclNumRows + 1,
+        (static_cast<size_t> (ptr_d.extent (0)) != lclNumRows + 1,
          std::logic_error, "(DynamicProfile branch) After packing ptr_d, "
-         "ptr_d.dimension_0() = " << ptr_d.dimension_0 () << " != "
+         "ptr_d.extent(0) = " << ptr_d.extent (0) << " != "
          "(lclNumRows+1) = " << (lclNumRows+1) << ".");
       {
         const auto valToCheck = Details::getEntryOnHost (ptr_d, lclNumRows);
@@ -4136,21 +4136,21 @@ namespace Tpetra {
           const size_t numEnt = numRowEnt_h(row);
           std::copy (lclInds2D_[row].begin (),
                      lclInds2D_[row].begin () + numEnt,
-                     ind_h.ptr_on_device () + ptr_h(row));
+                     ind_h.data () + ptr_h(row));
         }
         Kokkos::deep_copy (ind_d, ind_h);
       }
 
 #ifdef HAVE_TPETRA_DEBUG
       // Sanity check of packed row offsets.
-      if (ptr_d.dimension_0 () != 0) {
-        const size_t numOffsets = static_cast<size_t> (ptr_d.dimension_0 ());
+      if (ptr_d.extent (0) != 0) {
+        const size_t numOffsets = static_cast<size_t> (ptr_d.extent (0));
         const size_t valToCheck = Details::getEntryOnHost (ptr_d, numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (valToCheck != static_cast<size_t> (ind_d.dimension_0 ()),
+          (valToCheck != static_cast<size_t> (ind_d.extent (0)),
            std::logic_error, "(DynamicProfile branch) After packing column "
            "indices, ptr_d(" << (numOffsets-1) << ") = " << valToCheck
-           << " != ind_d.dimension_0() = " << ind_d.dimension_0 () << ".");
+           << " != ind_d.extent(0) = " << ind_d.extent (0) << ".");
       }
 #endif // HAVE_TPETRA_DEBUG
     }
@@ -4163,23 +4163,23 @@ namespace Tpetra {
       // StaticProfile also means that the graph's array of row
       // offsets must already be allocated.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_rowPtrs_.dimension_0 () == 0, std::logic_error,
+        (k_rowPtrs_.extent (0) == 0, std::logic_error,
          "(StaticProfile branch) k_rowPtrs_ has size zero, but shouldn't");
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_rowPtrs_.dimension_0 () != lclNumRows + 1, std::logic_error,
-         "(StaticProfile branch) k_rowPtrs_.dimension_0() = "
-         << k_rowPtrs_.dimension_0 () << " != (lclNumRows + 1) = "
+        (k_rowPtrs_.extent (0) != lclNumRows + 1, std::logic_error,
+         "(StaticProfile branch) k_rowPtrs_.extent(0) = "
+         << k_rowPtrs_.extent (0) << " != (lclNumRows + 1) = "
          << (lclNumRows + 1) << ".");
       {
-        const size_t numOffsets = k_rowPtrs_.dimension_0 ();
+        const size_t numOffsets = k_rowPtrs_.extent (0);
         const auto valToCheck =
           Details::getEntryOnHost (k_rowPtrs_, numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (numOffsets != 0 &&
-           k_lclInds1D_.dimension_0 () != valToCheck,
+           k_lclInds1D_.extent (0) != valToCheck,
            std::logic_error, "(StaticProfile branch) numOffsets = " <<
-           numOffsets << " != 0 and k_lclInds1D_.dimension_0() = " <<
-           k_lclInds1D_.dimension_0 () << " != k_rowPtrs_(" << numOffsets <<
+           numOffsets << " != 0 and k_lclInds1D_.extent(0) = " <<
+           k_lclInds1D_.extent (0) << " != k_rowPtrs_(" << numOffsets <<
            ") = " << valToCheck << ".");
       }
 #endif // HAVE_TPETRA_DEBUG
@@ -4218,17 +4218,17 @@ namespace Tpetra {
         // all those entries.
 
 #ifdef HAVE_TPETRA_DEBUG
-        if (k_rowPtrs_.dimension_0 () != 0) {
+        if (k_rowPtrs_.extent (0) != 0) {
           const size_t numOffsets =
-            static_cast<size_t> (k_rowPtrs_.dimension_0 ());
+            static_cast<size_t> (k_rowPtrs_.extent (0));
           const auto valToCheck =
             Details::getEntryOnHost (k_rowPtrs_, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (valToCheck != static_cast<size_t> (k_lclInds1D_.dimension_0 ()),
+            (valToCheck != static_cast<size_t> (k_lclInds1D_.extent (0)),
              std::logic_error, "(StaticProfile unpacked branch) Before "
              "allocating or packing, k_rowPtrs_(" << (numOffsets-1) << ") = "
-             << valToCheck << " != k_lclInds1D_.dimension_0() = "
-             << k_lclInds1D_.dimension_0 () << ".");
+             << valToCheck << " != k_lclInds1D_.extent(0) = "
+             << k_lclInds1D_.extent (0) << ".");
         }
 #endif // HAVE_TPETRA_DEBUG
 
@@ -4249,9 +4249,9 @@ namespace Tpetra {
           typename row_entries_type::const_type numRowEnt_h = k_numRowEntries_;
 #ifdef HAVE_TPETRA_DEBUG
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (numRowEnt_h.dimension_0 ()) != lclNumRows,
+            (static_cast<size_t> (numRowEnt_h.extent (0)) != lclNumRows,
              std::logic_error, "(StaticProfile unpacked branch) "
-             "numRowEnt_h.dimension_0() = " << numRowEnt_h.dimension_0 ()
+             "numRowEnt_h.extent(0) = " << numRowEnt_h.extent (0)
              << " != getNodeNumRows() = " << lclNumRows << "");
 #endif // HAVE_TPETRA_DEBUG
 
@@ -4259,9 +4259,9 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (ptr_d.dimension_0 ()) != lclNumRows + 1,
+            (static_cast<size_t> (ptr_d.extent (0)) != lclNumRows + 1,
              std::logic_error, "(StaticProfile unpacked branch) After "
-             "allocating ptr_d, ptr_d.dimension_0() = " << ptr_d.dimension_0 ()
+             "allocating ptr_d, ptr_d.extent(0) = " << ptr_d.extent (0)
              << " != lclNumRows+1 = " << (lclNumRows+1) << ".");
           {
             const auto valToCheck = Details::getEntryOnHost (ptr_d, lclNumRows);
@@ -4300,19 +4300,19 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (ptr_d.dimension_0 () == 0, std::logic_error, "(StaticProfile "
+          (ptr_d.extent (0) == 0, std::logic_error, "(StaticProfile "
            "\"Optimize Storage\"=true branch) After packing, "
-           "ptr_d.dimension_0() = 0.  This probably means k_rowPtrs_ was "
+           "ptr_d.extent(0) = 0.  This probably means k_rowPtrs_ was "
            "never allocated.");
-        if (ptr_d.dimension_0 () != 0) {
-          const size_t numOffsets = static_cast<size_t> (ptr_d.dimension_0 ());
+        if (ptr_d.extent (0) != 0) {
+          const size_t numOffsets = static_cast<size_t> (ptr_d.extent (0));
           const auto valToCheck = Details::getEntryOnHost (ptr_d, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (valToCheck) != ind_d.dimension_0 (),
+            (static_cast<size_t> (valToCheck) != ind_d.extent (0),
              std::logic_error, "(StaticProfile \"Optimize Storage\"=true "
              "branch) After packing, ptr_d(" << (numOffsets-1) << ") = "
-             << valToCheck << " != ind_d.dimension_0() = "
-             << ind_d.dimension_0 () << ".");
+             << valToCheck << " != ind_d.extent(0) = "
+             << ind_d.extent (0) << ".");
         }
 #endif // HAVE_TPETRA_DEBUG
       }
@@ -4322,19 +4322,19 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (ptr_d_const.dimension_0 () == 0, std::logic_error, "(StaticProfile "
-           "\"Optimize Storage\"=false branch) ptr_d_const.dimension_0() = 0.  "
+          (ptr_d_const.extent (0) == 0, std::logic_error, "(StaticProfile "
+           "\"Optimize Storage\"=false branch) ptr_d_const.extent(0) = 0.  "
            "This probably means that k_rowPtrs_ was never allocated.");
-        if (ptr_d_const.dimension_0 () != 0) {
+        if (ptr_d_const.extent (0) != 0) {
           const size_t numOffsets =
-            static_cast<size_t> (ptr_d_const.dimension_0 ());
+            static_cast<size_t> (ptr_d_const.extent (0));
           const size_t valToCheck =
             Details::getEntryOnHost (ptr_d_const, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (valToCheck != static_cast<size_t> (ind_d.dimension_0 ()),
+            (valToCheck != static_cast<size_t> (ind_d.extent (0)),
              std::logic_error, "(StaticProfile \"Optimize Storage\"=false "
              "branch) ptr_d_const(" << (numOffsets-1) << ") = " << valToCheck
-             << " != ind_d.dimension_0() = " << ind_d.dimension_0 () << ".");
+             << " != ind_d.extent(0) = " << ind_d.extent (0) << ".");
         }
 #endif // HAVE_TPETRA_DEBUG
       }
@@ -4343,18 +4343,18 @@ namespace Tpetra {
 #ifdef HAVE_TPETRA_DEBUG
     // Extra sanity checks.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<size_t> (ptr_d_const.dimension_0 ()) != lclNumRows + 1,
-       std::logic_error, "After packing, ptr_d_const.dimension_0() = " <<
-       ptr_d_const.dimension_0 () << " != lclNumRows+1 = " << (lclNumRows+1)
+      (static_cast<size_t> (ptr_d_const.extent (0)) != lclNumRows + 1,
+       std::logic_error, "After packing, ptr_d_const.extent(0) = " <<
+       ptr_d_const.extent (0) << " != lclNumRows+1 = " << (lclNumRows+1)
        << ".");
-    if (ptr_d_const.dimension_0 () != 0) {
-      const size_t numOffsets = static_cast<size_t> (ptr_d_const.dimension_0 ());
+    if (ptr_d_const.extent (0) != 0) {
+      const size_t numOffsets = static_cast<size_t> (ptr_d_const.extent (0));
       const auto valToCheck = Details::getEntryOnHost (ptr_d_const, numOffsets - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (valToCheck) != ind_d.dimension_0 (),
+        (static_cast<size_t> (valToCheck) != ind_d.extent (0),
          std::logic_error, "After packing, ptr_d_const(" << (numOffsets-1)
-         << ") = " << valToCheck << " != ind_d.dimension_0() = "
-         << ind_d.dimension_0 () << ".");
+         << ") = " << valToCheck << " != ind_d.extent(0) = "
+         << ind_d.extent (0) << ".");
     }
 #endif // HAVE_TPETRA_DEBUG
 
@@ -4923,8 +4923,8 @@ namespace Tpetra {
             lcl_col_inds_type>::select (k_gblInds1D_, k_lclInds1D_);
         }
         else {
-          if (k_rowPtrs_.dimension_0 () == 0) {
-            errStrm << "k_rowPtrs_.dimension_0() == 0.  This should never "
+          if (k_rowPtrs_.extent (0) == 0) {
+            errStrm << "k_rowPtrs_.extent(0) == 0.  This should never "
               "happen here.  Please report this bug to the Tpetra developers."
               << endl;
             // Need to return early.
@@ -5979,9 +5979,9 @@ namespace Tpetra {
       (! hasColMap (), std::runtime_error, "The graph must have a column Map.");
     const LO lclNumRows = static_cast<LO> (this->getNodeNumRows ());
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<LO> (offsets.dimension_0 ()) < lclNumRows,
-       std::invalid_argument, "offsets.dimension_0() = " <<
-       offsets.dimension_0 () << " < getNodeNumRows() = " << lclNumRows << ".");
+      (static_cast<LO> (offsets.extent (0)) < lclNumRows,
+       std::invalid_argument, "offsets.extent(0) = " <<
+       offsets.extent (0) << " < getNodeNumRows() = " << lclNumRows << ".");
 
     const map_type& rowMap = * (this->getRowMap ());
     const map_type& colMap = * (this->getColMap ());
@@ -6213,7 +6213,7 @@ namespace Tpetra {
       {
         // Host memory space != device memory space, so we must
         // allocate a temporary device View for the graph.
-        return device_offsets_type ("offsets", hostOffsets.dimension_0 ());
+        return device_offsets_type ("offsets", hostOffsets.extent (0));
       }
 
       static void

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -950,7 +950,7 @@ namespace Tpetra {
     /// \param inputVals [in] Kokkos::View of the values to use for
     ///   replacing the entries.
     ///
-    /// For all k in 0, ..., <tt>inputInds.dimension_0()-1</tt>,
+    /// For all k in 0, ..., <tt>inputInds.extent(0)-1</tt>,
     /// replace the value at entry <tt>(globalRow, inputInds(k))</tt>
     /// of the matrix with <tt>inputVals(k)</tt>.  That entry must
     /// exist in the matrix already.
@@ -965,16 +965,16 @@ namespace Tpetra {
     ///
     /// If the returned value N satisfies
     ///
-    /// <tt>0 <= N < inputInds.dimension_0()</tt>,
+    /// <tt>0 <= N < inputInds.extent(0)</tt>,
     ///
-    /// then <tt>inputInds.dimension_0() - N</tt> of the entries of
+    /// then <tt>inputInds.extent(0) - N</tt> of the entries of
     /// <tt>cols</tt> are not valid global column indices.  If the
     /// returned value is
     /// <tt>Teuchos::OrdinalTraits<LocalOrdinal>::invalid()</tt>, then
     /// at least one of the following is true:
     /// <ul>
     /// <li> <tt>! isFillActive ()</tt> </li>
-    /// <li> <tt> inputInds.dimension_0 () != inputVals.dimension_0 ()</tt> </li>
+    /// <li> <tt> inputInds.extent (0) != inputVals.extent (0)</tt> </li>
     /// </ul>
     template<class GlobalIndicesViewType,
              class ImplScalarViewType>
@@ -1012,8 +1012,8 @@ namespace Tpetra {
                      "Second template parameter ImplScalarViewType must "
                      "contain values of type impl_scalar_type.");
       typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.dimension_0 ();
-      if (static_cast<LO> (inputVals.dimension_0 ()) != numInputEnt) {
+      const LO numInputEnt = inputInds.extent (0);
+      if (static_cast<LO> (inputVals.extent (0)) != numInputEnt) {
         return Teuchos::OrdinalTraits<LO>::invalid ();
       }
       const Scalar* const inVals =
@@ -1094,9 +1094,9 @@ namespace Tpetra {
     ///
     /// If the returned value N satisfies
     ///
-    /// <tt>0 <= N < cols.dimension_0()</tt>,
+    /// <tt>0 <= N < cols.extent(0)</tt>,
     ///
-    /// then <tt>cols.dimension_0() - N</tt> of the entries of
+    /// then <tt>cols.extent(0) - N</tt> of the entries of
     /// <tt>cols</tt> are not valid local column indices.  If the
     /// returned value is
     /// <tt>Teuchos::OrdinalTraits<LocalOrdinal>::invalid()</tt>,
@@ -1104,7 +1104,7 @@ namespace Tpetra {
     ///   <ul>
     ///   <li> <tt>! isFillActive ()</tt> </li>
     ///   <li> <tt>! hasColMap ()</tt> </li>
-    ///   <li> <tt> cols.dimension_0 () != vals.dimension_0 ()</tt> </li>
+    ///   <li> <tt> cols.extent (0) != vals.extent (0)</tt> </li>
     ///   </ul>
     template<class LocalIndicesViewType,
              class ImplScalarViewType>
@@ -1143,8 +1143,8 @@ namespace Tpetra {
                      "contain values of type impl_scalar_type.");
 
       typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.dimension_0 ();
-      if (numInputEnt != inputVals.dimension_0 ()) {
+      const LO numInputEnt = inputInds.extent (0);
+      if (numInputEnt != inputVals.extent (0)) {
         return Teuchos::OrdinalTraits<LO>::invalid ();
       }
       const Scalar* const inVals =
@@ -1396,8 +1396,8 @@ namespace Tpetra {
                      "Second template parameter ImplScalarViewType must "
                      "contain values of type impl_scalar_type.");
       typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.dimension_0 ();
-      if (static_cast<LO> (inputVals.dimension_0 ()) != numInputEnt) {
+      const LO numInputEnt = inputInds.extent (0);
+      if (static_cast<LO> (inputVals.extent (0)) != numInputEnt) {
         return Teuchos::OrdinalTraits<LO>::invalid ();
       }
       return this->sumIntoLocalValues (localRow,
@@ -1702,8 +1702,8 @@ namespace Tpetra {
                      "Second template parameter ImplScalarViewType must "
                      "contain values of type impl_scalar_type.");
       typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.dimension_0 ();
-      if (static_cast<LO> (inputVals.dimension_0 ()) != numInputEnt) {
+      const LO numInputEnt = inputInds.extent (0);
+      if (static_cast<LO> (inputVals.extent (0)) != numInputEnt) {
         return Teuchos::OrdinalTraits<LO>::invalid ();
       }
       return this->transformLocalValues (lclRow,
@@ -1768,8 +1768,8 @@ namespace Tpetra {
                            const bool atomic = useAtomicUpdatesByDefault) const
     {
       typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.dimension_0 ();
-      if (static_cast<LO> (inputVals.dimension_0 ()) != numInputEnt) {
+      const LO numInputEnt = inputInds.extent (0);
+      if (static_cast<LO> (inputVals.extent (0)) != numInputEnt) {
         return Teuchos::OrdinalTraits<LO>::invalid ();
       }
       return this->transformGlobalValues (gblRow,
@@ -2848,8 +2848,8 @@ namespace Tpetra {
       // If the two pointers are NULL, then they don't alias one
       // another, even though they are equal.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-        X_lcl.ptr_on_device () == Y_lcl.ptr_on_device () &&
-        X_lcl.ptr_on_device () != NULL,
+        X_lcl.data () == Y_lcl.data () &&
+        X_lcl.data () != NULL,
         std::runtime_error, "X and Y may not alias one another.");
 #endif // HAVE_TPETRA_DEBUG
 
@@ -2991,9 +2991,9 @@ namespace Tpetra {
       typename local_matrix_type::row_map_type ptr = lclGraph.row_map;
       typename local_matrix_type::index_type ind = lclGraph.entries;
       typename local_matrix_type::values_type val = lclMatrix.values;
-      const offset_type* const ptrRaw = ptr.ptr_on_device ();
-      const LO* const indRaw = ind.ptr_on_device ();
-      const impl_scalar_type* const valRaw = val.ptr_on_device ();
+      const offset_type* const ptrRaw = ptr.data ();
+      const LO* const indRaw = ind.data ();
+      const impl_scalar_type* const valRaw = val.data ();
 
       const std::string dir ((direction == Forward) ? "F" : "B");
       // NOTE (mfh 28 Aug 2017) This assumes UVM.  We can't get around
@@ -3004,9 +3004,9 @@ namespace Tpetra {
       KokkosSparse::Impl::Sequential::gaussSeidel (static_cast<LO> (lclNumRows),
                                                    static_cast<LO> (numVecs),
                                                    ptrRaw, indRaw, valRaw,
-                                                   B_lcl.ptr_on_device (), B_stride[1],
-                                                   X_lcl.ptr_on_device (), X_stride[1],
-                                                   D_lcl.ptr_on_device (),
+                                                   B_lcl.data (), B_stride[1],
+                                                   X_lcl.data (), X_stride[1],
+                                                   D_lcl.data (),
                                                    static_cast<impl_scalar_type> (dampingFactor),
                                                    dir.c_str ());
       const_cast<DMV&> (B).template sync<dev_mem_space> ();
@@ -3100,9 +3100,9 @@ namespace Tpetra {
       typename local_matrix_type::index_type ind = lclGraph.entries;
       typename local_matrix_type::row_map_type ptr = lclGraph.row_map;
       typename local_matrix_type::values_type val = lclMatrix.values;
-      const offset_type* const ptrRaw = ptr.ptr_on_device ();
-      const LO* const indRaw = ind.ptr_on_device ();
-      const impl_scalar_type* const valRaw = val.ptr_on_device ();
+      const offset_type* const ptrRaw = ptr.data ();
+      const LO* const indRaw = ind.data ();
+      const impl_scalar_type* const valRaw = val.data ();
 
       const std::string dir = (direction == Forward) ? "F" : "B";
       // NOTE (mfh 28 Aug 2017) This assumes UVM.  We can't get around
@@ -3112,11 +3112,11 @@ namespace Tpetra {
       KokkosSparse::Impl::Sequential::reorderedGaussSeidel (static_cast<LO> (lclNumRows),
                                                             static_cast<LO> (numVecs),
                                                             ptrRaw, indRaw, valRaw,
-                                                            B_lcl.ptr_on_device (),
+                                                            B_lcl.data (),
                                                             B_stride[1],
-                                                            X_lcl.ptr_on_device (),
+                                                            X_lcl.data (),
                                                             X_stride[1],
-                                                            D_lcl.ptr_on_device (),
+                                                            D_lcl.data (),
                                                             rowIndices.getRawPtr (),
                                                             static_cast<LO> (lclNumRows),
                                                             static_cast<impl_scalar_type> (dampingFactor),

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -316,7 +316,7 @@ namespace Tpetra {
 
     const size_t numCols = graph->getColMap ()->getNodeNumElements ();
     auto lclGraph = graph->getLocalGraph ();
-    const size_t numEnt = lclGraph.entries.dimension_0 ();
+    const size_t numEnt = lclGraph.entries.extent (0);
     values_type val ("Tpetra::CrsMatrix::val", numEnt);
 
     this->lclMatrix_ = local_matrix_type ("Tpetra::CrsMatrix::lclMatrix_",
@@ -352,22 +352,22 @@ namespace Tpetra {
     // deadlock due to exceptions to segfaults, because users can
     // catch exceptions.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (values.dimension_0 () != columnIndices.dimension_0 (),
+      (values.extent (0) != columnIndices.extent (0),
        std::invalid_argument, "Input arrays don't have matching dimensions.  "
-       "values.dimension_0() = " << values.dimension_0 () << " != "
-       "columnIndices.dimension_0() = " << columnIndices.dimension_0 () << ".");
+       "values.extent(0) = " << values.extent (0) << " != "
+       "columnIndices.extent(0) = " << columnIndices.extent (0) << ".");
 #ifdef HAVE_TPETRA_DEBUG
-    if (rowPointers.dimension_0 () != 0) {
+    if (rowPointers.extent (0) != 0) {
       const size_t numEnt =
-        Details::getEntryOnHost (rowPointers, rowPointers.dimension_0 () - 1);
+        Details::getEntryOnHost (rowPointers, rowPointers.extent (0) - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (numEnt != static_cast<size_t> (columnIndices.dimension_0 ()) ||
-         numEnt != static_cast<size_t> (values.dimension_0 ()),
+        (numEnt != static_cast<size_t> (columnIndices.extent (0)) ||
+         numEnt != static_cast<size_t> (values.extent (0)),
          std::invalid_argument, "Last entry of rowPointers says that the matrix"
          " has " << numEnt << " entr" << (numEnt != 1 ? "ies" : "y") << ", but "
          "the dimensions of columnIndices and values don't match this.  "
-         "columnIndices.dimension_0() = " << columnIndices.dimension_0 () <<
-         " and values.dimension_0() = " << values.dimension_0 () << ".");
+         "columnIndices.extent(0) = " << columnIndices.extent (0) <<
+         " and values.extent(0) = " << values.extent (0) << ".");
     }
 #endif // HAVE_TPETRA_DEBUG
 
@@ -389,16 +389,16 @@ namespace Tpetra {
     // a local graph.
     auto lclGraph = graph->getLocalGraph ();
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (lclGraph.row_map.dimension_0 () != rowPointers.dimension_0 () ||
-       lclGraph.entries.dimension_0 () != columnIndices.dimension_0 (),
+      (lclGraph.row_map.extent (0) != rowPointers.extent (0) ||
+       lclGraph.entries.extent (0) != columnIndices.extent (0),
        std::logic_error, "CrsGraph's constructor (rowMap, colMap, ptr, "
        "ind[, params]) did not set the local graph correctly." << suffix);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (lclGraph.entries.dimension_0 () != values.dimension_0 (),
+      (lclGraph.entries.extent (0) != values.extent (0),
        std::logic_error, "CrsGraph's constructor (rowMap, colMap, ptr, ind[, "
        "params]) did not set the local graph correctly.  "
-       "lclGraph.entries.dimension_0() = " << lclGraph.entries.dimension_0 ()
-       << " != values.dimension_0() = " << values.dimension_0 () << suffix);
+       "lclGraph.entries.extent(0) = " << lclGraph.entries.extent (0)
+       << " != values.extent(0) = " << values.extent (0) << suffix);
 
     // myGraph_ not null means that the matrix owns the graph.  This
     // is true because the column indices come in as nonconst,
@@ -417,11 +417,11 @@ namespace Tpetra {
     lclMatrix_ = local_matrix_type ("Tpetra::CrsMatrix::lclMatrix_",
                                     numCols, values, lclGraph);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (lclMatrix_.values.dimension_0 () != values.dimension_0 (),
+      (lclMatrix_.values.extent (0) != values.extent (0),
        std::logic_error, "Local matrix's constructor did not set the values "
-       "correctly.  lclMatrix_.values.dimension_0() = " <<
-       lclMatrix_.values.dimension_0 () << " != values.dimension_0() = " <<
-       values.dimension_0 () << suffix);
+       "correctly.  lclMatrix_.values.extent(0) = " <<
+       lclMatrix_.values.extent (0) << " != values.extent(0) = " <<
+       values.extent (0) << suffix);
 
     // FIXME (22 Jun 2016) I would very much like to get rid of
     // k_values1D_ at some point.  I find it confusing to have all
@@ -482,8 +482,8 @@ namespace Tpetra {
     // That's how we tell whether the CrsGraph has a local graph.
     auto lclGraph = staticGraph_->getLocalGraph ();
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<size_t> (lclGraph.row_map.dimension_0 ()) != static_cast<size_t> (ptr.size ()) ||
-       static_cast<size_t> (lclGraph.entries.dimension_0 ()) != static_cast<size_t> (ind.size ()),
+      (static_cast<size_t> (lclGraph.row_map.extent (0)) != static_cast<size_t> (ptr.size ()) ||
+       static_cast<size_t> (lclGraph.entries.extent (0)) != static_cast<size_t> (ind.size ()),
        std::logic_error, "CrsGraph's constructor (rowMap, colMap, ptr, "
        "ind[, params]) did not set the local graph correctly.  Please "
        "report this bug to the Tpetra developers.");
@@ -994,9 +994,9 @@ namespace Tpetra {
       typename Graph::local_graph_type::row_map_type k_ptrs =
         this->staticGraph_->k_rowPtrs_;
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs.dimension_0 () != lclNumRows+1, std::logic_error,
+        (k_ptrs.extent (0) != lclNumRows+1, std::logic_error,
         "With StaticProfile, row offsets array has length "
-        << k_ptrs.dimension_0 () << " != (lclNumRows+1) = "
+        << k_ptrs.extent (0) << " != (lclNumRows+1) = "
         << (lclNumRows+1) << ".");
 
       const size_t lclTotalNumEntries =
@@ -1135,10 +1135,10 @@ namespace Tpetra {
         myGraph_->k_numRowEntries_;
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (numRowEnt_h.dimension_0 ()) != lclNumRows,
+        (static_cast<size_t> (numRowEnt_h.extent (0)) != lclNumRows,
          std::logic_error, "(DynamicProfile branch) numRowEnt_h has the "
-         "wrong length.  numRowEnt_h.dimension_0() = "
-         << numRowEnt_h.dimension_0 () << " != getNodeNumRows() = "
+         "wrong length.  numRowEnt_h.extent(0) = "
+         << numRowEnt_h.extent (0) << " != getNodeNumRows() = "
          << lclNumRows << ".");
 #endif // HAVE_TPETRA_DEBUG
 
@@ -1160,9 +1160,9 @@ namespace Tpetra {
         computeOffsetsFromCounts (h_ptrs, numRowEnt_h);
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (h_ptrs.dimension_0 ()) != lclNumRows + 1,
+        (static_cast<size_t> (h_ptrs.extent (0)) != lclNumRows + 1,
          std::logic_error, "(DynamicProfile branch) After packing h_ptrs, "
-         "h_ptrs.dimension_0() = " << h_ptrs.dimension_0 () << " != "
+         "h_ptrs.extent(0) = " << h_ptrs.extent (0) << " != "
          "(lclNumRows+1) = " << (lclNumRows+1) << ".");
       {
         const size_t h_ptrs_lastEnt = h_ptrs(lclNumRows); // it's a host View
@@ -1188,10 +1188,10 @@ namespace Tpetra {
         const size_t numEnt = numRowEnt_h(row);
         std::copy (lclInds2D[row].begin(),
                    lclInds2D[row].begin() + numEnt,
-                   h_inds.ptr_on_device() + h_ptrs(row));
+                   h_inds.data() + h_ptrs(row));
         std::copy (values2D_[row].begin(),
                    values2D_[row].begin() + numEnt,
-                   h_vals.ptr_on_device() + h_ptrs(row));
+                   h_vals.data() + h_ptrs(row));
       }
 
       // Copy the packed column indices and values to the device.
@@ -1204,24 +1204,24 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
       // Sanity check of packed row offsets.
-      if (k_ptrs.dimension_0 () != 0) {
-        const size_t numOffsets = static_cast<size_t> (k_ptrs.dimension_0 ());
+      if (k_ptrs.extent (0) != 0) {
+        const size_t numOffsets = static_cast<size_t> (k_ptrs.extent (0));
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (numOffsets != lclNumRows + 1, std::logic_error, "(DynamicProfile "
-           "branch) After copying into k_ptrs, k_ptrs.dimension_0() = " <<
+           "branch) After copying into k_ptrs, k_ptrs.extent(0) = " <<
            numOffsets << " != (lclNumRows+1) = " << (lclNumRows+1) << ".");
 
         const auto valToCheck = Details::getEntryOnHost (k_ptrs, numOffsets-1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_vals.dimension_0 (),
+          (static_cast<size_t> (valToCheck) != k_vals.extent (0),
           std::logic_error, "(DynamicProfile branch) After packing, k_ptrs("
            << (numOffsets-1) << ") = " << valToCheck << " != "
-           "k_vals.dimension_0() = " << k_vals.dimension_0 () << ".");
+           "k_vals.extent(0) = " << k_vals.extent (0) << ".");
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_inds.dimension_0 (),
+          (static_cast<size_t> (valToCheck) != k_inds.extent (0),
           std::logic_error, "(DynamicProfile branch) After packing, k_ptrs("
            << (numOffsets-1) << ") = " << valToCheck << " != "
-           "k_inds.dimension_0() = " << k_inds.dimension_0 () << ".");
+           "k_inds.extent(0) = " << k_inds.extent (0) << ".");
       }
 #endif // HAVE_TPETRA_DEBUG
     }
@@ -1237,23 +1237,23 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (curRowOffsets.dimension_0 () == 0, std::logic_error,
-         "(StaticProfile branch) curRowOffsets.dimension_0() == 0.");
+        (curRowOffsets.extent (0) == 0, std::logic_error,
+         "(StaticProfile branch) curRowOffsets.extent(0) == 0.");
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (curRowOffsets.dimension_0 () != lclNumRows + 1, std::logic_error,
-         "(StaticProfile branch) curRowOffsets.dimension_0() = "
-         << curRowOffsets.dimension_0 () << " != lclNumRows + 1 = "
+        (curRowOffsets.extent (0) != lclNumRows + 1, std::logic_error,
+         "(StaticProfile branch) curRowOffsets.extent(0) = "
+         << curRowOffsets.extent (0) << " != lclNumRows + 1 = "
          << (lclNumRows + 1) << ".")
       {
-        const size_t numOffsets = curRowOffsets.dimension_0 ();
+        const size_t numOffsets = curRowOffsets.extent (0);
         const auto valToCheck =
           Details::getEntryOnHost (curRowOffsets, numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (numOffsets != 0 &&
-           myGraph_->k_lclInds1D_.dimension_0 () != valToCheck,
+           myGraph_->k_lclInds1D_.extent (0) != valToCheck,
            std::logic_error, "(StaticProfile branch) numOffsets = " <<
-           numOffsets << " != 0 and myGraph_->k_lclInds1D_.dimension_0() = "
-           << myGraph_->k_lclInds1D_.dimension_0 () << " != curRowOffsets("
+           numOffsets << " != 0 and myGraph_->k_lclInds1D_.extent(0) = "
+           << myGraph_->k_lclInds1D_.extent (0) << " != curRowOffsets("
            << numOffsets << ") = " << valToCheck << ".");
       }
 #endif // HAVE_TPETRA_DEBUG
@@ -1266,26 +1266,26 @@ namespace Tpetra {
         // bound on the number of entries per row, but didn't fill all
         // those entries.
 #ifdef HAVE_TPETRA_DEBUG
-        if (curRowOffsets.dimension_0 () != 0) {
+        if (curRowOffsets.extent (0) != 0) {
           const size_t numOffsets =
-            static_cast<size_t> (curRowOffsets.dimension_0 ());
+            static_cast<size_t> (curRowOffsets.extent (0));
           const auto valToCheck =
             Details::getEntryOnHost (curRowOffsets, numOffsets-1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (static_cast<size_t> (valToCheck) !=
-             static_cast<size_t> (k_values1D_.dimension_0 ()),
+             static_cast<size_t> (k_values1D_.extent (0)),
              std::logic_error, "(StaticProfile unpacked branch) Before "
              "allocating or packing, curRowOffsets(" << (numOffsets-1) << ") = "
-             << valToCheck << " != k_values1D_.dimension_0()"
-             " = " << k_values1D_.dimension_0 () << ".");
+             << valToCheck << " != k_values1D_.extent(0)"
+             " = " << k_values1D_.extent (0) << ".");
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (static_cast<size_t> (valToCheck) !=
-             static_cast<size_t> (myGraph_->k_lclInds1D_.dimension_0 ()),
+             static_cast<size_t> (myGraph_->k_lclInds1D_.extent (0)),
              std::logic_error, "(StaticProfile unpacked branch) Before "
              "allocating or packing, curRowOffsets(" << (numOffsets-1) << ") = "
              << valToCheck
-             << " != myGraph_->k_lclInds1D_.dimension_0() = "
-             << myGraph_->k_lclInds1D_.dimension_0 () << ".");
+             << " != myGraph_->k_lclInds1D_.extent(0) = "
+             << myGraph_->k_lclInds1D_.extent (0) << ".");
         }
 #endif // HAVE_TPETRA_DEBUG
 
@@ -1318,10 +1318,10 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (k_ptrs.dimension_0 ()) != lclNumRows + 1,
+          (static_cast<size_t> (k_ptrs.extent (0)) != lclNumRows + 1,
            std::logic_error,
            "(StaticProfile unpacked branch) After packing k_ptrs, "
-           "k_ptrs.dimension_0() = " << k_ptrs.dimension_0 () << " != "
+           "k_ptrs.extent(0) = " << k_ptrs.extent (0) << " != "
            "lclNumRows+1 = " << (lclNumRows+1) << ".");
         {
           const auto valToCheck = Details::getEntryOnHost (k_ptrs, lclNumRows);
@@ -1366,25 +1366,25 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (k_ptrs.dimension_0 () == 0, std::logic_error,
+          (k_ptrs.extent (0) == 0, std::logic_error,
            "(StaticProfile \"Optimize Storage\" = "
-           "true branch) After packing, k_ptrs.dimension_0() = 0.  This "
+           "true branch) After packing, k_ptrs.extent(0) = 0.  This "
            "probably means that k_rowPtrs_ was never allocated.");
-        if (k_ptrs.dimension_0 () != 0) {
-          const size_t numOffsets = static_cast<size_t> (k_ptrs.dimension_0 ());
+        if (k_ptrs.extent (0) != 0) {
+          const size_t numOffsets = static_cast<size_t> (k_ptrs.extent (0));
           const auto valToCheck = Details::getEntryOnHost (k_ptrs, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (valToCheck) != k_vals.dimension_0 (),
+            (static_cast<size_t> (valToCheck) != k_vals.extent (0),
              std::logic_error,
              "(StaticProfile \"Optimize Storage\"=true branch) After packing, "
              "k_ptrs(" << (numOffsets-1) << ") = " << valToCheck <<
-             " != k_vals.dimension_0() = " << k_vals.dimension_0 () << ".");
+             " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (valToCheck) != k_inds.dimension_0 (),
+            (static_cast<size_t> (valToCheck) != k_inds.extent (0),
              std::logic_error,
              "(StaticProfile \"Optimize Storage\"=true branch) After packing, "
              "k_ptrs(" << (numOffsets-1) << ") = " << valToCheck <<
-             " != k_inds.dimension_0() = " << k_inds.dimension_0 () << ".");
+             " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
         }
 #endif // HAVE_TPETRA_DEBUG
       }
@@ -1395,25 +1395,25 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (k_ptrs_const.dimension_0 () == 0, std::logic_error,
+          (k_ptrs_const.extent (0) == 0, std::logic_error,
           "(StaticProfile \"Optimize Storage\"=false branch) "
-          "k_ptrs_const.dimension_0() = 0.  This probably means that "
+          "k_ptrs_const.extent(0) = 0.  This probably means that "
           "k_rowPtrs_ was never allocated.");
-        if (k_ptrs_const.dimension_0 () != 0) {
-          const size_t numOffsets = static_cast<size_t> (k_ptrs_const.dimension_0 ());
+        if (k_ptrs_const.extent (0) != 0) {
+          const size_t numOffsets = static_cast<size_t> (k_ptrs_const.extent (0));
           const auto valToCheck = Details::getEntryOnHost (k_ptrs_const, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (valToCheck) != k_vals.dimension_0 (),
+            (static_cast<size_t> (valToCheck) != k_vals.extent (0),
              std::logic_error,
              "(StaticProfile \"Optimize Storage\"=false branch) "
              "k_ptrs_const(" << (numOffsets-1) << ") = " << valToCheck
-             << " != k_vals.dimension_0() = " << k_vals.dimension_0 () << ".");
+             << " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (valToCheck) != k_inds.dimension_0 (),
+            (static_cast<size_t> (valToCheck) != k_inds.extent (0),
              std::logic_error,
              "(StaticProfile \"Optimize Storage\" = false branch) "
              "k_ptrs_const(" << (numOffsets-1) << ") = " << valToCheck
-             << " != k_inds.dimension_0() = " << k_inds.dimension_0 () << ".");
+             << " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
         }
 #endif // HAVE_TPETRA_DEBUG
       }
@@ -1422,24 +1422,24 @@ namespace Tpetra {
 #ifdef HAVE_TPETRA_DEBUG
     // Extra sanity checks.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<size_t> (k_ptrs_const.dimension_0 ()) != lclNumRows + 1,
-       std::logic_error, "After packing, k_ptrs_const.dimension_0() = " <<
-       k_ptrs_const.dimension_0 () << " != lclNumRows+1 = " << (lclNumRows+1)
+      (static_cast<size_t> (k_ptrs_const.extent (0)) != lclNumRows + 1,
+       std::logic_error, "After packing, k_ptrs_const.extent(0) = " <<
+       k_ptrs_const.extent (0) << " != lclNumRows+1 = " << (lclNumRows+1)
        << ".");
-    if (k_ptrs_const.dimension_0 () != 0) {
-      const size_t numOffsets = static_cast<size_t> (k_ptrs_const.dimension_0 ());
+    if (k_ptrs_const.extent (0) != 0) {
+      const size_t numOffsets = static_cast<size_t> (k_ptrs_const.extent (0));
       const size_t k_ptrs_const_numOffsetsMinus1 =
         Details::getEntryOnHost (k_ptrs_const, numOffsets - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs_const_numOffsetsMinus1 != k_vals.dimension_0 (),
+        (k_ptrs_const_numOffsetsMinus1 != k_vals.extent (0),
          std::logic_error, "After packing, k_ptrs_const(" << (numOffsets-1) <<
-         ") = " << k_ptrs_const_numOffsetsMinus1 << " != k_vals.dimension_0()"
-         " = " << k_vals.dimension_0 () << ".");
+         ") = " << k_ptrs_const_numOffsetsMinus1 << " != k_vals.extent(0)"
+         " = " << k_vals.extent (0) << ".");
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs_const_numOffsetsMinus1 != k_inds.dimension_0 (),
+        (k_ptrs_const_numOffsetsMinus1 != k_inds.extent (0),
          std::logic_error, "After packing, k_ptrs_const(" << (numOffsets-1) <<
-         ") = " << k_ptrs_const_numOffsetsMinus1 << " != k_inds.dimension_0()"
-         " = " << k_inds.dimension_0 () << ".");
+         ") = " << k_ptrs_const_numOffsetsMinus1 << " != k_inds.extent(0)"
+         " = " << k_inds.extent (0) << ".");
     }
 #endif // HAVE_TPETRA_DEBUG
 
@@ -1609,14 +1609,14 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (k_ptrs.dimension_0 ()) != lclNumRows + 1,
+        (static_cast<size_t> (k_ptrs.extent (0)) != lclNumRows + 1,
          std::logic_error, "In DynamicProfile branch, after packing k_ptrs, "
-         "k_ptrs.dimension_0() = " << k_ptrs.dimension_0 () << " != "
+         "k_ptrs.extent(0) = " << k_ptrs.extent (0) << " != "
          "(lclNumRows+1) = " << (lclNumRows+1) << ".");
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (h_ptrs.dimension_0 ()) != lclNumRows + 1,
+        (static_cast<size_t> (h_ptrs.extent (0)) != lclNumRows + 1,
          std::logic_error, "In DynamicProfile branch, after packing h_ptrs, "
-         "h_ptrs.dimension_0() = " << h_ptrs.dimension_0 () << " != "
+         "h_ptrs.extent(0) = " << h_ptrs.extent (0) << " != "
          "(lclNumRows+1) = " << (lclNumRows+1) << ".");
       {
         const auto valToCheck = Details::getEntryOnHost (k_ptrs, lclNumRows);
@@ -1638,22 +1638,22 @@ namespace Tpetra {
         const size_t numEnt = numRowEnt_h(lclRow);
         std::copy (values2D_[lclRow].begin(),
                    values2D_[lclRow].begin() + numEnt,
-                   h_vals.ptr_on_device() + h_ptrs(lclRow));
+                   h_vals.data() + h_ptrs(lclRow));
       }
       // Copy the packed values to the device.
       Kokkos::deep_copy (k_vals, h_vals);
 
 #ifdef HAVE_TPETRA_DEBUG
       // Sanity check of packed row offsets.
-      if (k_ptrs.dimension_0 () != 0) {
-        const size_t numOffsets = static_cast<size_t> (k_ptrs.dimension_0 ());
+      if (k_ptrs.extent (0) != 0) {
+        const size_t numOffsets = static_cast<size_t> (k_ptrs.extent (0));
         const auto valToCheck =
           Details::getEntryOnHost (k_ptrs, numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_vals.dimension_0 (),
+          (static_cast<size_t> (valToCheck) != k_vals.extent (0),
            std::logic_error, "(DynamicProfile branch) After packing, k_ptrs("
            << (numOffsets-1) << ") = " << valToCheck << " != "
-           "k_vals.dimension_0() = " << k_vals.dimension_0 () << ".");
+           "k_vals.extent(0) = " << k_vals.extent (0) << ".");
       }
 #endif // HAVE_TPETRA_DEBUG
     }
@@ -2660,7 +2660,7 @@ namespace Tpetra {
       return static_cast<LO> (0);
     }
     auto curRowVals = this->getRowViewNonConst (rowInfo);
-    return this->transformLocalValues (curRowVals.ptr_on_device (), graph,
+    return this->transformLocalValues (curRowVals.data (), graph,
                                        rowInfo, inputCols, inputVals,
                                        numInputEnt, f, atomic);
   }
@@ -2691,7 +2691,7 @@ namespace Tpetra {
       return static_cast<LO> (0);
     }
     auto curRowVals = this->getRowViewNonConst (rowInfo);
-    return this->transformGlobalValues (curRowVals.ptr_on_device (), graph,
+    return this->transformGlobalValues (curRowVals.data (), graph,
                                         rowInfo, inputCols, inputVals,
                                         numInputEnt, f, atomic);
   }
@@ -2712,11 +2712,11 @@ namespace Tpetra {
     typedef LocalOrdinal LO;
     typedef GlobalOrdinal GO;
 
-    //if (newVals.dimension_0 () != inds.dimension_0 ()) {
+    //if (newVals.extent (0) != inds.extent (0)) {
     // The sizes of the input arrays must match.
     //return Tpetra::Details::OrdinalTraits<LO>::invalid ();
     //}
-    //const LO numElts = static_cast<LO> (inds.dimension_0 ());
+    //const LO numElts = static_cast<LO> (inds.extent (0));
     const bool sorted = graph.isSorted ();
 
     LO numValid = 0; // number of valid input column indices
@@ -2821,11 +2821,11 @@ namespace Tpetra {
     typedef LocalOrdinal LO;
     typedef GlobalOrdinal GO;
 
-    //if (newVals.dimension_0 () != inds.dimension_0 ()) {
+    //if (newVals.extent (0) != inds.extent (0)) {
     // The sizes of the input arrays must match.
     //return Tpetra::Details::OrdinalTraits<LO>::invalid ();
     //}
-    //const LO numElts = static_cast<LO> (inds.dimension_0 ());
+    //const LO numElts = static_cast<LO> (inds.extent (0));
     const bool sorted = graph.isSorted ();
 
     LO numValid = 0; // number of valid input column indices
@@ -3060,14 +3060,14 @@ namespace Tpetra {
     typedef impl_scalar_type ST;
     typedef std::pair<size_t, size_t> range_type;
 
-    if (k_values1D_.dimension_0 () != 0 && rowinfo.allocSize > 0) {
+    if (k_values1D_.extent (0) != 0 && rowinfo.allocSize > 0) {
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION(
-        rowinfo.offset1D + rowinfo.allocSize > k_values1D_.dimension_0 (),
+        rowinfo.offset1D + rowinfo.allocSize > k_values1D_.extent (0),
         std::range_error, "Tpetra::CrsMatrix::getView: Invalid access "
         "to 1-D storage of values." << std::endl << "rowinfo.offset1D (" <<
         rowinfo.offset1D << ") + rowinfo.allocSize (" << rowinfo.allocSize <<
-        ") > k_values1D_.dimension_0() (" << k_values1D_.dimension_0 () << ").");
+        ") > k_values1D_.extent(0) (" << k_values1D_.extent (0) << ").");
 #endif // HAVE_TPETRA_DEBUG
       range_type range (rowinfo.offset1D, rowinfo.offset1D + rowinfo.allocSize);
       typedef View<const ST*, execution_space, MemoryUnmanaged> subview_type;
@@ -3078,7 +3078,7 @@ namespace Tpetra {
       // Instead, we create a temporary unmanaged view, then create
       // the subview from that.
       subview_type sv = Kokkos::subview (subview_type (k_values1D_), range);
-      const ST* const sv_raw = (rowinfo.allocSize == 0) ? NULL : sv.ptr_on_device ();
+      const ST* const sv_raw = (rowinfo.allocSize == 0) ? NULL : sv.data ();
       return ArrayView<const ST> (sv_raw, rowinfo.allocSize);
     }
     else if (values2D_ != Teuchos::null) {
@@ -3097,15 +3097,15 @@ namespace Tpetra {
                    LocalOrdinal& numEnt,
                    const RowInfo& rowinfo) const
   {
-    if (k_values1D_.dimension_0 () != 0 && rowinfo.allocSize > 0) {
+    if (k_values1D_.extent (0) != 0 && rowinfo.allocSize > 0) {
 #ifdef HAVE_TPETRA_DEBUG
-      if (rowinfo.offset1D + rowinfo.allocSize > k_values1D_.dimension_0 ()) {
+      if (rowinfo.offset1D + rowinfo.allocSize > k_values1D_.extent (0)) {
         vals = NULL;
         numEnt = 0;
         return Teuchos::OrdinalTraits<LocalOrdinal>::invalid ();
       }
 #endif // HAVE_TPETRA_DEBUG
-      vals = k_values1D_.ptr_on_device () + rowinfo.offset1D;
+      vals = k_values1D_.data () + rowinfo.offset1D;
       numEnt = rowinfo.allocSize;
     }
     else if (! values2D_.is_null ()) {
@@ -3156,15 +3156,15 @@ namespace Tpetra {
     typedef View<const ST*, execution_space, MemoryUnmanaged> subview_type;
     typedef std::pair<size_t, size_t> range_type;
 
-    if (k_values1D_.dimension_0 () != 0 && rowInfo.allocSize > 0) {
+    if (k_values1D_.extent (0) != 0 && rowInfo.allocSize > 0) {
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (rowInfo.offset1D + rowInfo.allocSize > this->k_values1D_.dimension_0 (),
+        (rowInfo.offset1D + rowInfo.allocSize > this->k_values1D_.extent (0),
          std::range_error, "Tpetra::CrsMatrix::getRowView: Invalid access "
          "to 1-D storage of values.  rowInfo.offset1D ("
          << rowInfo.offset1D << ") + rowInfo.allocSize (" << rowInfo.allocSize
-         << ") > this->k_values1D_.dimension_0() ("
-         << this->k_values1D_.dimension_0 () << ").");
+         << ") > this->k_values1D_.extent(0) ("
+         << this->k_values1D_.extent (0) << ").");
 #endif // HAVE_TPETRA_DEBUG
       range_type range (rowInfo.offset1D, rowInfo.offset1D + rowInfo.allocSize);
       // mfh 23 Nov 2015: Don't just create a subview of k_values1D_
@@ -3200,15 +3200,15 @@ namespace Tpetra {
     typedef View<ST*, execution_space, MemoryUnmanaged> subview_type;
     typedef std::pair<size_t, size_t> range_type;
 
-    if (k_values1D_.dimension_0 () != 0 && rowInfo.allocSize > 0) {
+    if (k_values1D_.extent (0) != 0 && rowInfo.allocSize > 0) {
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (rowInfo.offset1D + rowInfo.allocSize > this->k_values1D_.dimension_0 (),
+        (rowInfo.offset1D + rowInfo.allocSize > this->k_values1D_.extent (0),
          std::range_error, "Tpetra::CrsMatrix::getRowViewNonConst: Invalid "
          "access to 1-D storage of values.  rowInfo.offset1D ("
          << rowInfo.offset1D << ") + rowInfo.allocSize (" << rowInfo.allocSize
-         << ") > this->k_values1D_.dimension_0() ("
-         << this->k_values1D_.dimension_0 () << ").");
+         << ") > this->k_values1D_.extent(0) ("
+         << this->k_values1D_.extent (0) << ").");
 #endif // HAVE_TPETRA_DEBUG
       range_type range (rowInfo.offset1D, rowInfo.offset1D + rowInfo.allocSize);
       // mfh 23 Nov 2015: Don't just create a subview of k_values1D_
@@ -3538,7 +3538,7 @@ namespace Tpetra {
       else {
         numEnt = static_cast<LO> (rowInfo.numEntries);
         auto lclColInds = staticGraph_->getLocalKokkosRowView (rowInfo);
-        ind = lclColInds.ptr_on_device (); // FIXME (mfh 18 Jul 2016) UVM
+        ind = lclColInds.data (); // FIXME (mfh 18 Jul 2016) UVM
         const LO err = this->getViewRawConst (val, numEnt, rowInfo);
         return err;
       }
@@ -3731,10 +3731,10 @@ namespace Tpetra {
     // whether setAllIndices() did a shallow copy or a deep copy, so a
     // good way to check is to compare dimensions.
     auto lclGraph = myGraph_->getLocalGraph ();
-    const size_t numEnt = lclGraph.entries.dimension_0 ();
+    const size_t numEnt = lclGraph.entries.extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (lclGraph.row_map.dimension_0 () != rowPointers.dimension_0 () ||
-       numEnt != static_cast<size_t> (columnIndices.dimension_0 ()),
+      (lclGraph.row_map.extent (0) != rowPointers.extent (0) ||
+       numEnt != static_cast<size_t> (columnIndices.extent (0)),
        std::logic_error, "myGraph_->setAllIndices() did not correctly create "
        "local graph.  Please report this bug to the Tpetra developers.");
 
@@ -3781,10 +3781,10 @@ namespace Tpetra {
     ::Tpetra::Details::copyOffsets (ptrNative, ptrSizeT);
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (ptrNative.dimension_0 () != ptrSizeT.dimension_0 (),
-       std::logic_error, "ptrNative.dimension_0() = " <<
-       ptrNative.dimension_0 () << " != ptrSizeT.dimension_0() = "
-       << ptrSizeT.dimension_0 () << ".  Please report this bug to the "
+      (ptrNative.extent (0) != ptrSizeT.extent (0),
+       std::logic_error, "ptrNative.extent(0) = " <<
+       ptrNative.extent (0) << " != ptrSizeT.extent(0) = "
+       << ptrSizeT.extent (0) << ".  Please report this bug to the "
        "Tpetra developers.");
 
     auto indIn = getKokkosViewDeepCopy<DT> (ind ());
@@ -4210,9 +4210,9 @@ namespace Tpetra {
         auto vals = this->getRowViewNonConst (rowInfo);
         // FIXME (mfh 09 May 2017) This assumes CUDA UVM, at least for
         // lclColInds, if not also for values.
-        sort2 (lclColInds.ptr_on_device (),
-               lclColInds.ptr_on_device () + rowInfo.numEntries,
-               vals.ptr_on_device ());
+        sort2 (lclColInds.data (),
+               lclColInds.data () + rowInfo.numEntries,
+               vals.data ());
       }
       theGraph.indicesAreSorted_ = true;
     }
@@ -4806,12 +4806,12 @@ namespace Tpetra {
 
 #ifdef HAVE_TPETRA_DEBUG
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (rowInfo.allocSize != static_cast<size_t> (inds_view.dimension_0 ()) ||
-       rowInfo.allocSize != static_cast<size_t> (rowValues.dimension_0 ()),
+      (rowInfo.allocSize != static_cast<size_t> (inds_view.extent (0)) ||
+       rowInfo.allocSize != static_cast<size_t> (rowValues.extent (0)),
        std::runtime_error, "rowInfo.allocSize = " << rowInfo.allocSize
-       << " != inds_view.dimension_0() = " << inds_view.dimension_0 ()
+       << " != inds_view.extent(0) = " << inds_view.extent (0)
        << " || rowInfo.allocSize = " << rowInfo.allocSize
-       << " != rowValues.dimension_0() = " << rowValues.dimension_0 () << ".");
+       << " != rowValues.extent(0) = " << rowValues.extent (0) << ".");
 #endif // HAVE_TPETRA_DEBUG
 
     LocalOrdinal* newend = beg;
@@ -4883,9 +4883,9 @@ namespace Tpetra {
             auto vals = this->getRowViewNonConst (rowInfo);
             // FIXME (mfh 09 May 2017) This assumes CUDA UVM, at least
             // for lclColInds, if not also for values.
-            sort2 (lclColInds.ptr_on_device (),
-                   lclColInds.ptr_on_device () + rowInfo.numEntries,
-                   vals.ptr_on_device ());
+            sort2 (lclColInds.data (),
+                   lclColInds.data () + rowInfo.numEntries,
+                   vals.data ());
           }
           if (! merged) {
             numDups += this->mergeRowIndicesAndValues (graph, rowInfo);
@@ -5716,7 +5716,7 @@ namespace Tpetra {
 
       if (X_colMap->getLocalLength () != 0 && X_domainMap->getLocalLength ()) {
         TEUCHOS_TEST_FOR_EXCEPTION
-          (X_colMap_host_view.ptr_on_device () != X_domainMap_host_view.ptr_on_device (),
+          (X_colMap_host_view.data () != X_domainMap_host_view.data (),
            std::logic_error, "Tpetra::CrsMatrix::gaussSeidelCopy: Pointer to "
            "start of column Map view of X is not equal to pointer to start of "
            "(domain Map view of) X.  This may mean that Tpetra::MultiVector::"
@@ -5725,13 +5725,13 @@ namespace Tpetra {
       }
 
       TEUCHOS_TEST_FOR_EXCEPTION(
-        X_colMap_host_view.dimension_0 () < X_domainMap_host_view.dimension_0 () ||
+        X_colMap_host_view.extent (0) < X_domainMap_host_view.extent (0) ||
         X_colMap->getLocalLength () < X_domainMap->getLocalLength (),
         std::logic_error, "Tpetra::CrsMatrix::gaussSeidelCopy: "
         "X_colMap has fewer local rows than X_domainMap.  "
-        "X_colMap_host_view.dimension_0() = " << X_colMap_host_view.dimension_0 ()
-        << ", X_domainMap_host_view.dimension_0() = "
-        << X_domainMap_host_view.dimension_0 ()
+        "X_colMap_host_view.extent(0) = " << X_colMap_host_view.extent (0)
+        << ", X_domainMap_host_view.extent(0) = "
+        << X_domainMap_host_view.extent (0)
         << ", X_colMap->getLocalLength() = " << X_colMap->getLocalLength ()
         << ", and X_domainMap->getLocalLength() = "
         << X_domainMap->getLocalLength ()
@@ -5931,7 +5931,7 @@ namespace Tpetra {
       std::logic_error, err);
     // if matrix/graph are dynamic profile, then 1D allocation should not be present
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      getProfileType() == DynamicProfile && k_values1D_.dimension_0 () > 0,
+      getProfileType() == DynamicProfile && k_values1D_.extent (0) > 0,
       std::logic_error, err);
     // if values are allocated and they are non-zero in number, then
     // one of the allocations should be present
@@ -5940,13 +5940,13 @@ namespace Tpetra {
       staticGraph_->getNodeAllocationSize() > 0 &&
       staticGraph_->getNodeNumRows() > 0
       && values2D_.is_null () &&
-      k_values1D_.dimension_0 () == 0,
+      k_values1D_.extent (0) == 0,
       std::logic_error, err);
     // we cannot have both a 1D and 2D allocation
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      k_values1D_.dimension_0 () > 0 && values2D_ != Teuchos::null,
+      k_values1D_.extent (0) > 0 && values2D_ != Teuchos::null,
       std::logic_error, err << "  Specifically, k_values1D_ is allocated (has "
-      "size " << k_values1D_.dimension_0 () << " > 0) and values2D_ is also "
+      "size " << k_values1D_.extent (0) << " > 0) and values2D_ is also "
       "allocated.  CrsMatrix is not suppose to have both a 1-D and a 2-D "
       "allocation at the same time.");
 #endif
@@ -6432,12 +6432,12 @@ namespace Tpetra {
       std::cerr << os.str ();
     }
 
-    const auto numPermute = permuteToLIDs.dimension_0 ();
+    const auto numPermute = permuteToLIDs.extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (numPermute != permuteFromLIDs.dimension_0 (),
-       std::invalid_argument, "permuteToLIDs.dimension_0() = "
-       << numPermute << "!= permuteFromLIDs.dimension_0() = "
-       << permuteFromLIDs.dimension_0 () << ".");
+      (numPermute != permuteFromLIDs.extent (0),
+       std::invalid_argument, "permuteToLIDs.extent(0) = "
+       << numPermute << "!= permuteFromLIDs.extent(0) = "
+       << permuteFromLIDs.extent (0) << ".");
 
     // We want to keep permuteToLIDs and permuteFromLIDs on device, if
     // possible, but respect their current placement.  This is because
@@ -6656,7 +6656,7 @@ namespace Tpetra {
 
       // Allocate 'exports', and copy exports_a back into it.
       const size_t newAllocSize = static_cast<size_t> (exports_a.size ());
-      if (static_cast<size_t> (exports.dimension_0 ()) < newAllocSize) {
+      if (static_cast<size_t> (exports.extent (0)) < newAllocSize) {
         const std::string oldLabel = exports.d_view.label ();
         const std::string newLabel = (oldLabel == "") ? "exports" : oldLabel;
         exports = exports_type (newLabel, newAllocSize);
@@ -6937,7 +6937,7 @@ namespace Tpetra {
 
     // The number of export LIDs must fit in LocalOrdinal, assuming
     // that the LIDs are distinct and valid on the calling process.
-    const LO numExportLIDs = static_cast<LO> (exportLIDs.dimension_0 ());
+    const LO numExportLIDs = static_cast<LO> (exportLIDs.extent (0));
 
     // We need to access exportLIDs on host, but Kokkos forbids
     // sync'ing of a DualView of const.  We won't modify the entries,
@@ -6973,7 +6973,7 @@ namespace Tpetra {
     const size_t allocSize =
       static_cast<size_t> (numExportLIDs) * sizeof (LO) +
       totalNumEntries * (sizeof (IST) + sizeof (GO));
-    if (static_cast<size_t> (exports.dimension_0 ()) < allocSize) {
+    if (static_cast<size_t> (exports.extent (0)) < allocSize) {
       typedef Kokkos::DualView<char*, buffer_device_type> exports_type;
 
       const std::string oldLabel = exports.d_view.label ();
@@ -7062,11 +7062,11 @@ namespace Tpetra {
       std::cerr << os.str ();
     }
 
-    const size_t numExportLIDs = static_cast<size_t> (exportLIDs.dimension_0 ());
+    const size_t numExportLIDs = static_cast<size_t> (exportLIDs.extent (0));
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (numExportLIDs != static_cast<size_t> (numPacketsPerLID.dimension_0 ()),
+      (numExportLIDs != static_cast<size_t> (numPacketsPerLID.extent (0)),
        std::invalid_argument, "exportLIDs.size() = " << numExportLIDs
-       << " != numPacketsPerLID.size() = " << numPacketsPerLID.dimension_0 ()
+       << " != numPacketsPerLID.size() = " << numPacketsPerLID.extent (0)
        << ".");
 
     // Setting this to zero tells the caller to expect a possibly
@@ -7079,7 +7079,7 @@ namespace Tpetra {
     // compute."
     size_t totalNumEntries = 0;
     this->allocatePackSpaceNew (exports, totalNumEntries, exportLIDs);
-    const size_t bufSize = static_cast<size_t> (exports.dimension_0 ());
+    const size_t bufSize = static_cast<size_t> (exports.extent (0));
 
     // Write-only host access
     exports.modified_device() = 0;
@@ -7520,11 +7520,11 @@ namespace Tpetra {
       std::cerr << os.str ();
     }
 
-    const size_type numImportLIDs = importLIDs.dimension_0 ();
+    const size_type numImportLIDs = importLIDs.extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (numImportLIDs != static_cast<size_type> (numPacketsPerLID.dimension_0 ()),
+      (numImportLIDs != static_cast<size_type> (numPacketsPerLID.extent (0)),
        std::invalid_argument, "importLIDs.size() = " << numImportLIDs
-       << " != numPacketsPerLID.size() = " << numPacketsPerLID.dimension_0 ()
+       << " != numPacketsPerLID.size() = " << numPacketsPerLID.extent (0)
        << ".");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (combineMode != ADD && combineMode != INSERT && combineMode != REPLACE &&
@@ -7581,11 +7581,11 @@ namespace Tpetra {
       // We need to unpack a nonzero number of entries for this row.
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (offset + numBytes > static_cast<size_t> (imports_h.dimension_0 ()),
+        (offset + numBytes > static_cast<size_t> (imports_h.extent (0)),
          std::logic_error, "At local row index importLIDs_h[i=" << i << "]="
          << importLIDs_h[i] << ", offset (=" << offset << ") + numBytes (="
-         << numBytes << ") > imports_h.dimension_0()="
-         << imports_h.dimension_0 () << ".");
+         << numBytes << ") > imports_h.extent(0)="
+         << imports_h.extent (0) << ".");
 #endif // HAVE_TPETRA_DEBUG
 
       LO numEntLO = 0;

--- a/packages/tpetra/core/src/Tpetra_Details_Blas.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Blas.hpp
@@ -99,7 +99,7 @@ getStride2DView (const ViewType& A)
                  "IndexType must be a built-in integer type.");
   IndexType stride[8];
   A.stride (stride);
-  return (A.dimension_1 () > 1) ? stride[1] : A.dimension_0 ();
+  return (A.extent (1) > 1) ? stride[1] : A.extent (0);
 }
 
 namespace Impl {

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -132,7 +132,7 @@ public:
   ///   starting with zero.
   ///
   /// Add <tt>(keys[i], i)</tt> to the table,
-  /// for i = 0, 1, ..., <tt>keys.dimension_0()</tt>.
+  /// for i = 0, 1, ..., <tt>keys.extent(0)</tt>.
   ///
   /// \param keys [in] The keys in the hash table.  The table
   ///   <i>always</i> keeps a (shallow) copy, and thus hasKeys() is
@@ -156,7 +156,7 @@ public:
   ///   starting with \c startingValue.
   ///
   /// Add <tt>(keys[i], startingValue + i)</tt> to the table, for i =
-  /// 0, 1, ..., <tt>keys.dimension_0()</tt>.  This version is useful
+  /// 0, 1, ..., <tt>keys.extent(0)</tt>.  This version is useful
   /// if Map wants to exclude an initial sequence of contiguous GIDs
   /// from the table, and start with a given LID.
   ///
@@ -276,10 +276,10 @@ public:
     // That's why we use a specialized deep copy function here instead
     // of Kokkos::deep_copy.
     nonconst_ptr_type ptr (ViewAllocateWithoutInitializing ("ptr"),
-                           src.ptr_.dimension_0 ());
+                           src.ptr_.extent (0));
     ::Tpetra::Details::copyOffsets (ptr, src.ptr_);
     nonconst_val_type val (ViewAllocateWithoutInitializing ("val"),
-                           src.val_.dimension_0 ());
+                           src.val_.extent (0));
     // val and src.val_ have the same entry types, unlike (possibly)
     // ptr and src.ptr_.  Thus, we can use Kokkos::deep_copy here.
     Kokkos::deep_copy (val, src.val_);
@@ -363,16 +363,16 @@ public:
   ///
   /// This counts pairs with the same key value as separate pairs.
   KOKKOS_INLINE_FUNCTION offset_type numPairs () const {
-    // NOTE (mfh 26 May 2015) Using val_.dimension_0() only works
+    // NOTE (mfh 26 May 2015) Using val_.extent(0) only works
     // because the table stores pairs with duplicate keys separately.
     // If the table didn't do that, we would have to keep a separate
     // numPairs_ field (remembering the size of the input array of
     // keys).
     if (this->hasContiguousValues ()) {
-      return val_.dimension_0 () + static_cast<offset_type> (lastContigKey_ - firstContigKey_);
+      return val_.extent (0) + static_cast<offset_type> (lastContigKey_ - firstContigKey_);
     }
     else {
-      return val_.dimension_0 ();
+      return val_.extent (0);
     }
   }
 
@@ -539,9 +539,9 @@ private:
 
   //! The number of "buckets" in the bucket array.
   KOKKOS_INLINE_FUNCTION offset_type getSize () const {
-    return ptr_.dimension_0 () == 0 ?
+    return ptr_.extent (0) == 0 ?
       static_cast<offset_type> (0) :
-      static_cast<offset_type> (ptr_.dimension_0 () - 1);
+      static_cast<offset_type> (ptr_.extent (0) - 1);
   }
 
   //! Sanity checks; throw std::logic_error if any of them fail.

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -157,7 +157,7 @@ struct DeepCopyIfNeeded<KeyType, ArrayLayout, InputExecSpace, OutputExecSpace, t
     typedef typename output_view_type::non_const_type NC;
 
     NC dst (Kokkos::ViewAllocateWithoutInitializing (src.tracker ().label ()),
-            src.dimension_0 ());
+            src.extent (0));
     Kokkos::deep_copy (dst, src);
     return output_view_type (dst);
   }
@@ -381,7 +381,7 @@ public:
     counts_ (counts),
     ptr_ (ptr),
     keys_ (keys),
-    size_ (counts.dimension_0 ()),
+    size_ (counts.extent (0)),
     startingValue_ (startingValue),
     initMinKey_ (::Kokkos::Details::ArithTraits<key_type>::max ()),
     initMaxKey_ (::Kokkos::Details::ArithTraits<key_type>::is_integer ?
@@ -418,7 +418,7 @@ public:
     counts_ (counts),
     ptr_ (ptr),
     keys_ (keys),
-    size_ (counts.dimension_0 ()),
+    size_ (counts.extent (0)),
     startingValue_ (startingValue),
     initMinKey_ (initMinKey),
     initMaxKey_ (initMaxKey)
@@ -538,9 +538,9 @@ public:
                          const offsets_view_type& ptr) :
     pairs_ (pairs),
     ptr_ (ptr),
-    size_ (ptr_.dimension_0 () == 0 ?
+    size_ (ptr_.extent (0) == 0 ?
            size_type (0) :
-           ptr_.dimension_0 () - 1)
+           ptr_.extent (0) - 1)
   {}
 
   //! Set the initial value of the reduction result.
@@ -611,7 +611,7 @@ hasKeys () const {
   // FIXME (31 May 2015) This only works because vals_ contains no
   // padding.  If we ever pad within a "row" of vals_, we'll have to
   // change this.
-  return keys_.dimension_0 () == val_.dimension_0 ();
+  return keys_.extent (0) == val_.extent (0);
 }
 
 template<class KeyType, class ValueType, class DeviceType>
@@ -708,7 +708,7 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
                                keys.size ());
   using Kokkos::ViewAllocateWithoutInitializing;
   nonconst_keys_type keys_d (ViewAllocateWithoutInitializing ("FixedHashTable::keys"),
-                             keys_k.dimension_0 ());
+                             keys_k.extent (0));
   Kokkos::deep_copy (keys_d, keys_k);
   const KeyType initMinKey = this->minKey_;
   const KeyType initMaxKey = this->maxKey_;
@@ -719,10 +719,10 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
 #ifdef HAVE_TPETRA_DEBUG
     typedef typename keys_type::size_type size_type;
     TEUCHOS_TEST_FOR_EXCEPTION
-      (keys_.dimension_0 () != static_cast<size_type> (keys.size ()),
+      (keys_.extent (0) != static_cast<size_type> (keys.size ()),
        std::logic_error, "Tpetra::Details::FixedHashTable constructor: "
-       "keepKeys is true, but on return, keys_.dimension_0() = " <<
-       keys_.dimension_0 () << " != keys.size() = " << keys.size () <<
+       "keepKeys is true, but on return, keys_.extent(0) = " <<
+       keys_.extent (0) << " != keys.size() = " << keys.size () <<
        ".  Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
   }
@@ -762,7 +762,7 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
                                keys.size ());
   using Kokkos::ViewAllocateWithoutInitializing;
   nonconst_keys_type keys_d (ViewAllocateWithoutInitializing ("FixedHashTable::keys"),
-                             keys_k.dimension_0 ());
+                             keys_k.extent (0));
   Kokkos::deep_copy (keys_d, keys_k);
 
   const KeyType initMinKey = ::Kokkos::Details::ArithTraits<KeyType>::max ();
@@ -788,10 +788,10 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
 #ifdef HAVE_TPETRA_DEBUG
     typedef typename keys_type::size_type size_type;
     TEUCHOS_TEST_FOR_EXCEPTION
-      (keys_.dimension_0 () != static_cast<size_type> (keys.size ()),
+      (keys_.extent (0) != static_cast<size_type> (keys.size ()),
        std::logic_error, "Tpetra::Details::FixedHashTable constructor: "
-       "keepKeys is true, but on return, keys_.dimension_0() = " <<
-       keys_.dimension_0 () << " != keys.size() = " << keys.size () <<
+       "keepKeys is true, but on return, keys_.extent(0) = " <<
+       keys_.extent (0) << " != keys.size() = " << keys.size () <<
        ".  Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
   }
@@ -845,10 +845,10 @@ FixedHashTable (const keys_type& keys,
 #ifdef HAVE_TPETRA_DEBUG
     typedef typename keys_type::size_type size_type;
     TEUCHOS_TEST_FOR_EXCEPTION
-      (keys_.dimension_0 () != static_cast<size_type> (keys.size ()),
+      (keys_.extent (0) != static_cast<size_type> (keys.size ()),
        std::logic_error, "Tpetra::Details::FixedHashTable constructor: "
-       "keepKeys is true, but on return, keys_.dimension_0() = " <<
-       keys_.dimension_0 () << " != keys.size() = " << keys.size () <<
+       "keepKeys is true, but on return, keys_.extent(0) = " <<
+       keys_.extent (0) << " != keys.size() = " << keys.size () <<
        ".  Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
   }
@@ -888,7 +888,7 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
                                keys.size ());
   using Kokkos::ViewAllocateWithoutInitializing;
   nonconst_keys_type keys_d (ViewAllocateWithoutInitializing ("FixedHashTable::keys"),
-                             keys_k.dimension_0 ());
+                             keys_k.extent (0));
   Kokkos::deep_copy (keys_d, keys_k);
 
   const KeyType initMinKey = ::Kokkos::Details::ArithTraits<KeyType>::max ();
@@ -914,10 +914,10 @@ FixedHashTable (const Teuchos::ArrayView<const KeyType>& keys,
 #ifdef HAVE_TPETRA_DEBUG
     typedef typename keys_type::size_type size_type;
     TEUCHOS_TEST_FOR_EXCEPTION
-      (keys_.dimension_0 () != static_cast<size_type> (keys.size ()),
+      (keys_.extent (0) != static_cast<size_type> (keys.size ()),
        std::logic_error, "Tpetra::Details::FixedHashTable constructor: "
-       "keepKeys is true, but on return, keys_.dimension_0() = " <<
-       keys_.dimension_0 () << " != keys.size() = " << keys.size () <<
+       "keepKeys is true, but on return, keys_.extent(0) = " <<
+       keys_.extent (0) << " != keys.size() = " << keys.size () <<
        ".  Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
   }
@@ -1036,16 +1036,16 @@ init (const keys_type& keys,
   using Kokkos::subview;
   using Kokkos::ViewAllocateWithoutInitializing;
   using Teuchos::TypeNameTraits;
-  typedef typename std::decay<decltype (keys.dimension_0 ()) >::type size_type;
+  typedef typename std::decay<decltype (keys.extent (0)) >::type size_type;
   const char prefix[] = "Tpetra::Details::FixedHashTable: ";
 
-  const offset_type numKeys = static_cast<offset_type> (keys.dimension_0 ());
+  const offset_type numKeys = static_cast<offset_type> (keys.extent (0));
   {
     const offset_type theMaxVal = ::Kokkos::Details::ArithTraits<offset_type>::max ();
     const size_type maxValST = static_cast<size_type> (theMaxVal);
     TEUCHOS_TEST_FOR_EXCEPTION
-      (keys.dimension_0 () > maxValST, std::invalid_argument, prefix << "The "
-       "number of keys " << keys.dimension_0 () << " does not fit in "
+      (keys.extent (0) > maxValST, std::invalid_argument, prefix << "The "
+       "number of keys " << keys.extent (0) << " does not fit in "
        "offset_type = " << TypeNameTraits<offset_type>::name () << ", whose "
        "max value is " << theMaxVal << ".  This means that it is not possible to "
        "use this constructor.");
@@ -1298,7 +1298,7 @@ init (const host_input_keys_type& keys,
       KeyType initMinKey,
       KeyType initMaxKey)
 {
-  const offset_type numKeys = static_cast<offset_type> (keys.dimension_0 ());
+  const offset_type numKeys = static_cast<offset_type> (keys.extent (0));
   TEUCHOS_TEST_FOR_EXCEPTION
     (static_cast<unsigned long long> (numKeys) > static_cast<unsigned long long> (::Kokkos::Details::ArithTraits<ValueType>::max ()),
      std::invalid_argument, "Tpetra::Details::FixedHashTable: The number of "
@@ -1453,7 +1453,7 @@ description () const
   oss << "FixedHashTable<"
       << Teuchos::TypeNameTraits<KeyType>::name () << ","
       << Teuchos::TypeNameTraits<ValueType>::name () << ">: "
-      << "{ numKeys: " << val_.dimension_0 ()
+      << "{ numKeys: " << val_.extent (0)
       << ", tableSize: " << this->getSize () << " }";
   return oss.str();
 }
@@ -1503,7 +1503,7 @@ describe (Teuchos::FancyOStream& out,
       }
 
       const offset_type tableSize = this->getSize ();
-      const offset_type numKeys = val_.dimension_0 ();
+      const offset_type numKeys = val_.extent (0);
 
       out << "Table parameters:" << endl;
       {

--- a/packages/tpetra/core/src/Tpetra_Details_castAwayConstDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_castAwayConstDualView.hpp
@@ -69,10 +69,10 @@ castAwayConstDualView (const Kokkos::DualView<const ValueType*, DeviceType>& inp
 
   out_dev_view_type output_view_dev
     (const_cast<ValueType*> (input_dv.d_view.data ()),
-     input_dv.d_view.dimension_0 ());
+     input_dv.d_view.extent (0));
   out_host_view_type output_view_host
     (const_cast<ValueType*> (input_dv.h_view.data ()),
-     input_dv.h_view.dimension_0 ());
+     input_dv.h_view.extent (0));
 
   Kokkos::DualView<ValueType*, DeviceType> output_dv;
   output_dv.d_view = output_view_dev;

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -118,7 +118,7 @@ public:
                             const counts_view_type& counts) :
     offsets_ (offsets),
     counts_ (counts),
-    size_ (counts.dimension_0 ())
+    size_ (counts.extent (0))
   {}
 
   //! Set the initial value of the reduction result.
@@ -177,7 +177,7 @@ private:
 ///   may use a shorter type to improve performance.
 ///
 /// The type of each entry of the \c ptr array must be able to store
-/// <tt>ptr.dimension_0 () * count</tt>.  This functor makes no
+/// <tt>ptr.extent (0) * count</tt>.  This functor makes no
 /// attempt to check for overflow in this sum.
 template<class OffsetsViewType,
          class CountType,
@@ -212,9 +212,9 @@ public:
                                    const count_type count) :
     offsets_ (offsets),
     count_ (count),
-    size_ (offsets_.dimension_0 () == 0 ?
+    size_ (offsets_.extent (0) == 0 ?
            static_cast<size_type> (0) :
-           static_cast<size_type> (offsets_.dimension_0 () - 1))
+           static_cast<size_type> (offsets_.extent (0) - 1))
   {}
 
   //! Set the initial value of the reduction result.
@@ -314,8 +314,8 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
     TEUCHOS_TEST_FOR_EXCEPTION
       (numCounts >= numOffsets, std::invalid_argument,
        "Tpetra::Details::computeOffsetsFromCounts: "
-       "counts.dimension_0() = " << numCounts
-       << " >= ptr.dimension_0() = " << numOffsets << ".");
+       "counts.extent(0) = " << numCounts
+       << " >= ptr.extent(0) = " << numOffsets << ".");
 
     Kokkos::RangePolicy<execution_space, SizeType> range (0, numCounts+1);
     try {
@@ -406,7 +406,7 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
 ///   may use a shorter type to improve performance.
 ///
 /// The type of each entry of the \c ptr array must be able to store
-/// <tt>ptr.dimension_0 () * count</tt>.  This functor makes no
+/// <tt>ptr.extent (0) * count</tt>.  This functor makes no
 /// attempt to check for overflow in this sum.
 template<class OffsetsViewType,
          class CountType,

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -210,7 +210,7 @@ namespace { // (anonymous)
       typedef typename OutputViewType::execution_space execution_space;
       typedef typename OutputViewType::size_type index_type;
       typedef Kokkos::RangePolicy<execution_space, index_type> range_type;
-      Kokkos::parallel_for (range_type (0, dst.dimension_0 ()),
+      Kokkos::parallel_for (range_type (0, dst.extent (0)),
                             functor_type (dst, src));
     }
   };
@@ -259,7 +259,7 @@ namespace { // (anonymous)
         typename OutputViewType::device_type> output_space_copy_type;
       output_space_copy_type
         outputSpaceCopy (ViewAllocateWithoutInitializing ("outputSpace"),
-                         src.dimension_0 ());
+                         src.extent (0));
       Kokkos::deep_copy (outputSpaceCopy, src);
 
       // The output View's execution space can access
@@ -269,7 +269,7 @@ namespace { // (anonymous)
       typedef typename OutputViewType::execution_space execution_space;
       typedef typename OutputViewType::size_type index_type;
       typedef Kokkos::RangePolicy<execution_space, index_type> range_type;
-      Kokkos::parallel_for (range_type (0, dst.dimension_0 ()),
+      Kokkos::parallel_for (range_type (0, dst.extent (0)),
                             functor_type (dst, outputSpaceCopy));
     }
   };
@@ -300,11 +300,11 @@ copyConvert (const OutputViewType& dst,
                  "OutputViewType (the type of dst) must be a rank-1 Kokkos::View.");
   static_assert (static_cast<int> (InputViewType::rank) == 1,
                  "InputViewType (the type of src) must be a rank-1 Kokkos::View.");
-  if (dst.dimension_0 () != src.dimension_0 ()) {
+  if (dst.extent (0) != src.extent (0)) {
     std::ostringstream os;
     os << "Tpetra::Details::copyConvert: "
-       << "dst.dimension_0() = " << dst.dimension_0 ()
-       << " != src.dimension_0() = " << src.dimension_0 ()
+       << "dst.extent(0) = " << dst.extent (0)
+       << " != src.extent(0) = " << src.extent (0)
        << ".";
     throw std::invalid_argument (os.str ());
   }

--- a/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
@@ -314,7 +314,7 @@ namespace { // (anonymous)
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
 
       int noOverflow = 0; // output argument of the reduction
-      Kokkos::parallel_reduce (range_type (0, dst.dimension_0 ()),
+      Kokkos::parallel_reduce (range_type (0, dst.extent (0)),
                                functor_type (dst, src),
                                noOverflow);
       TEUCHOS_TEST_FOR_EXCEPTION
@@ -368,7 +368,7 @@ namespace { // (anonymous)
       using Kokkos::ViewAllocateWithoutInitializing;
       output_space_copy_type
         outputSpaceCopy (ViewAllocateWithoutInitializing ("outputSpace"),
-                         src.dimension_0 ());
+                         src.extent (0));
       Kokkos::deep_copy (outputSpaceCopy, src);
 
       // The output View's execution space can access
@@ -380,7 +380,7 @@ namespace { // (anonymous)
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
 
       int noOverflow = 0;
-      Kokkos::parallel_reduce (range_type (0, dst.dimension_0 ()),
+      Kokkos::parallel_reduce (range_type (0, dst.extent (0)),
                                functor_type (dst, outputSpaceCopy),
                                noOverflow);
       TEUCHOS_TEST_FOR_EXCEPTION
@@ -423,9 +423,9 @@ copyOffsets (const OutputViewType& dst, const InputViewType& src)
                  "The entries of src must be built-in integers.");
 
   TEUCHOS_TEST_FOR_EXCEPTION
-    (dst.dimension_0 () != src.dimension_0 (), std::invalid_argument,
-     "copyOffsets: dst.dimension_0() = " << dst.dimension_0 ()
-     << " != src.dimension_0() = " << src.dimension_0 () << ".");
+    (dst.extent (0) != src.extent (0), std::invalid_argument,
+     "copyOffsets: dst.extent(0) = " << dst.extent (0)
+     << " != src.extent(0) = " << src.extent (0) << ".");
 
   CopyOffsetsImpl<OutputViewType, InputViewType>::run (dst, src);
 }

--- a/packages/tpetra/core/src/Tpetra_Details_crsMatrixAssembleElement.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_crsMatrixAssembleElement.hpp
@@ -323,8 +323,8 @@ crsMatrixReplaceValues_sortedSortedLinear (const SparseMatrixType& A,
 /// \param lids [in/out] Local row and column indices of A to modify.
 ///   This function may sort this array, and output the permutation
 ///   that makes it sorted to \c sortPerm.  \c lids must have the same
-///   number of entries as <tt>rhs.dimension_0()</tt>,
-///   <tt>lhs.dimension_0()</tt>, and <tt>lhs.dimension_1()</tt>.
+///   number of entries as <tt>rhs.extent(0)</tt>,
+///   <tt>lhs.extent(0)</tt>, and <tt>lhs.extent(1)</tt>.
 /// \param sortPerm [out] Permutation that makes \c lids (on input)
 ///   sorted.  It must have the same number of writeable entries as
 ///   \c lids (see above).
@@ -391,7 +391,7 @@ crsMatrixAssembleElement_sortedLinear (const SparseMatrixType& A,
   static_assert (std::is_integral<LO>::value, "SparseMatrixType::ordinal_type "
                  "must be a built-in integer type.");
 
-  const LO eltDim = rhs.dimension_0 ();
+  const LO eltDim = rhs.extent (0);
 
   // Generate sort permutation
   for (LO i = 0; i < eltDim; ++i) {

--- a/packages/tpetra/core/src/Tpetra_Details_cublasGemm.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_cublasGemm.hpp
@@ -282,12 +282,12 @@ gemm (const char transA,
   const index_type ldb = getStride2DView<ViewType2, index_type> (B);
   const index_type ldc = getStride2DView<ViewType3, index_type> (C);
 
-  const index_type m = static_cast<index_type> (C.dimension_0 ());
-  const index_type n = static_cast<index_type> (C.dimension_1 ());
+  const index_type m = static_cast<index_type> (C.extent (0));
+  const index_type n = static_cast<index_type> (C.extent (1));
   const bool noTransA = (transA == 'N' || transA == 'n');
   const index_type k = static_cast<index_type> (noTransA ?
-                                                A.dimension_1 () :
-                                                A.dimension_0 ());
+                                                A.extent (1) :
+                                                A.extent (0));
   impl_type::gemm (transA, transB, m, n, k,
                    alpha, A.data (), lda,
                    B.data (), ldb,

--- a/packages/tpetra/core/src/Tpetra_Details_cublasGemv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_cublasGemv.hpp
@@ -277,8 +277,8 @@ gemv (const char trans,
   const index_type lda = getStride2DView<ViewType1, index_type> (A);
   const index_type incx = getStride1DView<ViewType2, index_type> (x);
   const index_type incy = getStride1DView<ViewType2, index_type> (y);
-  const index_type m = static_cast<index_type> (A.dimension_0 ());
-  const index_type n = static_cast<index_type> (A.dimension_1 ());
+  const index_type m = static_cast<index_type> (A.extent (0));
+  const index_type n = static_cast<index_type> (A.extent (1));
   impl_type::gemv (trans, m, n,
                    alpha, A.data (), lda,
                    x.data (), incx,

--- a/packages/tpetra/core/src/Tpetra_Details_defaultGemm.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_defaultGemm.hpp
@@ -108,10 +108,10 @@ gemm (const char transA,
   const CoefficientType ONE = STS::one ();
 
   // Get the dimensions
-  const IndexType m = C.dimension_0 ();
-  const IndexType n = C.dimension_1 ();
+  const IndexType m = C.extent (0);
+  const IndexType n = C.extent (1);
   const IndexType k = (transA == 'N' || transA == 'n') ?
-    A.dimension_1 () : A.dimension_0 ();
+    A.extent (1) : A.extent (0);
 
   const bool conjA = transA == 'C' || transA == 'c';
   const bool conjB = transB == 'C' || transB == 'c';

--- a/packages/tpetra/core/src/Tpetra_Details_defaultGemv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_defaultGemv.hpp
@@ -99,12 +99,12 @@ gemv (const char trans,
   // // Get the dimensions
   // IndexType m, n;
   // if (trans == 'N' || trans == 'n') {
-  //   m = static_cast<IndexType> (A.dimension_0 ());
-  //   n = static_cast<IndexType> (A.dimension_1 ());
+  //   m = static_cast<IndexType> (A.extent (0));
+  //   n = static_cast<IndexType> (A.extent (1));
   // }
   // else {
-  //   m = static_cast<IndexType> (A.dimension_1 ());
-  //   n = static_cast<IndexType> (A.dimension_0 ());
+  //   m = static_cast<IndexType> (A.extent (1));
+  //   n = static_cast<IndexType> (A.extent (0));
   // }
 
   // quick return if possible
@@ -119,17 +119,17 @@ gemv (const char trans,
         Kokkos::deep_copy (y, ArithTraits<y_value_type>::zero ());
       }
       else { // alpha == 1, beta != 0
-        for (IndexType i = 0; i < static_cast<IndexType> (y.dimension_0 ()); ++i) {
+        for (IndexType i = 0; i < static_cast<IndexType> (y.extent (0)); ++i) {
           y(i) = beta * y(i);
         }
       }
     }
     else { // alpha != 0
-      for (IndexType i = 0; i < static_cast<IndexType> (y.dimension_0 ()); ++i) {
+      for (IndexType i = 0; i < static_cast<IndexType> (y.extent (0)); ++i) {
         y_value_type y_i = (beta == ZERO) ?
           ArithTraits<y_value_type>::zero () :
           static_cast<y_value_type> (beta * y(i));
-        for (IndexType j = 0; j < static_cast<IndexType> (x.dimension_0 ()); ++j) {
+        for (IndexType j = 0; j < static_cast<IndexType> (x.extent (0)); ++j) {
           y_i += alpha * A(i,j) * x(j);
         }
         y(i) = y_i;
@@ -144,17 +144,17 @@ gemv (const char trans,
         Kokkos::deep_copy (y, ArithTraits<y_value_type>::zero ());
       }
       else { // alpha == 1, beta != 0
-        for (IndexType j = 0; j < static_cast<IndexType> (y.dimension_0 ()); ++j) {
+        for (IndexType j = 0; j < static_cast<IndexType> (y.extent (0)); ++j) {
           y(j) = beta * y(j);
         }
       }
     }
     else { // alpha != 0
-      for (IndexType j = 0; j < static_cast<IndexType> (y.dimension_0 ()); ++j) {
+      for (IndexType j = 0; j < static_cast<IndexType> (y.extent (0)); ++j) {
         y_value_type y_j = (beta == ZERO) ?
           ArithTraits<y_value_type>::zero () :
           static_cast<y_value_type> (beta * y(j));
-        for (IndexType i = 0; i < static_cast<IndexType> (x.dimension_0 ()); ++i) {
+        for (IndexType i = 0; i < static_cast<IndexType> (x.extent (0)); ++i) {
           const auto A_ij = conj ? Kokkos::ArithTraits<A_value_type>::conj (A(i,j)) : A(i,j);
           y_j += alpha * A_ij * x(i);
         }

--- a/packages/tpetra/core/src/Tpetra_Details_fill.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_fill.hpp
@@ -252,7 +252,7 @@ struct Fill<ViewType,
         for (IndexType j = 0; j < numCols; ++j) {
           auto X_j = Kokkos::subview (X, Kokkos::ALL (), j);
           memsetWrapper (X_j.data (), 0,
-                         X_j.dimension_0 () * sizeof (view_value_type));
+                         X_j.extent (0) * sizeof (view_value_type));
         }
       }
       else {

--- a/packages/tpetra/core/src/Tpetra_Details_gemv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_gemv.hpp
@@ -199,24 +199,24 @@ gemv (const char trans,
 
   const char prefix[] = "Tpetra::Details::Blas::gemv: ";
   if (trans == 'n' || trans == 'N') {
-    if (A.dimension_1 () != x.dimension_0 () ||
-        A.dimension_0 () != y.dimension_0 ()) {
+    if (A.extent (1) != x.extent (0) ||
+        A.extent (0) != y.extent (0)) {
       std::ostringstream os;
       os << prefix << "Dimensions don't match.  A is "
-         << A.dimension_0 () << " x " << A.dimension_1 ()
-         << ", x is " << x.dimension_0 ()
-         << ", y is " << y.dimension_0 () << std::endl;
+         << A.extent (0) << " x " << A.extent (1)
+         << ", x is " << x.extent (0)
+         << ", y is " << y.extent (0) << std::endl;
       throw std::invalid_argument (os.str ());
     }
   }
   else {
-    if (A.dimension_0 () != x.dimension_0 () ||
-        A.dimension_1 () != y.dimension_0 ()) {
+    if (A.extent (0) != x.extent (0) ||
+        A.extent (1) != y.extent (0)) {
       std::ostringstream os;
       os << prefix << "Dimensions don't match.  A^T is "
-         << A.dimension_1 () << " x " << A.dimension_0 ()
-         << ", x is " << x.dimension_0 ()
-         << ", y is " << y.dimension_0 () << std::endl;
+         << A.extent (1) << " x " << A.extent (0)
+         << ", x is " << x.extent (0)
+         << ", y is " << y.extent (0) << std::endl;
       throw std::invalid_argument (os.str ());
     }
   }

--- a/packages/tpetra/core/src/Tpetra_Details_getDiagCopyWithoutOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getDiagCopyWithoutOffsets_decl.hpp
@@ -202,7 +202,7 @@ getDiagCopyWithoutOffsets (const DiagType& D,
   diag_type D_out = D;
   CrsMatrixGetDiagCopyFunctor<diag_type, LocalMapType, CrsMatrixType>
     functor (D_out, rowMap, colMap, A);
-  const LO numRows = static_cast<LO> (D.dimension_0 ());
+  const LO numRows = static_cast<LO> (D.extent (0));
   LO errCount = 0;
   Kokkos::parallel_reduce (policy_type (0, numRows), functor, errCount);
   return errCount;

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -702,9 +702,9 @@ struct Iallreduce<PacketType,
     typedef typename std::remove_const<PacketType>::type packet_type;
 
     std::shared_ptr<CommRequest> req =
-      Impl::iallreduceRaw<packet_type> (sendbuf.ptr_on_device (),
-                                        recvbuf.ptr_on_device (),
-                                        static_cast<int> (sendbuf.dimension_0 ()),
+      Impl::iallreduceRaw<packet_type> (sendbuf.data (),
+                                        recvbuf.data (),
+                                        static_cast<int> (sendbuf.extent (0)),
                                         op, comm);
     return Impl::wrapIallreduceCommRequest (req, sendbuf, recvbuf);
 #else // NOT HAVE_TPETRACORE_MPI
@@ -764,8 +764,8 @@ struct Iallreduce<PacketType,
     typedef typename std::remove_const<PacketType>::type packet_type;
 
     std::shared_ptr<CommRequest> req =
-      Impl::iallreduceRaw<packet_type> (sendbuf.ptr_on_device (),
-                                        recvbuf.ptr_on_device (),
+      Impl::iallreduceRaw<packet_type> (sendbuf.data (),
+                                        recvbuf.data (),
                                         static_cast<int> (1),
                                         op, comm);
     return Impl::wrapIallreduceCommRequest (req, sendbuf, recvbuf);

--- a/packages/tpetra/core/src/Tpetra_Details_lclDot.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_lclDot.hpp
@@ -100,13 +100,13 @@ lclDot (const RV& dotsOut,
 #ifdef HAVE_TPETRA_DEBUG
   if (lclNumRows != 0) {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (X.dimension_0 () != lclNumRows, std::logic_error, prefix <<
-       "X.dimension_0() = " << X.dimension_0 () << " != lclNumRows "
+      (X.extent (0) != lclNumRows, std::logic_error, prefix <<
+       "X.extent(0) = " << X.extent (0) << " != lclNumRows "
        "= " << lclNumRows << ".  "
        "Please report this bug to the Tpetra developers.");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (Y.dimension_0 () != lclNumRows, std::logic_error, prefix <<
-       "Y.dimension_0() = " << Y.dimension_0 () << " != lclNumRows "
+      (Y.extent (0) != lclNumRows, std::logic_error, prefix <<
+       "Y.extent(0) = " << Y.extent (0) << " != lclNumRows "
        "= " << lclNumRows << ".  "
        "Please report this bug to the Tpetra developers.");
     // If a MultiVector is constant stride, then numVecs should
@@ -114,30 +114,30 @@ lclDot (const RV& dotsOut,
     // should be less than its View's number of columns.
     TEUCHOS_TEST_FOR_EXCEPTION
       (constantStrideX &&
-       (X.dimension_0 () != lclNumRows || X.dimension_1 () != numVecs),
-       std::logic_error, prefix << "X is " << X.dimension_0 () << " x " <<
-       X.dimension_1 () << " (constant stride), which differs from the "
+       (X.extent (0) != lclNumRows || X.extent (1) != numVecs),
+       std::logic_error, prefix << "X is " << X.extent (0) << " x " <<
+       X.extent (1) << " (constant stride), which differs from the "
        "local dimensions " << lclNumRows << " x " << numVecs << ".  "
        "Please report this bug to the Tpetra developers.");
     TEUCHOS_TEST_FOR_EXCEPTION
       (! constantStrideX &&
-       (X.dimension_0 () != lclNumRows || X.dimension_1 () < numVecs),
-       std::logic_error, prefix << "X is " << X.dimension_0 () << " x " <<
-       X.dimension_1 () << " (NOT constant stride), but the local "
+       (X.extent (0) != lclNumRows || X.extent (1) < numVecs),
+       std::logic_error, prefix << "X is " << X.extent (0) << " x " <<
+       X.extent (1) << " (NOT constant stride), but the local "
        "dimensions are " << lclNumRows << " x " << numVecs << ".  "
        "Please report this bug to the Tpetra developers.");
     TEUCHOS_TEST_FOR_EXCEPTION
       (constantStrideY &&
-       (Y.dimension_0 () != lclNumRows || Y.dimension_1 () != numVecs),
-       std::logic_error, prefix << "Y is " << Y.dimension_0 () << " x " <<
-       Y.dimension_1 () << " (constant stride), which differs from the "
+       (Y.extent (0) != lclNumRows || Y.extent (1) != numVecs),
+       std::logic_error, prefix << "Y is " << Y.extent (0) << " x " <<
+       Y.extent (1) << " (constant stride), which differs from the "
        "local dimensions " << lclNumRows << " x " << numVecs << ".  "
        "Please report this bug to the Tpetra developers.");
     TEUCHOS_TEST_FOR_EXCEPTION
       (! constantStrideY &&
-       (Y.dimension_0 () != lclNumRows || Y.dimension_1 () < numVecs),
-       std::logic_error, prefix << "Y is " << Y.dimension_0 () << " x " <<
-       Y.dimension_1 () << " (NOT constant stride), but the local "
+       (Y.extent (0) != lclNumRows || Y.extent (1) < numVecs),
+       std::logic_error, prefix << "Y is " << Y.extent (0) << " x " <<
+       Y.extent (1) << " (NOT constant stride), but the local "
        "dimensions are " << lclNumRows << " x " << numVecs << ".  "
        "Please report this bug to the Tpetra developers.");
   }
@@ -149,7 +149,7 @@ lclDot (const RV& dotsOut,
   }
   else { // lclNumRows != 0
     if (constantStrideX && constantStrideY) {
-      if (X.dimension_1 () == 1) {
+      if (X.extent (1) == 1) {
         typename RV::non_const_value_type result =
           KokkosBlas::dot (subview (X, ALL (), 0), subview (Y, ALL (), 0));
         Kokkos::deep_copy (theDots, result);

--- a/packages/tpetra/core/src/Tpetra_Details_libGemm.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_libGemm.hpp
@@ -280,12 +280,12 @@ gemm (const char transA,
   const index_type ldb = getStride2DView<ViewType2, index_type> (B);
   const index_type ldc = getStride2DView<ViewType3, index_type> (C);
 
-  const index_type m = static_cast<index_type> (C.dimension_0 ());
-  const index_type n = static_cast<index_type> (C.dimension_1 ());
+  const index_type m = static_cast<index_type> (C.extent (0));
+  const index_type n = static_cast<index_type> (C.extent (1));
   const bool noTransA = (transA == 'N' || transA == 'n');
   const index_type k = static_cast<index_type> (noTransA ?
-                                                A.dimension_1 () :
-                                                A.dimension_0 ());
+                                                A.extent (1) :
+                                                A.extent (0));
   impl_type::gemm (transA, transB, m, n, k,
                    alpha, A.data (), lda,
                    B.data (), ldb,

--- a/packages/tpetra/core/src/Tpetra_Details_libGemv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_libGemv.hpp
@@ -279,8 +279,8 @@ gemv (const char trans,
   const index_type lda = getStride2DView<ViewType1, index_type> (A);
   const index_type incx = getStride1DView<ViewType2, index_type> (x);
   const index_type incy = getStride1DView<ViewType2, index_type> (y);
-  const index_type m = static_cast<index_type> (A.dimension_0 ());
-  const index_type n = static_cast<index_type> (A.dimension_1 ());
+  const index_type m = static_cast<index_type> (A.extent (0));
+  const index_type n = static_cast<index_type> (A.extent (1));
   impl_type::gemv (trans, m, n,
                    alpha, A.data (), lda,
                    x.data (), incx,

--- a/packages/tpetra/core/src/Tpetra_Details_mklGemm.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_mklGemm.hpp
@@ -282,12 +282,12 @@ gemm (const char transA,
   const index_type ldb = getStride2DView<ViewType2, index_type> (B);
   const index_type ldc = getStride2DView<ViewType3, index_type> (C);
 
-  const index_type m = static_cast<index_type> (C.dimension_0 ());
-  const index_type n = static_cast<index_type> (C.dimension_1 ());
+  const index_type m = static_cast<index_type> (C.extent (0));
+  const index_type n = static_cast<index_type> (C.extent (1));
   const bool noTransA = (transA == 'N' || transA == 'n');
   const index_type k = static_cast<index_type> (noTransA ?
-                                                A.dimension_1 () :
-                                                A.dimension_0 ());
+                                                A.extent (1) :
+                                                A.extent (0));
   impl_type::gemm (transA, transB, m, n, k,
                    alpha, A.data (), lda,
                    B.data (), ldb,

--- a/packages/tpetra/core/src/Tpetra_Details_mklGemv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_mklGemv.hpp
@@ -264,8 +264,8 @@ gemv (const char trans,
   const index_type lda = getStride2DView<ViewType1, index_type> (A);
   const index_type incx = getStride1DView<ViewType2, index_type> (x);
   const index_type incy = getStride1DView<ViewType3, index_type> (y);
-  const index_type m = static_cast<index_type> (A.dimension_0 ());
-  const index_type n = static_cast<index_type> (A.dimension_1 ());
+  const index_type m = static_cast<index_type> (A.extent (0));
+  const index_type n = static_cast<index_type> (A.extent (1));
   impl_type::gemv (trans, m, n,
                    alpha, A.data (), lda,
                    x.data (), incx,

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -154,20 +154,20 @@ public:
     error_ ("error") // don't forget this, or you'll get segfaults!
   {
     if (debug) {
-      const size_t numRowsToPack = static_cast<size_t> (lclRowInds_.dimension_0 ());
+      const size_t numRowsToPack = static_cast<size_t> (lclRowInds_.extent (0));
 
-      if (numRowsToPack != static_cast<size_t> (counts_.dimension_0 ())) {
+      if (numRowsToPack != static_cast<size_t> (counts_.extent (0))) {
         std::ostringstream os;
-        os << "lclRowInds.dimension_0() = " << numRowsToPack
-           << " != counts.dimension_0() = " << counts_.dimension_0 ()
+        os << "lclRowInds.extent(0) = " << numRowsToPack
+           << " != counts.extent(0) = " << counts_.extent (0)
            << ".";
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
       }
       if (static_cast<size_t> (numRowsToPack + 1) !=
-          static_cast<size_t> (outputOffsets_.dimension_0 ())) {
+          static_cast<size_t> (outputOffsets_.extent (0))) {
         std::ostringstream os;
-        os << "lclRowInds.dimension_0() + 1 = " << (numRowsToPack + 1)
-           << " != outputOffsets.dimension_0() = " << outputOffsets_.dimension_0 ()
+        os << "lclRowInds.extent(0) + 1 = " << (numRowsToPack + 1)
+           << " != outputOffsets.extent(0) = " << outputOffsets_.extent (0)
            << ".";
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
       }
@@ -188,7 +188,7 @@ public:
 
     if (final) {
       if (debug) {
-        if (curInd >= static_cast<local_row_index_type> (outputOffsets_.dimension_0 ())) {
+        if (curInd >= static_cast<local_row_index_type> (outputOffsets_.extent (0))) {
           error_ () = 2;
           return;
         }
@@ -196,9 +196,9 @@ public:
       outputOffsets_(curInd) = update;
     }
 
-    if (curInd < static_cast<local_row_index_type> (counts_.dimension_0 ())) {
+    if (curInd < static_cast<local_row_index_type> (counts_.extent (0))) {
       const auto lclRow = lclRowInds_(curInd);
-      if (static_cast<size_t> (lclRow + 1) >= static_cast<size_t> (rowOffsets_.dimension_0 ()) ||
+      if (static_cast<size_t> (lclRow + 1) >= static_cast<size_t> (rowOffsets_.extent (0)) ||
           static_cast<local_row_index_type> (lclRow) < static_cast<local_row_index_type> (0)) {
         error_ () = 3;
         return;
@@ -276,28 +276,28 @@ computeNumPacketsAndOffsets(const OutputOffsetsViewType& outputOffsets,
   const char prefix[] = "computeNumPacketsAndOffsets: ";
 
   count_type count = 0;
-  const count_type numRowsToPack = lclRowInds.dimension_0 ();
+  const count_type numRowsToPack = lclRowInds.extent (0);
 
   if (numRowsToPack == 0) {
     return count;
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (rowOffsets.dimension_0 () <= static_cast<size_type> (1),
+      (rowOffsets.extent (0) <= static_cast<size_type> (1),
        std::invalid_argument, prefix << "There is at least one row to pack, "
-       "but the graph has no rows.  lclRowInds.dimension_0() = " <<
-       numRowsToPack << ", but rowOffsets.dimension_0() = " <<
-       rowOffsets.dimension_0 () << " <= 1.");
+       "but the graph has no rows.  lclRowInds.extent(0) = " <<
+       numRowsToPack << ", but rowOffsets.extent(0) = " <<
+       rowOffsets.extent (0) << " <= 1.");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (outputOffsets.dimension_0 () !=
+      (outputOffsets.extent (0) !=
        static_cast<size_type> (numRowsToPack + 1), std::invalid_argument,
        prefix << "Output dimension does not match number of rows to pack.  "
-       << "outputOffsets.dimension_0() = " << outputOffsets.dimension_0 ()
-       << " != lclRowInds.dimension_0() + 1 = "
+       << "outputOffsets.extent(0) = " << outputOffsets.extent (0)
+       << " != lclRowInds.extent(0) + 1 = "
        << static_cast<size_type> (numRowsToPack + 1) << ".");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (counts.dimension_0 () != numRowsToPack, std::invalid_argument,
-       prefix << "counts.dimension_0() = " << counts.dimension_0 ()
+      (counts.extent (0) != numRowsToPack, std::invalid_argument,
+       prefix << "counts.extent(0) = " << counts.extent (0)
        << " != numRowsToPack = " << numRowsToPack << ".");
 
     functor_type f (outputOffsets, counts, rowOffsets, lclRowInds, lclRowPids);
@@ -468,10 +468,10 @@ struct PackCrsGraphFunctor {
   {
     const LO numRows = local_graph_in.numRows ();
     const LO rowMapDim =
-      static_cast<LO> (local_graph.row_map.dimension_0 ());
+      static_cast<LO> (local_graph.row_map.extent (0));
     TEUCHOS_TEST_FOR_EXCEPTION
       (numRows != 0 && rowMapDim != numRows + static_cast<LO> (1),
-       std::logic_error, "local_graph.row_map.dimension_0() = "
+       std::logic_error, "local_graph.row_map.extent(0) = "
        << rowMapDim << " != numRows (= " << numRows << " ) + 1.");
   }
 
@@ -578,27 +578,27 @@ do_pack(const LocalGraph& local_graph,
   typedef Kokkos::RangePolicy<typename device_type::execution_space, LO> range_type;
   const char prefix[] = "Tpetra::Details::PackCrsGraphImpl::do_pack: ";
 
-  if (export_lids.dimension_0 () != 0) {
+  if (export_lids.extent (0) != 0) {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (static_cast<size_t> (offsets.dimension_0 ()) !=
-       static_cast<size_t> (export_lids.dimension_0 () + 1),
-       std::invalid_argument, prefix << "offsets.dimension_0() = "
-       << offsets.dimension_0 () << " != export_lids.dimension_0() (= "
-       << export_lids.dimension_0 () << ") + 1.");
+      (static_cast<size_t> (offsets.extent (0)) !=
+       static_cast<size_t> (export_lids.extent (0) + 1),
+       std::invalid_argument, prefix << "offsets.extent(0) = "
+       << offsets.extent (0) << " != export_lids.extent(0) (= "
+       << export_lids.extent (0) << ") + 1.");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (export_lids.dimension_0 () != num_packets_per_lid.dimension_0 (),
-       std::invalid_argument, prefix << "export_lids.dimension_0() = " <<
-       export_lids.dimension_0 () << " != num_packets_per_lid.dimension_0() = "
-       << num_packets_per_lid.dimension_0 () << ".");
+      (export_lids.extent (0) != num_packets_per_lid.extent (0),
+       std::invalid_argument, prefix << "export_lids.extent(0) = " <<
+       export_lids.extent (0) << " != num_packets_per_lid.extent(0) = "
+       << num_packets_per_lid.extent (0) << ".");
     // If exports has nonzero length at this point, then the graph
     // has at least one entry to pack.  Thus, if packing process
     // ranks, we had better have at least one process rank to pack.
     TEUCHOS_TEST_FOR_EXCEPTION
-      (pack_pids && exports.dimension_0 () != 0 &&
-       source_pids.dimension_0 () == 0, std::invalid_argument, prefix <<
-       "pack_pids is true, and exports.dimension_0() = " <<
-       exports.dimension_0 ()  << " != 0, meaning that we need to pack at "
-       "least one graph entry, but source_pids.dimension_0() = 0.");
+      (pack_pids && exports.extent (0) != 0 &&
+       source_pids.extent (0) == 0, std::invalid_argument, prefix <<
+       "pack_pids is true, and exports.extent(0) = " <<
+       exports.extent (0)  << " != 0, meaning that we need to pack at "
+       "least one graph entry, but source_pids.extent(0) = 0.");
   }
 
   typedef PackCrsGraphFunctor<Packet,LocalGraph,LocalMap,BufferDeviceType> pack_functor_type;
@@ -607,7 +607,7 @@ do_pack(const LocalGraph& local_graph,
                        source_pids, offsets, pack_pids);
 
   typename pack_functor_type::value_type result;
-  range_type range (0, num_packets_per_lid.dimension_0 ());
+  range_type range (0, num_packets_per_lid.extent (0));
   Kokkos::parallel_reduce (range, f, result);
 
   if (result.first != 0) {
@@ -697,19 +697,19 @@ packCrsGraph(const CrsGraph<LO,GO,NT>& sourceGraph,
   constant_num_packets = 0;
 
   const size_t num_export_lids =
-    static_cast<size_t> (export_lids.dimension_0 ());
+    static_cast<size_t> (export_lids.extent (0));
   TEUCHOS_TEST_FOR_EXCEPTION
     (num_export_lids !=
-     static_cast<size_t> (num_packets_per_lid.dimension_0 ()),
-     std::invalid_argument, prefix << "num_export_lids.dimension_0() = "
-     << num_export_lids << " != num_packets_per_lid.dimension_0() = "
-     << num_packets_per_lid.dimension_0 () << ".");
+     static_cast<size_t> (num_packets_per_lid.extent (0)),
+     std::invalid_argument, prefix << "num_export_lids.extent(0) = "
+     << num_export_lids << " != num_packets_per_lid.extent(0) = "
+     << num_packets_per_lid.extent (0) << ".");
   if (num_export_lids != 0) {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (num_packets_per_lid.ptr_on_device () == NULL, std::invalid_argument,
+      (num_packets_per_lid.data () == NULL, std::invalid_argument,
        prefix << "num_export_lids = "<< num_export_lids << " != 0, but "
-       "num_packets_per_lid.ptr_on_device() = "
-       << num_packets_per_lid.ptr_on_device () << " == NULL.");
+       "num_packets_per_lid.data() = "
+       << num_packets_per_lid.data () << " == NULL.");
   }
 
   if (num_export_lids == 0) {
@@ -732,7 +732,7 @@ packCrsGraph(const CrsGraph<LO,GO,NT>& sourceGraph,
                                 local_graph.row_map, export_lids, export_pids);
 
   // Resize the output pack buffer if needed.
-  if (count > static_cast<size_t> (exports.dimension_0 ())) {
+  if (count > static_cast<size_t> (exports.extent (0))) {
     // FIXME (26 Apr 2016) Fences around (UVM) allocations only
     // temporarily needed for #227 debugging.  Should be able to
     // remove them after that's fixed.
@@ -747,8 +747,8 @@ packCrsGraph(const CrsGraph<LO,GO,NT>& sourceGraph,
   }
   if (debug) {
     std::ostringstream os;
-    os << "*** count: " << count << ", exports.dimension_0(): "
-       << exports.dimension_0 () << std::endl;
+    os << "*** count: " << count << ", exports.extent(0): "
+       << exports.extent (0) << std::endl;
     std::cerr << os.str ();
   }
 
@@ -756,11 +756,11 @@ packCrsGraph(const CrsGraph<LO,GO,NT>& sourceGraph,
   // at least one entry to pack.  Thus, if packing process ranks, we
   // had better have at least one process rank to pack.
   TEUCHOS_TEST_FOR_EXCEPTION
-    (pack_pids && exports.dimension_0 () != 0 &&
-     export_pids.dimension_0 () == 0, std::invalid_argument, prefix <<
-     "pack_pids is true, and exports.dimension_0() = " <<
-     exports.dimension_0 ()  << " != 0, meaning that we need to pack at least "
-     "one graph entry, but export_pids.dimension_0() = 0.");
+    (pack_pids && exports.extent (0) != 0 &&
+     export_pids.extent (0) == 0, std::invalid_argument, prefix <<
+     "pack_pids is true, and exports.extent(0) = " <<
+     exports.extent (0)  << " != 0, meaning that we need to pack at least "
+     "one graph entry, but export_pids.extent(0) = 0.");
 
   typedef typename std::decay<decltype (local_graph)>::type
     local_graph_type;
@@ -850,8 +850,8 @@ packCrsGraph(const CrsGraph<LO, GO, NT>& sourceGraph,
   // The exports are an output of packCrsGraph, so we have to
   // copy them back to host.
   if (static_cast<size_t> (exports.size ()) !=
-      static_cast<size_t> (exports_dv.dimension_0 ())) {
-    exports.resize (exports_dv.dimension_0 ());
+      static_cast<size_t> (exports_dv.extent (0))) {
+    exports.resize (exports_dv.extent (0));
   }
   Kokkos::View<packet_type*, host_dev_type> exports_h (exports.getRawPtr (),
                                                        exports.size ());

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -163,20 +163,20 @@ public:
     error_ ("error") // don't forget this, or you'll get segfaults!
   {
     if (debug) {
-      const size_t numRowsToPack = static_cast<size_t> (lclRowInds_.dimension_0 ());
+      const size_t numRowsToPack = static_cast<size_t> (lclRowInds_.extent (0));
 
-      if (numRowsToPack != static_cast<size_t> (counts_.dimension_0 ())) {
+      if (numRowsToPack != static_cast<size_t> (counts_.extent (0))) {
         std::ostringstream os;
-        os << "lclRowInds.dimension_0() = " << numRowsToPack
-           << " != counts.dimension_0() = " << counts_.dimension_0 ()
+        os << "lclRowInds.extent(0) = " << numRowsToPack
+           << " != counts.extent(0) = " << counts_.extent (0)
            << ".";
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
       }
       if (static_cast<size_t> (numRowsToPack + 1) !=
-          static_cast<size_t> (outputOffsets_.dimension_0 ())) {
+          static_cast<size_t> (outputOffsets_.extent (0))) {
         std::ostringstream os;
-        os << "lclRowInds.dimension_0() + 1 = " << (numRowsToPack + 1)
-           << " != outputOffsets.dimension_0() = " << outputOffsets_.dimension_0 ()
+        os << "lclRowInds.extent(0) + 1 = " << (numRowsToPack + 1)
+           << " != outputOffsets.extent(0) = " << outputOffsets_.extent (0)
            << ".";
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
       }
@@ -197,7 +197,7 @@ public:
 
     if (final) {
       if (debug) {
-        if (curInd >= static_cast<local_row_index_type> (outputOffsets_.dimension_0 ())) {
+        if (curInd >= static_cast<local_row_index_type> (outputOffsets_.extent (0))) {
           error_ () = 2;
           return;
         }
@@ -205,9 +205,9 @@ public:
       outputOffsets_(curInd) = update;
     }
 
-    if (curInd < static_cast<local_row_index_type> (counts_.dimension_0 ())) {
+    if (curInd < static_cast<local_row_index_type> (counts_.extent (0))) {
       const auto lclRow = lclRowInds_(curInd);
-      if (static_cast<size_t> (lclRow + 1) >= static_cast<size_t> (rowOffsets_.dimension_0 ()) ||
+      if (static_cast<size_t> (lclRow + 1) >= static_cast<size_t> (rowOffsets_.extent (0)) ||
           static_cast<local_row_index_type> (lclRow) < static_cast<local_row_index_type> (0)) {
         error_ () = 3;
         return;
@@ -297,28 +297,28 @@ computeNumPacketsAndOffsets (const OutputOffsetsViewType& outputOffsets,
   const char prefix[] = "computeNumPacketsAndOffsets: ";
 
   count_type count = 0;
-  const count_type numRowsToPack = lclRowInds.dimension_0 ();
+  const count_type numRowsToPack = lclRowInds.extent (0);
 
   if (numRowsToPack == 0) {
     return count;
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (rowOffsets.dimension_0 () <= static_cast<size_type> (1),
+      (rowOffsets.extent (0) <= static_cast<size_type> (1),
        std::invalid_argument, prefix << "There is at least one row to pack, "
-       "but the matrix has no rows.  lclRowInds.dimension_0() = " <<
-       numRowsToPack << ", but rowOffsets.dimension_0() = " <<
-       rowOffsets.dimension_0 () << " <= 1.");
+       "but the matrix has no rows.  lclRowInds.extent(0) = " <<
+       numRowsToPack << ", but rowOffsets.extent(0) = " <<
+       rowOffsets.extent (0) << " <= 1.");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (outputOffsets.dimension_0 () !=
+      (outputOffsets.extent (0) !=
        static_cast<size_type> (numRowsToPack + 1), std::invalid_argument,
        prefix << "Output dimension does not match number of rows to pack.  "
-       << "outputOffsets.dimension_0() = " << outputOffsets.dimension_0 ()
-       << " != lclRowInds.dimension_0() + 1 = "
+       << "outputOffsets.extent(0) = " << outputOffsets.extent (0)
+       << " != lclRowInds.extent(0) + 1 = "
        << static_cast<size_type> (numRowsToPack + 1) << ".");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (counts.dimension_0 () != numRowsToPack, std::invalid_argument,
-       prefix << "counts.dimension_0() = " << counts.dimension_0 ()
+      (counts.extent (0) != numRowsToPack, std::invalid_argument,
+       prefix << "counts.extent(0) = " << counts.extent (0)
        << " != numRowsToPack = " << numRowsToPack << ".");
 
     functor_type f (outputOffsets, counts, rowOffsets,
@@ -540,10 +540,10 @@ struct PackCrsMatrixFunctor {
   {
     const LO numRows = local_matrix_in.numRows ();
     const LO rowMapDim =
-      static_cast<LO> (local_matrix.graph.row_map.dimension_0 ());
+      static_cast<LO> (local_matrix.graph.row_map.extent (0));
     TEUCHOS_TEST_FOR_EXCEPTION
       (numRows != 0 && rowMapDim != numRows + static_cast<LO> (1),
-       std::logic_error, "local_matrix.graph.row_map.dimension_0() = "
+       std::logic_error, "local_matrix.graph.row_map.extent(0) = "
        << rowMapDim << " != numRows (= " << numRows << " ) + 1.");
   }
 
@@ -660,27 +660,27 @@ do_pack (const LocalMatrix& local_matrix,
   typedef Kokkos::RangePolicy<typename DT::execution_space, LO> range_type;
   const char prefix[] = "Tpetra::Details::do_pack: ";
 
-  if (export_lids.dimension_0 () != 0) {
+  if (export_lids.extent (0) != 0) {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (static_cast<size_t> (offsets.dimension_0 ()) !=
-       static_cast<size_t> (export_lids.dimension_0 () + 1),
-       std::invalid_argument, prefix << "offsets.dimension_0() = "
-       << offsets.dimension_0 () << " != export_lids.dimension_0() (= "
-       << export_lids.dimension_0 () << ") + 1.");
+      (static_cast<size_t> (offsets.extent (0)) !=
+       static_cast<size_t> (export_lids.extent (0) + 1),
+       std::invalid_argument, prefix << "offsets.extent(0) = "
+       << offsets.extent (0) << " != export_lids.extent(0) (= "
+       << export_lids.extent (0) << ") + 1.");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (export_lids.dimension_0 () != num_packets_per_lid.dimension_0 (),
-       std::invalid_argument, prefix << "export_lids.dimension_0() = " <<
-       export_lids.dimension_0 () << " != num_packets_per_lid.dimension_0() = "
-       << num_packets_per_lid.dimension_0 () << ".");
+      (export_lids.extent (0) != num_packets_per_lid.extent (0),
+       std::invalid_argument, prefix << "export_lids.extent(0) = " <<
+       export_lids.extent (0) << " != num_packets_per_lid.extent(0) = "
+       << num_packets_per_lid.extent (0) << ".");
     // If exports has nonzero length at this point, then the matrix
     // has at least one entry to pack.  Thus, if packing process
     // ranks, we had better have at least one process rank to pack.
     TEUCHOS_TEST_FOR_EXCEPTION
-      (pack_pids && exports.dimension_0 () != 0 &&
-       source_pids.dimension_0 () == 0, std::invalid_argument, prefix <<
-       "pack_pids is true, and exports.dimension_0() = " <<
-       exports.dimension_0 ()  << " != 0, meaning that we need to pack at "
-       "least one matrix entry, but source_pids.dimension_0() = 0.");
+      (pack_pids && exports.extent (0) != 0 &&
+       source_pids.extent (0) == 0, std::invalid_argument, prefix <<
+       "pack_pids is true, and exports.extent(0) = " <<
+       exports.extent (0)  << " != 0, meaning that we need to pack at "
+       "least one matrix entry, but source_pids.extent(0) = 0.");
   }
 
   typedef PackCrsMatrixFunctor<LocalMatrix, LocalMap,
@@ -691,7 +691,7 @@ do_pack (const LocalMatrix& local_matrix,
                        pack_pids);
 
   typename pack_functor_type::value_type result;
-  range_type range (0, num_packets_per_lid.dimension_0 ());
+  range_type range (0, num_packets_per_lid.extent (0));
   Kokkos::parallel_reduce (range, f, result);
 
   if (result.first != 0) {
@@ -781,19 +781,19 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   constant_num_packets = 0;
 
   const size_t num_export_lids =
-    static_cast<size_t> (export_lids.dimension_0 ());
+    static_cast<size_t> (export_lids.extent (0));
   TEUCHOS_TEST_FOR_EXCEPTION
     (num_export_lids !=
-     static_cast<size_t> (num_packets_per_lid.dimension_0 ()),
-     std::invalid_argument, prefix << "num_export_lids.dimension_0() = "
-     << num_export_lids << " != num_packets_per_lid.dimension_0() = "
-     << num_packets_per_lid.dimension_0 () << ".");
+     static_cast<size_t> (num_packets_per_lid.extent (0)),
+     std::invalid_argument, prefix << "num_export_lids.extent(0) = "
+     << num_export_lids << " != num_packets_per_lid.extent(0) = "
+     << num_packets_per_lid.extent (0) << ".");
   if (num_export_lids != 0) {
     TEUCHOS_TEST_FOR_EXCEPTION
-      (num_packets_per_lid.ptr_on_device () == NULL, std::invalid_argument,
+      (num_packets_per_lid.data () == NULL, std::invalid_argument,
        prefix << "num_export_lids = "<< num_export_lids << " != 0, but "
-       "num_packets_per_lid.ptr_on_device() = "
-       << num_packets_per_lid.ptr_on_device () << " == NULL.");
+       "num_packets_per_lid.data() = "
+       << num_packets_per_lid.data () << " == NULL.");
   }
 
   const size_t num_bytes_per_lid = PackTraits<LO, DT>::packValueCount (LO (0));
@@ -816,7 +816,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
     // values should be packed (though this does assume that in our
     // packing scheme, rows with zero entries take zero bytes).
     size_t num_bytes_per_value_l = 0;
-    if (local_matrix.values.dimension_0() > 0) {
+    if (local_matrix.values.extent(0) > 0) {
       const ST& val = local_matrix.values(0);
       num_bytes_per_value_l = PackTraits<ST, DT>::packValueCount (val);
     }
@@ -850,7 +850,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                                  num_bytes_per_pid, num_bytes_per_value);
 
   // Resize the output pack buffer if needed.
-  if (count > static_cast<size_t> (exports.dimension_0 ())) {
+  if (count > static_cast<size_t> (exports.extent (0))) {
     // FIXME (26 Apr 2016) Fences around (UVM) allocations only
     // temporarily needed for #227 debugging.  Should be able to
     // remove them after that's fixed.
@@ -865,8 +865,8 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   }
   if (debug) {
     std::ostringstream os;
-    os << "*** count: " << count << ", exports.dimension_0(): "
-       << exports.dimension_0 () << std::endl;
+    os << "*** count: " << count << ", exports.extent(0): "
+       << exports.extent (0) << std::endl;
     std::cerr << os.str ();
   }
 
@@ -874,11 +874,11 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   // at least one entry to pack.  Thus, if packing process ranks, we
   // had better have at least one process rank to pack.
   TEUCHOS_TEST_FOR_EXCEPTION
-    (pack_pids && exports.dimension_0 () != 0 &&
-     export_pids.dimension_0 () == 0, std::invalid_argument, prefix <<
-     "pack_pids is true, and exports.dimension_0() = " <<
-     exports.dimension_0 ()  << " != 0, meaning that we need to pack at least "
-     "one matrix entry, but export_pids.dimension_0() = 0.");
+    (pack_pids && exports.extent (0) != 0 &&
+     export_pids.extent (0) == 0, std::invalid_argument, prefix <<
+     "pack_pids is true, and exports.extent(0) = " <<
+     exports.extent (0)  << " != 0, meaning that we need to pack at least "
+     "one matrix entry, but export_pids.extent(0) = 0.");
 
   typedef typename std::decay<decltype (local_matrix)>::type
     local_matrix_type;
@@ -968,8 +968,8 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   // The exports are an output of PackCrsMatrixImpl::packCrsMatrix, so we have
   // to copy them back to host.
   if (static_cast<size_t> (exports.size ()) !=
-      static_cast<size_t> (exports_dv.dimension_0 ())) {
-    exports.resize (exports_dv.dimension_0 ());
+      static_cast<size_t> (exports_dv.extent (0))) {
+    exports.resize (exports_dv.extent (0));
   }
   Kokkos::View<char*, host_dev_type> exports_h (exports.getRawPtr (),
                                                 exports.size ());

--- a/packages/tpetra/core/src/Tpetra_Details_reallocDualViewIfNeeded.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_reallocDualViewIfNeeded.hpp
@@ -94,7 +94,7 @@ reallocDualViewIfNeeded (Kokkos::DualView<ValueType*, DeviceType>& dv,
   using Tpetra::Details::ProfilingRegion;
   ProfilingRegion region ("Tpetra::Details::reallocDualViewIfNeeded");
 
-  const size_t curSize = static_cast<size_t> (dv.dimension_0 ());
+  const size_t curSize = static_cast<size_t> (dv.extent (0));
   if (curSize == newSize) {
     return false; // did not reallocate
   }

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -340,7 +340,7 @@ unpackAndCombine(
   const char prefix[] =
     "Tpetra::Details::UnpackAndCombineCrsGraphImpl::unpackAndCombine: ";
 
-  const size_t num_import_lids = static_cast<size_t>(import_lids.dimension_0());
+  const size_t num_import_lids = static_cast<size_t>(import_lids.extent(0));
   if (num_import_lids == 0) {
     // Nothing to unpack
     return;
@@ -361,11 +361,11 @@ unpackAndCombine(
 
     // Check that sizes of input objects are consistent.
     bool bad_num_import_lids =
-      num_import_lids != static_cast<size_t>(num_packets_per_lid.dimension_0());
+      num_import_lids != static_cast<size_t>(num_packets_per_lid.extent(0));
     TEUCHOS_TEST_FOR_EXCEPTION(bad_num_import_lids,
         std::invalid_argument,
         prefix << "importLIDs.size() (" << num_import_lids << ") != "
-        "numPacketsPerLID.size() (" << num_packets_per_lid.dimension_0() << ").");
+        "numPacketsPerLID.size() (" << num_packets_per_lid.extent(0) << ").");
   } // end QA error checking
 
   // Get the offsets
@@ -435,7 +435,7 @@ unpackAndCombineWithOwningPIDsCount(
   }
 
   // Count entries copied directly from the source graph with permuting.
-  num_items = static_cast<LO>(permute_from_lids.dimension_0());
+  num_items = static_cast<LO>(permute_from_lids.extent(0));
   if (num_items) {
     size_t kcnt = 0;
     parallel_reduce(
@@ -477,7 +477,7 @@ setupRowPointersForRemotes(
   typedef typename Kokkos::View<size_t*,device_type>::size_type size_type;
   typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
 
-  const size_type N = num_packets_per_lid.dimension_0();
+  const size_type N = num_packets_per_lid.extent(0);
   parallel_for("Setup row pointers for remotes",
     range_policy(0, N),
     KOKKOS_LAMBDA(const size_t i){
@@ -500,7 +500,7 @@ makeCrsRowPtrFromLengths(
   typedef typename device_type::execution_space execution_space;
   typedef typename Kokkos::View<size_t*,device_type>::size_type size_type;
   typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
-  const size_type N = new_start_row.dimension_0();
+  const size_type N = new_start_row.extent(0);
   parallel_scan(
     range_policy(0, N),
     KOKKOS_LAMBDA(const size_t& i, size_t& update, const bool& final) {
@@ -587,7 +587,7 @@ copyDataFromPermuteIDs(
   typedef typename Kokkos::View<LO*,device_type>::size_type size_type;
   typedef Kokkos::RangePolicy<execution_space, Kokkos::IndexType<size_type> > range_policy;
 
-  const size_type num_permute_to_lids = permute_to_lids.dimension_0();
+  const size_type num_permute_to_lids = permute_to_lids.extent(0);
 
   parallel_for(
     range_policy(0, num_permute_to_lids),
@@ -760,7 +760,7 @@ unpackAndCombineIntoCrsArrays(
   );
 
   // Permute IDs: Still local, but reordered
-  const size_type num_permute_to_lids = permute_to_lids.dimension_0();
+  const size_type num_permute_to_lids = permute_to_lids.extent(0);
   parallel_for(
     range_policy(0, num_permute_to_lids),
     KOKKOS_LAMBDA(const size_t i) {
@@ -772,7 +772,7 @@ unpackAndCombineIntoCrsArrays(
   );
 
   // Get the offsets from the number of packets per LID
-  const size_type num_import_lids = import_lids.dimension_0();
+  const size_type num_import_lids = import_lids.extent(0);
   View<size_t*, device_type> offsets("offsets", num_import_lids+1);
   computeOffsetsFromCounts(offsets, num_packets_per_lid);
 
@@ -780,11 +780,11 @@ unpackAndCombineIntoCrsArrays(
   {
     auto nth_offset_h = getEntryOnHost(offsets, num_import_lids);
     const bool condition =
-      nth_offset_h != static_cast<size_t>(imports.dimension_0());
+      nth_offset_h != static_cast<size_t>(imports.extent(0));
     TEUCHOS_TEST_FOR_EXCEPTION
       (condition, std::logic_error, prefix
        << "The final offset in bytes " << nth_offset_h
-       << " != imports.size() = " << imports.dimension_0()
+       << " != imports.size() = " << imports.extent(0)
        << ".  Please report this bug to the Tpetra developers.");
   }
 #endif // HAVE_TPETRA_DEBUG
@@ -815,7 +815,7 @@ unpackAndCombineIntoCrsArrays(
       tgt_rowptr, src_pids, permute_to_lids, permute_from_lids,
       local_graph, local_col_map, my_pid);
 
-  if (imports.dimension_0() <= 0) {
+  if (imports.extent(0) <= 0) {
     return;
   }
 

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -191,10 +191,10 @@ namespace Tpetra {
             out << "Process " << myRank << ":" << endl;
             Teuchos::OSTab tab2 (out);
             out << "Export buffer size (in packets): "
-                << exports_.dimension_0 ()
+                << exports_.extent (0)
                 << endl
                 << "Import buffer size (in packets): "
-                << imports_.dimension_0 ()
+                << imports_.extent (0)
                 << endl;
           }
           if (! comm.is_null ()) {
@@ -594,7 +594,7 @@ namespace Tpetra {
       const int myRank = this->getMap ()->getComm ()->getRank ();
       std::ostringstream os;
       os << "(Proc " << myRank << ") Reallocate (if needed) imports_ from "
-         << imports_.dimension_0 () << " to " << newSize << std::endl;
+         << imports_.extent (0) << " to " << newSize << std::endl;
       std::cerr << os.str ();
     }
     using Details::reallocDualViewIfNeeded;
@@ -829,8 +829,8 @@ namespace Tpetra {
         const size_t rbufLen = remoteLIDs.size() * constantNumPackets;
         if (debug) {
           std::ostringstream os;
-          os << "*** doTransferOld: Const # packets: imports_.dimension_0() = "
-             << imports_.dimension_0 () << ", rbufLen = " << rbufLen
+          os << "*** doTransferOld: Const # packets: imports_.extent(0) = "
+             << imports_.extent (0) << ", rbufLen = " << rbufLen
              << std::endl;
           std::cerr << os.str ();
         }
@@ -1042,7 +1042,7 @@ namespace Tpetra {
       typedef typename DT::execution_space DES;
       typedef Kokkos::RangePolicy<DES, IndexType> range_type;
 
-      const IndexType numOut = numImportPacketsPerLID.dimension_0 ();
+      const IndexType numOut = numImportPacketsPerLID.extent (0);
       size_t totalImportPackets = 0;
       parallel_reduce ("Count import packets",
                        range_type (0, numOut),
@@ -1152,7 +1152,7 @@ namespace Tpetra {
     // that if CM == INSERT || CM == REPLACE, the target object could
     // be write only.  We don't optimize for that here.
 
-    if (numSameIDs + permuteToLIDs.dimension_0 () != 0) {
+    if (numSameIDs + permuteToLIDs.extent (0) != 0) {
       // There is at least one GID to copy or permute.
       if (verbose) {
         std::ostringstream os;
@@ -1208,8 +1208,8 @@ namespace Tpetra {
         }
         // This only reallocates if necessary, that is, if the sizes
         // don't match.
-        this->reallocArraysForNumPacketsPerLid (exportLIDs.dimension_0 (),
-                                                remoteLIDs.dimension_0 ());
+        this->reallocArraysForNumPacketsPerLid (exportLIDs.extent (0),
+                                                remoteLIDs.extent (0));
       }
 
       if (verbose) {
@@ -1267,7 +1267,7 @@ namespace Tpetra {
         // already know (from the number of "remote" (incoming)
         // elements) how many incoming elements we expect, so we can
         // resize the buffer accordingly.
-        const size_t rbufLen = remoteLIDs.dimension_0 () * constantNumPackets;
+        const size_t rbufLen = remoteLIDs.extent (0) * constantNumPackets;
         reallocImportsIfNeeded (rbufLen, verbose);
       }
 
@@ -1534,8 +1534,8 @@ namespace Tpetra {
             if (verbose) {
               std::ostringstream os;
               os << *prefix << "7.1. Const # packets per LID: "
-                 << "exports_.dimension_0()=" << exports_.dimension_0 ()
-                 << ", imports_.dimension_0() = " << imports_.dimension_0 ()
+                 << "exports_.extent(0)=" << exports_.extent (0)
+                 << ", imports_.extent(0) = " << imports_.extent (0)
                  << endl;
               std::cerr << os.str ();
             }

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -2178,7 +2178,7 @@ namespace Tpetra {
         std::ostringstream os;
         os << "Proc " << myRank << ": doPosts: totalNumImportPackets = " <<
           totalNumImportPackets << " = " << totalReceiveLength_ << " * " <<
-          numPackets << "; imports.dimension_0() = " << imports.dimension_0 ()
+          numPackets << "; imports.extent(0) = " << imports.extent (0)
            << endl;
         *out_ << os.str ();
       }
@@ -2186,7 +2186,7 @@ namespace Tpetra {
 #ifdef HAVE_TPETRA_DEBUG
       // mfh 31 Mar 2016: Extra special all-reduce check to help diagnose #227.
       {
-        const size_t importBufSize = static_cast<size_t> (imports.dimension_0 ());
+        const size_t importBufSize = static_cast<size_t> (imports.extent (0));
         const int lclBad = (importBufSize < totalNumImportPackets) ? 1 : 0;
         int gblBad = 0;
         using Teuchos::reduceAll;
@@ -2203,11 +2203,11 @@ namespace Tpetra {
       }
 #else
       TEUCHOS_TEST_FOR_EXCEPTION
-        (static_cast<size_t> (imports.dimension_0 ()) < totalNumImportPackets,
+        (static_cast<size_t> (imports.extent (0)) < totalNumImportPackets,
          std::runtime_error,
          "Tpetra::Distributor::doPosts(3 args, Kokkos): The 'imports' "
          "array must have enough entries to hold the expected number of import "
-         "packets.  imports.dimension_0() = " << imports.dimension_0 () << " < "
+         "packets.  imports.extent(0) = " << imports.extent (0) << " < "
          "totalNumImportPackets = " << totalNumImportPackets << " = "
          "totalReceiveLength_ (" << totalReceiveLength_ << ") * numPackets ("
          << numPackets << ").");
@@ -2646,10 +2646,10 @@ namespace Tpetra {
       totalNumImportPackets += numImportPacketsPerLID[ii];
     }
     TEUCHOS_TEST_FOR_EXCEPTION(
-      imports.dimension_0 () < totalNumImportPackets, std::runtime_error,
+      imports.extent (0) < totalNumImportPackets, std::runtime_error,
       "Tpetra::Distributor::doPosts(4 args, Kokkos): The 'imports' array must have "
       "enough entries to hold the expected number of import packets.  "
-      "imports.dimension_0() = " << imports.dimension_0 () << " < "
+      "imports.extent(0) = " << imports.extent (0) << " < "
       "totalNumImportPackets = " << totalNumImportPackets << ".");
 #endif // HAVE_TEUCHOS_DEBUG
 

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -629,7 +629,7 @@ public:
   ///   has a column Map).
   /// \pre All diagonal entries of the matrix's graph must be
   ///   populated on this process.  Results are undefined otherwise.
-  /// \post <tt>offsets.dimension_0() == getNodeNumRows()</tt>
+  /// \post <tt>offsets.extent(0) == getNodeNumRows()</tt>
   ///
   /// This method creates an array of offsets of the local diagonal
   /// entries in the matrix.  This array is suitable for use in the

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -176,9 +176,9 @@ private:
   KOKKOS_INLINE_FUNCTION local_ordinal_type
   getNumLclMeshRows () const
   {
-    return ptr_.dimension_0 () == 0 ?
+    return ptr_.extent (0) == 0 ?
       static_cast<local_ordinal_type> (0) :
-      static_cast<local_ordinal_type> (ptr_.dimension_0 () - 1);
+      static_cast<local_ordinal_type> (ptr_.extent (0) - 1);
   }
 
   static constexpr local_ordinal_type defaultRowsPerTeam = 20;
@@ -255,7 +255,7 @@ public:
       shared_array_type (member.thread_scratch (1), blockSize_ * rowsPerTeam_);
 
     // This looks wrong!  All the threads are writing into the same local storage.
-    //out_little_vec_type Y_tlm (threadLocalMem.ptr_on_device (), blockSize_, 1);
+    //out_little_vec_type Y_tlm (threadLocalMem.data (), blockSize_, 1);
 
     const LO numLclMeshRows = getNumLclMeshRows ();
     const LO rowBeg = leagueRank * rowsPerTeam_;
@@ -274,7 +274,7 @@ public:
     parallel_for (Kokkos::TeamThreadRange (member, rowBeg, rowEnd),
                   [&] (const LO& lclRow) {
                     // Each thread in the team gets its own temp storage.
-                    out_little_vec_type Y_tlm (threadLocalMem.ptr_on_device () + blockSize_ * member.team_rank (), blockSize_);
+                    out_little_vec_type Y_tlm (threadLocalMem.data () + blockSize_ * member.team_rank (), blockSize_);
 
                     const offset_type Y_ptBeg = lclRow * blockSize_;
                     const offset_type Y_ptEnd = Y_ptBeg + blockSize_;
@@ -298,7 +298,7 @@ public:
                       const offset_type bs2 = blockSize_ * blockSize_;
                       for (offset_type absBlkOff = blkBeg; absBlkOff < blkEnd;
                            ++absBlkOff) {
-                        little_block_type A_cur (val_.ptr_on_device () + absBlkOff * bs2,
+                        little_block_type A_cur (val_.data () + absBlkOff * bs2,
                                                  blockSize_, blockSize_);
                         const offset_type X_blkCol = ind_[absBlkOff];
                         const offset_type X_ptBeg = X_blkCol * blockSize_;
@@ -445,7 +445,7 @@ public:
       const offset_type bs2 = blockSize_ * blockSize_;
       for (offset_type absBlkOff = blkBeg; absBlkOff < blkEnd;
            ++absBlkOff) {
-        little_block_type A_cur (val_.ptr_on_device () + absBlkOff * bs2,
+        little_block_type A_cur (val_.data () + absBlkOff * bs2,
                                  blockSize_, blockSize_);
         const offset_type X_blkCol = ind_[absBlkOff];
         const offset_type X_ptBeg = X_blkCol * blockSize_;
@@ -507,10 +507,10 @@ bcrsLocalApplyNoTrans (const AlphaCoeffType& alpha,
   typedef typename Kokkos::ArithTraits<typename std::decay<BetaCoeffType>::type>::val_type beta_type;
   typedef typename std::remove_const<typename GraphType::data_type>::type LO;
 
-  const LO numLocalMeshRows = graph.row_map.dimension_0 () == 0 ?
+  const LO numLocalMeshRows = graph.row_map.extent (0) == 0 ?
     static_cast<LO> (0) :
-    static_cast<LO> (graph.row_map.dimension_0 () - 1);
-  const LO numVecs = Y.dimension_1 ();
+    static_cast<LO> (graph.row_map.extent (0) - 1);
+  const LO numVecs = Y.extent (1);
   if (numLocalMeshRows == 0 || numVecs == 0) {
     return; // code below doesn't handle numVecs==0 correctly
   }
@@ -624,7 +624,7 @@ public:
     typedef Kokkos::View<const IST**, Kokkos::LayoutRight,
       device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       const_little_block_type;
-    const_little_block_type D_in (val_.ptr_on_device () + pointOffset,
+    const_little_block_type D_in (val_.data () + pointOffset,
                                   blockSize_, blockSize_);
     auto D_out = Kokkos::subview (diag_, lclRowInd, ALL (), ALL ());
     COPY (D_in, D_out);
@@ -1018,7 +1018,7 @@ public:
     typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
     auto vals_host_out =
       const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
-    impl_scalar_type* vals_host_out_raw = vals_host_out.ptr_on_device ();
+    impl_scalar_type* vals_host_out_raw = vals_host_out.data ();
 
     for (LO k = 0; k < numColInds; ++k, pointOffset += perBlockSize) {
       const LO relBlockOffset =
@@ -1292,9 +1292,9 @@ public:
     const LO lclNumMeshRows = static_cast<LO> (rowMeshMap_.getNodeNumElements ());
     const LO blockSize = this->getBlockSize ();
     TEUCHOS_TEST_FOR_EXCEPTION
-      (static_cast<LO> (diag.dimension_0 ()) < lclNumMeshRows ||
-       static_cast<LO> (diag.dimension_1 ()) < blockSize ||
-       static_cast<LO> (diag.dimension_2 ()) < blockSize,
+      (static_cast<LO> (diag.extent (0)) < lclNumMeshRows ||
+       static_cast<LO> (diag.extent (1)) < blockSize ||
+       static_cast<LO> (diag.extent (2)) < blockSize,
        std::invalid_argument, prefix <<
        "The input Kokkos::View is not big enough to hold all the data.");
     TEUCHOS_TEST_FOR_EXCEPTION
@@ -1342,9 +1342,9 @@ public:
     const LO lclNumMeshRows = static_cast<LO> (rowMeshMap_.getNodeNumElements ());
     const LO blockSize = this->getBlockSize ();
     TEUCHOS_TEST_FOR_EXCEPTION
-      (static_cast<LO> (diag.dimension_0 ()) < lclNumMeshRows ||
-       static_cast<LO> (diag.dimension_1 ()) < blockSize ||
-       static_cast<LO> (diag.dimension_2 ()) < blockSize,
+      (static_cast<LO> (diag.extent (0)) < lclNumMeshRows ||
+       static_cast<LO> (diag.extent (1)) < blockSize ||
+       static_cast<LO> (diag.extent (2)) < blockSize,
        std::invalid_argument, "Tpetra::BlockCrsMatrix::getLocalDiagCopy: "
        "The input Kokkos::View is not big enough to hold all the data.");
     TEUCHOS_TEST_FOR_EXCEPTION
@@ -1451,7 +1451,7 @@ public:
     typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
     auto vals_host_out =
       const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
-    impl_scalar_type* vals_host_out_raw = vals_host_out.ptr_on_device ();
+    impl_scalar_type* vals_host_out_raw = vals_host_out.data ();
 
     for (LO k = 0; k < numColInds; ++k, pointOffset += perBlockSize) {
       const LO relBlockOffset =
@@ -1505,7 +1505,7 @@ public:
     }
     else {
       const size_t absBlockOffsetStart = ptrHost_[localRowInd];
-      colInds = indHost_.ptr_on_device () + absBlockOffsetStart;
+      colInds = indHost_.data () + absBlockOffsetStart;
 
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
@@ -1522,7 +1522,7 @@ public:
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
       auto vals_host_out =
         const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
-      impl_scalar_type* vals_host_out_raw = vals_host_out.ptr_on_device ();
+      impl_scalar_type* vals_host_out_raw = vals_host_out.data ();
       impl_scalar_type* const vOut = vals_host_out_raw +
         absBlockOffsetStart * offsetPerBlock ();
       vals = reinterpret_cast<Scalar*> (vOut);
@@ -1909,7 +1909,7 @@ public:
     const size_t absEndOffset = ptrHost_[localRowIndex+1];
     const LO numEntriesInRow = static_cast<LO> (absEndOffset - absStartOffset);
     // Amortize pointer arithmetic over the search loop.
-    const LO* const curInd = indHost_.ptr_on_device () + absStartOffset;
+    const LO* const curInd = indHost_.data () + absStartOffset;
 
     // If the hint was correct, then the hint is the offset to return.
     if (hint < numEntriesInRow && curInd[hint] == colIndexToFind) {
@@ -2014,7 +2014,7 @@ public:
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
       auto vals_host =
         const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
-      const impl_scalar_type* vals_host_raw = vals_host.ptr_on_device ();
+      const impl_scalar_type* vals_host_raw = vals_host.data ();
 
       return getConstLocalBlockFromInput (vals_host_raw, absPointOffset);
     }
@@ -2079,7 +2079,7 @@ public:
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
       auto vals_host =
         const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
-      impl_scalar_type* vals_host_raw = vals_host.ptr_on_device ();
+      impl_scalar_type* vals_host_raw = vals_host.data ();
       return getNonConstLocalBlockFromInput (vals_host_raw, absPointOffset);
     }
   }
@@ -2738,13 +2738,13 @@ public:
       }
       const size_t numScalarEnt = numEnt * blockSize * blockSize;
       TEUCHOS_TEST_FOR_EXCEPTION(
-        static_cast<size_t> (imports.dimension_0 ()) <= offset,
-        std::logic_error, "unpackRow: imports.dimension_0() = "
-        << imports.dimension_0 () << " <= offset = " << offset << ".");
+        static_cast<size_t> (imports.extent (0)) <= offset,
+        std::logic_error, "unpackRow: imports.extent(0) = "
+        << imports.extent (0) << " <= offset = " << offset << ".");
       TEUCHOS_TEST_FOR_EXCEPTION(
-        static_cast<size_t> (imports.dimension_0 ()) < offset + numBytes,
-        std::logic_error, "unpackRow: imports.dimension_0() = "
-        << imports.dimension_0 () << " < offset + numBytes = "
+        static_cast<size_t> (imports.extent (0)) < offset + numBytes,
+        std::logic_error, "unpackRow: imports.extent(0) = "
+        << imports.extent (0) << " < offset + numBytes = "
         << (offset + numBytes) << ".");
 
       const GO gid = 0; // packValueCount wants this
@@ -3121,7 +3121,7 @@ public:
     // the same size as any other allocated instance.  Thus, it
     // suffices to find some allocated instance as a representative
     // value.
-    if (this->val_.h_view.dimension_0 () != 0) {
+    if (this->val_.h_view.extent (0) != 0) {
       const ST& val = this->val_.h_view[0];
       numBytesPerValue = PackTraits<ST, HES>::packValueCount (val);
     }
@@ -3218,9 +3218,9 @@ public:
 
       // Combine the incoming data with the matrix's current data.
       LO numCombd = 0;
-      const LO* const lidsRaw = const_cast<const LO*> (lidsOut.ptr_on_device ());
+      const LO* const lidsRaw = const_cast<const LO*> (lidsOut.data ());
       const Scalar* const valsRaw =
-        reinterpret_cast<const Scalar*> (const_cast<const ST*> (valsOut.ptr_on_device ()));
+        reinterpret_cast<const Scalar*> (const_cast<const ST*> (valsOut.data ()));
       if (CM == ADD) {
         numCombd = this->sumIntoLocalValues (lclRow, lidsRaw, valsRaw, numEnt);
       } else if (CM == INSERT || CM == REPLACE) {
@@ -3765,7 +3765,7 @@ public:
     auto vals_host_out =
       const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
     Scalar* vals_host_out_raw =
-      reinterpret_cast<Scalar*> (vals_host_out.ptr_on_device ());
+      reinterpret_cast<Scalar*> (vals_host_out.data ());
 
     // TODO amk: This is a temporary measure to make the code run with Ifpack2
     size_t rowOffset = 0;

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -135,7 +135,7 @@ lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const size_t> &ro
   ///   MapAo     = useReverseModeForOwnership ? transferThatDefinesOwnership.getSourceMap() : transferThatDefinesOwnership.getTargetMap();
   ///   MapAm     = useReverseModeForMigration ? transferThatDefinesMigration.getTargetMap() : transferThatDefinesMigration.getSourceMap();
   ///   VectorMap = useReverseModeForMigration ? transferThatDefinesMigration.getSourceMap() : transferThatDefinesMigration.getTargetMap();
-  /// Precondition: 
+  /// Precondition:
   ///  1) MapAo.isSameAs(*MapAm)                      - map compatibility between transfers
   ///  2) VectorMap->isSameAs(*owningPIDs->getMap())  - map compabibility between transfer & vector
   ///  3) OwningMap->isOneToOne()                     - owning map is 1-to-1
@@ -148,7 +148,7 @@ lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const size_t> &ro
                                      const ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, Node>& transferForMigratingData,
                                      bool useReverseModeForMigration,
                                      Tpetra::Vector<int,LocalOrdinal,GlobalOrdinal,Node> & owningPIDs);
- 
+
 } // namespace Import_Util
 } // namespace Tpetra
 
@@ -244,9 +244,9 @@ public:
 
   KOKKOS_FUNCTION void operator() (const size_t i) const
   {
-    const size_t nnz = ind_.dimension_0 ();
+    const size_t nnz = ind_.extent (0);
     const size_t start = ptr_(i);
-    const bool permute_values_array = val_.dimension_0() > 0;
+    const bool permute_values_array = val_.extent(0) > 0;
 
     if (start < nnz) {
       const size_t NumEntries = ptr_(i+1) - start;
@@ -289,10 +289,10 @@ public:
     // Code copied from  Epetra_CrsMatrix::SortEntries()
     // NOTE: This should not be taken as a particularly efficient way to sort
     // rows of matrices in parallel.  But it is correct, so that's something.
-    if (ptr.dimension_0 () == 0) {
+    if (ptr.extent (0) == 0) {
       return; // no rows, so nothing to sort
     }
-    const size_t NumRows = ptr.dimension_0 () - 1;
+    const size_t NumRows = ptr.extent (0) - 1;
 
     typedef size_t index_type; // what this function was using; not my choice
     typedef typename ValuesType::execution_space execution_space;
@@ -665,7 +665,7 @@ lowCommunicationMakeColMapAndReindex (const Teuchos::ArrayView<const size_t> &ro
 //   MapAo     = useReverseModeForOwnership ? transferThatDefinesOwnership.getSourceMap() : transferThatDefinesOwnership.getTargetMap();
 //   MapAm     = useReverseModeForMigration ? transferThatDefinesMigration.getTargetMap() : transferThatDefinesMigration.getSourceMap();
 //   VectorMap = useReverseModeForMigration ? transferThatDefinesMigration.getSourceMap() : transferThatDefinesMigration.getTargetMap();
-// Precondition: 
+// Precondition:
 //  1) MapAo.isSameAs(*MapAm)                      - map compatibility between transfers
 //  2) VectorMap->isSameAs(*owningPIDs->getMap())  - map compabibility between transfer & vector
 //  3) OwningMap->isOneToOne()                     - owning map is 1-to-1
@@ -692,13 +692,13 @@ void getTwoTransferOwnershipVector(const ::Tpetra::Details::Transfer<LocalOrdina
   TEUCHOS_TEST_FOR_EXCEPTION(!OwningMap->isOneToOne(),std::runtime_error,"Tpetra::Import_Util::getTwoTransferOwnershipVector owner must be 1-to-1");
 #endif
 
-  int rank = OwningMap->getComm()->getRank();  
+  int rank = OwningMap->getComm()->getRank();
   // Generate "A" vector and fill it with owning information.  We can read this from transferThatDefinesOwnership w/o communication
   // Note:  Due to the 1-to-1 requirement, several of these options throw
   Tpetra::Vector<int,LocalOrdinal,GlobalOrdinal,Node> temp(MapAo);
   const import_type* ownAsImport = dynamic_cast<const import_type*> (&transferThatDefinesOwnership);
-  const export_type* ownAsExport = dynamic_cast<const export_type*> (&transferThatDefinesOwnership);  
-  
+  const export_type* ownAsExport = dynamic_cast<const export_type*> (&transferThatDefinesOwnership);
+
   Teuchos::ArrayRCP<int> pids    = temp.getDataNonConst();
   Teuchos::ArrayView<int> v_pids = pids();
   if(ownAsImport && useReverseModeForOwnership)       {TEUCHOS_TEST_FOR_EXCEPTION(1,std::runtime_error,"Tpetra::Import_Util::getTwoTransferOwnershipVector owner must be 1-to-1");}

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1540,7 +1540,7 @@ namespace Tpetra {
         // the case that the memory spaces differ, so it doesn't hurt
         // to make a deep copy here.
         Kokkos::View<GO*, Kokkos::LayoutLeft, out_device_type>
-          lgMapOut ("lgMap", mapIn.lgMap_.dimension_0 ());
+          lgMapOut ("lgMap", mapIn.lgMap_.extent (0));
         Kokkos::deep_copy (lgMapOut, mapIn.lgMap_);
         mapOut.lgMap_ = lgMapOut; // cast to const
 

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -584,17 +584,17 @@ namespace Tpetra {
       // Compute the GID -> LID lookup table, _not_ including the
       // initial sequence of contiguous GIDs.
       {
-        const std::pair<size_t, size_t> ncRange (i, entryList_host.dimension_0 ());
+        const std::pair<size_t, size_t> ncRange (i, entryList_host.extent (0));
         auto nonContigGids_host = subview (entryList_host, ncRange);
         TEUCHOS_TEST_FOR_EXCEPTION
-          (static_cast<size_t> (nonContigGids_host.dimension_0 ()) !=
-           static_cast<size_t> (entryList_host.dimension_0 () - i),
+          (static_cast<size_t> (nonContigGids_host.extent (0)) !=
+           static_cast<size_t> (entryList_host.extent (0) - i),
            std::logic_error, "Tpetra::Map noncontiguous constructor: "
-           "nonContigGids_host.dimension_0() = "
-           << nonContigGids_host.dimension_0 ()
-           << " != entryList_host.dimension_0() - i = "
-           << (entryList_host.dimension_0 () - i) << " = "
-           << entryList_host.dimension_0 () << " - " << i
+           "nonContigGids_host.extent(0) = "
+           << nonContigGids_host.extent (0)
+           << " != entryList_host.extent(0) - i = "
+           << (entryList_host.extent (0) - i) << " = "
+           << entryList_host.extent (0) << " - " << i
            << ".  Please report this bug to the Tpetra developers.");
 
         // FixedHashTable's constructor expects an owned device View,
@@ -929,17 +929,17 @@ namespace Tpetra {
       // Compute the GID -> LID lookup table, _not_ including the
       // initial sequence of contiguous GIDs.
       {
-        const std::pair<size_t, size_t> ncRange (i, entryList.dimension_0 ());
+        const std::pair<size_t, size_t> ncRange (i, entryList.extent (0));
         auto nonContigGids = subview (entryList, ncRange);
         TEUCHOS_TEST_FOR_EXCEPTION
-          (static_cast<size_t> (nonContigGids.dimension_0 ()) !=
-           static_cast<size_t> (entryList.dimension_0 () - i),
+          (static_cast<size_t> (nonContigGids.extent (0)) !=
+           static_cast<size_t> (entryList.extent (0) - i),
            std::logic_error, "Tpetra::Map noncontiguous constructor: "
-           "nonContigGids.dimension_0() = "
-           << nonContigGids.dimension_0 ()
-           << " != entryList.dimension_0() - i = "
-           << (entryList.dimension_0 () - i) << " = "
-           << entryList.dimension_0 () << " - " << i
+           "nonContigGids.extent(0) = "
+           << nonContigGids.extent (0)
+           << " != entryList.extent(0) - i = "
+           << (entryList.extent (0) - i) << " = "
+           << entryList.extent (0) << " - " << i
            << ".  Please report this bug to the Tpetra developers.");
 
         glMap_ = global_to_local_table_type (nonContigGids,
@@ -1236,8 +1236,8 @@ namespace Tpetra {
       return true;
     }
     else if (! isContiguous () && ! map.isContiguous () &&
-             lgMap_.dimension_0 () != 0 && map.lgMap_.dimension_0 () != 0 &&
-             lgMap_.ptr_on_device () == map.lgMap_.ptr_on_device ()) {
+             lgMap_.extent (0) != 0 && map.lgMap_.extent (0) != 0 &&
+             lgMap_.data () == map.lgMap_.data ()) {
       // Noncontiguous Maps whose global index lists are nonempty and
       // have the same pointer must be the same (and therefore
       // contiguous).
@@ -1331,7 +1331,7 @@ namespace Tpetra {
         }
         return true;
       }
-      else if (this->lgMap_.ptr_on_device () == map.lgMap_.ptr_on_device ()) {
+      else if (this->lgMap_.data () == map.lgMap_.data ()) {
         // Pointers to LID->GID "map" (actually just an array) are the
         // same, and the number of GIDs are the same.
         return this->getNodeNumElements () == map.getNodeNumElements ();
@@ -1507,7 +1507,7 @@ namespace Tpetra {
     // have local entries, then create and fill the local-to-global
     // mapping.
     const bool needToCreateLocalToGlobalMapping =
-      lgMap_.dimension_0 () == 0 && numLocalElements_ > 0;
+      lgMap_.extent (0) == 0 && numLocalElements_ > 0;
 
     if (needToCreateLocalToGlobalMapping) {
 #ifdef HAVE_TEUCHOS_DEBUG
@@ -1552,12 +1552,12 @@ namespace Tpetra {
     (void) this->getMyGlobalIndices ();
 
     // This does NOT assume UVM; lgMapHost_ is a host pointer.
-    const GO* lgMapHostRawPtr = lgMapHost_.ptr_on_device ();
+    const GO* lgMapHostRawPtr = lgMapHost_.data ();
     // The third argument forces ArrayView not to try to track memory
     // in a debug build.  We have to use it because the memory does
     // not belong to a Teuchos memory management class.
     return Teuchos::ArrayView<const GO> (lgMapHostRawPtr,
-                                         lgMapHost_.dimension_0 (),
+                                         lgMapHost_.extent (0),
                                          Teuchos::RCP_DISABLE_NODE_LOOKUP);
   }
 
@@ -1800,14 +1800,14 @@ namespace Tpetra {
       // 10:   Process 3: origComm->replaceCommWithSubset(subsetComm) threw an exception: /scratch/prj/Trilinos/Trilinos/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp:1044:
 
       auto lgMap = this->getMyGlobalIndices ();
-      typedef typename std::decay<decltype (lgMap.dimension_0 ()) >::type size_type;
+      typedef typename std::decay<decltype (lgMap.extent (0)) >::type size_type;
       const size_type lclNumInds =
         static_cast<size_type> (this->getNodeNumElements ());
       using Teuchos::TypeNameTraits;
       TEUCHOS_TEST_FOR_EXCEPTION
-        (lgMap.dimension_0 () != lclNumInds, std::logic_error,
+        (lgMap.extent (0) != lclNumInds, std::logic_error,
          "Tpetra::Map::replaceCommWithSubset: Result of getMyGlobalIndices() "
-         "has length " << lgMap.dimension_0 () << " (of type " <<
+         "has length " << lgMap.extent (0) << " (of type " <<
          TypeNameTraits<size_type>::name () << ") != this->getNodeNumElements()"
          " = " << this->getNodeNumElements () << ".  The latter, upon being "
          "cast to size_type = " << TypeNameTraits<size_type>::name () << ", "

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -359,7 +359,7 @@ namespace Tpetra {
   /// expect.  The memory might not even be accessible from the host
   /// CPU.  Instead, we give access through a Kokkos::View, which
   /// behaves like a 2-D array.  You can ask the Kokkos::View for a
-  /// raw pointer by calling its <tt>ptr_on_device()</tt> method, but
+  /// raw pointer by calling its <tt>data()</tt> method, but
   /// then you are responsible for understanding its layout in memory.
   ///
   /// \section Kokkos_KR_MV_dist Parallel distribution of data
@@ -1561,7 +1561,7 @@ namespace Tpetra {
     /// \param dots [out] Device View with getNumVectors() entries.
     ///
     /// \pre <tt>this->getNumVectors () == A.getNumVectors ()</tt>
-    /// \pre <tt>dots.dimension_0 () == A.getNumVectors ()</tt>
+    /// \pre <tt>dots.extent (0) == A.getNumVectors ()</tt>
     ///
     /// \post <tt>dots(j) == (this->getVector[j])->dot (* (A.getVector[j]))</tt>
     void
@@ -1596,7 +1596,7 @@ namespace Tpetra {
     dot (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
          const Kokkos::View<T*, device_type>& dots) const
     {
-      const size_t numDots = dots.dimension_0 ();
+      const size_t numDots = dots.extent (0);
       Kokkos::View<dot_type*, device_type> dts ("MV::dot tmp", numDots);
       // Call overload that takes a Kokkos::View<dot_type*, device_type>.
       this->dot (A, dts);
@@ -1686,7 +1686,7 @@ namespace Tpetra {
     ///
     /// \param norms [out] Device View with getNumVectors() entries.
     ///
-    /// \pre <tt>norms.dimension_0 () == this->getNumVectors ()</tt>
+    /// \pre <tt>norms.extent (0) == this->getNumVectors ()</tt>
     /// \post <tt>norms(j) == (this->getVector[j])->norm1 (* (A.getVector[j]))</tt>
     ///
     /// The one-norm of a vector is the sum of the magnitudes of the
@@ -1728,7 +1728,7 @@ namespace Tpetra {
     typename std::enable_if< ! (std::is_same<mag_type, T>::value), void >::type
     norm1 (const Kokkos::View<T*, device_type>& norms) const
     {
-      const size_t numNorms = norms.dimension_0 ();
+      const size_t numNorms = norms.extent (0);
       Kokkos::View<mag_type*, device_type> tmpNorms ("MV::norm1 tmp", numNorms);
       // Call overload that takes a Kokkos::View<mag_type*, device_type>.
       this->norm1 (tmpNorms);
@@ -1778,7 +1778,7 @@ namespace Tpetra {
     ///
     /// \param norms [out] Device View with getNumVectors() entries.
     ///
-    /// \pre <tt>norms.dimension_0 () == this->getNumVectors ()</tt>
+    /// \pre <tt>norms.extent (0) == this->getNumVectors ()</tt>
     /// \post <tt>norms(j) == (this->getVector[j])->dot (* (A.getVector[j]))</tt>
     ///
     /// The two-norm of a vector is the standard Euclidean norm, the
@@ -1819,7 +1819,7 @@ namespace Tpetra {
     typename std::enable_if< ! (std::is_same<mag_type, T>::value), void >::type
     norm2 (const Kokkos::View<T*, device_type>& norms) const
     {
-      const size_t numNorms = norms.dimension_0 ();
+      const size_t numNorms = norms.extent (0);
       Kokkos::View<mag_type*, device_type> theNorms ("MV::norm2 tmp", numNorms);
       // Call overload that takes a Kokkos::View<mag_type*, device_type>.
       this->norm2 (theNorms);
@@ -1904,7 +1904,7 @@ namespace Tpetra {
     typename std::enable_if< ! (std::is_same<mag_type, T>::value), void >::type
     normInf (const Kokkos::View<T*, device_type>& norms) const
     {
-      const size_t numNorms = norms.dimension_0 ();
+      const size_t numNorms = norms.extent (0);
       Kokkos::View<mag_type*, device_type> theNorms ("MV::normInf tmp", numNorms);
       // Call overload that takes a Kokkos::View<mag_type*, device_type>.
       this->normInf (theNorms);

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -204,11 +204,11 @@ namespace { // (anonymous)
     }
     if (debug) {
       TEUCHOS_TEST_FOR_EXCEPTION
-        (static_cast<size_t> (d_view.dimension_0 ()) != lclNumRows ||
-         static_cast<size_t> (d_view.dimension_1 ()) != numCols, std::logic_error,
+        (static_cast<size_t> (d_view.extent (0)) != lclNumRows ||
+         static_cast<size_t> (d_view.extent (1)) != numCols, std::logic_error,
          "allocDualView: d_view's dimensions actual dimensions do not match "
-         "requested dimensions.  d_view is " << d_view.dimension_0 () << " x " <<
-         d_view.dimension_1 () << "; requested " << lclNumRows << " x " << numCols
+         "requested dimensions.  d_view is " << d_view.extent (0) << " x " <<
+         d_view.extent (1) << "; requested " << lclNumRows << " x " << numCols
          << ".  Please report this bug to the Tpetra developers.");
     }
 
@@ -272,7 +272,7 @@ namespace { // (anonymous)
                const Kokkos::Impl::ALL_t&,
                const std::pair<size_t, size_t>& colRng)
   {
-    if (X.dimension_0 () == 0 && X.dimension_1 () != 0) {
+    if (X.extent (0) == 0 && X.extent (1) != 0) {
       return DualViewType ("MV::DualView", 0, colRng.second - colRng.first);
     }
     else {
@@ -289,7 +289,7 @@ namespace { // (anonymous)
                const std::pair<size_t, size_t>& rowRng,
                const std::pair<size_t, size_t>& colRng)
   {
-    if (X.dimension_0 () == 0 && X.dimension_1 () != 0) {
+    if (X.extent (0) == 0 && X.extent (1) != 0) {
       return DualViewType ("MV::DualView", 0, colRng.second - colRng.first);
     }
     else {
@@ -385,14 +385,14 @@ namespace Tpetra {
     // stride might be 0, so take view_dimension instead.
     size_t stride[8];
     origView_.stride (stride);
-    const size_t LDA = (origView_.dimension_1 () > 1) ? stride[1] :
-      origView_.dimension_0 ();
+    const size_t LDA = (origView_.extent (1) > 1) ? stride[1] :
+      origView_.extent (0);
     const size_t lclNumRows = this->getLocalLength (); // comes from the Map
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       LDA < lclNumRows, std::invalid_argument, "The input Kokkos::DualView's "
       "column stride LDA = " << LDA << " < getLocalLength() = " << lclNumRows
       << ".  This may also mean that the input view's first dimension (number "
-      "of rows = " << view.dimension_0 () << ") does not not match the number "
+      "of rows = " << view.extent (0) << ") does not not match the number "
       "of entries in the Map on the calling process.");
   }
 
@@ -413,14 +413,14 @@ namespace Tpetra {
     // be 0, so take view_dimension instead.
     size_t stride[8];
     d_view.stride (stride);
-    const size_t LDA = (d_view.dimension_1 () > 1) ? stride[1] :
-      d_view.dimension_0 ();
+    const size_t LDA = (d_view.extent (1) > 1) ? stride[1] :
+      d_view.extent (0);
     const size_t lclNumRows = this->getLocalLength (); // comes from the Map
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       LDA < lclNumRows, std::invalid_argument, "The input Kokkos::View's "
       "column stride LDA = " << LDA << " < getLocalLength() = " << lclNumRows
       << ".  This may also mean that the input view's first dimension (number "
-      "of rows = " << d_view.dimension_0 () << ") does not not match the "
+      "of rows = " << d_view.extent (0) << ") does not not match the "
       "number of entries in the Map on the calling process.");
 
     // The difference between create_mirror and create_mirror_view, is
@@ -449,14 +449,14 @@ namespace Tpetra {
     // stride might be 0, so take view_dimension instead.
     size_t stride[8];
     origView_.stride (stride);
-    const size_t LDA = (origView_.dimension_1 () > 1) ? stride[1] :
-      origView_.dimension_0 ();
+    const size_t LDA = (origView_.extent (1) > 1) ? stride[1] :
+      origView_.extent (0);
     const size_t lclNumRows = this->getLocalLength (); // comes from the Map
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       LDA < lclNumRows, std::invalid_argument, "The input Kokkos::DualView's "
       "column stride LDA = " << LDA << " < getLocalLength() = " << lclNumRows
       << ".  This may also mean that the input origView's first dimension (number "
-      "of rows = " << origView.dimension_0 () << ") does not not match the number "
+      "of rows = " << origView.extent (0) << ") does not not match the number "
       "of entries in the Map on the calling process.");
   }
 
@@ -484,13 +484,13 @@ namespace Tpetra {
     // require the number of columns to match if the (Dual)View has
     // more than zero rows.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      view.dimension_1 () != 0 && static_cast<size_t> (view.dimension_0 ()) < lclNumRows,
-      std::invalid_argument, "view.dimension_0() = " << view.dimension_0 ()
+      view.extent (1) != 0 && static_cast<size_t> (view.extent (0)) < lclNumRows,
+      std::invalid_argument, "view.extent(0) = " << view.extent (0)
       << " < map->getNodeNumElements() = " << lclNumRows << ".");
     if (whichVectors.size () != 0) {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-        view.dimension_1 () != 0 && view.dimension_1 () == 0,
-        std::invalid_argument, "view.dimension_1() = 0, but whichVectors.size()"
+        view.extent (1) != 0 && view.extent (1) == 0,
+        std::invalid_argument, "view.extent(1) = 0, but whichVectors.size()"
         " = " << whichVectors.size () << " > 0.");
       size_t maxColInd = 0;
       typedef Teuchos::ArrayView<const size_t>::size_type size_type;
@@ -502,8 +502,8 @@ namespace Tpetra {
         maxColInd = std::max (maxColInd, whichVectors[k]);
       }
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-        view.dimension_1 () != 0 && static_cast<size_t> (view.dimension_1 ()) <= maxColInd,
-        std::invalid_argument, "view.dimension_1() = " << view.dimension_1 ()
+        view.extent (1) != 0 && static_cast<size_t> (view.extent (1)) <= maxColInd,
+        std::invalid_argument, "view.extent(1) = " << view.extent (1)
         << " <= max(whichVectors) = " << maxColInd << ".");
     }
 
@@ -511,8 +511,8 @@ namespace Tpetra {
     // stride might be 0, so take view_dimension instead.
     size_t stride[8];
     origView_.stride (stride);
-    const size_t LDA = (origView_.dimension_1 () > 1) ? stride[1] :
-      origView_.dimension_0 ();
+    const size_t LDA = (origView_.extent (1) > 1) ? stride[1] :
+      origView_.extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       LDA < lclNumRows, std::invalid_argument,
       "LDA = " << LDA << " < this->getLocalLength() = " << lclNumRows << ".");
@@ -558,13 +558,13 @@ namespace Tpetra {
     // require the number of columns to match if the (Dual)View has
     // more than zero rows.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      view.dimension_1 () != 0 && static_cast<size_t> (view.dimension_0 ()) < lclNumRows,
-      std::invalid_argument, "view.dimension_0() = " << view.dimension_0 ()
+      view.extent (1) != 0 && static_cast<size_t> (view.extent (0)) < lclNumRows,
+      std::invalid_argument, "view.extent(0) = " << view.extent (0)
       << " < map->getNodeNumElements() = " << lclNumRows << ".");
     if (whichVectors.size () != 0) {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-        view.dimension_1 () != 0 && view.dimension_1 () == 0,
-        std::invalid_argument, "view.dimension_1() = 0, but whichVectors.size()"
+        view.extent (1) != 0 && view.extent (1) == 0,
+        std::invalid_argument, "view.extent(1) = 0, but whichVectors.size()"
         " = " << whichVectors.size () << " > 0.");
       size_t maxColInd = 0;
       typedef Teuchos::ArrayView<const size_t>::size_type size_type;
@@ -576,16 +576,16 @@ namespace Tpetra {
         maxColInd = std::max (maxColInd, whichVectors[k]);
       }
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-        view.dimension_1 () != 0 && static_cast<size_t> (view.dimension_1 ()) <= maxColInd,
-        std::invalid_argument, "view.dimension_1() = " << view.dimension_1 ()
+        view.extent (1) != 0 && static_cast<size_t> (view.extent (1)) <= maxColInd,
+        std::invalid_argument, "view.extent(1) = " << view.extent (1)
         << " <= max(whichVectors) = " << maxColInd << ".");
     }
     // Get stride of view: if second dimension is 0, the
     // stride might be 0, so take view_dimension instead.
     size_t stride[8];
     origView_.stride (stride);
-    const size_t LDA = (origView_.dimension_1 () > 1) ? stride[1] :
-      origView_.dimension_0 ();
+    const size_t LDA = (origView_.extent (1) > 1) ? stride[1] :
+      origView_.extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       LDA < lclNumRows, std::invalid_argument, "Input DualView's column stride"
       " = " << LDA << " < this->getLocalLength() = " << lclNumRows << ".");
@@ -661,8 +661,8 @@ namespace Tpetra {
     // case.
     size_t outStrides[8];
     X_out.stride (outStrides);
-    const size_t outStride = (X_out.dimension_1 () > 1) ? outStrides[1] :
-      X_out.dimension_0 ();
+    const size_t outStride = (X_out.extent (1) > 1) ? outStrides[1] :
+      X_out.extent (0);
     if (LDA == outStride) { // strides are the same; deep_copy once
       // This only works because MultiVector uses LayoutLeft.
       // We would need a custom copy functor otherwise.
@@ -776,8 +776,8 @@ namespace Tpetra {
       // stride might be 0, so take view_dimension instead.
       size_t stride[8];
       origView_.stride (stride);
-      const size_t LDA = (origView_.dimension_1 () > 1) ? stride[1] :
-        origView_.dimension_0 ();
+      const size_t LDA = (origView_.extent (1) > 1) ? stride[1] :
+        origView_.extent (0);
       return LDA;
     }
     else {
@@ -848,10 +848,10 @@ namespace Tpetra {
     }
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (permuteToLIDs.dimension_0 () != permuteFromLIDs.dimension_0 (),
-       std::runtime_error, "permuteToLIDs.dimension_0() = "
-       << permuteToLIDs.dimension_0 () << " != permuteFromLIDs.dimension_0() = "
-       << permuteFromLIDs.dimension_0 () << ".");
+      (permuteToLIDs.extent (0) != permuteFromLIDs.extent (0),
+       std::runtime_error, "permuteToLIDs.extent(0) = "
+       << permuteToLIDs.extent (0) << " != permuteFromLIDs.extent(0) = "
+       << permuteFromLIDs.extent (0) << ".");
 
     // We've already called checkSizes(), so this cast must succeed.
     const MV& sourceMV = dynamic_cast<const MV&> (sourceObj);
@@ -948,8 +948,8 @@ namespace Tpetra {
     // (such as ADD).
 
     // If there are no permutations, we are done
-    if (permuteFromLIDs.dimension_0 () == 0 ||
-        permuteToLIDs.dimension_0 () == 0) {
+    if (permuteFromLIDs.extent (0) == 0 ||
+        permuteToLIDs.extent (0) == 0) {
       if (debug) {
         std::ostringstream os;
         os << "(Proc " << myRank << ") MV::copyAndPermuteNew: "
@@ -1013,10 +1013,10 @@ namespace Tpetra {
                                                              copyOnHost);
       }
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (tgtWhichVecs.dimension_0 ()) !=
+        (static_cast<size_t> (tgtWhichVecs.extent (0)) !=
          this->getNumVectors (),
-         std::logic_error, "tgtWhichVecs.dimension_0() = " <<
-         tgtWhichVecs.dimension_0 () << " != this->getNumVectors() = " <<
+         std::logic_error, "tgtWhichVecs.extent(0) = " <<
+         tgtWhichVecs.extent (0) << " != this->getNumVectors() = " <<
          this->getNumVectors () << ".");
 
       if (sourceMV.whichVectors_.size () == 0) {
@@ -1039,9 +1039,9 @@ namespace Tpetra {
                                                              copyOnHost);
       }
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (srcWhichVecs.dimension_0 ()) !=
+        (static_cast<size_t> (srcWhichVecs.extent (0)) !=
          sourceMV.getNumVectors (), std::logic_error,
-         "srcWhichVecs.dimension_0() = " << srcWhichVecs.dimension_0 ()
+         "srcWhichVecs.extent(0) = " << srcWhichVecs.extent (0)
          << " != sourceMV.getNumVectors() = " << sourceMV.getNumVectors ()
          << ".");
     }
@@ -1214,8 +1214,8 @@ namespace Tpetra {
         // sourceMV was most recently updated on device; copy to host.
         // Allocate a new host mirror.  We'll use it for packing below.
         src_host = decltype (src_host) ("MV::DualView::h_view",
-                                        src_dev.dimension_0 (),
-                                        src_dev.dimension_1 ());
+                                        src_dev.extent (0),
+                                        src_dev.extent (1));
         Kokkos::deep_copy (src_host, src_dev);
       }
     }
@@ -1230,8 +1230,8 @@ namespace Tpetra {
         // sourceMV was most recently updated on host; copy to device.
         // Allocate a new "device mirror."  We'll use it for packing below.
         src_dev = decltype (src_dev) ("MV::DualView::d_view",
-                                      src_host.dimension_0 (),
-                                      src_host.dimension_1 ());
+                                      src_host.extent (0),
+                                      src_host.extent (1));
         Kokkos::deep_copy (src_dev, src_host);
       }
     }
@@ -1245,7 +1245,7 @@ namespace Tpetra {
 
     // If we have no exports, there is nothing to do.  Make sure this
     // goes _after_ setting constantNumPackets correctly.
-    if (exportLIDs.dimension_0 () == 0) {
+    if (exportLIDs.extent (0) == 0) {
       if (printDebugOutput) {
         std::ostringstream os;
         os << "Proc " << myRank << ": MV::packAndPrepareNew: "
@@ -1270,13 +1270,13 @@ namespace Tpetra {
     // needs to know how to index into that data.  Kokkos is good at
     // decoupling storage intent from data layout choice.
 
-    const size_t numExportLIDs = exportLIDs.dimension_0 ();
+    const size_t numExportLIDs = exportLIDs.extent (0);
     const size_t newExportsSize = numCols * numExportLIDs;
     if (printDebugOutput) {
       std::ostringstream os;
       os << "Proc " << myRank << ": MV::packAndPrepareNew: realloc: "
          << "numExportLIDs = " << numExportLIDs
-         << ", exports.dimension_0() = " << exports.dimension_0 ()
+         << ", exports.extent(0) = " << exports.extent (0)
          << ", newExportsSize = " << newExportsSize << std::endl;
       std::cerr << os.str ();
     }
@@ -1464,20 +1464,20 @@ namespace Tpetra {
     }
 
     // If we have no imports, there is nothing to do
-    if (importLIDs.dimension_0 () == 0) {
+    if (importLIDs.extent (0) == 0) {
       return;
     }
 
     const size_t numVecs = getNumVectors ();
     if (debugCheckIndices) {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (imports.dimension_0 ()) !=
-         numVecs * importLIDs.dimension_0 (),
+        (static_cast<size_t> (imports.extent (0)) !=
+         numVecs * importLIDs.extent (0),
          std::runtime_error,
-         "imports.dimension_0() = " << imports.dimension_0 ()
-         << " != getNumVectors() * importLIDs.dimension_0() = " << numVecs
-         << " * " << importLIDs.dimension_0 () << " = "
-         << numVecs * importLIDs.dimension_0 () << ".");
+         "imports.extent(0) = " << imports.extent (0)
+         << " != getNumVectors() * importLIDs.extent(0) = " << numVecs
+         << " * " << importLIDs.extent (0) << " = "
+         << numVecs * importLIDs.extent (0) << ".");
 
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (constantNumPackets == static_cast<size_t> (0), std::runtime_error,
@@ -1597,7 +1597,7 @@ namespace Tpetra {
       std::cerr << os.str ();
     }
 
-    if (numVecs > 0 && importLIDs.dimension_0 () > 0) {
+    if (numVecs > 0 && importLIDs.extent (0) > 0) {
       typedef typename Kokkos::DualView<IST*,
         device_type>::t_dev::execution_space dev_exec_space;
       typedef typename Kokkos::DualView<IST*,
@@ -1739,7 +1739,7 @@ namespace Tpetra {
   getNumVectors () const
   {
     if (isConstantStride ()) {
-      return static_cast<size_t> (view_.dimension_1 ());
+      return static_cast<size_t> (view_.extent (1));
     } else {
       return static_cast<size_t> (whichVectors_.size ());
     }
@@ -1758,7 +1758,7 @@ namespace Tpetra {
       using Teuchos::reduceAll;
       typedef typename RV::non_const_value_type dot_type;
 
-      const size_t numVecs = dotsOut.dimension_0 ();
+      const size_t numVecs = dotsOut.extent (0);
 
       // If the MultiVector is distributed over multiple processes, do
       // the distributed (interprocess) part of the dot product.  We
@@ -1785,12 +1785,12 @@ namespace Tpetra {
           // sum.
           typename RV::non_const_type lclDots (Kokkos::ViewAllocateWithoutInitializing ("tmp"), numVecs);
           Kokkos::deep_copy (lclDots, dotsOut);
-          const dot_type* const lclSum = lclDots.ptr_on_device ();
-          dot_type* const gblSum = dotsOut.ptr_on_device ();
+          const dot_type* const lclSum = lclDots.data ();
+          dot_type* const gblSum = dotsOut.data ();
           reduceAll<int, dot_type> (*comm, REDUCE_SUM, nv, lclSum, gblSum);
         }
         else {
-          dot_type* const inout = dotsOut.ptr_on_device ();
+          dot_type* const inout = dotsOut.data ();
           reduceAll<int, dot_type> (*comm, REDUCE_SUM, nv, inout, inout);
         }
       }
@@ -1821,7 +1821,7 @@ namespace Tpetra {
       return; // nothing to do
     }
     const size_t lclNumRows = this->getLocalLength ();
-    const size_t numDots = static_cast<size_t> (dots.dimension_0 ());
+    const size_t numDots = static_cast<size_t> (dots.extent (0));
     const bool debug = Behavior::debug ();
 
     if (debug) {
@@ -1852,7 +1852,7 @@ namespace Tpetra {
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       numDots != numVecs, std::runtime_error,
       "The output array 'dots' must have the same number of entries as the "
-      "number of columns (vectors) in *this and A.  dots.dimension_0() = " <<
+      "number of columns (vectors) in *this and A.  dots.extent(0) = " <<
       numDots << " != this->getNumVectors() = " << numVecs << ".");
 
     const std::pair<size_t, size_t> colRng (0, numVecs);
@@ -2018,7 +2018,7 @@ namespace Tpetra {
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (numDots != numVecs, std::runtime_error,
        "The output array 'dots' must have the same number of entries as the "
-       "number of columns (vectors) in *this and A.  dots.dimension_0() = " <<
+       "number of columns (vectors) in *this and A.  dots.extent(0) = " <<
        numDots << " != this->getNumVectors() = " << numVecs << ".");
 
     if (numVecs == 1 && this->isConstantStride () && A.isConstantStride ()) {
@@ -2136,7 +2136,7 @@ namespace Tpetra {
     if (! comm.is_null () && this->isDistributed ()) {
       // Assume that MPI can access device memory.
       reduceAll<int, mag_type> (*comm, REDUCE_SUM, static_cast<int> (numVecs),
-                                lclNrms.ptr_on_device (), norms.getRawPtr ());
+                                lclNrms.data (), norms.getRawPtr ());
       for (size_t k = 0; k < numVecs; ++k) {
         norms[k] = ATM::sqrt (norms[k] * OneOverN);
       }
@@ -2238,19 +2238,19 @@ namespace Tpetra {
       // it returns a 0 x 0 (Dual)View.
       TEUCHOS_TEST_FOR_EXCEPTION(
         lclNumRows != 0 && constantStride && ( \
-          ( X.dimension_0 () != lclNumRows ) ||
-          ( X.dimension_1 () != numVecs    ) ),
-        std::logic_error, "Constant Stride X's dimensions are " << X.dimension_0 () << " x "
-        << X.dimension_1 () << ", which differ from the local dimensions "
+          ( X.extent (0) != lclNumRows ) ||
+          ( X.extent (1) != numVecs    ) ),
+        std::logic_error, "Constant Stride X's dimensions are " << X.extent (0) << " x "
+        << X.extent (1) << ", which differ from the local dimensions "
         << lclNumRows << " x " << numVecs << ".  Please report this bug to "
         "the Tpetra developers.");
 
       TEUCHOS_TEST_FOR_EXCEPTION(
         lclNumRows != 0 && !constantStride && ( \
-          ( X.dimension_0 () != lclNumRows ) ||
-          ( X.dimension_1 () < numVecs    ) ),
-        std::logic_error, "Strided X's dimensions are " << X.dimension_0 () << " x "
-        << X.dimension_1 () << ", which are incompatible with the local dimensions "
+          ( X.extent (0) != lclNumRows ) ||
+          ( X.extent (1) < numVecs    ) ),
+        std::logic_error, "Strided X's dimensions are " << X.extent (0) << " x "
+        << X.extent (1) << ", which are incompatible with the local dimensions "
         << lclNumRows << " x " << numVecs << ".  Please report this bug to "
         "the Tpetra developers.");
 
@@ -2337,7 +2337,7 @@ namespace Tpetra {
       using Teuchos::reduceAll;
       typedef typename RV::non_const_value_type mag_type;
 
-      const size_t numVecs = normsOut.dimension_0 ();
+      const size_t numVecs = normsOut.extent (0);
 
       // If the MultiVector is distributed over multiple processes, do
       // the distributed (interprocess) part of the norm.  We assume
@@ -2360,8 +2360,8 @@ namespace Tpetra {
         // a copy of the local sum.
         RV lclNorms ("MV::normImpl lcl", numVecs);
         Kokkos::deep_copy (lclNorms, normsOut);
-        const mag_type* const lclSum = lclNorms.ptr_on_device ();
-        mag_type* const gblSum = normsOut.ptr_on_device ();
+        const mag_type* const lclSum = lclNorms.data ();
+        mag_type* const gblSum = normsOut.data ();
         const int nv = static_cast<int> (numVecs);
         if (whichNorm == IMPL_NORM_INF) {
           reduceAll<int, mag_type> (*comm, REDUCE_MAX, nv, lclSum, gblSum);
@@ -2418,11 +2418,11 @@ namespace Tpetra {
       return; // nothing to do
     }
     const size_t lclNumRows = this->getLocalLength ();
-    const size_t numNorms = static_cast<size_t> (norms.dimension_0 ());
+    const size_t numNorms = static_cast<size_t> (norms.extent (0));
     TEUCHOS_TEST_FOR_EXCEPTION(
       numNorms < numVecs, std::runtime_error, "Tpetra::MultiVector::normImpl: "
       "'norms' must have at least as many entries as the number of vectors in "
-      "*this.  norms.dimension_0() = " << numNorms << " < this->getNumVectors()"
+      "*this.  norms.extent(0) = " << numNorms << " < this->getNumVectors()"
       " = " << numVecs << ".");
 
     const std::pair<size_t, size_t> colRng (0, numVecs);
@@ -2529,7 +2529,7 @@ namespace Tpetra {
       // copy lclSums into meansOut.
       if (! comm.is_null () && this->isDistributed ()) {
         reduceAll (*comm, REDUCE_SUM, static_cast<int> (numVecs),
-                   lclSums.ptr_on_device (), meansOut.ptr_on_device ());
+                   lclSums.data (), meansOut.data ());
       }
       else {
         Kokkos::deep_copy (meansOut, lclSums);
@@ -2558,7 +2558,7 @@ namespace Tpetra {
       // into meansOut.
       if (! comm.is_null () && this->isDistributed ()) {
         reduceAll (*comm, REDUCE_SUM, static_cast<int> (numVecs),
-                   lclSums.ptr_on_device (), meansOut.ptr_on_device ());
+                   lclSums.data (), meansOut.data ());
       }
       else {
         Kokkos::deep_copy (meansOut, lclSums);
@@ -2769,10 +2769,10 @@ namespace Tpetra {
       // Case 3: current Map is null, new Map is nonnull.
       // Reallocate the DualView with the right dimensions.
       const size_t newNumRows = newMap->getNodeNumElements ();
-      const size_t origNumRows = view_.dimension_0 ();
+      const size_t origNumRows = view_.extent (0);
       const size_t numCols = this->getNumVectors ();
 
-      if (origNumRows != newNumRows || view_.dimension_1 () != numCols) {
+      if (origNumRows != newNumRows || view_.extent (1) != numCols) {
         view_ = allocDualView<Scalar, LocalOrdinal, GlobalOrdinal, Node> (newNumRows, numCols);
       }
     }
@@ -2878,9 +2878,9 @@ namespace Tpetra {
     const size_t lclNumRows = this->getLocalLength ();
     const size_t numVecs = this->getNumVectors ();
     TEUCHOS_TEST_FOR_EXCEPTION(
-      static_cast<size_t> (alphas.dimension_0 ()) != numVecs,
+      static_cast<size_t> (alphas.extent (0)) != numVecs,
       std::invalid_argument, "Tpetra::MultiVector::scale(alphas): "
-      "alphas.dimension_0() = " << alphas.dimension_0 ()
+      "alphas.extent(0) = " << alphas.extent (0)
       << " != this->getNumVectors () = " << numVecs << ".");
     const std::pair<size_t, size_t> rowRng (0, lclNumRows);
     const std::pair<size_t, size_t> colRng (0, numVecs);
@@ -3338,9 +3338,9 @@ namespace Tpetra {
       Kokkos::Compat::persistingView (hostView_j, 0, getLocalLength ());
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<size_t> (hostView_j.dimension_0 ()) <
+      (static_cast<size_t> (hostView_j.extent (0)) <
        static_cast<size_t> (dataAsArcp.size ()), std::logic_error,
-       "hostView_j.dimension_0() = " << hostView_j.dimension_0 ()
+       "hostView_j.extent(0) = " << hostView_j.extent (0)
        << " < dataAsArcp.size() = " << dataAsArcp.size () << ".  "
        "Please report this bug to the Tpetra developers.");
 
@@ -3379,9 +3379,9 @@ namespace Tpetra {
       Kokkos::Compat::persistingView (hostView_j, 0, getLocalLength ());
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<size_t> (hostView_j.dimension_0 ()) <
+      (static_cast<size_t> (hostView_j.extent (0)) <
        static_cast<size_t> (dataAsArcp.size ()), std::logic_error,
-       "hostView_j.dimension_0() = " << hostView_j.dimension_0 ()
+       "hostView_j.extent(0) = " << hostView_j.extent (0)
        << " < dataAsArcp.size() = " << dataAsArcp.size () << ".  "
        "Please report this bug to the Tpetra developers.");
 
@@ -3463,14 +3463,14 @@ namespace Tpetra {
   size_t
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getOrigNumLocalRows () const {
-    return origView_.dimension_0 ();
+    return origView_.extent (0);
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   size_t
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getOrigNumLocalCols () const {
-    return origView_.dimension_1 ();
+    return origView_.extent (1);
   }
 
   template <class Scalar, class LO, class GO, class Node>
@@ -3508,10 +3508,10 @@ namespace Tpetra {
     const size_t lclNumRowsBefore = X.getLocalLength ();
     const size_t numColsBefore = X.getNumVectors ();
     const impl_scalar_type* hostPtrBefore =
-      X.template getLocalView<Kokkos::HostSpace> ().ptr_on_device ();
+      X.template getLocalView<Kokkos::HostSpace> ().data ();
 #endif // HAVE_TPETRA_DEBUG
 
-    const std::pair<size_t, size_t> origRowRng (offset, X.origView_.dimension_0 ());
+    const std::pair<size_t, size_t> origRowRng (offset, X.origView_.extent (0));
     const std::pair<size_t, size_t> rowRng (offset, offset + newNumRows);
 
     dual_view_type newOrigView = subview (X.origView_, origRowRng, ALL ());
@@ -3532,13 +3532,13 @@ namespace Tpetra {
     // reason, the ([0,0], [0,2]) subview of a 0 x 2 DualView is 0 x
     // 0.  We work around by creating a new empty DualView of the
     // desired (degenerate) dimensions.
-    if (newOrigView.dimension_0 () == 0 &&
-        newOrigView.dimension_1 () != X.origView_.dimension_1 ()) {
+    if (newOrigView.extent (0) == 0 &&
+        newOrigView.extent (1) != X.origView_.extent (1)) {
       newOrigView = allocDualView<Scalar, LO, GO, Node> (size_t (0),
                                                          X.getNumVectors ());
     }
-    if (newView.dimension_0 () == 0 &&
-        newView.dimension_1 () != X.view_.dimension_1 ()) {
+    if (newView.extent (0) == 0 &&
+        newView.extent (1) != X.view_.extent (1)) {
       newView = allocDualView<Scalar, LO, GO, Node> (size_t (0),
                                                      X.getNumVectors ());
     }
@@ -3554,7 +3554,7 @@ namespace Tpetra {
     const size_t lclNumRowsAfter = X.getLocalLength ();
     const size_t numColsAfter = X.getNumVectors ();
     const impl_scalar_type* hostPtrAfter =
-      X.template getLocalView<Kokkos::HostSpace> ().ptr_on_device ();
+      X.template getLocalView<Kokkos::HostSpace> ().data ();
 
     const size_t strideRet = subViewMV.isConstantStride () ?
       subViewMV.getStride () :
@@ -3825,13 +3825,13 @@ namespace Tpetra {
     // exports_.  Taking subviews now ensures that their lengths will
     // be exactly what we need, so we won't have to resize them later.
     {
-      const size_t newSize = X.imports_.dimension_0 () / numCols;
+      const size_t newSize = X.imports_.extent (0) / numCols;
       auto newImports = X.imports_;
       newImports.d_view = subview (X.imports_.d_view, range_type (0, newSize));
       newImports.h_view = subview (X.imports_.h_view, range_type (0, newSize));
     }
     {
-      const size_t newSize = X.exports_.dimension_0 () / numCols;
+      const size_t newSize = X.exports_.extent (0) / numCols;
       auto newExports = X.exports_;
       newExports.d_view = subview (X.exports_.d_view, range_type (0, newSize));
       newExports.h_view = subview (X.exports_.h_view, range_type (0, newSize));
@@ -3928,7 +3928,7 @@ namespace Tpetra {
       if (useHostVersion) {
         auto srcColView_host = Kokkos::subview (srcView_host, rowRange, srcCol);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-          dstColView.dimension_0 () != srcColView_host.dimension_0 (),
+          dstColView.extent (0) != srcColView_host.extent (0),
           std::logic_error, ": srcColView and dstColView_host have different "
           "dimensions.  Please report this bug to the Tpetra developers.");
         Kokkos::deep_copy (dstColView, srcColView_host);
@@ -3936,7 +3936,7 @@ namespace Tpetra {
       else {
         auto srcColView_dev = Kokkos::subview (srcView_dev, rowRange, srcCol);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-          dstColView.dimension_0 () != srcColView_dev.dimension_0 (),
+          dstColView.extent (0) != srcColView_dev.extent (0),
           std::logic_error, ": srcColView and dstColView_dev have different "
           "dimensions.  Please report this bug to the Tpetra developers.");
         Kokkos::deep_copy (dstColView, srcColView_dev);
@@ -4421,7 +4421,7 @@ namespace Tpetra {
     host_view_type srcView_host;
     if (useHostVersion) {
       srcView_host = this->template getLocalView<Kokkos::HostSpace> ();
-      if (lclNumRows != static_cast<size_t> (srcView_host.dimension_0 ())) {
+      if (lclNumRows != static_cast<size_t> (srcView_host.extent (0))) {
         // Make sure the number of rows is correct.  If not, take a subview.
         const Kokkos::pair<size_t, size_t> rowRng (0, lclNumRows);
         srcView_host = Kokkos::subview (srcView_host, rowRng, Kokkos::ALL ());
@@ -4429,7 +4429,7 @@ namespace Tpetra {
     }
     else {
       srcView_dev = this->template getLocalView<device_type> ();
-      if (lclNumRows != static_cast<size_t> (srcView_dev.dimension_0 ())) {
+      if (lclNumRows != static_cast<size_t> (srcView_dev.extent (0))) {
         // Make sure the number of rows is correct.  If not, take a subview.
         const Kokkos::pair<size_t, size_t> rowRng (0, lclNumRows);
         srcView_dev = Kokkos::subview (srcView_dev, rowRng, Kokkos::ALL ());
@@ -4499,8 +4499,8 @@ namespace Tpetra {
          << tgtBuf_host.size () << " < lclNumRows*numCols = " << totalAllocSize
          << ".  Please report this bug to the Tpetra developers.");
       reduceAll<int, impl_scalar_type> (comm, REDUCE_SUM, reduceCount,
-                                        srcBuf_host.ptr_on_device (),
-                                        tgtBuf_host.ptr_on_device ());
+                                        srcBuf_host.data (),
+                                        tgtBuf_host.data ());
     }
     else { // use device version
       TEUCHOS_TEST_FOR_EXCEPTION
@@ -4509,8 +4509,8 @@ namespace Tpetra {
          << tgtBuf_dev.size () << " < lclNumRows*numCols = " << totalAllocSize
          << ".  Please report this bug to the Tpetra developers.");
       reduceAll<int, impl_scalar_type> (comm, REDUCE_SUM, reduceCount,
-                                        srcBuf_dev.ptr_on_device (),
-                                        tgtBuf_dev.ptr_on_device ());
+                                        srcBuf_dev.data (),
+                                        tgtBuf_dev.data ());
     }
 
     // Write back the results to *this.
@@ -5179,9 +5179,9 @@ namespace Tpetra {
     size_t l1 = this->getLocalLength();
     size_t l2 = vec.getLocalLength();
     if ((l1!=l2) || (this->getNumVectors() != vec.getNumVectors()))
-      return false;    
+      return false;
     if(l1==0)  return true;
-     
+
     auto v1 = this->template getLocalView<HES>();
     auto v2 = vec.template getLocalView<HES>();
     if(Details::PackTraits<ST,HES>::packValueCount(v1(0,0)) != Details::PackTraits<ST,HES>::packValueCount(v2(0,0)))

--- a/packages/tpetra/core/src/Tpetra_TsqrAdaptor.hpp
+++ b/packages/tpetra/core/src/Tpetra_TsqrAdaptor.hpp
@@ -229,12 +229,12 @@ namespace Tpetra {
       auto A_view = A.template getLocalView<Kokkos::HostSpace> ();
       auto Q_view = Q.template getLocalView<Kokkos::HostSpace> ();
       scalar_type* const A_ptr =
-        reinterpret_cast<scalar_type*> (A_view.ptr_on_device ());
+        reinterpret_cast<scalar_type*> (A_view.data ());
       scalar_type* const Q_ptr =
-        reinterpret_cast<scalar_type*> (Q_view.ptr_on_device ());
+        reinterpret_cast<scalar_type*> (Q_view.data ());
       const bool contiguousCacheBlocks = false;
-      tsqr_->factorExplicitRaw (A_view.dimension_0 (),
-                                A_view.dimension_1 (),
+      tsqr_->factorExplicitRaw (A_view.extent (0),
+                                A_view.extent (1),
                                 A_ptr, A.getStride (),
                                 Q_ptr, Q.getStride (),
                                 R.values (), R.stride (),
@@ -289,10 +289,10 @@ namespace Tpetra {
       Q.template modify<Kokkos::HostSpace> ();
       auto Q_view = Q.template getLocalView<Kokkos::HostSpace> ();
       scalar_type* const Q_ptr =
-        reinterpret_cast<scalar_type*> (Q_view.ptr_on_device ());
+        reinterpret_cast<scalar_type*> (Q_view.data ());
       const bool contiguousCacheBlocks = false;
-      return tsqr_->revealRankRaw (Q_view.dimension_0 (),
-                                   Q_view.dimension_1 (),
+      return tsqr_->revealRankRaw (Q_view.extent (0),
+                                   Q_view.extent (1),
                                    Q_ptr, Q.getStride (),
                                    R.values (), R.stride (),
                                    tol, contiguousCacheBlocks);

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -884,8 +884,8 @@ namespace Tpetra {
 
       auto x_host = x.template view<Kokkos::HostSpace> ();
       typedef typename DualViewType::t_dev::value_type value_type;
-      return Teuchos::ArrayView<value_type> (x_host.ptr_on_device (),
-                                             x_host.dimension_0 ());
+      return Teuchos::ArrayView<value_type> (x_host.data (),
+                                             x_host.extent (0));
     }
 
     /// \brief Get a 1-D Kokkos::DualView which is a deep copy of the
@@ -942,7 +942,7 @@ namespace Tpetra {
       const auto dev = dv.modified_host ();
 
       std::ostringstream os;
-      os << name << ": {size: " << dv.dimension_0 ()
+      os << name << ": {size: " << dv.extent (0)
          << ", sync: {host: " << host << ", dev: " << dev << "}";
       return os.str ();
     }

--- a/packages/tpetra/core/src/Tpetra_Vector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_def.hpp
@@ -248,7 +248,7 @@ namespace Tpetra {
 
     if (! comm.is_null () && this->isDistributed ()) {
       // Assume that MPI can access device memory.
-      reduceAll<int, mag_type> (*comm, REDUCE_SUM, 1, lclNrm.ptr_on_device (),
+      reduceAll<int, mag_type> (*comm, REDUCE_SUM, 1, lclNrm.data (),
                                 &gblNrm);
       gblNrm = ATM::sqrt (gblNrm * OneOverN);
     }

--- a/packages/tpetra/core/src/Tpetra_idot.hpp
+++ b/packages/tpetra/core/src/Tpetra_idot.hpp
@@ -203,7 +203,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
           auto Y_j_2d = Y_j->template getLocalView<dev_memory_space> ();
           auto Y_j_1d = subview (Y_j_2d, rowRange, 0);
           typename decltype (Y_j_1d_h)::non_const_type
-            Y_j_1d_h_nc ("Y_j_1d_h", Y_j_1d.dimension_0 ());
+            Y_j_1d_h_nc ("Y_j_1d_h", Y_j_1d.extent (0));
           deep_copy (Y_j_1d_h_nc, Y_j_1d);
           Y_j_1d_h = Y_j_1d_h_nc;
         }
@@ -223,7 +223,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
           auto Y_j_2d_h = Y_j->template getLocalView<host_memory_space> ();
           auto Y_j_1d_h = subview (Y_j_2d_h, rowRange, 0);
           typename decltype (Y_j_1d)::non_const_type
-            Y_j_1d_nc ("Y_j_1d", Y_j_1d_h.dimension_0 ());
+            Y_j_1d_nc ("Y_j_1d", Y_j_1d_h.extent (0));
           deep_copy (Y_j_1d_nc, Y_j_1d_h);
           Y_j_1d = Y_j_1d_nc;
         }
@@ -244,7 +244,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
       if (Y_copyToHost) {
         auto Y_lcl = Y.template getLocalView<dev_memory_space> ();
         typename decltype (Y_lcl_h)::non_const_type
-          Y_lcl_h_nc ("Y_lcl_h", Y_lcl.dimension_0 (), Y_numVecs);
+          Y_lcl_h_nc ("Y_lcl_h", Y_lcl.extent (0), Y_numVecs);
         deep_copy (Y_lcl_h_nc, Y_lcl);
         Y_lcl_h = Y_lcl_h_nc;
       }
@@ -273,7 +273,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
       if (Y_copyToDev) {
         auto Y_lcl_h = Y.template getLocalView<host_memory_space> ();
         typename decltype (Y_lcl)::non_const_type
-          Y_lcl_nc ("Y_lcl", Y_lcl_h.dimension_0 (), Y_numVecs);
+          Y_lcl_nc ("Y_lcl", Y_lcl_h.extent (0), Y_numVecs);
         deep_copy (Y_lcl_nc, Y_lcl_h);
         Y_lcl = Y_lcl_nc;
       }
@@ -418,7 +418,7 @@ idot (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* resultRaw,
     result_dev_view_type lclResult = needCopy ?
       result_dev_view_type ("lclResult", numVecs) :
       gblResult;
-    Details::lclDotRaw (lclResult.ptr_on_device (), X, Y, resultOnDevice);
+    Details::lclDotRaw (lclResult.data (), X, Y, resultOnDevice);
     return iallreduce (lclResult, gblResult, ::Teuchos::REDUCE_SUM, *comm);
   }
   else {
@@ -426,7 +426,7 @@ idot (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* resultRaw,
     result_host_view_type lclResult = needCopy ?
       result_host_view_type ("lclResult", numVecs) :
       gblResult;
-    Details::lclDotRaw (lclResult.ptr_on_device (), X, Y, resultOnDevice);
+    Details::lclDotRaw (lclResult.data (), X, Y, resultOnDevice);
     return iallreduce (lclResult, gblResult, ::Teuchos::REDUCE_SUM, *comm);
   }
 }
@@ -504,7 +504,7 @@ idot (const Kokkos::View<typename ::Tpetra::Vector<SC, LO, GO, NT>::dot_type,
   result_view_type lclResult = needCopy ?
     result_view_type ("lclResult") :
     gblResult;
-  Details::lclDotRaw (lclResult.ptr_on_device (), X, Y, resultOnDevice);
+  Details::lclDotRaw (lclResult.data (), X, Y, resultOnDevice);
   return iallreduce (lclResult, gblResult, ::Teuchos::REDUCE_SUM, *comm);
 }
 
@@ -617,9 +617,9 @@ idot (const Kokkos::View<typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_typ
   constexpr bool resultOnDevice = true; // 'result' is a device View
   result_view_type gblResult = result;
   result_view_type lclResult = needCopy ?
-    result_view_type ("lclResult", result.dimension_0 ()) :
+    result_view_type ("lclResult", result.extent (0)) :
     gblResult;
-  Details::lclDotRaw (lclResult.ptr_on_device (), X, Y, resultOnDevice);
+  Details::lclDotRaw (lclResult.data (), X, Y, resultOnDevice);
   return iallreduce (lclResult, gblResult, ::Teuchos::REDUCE_SUM, *comm);
 }
 

--- a/packages/tpetra/core/src/kokkos_refactor/Kokkos_MV_GEMM.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Kokkos_MV_GEMM.hpp
@@ -188,7 +188,7 @@ namespace Kokkos {
     size_t getStride2DView (ViewType A) {
       size_t stride[8];
       A.stride (stride);
-      return A.dimension_1 () > 1 ? stride[1] : A.dimension_0 ();
+      return A.extent (1) > 1 ? stride[1] : A.extent (0);
     }
   }
 
@@ -210,17 +210,17 @@ namespace Kokkos {
           const Scalar& beta,
           const View<Scalar**, LayoutLeft, DeviceType>& C)
     {
-      const int n = static_cast<int> (C.dimension_1 ());
+      const int n = static_cast<int> (C.extent (1));
 
       // For some BLAS implementations (e.g., MKL), GEMM when B has
       // one column may be signficantly less efficient than GEMV.
       if (n == 1 && transB == Teuchos::NO_TRANS) {
         const int lda = static_cast<int> (Impl::getStride2DView (A));
         Teuchos::BLAS<int,Scalar> blas;
-        blas.GEMV (transA, A.dimension_0 (), A.dimension_1 (),
-                   alpha, A.ptr_on_device (), lda,
-                   B.ptr_on_device (), static_cast<int> (1),
-                   beta, C.ptr_on_device (), static_cast<int> (1));
+        blas.GEMV (transA, A.extent (0), A.extent (1),
+                   alpha, A.data (), lda,
+                   B.data (), static_cast<int> (1),
+                   beta, C.data (), static_cast<int> (1));
       }
       else {
         const char ctransA = (transA == Teuchos::CONJ_TRANS ? 'C' :
@@ -247,7 +247,7 @@ namespace Kokkos {
           const double& beta,
           const View<double**, LayoutLeft, DeviceType>& C)
     {
-      const int n = static_cast<int> (C.dimension_1 ());
+      const int n = static_cast<int> (C.extent (1));
 
       // For some BLAS implementations (e.g., MKL), GEMM when B has
       // one column may be signficantly less efficient than GEMV.

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -192,7 +192,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
 
       const index_type lclRow = idx(k);
       if (lclRow < static_cast<index_type> (0) ||
-          lclRow >= static_cast<index_type> (src.dimension_0 ())) {
+          lclRow >= static_cast<index_type> (src.extent (0))) {
         result = 0; // failed!
       }
       else {
@@ -235,10 +235,10 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<index_type> badIndices;
-        const size_type numInds = idx_h.dimension_0 ();
+        const size_type numInds = idx_h.extent (0);
         for (size_type k = 0; k < numInds; ++k) {
           if (idx_h(k) < static_cast<index_type> (0) ||
-              idx_h(k) >= static_cast<index_type> (src.dimension_0 ())) {
+              idx_h(k) >= static_cast<index_type> (src.extent (0))) {
             badIndices.push_back (idx_h(k));
           }
         }
@@ -354,7 +354,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
 
       const index_type lclRow = idx(k);
       if (lclRow < static_cast<index_type> (0) ||
-          lclRow >= static_cast<index_type> (src.dimension_0 ())) {
+          lclRow >= static_cast<index_type> (src.extent (0))) {
         result = 0; // failed!
       }
       else {
@@ -400,10 +400,10 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<index_type> badIndices;
-        const size_type numInds = idx_h.dimension_0 ();
+        const size_type numInds = idx_h.extent (0);
         for (size_type k = 0; k < numInds; ++k) {
           if (idx_h(k) < static_cast<index_type> (0) ||
-              idx_h(k) >= static_cast<index_type> (src.dimension_0 ())) {
+              idx_h(k) >= static_cast<index_type> (src.extent (0))) {
             badIndices.push_back (idx_h(k));
           }
         }
@@ -531,14 +531,14 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
 
       const row_index_type lclRow = idx(k);
       if (lclRow < static_cast<row_index_type> (0) ||
-          lclRow >= static_cast<row_index_type> (src.dimension_0 ())) {
+          lclRow >= static_cast<row_index_type> (src.extent (0))) {
         result.first = 0; // failed!
       }
       else {
         const size_type offset = k*numCols;
         for (size_type j = 0; j < numCols; ++j) {
           const col_index_type lclCol = col(j);
-          if (Impl::outOfBounds<col_index_type> (lclCol, src.dimension_1 ())) {
+          if (Impl::outOfBounds<col_index_type> (lclCol, src.extent (1))) {
             result.second = 0; // failed!
           }
           else { // all indices are valid; do the assignment
@@ -595,9 +595,9 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
           Kokkos::deep_copy (idx_h, idx);
 
           std::vector<row_index_type> badRows;
-          const size_type numInds = idx_h.dimension_0 ();
+          const size_type numInds = idx_h.extent (0);
           for (size_type k = 0; k < numInds; ++k) {
-            if (Impl::outOfBounds<row_index_type> (idx_h(k), src.dimension_0 ())) {
+            if (Impl::outOfBounds<row_index_type> (idx_h(k), src.extent (0))) {
               badRows.push_back (idx_h(k));
             }
           }
@@ -621,9 +621,9 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
           Kokkos::deep_copy (col_h, col);
 
           std::vector<col_index_type> badCols;
-          const size_type numInds = col_h.dimension_0 ();
+          const size_type numInds = col_h.extent (0);
           for (size_type k = 0; k < numInds; ++k) {
-            if (Impl::outOfBounds<col_index_type> (col_h(k), src.dimension_1 ())) {
+            if (Impl::outOfBounds<col_index_type> (col_h(k), src.extent (1))) {
               badCols.push_back (col_h(k));
             }
           }
@@ -906,7 +906,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
 
       const index_type lclRow = idx(k);
       if (lclRow < static_cast<index_type> (0) ||
-          lclRow >= static_cast<index_type> (dst.dimension_0 ())) {
+          lclRow >= static_cast<index_type> (dst.extent (0))) {
         result = 0; // failed!
       }
       else {
@@ -955,10 +955,10 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<index_type> badIndices;
-        const size_type numInds = idx_h.dimension_0 ();
+        const size_type numInds = idx_h.extent (0);
         for (size_type k = 0; k < numInds; ++k) {
           if (idx_h(k) < static_cast<index_type> (0) ||
-              idx_h(k) >= static_cast<index_type> (dst.dimension_0 ())) {
+              idx_h(k) >= static_cast<index_type> (dst.extent (0))) {
             badIndices.push_back (idx_h(k));
           }
         }
@@ -1163,7 +1163,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
 
       const row_index_type lclRow = idx(k);
       if (lclRow < static_cast<row_index_type> (0) ||
-          lclRow >= static_cast<row_index_type> (dst.dimension_0 ())) {
+          lclRow >= static_cast<row_index_type> (dst.extent (0))) {
         result.first = 0; // failed!
       }
       else {
@@ -1171,7 +1171,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         for (size_type j = 0; j < numCols; ++j) {
           const col_index_type lclCol = col(j);
 
-          if (Impl::outOfBounds<col_index_type> (lclCol, dst.dimension_1 ())) {
+          if (Impl::outOfBounds<col_index_type> (lclCol, dst.extent (1))) {
             result.second = 0; // failed!
           }
           else { // all indices are valid; apply the op
@@ -1231,10 +1231,10 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
           Kokkos::deep_copy (idx_h, idx);
 
           std::vector<row_index_type> badRows;
-          const size_type numInds = idx_h.dimension_0 ();
+          const size_type numInds = idx_h.extent (0);
           for (size_type k = 0; k < numInds; ++k) {
             if (idx_h(k) < static_cast<row_index_type> (0) ||
-                idx_h(k) >= static_cast<row_index_type> (dst.dimension_0 ())) {
+                idx_h(k) >= static_cast<row_index_type> (dst.extent (0))) {
               badRows.push_back (idx_h(k));
             }
           }
@@ -1258,9 +1258,9 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
           Kokkos::deep_copy (col_h, col);
 
           std::vector<col_index_type> badCols;
-          const size_type numInds = col_h.dimension_0 ();
+          const size_type numInds = col_h.extent (0);
           for (size_type k = 0; k < numInds; ++k) {
-            if (Impl::outOfBounds<col_index_type> (col_h(k), dst.dimension_1 ())) {
+            if (Impl::outOfBounds<col_index_type> (col_h(k), dst.extent (1))) {
               badCols.push_back (col_h(k));
             }
           }

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp
@@ -95,30 +95,30 @@ namespace Details {
       src_ (src),
       dstWhichVecs_ (dstWhichVecs),
       srcWhichVecs_ (srcWhichVecs),
-      numVecs_ (DstConstStride ? dst.dimension_1 () : dstWhichVecs.dimension_0 ())
+      numVecs_ (DstConstStride ? dst.extent (1) : dstWhichVecs.extent (0))
     {
       TEUCHOS_TEST_FOR_EXCEPTION(
         ! DstConstStride && ! SrcConstStride &&
-        dstWhichVecs.dimension_0 () != srcWhichVecs.dimension_0 (),
+        dstWhichVecs.extent (0) != srcWhichVecs.extent (0),
         std::invalid_argument, "LocalDeepCopyFunctor (4-arg constructor): "
         "Neither src nor dst have constant stride, but "
-        "dstWhichVecs.dimension_0() = " << dstWhichVecs.dimension_0 ()
-        << " != srcWhichVecs.dimension_0() = " << srcWhichVecs.dimension_0 ()
+        "dstWhichVecs.extent(0) = " << dstWhichVecs.extent (0)
+        << " != srcWhichVecs.extent(0) = " << srcWhichVecs.extent (0)
         << ".");
       TEUCHOS_TEST_FOR_EXCEPTION(
         DstConstStride && ! SrcConstStride &&
-        srcWhichVecs.dimension_0 () != dst.dimension_1 (),
+        srcWhichVecs.extent (0) != dst.extent (1),
         std::invalid_argument, "LocalDeepCopyFunctor (4-arg constructor): "
-        "src does not have constant stride, but srcWhichVecs.dimension_0() = "
-        << srcWhichVecs.dimension_0 () << " != dst.dimension_1() = "
-        << dst.dimension_1 () << ".");
+        "src does not have constant stride, but srcWhichVecs.extent(0) = "
+        << srcWhichVecs.extent (0) << " != dst.extent(1) = "
+        << dst.extent (1) << ".");
       TEUCHOS_TEST_FOR_EXCEPTION(
         ! DstConstStride && SrcConstStride &&
-        dstWhichVecs.dimension_0 () != src.dimension_1 (),
+        dstWhichVecs.extent (0) != src.extent (1),
         std::invalid_argument, "LocalDeepCopyFunctor (4-arg constructor): "
-        "dst does not have constant stride, but dstWhichVecs.dimension_0() = "
-        << dstWhichVecs.dimension_0 () << " != src.dimension_1() = "
-        << src.dimension_1 () << ".");
+        "dst does not have constant stride, but dstWhichVecs.extent(0) = "
+        << dstWhichVecs.extent (0) << " != src.extent(1) = "
+        << src.extent (1) << ".");
     }
 
     // You may only call the 2-argument constructor if DstConstStride
@@ -126,7 +126,7 @@ namespace Details {
     LocalDeepCopyFunctor (const DstViewType& dst, const SrcViewType& src) :
       dst_ (dst),
       src_ (src),
-      numVecs_ (dst.dimension_1 ())
+      numVecs_ (dst.extent (1))
     {
       TEUCHOS_TEST_FOR_EXCEPTION(
         ! DstConstStride || ! SrcConstStride, std::logic_error,
@@ -190,10 +190,10 @@ namespace Details {
         DstWhichVecsType, SrcWhichVecsType, true, true> functor_type;
       functor_type f (dst, src);
       typedef typename DstViewType::execution_space execution_space;
-      typedef decltype (dst.dimension_0 ()) size_type;
+      typedef decltype (dst.extent (0)) size_type;
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
 
-      Kokkos::parallel_for (range_type (0, dst.dimension_0 ()), f);
+      Kokkos::parallel_for (range_type (0, dst.extent (0)), f);
     }
 
     static void
@@ -212,7 +212,7 @@ namespace Details {
       // to copy one column at a time.
 
       typedef typename DstViewType::execution_space execution_space;
-      typedef decltype (dst.dimension_0 ()) size_type;
+      typedef decltype (dst.extent (0)) size_type;
       typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
 
       if (dstConstStride) {
@@ -222,13 +222,13 @@ namespace Details {
           typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
             DstWhichVecsType, SrcWhichVecsType, true, true> functor_type;
           functor_type f (dst, src);
-          Kokkos::parallel_for (range_type (0, dst.dimension_0 ()), f);
+          Kokkos::parallel_for (range_type (0, dst.extent (0)), f);
         }
         else { // ! srcConstStride
           typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
             DstWhichVecsType, SrcWhichVecsType, true, false> functor_type;
           functor_type f (dst, src, srcWhichVecs, srcWhichVecs);
-          Kokkos::parallel_for (range_type (0, dst.dimension_0 ()), f);
+          Kokkos::parallel_for (range_type (0, dst.extent (0)), f);
         }
       }
       else { // ! dstConstStride
@@ -236,13 +236,13 @@ namespace Details {
           typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
             DstWhichVecsType, SrcWhichVecsType, false, true> functor_type;
           functor_type f (dst, src, dstWhichVecs, dstWhichVecs);
-          Kokkos::parallel_for (range_type (0, dst.dimension_0 ()), f);
+          Kokkos::parallel_for (range_type (0, dst.extent (0)), f);
         }
         else { // ! srcConstStride
           typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
             DstWhichVecsType, SrcWhichVecsType, false, false> functor_type;
           functor_type f (dst, src, dstWhichVecs, srcWhichVecs);
-          Kokkos::parallel_for (range_type (0, dst.dimension_0 ()), f);
+          Kokkos::parallel_for (range_type (0, dst.extent (0)), f);
         }
       }
     }

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -167,9 +167,9 @@ namespace {
       Kokkos::fill_random (C_orig, randPool, minVal, maxVal);
     }
 
-    mat_type A ("A", A_orig.dimension_0 (), A_orig.dimension_1 ());
-    mat_type B ("B", B_orig.dimension_0 (), B_orig.dimension_1 ());
-    mat_type C ("C", C_orig.dimension_0 (), C_orig.dimension_1 ());
+    mat_type A ("A", A_orig.extent (0), A_orig.extent (1));
+    mat_type B ("B", B_orig.extent (0), B_orig.extent (1));
+    mat_type C ("C", C_orig.extent (0), C_orig.extent (1));
     auto A_host = Kokkos::create_mirror_view (A);
     auto B_host = Kokkos::create_mirror_view (B);
     auto C_host = Kokkos::create_mirror_view (C);
@@ -178,9 +178,9 @@ namespace {
     // and C, in case the routine to test is buggy and modifies the
     // wrong thing.  The host mirror of a View may be the View itself,
     // thus the same allocation.
-    host_mat_type A2 ("A2", A.dimension_0 (), A.dimension_1 ());
-    host_mat_type B2 ("B2", B.dimension_0 (), B.dimension_1 ());
-    host_mat_type C2 ("C2", C.dimension_0 (), C.dimension_1 ());
+    host_mat_type A2 ("A2", A.extent (0), A.extent (1));
+    host_mat_type B2 ("B2", B.extent (0), B.extent (1));
+    host_mat_type C2 ("C2", C.extent (0), C.extent (1));
 
     // Use the host versions of A, B, and C to compute max norms.
     // We'll need these for relative error bounds.
@@ -189,24 +189,24 @@ namespace {
     mag_type C_norm = Kokkos::ArithTraits<mag_type>::zero ();
     {
       Kokkos::deep_copy (A2, A_orig);
-      for (LO i = 0; i < static_cast<LO> (A2.dimension_0 ()); ++i) {
-        for (LO j = 0; j < static_cast<LO> (A2.dimension_1 ()); ++j) {
+      for (LO i = 0; i < static_cast<LO> (A2.extent (0)); ++i) {
+        for (LO j = 0; j < static_cast<LO> (A2.extent (1)); ++j) {
           const mag_type curAbs =
             Kokkos::ArithTraits<entry_type>::abs (A2(i,j));
           A_norm = (curAbs > A_norm) ? curAbs : A_norm;
         }
       }
       Kokkos::deep_copy (B2, B_orig);
-      for (LO i = 0; i < static_cast<LO> (B2.dimension_0 ()); ++i) {
-        for (LO j = 0; j < static_cast<LO> (B2.dimension_1 ()); ++j) {
+      for (LO i = 0; i < static_cast<LO> (B2.extent (0)); ++i) {
+        for (LO j = 0; j < static_cast<LO> (B2.extent (1)); ++j) {
           const mag_type curAbs =
             Kokkos::ArithTraits<entry_type>::abs (B2(i,j));
           B_norm = (curAbs > B_norm) ? curAbs : B_norm;
         }
       }
       Kokkos::deep_copy (C2, A_orig);
-      for (LO i = 0; i < static_cast<LO> (C2.dimension_0 ()); ++i) {
-        for (LO j = 0; j < static_cast<LO> (C2.dimension_1 ()); ++j) {
+      for (LO i = 0; i < static_cast<LO> (C2.extent (0)); ++i) {
+        for (LO j = 0; j < static_cast<LO> (C2.extent (1)); ++j) {
           const mag_type curAbs =
             Kokkos::ArithTraits<entry_type>::abs (C2(i,j));
           C_norm = (curAbs > C_norm) ? curAbs : C_norm;
@@ -281,8 +281,8 @@ namespace {
 
         {
           mag_type maxErr = Kokkos::ArithTraits<mag_type>::zero ();
-          for (LO i = 0; i < static_cast<LO> (C_host.dimension_0 ()); ++i) {
-            for (LO j = 0; j < static_cast<LO> (C_host.dimension_1 ()); ++j) {
+          for (LO i = 0; i < static_cast<LO> (C_host.extent (0)); ++i) {
+            for (LO j = 0; j < static_cast<LO> (C_host.extent (1)); ++j) {
               const mag_type curErr =
                 Kokkos::ArithTraits<entry_type>::abs (C_host(i,j) - C2(i,j));
               maxErr = (curErr > maxErr) ? curErr : maxErr;
@@ -309,8 +309,8 @@ namespace {
 
         {
           mag_type maxErr = Kokkos::ArithTraits<mag_type>::zero ();
-          for (LO i = 0; i < static_cast<LO> (C_host.dimension_0 ()); ++i) {
-            for (LO j = 0; j < static_cast<LO> (C_host.dimension_1 ()); ++j) {
+          for (LO i = 0; i < static_cast<LO> (C_host.extent (0)); ++i) {
+            for (LO j = 0; j < static_cast<LO> (C_host.extent (1)); ++j) {
               const mag_type curErr =
                 Kokkos::ArithTraits<entry_type>::abs (C_host(i,j) - C2(i,j));
               maxErr = (curErr > maxErr) ? curErr : maxErr;

--- a/packages/tpetra/core/test/Blas/gemv.cpp
+++ b/packages/tpetra/core/test/Blas/gemv.cpp
@@ -183,13 +183,13 @@ namespace {
         }
       }
       Kokkos::deep_copy (x2, x_orig);
-      for (int i = 0; i < static_cast<int> (x2.dimension_0 ()); ++i) {
+      for (int i = 0; i < static_cast<int> (x2.extent (0)); ++i) {
         const mag_type curAbs =
           Kokkos::ArithTraits<entry_type>::abs (x2(i));
         x_norm = (curAbs > x_norm) ? curAbs : x_norm;
       }
       Kokkos::deep_copy (y2, y_orig);
-      for (int i = 0; i < static_cast<int> (y2.dimension_0 ()); ++i) {
+      for (int i = 0; i < static_cast<int> (y2.extent (0)); ++i) {
         const mag_type curAbs =
           Kokkos::ArithTraits<entry_type>::abs (y2(i));
         y_norm = (curAbs > y_norm) ? curAbs : y_norm;
@@ -281,7 +281,7 @@ namespace {
             Kokkos::deep_copy (x_host, x);
 
             mag_type maxErr = Kokkos::ArithTraits<mag_type>::zero ();
-            for (LO i = 0; i < static_cast<LO> (x.dimension_0 ()); ++i) {
+            for (LO i = 0; i < static_cast<LO> (x.extent (0)); ++i) {
               const mag_type curErr =
                 Kokkos::ArithTraits<entry_type>::abs (x_host(i) - x2(i));
               maxErr = (curErr > maxErr) ? curErr : maxErr;
@@ -305,7 +305,7 @@ namespace {
             Kokkos::deep_copy (y_host, y);
 
             mag_type maxErr = Kokkos::ArithTraits<mag_type>::zero ();
-            for (LO i = 0; i < static_cast<LO> (y.dimension_0 ()); ++i) {
+            for (LO i = 0; i < static_cast<LO> (y.extent (0)); ++i) {
               const mag_type curErr =
                 Kokkos::ArithTraits<entry_type>::abs (y_host(i) - y2(i));
               maxErr = (curErr > maxErr) ? curErr : maxErr;

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -389,8 +389,8 @@ namespace {
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         little_vec_type X_lcl = X.getLocalBlock (lclDomIdx);
-        TEST_ASSERT( X_lcl.ptr_on_device () != NULL );
-        TEST_ASSERT( static_cast<size_t> (X_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+        TEST_ASSERT( X_lcl.data () != NULL );
+        TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
         for (LO i = 0; i < blockSize; ++i) {
           X_lcl(i) = static_cast<Scalar> (static_cast<MT> (blockSize - i));
         }
@@ -402,8 +402,8 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
-        TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-        TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+        TEST_ASSERT( Y_lcl.data () != NULL );
+        TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
         // Test that each actual output value matches its expected value.
         for (LO i = 0; i < blockSize; ++i) {
@@ -433,8 +433,8 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
-        TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-        TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+        TEST_ASSERT( Y_lcl.data () != NULL );
+        TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
         // Test that each actual output value matches its expected value.
         for (LO i = 0; i < blockSize; ++i) {
@@ -496,8 +496,8 @@ namespace {
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         for (LO j = 0; j < numVecs; ++j) {
           little_vec_type X_lcl = X.getLocalBlock (lclDomIdx, j);
-          TEST_ASSERT( X_lcl.ptr_on_device () != NULL );
-          TEST_ASSERT( static_cast<size_t> (X_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+          TEST_ASSERT( X_lcl.data () != NULL );
+          TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
           for (LO i = 0; i < blockSize; ++i) {
             X_lcl(i) = static_cast<Scalar> (static_cast<MT> ((blockSize - i) * (j + 1)));
           }
@@ -511,8 +511,8 @@ namespace {
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
           little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
-          TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-          TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+          TEST_ASSERT( Y_lcl.data () != NULL );
+          TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
           // Test that each actual output value matches its expected value.
           for (LO i = 0; i < blockSize; ++i) {
@@ -545,8 +545,8 @@ namespace {
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
           little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
-          TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-          TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+          TEST_ASSERT( Y_lcl.data () != NULL );
+          TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
           // Test that each actual output value matches its expected value.
           for (LO i = 0; i < blockSize; ++i) {
@@ -604,8 +604,8 @@ namespace {
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         little_vec_type X_lcl = X.getLocalBlock (lclDomIdx);
-        TEST_ASSERT( X_lcl.ptr_on_device () != NULL );
-        TEST_ASSERT( static_cast<size_t> (X_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+        TEST_ASSERT( X_lcl.data () != NULL );
+        TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
         for (LO i = 0; i < blockSize; ++i) {
           X_lcl(i) = static_cast<Scalar> (static_cast<MT> (blockSize - i));
         }
@@ -624,8 +624,8 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
-        TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-        TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+        TEST_ASSERT( Y_lcl.data () != NULL );
+        TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
         // Test that each actual output value matches its expected value.
         for (LO i = 0; i < blockSize; ++i) {
@@ -655,8 +655,8 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
-        TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-        TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+        TEST_ASSERT( Y_lcl.data () != NULL );
+        TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
         // Test that each actual output value matches its expected value.
         for (LO i = 0; i < blockSize; ++i) {
@@ -718,8 +718,8 @@ namespace {
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         for (LO j = 0; j < numVecs; ++j) {
           little_vec_type X_lcl = X.getLocalBlock (lclDomIdx, j);
-          TEST_ASSERT( X_lcl.ptr_on_device () != NULL );
-          TEST_ASSERT( static_cast<size_t> (X_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+          TEST_ASSERT( X_lcl.data () != NULL );
+          TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
           for (LO i = 0; i < blockSize; ++i) {
             X_lcl(i) = static_cast<Scalar> (static_cast<MT> ((blockSize - i) * (j + 1)));
           }
@@ -740,8 +740,8 @@ namespace {
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
           little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
-          TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-          TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+          TEST_ASSERT( Y_lcl.data () != NULL );
+          TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
           // Test that each actual output value matches its expected value.
           for (LO i = 0; i < blockSize; ++i) {
@@ -774,8 +774,8 @@ namespace {
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
           little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
-          TEST_ASSERT( Y_lcl.ptr_on_device () != NULL );
-          TEST_ASSERT( static_cast<size_t> (Y_lcl.dimension_0 ()) == static_cast<size_t> (blockSize) );
+          TEST_ASSERT( Y_lcl.data () != NULL );
+          TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
           // Test that each actual output value matches its expected value.
           for (LO i = 0; i < blockSize; ++i) {
@@ -1044,20 +1044,20 @@ namespace {
     // OK to use here.)
     bool meshOffsetsCorrect = true;
     if (numLclMeshPoints == 0) {
-      TEST_EQUALITY( diagMeshOffsets.dimension_0 (), 0 );
-      if (diagMeshOffsets.dimension_0 () != 0) {
+      TEST_EQUALITY( diagMeshOffsets.extent (0), 0 );
+      if (diagMeshOffsets.extent (0) != 0) {
         meshOffsetsCorrect = false;
       }
     }
     else {
-      TEST_ASSERT( diagMeshOffsets.dimension_0 () != 0 );
+      TEST_ASSERT( diagMeshOffsets.extent (0) != 0 );
       auto localGraph = graph.getLocalGraph ();
       const auto& colMap = * (graph.getColMap ());
 
       TEST_EQUALITY( static_cast<size_t> (numLclMeshPoints + 1),
-                     static_cast<size_t> (localGraph.row_map.dimension_0 ()) );
+                     static_cast<size_t> (localGraph.row_map.extent (0)) );
       if (static_cast<size_t> (numLclMeshPoints + 1) ==
-          static_cast<size_t> (localGraph.row_map.dimension_0 ())) {
+          static_cast<size_t> (localGraph.row_map.extent (0))) {
         for (LO lclRowInd = 0;
              lclRowInd < static_cast<LO> (numLclMeshPoints);
              ++lclRowInd) {
@@ -1841,7 +1841,7 @@ namespace {
     Kokkos::View<int**, device_type> pivots ("pivots", numLocalMeshPoints, blockSize);
     // That's how we found this test: the pivots array was filled with ones.
     Kokkos::deep_copy (pivots, 1);
-    out << "pivots size = " << pivots.dimension_0() << endl;
+    out << "pivots size = " << pivots.extent(0) << endl;
 
     for (LO lclMeshRow = 0; lclMeshRow < static_cast<LO> (numLocalMeshPoints); ++lclMeshRow) {
       auto diagBlock = Kokkos::subview (blockDiag, lclMeshRow, ALL (), ALL ());
@@ -1881,7 +1881,7 @@ namespace {
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex (); ++lclRowInd) {
       typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
-      ST* x = reinterpret_cast<ST*> (xlcl.ptr_on_device ());
+      ST* x = reinterpret_cast<ST*> (xlcl.data ());
       out << "row = " << lclRowInd << endl;
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[k], tol );
@@ -1894,7 +1894,7 @@ namespace {
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex (); ++lclRowInd) {
       typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
-      ST* x = reinterpret_cast<ST*> (xlcl.ptr_on_device ());
+      ST* x = reinterpret_cast<ST*> (xlcl.data ());
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[k], tol );
       }
@@ -2072,7 +2072,7 @@ namespace {
          lclRowInd <= meshRowMap.getMaxLocalIndex(); ++lclRowInd) {
       const LO rowOffset = lclRowInd - meshRowMap.getMinLocalIndex ();
       typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
-      ST* x = reinterpret_cast<ST*> (xlcl.ptr_on_device ());
+      ST* x = reinterpret_cast<ST*> (xlcl.data ());
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[rowOffset], tol );
         x[k] = -STS::one ();
@@ -2137,7 +2137,7 @@ namespace {
          lclRowInd <= meshRowMap.getMaxLocalIndex(); ++lclRowInd) {
       const LO rowOffset = lclRowInd - meshRowMap.getMinLocalIndex ();
       typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
-      ST* x = reinterpret_cast<ST*> (xlcl.ptr_on_device ());
+      ST* x = reinterpret_cast<ST*> (xlcl.data ());
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[rowOffset], tol );
         x[k] = -STS::one ();

--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -62,12 +62,12 @@ namespace {
   struct LittleEqual<ViewType1, ViewType2, 2, 2> {
     static bool equal (const ViewType1& X, const ViewType2& Y)
     {
-      if (X.dimension_0 () != Y.dimension_0 () ||
-          X.dimension_1 () != Y.dimension_1 ()) {
+      if (X.extent (0) != Y.extent (0) ||
+          X.extent (1) != Y.extent (1)) {
         return false;
       }
-      for (int j = 0; j < static_cast<int> (X.dimension_1 ()); ++j) {
-        for (int i = 0; i < static_cast<int> (X.dimension_0 ()); ++i) {
+      for (int j = 0; j < static_cast<int> (X.extent (1)); ++j) {
+        for (int i = 0; i < static_cast<int> (X.extent (0)); ++i) {
           if (X(i,j) != Y(i,j)) {
             return false;
           }
@@ -82,10 +82,10 @@ namespace {
   struct LittleEqual<ViewType1, ViewType2, 1, 1> {
     static bool equal (const ViewType1& X, const ViewType2& Y)
     {
-      if (X.dimension_0 () != Y.dimension_0 ()) {
+      if (X.extent (0) != Y.extent (0)) {
         return false;
       }
-      for (int i = 0; i < static_cast<int> (X.dimension_0 ()); ++i) {
+      for (int i = 0; i < static_cast<int> (X.extent (0)); ++i) {
         if (X(i) != Y(i)) {
           return false;
         }
@@ -362,13 +362,13 @@ namespace {
     const LO colToModify = 1;
     little_vec_type X_overlap =
       X.getLocalBlock (meshMap.getLocalElement (meshMap.getMinGlobalIndex ()), colToModify);
-    TEST_ASSERT( X_overlap.ptr_on_device () != NULL );
-    TEST_EQUALITY_CONST( static_cast<size_t> (X_overlap.dimension_0 ()), static_cast<size_t> (blockSize) );
+    TEST_ASSERT( X_overlap.data () != NULL );
+    TEST_EQUALITY_CONST( static_cast<size_t> (X_overlap.extent (0)), static_cast<size_t> (blockSize) );
 
     // {
     //   std::ostringstream os;
     //   os << "Proc " << myRank
-    //      << ": X_overlap.ptr_on_device() = " << X_overlap.ptr_on_device ()
+    //      << ": X_overlap.data() = " << X_overlap.data ()
     //      << ", X_overlap.getBlockSize() = " << X_overlap.getBlockSize ()
     //      << ", meshMap.getMinGlobalIndex() = " << meshMap.getMinGlobalIndex ()
     //      << std::endl;
@@ -376,8 +376,8 @@ namespace {
     // }
 
     {
-      const int lclOk = (X_overlap.ptr_on_device () != NULL &&
-                         static_cast<size_t> (X_overlap.dimension_0 ()) == static_cast<size_t> (blockSize)) ? 1 : 0;
+      const int lclOk = (X_overlap.data () != NULL &&
+                         static_cast<size_t> (X_overlap.extent (0)) == static_cast<size_t> (blockSize)) ? 1 : 0;
       int gblOk = 1;
       reduceAll<int, int> (*comm, REDUCE_MIN, lclOk, outArg (gblOk));
       TEUCHOS_TEST_FOR_EXCEPTION(

--- a/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
@@ -164,7 +164,7 @@ namespace {
     int info = 0;
     {
       lapack.GETRF (blockSize, blockSize, teuchosBlock.values (),
-                    teuchosBlock.stride (), ipiv.ptr_on_device (),
+                    teuchosBlock.stride (), ipiv.data (),
                     &info);
       TEST_EQUALITY_CONST( info, 0 );
       if (info != 0) {
@@ -174,7 +174,7 @@ namespace {
       }
       IST workQuery = zero;
       lapack.GETRI (blockSize, teuchosBlock.values (),
-                    teuchosBlock.stride (), ipiv.ptr_on_device (),
+                    teuchosBlock.stride (), ipiv.data (),
                     reinterpret_cast<Scalar*> (&workQuery), -1, &info);
       TEST_EQUALITY_CONST( info, 0 );
       if (info != 0) {
@@ -183,12 +183,12 @@ namespace {
         return;
       }
       const int lwork = static_cast<int> (KAT::real (workQuery));
-      if (work.dimension_0 () < static_cast<size_t> (lwork)) {
+      if (work.extent (0) < static_cast<size_t> (lwork)) {
         work = decltype (work) ("work", lwork);
       }
       lapack.GETRI (blockSize, teuchosBlock.values (),
-                    teuchosBlock.stride (), ipiv.ptr_on_device (),
-                    reinterpret_cast<Scalar*> (work.ptr_on_device ()),
+                    teuchosBlock.stride (), ipiv.data (),
+                    reinterpret_cast<Scalar*> (work.data ()),
                     lwork, &info);
       TEST_EQUALITY_CONST( info, 0 );
       if (info != 0) {
@@ -246,9 +246,9 @@ namespace {
     blas.GEMV (Teuchos::NO_TRANS, blockSize, blockSize,
                static_cast<Scalar> (1.0),
                teuchosBlock.values (), teuchosBlock.stride (),
-               reinterpret_cast<Scalar*> (prototypeX.ptr_on_device ()), 1,
+               reinterpret_cast<Scalar*> (prototypeX.data ()), 1,
                static_cast<Scalar> (0.0),
-               reinterpret_cast<Scalar*> (prototypeY.ptr_on_device ()), 1);
+               reinterpret_cast<Scalar*> (prototypeY.data ()), 1);
 
     myOut << "Constructing block diagonal (as 3-D Kokkos::View)" << endl;
 

--- a/packages/tpetra/core/test/Block/BlockView.cpp
+++ b/packages/tpetra/core/test/Block/BlockView.cpp
@@ -149,7 +149,7 @@ namespace {
     LO info;
 
     lapack_type lapackOBJ;
-    lapackOBJ.GETRF (3, 3, reinterpret_cast<ST*> (true_A.ptr_on_device ()), 3, true_piv.ptr_on_device(), &info);
+    lapackOBJ.GETRF (3, 3, reinterpret_cast<ST*> (true_A.data ()), 3, true_piv.data(), &info);
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compute our factorization
@@ -157,8 +157,8 @@ namespace {
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compare the two solutions
-    Teuchos::ArrayView<ST> ptr1 (reinterpret_cast<ST*> (A.ptr_on_device ()), 9);
-    Teuchos::ArrayView<ST> ptr2 (reinterpret_cast<ST*> (true_A.ptr_on_device ()), 9);
+    Teuchos::ArrayView<ST> ptr1 (reinterpret_cast<ST*> (A.data ()), 9);
+    Teuchos::ArrayView<ST> ptr2 (reinterpret_cast<ST*> (true_A.data ()), 9);
     TEST_COMPARE_FLOATING_ARRAYS( ptr1, ptr2, tol );
     TEST_COMPARE_ARRAYS( ipiv, true_piv );
 
@@ -173,9 +173,9 @@ namespace {
       true_rhs(i) = rhs(i);
 
     // Compute the true solution
-    lapackOBJ.GETRS ('n', 3, 1, reinterpret_cast<ST*> (true_A.ptr_on_device ()),
-                     3, true_piv.ptr_on_device (),
-                     reinterpret_cast<ST*> (true_rhs.ptr_on_device ()), 3,
+    lapackOBJ.GETRS ('n', 3, 1, reinterpret_cast<ST*> (true_A.data ()),
+                     3, true_piv.data (),
+                     reinterpret_cast<ST*> (true_rhs.data ()), 3,
                      &info);
     TEST_EQUALITY_CONST( info, 0 );
 
@@ -184,8 +184,8 @@ namespace {
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compare the solutions
-    Teuchos::ArrayView<ST> ptr3 (reinterpret_cast<ST*> (rhs.ptr_on_device ()), 3);
-    Teuchos::ArrayView<ST> ptr4 (reinterpret_cast<ST*> (true_rhs.ptr_on_device ()), 3);
+    Teuchos::ArrayView<ST> ptr3 (reinterpret_cast<ST*> (rhs.data ()), 3);
+    Teuchos::ArrayView<ST> ptr4 (reinterpret_cast<ST*> (true_rhs.data ()), 3);
     TEST_COMPARE_FLOATING_ARRAYS( ptr3, ptr4, tol );
 
     // Compute the inverse
@@ -194,9 +194,9 @@ namespace {
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compute the true inverse
-    lapackOBJ.GETRI (3, reinterpret_cast<ST*> (true_A.ptr_on_device ()), 3,
-                     true_piv.ptr_on_device (),
-                     reinterpret_cast<ST*> (work.ptr_on_device ()), 3, &info);
+    lapackOBJ.GETRI (3, reinterpret_cast<ST*> (true_A.data ()), 3,
+                     true_piv.data (),
+                     reinterpret_cast<ST*> (work.data ()), 3, &info);
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compare the inverses
@@ -248,8 +248,8 @@ namespace {
     LO info;
 
     lapack_type lapackOBJ;
-    lapackOBJ.GETRF (3, 3, reinterpret_cast<ST*> (true_A.ptr_on_device ()),
-                     3, true_piv.ptr_on_device (), &info);
+    lapackOBJ.GETRF (3, 3, reinterpret_cast<ST*> (true_A.data ()),
+                     3, true_piv.data (), &info);
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compute our factorization
@@ -257,8 +257,8 @@ namespace {
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compare the two solutions
-    Teuchos::ArrayView<ST> ptr1 (reinterpret_cast<ST*> (A.ptr_on_device ()), 9);
-    Teuchos::ArrayView<ST> ptr2 (reinterpret_cast<ST*> (true_A.ptr_on_device ()), 9);
+    Teuchos::ArrayView<ST> ptr1 (reinterpret_cast<ST*> (A.data ()), 9);
+    Teuchos::ArrayView<ST> ptr2 (reinterpret_cast<ST*> (true_A.data ()), 9);
     TEST_COMPARE_FLOATING_ARRAYS( ptr1, ptr2, tol );
     TEST_COMPARE_ARRAYS( ipiv, true_piv );
 
@@ -273,9 +273,9 @@ namespace {
       true_rhs(i) = rhs(i);
 
     // Compute the true solution
-    lapackOBJ.GETRS ('n', 3, 1, reinterpret_cast<ST*> (true_A.ptr_on_device ()),
-                     3, true_piv.ptr_on_device (),
-                     reinterpret_cast<ST*> (true_rhs.ptr_on_device ()), 3,
+    lapackOBJ.GETRS ('n', 3, 1, reinterpret_cast<ST*> (true_A.data ()),
+                     3, true_piv.data (),
+                     reinterpret_cast<ST*> (true_rhs.data ()), 3,
                      &info);
     TEST_EQUALITY_CONST( info, 0 );
 
@@ -284,8 +284,8 @@ namespace {
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compare the solutions
-    Teuchos::ArrayView<ST> ptr3 (reinterpret_cast<ST*> (rhs.ptr_on_device ()), 3);
-    Teuchos::ArrayView<ST> ptr4 (reinterpret_cast<ST*> (true_rhs.ptr_on_device ()), 3);
+    Teuchos::ArrayView<ST> ptr3 (reinterpret_cast<ST*> (rhs.data ()), 3);
+    Teuchos::ArrayView<ST> ptr4 (reinterpret_cast<ST*> (true_rhs.data ()), 3);
     TEST_COMPARE_FLOATING_ARRAYS( ptr3, ptr4, tol );
 
     // Compute the inverse
@@ -294,9 +294,9 @@ namespace {
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compute the true inverse
-    lapackOBJ.GETRI (3, reinterpret_cast<ST*> (true_A.ptr_on_device ()), 3,
-                     true_piv.ptr_on_device (),
-                     reinterpret_cast<ST*> (work.ptr_on_device ()), 3, &info);
+    lapackOBJ.GETRI (3, reinterpret_cast<ST*> (true_A.data ()), 3,
+                     true_piv.data (),
+                     reinterpret_cast<ST*> (work.data ()), 3, &info);
     TEST_EQUALITY_CONST( info, 0 );
 
     // Compare the inverses

--- a/packages/tpetra/core/test/CrsMatrix/assembleElement.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/assembleElement.cpp
@@ -105,8 +105,8 @@ namespace TpetraTest {
 
     if (i == 0) {
       const ordinal_type retval =
-        crsMatrixAssembleElement_sortedLinear (A_, x_, lids_.ptr_on_device (),
-                                               sortPerm_.ptr_on_device (),
+        crsMatrixAssembleElement_sortedLinear (A_, x_, lids_.data (),
+                                               sortPerm_.data (),
                                                rhs_, lhs_, forceAtomic_,
                                                checkInputIndices_);
       result_() = retval;
@@ -181,15 +181,15 @@ namespace { // (anonymous)
     typedef Kokkos::RangePolicy<execution_space, ordinal_type> range_type;
 
     TEUCHOS_TEST_FOR_EXCEPTION
-      (expectedVectorValues.dimension_0 () != x.dimension_0 (),
+      (expectedVectorValues.extent (0) != x.extent (0),
        std::invalid_argument,
-       "expectedVectorValues.dimension_0() = " << expectedVectorValues.dimension_0 ()
-       << " != x.dimension_0() = " << x.dimension_0 () << ".");
+       "expectedVectorValues.extent(0) = " << expectedVectorValues.extent (0)
+       << " != x.extent(0) = " << x.extent (0) << ".");
     TEUCHOS_TEST_FOR_EXCEPTION
-      (expectedMatrixValues.dimension_0 () != A.values.dimension_0 (),
+      (expectedMatrixValues.extent (0) != A.values.extent (0),
        std::invalid_argument,
-       "expectedMatrixValues.dimension_0() = " << expectedMatrixValues.dimension_0 ()
-       << " != A.values.dimension_0() = " << A.values.dimension_0 () << ".");
+       "expectedMatrixValues.extent(0) = " << expectedMatrixValues.extent (0)
+       << " != A.values.extent(0) = " << A.values.extent (0) << ".");
 
     functor_type functor (A, x, lids, sortPerm, rhs, lhs, forceAtomic, checkInputIndices);
     // It's a "parallel" loop with one loop iteration.  The point is
@@ -255,15 +255,15 @@ namespace { // (anonymous)
           }
         }
         out << "Element matrix (lhs): [";
-        for (LO i = 0; i < static_cast<LO> (lhs_h.dimension_0 ()); ++i) {
-          for (LO j = 0; j < static_cast<LO> (lhs_h.dimension_1 ()); ++j) {
+        for (LO i = 0; i < static_cast<LO> (lhs_h.extent (0)); ++i) {
+          for (LO j = 0; j < static_cast<LO> (lhs_h.extent (1)); ++j) {
             constexpr int width = Kokkos::ArithTraits<SC>::is_complex ? 7 : 3;
             out << std::setw (width) << lhs_h(i,j);
-            if (j + LO (1) < static_cast<LO> (lhs_h.dimension_1 ())) {
+            if (j + LO (1) < static_cast<LO> (lhs_h.extent (1))) {
               out << " ";
             }
           }
-          if (i + LO (1) < static_cast<LO> (lhs_h.dimension_0 ())) {
+          if (i + LO (1) < static_cast<LO> (lhs_h.extent (0))) {
             out << endl;
           }
         }
@@ -277,7 +277,7 @@ namespace { // (anonymous)
       {
         auto rhs_h = Kokkos::create_mirror_view (rhs_d);
         SC curVal = ONE;
-        for (LO i = 0; i < static_cast<LO> (rhs_h.dimension_0 ()); ++i) {
+        for (LO i = 0; i < static_cast<LO> (rhs_h.extent (0)); ++i) {
           rhs_h(i) = -curVal;
           curVal = curVal + ONE;
         }
@@ -459,9 +459,9 @@ namespace { // (anonymous)
         auto ptr = Kokkos::create_mirror_view (A.graph.row_map);
         Kokkos::deep_copy (ptr, A.graph.row_map);
         out << "ptr: [";
-        for (LO k = 0; k < static_cast<LO> (ptr.dimension_0 ()); ++k) {
+        for (LO k = 0; k < static_cast<LO> (ptr.extent (0)); ++k) {
           out << ptr(k);
-          if (k + LO (1) < static_cast<LO> (ptr.dimension_0 ())) {
+          if (k + LO (1) < static_cast<LO> (ptr.extent (0))) {
             out << ",";
           }
         }
@@ -469,9 +469,9 @@ namespace { // (anonymous)
         auto ind = Kokkos::create_mirror_view (A.graph.entries);
         Kokkos::deep_copy (ind, A.graph.entries);
         out << "ind: [";
-        for (offset_type k = 0; k < static_cast<offset_type> (ind.dimension_0 ()); ++k) {
+        for (offset_type k = 0; k < static_cast<offset_type> (ind.extent (0)); ++k) {
           out << ind(k);
-          if (k + offset_type (1) < static_cast<offset_type> (ind.dimension_0 ())) {
+          if (k + offset_type (1) < static_cast<offset_type> (ind.extent (0))) {
             out << ",";
           }
         }
@@ -479,9 +479,9 @@ namespace { // (anonymous)
         auto val = Kokkos::create_mirror_view (A.values);
         Kokkos::deep_copy (val, A.values);
         out << "val: [";
-        for (offset_type k = 0; k < static_cast<offset_type> (val.dimension_0 ()); ++k) {
+        for (offset_type k = 0; k < static_cast<offset_type> (val.extent (0)); ++k) {
           out << val(k);
-          if (k + offset_type (1) < static_cast<offset_type> (val.dimension_0 ())) {
+          if (k + offset_type (1) < static_cast<offset_type> (val.extent (0))) {
             out << ",";
           }
         }
@@ -521,10 +521,10 @@ namespace { // (anonymous)
         Kokkos::deep_copy (A_val_h, A.values);
         auto val_h = Kokkos::create_mirror_view (expectedMatrixValues);
         Kokkos::deep_copy (val_h, expectedMatrixValues);
-        TEST_EQUALITY( A_val_h.dimension_0 (), val_h.dimension_0 () );
-        if (A_val_h.dimension_0 () == val_h.dimension_0 ()) {
+        TEST_EQUALITY( A_val_h.extent (0), val_h.extent (0) );
+        if (A_val_h.extent (0) == val_h.extent (0)) {
           bool same = true;
-          const offset_type len = A_val_h.dimension_0 ();
+          const offset_type len = A_val_h.extent (0);
           for (offset_type k = 0; k < len; ++k) {
             if (A_val_h(k) != val_h(k)) {
               same = false;
@@ -557,10 +557,10 @@ namespace { // (anonymous)
         Kokkos::deep_copy (b_h, b);
         auto b_exp_h = Kokkos::create_mirror_view (expectedVectorValues);
         Kokkos::deep_copy (b_exp_h, expectedVectorValues);
-        TEST_EQUALITY( b_h.dimension_0 (), b_exp_h.dimension_0 () );
-        if (b_h.dimension_0 (), b_exp_h.dimension_0 ()) {
+        TEST_EQUALITY( b_h.extent (0), b_exp_h.extent (0) );
+        if (b_h.extent (0), b_exp_h.extent (0)) {
           bool same = true;
-          const offset_type len = b_h.dimension_0 ();
+          const offset_type len = b_h.extent (0);
           for (offset_type k = 0; k < len; ++k) {
             if (b_h(k) != b_exp_h(k)) {
               same = false;
@@ -571,20 +571,20 @@ namespace { // (anonymous)
         }
         out << "Actual output b  : [";
         for (offset_type k = 0;
-             k < static_cast<offset_type> (b_h.dimension_0 ()); ++k) {
+             k < static_cast<offset_type> (b_h.extent (0)); ++k) {
           out << b_h(k);
           if (k + offset_type (1) <
-              static_cast<offset_type> (b_h.dimension_0 ())) {
+              static_cast<offset_type> (b_h.extent (0))) {
             out << ",";
           }
         }
         out << "]" << endl;
         out << "Expected output b: [";
         for (offset_type k = 0;
-             k < static_cast<offset_type> (b_exp_h.dimension_0 ()); ++k) {
+             k < static_cast<offset_type> (b_exp_h.extent (0)); ++k) {
           out << b_exp_h(k);
           if (k + offset_type (1) <
-              static_cast<offset_type> (b_exp_h.dimension_0 ())) {
+              static_cast<offset_type> (b_exp_h.extent (0))) {
             out << ",";
           }
         }

--- a/packages/tpetra/core/test/Distributor/createfromsendsandrecvs.cpp
+++ b/packages/tpetra/core/test/Distributor/createfromsendsandrecvs.cpp
@@ -153,7 +153,7 @@ namespace { // (anonymous)
       for (LO k = 0; k < static_cast<LO> (lclColInds.size ()); ++k) {
         const LO lclColInd = lclColInds[k];
         const LO err =
-          A->replaceLocalValues (lclRow, &lclColInd, curBlk.ptr_on_device (), 1);
+          A->replaceLocalValues (lclRow, &lclColInd, curBlk.data (), 1);
         TEUCHOS_TEST_FOR_EXCEPTION(err != 1, std::logic_error, "Bug");
       }
     }

--- a/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
+++ b/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
@@ -164,13 +164,13 @@ namespace { // (anonymous)
               const bool testValues = true)
     {
       using std::endl;
-      const size_type numKeys = keys.dimension_0 ();
+      const size_type numKeys = keys.extent (0);
 
       out << "Test " << numKeys << " key" << (numKeys != 1 ? "s" : "") << ":  ";
       TEUCHOS_TEST_FOR_EXCEPTION
-        (numKeys != vals.dimension_0 (), std::logic_error,
-         "keys and vals are not the same length!  keys.dimension_0() = "
-         << numKeys << " != vals.dimension_0() = " << vals.dimension_0 ()
+        (numKeys != vals.extent (0), std::logic_error,
+         "keys and vals are not the same length!  keys.extent(0) = "
+         << numKeys << " != vals.extent(0) = " << vals.extent (0)
          << ".");
 
       const bool testReverse = table.hasKeys ();
@@ -256,7 +256,7 @@ namespace { // (anonymous)
     // Pick something other than 0, just to make sure that it works.
     const ValueType startingValue = 1;
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
     out << "Create table" << endl;
 
     const bool keepKeys = true;
@@ -341,7 +341,7 @@ namespace { // (anonymous)
     }
     Kokkos::deep_copy (vals, vals_h);
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
     out << " Create table" << endl;
 
     const bool keepKeys = true;
@@ -486,7 +486,7 @@ namespace { // (anonymous)
     }
     Kokkos::deep_copy (vals, vals_h);
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
     out << " Create table" << endl;
 
     const bool keepKeys = true;
@@ -631,8 +631,8 @@ namespace { // (anonymous)
     vals_h(0) = static_cast<ValueType> (400);
     Kokkos::deep_copy (vals, vals_h);
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
-    Teuchos::ArrayView<const ValueType> vals_av (vals_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
+    Teuchos::ArrayView<const ValueType> vals_av (vals_h.data (), numKeys);
     out << " Create table" << endl;
 
     Teuchos::RCP<table_type> table;
@@ -709,7 +709,7 @@ namespace { // (anonymous)
     }
     Kokkos::deep_copy (vals, vals_h);
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
     out << " Create table" << endl;
 
     const bool keepKeys = true;
@@ -831,9 +831,9 @@ namespace { // (anonymous)
       TEST_EQUALITY( inTable.maxVal (), outTable->maxVal () );
       TEST_EQUALITY( inTable.numPairs (), outTable->numPairs () );
 
-      Kokkos::View<KeyType*, Kokkos::LayoutLeft, OutDeviceType> keys_out ("keys", keys.dimension_0 ());
+      Kokkos::View<KeyType*, Kokkos::LayoutLeft, OutDeviceType> keys_out ("keys", keys.extent (0));
       Kokkos::deep_copy (keys_out, keys);
-      Kokkos::View<ValueType*, Kokkos::LayoutLeft, OutDeviceType> vals_out ("vals", vals.dimension_0 ());
+      Kokkos::View<ValueType*, Kokkos::LayoutLeft, OutDeviceType> vals_out ("vals", vals.extent (0));
       Kokkos::deep_copy (vals_out, vals);
 
       success = TestFixedHashTable<KeyType, ValueType, OutDeviceType>::testKeys (out, *outTable, keys_out, vals_out, testValues);
@@ -888,7 +888,7 @@ namespace { // (anonymous)
     }
     Kokkos::deep_copy (vals, vals_h);
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
     out << " Create table" << endl;
 
     const bool keepKeys = true;
@@ -1031,7 +1031,7 @@ namespace { // (anonymous)
     }
     Kokkos::deep_copy (vals, vals_h);
 
-    Teuchos::ArrayView<const KeyType> keys_av (keys_h.ptr_on_device (), numKeys);
+    Teuchos::ArrayView<const KeyType> keys_av (keys_h.data (), numKeys);
     out << " Create table" << endl;
 
     const bool keepKeys = true;

--- a/packages/tpetra/core/test/HashTable/computeOffsetsFromCounts.cpp
+++ b/packages/tpetra/core/test/HashTable/computeOffsetsFromCounts.cpp
@@ -73,7 +73,7 @@ namespace TpetraTest {
     typedef SumOfCounts<OffsetType, CountType, DeviceType> functor_type;
 
     OffsetType total = 0;
-    range_type range (0, counts.dimension_0 ());
+    range_type range (0, counts.extent (0));
     Kokkos::parallel_reduce (range, functor_type (counts), total);
     return total;
   }
@@ -211,7 +211,7 @@ namespace { // (anonymous)
       Teuchos::OSTab tab2 (out);
       using Kokkos::subview;
       typedef Kokkos::pair<size_t, size_t> range_type;
-      auto counts_in = subview (offsets, range_type (0, counts.dimension_0 ()));
+      auto counts_in = subview (offsets, range_type (0, counts.extent (0)));
       Kokkos::deep_copy (counts_in, counts);
 
       OffsetType computedTotal = 0;

--- a/packages/tpetra/core/test/ImportExport/ImportExport_ImportConstructExpert.cpp
+++ b/packages/tpetra/core/test/ImportExport/ImportExport_ImportConstructExpert.cpp
@@ -167,7 +167,7 @@ namespace {
       for (LO k = 0; k < static_cast<LO> (lclColInds.size ()); ++k) {
         const LO lclColInd = lclColInds[k];
         const LO err =
-          A->replaceLocalValues (lclRow, &lclColInd, curBlk.ptr_on_device (), 1);
+          A->replaceLocalValues (lclRow, &lclColInd, curBlk.data (), 1);
         TEUCHOS_TEST_FOR_EXCEPTION(err != 1, std::logic_error, "Bug");
       }
     }
@@ -182,10 +182,10 @@ namespace {
 
     Teuchos::Array<LO> saveremoteLIDs = G->getImporter()->getRemoteLIDs();
     Teuchos::Array<LO> remoteLIDs = G->getImporter()->getRemoteLIDs();
-    
+
     Teuchos::Array<GO> remoteGIDs(remoteLIDs.size());
     Teuchos::Array<int> userRemotePIDs(remoteLIDs.size());
-    for(size_t i=0; i< (size_t)remoteLIDs.size(); i++) 
+    for(size_t i=0; i< (size_t)remoteLIDs.size(); i++)
       remoteGIDs[i] = target->getGlobalElement(G->getImporter()->getRemoteLIDs()[i]);
     Tpetra::Import_Util::getRemotePIDs(*G->getImporter(),userRemotePIDs);
 
@@ -194,14 +194,14 @@ namespace {
 
 
     Tpetra::Import<LO,GO,NT> newimport(source,
-				       target,
-				       userRemotePIDs,
-				       remoteGIDs,
-				       exportLIDs,
-				       userExportPIDs ,
-				       false,
-				       Teuchos::null,
-				       Teuchos::null ); // plist == null
+                                       target,
+                                       userRemotePIDs,
+                                       remoteGIDs,
+                                       exportLIDs,
+                                       userExportPIDs ,
+                                       false,
+                                       Teuchos::null,
+                                       Teuchos::null ); // plist == null
 
     Teuchos::RCP<const map_type> newsource = newimport.getSourceMap ();
     Teuchos::RCP<const map_type> newtarget = newimport.getTargetMap ();

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -83,8 +83,8 @@ namespace {
 
     auto x_host = x.template view<Kokkos::HostSpace> ();
     typedef typename DualViewType::t_dev::value_type value_type;
-    return Teuchos::ArrayView<value_type> (x_host.ptr_on_device (),
-                                           x_host.dimension_0 ());
+    return Teuchos::ArrayView<value_type> (x_host.data (),
+                                           x_host.extent (0));
   }
 
   using Teuchos::as;
@@ -2647,7 +2647,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO
   typedef Tpetra::Vector<int,LO, GO, Node> IntVectorType;
   RCP<const ImportType> ImportOwn, ImportXfer;
   RCP<MapType> Map0, Map1, Map2;
-  
+
   // Get Rank
   const int NumProc = Comm->getSize ();
   const int MyPID   = Comm->getRank ();
@@ -2705,11 +2705,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO
     oss<<"\n["<<MyPID<<"] Ownership = ";
     for(int i=0; i<num_per_proc; i++)
       oss<<odata[i]<< " ";
-    std::cout<<oss.str()<<std::endl; 
+    std::cout<<oss.str()<<std::endl;
   }
 #endif
-  
-  
+
+
   // Check answer [ownership(GID i) should contain the owning PID in Map0]
   for(size_t i=0; i<Map2->getNodeNumElements(); i++) {
     GO GID  = Map2->getGlobalElement(i);

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -702,7 +702,7 @@ mult_test_results jacobi_test(
     if(!done) {
       Dinv.putScalar(omega);
       RCP<Matrix_t> AB = rcp(new Matrix_t(B->getRowMap(),0));
-      
+
       Tpetra::MatrixMatrix::Multiply(*A,false,*B,false,*AB);
       AB->leftScale(Dinv);
       Tpetra::MatrixMatrix::Add(*AB,false,-one,*B,false,one,C2);
@@ -1495,7 +1495,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, threaded_add_sorted, SC, LO, GO
   ISC one(1);
   Tpetra::MatrixMatrix::AddDetails::AddKernels<SC, LO, GO, NT>::addSorted(valsCRS[0], rowptrsCRS[0], colindsCRS[0], one, valsCRS[1], rowptrsCRS[1], colindsCRS[1], one, valsCRS[2], rowptrsCRS[2], colindsCRS[2]);
   //now scan through C's rows and entries to check they are correct
-  TEUCHOS_TEST_FOR_EXCEPTION(rowptrsCRS[0].dimension_0() != rowptrsCRS[2].dimension_0(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION(rowptrsCRS[0].extent(0) != rowptrsCRS[2].extent(0), std::logic_error,
       "Threaded addition of sorted Kokkos::CrsMatrix returned a matrix with the wrong number of rows.");
   for(size_t i = 0; i < nrows; i++)
   {
@@ -1609,7 +1609,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, threaded_add_unsorted, SC, LO, 
   ISC one(1);
   Tpetra::MatrixMatrix::AddDetails::AddKernels<SC, LO, GO, NT>::addUnsorted(valsCRS[0], rowptrsCRS[0], colindsCRS[0], one, valsCRS[1], rowptrsCRS[1], colindsCRS[1], one, nrows, valsCRS[2], rowptrsCRS[2], colindsCRS[2]);
   //now scan through C's rows and entries to check they are correct
-  TEUCHOS_TEST_FOR_EXCEPTION(rowptrsCRS[0].dimension_0() != rowptrsCRS[2].dimension_0(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION(rowptrsCRS[0].extent(0) != rowptrsCRS[2].extent(0), std::logic_error,
       "Threaded addition of sorted Kokkos::CrsMatrix returned a matrix with the wrong number of rows.");
   for(size_t i = 0; i < nrows; i++)
   {

--- a/packages/tpetra/core/test/MultiVector/Issue364.cpp
+++ b/packages/tpetra/core/test/MultiVector/Issue364.cpp
@@ -67,7 +67,7 @@ public:
     typedef typename ViewType::execution_space execution_space;
     typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
     int result = 1;
-    Kokkos::parallel_reduce (range_type (0, x.dimension_0 ()),
+    Kokkos::parallel_reduce (range_type (0, x.extent (0)),
                              VectorsEqual<ViewType> (x, y),
                              result);
     return result == 1;
@@ -113,7 +113,7 @@ public:
   static void run (const ViewType& x) {
     typedef typename ViewType::execution_space execution_space;
     typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-    Kokkos::parallel_for (range_type (0, x.dimension_0 ()),
+    Kokkos::parallel_for (range_type (0, x.extent (0)),
                           NegateAllEntries<ViewType> (x));
   }
 
@@ -200,8 +200,8 @@ namespace { // (anonymous)
       X.template modify<host_memory_space> ();
       auto X_lcl = X.template getLocalView<host_memory_space> ();
 
-      TEST_EQUALITY( static_cast<LO> (X_lcl.dimension_0 ()), lclNumRows );
-      TEST_EQUALITY( static_cast<LO> (X_lcl.dimension_1 ()), numVecs );
+      TEST_EQUALITY( static_cast<LO> (X_lcl.extent (0)), lclNumRows );
+      TEST_EQUALITY( static_cast<LO> (X_lcl.extent (1)), numVecs );
       if (! success) {
         return;
       }
@@ -252,7 +252,7 @@ namespace { // (anonymous)
         auto X_sub_lcl_j_1d =
           Kokkos::subview (X_sub_lcl_j_2d, Kokkos::ALL (), 0);
 
-        TEST_EQUALITY( static_cast<LO> (X_sub_lcl_j_1d.dimension_0 ()),
+        TEST_EQUALITY( static_cast<LO> (X_sub_lcl_j_1d.extent (0)),
                        lclNumRows );
         if (! success) {
           return;
@@ -305,11 +305,11 @@ namespace { // (anonymous)
         auto X_copy_lcl_j_1d =
           Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
 
-        TEST_EQUALITY( static_cast<LO> (X_sub_lcl_j_1d.dimension_0 ()),
+        TEST_EQUALITY( static_cast<LO> (X_sub_lcl_j_1d.extent (0)),
                        lclNumRows );
-        TEST_EQUALITY( static_cast<LO> (X_lcl_j_1d.dimension_0 ()),
+        TEST_EQUALITY( static_cast<LO> (X_lcl_j_1d.extent (0)),
                        lclNumRows );
-        TEST_EQUALITY( static_cast<LO> (X_copy_lcl_j_1d.dimension_0 ()),
+        TEST_EQUALITY( static_cast<LO> (X_copy_lcl_j_1d.extent (0)),
                        lclNumRows );
         if (! success) {
           return;
@@ -452,8 +452,8 @@ namespace { // (anonymous)
         X.template modify<host_memory_space> ();
         auto X_lcl = X.template getLocalView<host_memory_space> ();
 
-        TEST_EQUALITY( static_cast<LO> (X_lcl.dimension_0 ()), lclNumRows );
-        TEST_EQUALITY( static_cast<LO> (X_lcl.dimension_1 ()), numVecs );
+        TEST_EQUALITY( static_cast<LO> (X_lcl.extent (0)), lclNumRows );
+        TEST_EQUALITY( static_cast<LO> (X_lcl.extent (1)), numVecs );
         if (! success) {
           return;
         }
@@ -511,7 +511,7 @@ namespace { // (anonymous)
           auto Y_j = Y->getVector (k);
           auto Y_lcl_j_2d = Y_j->template getLocalView<host_memory_space> ();
           auto Y_lcl_j_1d = Kokkos::subview (Y_lcl_j_2d, Kokkos::ALL (), 0);
-          TEST_EQUALITY( static_cast<LO> (Y_lcl_j_1d.dimension_0 ()), lclNumRows );
+          TEST_EQUALITY( static_cast<LO> (Y_lcl_j_1d.extent (0)), lclNumRows );
           if (! success) {
             return;
           }
@@ -537,7 +537,7 @@ namespace { // (anonymous)
           auto Z_j = Z->getVector (k);
           auto Z_lcl_j_2d = Z_j->template getLocalView<dev_memory_space> ();
           auto Z_lcl_j_1d = Kokkos::subview (Z_lcl_j_2d, Kokkos::ALL (), 0);
-          TEST_EQUALITY( static_cast<LO> (Z_lcl_j_1d.dimension_0 ()), lclNumRows );
+          TEST_EQUALITY( static_cast<LO> (Z_lcl_j_1d.extent (0)), lclNumRows );
           if (! success) {
             return;
           }
@@ -573,7 +573,7 @@ namespace { // (anonymous)
           }
           auto X_lcl_j_2d = X_j->template getLocalView<host_memory_space> ();
           auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
-          TEST_EQUALITY( static_cast<LO> (X_lcl_j_1d.dimension_0 ()),
+          TEST_EQUALITY( static_cast<LO> (X_lcl_j_1d.extent (0)),
                          lclNumRows );
 
           auto X_copy_j = X_copy.getVector (k);
@@ -582,7 +582,7 @@ namespace { // (anonymous)
           }
           auto X_copy_lcl_j_2d = X_copy_j->template getLocalView<host_memory_space> ();
           auto X_copy_lcl_j_1d = Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
-          TEST_EQUALITY( static_cast<LO> (X_copy_lcl_j_1d.dimension_0 ()),
+          TEST_EQUALITY( static_cast<LO> (X_copy_lcl_j_1d.extent (0)),
                          lclNumRows );
 
           auto Y_j = Y->getVector (k);
@@ -591,7 +591,7 @@ namespace { // (anonymous)
           }
           auto Y_lcl_j_2d = Y_j->template getLocalView<host_memory_space> ();
           auto Y_lcl_j_1d = Kokkos::subview (Y_lcl_j_2d, Kokkos::ALL (), 0);
-          TEST_EQUALITY( static_cast<LO> (Y_lcl_j_1d.dimension_0 ()),
+          TEST_EQUALITY( static_cast<LO> (Y_lcl_j_1d.extent (0)),
                          lclNumRows );
           if (! success) {
             return;

--- a/packages/tpetra/core/test/MultiVector/MV_Kokkos_DualView_subview.cpp
+++ b/packages/tpetra/core/test/MultiVector/MV_Kokkos_DualView_subview.cpp
@@ -105,12 +105,12 @@ namespace { // (anonymous)
     out << "Create a " << numRows << " x " << numCols << " DualView" << endl;
     dual_view_type X ("X", numRows, numCols);
 
-    TEST_EQUALITY_CONST( X.dimension_0 (), numRows );
-    TEST_EQUALITY_CONST( X.dimension_1 (), numCols );
-    TEST_EQUALITY_CONST( X.d_view.dimension_0 (), numRows );
-    TEST_EQUALITY_CONST( X.d_view.dimension_1 (), numCols );
-    TEST_EQUALITY_CONST( X.h_view.dimension_0 (), numRows );
-    TEST_EQUALITY_CONST( X.h_view.dimension_1 (), numCols );
+    TEST_EQUALITY_CONST( X.extent (0), numRows );
+    TEST_EQUALITY_CONST( X.extent (1), numCols );
+    TEST_EQUALITY_CONST( X.d_view.extent (0), numRows );
+    TEST_EQUALITY_CONST( X.d_view.extent (1), numCols );
+    TEST_EQUALITY_CONST( X.h_view.extent (0), numRows );
+    TEST_EQUALITY_CONST( X.h_view.extent (1), numCols );
     out << endl;
 
     newNumRows = numRows;
@@ -121,15 +121,15 @@ namespace { // (anonymous)
         << "," << colRng.second << "))" << endl;
     X_sub = subview (X, ALL (), colRng);
 
-    out << "X_sub claims to be " << X_sub.dimension_0 () << " x "
-        << X_sub.dimension_1 () << endl;
+    out << "X_sub claims to be " << X_sub.extent (0) << " x "
+        << X_sub.extent (1) << endl;
 
-    TEST_EQUALITY_CONST( X_sub.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_1 (), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
     out << endl;
 
     newNumRows = numRows;
@@ -140,15 +140,15 @@ namespace { // (anonymous)
         << "," << colRng.second << "))" << endl;
     X_sub = subview (X, ALL (), colRng);
 
-    out << "X_sub claims to be " << X_sub.dimension_0 () << " x "
-        << X_sub.dimension_1 () << endl;
+    out << "X_sub claims to be " << X_sub.extent (0) << " x "
+        << X_sub.extent (1) << endl;
 
-    TEST_EQUALITY_CONST( X_sub.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_1 (), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
     out << endl;
 
     newNumRows = 0;
@@ -159,15 +159,15 @@ namespace { // (anonymous)
         << rowRng.second << "), ALL)" << endl;
     X_sub = subview (X, rowRng, ALL ());
 
-    out << "X_sub claims to be " << X_sub.dimension_0 () << " x "
-        << X_sub.dimension_1 () << endl;
+    out << "X_sub claims to be " << X_sub.extent (0) << " x "
+        << X_sub.extent (1) << endl;
 
-    TEST_EQUALITY_CONST( X_sub.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_1 (), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
     out << endl;
 
     newNumRows = 0;
@@ -180,15 +180,15 @@ namespace { // (anonymous)
         << colRng.second << "))" << endl;
     X_sub = subview (X, rowRng, colRng);
 
-    out << "X_sub claims to be " << X_sub.dimension_0 () << " x "
-        << X_sub.dimension_1 () << endl;
+    out << "X_sub claims to be " << X_sub.extent (0) << " x "
+        << X_sub.extent (1) << endl;
 
-    TEST_EQUALITY_CONST( X_sub.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.dimension_1 (), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_0 (), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.dimension_1 (), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
     out << endl;
   }
 

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -1661,15 +1661,15 @@ namespace {
 
       // Make sure the pointers match.  It doesn't really matter to
       // what X2_local points, as long as it has zero rows.
-      TEST_EQUALITY( X1_local.ptr_on_device (), X_local.ptr_on_device () );
+      TEST_EQUALITY( X1_local.data (), X_local.data () );
 
       // Make sure the local dimensions of X1 are correct.
-      TEST_EQUALITY( X1_local.dimension_0 (), X_local.dimension_0 () );
-      TEST_EQUALITY( X1_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY( X1_local.extent (0), X_local.extent (0) );
+      TEST_EQUALITY( X1_local.extent (1), X_local.extent (1) );
 
       // Make sure the local dimensions of X2 are correct.
-      TEST_EQUALITY_CONST( X2_local.dimension_0 (), static_cast<size_t> (0) );
-      TEST_EQUALITY( X2_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY_CONST( X2_local.extent (0), static_cast<size_t> (0) );
+      TEST_EQUALITY( X2_local.extent (1), X_local.extent (1) );
 
       // Make sure that nothing bad happens on deallocation.
       try {
@@ -1714,15 +1714,15 @@ namespace {
 
       // Make sure the pointers match.  It doesn't really matter to
       // what X2_local points, as long as it has zero rows.
-      TEST_EQUALITY( X1_local.ptr_on_device (), X_local.ptr_on_device () );
+      TEST_EQUALITY( X1_local.data (), X_local.data () );
 
       // Make sure the local dimensions of X1 are correct.
-      TEST_EQUALITY( X1_local.dimension_0 (), X_local.dimension_0 () );
-      TEST_EQUALITY( X1_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY( X1_local.extent (0), X_local.extent (0) );
+      TEST_EQUALITY( X1_local.extent (1), X_local.extent (1) );
 
       // Make sure the local dimensions of X2 are correct.
-      TEST_EQUALITY_CONST( X2_local.dimension_0 (), static_cast<size_t> (0) );
-      TEST_EQUALITY( X2_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY_CONST( X2_local.extent (0), static_cast<size_t> (0) );
+      TEST_EQUALITY( X2_local.extent (1), X_local.extent (1) );
 
       // Make sure that nothing bad happens on deallocation.
       try {
@@ -1768,15 +1768,15 @@ namespace {
       auto X2_local = X2->template getLocalView<typename MV::dual_view_type::t_host::memory_space> ();
       // Make sure the pointers match.  It doesn't really matter to
       // what X1_local points, as long as it has zero rows.
-      TEST_EQUALITY( X2_local.ptr_on_device (), X_local.ptr_on_device () );
+      TEST_EQUALITY( X2_local.data (), X_local.data () );
 
       // Make sure the local dimensions of X1 are correct.
-      TEST_EQUALITY_CONST( X1_local.dimension_0 (), static_cast<size_t> (0) );
-      TEST_EQUALITY( X1_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY_CONST( X1_local.extent (0), static_cast<size_t> (0) );
+      TEST_EQUALITY( X1_local.extent (1), X_local.extent (1) );
 
       // Make sure the local dimensions of X2 are correct.
-      TEST_EQUALITY( X2_local.dimension_0 (), X_local.dimension_0 () );
-      TEST_EQUALITY( X2_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY( X2_local.extent (0), X_local.extent (0) );
+      TEST_EQUALITY( X2_local.extent (1), X_local.extent (1) );
 
       // Make sure that nothing bad happens on deallocation.
       try {
@@ -1821,15 +1821,15 @@ namespace {
 
       // Make sure the pointers match.  It doesn't really matter to
       // what X1_local points, as long as it has zero rows.
-      TEST_EQUALITY( X2_local.ptr_on_device (), X_local.ptr_on_device () );
+      TEST_EQUALITY( X2_local.data (), X_local.data () );
 
       // Make sure the local dimensions of X1 are correct.
-      TEST_EQUALITY_CONST( X1_local.dimension_0 (), static_cast<size_t> (0) );
-      TEST_EQUALITY( X1_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY_CONST( X1_local.extent (0), static_cast<size_t> (0) );
+      TEST_EQUALITY( X1_local.extent (1), X_local.extent (1) );
 
       // Make sure the local dimensions of X2 are correct.
-      TEST_EQUALITY( X2_local.dimension_0 (), X_local.dimension_0 () );
-      TEST_EQUALITY( X2_local.dimension_1 (), X_local.dimension_1 () );
+      TEST_EQUALITY( X2_local.extent (0), X_local.extent (0) );
+      TEST_EQUALITY( X2_local.extent (1), X_local.extent (1) );
 
       // Make sure that nothing bad happens on deallocation.
       try {
@@ -3100,16 +3100,16 @@ namespace {
     //     X.template getLocalView<typename host_view_type::execution_space> ();
 
     //   if (comm->getRank () == 0) {
-    //     TEST_EQUALITY( X_dev.dimension_0 (), static_cast<size_t> (0) );
-    //     TEST_EQUALITY( X_dev.dimension_1 (), numCols );
-    //     TEST_EQUALITY( X_host.dimension_0 (), static_cast<size_t> (0) );
-    //     TEST_EQUALITY( X_host.dimension_1 (), numCols );
+    //     TEST_EQUALITY( X_dev.extent (0), static_cast<size_t> (0) );
+    //     TEST_EQUALITY( X_dev.extent (1), numCols );
+    //     TEST_EQUALITY( X_host.extent (0), static_cast<size_t> (0) );
+    //     TEST_EQUALITY( X_host.extent (1), numCols );
     //   }
     //   else { // my rank is not zero
-    //     TEST_EQUALITY( X_dev.dimension_0 (), lclNumRows );
-    //     TEST_EQUALITY( X_dev.dimension_1 (), numCols );
-    //     TEST_EQUALITY( X_host.dimension_0 (), lclNumRows );
-    //     TEST_EQUALITY( X_host.dimension_1 (), numCols );
+    //     TEST_EQUALITY( X_dev.extent (0), lclNumRows );
+    //     TEST_EQUALITY( X_dev.extent (1), numCols );
+    //     TEST_EQUALITY( X_host.extent (0), lclNumRows );
+    //     TEST_EQUALITY( X_host.extent (1), numCols );
     //   }
     // }
 #endif // TPETRA_HAVE_KOKKOS_REFACTOR
@@ -3142,10 +3142,10 @@ namespace {
     //   host_view_type X_host =
     //     X.template getLocalView<typename host_view_type::execution_space> ();
 
-    //   TEST_EQUALITY( X_dev.dimension_0 (), lclNumRows );
-    //   TEST_EQUALITY( X_dev.dimension_1 (), numCols );
-    //   TEST_EQUALITY( X_host.dimension_0 (), lclNumRows );
-    //   TEST_EQUALITY( X_host.dimension_1 (), numCols );
+    //   TEST_EQUALITY( X_dev.extent (0), lclNumRows );
+    //   TEST_EQUALITY( X_dev.extent (1), numCols );
+    //   TEST_EQUALITY( X_host.extent (0), lclNumRows );
+    //   TEST_EQUALITY( X_host.extent (1), numCols );
     // }
 #endif // TPETRA_HAVE_KOKKOS_REFACTOR
 

--- a/packages/tpetra/tsqr/src/Tsqr_CombineNative.hpp
+++ b/packages/tpetra/tsqr/src/Tsqr_CombineNative.hpp
@@ -491,8 +491,8 @@ namespace TSQR {
        const Kokkos::View<scalar_type**, Kokkos::LayoutLeft, device_type>& A) const
   {
     constexpr scalar_type ZERO {0.0};
-    const Ordinal m = A.dimension_0 ();
-    const Ordinal n = A.dimension_1 ();
+    const Ordinal m = A.extent (0);
+    const Ordinal n = A.extent (1);
 
     constexpr Ordinal incy {1};
     //Ordinal jy = (incy > 0) ? 1 : 1 - (n-1) * incy;
@@ -524,8 +524,8 @@ namespace TSQR {
     using x_vec_type = Kokkos::View<const scalar_type*, Kokkos::LayoutLeft, device_type>;
     using range_type = std::pair<Ordinal, Ordinal>;
 
-    const Ordinal m = A.dimension_0 ();
-    const Ordinal n = A.dimension_1 ();
+    const Ordinal m = A.extent (0);
+    const Ordinal n = A.extent (1);
 
     const bool no_trans = (trans[0] == 'N' || trans[0] == 'n');
     x_vec_type x_view = Kokkos::subview (x, range_type (0, no_trans ? n : m));
@@ -548,8 +548,8 @@ namespace TSQR {
     constexpr scalar_type ZERO {0.0};
     constexpr scalar_type ONE {1.0};
 
-    const Ordinal m = A_view.dimension_0 ();
-    const Ordinal n = A_view.dimension_1 ();
+    const Ordinal m = A_view.extent (0);
+    const Ordinal n = A_view.extent (1);
 
     for (Ordinal k = 0; k < n; ++k) {
       work_view(k) = ZERO;
@@ -624,9 +624,9 @@ namespace TSQR {
       Kokkos::View<const scalar_type*, Kokkos::LayoutLeft, device_type>;
     constexpr scalar_type ZERO {0.0};
 
-    const Ordinal m = A.dimension_0 ();
-    const Ordinal ncols_Q = A.dimension_1 ();
-    const Ordinal ncols_C = C_top.dimension_1 ();
+    const Ordinal m = A.extent (0);
+    const Ordinal ncols_Q = A.extent (1);
+    const Ordinal ncols_C = C_top.extent (1);
 
     for (Ordinal i = 0; i < ncols_C; ++i) {
       work(i) = ZERO;
@@ -717,7 +717,7 @@ namespace TSQR {
     constexpr scalar_type ZERO {0.0};
     constexpr scalar_type ONE {1.0};
 
-    const Ordinal n = R_top.dimension_0 ();
+    const Ordinal n = R_top.extent (0);
     for (Ordinal k = 0; k < n; ++k) {
       work_view(k) = ZERO;
     }
@@ -845,8 +845,8 @@ namespace TSQR {
     using const_vec_type =
       Kokkos::View<const scalar_type*, Kokkos::LayoutLeft, device_type>;
     constexpr scalar_type ZERO {0.0};
-    const Ordinal ncols_C = C_top.dimension_1 ();
-    const Ordinal ncols_Q = R_bot.dimension_1 ();
+    const Ordinal ncols_C = C_top.extent (1);
+    const Ordinal ncols_Q = R_bot.extent (1);
 
     Ordinal j_start, j_end, j_step;
     if (applyType == ApplyType::NoTranspose) {


### PR DESCRIPTION
@trilinos/tpetra

Kokkos::View methods ptr_on_device() and dimension_N() (replace N with 0, 1, 2, ...) have been deprecated for a long time.  Kokkos has replaced them with data() resp. extent(N).

This commit replaces all uses of the deprecated methods in Tpetra, with their nondeprecated replacements.  This fixes #2705.

@trilinos/tpetra 