### PR TITLE
Teuchos,Ifpack2,Xpetra,MueLu,TrilinosCouplings: Remove use of deprecated Kokkos::View methods (ptr_on_device and dimension_N)

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -145,7 +145,7 @@ getValidParameters () const
   validParams->set("Amesos2",dummyList);
   validParams->sublist("Amesos2").disableRecursiveValidation();
   validParams->set("Amesos2 solver name", "KLU2");
-  
+
   Teuchos::ArrayRCP<int> tmp;
   validParams->set("partitioner: map", tmp);
 
@@ -156,7 +156,7 @@ getValidParameters () const
                                    typename MatrixType::global_ordinal_type,
                                    typename MatrixType::node_type> > dummy;
   validParams->set("partitioner: coordinates",dummy);
-  
+
   return validParams;
 }
 
@@ -415,9 +415,9 @@ size_t BlockRelaxation<MatrixType,ContainerType>::getNodeSmootherComplexity() co
   // Relaxation methods cost roughly one apply + one block-diagonal inverse per iteration
   // NOTE: This approximates all blocks as dense, which may overstate the cost if you have a sparse (or banded) container.
   size_t block_nnz = 0;
-  for (local_ordinal_type i = 0; i < NumLocalBlocks_; ++i) 
+  for (local_ordinal_type i = 0; i < NumLocalBlocks_; ++i)
     block_nnz += Partitioner_->numRowsInPart(i) *Partitioner_->numRowsInPart(i);
-    
+
   return block_nnz + A_->getNodeNumEntries();
 }
 
