### PR TITLE
Set Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D=TRUE for GCC 4.8.4 + OpenMP build (#2712)

### DIFF
--- a/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake
+++ b/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake
@@ -23,6 +23,9 @@ TRIL_SET_CACHE_VAR(MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none"
 # NOTE: The above is a workaround for the problem of having threads on MPI
 # ranks bind to the same cores (see #2422).
 
+# Disable just one Teko sub-unit test that fails with GCC 4.8.4 + OpenMP (#2712)
+TRIL_SET_BOOL_CACHE_VAR(Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D TRUE)
+
 # NOTE: The order of these includes matters!
 
 include("${CMAKE_CURRENT_LIST_DIR}/MpiReleaseDebugSharedPtSettings.cmake")


### PR DESCRIPTION
**CC:* @trilinos/teko, @eric-c-cyr 

## Description

This makes the remaining unit tests in the test `Teko_testdriver_tpetra_MPI_1`
pass.  This addresses #2712. This is the same "fix" as for issue #2652 which
was for GCC 6.1.0.

## How Has This Been Tested?

I tested this locally as described in the "Steps to Reproduce" in #2712.

The full output from the passing tests after the commit is shown below.

<details>
<summary>
  <b>Teko_testdriver_tpetra_MPI_1 passing tests output:</b> (click to expand)
</summary>

````
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false
Teuchos::GlobalMPISession::GlobalMPISession(): started processor with name crf450.srn.sandia.gov and rank 0!
Running test "SIMPLEPreconditionerFactory_tpetra"
   "createPrec" ... PASSED
   Teko: Begin debug MSG
      SIMPLE Parameters: 
         inv type    = ""
         inv v type  = "Ifpack2"
         inv p type  = "Ifpack2"
         alpha       = 1
         use mass    = 0
         vel scaling = Lumped
      SIMPLE Parameter list: 
      Explicit Velocity Inverse Type = Lumped
      Inverse Pressure Type = Ifpack2
      Inverse Velocity Type = Ifpack2
   Teko: End debug MSG
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   "initializePrec(lumped)" ... PASSED
   Teko: Begin debug MSG
      SIMPLE Parameters: 
         inv type    = ""
         inv v type  = "Ifpack2"
         inv p type  = "Ifpack2"
         alpha       = 1
         use mass    = 0
         vel scaling = Diagonal
      SIMPLE Parameter list: 
      Explicit Velocity Inverse Type = Diagonal
      Inverse Pressure Type = Ifpack2
      Inverse Velocity Type = Ifpack2
   Teko: End debug MSG
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   "initializePrec(diag)" ... PASSED
   Teko: Begin debug MSG
      SIMPLE Parameters: 
         inv type    = ""
         inv v type  = "Ifpack2"
         inv p type  = "Ifpack2"
         alpha       = 1
         use mass    = 0
         vel scaling = AbsRowSum
      SIMPLE Parameter list: 
      Explicit Velocity Inverse Type = AbsRowSum
      Inverse Pressure Type = Ifpack2
      Inverse Velocity Type = Ifpack2
   Teko: End debug MSG
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   "initializePrec(absrowsum)" ... PASSED
   "uninitializePrec" ... PASSED
   "isCompatable" ... PASSED
   "diagonal(diag)" ... PASSED
   "diagonal(block-1)" ... PASSED
   "diagonal(block-2)" ... PASSED
   "result(diag)" ... PASSED
   "result(block-1)" ... PASSED
   "result(block-2)" ... PASSED
Test "SIMPLEPreconditionerFactory_tpetra" completed ... PASSED (12)
Running test "DiagonalPreconditionerFactory_tpetra"
   "createPrec" ... PASSED
   "initializePrec" ... PASSED
||Z-Y||/||Z|| = 0
   "canApply" ... PASSED
Test "DiagonalPreconditionerFactory_tpetra" completed ... PASSED (3)
Running test "LU2x2PreconditionerFactory_tpetra"
   "createPrec" ... PASSED
   "initializePrec" ... PASSED
   "uninitializePrec" ... PASSED
   "isCompatable" ... PASSED
   "identity" ... PASSED
   "diagonal" ... PASSED
   "result" ... PASSED
   "alphabeta" ... PASSED
Test "LU2x2PreconditionerFactory_tpetra" completed ... PASSED (8)
Running test "LSCStablePreconditionerFactory_tpetra"
   "createPrec" ... PASSED
Teko: LSCPrecFact::buildPO BuildStateTime = 7.86781e-06
Teko: LSCPrecFact::buildPO GetInvTime = 9.05991e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.000311136
   "initializePrec" ... PASSED
   "uninitializePrec" ... PASSED
   "isCompatable" ... PASSED
Teko: LSCPrecFact::buildPO BuildStateTime = 0
Teko: LSCPrecFact::buildPO GetInvTime = 5.96046e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.000273943
   "identity" ... PASSED
Teko: LSCPrecFact::buildPO BuildStateTime = 0
Teko: LSCPrecFact::buildPO GetInvTime = 5.96046e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.000271082
   "diagonal" ... PASSED
Teko: LSCPrecFact::buildPO BuildStateTime = 0
Teko: LSCPrecFact::buildPO GetInvTime = 0
Teko: LSCPrecFact::buildPO TotalTime = 0.000233173
   "result" ... PASSED
Test "LSCStablePreconditionerFactory_tpetra" completed ... PASSED (7)
Running test "LSCStabilized_tpetra"
Teko: LSCPrecFact::buildPO BuildStateTime = 0
Teko: LSCPrecFact::buildPO GetInvTime = 6.91414e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.00036478
   "diagonal" ... PASSED
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: LSC::initializeState Build Scaling <mass> type "Diagonal"
   Teko: Begin debug MSG
      LSC Gamma Parameter = 0.237413
      LSC Alpha Parameter = 0.667104
   Teko: End debug MSG
Teko: LSC::buildState BuildOpsTime = 0.030206
Teko: LSC::computeInverses Building inv(F)
Teko: LSC::computeInverses GetInvF = 0.000571966
Teko: LSC::computeInverses Building inv(BQBtmC)
Teko: LSC::computeInverses GetInvBQBt = 0.000556946
Teko: LSC::buildState BuildInvTime = 0.00115108
Teko: LSCPrecFact::buildPO BuildStateTime = 0.031364
Teko: LSCPrecFact::buildPO GetInvTime = 5.00679e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.031661
   "strategy" ... PASSED
Test "LSCStabilized_tpetra" completed ... PASSED (2)
Running test "Jacobi2x2PreconditionerFactory_tpetra"
   "createPrec" ... PASSED
   "initializePrec" ... PASSED
   "uninitializePrec" ... PASSED
   "isCompatable" ... PASSED
   "identity" ... PASSED
   "diagonal" ... PASSED
   "result" ... PASSED
   Teko: Begin debug MSG
      Looked up "Block Jacobi"
      Built Teuchos::RCP<Teko::PreconditionerFactory>{ptr=0x18c7228,node=0x191e8a0,strong_count=1,weak_count=0}
   Teko: End debug MSG
Teko: JacobiPrecFact: Building default inverse "Ifpack2"
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   Teko: Begin debug MSG
      Looked up "Block Jacobi"
      Built Teuchos::RCP<Teko::PreconditionerFactory>{ptr=0x1938078,node=0x191e8a0,strong_count=1,weak_count=0}
   Teko: End debug MSG
Teko: JacobiPrecFact: Building default inverse "ML"
Teko: Inverse "ML" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: JacobiPrecFact: Building inverse 1 "Amesos"
Teko: Inverse "Amesos" is of type strat prec = 0, strat solv = 1, block prec = 0
Teko: JacobiPrecFact: Building inverse 3 "Ifpack"
Teko: Inverse "Ifpack" is of type strat prec = 1, strat solv = 0, block prec = 0
   "initializeFromParameterList" ... PASSED
Test "Jacobi2x2PreconditionerFactory_tpetra" completed ... PASSED (8)
Running test "BlockJacobiPreconditionerFactory_tpetra"
   "createPrec" ... PASSED
   "initializePrec" ... PASSED
   "uninitializePrec" ... PASSED
   "isCompatible" ... PASSED
Test "BlockJacobiPreconditionerFactory_tpetra" completed ... PASSED (4)
Running test "BlockUpperTriInverseOp_tpetra"
   "apply" ... PASSED
   "alphabeta" ... PASSED
Test "BlockUpperTriInverseOp_tpetra" completed ... PASSED (2)
Running test "BlockLowerTriInverseOp_tpetra"
   "apply" ... PASSED
   "alphabeta" ... PASSED
Test "BlockLowerTriInverseOp_tpetra" completed ... PASSED (2)
Running test "tTpetraOperatorWrapper"
   "functionality" ... PASSED
Test "tTpetraOperatorWrapper" completed ... PASSED (1)
Running test "InterlacedTpetra"
   "buildSubMaps_num" ... PASSED
   "buildSubMaps_vec" ... PASSED
   "buildMaps" ... PASSED
   "one2many" ... PASSED
   "many2one" ... PASSED
Test "InterlacedTpetra" completed ... PASSED (5)
Running test "BlockingTpetra"
   "buildMaps" ... PASSED
   "one2many" ... PASSED
   "many2one" ... PASSED
   "buildSubBlock" ... PASSED
Test "BlockingTpetra" completed ... PASSED (4)
Running test "TpetraThyraConverter"
   "blockThyraToTpetra" ... PASSED
   "single_blockThyraToTpetra" ... PASSED
   "blockTpetraToThyra" ... PASSED
   "single_blockTpetraToThyra" ... PASSED
Test "TpetraThyraConverter" completed ... PASSED (4)
Running test "tGraphLaplacian_tpetra"
   "single_array" ... PASSED
   "multi_array" ... PASSED
Test "tGraphLaplacian_tpetra" completed ... PASSED (2)
Running test "tParallelInverse_tpetra"
Teko: Inverse "Belos" is of type strat prec = 0, strat solv = 1, block prec = 0
   "inverse" ... PASSED
Teko: Inverse "Belos" is of type strat prec = 0, strat solv = 1, block prec = 0
   "stridedInverse" ... PASSED
Test "tParallelInverse_tpetra" completed ... PASSED (2)
Running test "tExplicitOps_tpetra"
   "mult_diagScaleMatProd" ... PASSED
   "mult_diagScaling" ... PASSED
   "add" ... PASSED
   "mult_modScaleMatProd" ... PASSED
   "add_mod" ... PASSED
Test "tExplicitOps_tpetra" completed ... PASSED (5)
Running test "LSCHIntegrationTest_tpetra"
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: LSC::initializeState Build Scaling <mass> type "Diagonal"
Teko: LSC::buildState BuildOpsTime = 0.00134397
Teko: LSC::computeInverses Building inv(F)
Teko: LSC::computeInverses GetInvF = 0.00051403
Teko: LSC::computeInverses Building inv(BQBtmC)
Teko: LSC::computeInverses GetInvBQBt = 0.000458956
Teko: LSC::computeInverses Building inv(BHBtmC)
Teko: LSC::computeInverses GetInvBHBt = 0.000464916
Teko: LSC::buildState BuildInvTime = 0.00146484
Teko: LSCPrecFact::buildPO BuildStateTime = 0.00282001
Teko: LSCPrecFact::buildPO GetInvTime = 3.09944e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.00306487
   "hScaling" ... PASSED
Test "LSCHIntegrationTest_tpetra" completed ... PASSED (1)
Running test "Lumping_tpetra"
   "lumping" ... PASSED
   "invLumping" ... PASSED
Test "Lumping_tpetra" completed ... PASSED (2)
Running test "AbsRowSum_tpetra"
   "absRowSum" ... PASSED
   "invAbsRowSum" ... PASSED
Test "AbsRowSum_tpetra" completed ... PASSED (2)
Running test "NeumannSeries_tpetra"
Teko: Inverse "Neumann" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: Inverse "Neumann" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   "test_simpleOp" ... PASSED
Teko: Inverse "Neumann" is of type strat prec = 1, strat solv = 0, block prec = 0
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   "test_scaledOp" ... PASSED
Test "NeumannSeries_tpetra" completed ... PASSED (2)
Running test "PCDStrategy_tpetra"
Teko: Inverse "Ifpack2" is of type strat prec = 1, strat solv = 0, block prec = 0
   "PCDStrategy" ... PASSED
Test "PCDStrategy_tpetra" completed ... PASSED (1)
Running test "LSCIntegrationTest_tpetra"
Teko: LSC::initializeState Build Scaling <mass> type "Diagonal"
Teko: LSC::buildState BuildOpsTime = 0.0159559
Teko: LSC::computeInverses Building inv(F)
Teko: LSC::computeInverses GetInvF = 0.40375
Teko: LSC::computeInverses Building inv(BQBtmC)
Teko: LSC::computeInverses GetInvBQBt = 0.0651131
Teko: LSC::buildState BuildInvTime = 0.46889
Teko: LSCPrecFact::buildPO BuildStateTime = 0.484859
Teko: LSCPrecFact::buildPO GetInvTime = 3.09944e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.485409
   "withmassStable" ... PASSED
Teko: LSC::initializeState Build Scaling <F> type "Diagonal"
Teko: LSC::buildState BuildOpsTime = 0.0159519
Teko: LSC::computeInverses Building inv(F)
Teko: LSC::computeInverses GetInvF = 0.442643
Teko: LSC::computeInverses Building inv(BQBtmC)
Teko: LSC::computeInverses GetInvBQBt = 0.0693798
Teko: LSC::buildState BuildInvTime = 0.512061
Teko: LSCPrecFact::buildPO BuildStateTime = 0.52803
Teko: LSCPrecFact::buildPO GetInvTime = 5.00679e-06
Teko: LSCPrecFact::buildPO TotalTime = 0.528408
   "nomassStable" ... PASSED
   Teko: Begin debug MSG
      Looked up "NS LSC"
      Built Teuchos::RCP<Teko::PreconditionerFactory>{ptr=0x21ece78,node=0x1d65f10,strong_count=1,weak_count=0}
   Teko: End debug MSG
Teko: Building LSC strategy "Basic Inverse"
   Teko: Begin debug MSG
      LSC Inverse Strategy Parameters: 
         inv type   = "Amesos"
         inv v type = "Ifpack"
         inv p type = "Ifpack"
         bndry rows = 1
         use ldu    = 1
         use mass    = 0
         use w-scaling    = 0
         assume stable    = 0
         scale type    = Diagonal
      LSC  Inverse Strategy Parameter list: 
      Inverse Type = Amesos
      Inverse Velocity Type = Ifpack
      Inverse Pressure Type = Ifpack
      Ignore Boundary Rows = 1
      Use LDU = 1
   Teko: End debug MSG
Teko: Inverse "Ifpack" is of type strat prec = 1, strat solv = 0, block prec = 0
   Teko: Begin debug MSG
      Looked up "NS LSC"
      Built Teuchos::RCP<Teko::PreconditionerFactory>{ptr=0x225acd8,node=0x3e496a0,strong_count=1,weak_count=0}
   Teko: End debug MSG
Teko: Building LSC strategy "Basic Inverse"
   Teko: Begin debug MSG
      LSC Inverse Strategy Parameters: 
         inv type   = "Amesos"
         inv v type = "Ifpack"
         inv p type = "Ifpack"
         bndry rows = 1
         use ldu    = 1
         use mass    = 0
         use w-scaling    = 0
         assume stable    = 0
         scale type    = Diagonal
      LSC  Inverse Strategy Parameter list: 
      Inverse Type = Amesos
      Inverse Velocity Type = Ifpack
      Inverse Pressure Type = Ifpack
      Ignore Boundary Rows = 1
      Use LDU = 1
   Teko: End debug MSG
Teko: Inverse "Ifpack" is of type strat prec = 1, strat solv = 0, block prec = 0
   Teko: Begin debug MSG
      Looked up "NS LSC"
      Built Teuchos::RCP<Teko::PreconditionerFactory>{ptr=0x21ece78,node=0x1d65f10,strong_count=1,weak_count=0}
   Teko: End debug MSG
Teko: Building LSC strategy "The Cat"
LSC Construction failed: Strategy "The Cat" could not be constructed
   Teko: Begin debug MSG
      Looked up "NS LSC"
      Built Teuchos::RCP<Teko::PreconditionerFactory>{ptr=0x21ece78,node=0x1d65f10,strong_count=1,weak_count=0}
   Teko: End debug MSG
LSC Construction failed: Strategy "The Cat" requires a "Strategy Settings" sublist
   "plConstruction" ... PASSED
Test "LSCIntegrationTest_tpetra" completed ... PASSED (3)
Running test "tStridedTpetraOperator"
   "numvars_constr" ... PASSED
   "vector_constr" ... PASSED
   "reorder(flat reorder)" ... PASSED
   "reorder(composite reorder = 1)" ... PASSED
   "reorder(composite reorder = 2)" ... PASSED
Test "tStridedTpetraOperator" completed ... PASSED (5)
Running test "tBlockedTpetraOperator"
   "vector_constr" ... PASSED
   "reorder(flat reorder)" ... PASSED
   "reorder(composite reorder = 1)" ... PASSED
   "reorder(composite reorder = 2)" ... PASSED
Test "tBlockedTpetraOperator" completed ... PASSED (4)

Tests Passed: 91, Tests Failed: 0
(Incidently, you want no failures)
```
</details>

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