@@ -470,7 +470,7 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
   {
     auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
     auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-    if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+    if (X_lcl_host.data () == Y_lcl_host.data ()) {
       X_copy = rcp (new MV (X, Teuchos::Copy));
     } else {
       X_copy = rcpFromRef (X);
@@ -612,7 +612,7 @@ initialize ()
     TEUCHOS_TEST_FOR_EXCEPTION
       (hasBlockCrsMatrix_, std::runtime_error,
        "Ifpack2::BlockRelaxation::initialize: "
-       "We do not support overlapped Jacobi yet for Tpetra::BlockCrsMatrix.  Sorry!");      
+       "We do not support overlapped Jacobi yet for Tpetra::BlockCrsMatrix.  Sorry!");
 
     // weight of each vertex
     W_ = rcp (new vector_type (A_->getRowMap ()));

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
@@ -298,7 +298,7 @@ struct DefaultVectorizationMethod<Kokkos::Cuda, double> {
 template <>
 struct VectorizationTraits<SIMD<double> > {
   typedef double value_type;
-  typedef Kokkos::DefaultHostExecutionSpace exec_space; 
+  typedef Kokkos::DefaultHostExecutionSpace exec_space;
   enum : int { vector_length = DefaultVectorLength<double,typename exec_space::memory_space>::value };
   typedef Vector<SIMD<double>, vector_length> vector_type;
 };
@@ -1762,7 +1762,7 @@ public: // Intended to be private, but public for Cuda.
 #else // __KOKKOSBATCHED_PROMOTION__
       if (add_to_diag)
         KokkosBatched::Details::Todo::Serial_LU_Internal_Unblocked_invoke(
-          A.dimension_0(), A.dimension_1(), A.data(), A.stride_0(), A.stride_1(), diag_safety);
+          A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), diag_safety);
       else {
         namespace kbe = KokkosBatched::Experimental;
         kbe::SerialLU<kbe::Algo::LU::Blocked>::invoke(A);
@@ -1989,7 +1989,7 @@ public: // Intended to be private, but public for Cuda.
       namespace kbe = KokkosBatched::Experimental;
       kbe::SerialTrsvInternalLower<kbe::Algo::Trsv::Unblocked>::invoke(
         true,
-        values.dimension_1(),
+        values.extent(1),
         a,
         values.data() + i0*bs2, values.stride_1(), values.stride_2(),
         X.data() + r0*xsz, X.stride_1());
@@ -2002,7 +2002,7 @@ public: // Intended to be private, but public for Cuda.
       namespace kbe = KokkosBatched::Experimental;
       kbe::SerialTrsmInternalLeftLower<kbe::Algo::Trsm::Blocked>::invoke(
         true,
-        values.dimension_1(), X.dimension_2(),
+        values.extent(1), X.extent(2),
         a,
         values.data() + i0*bs2, values.stride_1(), values.stride_2(),
         X.data() + r0*xsz, X.stride_1(), X.stride_2());
@@ -2015,7 +2015,7 @@ public: // Intended to be private, but public for Cuda.
       namespace kbe = KokkosBatched::Experimental;
       kbe::SerialTrsvInternalUpper<kbe::Algo::Trsv::Unblocked>::invoke(
         false,
-        values.dimension_1(),
+        values.extent(1),
         a,
         values.data() + i0*bs2, values.stride_1(), values.stride_2(),
         X.data() + r0*xsz, X.stride_1());
@@ -2028,7 +2028,7 @@ public: // Intended to be private, but public for Cuda.
       namespace kbe = KokkosBatched::Experimental;
       kbe::SerialTrsmInternalLeftUpper<kbe::Algo::Trsm::Blocked>::invoke(
         false,
-        values.dimension_1(), X.dimension_2(),
+        values.extent(1), X.extent(2),
         a,
         values.data() + i0*bs2, values.stride_1(), values.stride_2(),
         X.data() + r0*xsz, X.stride_1(), X.stride_2());
@@ -2042,7 +2042,7 @@ public: // Intended to be private, but public for Cuda.
            typename std::enable_if<std::is_same<Tag, VecTag>::value>::type* = 0) const {
       namespace kbe = KokkosBatched::Experimental;
       kbe::SerialGemvInternal<kbe::Algo::Gemv::Unblocked>::invoke(
-        values.dimension_1(), values.dimension_2(),
+        values.extent(1), values.extent(2),
         a,
         values.data() + a0*bs2, values.stride_1(), values.stride_2(),
         X.data() + b0*xsz, X.stride_1(),
@@ -2056,7 +2056,7 @@ public: // Intended to be private, but public for Cuda.
            typename std::enable_if<std::is_same<Tag, MatTag>::value>::type* = 0) const {
       namespace kbe = KokkosBatched::Experimental;
       kbe::SerialGemmInternal<kbe::Algo::Gemm::Blocked>::invoke(
-        X.dimension_1(), X.dimension_2(), values.dimension_2(),
+        X.extent(1), X.extent(2), values.extent(2),
         a,
         values.data() + a0*bs2, values.stride_1(), values.stride_2(),
         X.data() + b0*xsz, X.stride_1(), X.stride_2(),
@@ -2069,8 +2069,8 @@ public: // Intended to be private, but public for Cuda.
            const typename Tridiags::PackedMultiVector& X_)
       : pack_td_ptr(btdm.pack_td_ptr), values(btdm.values),
         packptr(packptr_), part2packrowidx0(part2packrowidx0_),
-        X(X_), bs2(values.dimension_1()*values.dimension_1()),
-        xsz(values.dimension_1()*X.dimension_2())
+        X(X_), bs2(values.extent(1)*values.extent(1)),
+        xsz(values.extent(1)*X.extent(2))
     {}
 
     template <typename Tag>

--- a/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
@@ -464,7 +464,7 @@ applyImpl (const MV& X,
   {
     auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
     auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-    if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+    if (X_lcl_host.data () == Y_lcl_host.data ()) {
       X_copy = rcp (new MV (X, Teuchos::Copy));
       copiedInput = true;
     } else {

--- a/packages/ifpack2/src/Ifpack2_Container.hpp
+++ b/packages/ifpack2/src/Ifpack2_Container.hpp
@@ -450,7 +450,7 @@ void Container<MatrixType>::DoJacobi(HostView& X, HostView& Y, int stride) const
   const scalar_type one = STS::one();
   // Note: Flop counts copied naively from Ifpack.
   // use partitions_ and blockRows_
-  size_t numVecs = X.dimension_1();
+  size_t numVecs = X.extent(1);
   // Non-overlapping Jacobi
   for (local_ordinal_type i = 0; i < numBlocks_; i++)
   {
@@ -503,7 +503,7 @@ void Container<MatrixType>::DoGaussSeidel(HostView& X, HostView& Y, HostView& Y2
   // Note: Flop counts copied naively from Ifpack.
   const scalar_type one = STS::one();
   const size_t Length = inputMatrix_->getNodeMaxNumRowEntries();
-  auto numVecs = X.dimension_1();
+  auto numVecs = X.extent(1);
   Array<scalar_type> Values;
   Array<local_ordinal_type> Indices;
   Indices.resize(Length);
@@ -513,7 +513,7 @@ void Container<MatrixType>::DoGaussSeidel(HostView& X, HostView& Y, HostView& Y2
   // One to store the sum of the corrections (initialized to zero)
   // One to store the temporary residual (doesn't matter if it is zeroed or not)
   // My apologies for making the names clear and meaningful. (X=RHS, Y=guess?! Nice.)
-  HostView Resid("", X.dimension_0(), X.dimension_1());
+  HostView Resid("", X.extent(0), X.extent(1));
   for(local_ordinal_type i = 0; i < numBlocks_; i++)
   {
     if(blockRows_[i] > 1 || hasBlockCrs_)
@@ -608,7 +608,7 @@ void Container<MatrixType>::DoSGS(HostView& X, HostView& Y, HostView& Y2, int st
   using Teuchos::rcp;
   using Teuchos::rcpFromRef;
   const scalar_type one = STS::one();
-  auto numVecs = X.dimension_1();
+  auto numVecs = X.extent(1);
   const size_t Length = inputMatrix_->getNodeMaxNumRowEntries();
   Array<scalar_type> Values;
   Array<local_ordinal_type> Indices(Length);
@@ -617,7 +617,7 @@ void Container<MatrixType>::DoSGS(HostView& X, HostView& Y, HostView& Y2, int st
   // One to store the sum of the corrections (initialized to zero)
   // One to store the temporary residual (doesn't matter if it is zeroed or not)
   // My apologies for making the names clear and meaningful. (X=RHS, Y=guess?! Nice.)
-  HostView Resid("", X.dimension_0(), X.dimension_1());
+  HostView Resid("", X.extent(0), X.extent(1));
   // Forward Sweep
   for(local_ordinal_type i = 0; i < numBlocks_; i++)
   {

--- a/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
@@ -463,7 +463,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     {
       auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
       auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-      if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+      if (X_lcl_host.data () == Y_lcl_host.data ()) {
         X_temp = rcp (new MV (X, Teuchos::Copy));
       } else {
         X_temp = rcpFromRef (X);

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -119,7 +119,7 @@ struct LocalReciprocalThreshold {
            const typename XV::non_const_value_type& minVal)
   {
     typedef typename XV::execution_space execution_space;
-    Kokkos::RangePolicy<execution_space, SizeType> policy (0, X.dimension_0 ());
+    Kokkos::RangePolicy<execution_space, SizeType> policy (0, X.extent (0));
     V_ReciprocalThresholdSelfFunctor<XV, SizeType> op (X, minVal);
     Kokkos::parallel_for (policy, op);
   }
@@ -821,7 +821,7 @@ Chebyshev<ScalarType, MV>::compute ()
       if (! A_crsMat.is_null () && A_crsMat->isStaticGraph ()) {
         // It's a CrsMatrix with a const graph; cache diagonal offsets.
         const size_t lclNumRows = A_crsMat->getNodeNumRows ();
-        if (diagOffsets_.dimension_0 () < lclNumRows) {
+        if (diagOffsets_.extent (0) < lclNumRows) {
           diagOffsets_ = offsets_type (); // clear first to save memory
           diagOffsets_ = offsets_type ("offsets", lclNumRows);
         }
@@ -839,7 +839,7 @@ Chebyshev<ScalarType, MV>::compute ()
         // if we haven't already.
         if (! savedDiagOffsets_) {
           const size_t lclNumRows = A_crsMat->getNodeNumRows ();
-          if (diagOffsets_.dimension_0 () < lclNumRows) {
+          if (diagOffsets_.extent (0) < lclNumRows) {
             diagOffsets_ = offsets_type (); // clear first to save memory
             diagOffsets_ = offsets_type ("offsets", lclNumRows);
           }

--- a/packages/ifpack2/src/Ifpack2_Details_CrsArrays.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_CrsArrays.hpp
@@ -45,8 +45,8 @@
 ///   (row pointers, column indices, and values) from Tpetra::RowMatrix.
 ///   This is used by Ifpack2's FastILU wrapper.
 
-#ifndef __IFPACK2_CRSARRAYS_DECL_HPP__ 
-#define __IFPACK2_CRSARRAYS_DECL_HPP__ 
+#ifndef __IFPACK2_CRSARRAYS_DECL_HPP__
+#define __IFPACK2_CRSARRAYS_DECL_HPP__
 
 #include <Tpetra_RowMatrix.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -117,10 +117,10 @@ struct CrsArrayReader
     OrdinalArrayHost& colinds;
   };
 
-  //! Functor for getting matrix values in parallel 
+  //! Functor for getting matrix values in parallel
   struct GetValuesFunctor
   {
-    GetValuesFunctor(const TRowMatrix* A_, const OrdinalArrayHost& rowptrs_, ScalarArrayHost& vals_) : 
+    GetValuesFunctor(const TRowMatrix* A_, const OrdinalArrayHost& rowptrs_, ScalarArrayHost& vals_) :
       A(A_), rowptrs(rowptrs_), vals(vals_) {}
     KOKKOS_INLINE_FUNCTION void operator()(const int row) const
     {
@@ -221,7 +221,7 @@ struct CrsArrayReader
     auto rowmap = A->getLocalMatrix().graph.row_map;
     //allocate rowptrs, it's a deep copy (colinds is a shallow copy so not necessary for it)
     rowptrs = OrdinalArray("RowPtrs", A->getNodeNumRows() + 1);
-    for(size_t i = 0; i < rowmap.dimension_0(); i++)
+    for(size_t i = 0; i < rowmap.extent(0); i++)
     {
       rowptrs[i] = rowmap[i];
     }

--- a/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
@@ -138,8 +138,8 @@ public:
                         const Teuchos::ArrayView<const LO>& perm) const
   {
     //note: j is col, i is row
-    for(size_t j = 0; j < X_out.dimension_1(); ++j) {
-      for(size_t i = 0; i < X_out.dimension_0(); ++i) {
+    for(size_t j = 0; j < X_out.extent(1); ++j) {
+      for(size_t i = 0; i < X_out.extent(0); ++i) {
         const LO i_perm = perm[i];
         X_out(i, j) = X_in(i_perm, j);
       }
@@ -151,8 +151,8 @@ public:
                          OutView& X_out,
                          const Teuchos::ArrayView<const LO>& perm) const
   {
-    for(size_t j = 0; j < X_out.dimension_1(); ++j) {
-      for(size_t i = 0; i < X_out.dimension_0(); ++i) {
+    for(size_t j = 0; j < X_out.extent(1); ++j) {
+      for(size_t i = 0; i < X_out.extent(0); ++i) {
         const LO i_perm = perm[i];
         X_in(i_perm, j) = X_out(i, j);
       }
@@ -182,7 +182,7 @@ public:
                        MV_out& X_out,
                        const Teuchos::ArrayView<const LO>& perm) const
   {
-    for(size_t j = 0; j < X_in.dimension_1(); ++j) {
+    for(size_t j = 0; j < X_in.extent(1); ++j) {
       Teuchos::ArrayRCP<const OutScalar> X_out_j = X_out.getData(j);
       for(size_t i = 0; i < X_out.getLocalLength(); ++i) {
         const LO i_perm = perm[i];

--- a/packages/ifpack2/src/Ifpack2_Diagonal_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Diagonal_def.hpp
@@ -184,7 +184,7 @@ void Diagonal<MatrixType>::initialize ()
     }
     else {
       const size_t lclNumRows = A_crs->getNodeNumRows ();
-      if (offsets_.dimension_0 () < lclNumRows) {
+      if (offsets_.extent (0) < lclNumRows) {
         offsets_ = offsets_type (); // clear first to save memory
         offsets_ = offsets_type ("offsets", lclNumRows);
       }

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -613,7 +613,7 @@ void RBILUK<MatrixType>::compute ()
         Tpetra::Experimental::GEMM ("N", "N", STS::one (), currentVal, dmatInverse,
                                     STS::zero (), matTmp);
 #endif
-        //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*> (currentVal.ptr_on_device ()), reinterpret_cast<impl_scalar_type*> (dmatInverse.ptr_on_device ()), reinterpret_cast<impl_scalar_type*> (matTmp.ptr_on_device ()), blockSize_);
+        //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*> (currentVal.data ()), reinterpret_cast<impl_scalar_type*> (dmatInverse.data ()), reinterpret_cast<impl_scalar_type*> (matTmp.data ()), blockSize_);
         //currentVal.assign(matTmp);
         Tpetra::Experimental::COPY (matTmp, currentVal);
 
@@ -638,7 +638,7 @@ void RBILUK<MatrixType>::compute ()
               Tpetra::Experimental::GEMM ("N", "N", magnitude_type(-STM::one ()), multiplier, uumat,
                                           STM::one (), kkval);
 #endif
-              //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*> (multiplier.ptr_on_device ()), reinterpret_cast<impl_scalar_type*> (uumat.ptr_on_device ()), reinterpret_cast<impl_scalar_type*> (kkval.ptr_on_device ()), blockSize_, -STM::one(), STM::one());
+              //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*> (multiplier.data ()), reinterpret_cast<impl_scalar_type*> (uumat.data ()), reinterpret_cast<impl_scalar_type*> (kkval.data ()), blockSize_, -STM::one(), STM::one());
             }
           }
         }
@@ -659,7 +659,7 @@ void RBILUK<MatrixType>::compute ()
               Tpetra::Experimental::GEMM ("N", "N", magnitude_type(-STM::one ()), multiplier, uumat,
                                           STM::one (), kkval);
 #endif
-              //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*>(multiplier.ptr_on_device ()), reinterpret_cast<impl_scalar_type*>(uumat.ptr_on_device ()), reinterpret_cast<impl_scalar_type*>(kkval.ptr_on_device ()), blockSize_, -STM::one(), STM::one());
+              //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*>(multiplier.data ()), reinterpret_cast<impl_scalar_type*>(uumat.data ()), reinterpret_cast<impl_scalar_type*>(kkval.data ()), blockSize_, -STM::one(), STM::one());
             }
             else {
 #ifndef IFPACK2_RBILUK_INITIAL_NOKK
@@ -672,7 +672,7 @@ void RBILUK<MatrixType>::compute ()
               Tpetra::Experimental::GEMM ("N", "N", magnitude_type(-STM::one ()), multiplier, uumat,
                                           STM::one (), diagModBlock);
 #endif
-              //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*>(multiplier.ptr_on_device ()), reinterpret_cast<impl_scalar_type*>(uumat.ptr_on_device ()), reinterpret_cast<impl_scalar_type*>(diagModBlock.ptr_on_device ()), blockSize_, -STM::one(), STM::one());
+              //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*>(multiplier.data ()), reinterpret_cast<impl_scalar_type*>(uumat.data ()), reinterpret_cast<impl_scalar_type*>(diagModBlock.data ()), blockSize_, -STM::one(), STM::one());
             }
           }
         }
@@ -731,7 +731,7 @@ void RBILUK<MatrixType>::compute ()
         Tpetra::Experimental::GEMM ("N", "N", STS::one (), dmat, currentVal,
                                     STS::zero (), matTmp);
 #endif
-        //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*>(dmat.ptr_on_device ()), reinterpret_cast<impl_scalar_type*>(currentVal.ptr_on_device ()), reinterpret_cast<impl_scalar_type*>(matTmp.ptr_on_device ()), blockSize_);
+        //blockMatOpts.square_matrix_matrix_multiply(reinterpret_cast<impl_scalar_type*>(dmat.data ()), reinterpret_cast<impl_scalar_type*>(currentVal.data ()), reinterpret_cast<impl_scalar_type*>(matTmp.data ()), blockSize_);
         //currentVal.assign(matTmp);
         Tpetra::Experimental::COPY (matTmp, currentVal);
       }

--- a/packages/ifpack2/src/Ifpack2_Hiptmair_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hiptmair_def.hpp
@@ -317,7 +317,7 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
     {
       auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
       auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-      if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+      if (X_lcl_host.data () == Y_lcl_host.data ()) {
         Xcopy = rcp (new MV (X, Teuchos::Copy));
       } else {
         Xcopy = rcpFromRef (X);

--- a/packages/ifpack2/src/Ifpack2_Krylov_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Krylov_def.hpp
@@ -469,7 +469,7 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
     {
       auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
       auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-      if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+      if (X_lcl_host.data () == Y_lcl_host.data ()) {
         Xcopy = rcp (new MV (X, Teuchos::Copy));
       } else {
         Xcopy = rcpFromRef (X);

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -185,12 +185,12 @@ public:
     const auto& X_view = X.template getLocalView<Kokkos::HostSpace>();
     const auto& Y_view = Y.template getLocalView<Kokkos::HostSpace>();
     // Only does something if #rhs > current capacity.
-    HTST::reset_max_nrhs(Timpl_.get(), X_view.dimension_1());
+    HTST::reset_max_nrhs(Timpl_.get(), X_view.extent(1));
     // Switch alpha and beta because of HTS's opposite convention.
     HTST::solve_omp(Timpl_.get(),
                     // For std/Kokkos::complex.
                     reinterpret_cast<const scalar_type*>(X_view.data()),
-                    X_view.dimension_1(),
+                    X_view.extent(1),
                     // For std/Kokkos::complex.
                     reinterpret_cast<scalar_type*>(Y_view.data()),
                     beta, alpha);
@@ -394,9 +394,9 @@ initialize ()
     auto numCols = Alocal.numCols();
     auto numNnz = Alocal.nnz();
 
-    typename decltype(ptr)::non_const_type  newptr ("ptr", ptr.dimension_0 ());
-    typename decltype(ind)::non_const_type  newind ("ind", ind.dimension_0 ());
-    decltype(val)                           newval ("val", val.dimension_0 ());
+    typename decltype(ptr)::non_const_type  newptr ("ptr", ptr.extent (0));
+    typename decltype(ind)::non_const_type  newind ("ind", ind.extent (0));
+    decltype(val)                           newval ("val", val.extent (0));
 
     // FIXME: The code below assumes UVM
     crs_matrix_type::execution_space::fence();

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -514,7 +514,7 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
       {
         auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
         auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-        if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+        if (X_lcl_host.data () == Y_lcl_host.data ()) {
           Xcopy = rcp (new MV (X, Teuchos::Copy));
         } else {
           Xcopy = rcpFromRef (X);
@@ -685,10 +685,10 @@ public:
   InvertDiagBlocks (BlockDiagView& block_diag)
     : block_diag_(block_diag)
   {
-    const auto blksz = block_diag.dimension_1();
-    Kokkos::resize(rwrk_buf_, block_diag_.dimension_0(), blksz);
+    const auto blksz = block_diag.extent(1);
+    Kokkos::resize(rwrk_buf_, block_diag_.extent(0), blksz);
     rwrk_ = rwrk_buf_;
-    Kokkos::resize(iwrk_buf_, block_diag_.dimension_0(), blksz);
+    Kokkos::resize(iwrk_buf_, block_diag_.extent(0), blksz);
     iwrk_ = iwrk_buf_;
   }
 
@@ -762,7 +762,7 @@ void Relaxation<MatrixType>::computeBlockCrs ()
       blockDiag_ = block_diag_type (); // clear it before reallocating
       blockDiag_ = block_diag_type ("Ifpack2::Relaxation::blockDiag_",
                                     lclNumMeshRows, blockSize, blockSize);
-      if (Teuchos::as<LO>(diagOffsets_.dimension_0 () ) < lclNumMeshRows) {
+      if (Teuchos::as<LO>(diagOffsets_.extent (0) ) < lclNumMeshRows) {
         // Clear diagOffsets_ first (by assigning an empty View to it)
         // to save memory, before reallocating.
         diagOffsets_ = Kokkos::View<size_t*, device_type> ();
@@ -770,11 +770,11 @@ void Relaxation<MatrixType>::computeBlockCrs ()
       }
       blockCrsA->getCrsGraph ().getLocalDiagOffsets (diagOffsets_);
       TEUCHOS_TEST_FOR_EXCEPTION
-        (static_cast<size_t> (diagOffsets_.dimension_0 ()) !=
-         static_cast<size_t> (blockDiag_.dimension_0 ()),
-         std::logic_error, "diagOffsets_.dimension_0() = " <<
-         diagOffsets_.dimension_0 () << " != blockDiag_.dimension_0() = "
-         << blockDiag_.dimension_0 () <<
+        (static_cast<size_t> (diagOffsets_.extent (0)) !=
+         static_cast<size_t> (blockDiag_.extent (0)),
+         std::logic_error, "diagOffsets_.extent(0) = " <<
+         diagOffsets_.extent (0) << " != blockDiag_.extent(0) = "
+         << blockDiag_.extent (0) <<
          ".  Please report this bug to the Ifpack2 developers.");
       savedDiagOffsets_ = true;
     }
@@ -935,7 +935,7 @@ void Relaxation<MatrixType>::compute ()
       } else {
         if (! savedDiagOffsets_) { // we haven't precomputed offsets
           const size_t lclNumRows = A_->getRowMap ()->getNodeNumElements ();
-          if (diagOffsets_.dimension_0 () < lclNumRows) {
+          if (diagOffsets_.extent (0) < lclNumRows) {
             typedef typename node_type::device_type DT;
             diagOffsets_ = Kokkos::View<size_t*, DT> (); // clear 1st to save mem
             diagOffsets_ = Kokkos::View<size_t*, DT> ("offsets", lclNumRows);
@@ -976,7 +976,7 @@ void Relaxation<MatrixType>::compute ()
     auto diag_2d = Diagonal_->template getLocalView<Kokkos::HostSpace> ();
     auto diag_1d = Kokkos::subview (diag_2d, Kokkos::ALL (), 0);
     // FIXME (mfh 12 Jan 2016) temp fix for Kokkos::complex vs. std::complex.
-    scalar_type* const diag = reinterpret_cast<scalar_type*> (diag_1d.ptr_on_device ());
+    scalar_type* const diag = reinterpret_cast<scalar_type*> (diag_1d.data ());
 
     // Setup for L1 Methods.
     // Here we add half the value of the off-processor entries in the row,
@@ -1877,7 +1877,7 @@ MTGaussSeidel (const crs_matrix_type* crsMat,
 
     if (X_colMap->getLocalLength () != 0 && X_domainMap->getLocalLength ()) {
       TEUCHOS_TEST_FOR_EXCEPTION(
-        X_colMap_host_view.ptr_on_device () != X_domainMap_host_view.ptr_on_device (),
+        X_colMap_host_view.data () != X_domainMap_host_view.data (),
         std::logic_error, "Ifpack2::Relaxation::MTGaussSeidel: "
         "Pointer to start of column Map view of X is not equal to pointer to "
         "start of (domain Map view of) X.  This may mean that "
@@ -1886,13 +1886,13 @@ MTGaussSeidel (const crs_matrix_type* crsMat,
     }
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-      X_colMap_host_view.dimension_0 () < X_domainMap_host_view.dimension_0 () ||
+      X_colMap_host_view.extent (0) < X_domainMap_host_view.extent (0) ||
       X_colMap->getLocalLength () < X_domainMap->getLocalLength (),
       std::logic_error, "Ifpack2::Relaxation::MTGaussSeidel: "
       "X_colMap has fewer local rows than X_domainMap.  "
-      "X_colMap_host_view.dimension_0() = " << X_colMap_host_view.dimension_0 ()
-      << ", X_domainMap_host_view.dimension_0() = "
-      << X_domainMap_host_view.dimension_0 ()
+      "X_colMap_host_view.extent(0) = " << X_colMap_host_view.extent (0)
+      << ", X_domainMap_host_view.extent(0) = "
+      << X_domainMap_host_view.extent (0)
       << ", X_colMap->getLocalLength() = " << X_colMap->getLocalLength ()
       << ", and X_domainMap->getLocalLength() = "
       << X_domainMap->getLocalLength ()
@@ -1969,7 +1969,7 @@ MTGaussSeidel (const crs_matrix_type* crsMat,
   bool update_y_vector = true;
   //false as it was done up already, and we dont want to zero it in each sweep.
   bool zero_x_vector = false;
-  
+
   for (int sweep = 0; sweep < numSweeps; ++sweep) {
     if (! importer.is_null () && sweep > 0) {
       // We already did the first Import for the zeroth sweep above,

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
@@ -243,7 +243,7 @@ apply (HostView& X,
 
   // Tpetra::MultiVector specialization corresponding to InverseType.
   Details::MultiVectorLocalGatherScatter<mv_type, inverse_mv_type> mvgs;
-  size_t numVecs = X.dimension_1();
+  size_t numVecs = X.extent(1);
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     ! IsComputed_, std::runtime_error, "Ifpack2::SparseContainer::apply: "
@@ -251,10 +251,10 @@ apply (HostView& X,
     "You may call the apply() method as many times as you want after calling "
     "compute() once, but you must have called compute() at least once.");
   TEUCHOS_TEST_FOR_EXCEPTION(
-    X.dimension_1() != Y.dimension_1(), std::runtime_error,
+    X.extent(1) != Y.extent(1), std::runtime_error,
     "Ifpack2::SparseContainer::apply: X and Y have different numbers of "
-    "vectors.  X has " << X.dimension_1()
-    << ", but Y has " << Y.dimension_1() << ".");
+    "vectors.  X has " << X.extent(1)
+    << ", but Y has " << Y.extent(1) << ".");
 
   if (numVecs == 0) {
     return; // done! nothing to do
@@ -365,7 +365,7 @@ weightedApply (HostView& X,
   typedef Tpetra::Vector<InverseScalar, InverseLocalOrdinal, InverseGlobalOrdinal, InverseNode> inverse_vector_type;
 
   Details::MultiVectorLocalGatherScatter<mv_type, inverse_mv_type> mvgs;
-  const size_t numVecs = X.dimension_1();
+  const size_t numVecs = X.extent(1);
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     ! IsComputed_, std::runtime_error, "Ifpack2::SparseContainer::"
@@ -374,10 +374,10 @@ weightedApply (HostView& X,
     "after calling compute() once, but you must have called compute() at least "
     "once.");
   TEUCHOS_TEST_FOR_EXCEPTION(
-    X.dimension_1() != Y.dimension_1(), std::runtime_error,
+    X.extent(1) != Y.extent(1), std::runtime_error,
     "Ifpack2::SparseContainer::weightedApply: X and Y have different numbers "
-    "of vectors.  X has " << X.dimension_1() << ", but Y has "
-    << Y.dimension_1() << ".");
+    "of vectors.  X has " << X.extent(1) << ", but Y has "
+    << Y.extent(1) << ".");
 
   if (numVecs == 0) {
     return; // done! nothing to do

--- a/packages/ifpack2/src/supportgraph/Ifpack2_SupportGraph_def.hpp
+++ b/packages/ifpack2/src/supportgraph/Ifpack2_SupportGraph_def.hpp
@@ -648,7 +648,7 @@ apply (const Tpetra::MultiVector<scalar_type,
     {
       auto X_lcl_host = X.getLocalView<Kokkos::HostSpace> ();
       auto Y_lcl_host = Y.getLocalView<Kokkos::HostSpace> ();
-      if (X_lcl_host.ptr_on_device () == Y_lcl_host.ptr_on_device ()) {
+      if (X_lcl_host.data () == Y_lcl_host.data ()) {
         Xcopy = rcp (new MV (X, Teuchos::Copy));
       } else {
         Xcopy = rcpFromRef (X);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAmesos2solver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAmesos2solver.cpp
@@ -154,7 +154,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Amesos2Wrapper, Test0, Scalar, LO, GO)
     diff.update (STS::one (), x, -STS::one ());
     diff.normInf (norms);
     Kokkos::deep_copy (norms_h, norms);
-    for (LO j = 0; j < static_cast<LO> (norms_h.dimension_0 ()); ++j) {
+    for (LO j = 0; j < static_cast<LO> (norms_h.extent (0)); ++j) {
       const mag_type absVal = ArithTraits<mag_type>::abs (norms_h(j));
       TEST_ASSERT( absVal <= bound );
       if (absVal > bound) {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -220,7 +220,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, Test2, Scalar, LO, GO)
   y.template sync<Kokkos::HostSpace> ();
   auto x_lcl_host = x.template getLocalView<Kokkos::HostSpace> ();
   auto y_lcl_host = x.template getLocalView<Kokkos::HostSpace> ();
-  TEST_EQUALITY( x_lcl_host.ptr_on_device (), y_lcl_host.ptr_on_device () ); // vector x and y are pointing to the same memory location (such test only works if num of local elements != 0)
+  TEST_EQUALITY( x_lcl_host.data (), y_lcl_host.data () ); // vector x and y are pointing to the same memory location (such test only works if num of local elements != 0)
 
   prec.apply(x, y);
 
@@ -708,7 +708,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestDiagonalBlockCrsMa
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol,1e-14);
     }
@@ -836,7 +836,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestLowerTriangularBlo
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(lcl_row,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }
@@ -897,7 +897,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestUpperTriangularBlo
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    auto yb = ylcl.ptr_on_device();
+    auto yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestLocalSparseTriangularSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestLocalSparseTriangularSolver.cpp
@@ -285,11 +285,11 @@ void testCompareToLocalSolve (bool& success, Teuchos::FancyOStream& out,
 
         local_matrix_type A_lcl = A->getLocalMatrix ();
 
-        typename local_matrix_type::row_map_type::non_const_type ptr ("A_copy.ptr", A_lcl.graph.row_map.dimension_0 ());
+        typename local_matrix_type::row_map_type::non_const_type ptr ("A_copy.ptr", A_lcl.graph.row_map.extent (0));
         Kokkos::deep_copy (ptr, A_lcl.graph.row_map);
-        typename local_graph_type::entries_type::non_const_type ind ("A_copy.ind", A_lcl.graph.entries.dimension_0 ());
+        typename local_graph_type::entries_type::non_const_type ind ("A_copy.ind", A_lcl.graph.entries.extent (0));
         Kokkos::deep_copy (ind, A_lcl.graph.entries);
-        typename local_matrix_type::values_type::non_const_type val ("A_copy.val", A_lcl.values.dimension_0 ());
+        typename local_matrix_type::values_type::non_const_type val ("A_copy.val", A_lcl.values.extent (0));
         Kokkos::deep_copy (val, A_lcl.values);
 
         TEST_NOTHROW( A_copy = rcp (new crs_matrix_type (rowMap, A->getColMap (), ptr, ind, val)) );
@@ -454,7 +454,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(LocalSparseTriangularSolver, CompareHTSToLocal
 #ifdef HAVE_IFPACK2_SHYLU_NODEHTS
   testCompareToLocalSolve<Scalar, LocalOrdinal, GlobalOrdinal> (success, out, TrisolverDetails::HTS);
 #else
-  
+
 #endif
 }
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
@@ -208,7 +208,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, LowerTriangularBlockCrsMatrix, Scalar,
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(lcl_row,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }
@@ -262,7 +262,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, UpperTriangularBlockCrsMatrix, Scalar,
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }
@@ -316,7 +316,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, FullLocalBlockCrsMatrix, Scalar, Local
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }
@@ -733,7 +733,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, DiagonalBlockCrsMatrix, Scalar, LocalO
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol,1e-14);
     }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
@@ -194,8 +194,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, Test2, Scalar, LocalOrdinal
 
   TEST_INEQUALITY(&x, &y); // vector x and y are different
   // Vectors x and y point to the same data.
-  TEST_EQUALITY(x.template getLocalView<Kokkos::HostSpace> ().ptr_on_device (),
-                y.template getLocalView<Kokkos::HostSpace> ().ptr_on_device ());
+  TEST_EQUALITY(x.template getLocalView<Kokkos::HostSpace> ().data (),
+                y.template getLocalView<Kokkos::HostSpace> ().data ());
 
   prec.apply(x, y);
 
@@ -887,7 +887,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestDiagonalBlockCrsMatrix,
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol,1e-14);
     }
@@ -1005,7 +1005,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestLowerTriangularBlockCrs
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(lcl_row,0);
-    Scalar* yb = ylcl.ptr_on_device();
+    Scalar* yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }
@@ -1056,7 +1056,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestUpperTriangularBlockCrs
 
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
-    auto yb = ylcl.ptr_on_device();
+    auto yb = ylcl.data();
     for (int j = 0; j < blockSize; ++j) {
       TEST_FLOATING_EQUALITY(yb[j],exactSol[k],1e-14);
     }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestSingleProcessRILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestSingleProcessRILUK.cpp
@@ -210,7 +210,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2RILUKSingleProcess, Test1, Scalar, LO, 
     diff.update (STS::one (), x, -STS::one ());
     diff.normInf (norms);
     Kokkos::deep_copy (norms_h, norms);
-    for (LO j = 0; j < static_cast<LO> (norms_h.dimension_0 ()); ++j) {
+    for (LO j = 0; j < static_cast<LO> (norms_h.extent (0)); ++j) {
       const mag_type absVal = ArithTraits<mag_type>::abs (norms_h(j));
       TEST_ASSERT( absVal <= bound );
       if (absVal > bound) {
@@ -251,7 +251,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2RILUKSingleProcess, Test1, Scalar, LO, 
       diff.normInf (norms);
       Kokkos::deep_copy (norms_h, norms);
 
-      for (LO j = 0; j < static_cast<LO> (norms_h.dimension_0 ()); ++j) {
+      for (LO j = 0; j < static_cast<LO> (norms_h.extent (0)); ++j) {
         const mag_type absVal = ArithTraits<mag_type>::abs (norms_h(j));
         TEST_ASSERT( absVal <= bound );
         if (absVal > bound) {

--- a/packages/teuchos/kokkoscomm/src/Kokkos_TeuchosCommAdapters.hpp
+++ b/packages/teuchos/kokkoscomm/src/Kokkos_TeuchosCommAdapters.hpp
@@ -68,7 +68,7 @@ send (const ViewType& sendBuffer,
       const int tag,
       const Comm<Ordinal>& comm)
 {
-  send(sendBuffer.ptr_on_device(), count, destRank, tag, comm);
+  send(sendBuffer.data(), count, destRank, tag, comm);
 }
 
 //! Variant of ssend() that takes a tag (and restores the correct order of arguments).
@@ -80,7 +80,7 @@ ssend (const ViewType& sendBuffer,
        const int tag,
        const Comm<Ordinal>& comm)
 {
-  ssend(sendBuffer.ptr_on_device(), count, destRank, tag, comm);
+  ssend(sendBuffer.data(), count, destRank, tag, comm);
 }
 
 //! Variant of readySend() that accepts a message tag.
@@ -92,7 +92,7 @@ readySend (const ViewType& sendBuffer,
            const int tag,
            const Comm<Ordinal>& comm)
 {
-  readySend(sendBuffer.ptr_on_device(), count, destRank, tag, comm);
+  readySend(sendBuffer.data(), count, destRank, tag, comm);
 }
 
 //! Variant of isend() that takes a tag (and restores the correct order of arguments).
@@ -147,10 +147,10 @@ reduceAll (const SendViewType& sendBuf,
     "The send View's rank is " << SendViewType::rank << " and the receive "
     "View's rank is " << RecvViewType::rank << ".");
   TEUCHOS_TEST_FOR_EXCEPTION(
-    sendBuf.dimension_0 () != recvBuf.dimension_0 (), std::invalid_argument,
-    "Send and receive buffer lengths do not match.  sendBuf.dimension_0() = "
-    << sendBuf.dimension_0 () << " != recvBuf.dimension_0() = "
-    << recvBuf.dimension_0 () << ".");
+    sendBuf.extent (0) != recvBuf.extent (0), std::invalid_argument,
+    "Send and receive buffer lengths do not match.  sendBuf.extent(0) = "
+    << sendBuf.extent (0) << " != recvBuf.extent(0) = "
+    << recvBuf.extent (0) << ".");
 
   // mfh 04 Nov 2014: Don't let Teuchos::SerialComm do a deep copy;
   // that always happens on the host, since SerialComm doesn't know
@@ -159,10 +159,10 @@ reduceAll (const SendViewType& sendBuf,
     Kokkos::deep_copy (recvBuf, sendBuf);
   }
   else {
-    const Ordinal count = static_cast<Ordinal> (sendBuf.dimension_0 ());
+    const Ordinal count = static_cast<Ordinal> (sendBuf.extent (0));
     reduceAll (comm, reductionType, count,
-               sendBuf.ptr_on_device (),
-               recvBuf.ptr_on_device ());
+               sendBuf.data (),
+               recvBuf.data ());
   }
 }
 
@@ -203,8 +203,8 @@ reduceAll(const Comm<Ordinal>& comm,
   }
   else {
     reduceAll (comm, serializer, reductType, count,
-               sendBuffer.ptr_on_device (),
-               recvBuffer.ptr_on_device ());
+               sendBuffer.data (),
+               recvBuffer.data ());
   }
 }
 
@@ -216,7 +216,7 @@ broadcast(const Comm<Ordinal>& comm,
                const Ordinal count,
                const ViewType& buffer)
 {
-  broadcast( comm, rootRank, count, buffer.ptr_on_device() );
+  broadcast( comm, rootRank, count, buffer.data() );
 }
 
 template<typename Ordinal,
@@ -229,7 +229,7 @@ broadcast(const Comm<Ordinal>& comm,
                const Ordinal count,
                const ViewType& buffer)
 {
-  broadcast( comm, serializer, rootRank, count, buffer.ptr_on_device() );
+  broadcast( comm, serializer, rootRank, count, buffer.data() );
 }
 
 } // namespace Teuchos

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
@@ -66,13 +66,13 @@ namespace Kokkos {
     Teuchos::ArrayView<typename ViewType::value_type>
     getArrayView(const ViewType& a) {
       return Teuchos::ArrayView<typename ViewType::value_type>(
-        a.ptr_on_device(), a.size());
+        a.data(), a.size());
     }
     template <typename ViewType>
     Teuchos::ArrayView<const typename ViewType::value_type>
     getConstArrayView(const ViewType& a) {
       return Teuchos::ArrayView<const typename ViewType::value_type>(
-        a.ptr_on_device(), a.size());
+        a.data(), a.size());
     }
 
    // Convert Teuchos::ArrayView to Kokkos::View through deep_copy
@@ -184,7 +184,7 @@ namespace Kokkos {
       // allocated (e.g.,) using new or malloc, but it's not a problem
       // here, because the custom deallocator does not free anything.
       // Nevertheless, it's better not to trouble the tracking system.
-      return Teuchos::arcp(view.ptr_on_device(), 0, view.capacity(),
+      return Teuchos::arcp(view.data(), 0, view.capacity(),
                            deallocator(view), false);
     }
 
@@ -195,7 +195,7 @@ namespace Kokkos {
       const ViewType& view,
       typename Teuchos::ArrayRCP<typename ViewType::value_type>::size_type offset,
       typename Teuchos::ArrayRCP<typename ViewType::value_type>::size_type size) {
-      return Teuchos::arcp(view.ptr_on_device()+offset, 0, size,
+      return Teuchos::arcp(view.data()+offset, 0, size,
                            deallocator(view), false);
     }
 

--- a/packages/teuchos/kokkoscompat/test/linkTest.cpp
+++ b/packages/teuchos/kokkoscompat/test/linkTest.cpp
@@ -122,7 +122,7 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, NoInteraction ) {
 
   typedef Kokkos::View<double*, TestDevice> ka_view_type;
   ka_view_type y ("y", numElts);
-  Kokkos::parallel_for (y.dimension_0 (), FillFunctor<TestDevice> (y));
+  Kokkos::parallel_for (y.extent (0), FillFunctor<TestDevice> (y));
   TestDevice::finalize();
 }
 
@@ -136,14 +136,10 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayViewOfView ) {
 
   const size_type numElts = 10;
   ka_view_type y ("y", numElts);
-  Kokkos::parallel_for (y.dimension_0 (), FillFunctor<TestDevice> (y));
+  Kokkos::parallel_for (y.extent (0), FillFunctor<TestDevice> (y));
 
-  // It's possible to get the View's raw pointer because we know its
-  // layout.  Not every kind of View necessarily implements the
-  // ptr_on_device() method, but certainly Views in HostSpace memory with
-  // left or right (Fortran or C) layout implement this method.
-  double* const y_raw = y.ptr_on_device ();
-  const size_type y_size = static_cast<size_type> (y.dimension_0 ());
+  double* const y_raw = y.data ();
+  const size_type y_size = static_cast<size_type> (y.extent (0));
 
   Teuchos::ArrayView<double> y_view (y_raw, y_size);
   TEST_EQUALITY_CONST( y_view.size(), y_size );
@@ -180,7 +176,7 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ViewOfArrayView ) {
   // subview with the desired dimensions.
   ka_view_type x_view (x.getRawPtr (), x.size ());
 
-  TEST_EQUALITY( x.size(), static_cast<size_type>(x_view.dimension_0()) );
+  TEST_EQUALITY( x.size(), static_cast<size_type>(x_view.extent(0)) );
   for (size_type k = 0; k < x.size (); ++k) {
     TEST_EQUALITY( x_view[k], x[k] );
   }
@@ -189,7 +185,7 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ViewOfArrayView ) {
   // x.getRawPtr() returns double*.
   ka_const_view_type x_view_const ( (const double*) x.getRawPtr (), x.size ());
 
-  TEST_EQUALITY( x.size(), static_cast<size_type>(x_view_const.dimension_0()) );
+  TEST_EQUALITY( x.size(), static_cast<size_type>(x_view_const.extent(0)) );
   for (size_type k = 0; k < x.size (); ++k) {
     TEST_EQUALITY( x_view_const[k], x[k] );
   }
@@ -214,8 +210,8 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayRCP1D_of_2DView ) {
 
   ka_view_type X ("X", stride, numCols);
   ka_view_type X_view = Kokkos::subview (X, std::make_pair (ZERO, numRows), std::make_pair (ZERO, numCols));
-  TEST_EQUALITY(X_view.dimension_0(), numRows);
-  TEST_EQUALITY(X_view.dimension_1(), numCols);
+  TEST_EQUALITY(X_view.extent(0), numRows);
+  TEST_EQUALITY(X_view.extent(1), numCols);
 
   // Test that the strides of X_view are correct, for int.  Kokkos
   // Array templates the stride() method on the integer type of the
@@ -244,9 +240,9 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayRCP1D_of_2DView ) {
   // View's raw pointer, but still defers to the View for memory
   // management.
 
-  Teuchos::ArrayRCP<double> Y_values (X.ptr_on_device (), 0, stride*numCols, Deallocator<double, ka_view_type> (X), true);
-  TEST_EQUALITY(Y_values.getRawPtr(), X.ptr_on_device());
-  TEST_EQUALITY(Y_values.getRawPtr(), X_view.ptr_on_device());
+  Teuchos::ArrayRCP<double> Y_values (X.data (), 0, stride*numCols, Deallocator<double, ka_view_type> (X), true);
+  TEST_EQUALITY(Y_values.getRawPtr(), X.data());
+  TEST_EQUALITY(Y_values.getRawPtr(), X_view.data());
   TEST_EQUALITY(Y_values.size(), stride*numCols);
 
   TestDevice::finalize();
@@ -277,8 +273,8 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayRCP2D_of_2DView ) {
   ka_view_type X ("X", stride, numCols);
   ka_view_type X_view = Kokkos::subview (X, std::make_pair (ZERO, numRows), std::make_pair (ZERO, numCols));
   TEST_EQUALITY( & X(0,0) , & X_view(0,0) );
-  TEST_EQUALITY(X_view.dimension_0(), numRows);
-  TEST_EQUALITY(X_view.dimension_1(), numCols);
+  TEST_EQUALITY(X_view.extent(0), numRows);
+  TEST_EQUALITY(X_view.extent(1), numCols);
 
   // Test that the strides of X_view are correct, for size_t.
   {
@@ -294,12 +290,12 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayRCP2D_of_2DView ) {
 
   // Make a 2-D "view" (array of arrays) of X_view.  This is how we
   // will implement Tpetra::MultiVector methods like get2dView.
-  Teuchos::ArrayRCP<Teuchos::ArrayRCP<double> > Y_2D (X_view.dimension_1 ());
-  for (size_t j = 0; j < static_cast<size_t> (X_view.dimension_1 ()); ++j) {
+  Teuchos::ArrayRCP<Teuchos::ArrayRCP<double> > Y_2D (X_view.extent (1));
+  for (size_t j = 0; j < static_cast<size_t> (X_view.extent (1)); ++j) {
     ka_view_type X_j = Kokkos::subview (X_view, std::make_pair (ZERO, numRows), std::make_pair (j, j+1));
     TEST_EQUALITY( & X_view(0,j) , & X_j(0,0) );
-    TEST_EQUALITY(static_cast<size_t>(X_j.dimension_0()), numRows);
-    TEST_EQUALITY_CONST(X_j.dimension_1(), 1);
+    TEST_EQUALITY(static_cast<size_t>(X_j.extent(0)), numRows);
+    TEST_EQUALITY_CONST(X_j.extent(1), 1);
 
     // Test that the strides of X_j are correct.
     {
@@ -320,7 +316,7 @@ TEUCHOS_UNIT_TEST( LinkTeuchosAndKokkos, ArrayRCP2D_of_2DView ) {
     // X_j, and doesn't actually deallocate memory.  That way, the
     // ArrayRCP can use the View's raw pointer, but still defers to
     // the View for memory management.
-    Teuchos::ArrayRCP<double> Y_j (X_j.ptr_on_device (), 0, numRows, Deallocator<double, ka_view_type> (X_j), true);
+    Teuchos::ArrayRCP<double> Y_j (X_j.data (), 0, numRows, Deallocator<double, ka_view_type> (X_j), true);
     Y_2D[j] = Y_j;
   }
   TestDevice::finalize();

--- a/packages/trilinoscouplings/examples/fenl/BelosSolve.hpp
+++ b/packages/trilinoscouplings/examples/fenl/BelosSolve.hpp
@@ -82,12 +82,12 @@ struct FillCoords {
   const size_type m_dim;
 
   FillCoords( const coords_type& coords, const coords_vec_type& coords_vec )
-    : m_coords(coords), m_coords_vec(coords_vec), m_dim(coords.dimension_1())
+    : m_coords(coords), m_coords_vec(coords_vec), m_dim(coords.extent(1))
   {
     // Note:  coords contains off-processor halo nodes and thus is longer
     // than coords_vec, which is the same length as the solution vector.
     // These extra halo nodes are stored at the end.
-    Kokkos::parallel_for( m_coords_vec.dimension_0(), *this );
+    Kokkos::parallel_for( m_coords_vec.extent(0), *this );
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -159,7 +159,7 @@ belos_solve(
     typename Mesh::node_coord_type node_coords = mesh.node_coord();
     //Teuchos::RCP<VectorType> coords =
     Teuchos::RCP<Tpetra::MultiVector<double,LO,GO,N> > coords =
-      Teuchos::rcp(new Tpetra::MultiVector<double,LO,GO,N>(x.getMap(), node_coords.dimension_1()));
+      Teuchos::rcp(new Tpetra::MultiVector<double,LO,GO,N>(x.getMap(), node_coords.extent(1)));
     fill_coords(node_coords, coords->getDualView().d_view);
 
     RCP<ParameterList> mueluParams = Teuchos::sublist(fenlParams, "MueLu");

--- a/packages/trilinoscouplings/examples/fenl/BoxElemFixture.hpp
+++ b/packages/trilinoscouplings/examples/fenl/BoxElemFixture.hpp
@@ -157,7 +157,7 @@ public:
   inline bool ok() const { return m_box_part.ok(); }
 
   KOKKOS_INLINE_FUNCTION
-  size_t node_count() const { return m_node_grid.dimension_0(); }
+  size_t node_count() const { return m_node_grid.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   size_t node_count_owned() const { return m_box_part.owns_node_count(); }
@@ -166,7 +166,7 @@ public:
   size_t node_count_global() const { return m_box_part.global_node_count(); }
 
   KOKKOS_INLINE_FUNCTION
-  size_t elem_count() const { return m_elem_node.dimension_0(); }
+  size_t elem_count() const { return m_elem_node.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   size_t elem_count_global() const { return m_box_part.global_elem_count(); }
@@ -280,11 +280,11 @@ public:
     }
 
     const size_t nwork =
-      std::max( m_recv_node.dimension_0() ,
-      std::max( m_send_node.dimension_0() ,
-      std::max( m_send_node_id.dimension_0() ,
-      std::max( m_node_grid.dimension_0() ,
-                m_elem_node.dimension_0() * m_elem_node.dimension_1() ))));
+      std::max( m_recv_node.extent(0) ,
+      std::max( m_send_node.extent(0) ,
+      std::max( m_send_node_id.extent(0) ,
+      std::max( m_node_grid.extent(0) ,
+                m_elem_node.extent(0) * m_elem_node.extent(1) ))));
 
     Kokkos::parallel_for( nwork , *this );
   }
@@ -295,7 +295,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t i ) const
   {
-    if ( i < m_elem_node.dimension_0() * m_elem_node.dimension_1() ) {
+    if ( i < m_elem_node.extent(0) * m_elem_node.extent(1) ) {
 
       const size_t ielem = i / ElemNode ;
       const size_t inode = i % ElemNode ;
@@ -315,7 +315,7 @@ public:
       m_elem_node(ielem,inode) = m_box_part.local_node_id( nodeGrid );
     }
 
-    if ( i < m_node_grid.dimension_0() ) {
+    if ( i < m_node_grid.extent(0) ) {
       size_t nodeGrid[SpaceDim] ;
       m_box_part.local_node_coord( i , nodeGrid );
       m_node_grid(i,0) = nodeGrid[0] ;
@@ -330,17 +330,17 @@ public:
                    m_node_coord(i,2) );
     }
 
-    if ( i < m_recv_node.dimension_0() ) {
+    if ( i < m_recv_node.extent(0) ) {
       m_recv_node(i,0) = m_box_part.recv_node_rank(i);
       m_recv_node(i,1) = m_box_part.recv_node_count(i);
     }
 
-    if ( i < m_send_node.dimension_0() ) {
+    if ( i < m_send_node.extent(0) ) {
       m_send_node(i,0) = m_box_part.send_node_rank(i);
       m_send_node(i,1) = m_box_part.send_node_count(i);
     }
 
-    if ( i < m_send_node_id.dimension_0() ) {
+    if ( i < m_send_node_id.extent(0) ) {
       m_send_node_id(i) = m_box_part.send_node_id(i);
     }
   }

--- a/packages/trilinoscouplings/examples/fenl/SampleGrouping.hpp
+++ b/packages/trilinoscouplings/examples/fenl/SampleGrouping.hpp
@@ -117,14 +117,14 @@ public:
     typedef typename RV::HostMirror HRV;
     RV rv = m_max_min_functor.m_coeff_function.getRandomVariables();
     HRV hrv = Kokkos::create_mirror_view(rv);
-    const Ordinal dim = rv.dimension_0();
+    const Ordinal dim = rv.extent(0);
     Teuchos::Array< std::pair<Scalar,Ordinal> > coeffs(num_samples);
     for (Ordinal sample_index=0; sample_index<num_samples; ++sample_index) {
       for (Ordinal i=0; i<dim; ++i)
         hrv(i) = samples[sample_index][i];
       Kokkos::deep_copy( rv, hrv );
 
-      Ordinal num_elem = m_max_min_functor.m_elem_node_ids.dimension_0();
+      Ordinal num_elem = m_max_min_functor.m_elem_node_ids.extent(0);
       Scalar local_coeff[2] = { 0.0,  Kokkos::ArithTraits<Scalar>::max() };
       parallel_reduce( num_elem, m_max_min_functor, local_coeff );
 

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors_pce.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors_pce.hpp
@@ -116,7 +116,7 @@ public:
     , solution( arg_solution )
     , solution_dp( arg_solution_dp )
     , pce_size( Kokkos::dimension_scalar(solution) )
-    , num_param( solution_dp.dimension_1() )
+    , num_param( solution_dp.extent(1) )
     , value_count( pce_size*(num_param+1) )
     , cijk( Kokkos::cijk(solution) )
     {
@@ -130,7 +130,7 @@ public:
   {
     scalar_type response(cijk, value_count);
     //Kokkos::parallel_reduce( fixture.elem_count() , *this , response.coeff() );
-    Kokkos::parallel_reduce( solution.dimension_0() , *this , response.coeff() );
+    Kokkos::parallel_reduce( solution.extent(0) , *this , response.coeff() );
     return response;
   }
 
@@ -308,7 +308,7 @@ struct EvaluatePCE {
 
   void apply(const unsigned arg_qp) {
     qp = arg_qp;
-    Kokkos::parallel_for( pce_view.dimension_1(), *this );
+    Kokkos::parallel_for( pce_view.extent(1), *this );
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -351,7 +351,7 @@ struct AssemblePCE {
 
   void apply( const unsigned arg_qp ) {
     qp = arg_qp;
-    Kokkos::parallel_for( pce_view.dimension_1(), *this );
+    Kokkos::parallel_for( pce_view.extent(1), *this );
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -394,7 +394,7 @@ struct AssembleRightPCE {
 
   void apply( const unsigned arg_qp ) {
     qp = arg_qp;
-    Kokkos::parallel_for( pce_view.dimension_0(), *this );
+    Kokkos::parallel_for( pce_view.extent(0), *this );
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -439,7 +439,7 @@ struct EvaluatePCE< pce_view_type,
     quad_values( arg_quad_values ),
     qp( 0 ),
     num_pce( Kokkos::dimension_scalar(arg_pce_view) ),
-    row_count( pce_view.dimension_1() ) {}
+    row_count( pce_view.extent(1) ) {}
 
   void apply(const unsigned arg_qp) {
     qp = arg_qp;
@@ -534,7 +534,7 @@ struct AssemblePCE< pce_view_type,
 
   void apply(const unsigned arg_qp) {
     qp = arg_qp;
-    Kokkos::parallel_for( Kokkos::MPVectorWorkConfig<execution_space>( pce_view.dimension_1(),
+    Kokkos::parallel_for( Kokkos::MPVectorWorkConfig<execution_space>( pce_view.extent(1),
                                                       EnsembleSize ),
                           *this );
   }
@@ -593,7 +593,7 @@ struct AssembleRightPCE< pce_view_type,
     quad_weights( arg_quad_weights ),
     qp( 0 ),
     num_pce( Kokkos::dimension_scalar(arg_pce_view) ),
-    row_count( pce_view.dimension_0() ) {}
+    row_count( pce_view.extent(0) ) {}
 
   void apply(const unsigned arg_qp) {
     qp = arg_qp;
@@ -754,8 +754,8 @@ public:
     : solution( arg_solution )
     , residual( arg_residual )
     , jacobian( arg_jacobian )
-    , scalar_solution( "scalar_solution", solution.dimension_0() )
-    , scalar_residual( "scalar_residual", residual.dimension_0() )
+    , scalar_solution( "scalar_solution", solution.extent(0) )
+    , scalar_residual( "scalar_residual", residual.extent(0) )
     , scalar_jacobian( "scalar_jacobian", jacobian.graph )
     , scalar_diffusion_coefficient( arg_coeff_function.m_mean,
                                     arg_coeff_function.m_variance,
@@ -799,8 +799,8 @@ public:
 
     // Note:  num_quad_points is aligned to the ensemble size to make
     // things easier
-    const unsigned num_quad_points = quad_points.dimension_0();
-    const unsigned dim = quad_points.dimension_1();
+    const unsigned num_quad_points = quad_points.extent(0);
+    const unsigned dim = quad_points.extent(1);
 
     evaluate_solution_type evaluate_pce(solution, scalar_solution, quad_values);
     assemble_residual_type assemble_res(residual, scalar_residual,

--- a/packages/trilinoscouplings/examples/fenl/fenl_impl.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_impl.hpp
@@ -100,7 +100,7 @@ public:
 template <class Map, class Fixture >
 void build_lid_to_gid(const Map& lid_to_gid, const Fixture& fixture) {
   typedef BuildLocalToGlobalMap<Map,Fixture> F;
-  Kokkos::parallel_for(lid_to_gid.dimension_0(), F(lid_to_gid, fixture));
+  Kokkos::parallel_for(lid_to_gid.extent(0), F(lid_to_gid, fixture));
 }
 
 } /* namespace FENL */
@@ -170,8 +170,8 @@ private:
     Kokkos::deep_copy(lid_to_gid_row_host, lid_to_gid_row);
 
     return  Teuchos::rcp (new MapType( fixture.node_count_global(),
-        Teuchos::arrayView(lid_to_gid_row_host.ptr_on_device(),
-                           lid_to_gid_row_host.dimension_0()),
+        Teuchos::arrayView(lid_to_gid_row_host.data(),
+                           lid_to_gid_row_host.extent(0)),
         0, comm, node));
   }
 
@@ -188,8 +188,8 @@ private:
 
     return Teuchos::rcp (new MapType (
         Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
-        Teuchos::arrayView( lid_to_gid_all_host.ptr_on_device(),
-                            lid_to_gid_all_host.dimension_0()),
+        Teuchos::arrayView( lid_to_gid_all_host.data(),
+                            lid_to_gid_all_host.extent(0)),
         0,comm, node) );
   }
 
@@ -309,11 +309,11 @@ public:
         std::cout << "}" << std::endl ;
 
         std::cout << "ElemGraph {" << std::endl ;
-        for ( unsigned ielem = 0 ; ielem < elem_graph.dimension_0() ; ++ielem ) {
+        for ( unsigned ielem = 0 ; ielem < elem_graph.extent(0) ; ++ielem ) {
           std::cout << "  elem[" << ielem << "]{" ;
-          for ( unsigned irow = 0 ; irow < elem_graph.dimension_1() ; ++irow ) {
+          for ( unsigned irow = 0 ; irow < elem_graph.extent(1) ; ++irow ) {
             std::cout << " {" ;
-            for ( unsigned icol = 0 ; icol < elem_graph.dimension_2() ; ++icol ) {
+            for ( unsigned icol = 0 ; icol < elem_graph.extent(2) ; ++icol ) {
               std::cout << " " << elem_graph(ielem,irow,icol);
             }
             std::cout << " }" ;

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -1188,7 +1188,7 @@ namespace {
 
     // check that the local_matrix_type taken the second time is the same
     local_matrix_type view3 = A->getLocalMatrix();
-    TEST_EQUALITY(view2.graph.row_map.ptr_on_device(), view3.graph.row_map.ptr_on_device());
+    TEST_EQUALITY(view2.graph.row_map.data(), view3.graph.row_map.data());
 
     for (LO r = 0; r < view2.numRows(); ++r) {
       // extract data from current row r

--- a/packages/xpetra/test/MultiVector/MultiVector_UnitTestsXpetraSpecific.cpp
+++ b/packages/xpetra/test/MultiVector/MultiVector_UnitTestsXpetraSpecific.cpp
@@ -170,19 +170,19 @@ namespace {
     // get a view of the multivector data on the host memory
     typename dual_view_type::t_host_um hostView = mv->getHostLocalView ();
 
-    TEST_EQUALITY(hostView.dimension_0(), numLocal);
-    TEST_EQUALITY(hostView.dimension_1(), 3);
+    TEST_EQUALITY(hostView.extent(0), numLocal);
+    TEST_EQUALITY(hostView.extent(1), 3);
     TEST_EQUALITY(hostView.size(), numLocal * 3);
     for(size_t k=0; k < 3; k++) {
-      for(size_t i = 0; i < hostView.dimension_0(); i++) {
+      for(size_t i = 0; i < hostView.extent(0); i++) {
         TEST_EQUALITY(Teuchos::as<Scalar>(hostView(i,k)), Teuchos::as<Scalar>(i*(k+1) + comm->getRank()));
       }
     }
 
     // overwrite data in hostView
-    for(size_t r = 0; r < hostView.dimension_0(); r++) {
-      for(size_t c = 0; c < hostView.dimension_1(); c++) {
-        hostView(r,c) = comm->getRank() + c*hostView.dimension_1() + r + 42.0;
+    for(size_t r = 0; r < hostView.extent(0); r++) {
+      for(size_t c = 0; c < hostView.extent(1); c++) {
+        hostView(r,c) = comm->getRank() + c*hostView.extent(1) + r + 42.0;
       }
     }
 
@@ -191,7 +191,7 @@ namespace {
     for(size_t k=0; k < 3; k++) {
       Teuchos::ArrayRCP<const Scalar> vData = mv->getData(k);
       for(size_t i=0; i< numLocal; i++) {
-        TEST_EQUALITY(Teuchos::as<Scalar>(vData[i]), Teuchos::as<Scalar>(comm->getRank() + k*hostView.dimension_1() + i + 42.0));
+        TEST_EQUALITY(Teuchos::as<Scalar>(vData[i]), Teuchos::as<Scalar>(comm->getRank() + k*hostView.extent(1) + i + 42.0));
       }
     }
 
@@ -204,8 +204,8 @@ namespace {
     }
 
     // check updated data in view
-    for(size_t r = 0; r < hostView.dimension_0(); r++) {
-      for(size_t c = 0; c < hostView.dimension_1(); c++) {
+    for(size_t r = 0; r < hostView.extent(0); r++) {
+      for(size_t c = 0; c < hostView.extent(1); c++) {
         TEST_EQUALITY(Teuchos::as<Scalar>(hostView(r,c)), Teuchos::as<Scalar>(c * numLocal + r));
       }
     }


### PR DESCRIPTION
Remove use of deprecated Kokkos::View methods (ptr_on_device and dimension_N) from Teuchos, Ifpack2, Xpetra, MueLu, and TrilinosCouplings.

@trilinos/teuchos @trilinos/ifpack2 @trilinos/xpetra @trilinos/muelu 