### PR TITLE
Tempus: Improved testing; added testing of xDot. #2716

### DIFF
--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -29,7 +29,7 @@ namespace {
   static std::string Static_name     = "Static";
   static std::string Unlimited_name  = "Unlimited";
   static std::string Storage_name    = "Storage Type";
-  static std::string Storage_default = Unlimited_name;
+  static std::string Storage_default = Undo_name;
 
   static std::string StorageLimit_name    = "Storage Limit";
   static int         StorageLimit_default = 2;
@@ -246,7 +246,7 @@ void SolutionHistory<Scalar>::initWorkingState()
       // Recycle old state and copy currentState
       newState = (*history_)[0];
       history_->erase(history_->begin());
-      newState->copy(getCurrentState());
+      if (getNumStates() > 0) newState->copy(getCurrentState());
       // When using the Griewank algorithm, we will want to select which
       // older state to recycle.
     }

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -142,7 +142,14 @@ void StepperBackwardEuler<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperBackwardEuler::takeStep()");
   {
-    //Stepper<Scalar> & thisStepper = dynamic_cast<Stepper<Scalar> * > (this);
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperBackwardEuler<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for Backward Euler.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -141,6 +141,14 @@ void StepperDIRK<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperDIRK::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperDIRK<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for DIRK.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -269,6 +269,14 @@ void StepperExplicitRK<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperExplicitRK::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperExplicitRK<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for ExplicitRK.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -105,6 +105,14 @@ void StepperForwardEuler<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperForwardEuler::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperForwardEuler<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for Forward Euler.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -184,8 +184,16 @@ void StepperHHTAlpha<Scalar>::takeStep(
 #endif
   using Teuchos::RCP;
 
-  TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperBackardEuler::takeStep()");
+  TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperHHTAlpha::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperHHTAlpha<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for HHTAlpha.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -190,7 +190,7 @@ void StepperIMEX_RK_Partition<Scalar>::setTableaus(
     this->setExplicitTableau("General ERK",  explicitPL);
     this->setImplicitTableau("General DIRK", implicitPL);
     description_ = stepperType;
-    order_ = 0;   // TODO: Determine overall order
+    order_ = pList->get<int>("overall order", 0);
 
   } else {
     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error,
@@ -473,6 +473,14 @@ void StepperIMEX_RK_Partition<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperIMEX_RK_Partition::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperIMEX_RK_Partition<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for IMEX_RK_Partition.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -189,7 +189,7 @@ void StepperIMEX_RK<Scalar>::setTableaus(
     this->setExplicitTableau("General ERK",  explicitPL);
     this->setImplicitTableau("General DIRK", implicitPL);
     description_ = stepperType;
-    order_ = 0;  // TODO: Determine overall order
+    order_ = pList->get<int>("overall order", 0);
 
   } else {
     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error,
@@ -468,6 +468,14 @@ void StepperIMEX_RK<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperIMEX_RK::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperIMEX_RK<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for IMEX_RK.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -105,6 +105,14 @@ void StepperLeapfrog<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperLeapfrog::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperLeapfrog<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for Leapfrog.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     typedef Thyra::ModelEvaluatorBase MEB;
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -129,6 +129,14 @@ void StepperNewmarkExplicitAForm<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperNewmarkExplicitAForm::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperNewmarkExplicitAForm<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for NewmarkExplicitAForm.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -147,6 +147,14 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperNewmarkImplicitAForm::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperNewmarkImplicitAForm<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for NewmarkImplicitAForm.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -150,10 +150,16 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperNewmarkImplicitDForm::takeStep()");
   {
-    RCP<SolutionState<Scalar>> workingState =
-        solutionHistory->getWorkingState();
-    RCP<SolutionState<Scalar>> currentState =
-        solutionHistory->getCurrentState();
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperNewmarkImplicitDForm<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for NewmarkImplicitDForm.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
+    RCP<SolutionState<Scalar>> workingState =solutionHistory->getWorkingState();
+    RCP<SolutionState<Scalar>> currentState =solutionHistory->getCurrentState();
 
     Teuchos::RCP<WrapperModelEvaluatorSecondOrder<Scalar> > wrapperModel =
       Teuchos::rcp_dynamic_cast<WrapperModelEvaluatorSecondOrder<Scalar> >(

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -217,6 +217,14 @@ void StepperOperatorSplit<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperOperatorSplit::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperOperatorSplit<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for OperatorSplit.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperOSObserver_->observeBeginTakeStep(solutionHistory, *this);
 
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -78,6 +78,14 @@ void StepperTrapezoidal<Scalar>::takeStep(
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperTrapezoidal::takeStep()");
   {
+    TEUCHOS_TEST_FOR_EXCEPTION(solutionHistory->getNumStates() < 2,
+      std::logic_error,
+      "Error - StepperTrapezoidal<Scalar>::takeStep(...)\n"
+      "Need at least two SolutionStates for Trapezoidal.\n"
+      "  Number of States = " << solutionHistory->getNumStates() << "\n"
+      "Try setting in \"Solution History\" \"Storage Type\" = \"Undo\"\n"
+      "  or \"Storage Type\" = \"Static\" and \"Storage Limit\" = \"2\"\n");
+
     stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -6,8 +6,8 @@
 // ****************************************************************************
 // @HEADER
 
-#ifndef Tempus_TimeStepControlStrategy_BasicBS_hpp
-#define Tempus_TimeStepControlStrategy_BasicBS_hpp
+#ifndef Tempus_TimeStepControlStrategy_BasicVS_hpp
+#define Tempus_TimeStepControlStrategy_BasicVS_hpp
 
 #include "Tempus_TimeStepControl.hpp"
 #include "Tempus_TimeStepControlStrategy.hpp"
@@ -23,9 +23,82 @@ namespace Tempus {
 
 /** \brief StepControlStrategy class for TimeStepControl
  *
- * Section 2.2.1 / Algorithm 2.4 of A. Denner, "Experiments on
- * Temporal Variable Step BDF2 Algorithms", Masters Thesis,
- * U Wisconsin-Madison, 2014.
+ *  This TimeStepControlStrategy primarily tries to maintain a
+ *  certain level of change in the solution ill-respective of the
+ *  error involved, e.g., the solution should change by 1% every
+ *  time step.  The relative solution change is measured by
+ *  \f[
+ *    \eta_{n-1} = \frac{|| x_{n-1} - x_{n-2} ||}{ || x_{n-2} || + \epsilon }
+ *  \f]
+ *  where \f$\epsilon\f$ is a small constant to ensure that \f$\eta_n\f$
+ *  remains finite.  The user can select the desired relative
+ *  change in the solution by choosing a range for \f$\eta_n\f$
+ *  \f[
+ *    \eta_{min} < \eta_n < \eta_{max}
+ *  \f]
+ *  If the solution change is outside this range, an amplification
+ *  (\f$\rho\f$) or reduction factor (\f$\sigma\f$) is applied to
+ *  the timestep to bring the solution change back into the desired
+ *  range.  This can be written as
+ *  \f[
+ *    \Delta t_n = \left\{
+ *      \begin{array}{rll}
+ *        \sigma \Delta t_{n-1} & \mbox{if $\eta_{n-1} > \eta_{max}$}
+ *                              & \mbox{where $0 < \sigma < 1$}             \\
+ *        \rho   \Delta t_{n-1} & \mbox{else if $\eta_{n-1} < \eta_{min}$}
+ *                              & \mbox{where $\rho > 1$}                   \\
+ *               \Delta t_{n-1} &
+ *                        \mbox{else if $\eta_{min}<\eta_{n-1}<\eta_{max}$} \\
+ *      \end{array}
+ *    \right.
+ *  \f]
+ *  In the full implementation, several other mechanisms can amplify
+ *  or reduce the timestep.
+ *  - Stepper fails
+ *  - Maximum Absolute error, \f$e_{abs}^{max}\f$
+ *  - Maximum Relative error, \f$e_{rel}^{max}\f$
+ *  - Order, \f$p\f$
+ *  \f[
+ *    \Delta t_n = \left\{
+ *      \begin{array}{rll}
+ *        \sigma \Delta t_{n-1} & \mbox{if Stepper fails}
+ *                              & \mbox{where $0 < \sigma < 1$}            \\
+ *        \rho   \Delta t_{n-1} & \mbox{else if $\eta_{n-1} < \eta_{min}$}
+ *                              & \mbox{where $\rho > 1$}                  \\
+ *        \sigma \Delta t_{n-1} & \mbox{else if $\eta_{n-1} > \eta_{max}$}
+ *                              & \mbox{where $0 < \sigma < 1$}            \\
+ *        \sigma \Delta t_{n-1} & \mbox{else if $e_{abs} > e_{abs}^{max}$}
+ *                              & \mbox{where $0 < \sigma < 1$}            \\
+ *        \sigma \Delta t_{n-1} & \mbox{else if $e_{rel} > e_{rel}^{max}$}
+ *                              & \mbox{where $0 < \sigma < 1$}            \\
+ *        \rho   \Delta t_{n-1} & \mbox{else if $p < p_{min}$}
+ *                              & \mbox{where $\rho > 1$}                  \\
+ *        \sigma \Delta t_{n-1} & \mbox{else if $p > p_{max}$}
+ *                              & \mbox{where $0 < \sigma < 1$}            \\
+ *               \Delta t_{n-1} & \mbox{else} &                            \\
+ *      \end{array}
+ *    \right.
+ *  \f]
+ *
+ *  Note
+ *  - Only one amplification or reduction is applied each timestep.
+ *  - The priority is specified by the order of list.
+ *  - The timestep, \f$\Delta t_n\f$, is still constrained to the
+ *    maximum and minimum timestep size.
+ *    \f$\Delta t_{min} < \Delta t_n < \Delta t_{max}\f$
+ *  - If \f$ \eta_{min} < \eta_n < \eta_{max}\f$, the timestep
+ *    is unchanged, i.e., constant timestep size.
+ *  - To have constant timesteps, set \f$\eta_{min}=0\f$ and
+ *    \f$\eta_{max}=10^{16}\f$.  These are the defaults.
+ *  - From (Denner, 2014), amplification factor, \f$\rho\f$, is
+ *    required to be less than 1.91 for stability (\f$\rho < 1.91\f$).
+ *  - Denner (2014) suggests that \f$\eta_{min} = 0.1*\eta_{max}\f$
+ *    and the numerical tests confirm this for their problems.
+ *
+ *  #### References
+ *  Section 2.2.1 / Algorithm 2.4 of A. Denner, "Experiments on
+ *  Temporal Variable Step BDF2 Algorithms", Masters Thesis,
+ *  U Wisconsin-Madison, 2014.
  *
  */
 template<class Scalar>
@@ -181,11 +254,10 @@ public:
        // stability.
        pl->set<double>("Amplification Factor", 1.75, "Amplification factor");
        pl->set<double>("Reduction Factor"    , 0.5 , "Reduction factor");
-       //FIXME? may need to modify default values of monitoring function
-       //IKT, 1/5/17: from (Denner, 2014), it seems a reasonable choice for eta_min is 0.1*eta_max
-       //Numerical tests confirm this. TODO: Change default value of eta_min to 1.0e-2?
-       pl->set<double>("Minimum Value Monitoring Function" , 1.0e-6      , "Min value eta");
-       pl->set<double>("Maximum Value Monitoring Function" , 1.0e-1      , "Max value eta");
+       // From (Denner, 2014), it seems a reasonable choice for eta_min is
+       // 0.1*eta_max.  Numerical tests confirm this.
+       pl->set<double>("Minimum Value Monitoring Function", 0.0    , "Min value eta");
+       pl->set<double>("Maximum Value Monitoring Function", 1.0e-16, "Max value eta");
        pl->set<std::string>("Name", "Basic VS");
        return pl;
     }
@@ -206,9 +278,9 @@ public:
     virtual Scalar getReductFactor() const
       { return tscsPL_->get<double>("Reduction Factor");}
     virtual Scalar getMinEta() const
-      { return tscsPL_->get<double>   ("Minimum Value Monitoring Function"); }
+      { return tscsPL_->get<double>("Minimum Value Monitoring Function"); }
     virtual Scalar getMaxEta() const
-      { return tscsPL_->get<double>   ("Maximum Value Monitoring Function"); }
+      { return tscsPL_->get<double>("Maximum Value Monitoring Function"); }
 
     Scalar computeEta(const TimeStepControl<Scalar> tsc,
           const Teuchos::RCP<SolutionHistory<Scalar> > & solutionHistory)
@@ -260,4 +332,4 @@ private:
     Teuchos::RCP<Teuchos::ParameterList> tscsPL_;
 };
 } // namespace Tempus
-#endif // Tempus_StepControlStrategy_BasicBS_hpp
+#endif // Tempus_TimeStepControlStrategy_BasicVS_hpp

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -23,8 +23,8 @@ namespace Tempus {
  *
  */
 template<class Scalar>
-class TimeStepControlStrategyConstant 
-  : virtual public TimeStepControlStrategy<Scalar> 
+class TimeStepControlStrategyConstant
+  : virtual public TimeStepControlStrategy<Scalar>
 {
 public:
 
@@ -36,22 +36,23 @@ public:
 
   /** \brief Determine the time step size.*/
   virtual void getNextTimeStep(const TimeStepControl<Scalar> tsc,
-    Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory, 
+    Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
     Status & integratorStatus) override
   {
-     Teuchos::RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
-     Teuchos::RCP<SolutionStateMetaData<Scalar> > metaData = workingState->getMetaData();
+     using Teuchos::RCP;
+     RCP<SolutionState<Scalar> >workingState=solutionHistory->getWorkingState();
+     RCP<SolutionStateMetaData<Scalar> > metaData = workingState->getMetaData();
      const Scalar errorAbs = metaData->getErrorAbs();
      const Scalar errorRel = metaData->getErrorRel();
      int order = metaData->getOrder();
      Scalar dt = metaData->getDt();
-     Teuchos::RCP<StepperState<Scalar> > stepperState = workingState->getStepperState();
+     RCP<StepperState<Scalar> > stepperState = workingState->getStepperState();
      bool printChanges = solutionHistory->getVerbLevel() !=
         Teuchos::as<int>(Teuchos::VERB_NONE);
 
      dt = tsc.getInitTimeStep();
 
-     Teuchos::RCP<Teuchos::FancyOStream> out = tsc.getOStream();
+     RCP<Teuchos::FancyOStream> out = tsc.getOStream();
      Teuchos::OSTab ostab(out,1,"getNextTimeStep");
 
      auto changeOrder = [] (int order_old, int order_new, std::string reason) {
@@ -120,13 +121,14 @@ public:
 
      // Consistency checks
      TEUCHOS_TEST_FOR_EXCEPTION(
-           (order < tsc.getMinOrder() || order > tsc.getMaxOrder()), std::out_of_range,
-           "Error - Solution order is out of range and can not change "
-           "time step size!\n"
-           "    Time step type == CONSTANT_STEP_SIZE\n"
-           "    [order_min, order_max] = [" <<tsc.getMinOrder()<< ", "
-           <<tsc.getMaxOrder()<< "]\n"
-           "    order = " << order << "\n");
+       (order < tsc.getMinOrder() || order > tsc.getMaxOrder()),
+       std::out_of_range,
+       "Error - Solution order is out of range and can not change "
+       "time step size!\n"
+       "    Time step type == CONSTANT_STEP_SIZE\n"
+       "    [order_min, order_max] = [" <<tsc.getMinOrder()<< ", "
+       <<tsc.getMaxOrder()<< "]\n"
+       "    order = " << order << "\n");
 
      // update order and dt
      metaData->setOrder(order);

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -56,6 +56,9 @@ public:
   /// Destructor
   virtual ~TimeStepControl() {}
 
+  virtual void initialize(Teuchos::RCP<Teuchos::ParameterList> pList =
+    Teuchos::null) { this->setParameterList(pList); }
+
   /** \brief Determine the time step size.*/
   virtual void getNextTimeStep(
     const Teuchos::RCP<SolutionHistory<Scalar> > & solutionHistory,
@@ -125,8 +128,8 @@ public:
                get<int>("Maximum Number of Consecutive Stepper Failures"); }
     virtual int getNumTimeSteps() const
       { return tscPL_->get<int>("Number of Time Steps"); }
-    virtual Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> 
-       getTimeStepControlStrategy() const { return stepControlStategy_;}
+    virtual Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>>
+       getTimeStepControlStrategy() const { return stepControlStrategy_;}
   //@}
 
   /// \name Set ParameterList values
@@ -191,7 +194,7 @@ protected:
   bool outputAdjustedDt_; ///< Flag indicating that dt was adjusted for output.
   Scalar dtAfterOutput_;  ///< dt to reinstate after output step.
 
-  Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStategy_;
+  Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy_;
 
 };
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -58,8 +58,6 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     Teuchos::OSTab ostab(out,1,"getNextTimeStep");
     bool printChanges = solutionHistory->getVerbLevel() !=
                         Teuchos::as<int>(Teuchos::VERB_NONE);
-    //bool printChangesHi = solutionHistory->getVerbLevel() >=
-    //                      Teuchos::as<int>(Teuchos::VERB_HIGH);
 
     auto changeDT = [] (Scalar dt_old, Scalar dt_new, std::string reason) {
       std::stringstream message;

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -31,7 +31,7 @@ TimeStepControl<Scalar>::TimeStepControl(
   Teuchos::RCP<Teuchos::ParameterList> pList)
   : outputAdjustedDt_(false), dtAfterOutput_(0.0)
 {
-  this->setParameterList(pList);
+  this->initialize(pList);
 }
 
 template<class Scalar>
@@ -41,7 +41,7 @@ TimeStepControl<Scalar>::TimeStepControl(const TimeStepControl<Scalar>& tsc_)
     outputTimes_        (tsc_.outputTimes_        ),
     outputAdjustedDt_   (tsc_.outputAdjustedDt_   ),
     dtAfterOutput_      (tsc_.dtAfterOutput_      ),
-    stepControlStategy_ (tsc_.stepControlStategy_ )
+    stepControlStrategy_(tsc_.stepControlStrategy_ )
 {}
 
 
@@ -58,8 +58,8 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     Teuchos::OSTab ostab(out,1,"getNextTimeStep");
     bool printChanges = solutionHistory->getVerbLevel() !=
                         Teuchos::as<int>(Teuchos::VERB_NONE);
-    bool printChangesHi = solutionHistory->getVerbLevel() >=
-                          Teuchos::as<int>(Teuchos::VERB_HIGH);
+    //bool printChangesHi = solutionHistory->getVerbLevel() >=
+    //                      Teuchos::as<int>(Teuchos::VERB_HIGH);
 
     auto changeDT = [] (Scalar dt_old, Scalar dt_new, std::string reason) {
       std::stringstream message;
@@ -82,37 +82,41 @@ void TimeStepControl<Scalar>::getNextTimeStep(
 
     output = false;
 
-    // If last time step was adjusted for output, reinstate previous dt.
-    if (outputAdjustedDt_ == true) {
-      if (printChanges) *out << changeDT(dt, dtAfterOutput_,
-        "Reset dt after output.");
-      dt = dtAfterOutput_;
-      outputAdjustedDt_ = false;
-      dtAfterOutput_ = 0.0;
-    }
+    if (getStepType() == "Variable") {
+      // If last time step was adjusted for output, reinstate previous dt.
+      if (outputAdjustedDt_ == true) {
+        if (printChanges) *out << changeDT(dt, dtAfterOutput_,
+          "Reset dt after output.");
+        dt = dtAfterOutput_;
+        outputAdjustedDt_ = false;
+        dtAfterOutput_ = 0.0;
+      }
 
-    if (dt <= 0.0) {
-      if (printChanges) *out << changeDT(dt, getInitTimeStep(),
-        "Reset dt to initial dt.");
-      dt = getInitTimeStep();
-    }
+      if (dt <= 0.0) {
+        if (printChanges) *out << changeDT(dt, getInitTimeStep(),
+          "Reset dt to initial dt.");
+        dt = getInitTimeStep();
+      }
 
-    if (dt < getMinTimeStep()) {
-      if (printChanges) *out << changeDT(dt, getMinTimeStep(),
-        "Reset dt to minimum dt.");
-      dt = getMinTimeStep();
+      if (dt < getMinTimeStep()) {
+        if (printChanges) *out << changeDT(dt, getMinTimeStep(),
+          "Reset dt to minimum dt.");
+        dt = getMinTimeStep();
+      }
     }
 
     // update dt in metaData for the step control strategy to be informed
     metaData->setDt(dt);
 
     // call the step control strategy (to update order/dt if needed)
-    stepControlStategy_->getNextTimeStep(*this, solutionHistory, integratorStatus);
+    stepControlStrategy_->getNextTimeStep(*this, solutionHistory,
+                                         integratorStatus);
 
-    // get the order and dt (probably have changed by stepControlStategy_)
+    // get the order and dt (probably have changed by stepControlStrategy_)
     order = metaData->getOrder();
     dt = metaData->getDt();
 
+    if (getStepType() == "Variable") {
       if (dt < getMinTimeStep()) { // decreased below minimum dt
         if (printChanges) *out << changeDT(dt, getMinTimeStep(),
           "dt is too small.  Resetting to minimum dt.");
@@ -123,6 +127,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
           "dt is too large.  Resetting to maximum dt.");
         dt = getMaxTimeStep();
       }
+    }
 
 
     // Check if we need to output this step index
@@ -130,38 +135,45 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       std::find(outputIndices_.begin(), outputIndices_.end(), iStep);
     if (it != outputIndices_.end()) output = true;
 
-    // Adjust time step to hit output times.
+    // Adjust time step to hit output times (if Variable timestep).
     Scalar reltol = 1.0e-6;
     for (size_t i=0; i < outputTimes_.size(); ++i) {
       const Scalar oTime = outputTimes_[i];
       if (lastTime < oTime && oTime <= lastTime+dt+getMinTimeStep()) {
         if (std::abs((lastTime+dt-oTime)/(lastTime+dt)) < reltol) {
-          if (printChangesHi) *out << changeDT(dt, oTime - lastTime,
-            "Adjusting dt for numerical roundoff to hit the next output time.");
-          // Next output time IS VERY near next time (<reltol away from it),
-          // e.g., adjust for numerical roundoff.
           output = true;
-          outputAdjustedDt_ = true;
-          dtAfterOutput_ = dt;
-          dt = oTime - lastTime;
+          if (getStepType() == "Variable") {
+            if (printChanges) *out << changeDT(dt, oTime - lastTime,
+              "Adjusting dt for numerical roundoff to hit the next output time.");
+            // Next output time IS VERY near next time (<reltol away from it),
+            // e.g., adjust for numerical roundoff.
+            outputAdjustedDt_ = true;
+            dtAfterOutput_ = dt;
+            dt = oTime - lastTime;
+          }
         } else if (lastTime*(1.0+reltol) < oTime &&
                    oTime < (lastTime+dt-getMinTimeStep())*(1.0+reltol)) {
-          if (printChanges) *out << changeDT(dt, oTime - lastTime,
-            "Adjusting dt to hit the next output time.");
-          // Next output time is not near next time
-          // (>getMinTimeStep() away from it).
-          // Take time step to hit output time.
           output = true;
-          outputAdjustedDt_ = true;
-          dtAfterOutput_ = dt;
-          dt = oTime - lastTime;
+          if (getStepType() == "Variable") {
+            if (printChanges) *out << changeDT(dt, oTime - lastTime,
+              "Adjusting dt to hit the next output time.");
+            // Next output time is not near next time
+            // (>getMinTimeStep() away from it).
+            // Take time step to hit output time.
+            outputAdjustedDt_ = true;
+            dtAfterOutput_ = dt;
+            dt = oTime - lastTime;
+          }
         } else {
-          if (printChanges) *out << changeDT(dt, (oTime - lastTime)/2.0,
-            "The next output time is within the minimum dt of the next time.  "
-            "Adjusting dt to take two steps.");
-          // Next output time IS near next time (<getMinTimeStep() away from it)
-          // Take two time steps to get to next output time.
-          dt = (oTime - lastTime)/2.0;
+          if (getStepType() == "Variable") {
+            if (printChanges) *out << changeDT(dt, (oTime - lastTime)/2.0,
+              "The next output time is within the minimum dt of the next time. "
+              "Adjusting dt to take two steps.");
+            // Next output time IS near next time
+            // (<getMinTimeStep() away from it).
+            // Take two time steps to get to next output time.
+            dt = (oTime - lastTime)/2.0;
+          }
         }
         break;
       }
@@ -171,7 +183,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     // numerical differences.
     if ((lastTime + dt > getFinalTime() ) ||
         (std::abs((lastTime+dt-getFinalTime())/(lastTime+dt)) < reltol)) {
-      if (printChangesHi) *out << changeDT(dt, getFinalTime() - lastTime,
+      if (printChanges) *out << changeDT(dt, getFinalTime() - lastTime,
         "Adjusting dt to hit the final time.");
       dt = getFinalTime() - lastTime;
     }
@@ -229,6 +241,8 @@ void TimeStepControl<Scalar>::setNumTimeSteps(int numTimeSteps)
     double initTimeStep = (finalTime - initTime)/numTimeSteps;
     if (numTimeSteps == 0) initTimeStep = Scalar(0.0);
     tscPL_->set<double>     ("Initial Time Step", initTimeStep);
+    tscPL_->set<double>     ("Minimum Time Step", initTimeStep);
+    tscPL_->set<double>     ("Maximum Time Step", initTimeStep);
     tscPL_->set<std::string>("Integrator Step Type", "Constant");
 
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
@@ -278,6 +292,11 @@ void TimeStepControl<Scalar>::setParameterList(
   tscPL_->validateParametersAndSetDefaults(*this->getValidParameters(), 0);
 
   // Override parameters
+  if (getStepType() == "Constant") {
+    const double initTimeStep = tscPL_->get<double>("Initial Time Step");
+    tscPL_->set<double>     ("Minimum Time Step", initTimeStep);
+    tscPL_->set<double>     ("Maximum Time Step", initTimeStep);
+  }
   setNumTimeSteps(getNumTimeSteps());
 
   // set the time step control strategy
@@ -426,16 +445,16 @@ void TimeStepControl<Scalar>::setTimeStepControlStrategy(
    using Teuchos::RCP;
    using Teuchos::ParameterList;
 
-   if (stepControlStategy_ == Teuchos::null){
-      stepControlStategy_ =
+   if (stepControlStrategy_ == Teuchos::null){
+      stepControlStrategy_ =
          Teuchos::rcp(new TimeStepControlStrategyComposite<Scalar>());
    }
 
    if (tscs == Teuchos::null) {
-      // Create stepControlStategy_ if null, otherwise keep current parameters.
+      // Create stepControlStrategy_ if null, otherwise keep current parameters.
 
       if (getStepType() == "Constant"){
-         stepControlStategy_->addStrategy(
+         stepControlStrategy_->addStrategy(
                Teuchos::rcp(new TimeStepControlStrategyConstant<Scalar>()));
       } else if (getStepType() == "Variable") {
          // add TSCS from "Time Step Control Strategy List"
@@ -477,13 +496,13 @@ void TimeStepControl<Scalar>::setTimeStepControlStrategy(
             else if(pl->get<std::string>("Name") == "Basic VS")
                ts = Teuchos::rcp(new TimeStepControlStrategyBasicVS<Scalar>(pl));
 
-            stepControlStategy_->addStrategy(ts);
+            stepControlStrategy_->addStrategy(ts);
          }
       }
 
    } else {
       // just add the new tscs to the vector of strategies
-      stepControlStategy_->addStrategy(tscs);
+      stepControlStrategy_->addStrategy(tscs);
    }
 
 }
@@ -495,26 +514,14 @@ TimeStepControl<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
-  const double stdMin = 1.0e+04*std::numeric_limits<double>::epsilon();
   const double stdMax =         std::numeric_limits<double>::max();
   pl->set<double>("Initial Time"         , 0.0    , "Initial time");
   pl->set<double>("Final Time"           , stdMax , "Final time");
   pl->set<int>   ("Initial Time Index"   , 0      , "Initial time index");
   pl->set<int>   ("Final Time Index"     , 1000000, "Final time index");
-  pl->set<double>("Minimum Time Step"    , stdMin , "Minimum time step size");
-  pl->set<double>("Initial Time Step"    , stdMin , "Initial time step size");
+  pl->set<double>("Minimum Time Step"    , 0.0    , "Minimum time step size");
+  pl->set<double>("Initial Time Step"    , 1.0    , "Initial time step size");
   pl->set<double>("Maximum Time Step"    , stdMax , "Maximum time step size");
-  //From (Denner, 2014), amplification factor can be at most 1.91 for stability.
-/*
-  pl->set<double>("Amplification Factor" , 1.75   , "Amplification factor");
-  pl->set<double>("Reduction Factor"     , 0.5    , "Reduction factor");
-  //FIXME? may need to modify default values of monitoring function
-  //IKT, 1/5/17: from (Denner, 2014), it seems a reasonable choice for
-  //eta_min is 0.1*eta_max.  Numerical tests confirm this.
-  //TODO: Change default value of eta_min to 1.0e-2?
-  pl->set<double>("Minimum Value Monitoring Function", 1.0e-6, "Min value eta");
-  pl->set<double>("Maximum Value Monitoring Function", 1.0e-1, "Max value eta");
-*/
   pl->set<int>   ("Minimum Order", 0,
     "Minimum time-integration order.  If set to zero (default), the\n"
     "Stepper minimum order is used.");

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SteadyQuadratic.xml
@@ -1,4 +1,4 @@
-<ParameterList name="BackwardEuler_SteadyQuadratic">
+<ParameterList name="BDF2_SteadyQuadratic">
   <ParameterList name="SteadyQuadraticModel">
     <Parameter name="Coeff b" type="double" value="1.0"/>
   </ParameterList>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -442,15 +442,19 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
   double xSlope = 0.0;
   double xDotSlope = 0.0;
   RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
-  double order = stepper->getOrder();
   writeOrderError("Tempus_BackwardEuler_CDR-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
                   solutionsDot, xDotErrorNorm, xDotSlope);
-  TEST_FLOATING_EQUALITY( xSlope, order, 0.35 );
-  TEST_COMPARE(xSlope, >, 0.95);
-  TEST_FLOATING_EQUALITY( xDotSlope, order, 0.35 );
-  TEST_COMPARE(xDotSlope, >, 0.95);
+
+  TEST_FLOATING_EQUALITY( xSlope,            1.32213, 0.01   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.116919, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,         1.32052, 0.01 );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.449888, 1.0e-4 );
+  // At small dt, slopes should be equal to order.
+  //double order = stepper->getOrder();
+  //TEST_FLOATING_EQUALITY( xSlope,              order, 0.01   );
+  //TEST_FLOATING_EQUALITY( xDotSlope,           order, 0.01 );
 
   // Write fine mesh solution at final time
   // This only works for ONE MPI process
@@ -556,8 +560,10 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.10   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],  0.571031, 1.0e-4 );
-  TEST_FLOATING_EQUALITY( xDotSlope,       1.74898, 0.10 );//=order at small dt
+  TEST_FLOATING_EQUALITY( xDotSlope,       1.74898, 0.10   );
   TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 1.0038, 1.0e-4 );
+  // At small dt, slopes should be equal to order.
+  //TEST_FLOATING_EQUALITY( xDotSlope,       order, 0.01 );
 
   Teuchos::TimeMonitor::summarize();
 }

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -45,7 +45,15 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_PARAMETERLIST
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS
+#define TEST_CDR
+#define TEST_VANDERPOL
 
+
+#ifdef TEST_PARAMETERLIST
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
@@ -87,8 +95,10 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
     TEST_ASSERT(haveSameValues(*stepperPL, *defaultPL, true))
   }
 }
+#endif // TEST_PARAMETERLIST
 
 
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
@@ -128,6 +138,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -193,17 +204,23 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.798923, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.516729, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_SINCOS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 7;
   double dt = 0.2;
-  double order = 0.0;
+  double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -226,9 +243,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -243,64 +258,72 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-    // Time-integrated solution and the exact solution
-    RCP<Thyra::VectorBase<double> > x = integrator->getX();
-    RCP<const Thyra::VectorBase<double> > x_exact =
-      model->getExactSolution(time).get_x();
-
     // Plot sample solution and exact solution
     if (n == 0) {
-      std::ofstream ftmp("Tempus_BackwardEuler_SinCos.dat");
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      RCP<const Thyra::VectorBase<double> > x_exact_plot;
+      writeSolution("Tempus_BackwardEuler_SinCos.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        double time = solutionState->getTime();
-        RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-        x_exact_plot = model->getExactSolution(time).get_x();
-        ftmp << time << "   "
-             << get_ele(*(x_plot), 0) << "   "
-             << get_ele(*(x_plot), 1) << "   "
-             << get_ele(*(x_exact_plot), 0) << "   "
-             << get_ele(*(x_exact_plot), 1) << std::endl;
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
       }
-      ftmp.close();
+      writeSolution("Tempus_BackwardEuler_SinCos-Ref.dat", solnHistExact);
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = BackwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.01 );
-  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0486418, 1.0e-4 );
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_BackwardEuler_SinCos-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_BackwardEuler_SinCos-Error.dat");
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0486418, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
+
+  Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_SINCOS
 
 
+#ifdef TEST_CDR
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
@@ -313,12 +336,14 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
   comm = Teuchos::rcp(new Epetra_SerialComm);
 #endif
 
+  RCP<Tempus::IntegratorBasic<double> > integrator;
   std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 5;
   double dt = 0.2;
-  double order = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -362,9 +387,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -378,10 +401,13 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
     TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
     // Store off the final solution and step size
+    StepSize.push_back(dt);
     auto solution = Thyra::createMember(model->get_x_space());
     Thyra::copy(*(integrator->getX()),solution.ptr());
     solutions.push_back(solution);
-    StepSize.push_back(dt);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
@@ -412,40 +438,19 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
     }
   }
 
-  // Calculate the error - use the most temporally refined mesh for
-  // the base solution.
-  auto base_solution = solutions[solutions.size()-1];
-  std::vector<double> StepSizeCheck;
-  for (std::size_t i=0; i < (solutions.size()-1); ++i) {
-    auto tmp = solutions[i];
-    Thyra::Vp_StV(tmp.ptr(), -1.0, *base_solution);
-    const double L2norm = Thyra::norm_2(*tmp);
-    StepSizeCheck.push_back(StepSize[i]);
-    ErrorNorm.push_back(L2norm);
-  }
-
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-  std::cout << "  Stepper = BackwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.35 );
-  TEST_COMPARE(slope, >, 0.95);
-  out << "\n\n ** Slope on Backward Euler Method = " << slope
-      << "\n" << std::endl;
-
-  // Write error data
-  {
-    std::ofstream ftmp("Tempus_BackwardEuler_CDR-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-      ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
-  }
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_BackwardEuler_CDR-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
+  TEST_FLOATING_EQUALITY( xSlope, order, 0.35 );
+  TEST_COMPARE(xSlope, >, 0.95);
+  TEST_FLOATING_EQUALITY( xDotSlope, order, 0.35 );
+  TEST_COMPARE(xDotSlope, >, 0.95);
 
   // Write fine mesh solution at final time
   // This only works for ONE MPI process
@@ -471,17 +476,22 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
 
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_CDR
 
+
+#ifdef TEST_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
   std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 4;
   double dt = 0.05;
-  double order = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -501,9 +511,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -517,67 +525,43 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
     TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
     // Store off the final solution and step size
+    StepSize.push_back(dt);
     auto solution = Thyra::createMember(model->get_x_space());
     Thyra::copy(*(integrator->getX()),solution.ptr());
     solutions.push_back(solution);
-    StepSize.push_back(dt);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
     if ((n == 0) or (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_BackwardEuler_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_BackwardEuler_VanDerPol.dat";
-      std::ofstream ftmp(fname);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      int nStates = solutionHistory->getNumStates();
-      for (int i=0; i<nStates; i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        RCP<const Thyra::VectorBase<double> > x = solutionState->getX();
-        double ttime = solutionState->getTime();
-        ftmp << ttime << "   " << get_ele(*x, 0) << "   " << get_ele(*x, 1)
-             << std::endl;
-      }
-      ftmp.close();
+      writeSolution(fname, solutionHistory);
     }
-  }
-
-  // Calculate the error - use the most temporally refined mesh for
-  // the reference solution.
-  auto ref_solution = solutions[solutions.size()-1];
-  std::vector<double> StepSizeCheck;
-  for (std::size_t i=0; i < (solutions.size()-1); ++i) {
-    auto tmp = solutions[i];
-    Thyra::Vp_StV(tmp.ptr(), -1.0, *ref_solution);
-    const double L2norm = Thyra::norm_2(*tmp);
-    StepSizeCheck.push_back(StepSize[i]);
-    ErrorNorm.push_back(L2norm);
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-  std::cout << "  Stepper = BackwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.10 );
-  out << "\n\n ** Slope on Backward Euler Method = " << slope
-      << "\n" << std::endl;
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_BackwardEuler_VanDerPol-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  // Write error data
-  {
-    std::ofstream ftmp("Tempus_BackwardEuler_VanDerPol-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-      ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
-  }
+  TEST_FLOATING_EQUALITY( xSlope,            order, 0.10   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],  0.571031, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,       1.74898, 0.10 );//=order at small dt
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 1.0038, 1.0e-4 );
 
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_VANDERPOL
 
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_VanDerPol.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_VanDerPol.xml
@@ -24,7 +24,7 @@
         <Parameter name="Final Time"             type="double" value="3.0"/>
         <Parameter name="Initial Time Index"     type="int"    value="0"/>
         <Parameter name="Final Time Index"       type="int"    value="500000"/>
-        <Parameter name="Minimum Time Step"      type="double" value="0.00001"/>
+        <Parameter name="Minimum Time Step"      type="double" value="1.0e-08"/>
         <Parameter name="Initial Time Step"      type="double" value="0.1"/>
         <Parameter name="Maximum Time Step"      type="double" value="0.1"/>
         <Parameter name="Minimum Order"          type="int"    value="1"/>
@@ -45,8 +45,8 @@
                 <Parameter name="Name" type="string" value="Basic VS"/>
                 <Parameter name="Reduction Factor" type="double" value="0.5"/>
                 <Parameter name="Amplification Factor" type="double" value="1.75"/>
-                <Parameter name="Minimum Value Monitoring Function" type="double" value="5.0e-2"/>
-                <Parameter name="Maximum Value Monitoring Function" type="double" value="5.0e-1"/>
+                <Parameter name="Minimum Value Monitoring Function" type="double" value="0.0"/>
+                <Parameter name="Maximum Value Monitoring Function" type="double" value="1.0e+10"/>
             </ParameterList>
         </ParameterList>
       </ParameterList>

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -59,7 +59,7 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
-    std::string RKMethod_ = RKMethods[m];
+    std::string RKMethod = RKMethods[m];
 
     // Read params from .xml file
     RCP<ParameterList> pList =
@@ -276,9 +276,9 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
-    std::string RKMethod_ = RKMethods[m];
-    std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');
-    std::replace(RKMethod_.begin(), RKMethod_.end(), '/', '.');
+    std::string RKMethod = RKMethods[m];
+    std::replace(RKMethod.begin(), RKMethod.end(), ' ', '_');
+    std::replace(RKMethod.begin(), RKMethod.end(), '/', '.');
 
     RCP<Tempus::IntegratorBasic<double> > integrator;
     std::vector<RCP<Thyra::VectorBase<double>>> solutions;
@@ -345,7 +345,7 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
       if (n == 0) {
         RCP<const SolutionHistory<double> > solutionHistory =
           integrator->getSolutionHistory();
-        writeSolution("Tempus_"+RKMethod_+"_SinCos.dat", solutionHistory);
+        writeSolution("Tempus_"+RKMethod+"_SinCos.dat", solutionHistory);
 
         RCP<Tempus::SolutionHistory<double> > solnHistExact =
           Teuchos::rcp(new Tempus::SolutionHistory<double>());
@@ -358,7 +358,7 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
           state->setTime((*solutionHistory)[i]->getTime());
           solnHistExact->addState(state);
         }
-        writeSolution("Tempus_"+RKMethod_+"_SinCos-Ref.dat", solnHistExact);
+        writeSolution("Tempus_"+RKMethod+"_SinCos-Ref.dat", solnHistExact);
       }
 
       // Store off the final solution and step size
@@ -379,21 +379,21 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
                     solutionDot.ptr());
         solutionsDot.push_back(solutionDot);
       }
-    //Teuchos::TimeMonitor::summarize();
     }
 
     // Check the order and intercept
     double xSlope = 0.0;
-    //double xDotSlope = 0.0;
+    double xDotSlope = 0.0;
     RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
     double order = stepper->getOrder();
-    writeOrderError("Tempus_"+RKMethod_+"_SinCos-Error.dat",
+    writeOrderError("Tempus_"+RKMethod+"_SinCos-Error.dat",
                     stepper, StepSize,
-                    solutions,    xErrorNorm,    xSlope); //,
-                    //solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutions,    xErrorNorm,    xSlope,
+                    solutionsDot, xDotErrorNorm, xDotSlope);
 
     TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], RKMethodErrors[m], 5.0e-4 );
+    // xDot not yet available for DIRK methods.
     //TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
     //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
 
@@ -407,7 +407,12 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
 // ************************************************************
 TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
 {
-  std::string RKMethod_ = "SDIRK 2 Stage 2nd order";
+  std::vector<std::string> RKMethods;
+  RKMethods.push_back("SDIRK 2 Stage 2nd order");
+
+  std::string RKMethod = RKMethods[0];
+  std::replace(RKMethod.begin(), RKMethod.end(), ' ', '_');
+  std::replace(RKMethod.begin(), RKMethod.end(), '/', '.');
 
   RCP<Tempus::IntegratorBasic<double> > integrator;
   std::vector<RCP<Thyra::VectorBase<double>>> solutions;
@@ -432,7 +437,7 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
 
     // Set the Stepper
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
-    pl->sublist("Default Stepper").set("Stepper Type", RKMethod_);
+    pl->sublist("Default Stepper").set("Stepper Type", RKMethods[0]);
     pl->sublist("Default Stepper").set("gamma", 0.2928932188134524);
 
     // Set the step size
@@ -467,8 +472,8 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
     if ((n == 0) or (n == nTimeStepSizes-1)) {
-      std::string fname = "Tempus_"+RKMethod_+"_VanDerPol-Ref.dat";
-      if (n == 0) fname = "Tempus_"+RKMethod_+"_VanDerPol.dat";
+      std::string fname = "Tempus_"+RKMethod+"_VanDerPol-Ref.dat";
+      if (n == 0) fname = "Tempus_"+RKMethod+"_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
       writeSolution(fname, solutionHistory);
@@ -477,16 +482,17 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
 
   // Check the order and intercept
   double xSlope = 0.0;
-  //double xDotSlope = 0.0;
+  double xDotSlope = 0.0;
   RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
   double order = stepper->getOrder();
-  writeOrderError("Tempus_"+RKMethod_+"_VanDerPol-Error.dat",
+  writeOrderError("Tempus_"+RKMethod+"_VanDerPol-Error.dat",
                   stepper, StepSize,
-                  solutions,    xErrorNorm,    xSlope); //,
-                  //solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.06   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],  3.42577e-05, 1.0e-4 );
+  // xDot not yet available for DIRK methods.
   //TEST_FLOATING_EQUALITY( xDotSlope,        1.74898, 0.10 );
   //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  1.0038, 1.0e-4 );
 

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -33,7 +33,14 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_PARAMETERLIST
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS
+#define TEST_VANDERPOL
 
+
+#ifdef TEST_PARAMETERLIST
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(DIRK, ParameterList)
@@ -134,7 +141,10 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
     }
   }
 }
+#endif // TEST_PARAMETERLIST
 
+
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
@@ -166,6 +176,7 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -231,8 +242,10 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540304, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_SINCOS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(DIRK, SinCos)
@@ -266,20 +279,22 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
     std::string RKMethod_ = RKMethods[m];
     std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');
     std::replace(RKMethod_.begin(), RKMethod_.end(), '/', '.');
+
+    RCP<Tempus::IntegratorBasic<double> > integrator;
+    std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+    std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
     std::vector<double> StepSize;
-    std::vector<double> ErrorNorm;
-    const int nTimeStepSizes = 3; // 7 for error plots
+    std::vector<double> xErrorNorm;
+    std::vector<double> xDotErrorNorm;
+
+    const int nTimeStepSizes = 2; // 7 for error plots
     double dt = 0.05;
-    double order = 0.0;
+    double time = 0.0;
     for (int n=0; n<nTimeStepSizes; n++) {
 
       // Read params from .xml file
       RCP<ParameterList> pList =
         getParametersFromXmlFile("Tempus_DIRK_SinCos.xml");
-
-      //std::ofstream ftmp("PL.txt");
-      //pList->print(ftmp);
-      //ftmp.close();
 
       // Setup the SinCosModel
       RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
@@ -305,9 +320,7 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
-      RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(pl, model);
-      order = integrator->getStepper()->getOrder();
+      integrator = Tempus::integratorBasic<double>(pl, model);
 
       // Initial Conditions
       // During the Integrator construction, the initial SolutionState
@@ -322,88 +335,90 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
       TEST_ASSERT(integratorStatus)
 
       // Test if at 'Final Time'
-      double time = integrator->getTime();
+      time = integrator->getTime();
       double timeFinal = pl->sublist("Default Integrator")
         .sublist("Time Step Control").get<double>("Final Time");
       double tol = 100.0 * std::numeric_limits<double>::epsilon();
       TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
-      // Time-integrated solution and the exact solution
-      RCP<Thyra::VectorBase<double> > x = integrator->getX();
-      RCP<const Thyra::VectorBase<double> > x_exact =
-        model->getExactSolution(time).get_x();
-
       // Plot sample solution and exact solution
       if (n == 0) {
-        std::ofstream ftmp("Tempus_"+RKMethod_+"_SinCos.dat");
         RCP<const SolutionHistory<double> > solutionHistory =
           integrator->getSolutionHistory();
-        int nStates = solutionHistory->getNumStates();
-        RCP<const Thyra::VectorBase<double> > x_exact_plot;
-        for (int i=0; i<nStates; i++) {
-          RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-          double time = solutionState->getTime();
-          RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-          x_exact_plot = model->getExactSolution(time).get_x();
-          ftmp << time << "   "
-               << Thyra::get_ele(*(x_plot), 0) << "   "
-               << Thyra::get_ele(*(x_plot), 1) << "   "
-               << Thyra::get_ele(*(x_exact_plot), 0) << "   "
-               << Thyra::get_ele(*(x_exact_plot), 1) << std::endl;
+        writeSolution("Tempus_"+RKMethod_+"_SinCos.dat", solutionHistory);
+
+        RCP<Tempus::SolutionHistory<double> > solnHistExact =
+          Teuchos::rcp(new Tempus::SolutionHistory<double>());
+        for (int i=0; i<solutionHistory->getNumStates(); i++) {
+          double time = (*solutionHistory)[i]->getTime();
+          RCP<Tempus::SolutionState<double> > state =
+            Teuchos::rcp(new Tempus::SolutionState<double>(
+              model->getExactSolution(time).get_x(),
+              model->getExactSolution(time).get_x_dot()));
+          state->setTime((*solutionHistory)[i]->getTime());
+          solnHistExact->addState(state);
         }
-        ftmp.close();
+        writeSolution("Tempus_"+RKMethod_+"_SinCos-Ref.dat", solnHistExact);
       }
 
-      // Calculate the error
-      RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-      Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+      // Store off the final solution and step size
       StepSize.push_back(dt);
-      const double L2norm = Thyra::norm_2(*xdiff);
-      ErrorNorm.push_back(L2norm);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(integrator->getX()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+      if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+        StepSize.push_back(0.0);
+        auto solution = Thyra::createMember(model->get_x_space());
+        Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+        solutions.push_back(solution);
+        auto solutionDot = Thyra::createMember(model->get_x_space());
+        Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                    solutionDot.ptr());
+        solutionsDot.push_back(solutionDot);
+      }
+    //Teuchos::TimeMonitor::summarize();
     }
-
-    std::ofstream ftmp("Tempus_"+RKMethod_+"_SinCos-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (int n=0; n<(int)StepSize.size(); n++) {
-      ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
-
-    //if (RKMethods[m] == "SDIRK 5 Stage 4th order") {
-    //  StepSize.pop_back();  StepSize.pop_back();
-    //  ErrorNorm.pop_back(); ErrorNorm.pop_back();
-    //} else if (RKMethods[m] == "SDIRK 5 Stage 5th order") {
-    //  StepSize.pop_back();  StepSize.pop_back();  StepSize.pop_back();
-    //  ErrorNorm.pop_back(); ErrorNorm.pop_back(); ErrorNorm.pop_back();
-    //}
 
     // Check the order and intercept
-    double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-    std::cout << "  Stepper = " << RKMethods[m] << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Expected order: " << order << std::endl;
-    std::cout << "  Observed order: " << slope << std::endl;
-    std::cout << "  =========================" << std::endl;
-    TEST_FLOATING_EQUALITY( slope, order, 0.03 );
-    TEST_FLOATING_EQUALITY( ErrorNorm[0], RKMethodErrors[m], 5.0e-4 );
+    double xSlope = 0.0;
+    //double xDotSlope = 0.0;
+    RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+    double order = stepper->getOrder();
+    writeOrderError("Tempus_"+RKMethod_+"_SinCos-Error.dat",
+                    stepper, StepSize,
+                    solutions,    xErrorNorm,    xSlope); //,
+                    //solutionsDot, xDotErrorNorm, xDotSlope);
+
+    TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
+    TEST_FLOATING_EQUALITY( xErrorNorm[0], RKMethodErrors[m], 5.0e-4 );
+    //TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
+    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
 
   }
-  Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_SINCOS
 
 
+#ifdef TEST_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
 {
   std::string RKMethod_ = "SDIRK 2 Stage 2nd order";
+
+  RCP<Tempus::IntegratorBasic<double> > integrator;
   std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
+
   const int nTimeStepSizes = 3;  // 8 for error plot
   double dt = 0.05;
-  double order = 0.0;
+  double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -427,82 +442,57 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
     // Setup the Integrator and reset initial time step
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
       .sublist("Time Step Control").get<double>("Final Time");
     double tol = 100.0 * std::numeric_limits<double>::epsilon();
     TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
     // Store off the final solution and step size
+    StepSize.push_back(dt);
     auto solution = Thyra::createMember(model->get_x_space());
     Thyra::copy(*(integrator->getX()),solution.ptr());
     solutions.push_back(solution);
-    StepSize.push_back(dt);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
     if ((n == 0) or (n == nTimeStepSizes-1)) {
-      std::string fname = "Tempus_DIRK_VanDerPol-Ref.dat";
-      if (n == 0) fname = "Tempus_DIRK_VanDerPol.dat";
-      std::ofstream ftmp(fname);
+      std::string fname = "Tempus_"+RKMethod_+"_VanDerPol-Ref.dat";
+      if (n == 0) fname = "Tempus_"+RKMethod_+"_VanDerPol.dat";
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      int nStates = solutionHistory->getNumStates();
-      for (int i=0; i<nStates; i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        RCP<const Thyra::VectorBase<double> > x = solutionState->getX();
-        double ttime = solutionState->getTime();
-        ftmp << ttime << "   " << get_ele(*x, 0) << "   " << get_ele(*x, 1)
-             << std::endl;
-      }
-      ftmp.close();
+      writeSolution(fname, solutionHistory);
     }
-  }
-
-  // Calculate the error - use the most temporally refined mesh for
-  // the reference solution.
-  auto ref_solution = solutions[solutions.size()-1];
-  std::vector<double> StepSizeCheck;
-  for (std::size_t i=0; i < (solutions.size()-1); ++i) {
-    auto tmp = solutions[i];
-    Thyra::Vp_StV(tmp.ptr(), -1.0, *ref_solution);
-    const double L2norm = Thyra::norm_2(*tmp);
-    StepSizeCheck.push_back(StepSize[i]);
-    ErrorNorm.push_back(L2norm);
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-  std::cout << "  Stepper = " << RKMethod_ << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.06 );
-  out << "\n\n ** Slope on " << RKMethod_ << " = " << slope
-      << "\n" << std::endl;
+  double xSlope = 0.0;
+  //double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_"+RKMethod_+"_VanDerPol-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope); //,
+                  //solutionsDot, xDotErrorNorm, xDotSlope);
 
-  // Write error data
-  {
-    std::ofstream ftmp("Tempus_DIRK_VanDerPol-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-      ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
-  }
+  TEST_FLOATING_EQUALITY( xSlope,            order, 0.06   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],  3.42577e-05, 1.0e-4 );
+  //TEST_FLOATING_EQUALITY( xDotSlope,        1.74898, 0.10 );
+  //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  1.0038, 1.0e-4 );
+
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_VANDERPOL
 
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -62,9 +62,9 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
-    std::string RKMethod_ = RKMethods[m];
-    std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');
-    std::replace(RKMethod_.begin(), RKMethod_.end(), '/', '.');
+    std::string RKMethod = RKMethods[m];
+    std::replace(RKMethod.begin(), RKMethod.end(), ' ', '_');
+    std::replace(RKMethod.begin(), RKMethod.end(), '/', '.');
 
     // Read params from .xml file
     RCP<ParameterList> pList =
@@ -254,9 +254,9 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
-    std::string RKMethod_ = RKMethods[m];
-    std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');
-    std::replace(RKMethod_.begin(), RKMethod_.end(), '/', '.');
+    std::string RKMethod = RKMethods[m];
+    std::replace(RKMethod.begin(), RKMethod.end(), ' ', '_');
+    std::replace(RKMethod.begin(), RKMethod.end(), '/', '.');
 
     RCP<Tempus::IntegratorBasic<double> > integrator;
     std::vector<RCP<Thyra::VectorBase<double>>> solutions;
@@ -325,7 +325,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
       if (n == 0) {
         RCP<const SolutionHistory<double> > solutionHistory =
           integrator->getSolutionHistory();
-        writeSolution("Tempus_"+RKMethod_+"_SinCos.dat", solutionHistory);
+        writeSolution("Tempus_"+RKMethod+"_SinCos.dat", solutionHistory);
 
         RCP<Tempus::SolutionHistory<double> > solnHistExact =
           Teuchos::rcp(new Tempus::SolutionHistory<double>());
@@ -338,7 +338,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
           state->setTime((*solutionHistory)[i]->getTime());
           solnHistExact->addState(state);
         }
-        writeSolution("Tempus_"+RKMethod_+"_SinCos-Ref.dat", solnHistExact);
+        writeSolution("Tempus_"+RKMethod+"_SinCos-Ref.dat", solnHistExact);
       }
 
       // Store off the final solution and step size
@@ -363,18 +363,19 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
 
     // Check the order and intercept
     double xSlope = 0.0;
-    //double xDotSlope = 0.0;
+    double xDotSlope = 0.0;
     RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
     double order = stepper->getOrder();
-    writeOrderError("Tempus_"+RKMethod_+"_SinCos-Error.dat",
+    writeOrderError("Tempus_"+RKMethod+"_SinCos-Error.dat",
                     stepper, StepSize,
-                    solutions,    xErrorNorm,    xSlope);  //,
-                    //solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutions,    xErrorNorm,    xSlope,
+                    solutionsDot, xDotErrorNorm, xDotSlope);
 
     TEST_FLOATING_EQUALITY( xSlope,                    order, 0.01   );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], RKMethodErrors[m], 1.0e-4 );
-    //TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
-    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
+    // xDot not yet available for ExplicitRK methods.
+    //TEST_FLOATING_EQUALITY( xDotSlope,                 order, 0.01   );
+    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],      0.0486418, 1.0e-4 );
 
   }
   //Teuchos::TimeMonitor::summarize();
@@ -422,7 +423,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
      RCP<Tempus::IntegratorBasic<double> > integrator =
         Tempus::integratorBasic<double>(pl, model);
 
-     const std::string RKMethod_ =
+     const std::string RKMethod =
         pl->sublist(integratorChoice).get<std::string>("Stepper Name");
 
      // Integrate to timeMax
@@ -477,7 +478,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
      }
 
      // Plot sample solution and exact solution
-     std::ofstream ftmp("Tempus_"+integratorChoice+RKMethod_+"_VDP_Example.dat");
+     std::ofstream ftmp("Tempus_"+integratorChoice+RKMethod+"_VDP_Example.dat");
      RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
      int nStates = solutionHistory->getNumStates();

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -34,7 +34,14 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_PARAMETERLIST
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS
+#define TEST_EMBEDDED_VANDERPOL
 
+
+#ifdef TEST_PARAMETERLIST
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
@@ -107,7 +114,10 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
     }
   }
 }
+#endif // TEST_PARAMETERLIST
 
+
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
@@ -139,6 +149,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -204,8 +215,10 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540303, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_SINCOS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
@@ -244,20 +257,22 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
     std::string RKMethod_ = RKMethods[m];
     std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');
     std::replace(RKMethod_.begin(), RKMethod_.end(), '/', '.');
+
+    RCP<Tempus::IntegratorBasic<double> > integrator;
+    std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+    std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
     std::vector<double> StepSize;
-    std::vector<double> ErrorNorm;
+    std::vector<double> xErrorNorm;
+    std::vector<double> xDotErrorNorm;
+
     const int nTimeStepSizes = 7;
     double dt = 0.2;
-    double order = 0.0;
+    double time = 0.0;
     for (int n=0; n<nTimeStepSizes; n++) {
 
       // Read params from .xml file
       RCP<ParameterList> pList =
         getParametersFromXmlFile("Tempus_ExplicitRK_SinCos.xml");
-
-      //std::ofstream ftmp("PL.txt");
-      //pList->print(ftmp);
-      //ftmp.close();
 
       // Setup the SinCosModel
       RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
@@ -281,9 +296,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
       // Setup the Integrator and reset initial time step
       pl->sublist("Demo Integrator")
         .sublist("Time Step Control").set("Initial Time Step", dt);
-      RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(pl, model);
-      order = integrator->getStepper()->getOrder();
+      integrator = Tempus::integratorBasic<double>(pl, model);
 
       // Initial Conditions
       // During the Integrator construction, the initial SolutionState
@@ -298,7 +311,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
       TEST_ASSERT(integratorStatus)
 
       // Test if at 'Final Time'
-      double time = integrator->getTime();
+      time = integrator->getTime();
       double timeFinal = pl->sublist("Demo Integrator")
         .sublist("Time Step Control").get<double>("Final Time");
       TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
@@ -310,57 +323,66 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
 
       // Plot sample solution and exact solution
       if (n == 0) {
-        std::ofstream ftmp("Tempus_"+RKMethod_+"_SinCos.dat");
         RCP<const SolutionHistory<double> > solutionHistory =
           integrator->getSolutionHistory();
-        int nStates = solutionHistory->getNumStates();
-        RCP<const Thyra::VectorBase<double> > x_exact_plot;
-        for (int i=0; i<nStates; i++) {
-          RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-          double time = solutionState->getTime();
-          RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-          x_exact_plot = model->getExactSolution(time).get_x();
-          ftmp << time << "   "
-               << Thyra::get_ele(*(x_plot), 0) << "   "
-               << Thyra::get_ele(*(x_plot), 1) << "   "
-               << Thyra::get_ele(*(x_exact_plot), 0) << "   "
-               << Thyra::get_ele(*(x_exact_plot), 1) << std::endl;
+        writeSolution("Tempus_"+RKMethod_+"_SinCos.dat", solutionHistory);
+
+        RCP<Tempus::SolutionHistory<double> > solnHistExact =
+          Teuchos::rcp(new Tempus::SolutionHistory<double>());
+        for (int i=0; i<solutionHistory->getNumStates(); i++) {
+          double time = (*solutionHistory)[i]->getTime();
+          RCP<Tempus::SolutionState<double> > state =
+            Teuchos::rcp(new Tempus::SolutionState<double>(
+              model->getExactSolution(time).get_x(),
+              model->getExactSolution(time).get_x_dot()));
+          state->setTime((*solutionHistory)[i]->getTime());
+          solnHistExact->addState(state);
         }
-        ftmp.close();
+        writeSolution("Tempus_"+RKMethod_+"_SinCos-Ref.dat", solnHistExact);
       }
 
-      // Calculate the error
-      RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-      Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+      // Store off the final solution and step size
       StepSize.push_back(dt);
-      const double L2norm = Thyra::norm_2(*xdiff);
-      ErrorNorm.push_back(L2norm);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(integrator->getX()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+      if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+        StepSize.push_back(0.0);
+        auto solution = Thyra::createMember(model->get_x_space());
+        Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+        solutions.push_back(solution);
+        auto solutionDot = Thyra::createMember(model->get_x_space());
+        Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                    solutionDot.ptr());
+        solutionsDot.push_back(solutionDot);
+      }
     }
 
     // Check the order and intercept
-    double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-    std::cout << "  Stepper = " << RKMethods[m] << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Expected order: " << order << std::endl;
-    std::cout << "  Observed order: " << slope << std::endl;
-    std::cout << "  =========================" << std::endl;
-    TEST_FLOATING_EQUALITY( slope, order, 0.01 );
-    TEST_FLOATING_EQUALITY( ErrorNorm[0], RKMethodErrors[m], 1.0e-4 );
+    double xSlope = 0.0;
+    //double xDotSlope = 0.0;
+    RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+    double order = stepper->getOrder();
+    writeOrderError("Tempus_"+RKMethod_+"_SinCos-Error.dat",
+                    stepper, StepSize,
+                    solutions,    xErrorNorm,    xSlope);  //,
+                    //solutionsDot, xDotErrorNorm, xDotSlope);
 
-    std::ofstream ftmp("Tempus_"+RKMethod_+"_SinCos-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (int n=0; n<nTimeStepSizes; n++) {
-      ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
+    TEST_FLOATING_EQUALITY( xSlope,                    order, 0.01   );
+    TEST_FLOATING_EQUALITY( xErrorNorm[0], RKMethodErrors[m], 1.0e-4 );
+    //TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
+    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
 
   }
-
-  Teuchos::TimeMonitor::summarize();
+  //Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_SINCOS
 
 
+#ifdef TEST_EMBEDDED_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
@@ -375,7 +397,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
 
   // the embedded solution will test the following:
   // using the starting stepsize routine, this has now decreased
-  const int refIstep = 45; 
+  const int refIstep = 45;
 
   for(auto integratorChoice : IntegratorList){
 
@@ -450,7 +472,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
         TEST_EQUALITY(iStep, refIstep);
         std::cout << "Tolerance = " << absTol
            << " L2norm = "   << L2norm
-           << " iStep = "    << iStep  
+           << " iStep = "    << iStep
            << " nFail = "    << nFail << std::endl;
      }
 
@@ -474,5 +496,6 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
 
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_EMBEDDED_VANDERPOL
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -35,6 +35,15 @@ using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_PARAMETERLIST
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS
+#define TEST_VANDERPOL
+#define TEST_NUMBER_TIMESTEPS
+
+
+#ifdef TEST_PARAMETERLIST
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
@@ -77,8 +86,10 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
     TEST_ASSERT(haveSameValues(*stepperPL, *defaultPL, true))
   }
 }
+#endif // TEST_PARAMETERLIST
 
 
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
@@ -110,6 +121,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -174,17 +186,23 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.882508, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.570790, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_SINCOS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 7;
   double dt = 0.2;
-  double order = 0.0;
+  double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -207,9 +225,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -229,7 +245,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
     TEST_EQUALITY(physicsState->getName(), "Tempus::PhysicsState");
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal = pl->sublist("Demo Integrator")
       .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
@@ -241,63 +257,77 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
 
     // Plot sample solution and exact solution
     if (n == 0) {
-      std::ofstream ftmp("Tempus_ForwardEuler_SinCos.dat");
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      RCP<const Thyra::VectorBase<double> > x_exact_plot;
+      writeSolution("Tempus_ForwardEuler_SinCos.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        double time = solutionState->getTime();
-        RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-        x_exact_plot = model->getExactSolution(time).get_x();
-        ftmp << time << "   "
-             << Thyra::get_ele(*(x_plot), 0) << "   "
-             << Thyra::get_ele(*(x_plot), 1) << "   "
-             << Thyra::get_ele(*(x_exact_plot), 0) << "   "
-             << Thyra::get_ele(*(x_exact_plot), 1) << std::endl;
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
       }
-      ftmp.close();
+      writeSolution("Tempus_ForwardEuler_SinCos-Ref.dat", solnHistExact);
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = ForwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.01 );
-  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.051123, 1.0e-4 );
+  double xSlope = 0.0;
+  //double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_ForwardEuler_SinCos-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope); //,
+                  //solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_ForwardEuler_SinCos-Error.dat");
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],     0.051123, 1.0e-4 );
+  //TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
+  //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
 
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_SINCOS
 
+
+#ifdef TEST_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
   std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 7;  // 8 for Error plot
   double dt = 0.2;
-  double order = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -317,9 +347,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
@@ -333,30 +361,40 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
     TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
     // Store off the final solution and step size
+    StepSize.push_back(dt);
     auto solution = Thyra::createMember(model->get_x_space());
     Thyra::copy(*(integrator->getX()),solution.ptr());
     solutions.push_back(solution);
-    StepSize.push_back(dt);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
     if ((n == 0) or (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_ForwardEuler_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_ForwardEuler_VanDerPol.dat";
-      std::ofstream ftmp(fname);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      int nStates = solutionHistory->getNumStates();
-      for (int i=0; i<nStates; i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        RCP<const Thyra::VectorBase<double> > x = solutionState->getX();
-        double ttime = solutionState->getTime();
-        ftmp << ttime << "   " << get_ele(*x, 0) << "   " << get_ele(*x, 1)
-             << std::endl;
-      }
-      ftmp.close();
+      writeSolution(fname, solutionHistory);
     }
   }
+
+  // Check the order and intercept
+  double xSlope = 0.0;
+  //double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_ForwardEuler_VanDerPol-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope); //,
+                  //solutionsDot, xDotErrorNorm, xDotSlope);
+
+  TEST_FLOATING_EQUALITY( xSlope,            order, 0.10   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],  0.387476, 1.0e-4 );
+  //TEST_FLOATING_EQUALITY( xDotSlope,     1.74898, 0.10 );//=order at small dt
+  //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 1.0038, 1.0e-4 );
+
 
   // Calculate the error - use the most temporally refined mesh for
   // the reference solution.
@@ -367,35 +405,15 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
     Thyra::Vp_StV(tmp.ptr(), -1.0, *ref_solution);
     const double L2norm = Thyra::norm_2(*tmp);
     StepSizeCheck.push_back(StepSize[i]);
-    ErrorNorm.push_back(L2norm);
-  }
-
-  // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-  std::cout << "  Stepper = ForwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.08 );
-  TEST_COMPARE(slope, >, 0.95);
-  out << "\n\n ** Slope on Forward Euler Method = " << slope
-      << "\n" << std::endl;
-
-  // Write error data
-  {
-    std::ofstream ftmp("Tempus_ForwardEuler_VanDerPol-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-      ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
+    xErrorNorm.push_back(L2norm);
   }
 
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_VANDERPOL
 
+
+#ifdef TEST_NUMBER_TIMESTEPS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(ForwardEuler, NumberTimeSteps)
@@ -441,5 +459,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, NumberTimeSteps)
     // in the parameter list
     TEST_EQUALITY(numTimeSteps, integrator->getIndex());
 }
+#endif // TEST_NUMBER_TIMESTEPS
+
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -297,16 +297,17 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
 
   // Check the order and intercept
   double xSlope = 0.0;
-  //double xDotSlope = 0.0;
+  double xDotSlope = 0.0;
   RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
   double order = stepper->getOrder();
   writeOrderError("Tempus_ForwardEuler_SinCos-Error.dat",
                   stepper, StepSize,
-                  solutions,    xErrorNorm,    xSlope); //,
-                  //solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],     0.051123, 1.0e-4 );
+  // xDot not yet available for Forward Euler.
   //TEST_FLOATING_EQUALITY( xDotSlope,            order, 0.01   );
   //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.0486418, 1.0e-4 );
 
@@ -382,19 +383,19 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
 
   // Check the order and intercept
   double xSlope = 0.0;
-  //double xDotSlope = 0.0;
+  double xDotSlope = 0.0;
   RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
   double order = stepper->getOrder();
   writeOrderError("Tempus_ForwardEuler_VanDerPol-Error.dat",
                   stepper, StepSize,
-                  solutions,    xErrorNorm,    xSlope); //,
-                  //solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.10   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],  0.387476, 1.0e-4 );
-  //TEST_FLOATING_EQUALITY( xDotSlope,     1.74898, 0.10 );//=order at small dt
+  // xDot not yet available for Forward Euler.
+  //TEST_FLOATING_EQUALITY( xDotSlope,       1.74898, 0.10   );
   //TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 1.0038, 1.0e-4 );
-
 
   // Calculate the error - use the most temporally refined mesh for
   // the reference solution.

--- a/packages/tempus/test/HHTAlpha/CMakeLists.txt
+++ b/packages/tempus/test/HHTAlpha/CMakeLists.txt
@@ -19,6 +19,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 #  )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Test_HHTAlpha_CopyFiles
-  DEST_FILES Tempus_Newmark_BallParabolic.xml Tempus_Newmark_SinCos_SecondOrder.xml Tempus_Newmark_SinCos_FirstOrder.xml Tempus_Newmark_SinCos_ExplicitCD.xml 
+  DEST_FILES Tempus_HHTAlpha_BallParabolic.xml Tempus_HHTAlpha_SinCos_SecondOrder.xml Tempus_HHTAlpha_SinCos_FirstOrder.xml Tempus_HHTAlpha_SinCos_ExplicitCD.xml 
   EXEDEPS HHTAlpha
   )

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
@@ -45,13 +45,16 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
-//IKT, 3/22/17: comment out any of the following
-//if you wish not to build/run all the test cases.
+// Comment out any of the following tests to exclude from build/run.
 #define TEST_BALL_PARABOLIC
-#define TEST_SIN_COS
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS_SECONDORDER
+#define TEST_SINCOS_FIRSTORDER
+#define TEST_SINCOS_CD
 
 
 #ifdef TEST_BALL_PARABOLIC
+// ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(HHTAlpha, BallParabolic)
 {
@@ -59,7 +62,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, BallParabolic)
   double tolerance = 1.0e-14;
   // Read params from .xml file
   RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Newmark_BallParabolic.xml");
+    getParametersFromXmlFile("Tempus_HHTAlpha_BallParabolic.xml");
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
@@ -88,7 +91,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, BallParabolic)
     model->getExactSolution(time).get_x();
 
   // Plot sample solution and exact solution
-  std::ofstream ftmp("Tempus_Newmark_BallParabolic.dat");
+  std::ofstream ftmp("Tempus_HHTAlpha_BallParabolic.dat");
   ftmp.precision(16);
   RCP<const SolutionHistory<double> > solutionHistory =
     integrator->getSolutionHistory();
@@ -115,8 +118,10 @@ TEUCHOS_UNIT_TEST(HHTAlpha, BallParabolic)
     "\n Test failed!  Max error = " << err << " > tolerance = " << tolerance << "\n!");
 
 }
-#endif
+#endif // TEST_BALL_PARABOLIC
 
+
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
@@ -125,7 +130,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
 
   // Read params from .xml file
   RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Newmark_SinCos_SecondOrder.xml");
+    getParametersFromXmlFile("Tempus_HHTAlpha_SinCos_SecondOrder.xml");
   RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
   // Setup the HarmonicOscillatorModel
@@ -147,6 +152,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
@@ -213,20 +219,25 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   std::cout << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.144918, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
-#ifdef TEST_SIN_COS
+#ifdef TEST_SINCOS_SECONDORDER
 // ************************************************************
 TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 8;
-  double order = 0.0;
+  double time = 0.0;
 
   // Read params from .xml file
   RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Newmark_SinCos_SecondOrder.xml");
+    getParametersFromXmlFile("Tempus_HHTAlpha_SinCos_SecondOrder.xml");
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
@@ -254,16 +265,14 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
@@ -275,7 +284,26 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
 
     // Plot sample solution and exact solution at most-refined resolution
     if (n == nTimeStepSizes-1) {
-      std::ofstream ftmp("Tempus_Newmark_SinCos_SecondOrder.dat");
+      RCP<const SolutionHistory<double> > solutionHistory =
+        integrator->getSolutionHistory();
+      writeSolution("Tempus_HHTAlpha_SinCos_SecondOrder.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      for (int i=0; i<solutionHistory->getNumStates(); i++) {
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
+      }
+      writeSolution("Tempus_HHTAlpha_SinCos_SecondOrder-Ref.dat", solnHistExact);
+
+      // Problem specific output
+      {
+      std::ofstream ftmp("Tempus_HHTAlpha_SinCos_SecondOrder-Energy.dat");
       ftmp.precision(16);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
@@ -302,47 +330,64 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
              << ke << "   " << pe << "   " << te << std::endl;
       }
       ftmp.close();
+      }
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = HHT-Alpha" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.02 );
-  //TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0486418, 1.0e-4 );
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_HHTAlpha_SinCos_SecondOrder-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_Newmark-Error_SinCos_SecondOrder.dat");
-  ftmp.precision(16);
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,                order, 0.02   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.00644755, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,             order, 0.01   );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0],   0.104392, 1.0e-4 );
 }
+#endif // TEST_SINCOS_SECONDORDER
 
+
+#ifdef TEST_SINCOS_FIRSTORDER
+// ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 8;
-  double order = 0.0;
+  double time = 0.0;
 
   // Read params from .xml file
   RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Newmark_SinCos_FirstOrder.xml");
+    getParametersFromXmlFile("Tempus_HHTAlpha_SinCos_FirstOrder.xml");
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
@@ -370,16 +415,14 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
@@ -391,7 +434,26 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
 
     // Plot sample solution and exact solution at most-refined resolution
     if (n == nTimeStepSizes-1) {
-      std::ofstream ftmp("Tempus_Newmark_SinCos_FirstOrder.dat");
+      RCP<const SolutionHistory<double> > solutionHistory =
+        integrator->getSolutionHistory();
+      writeSolution("Tempus_HHTAlpha_SinCos_FirstOrder.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      for (int i=0; i<solutionHistory->getNumStates(); i++) {
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
+      }
+      writeSolution("Tempus_HHTAlpha_SinCos_FirstOrder-Ref.dat", solnHistExact);
+
+      // Problem specific output
+      {
+      std::ofstream ftmp("Tempus_HHTAlpha_SinCos_FirstOrder-Energy.dat");
       ftmp.precision(16);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
@@ -418,47 +480,65 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
              << ke << "   " << pe << "   " << te << std::endl;
       }
       ftmp.close();
+      }
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = HHT-Alpha" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.02 );
-  //TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0486418, 1.0e-4 );
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_HHTAlpha_SinCos_FirstOrder-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_Newmark-Error_SinCos_FirstOrder.dat");
-  ftmp.precision(16);
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,              order, 0.02   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.048932, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,         1.18873, 0.01   );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.393504, 1.0e-4 );
+
 }
+#endif // TEST_SINCOS_FIRSTORDER
 
+
+#ifdef TEST_SINCOS_CD
 // ************************************************************
-TEUCHOS_UNIT_TEST(NewmarkExplicit, SinCos_CD)
+// ************************************************************
+TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_CD)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 8;
-  double order = 0.0;
+  double time = 0.0;
 
   // Read params from .xml file
   RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Newmark_SinCos_ExplicitCD.xml");
+    getParametersFromXmlFile("Tempus_HHTAlpha_SinCos_ExplicitCD.xml");
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
@@ -486,16 +566,14 @@ TEUCHOS_UNIT_TEST(NewmarkExplicit, SinCos_CD)
               << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
@@ -507,7 +585,26 @@ TEUCHOS_UNIT_TEST(NewmarkExplicit, SinCos_CD)
 
     // Plot sample solution and exact solution at most-refined resolution
     if (n == nTimeStepSizes-1) {
-      std::ofstream ftmp("Tempus_Newmark_SinCos_ExplicitCD.dat");
+      RCP<const SolutionHistory<double> > solutionHistory =
+        integrator->getSolutionHistory();
+      writeSolution("Tempus_HHTAlpha_SinCos_ExplicitCD.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      for (int i=0; i<solutionHistory->getNumStates(); i++) {
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
+      }
+      writeSolution("Tempus_HHTAlpha_SinCos_ExplicitCD-Ref.dat", solnHistExact);
+
+      // Problem specific output
+      {
+      std::ofstream ftmp("Tempus_HHTAlpha_SinCos_ExplicitCD-Energy.dat");
       ftmp.precision(16);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
@@ -534,36 +631,44 @@ TEUCHOS_UNIT_TEST(NewmarkExplicit, SinCos_CD)
              << ke << "   " << pe << "   " << te << std::endl;
       }
       ftmp.close();
+      }
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = HHT-Alpha" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.02 );
-  //TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0486418, 1.0e-4 );
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_HHTAlpha_SinCos_ExplicitCD-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_Newmark-Error_SinCos_ExplicitCD.dat");
-  ftmp.precision(16);
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,                order, 0.02   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.00451069, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,             order, 0.01   );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  0.0551522, 1.0e-4 );
 }
-#endif
+#endif // TEST_SINCOS_CD
+
 }
-
-

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_BallParabolic.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_BallParabolic.xml
@@ -1,9 +1,8 @@
-<ParameterList name="Newmark_HarmonicOscillator">
+<ParameterList name="HHTAlpha_HarmonicOscillator">
   <ParameterList name="HarmonicOscillatorModel">
     <Parameter name="Damping coeff c" type="double" value="0.0"/>
-    <Parameter name="Forcing coeff f" type="double" value="0.0"/>
-    <!--We set sqrt(k) = 2*pi, so that the period of the solution is 1-->
-    <Parameter name="x coeff k" type="double" value="39.4784176"/>
+    <Parameter name="Forcing coeff f" type="double" value="-1.0"/>
+    <Parameter name="x coeff k" type="double" value="0.0"/>
     <Parameter name="Mass coeff m" type="double" value="1.0"/>
   </ParameterList>
   <ParameterList name="Tempus">
@@ -20,12 +19,10 @@
       </ParameterList>
       <ParameterList name="Time Step Control">
         <Parameter name="Initial Time"           type="double" value="0.0"/>
-        <!--Integrate for 2.2 periods.  We do not integrate an integer number of periods
-             to avoid having a 0 value of the solution at the final time.-->
-        <Parameter name="Final Time"             type="double" value="2.2"/>
+        <Parameter name="Final Time"             type="double" value="2.0"/>
         <Parameter name="Initial Time Index"     type="int"    value="0"/>
         <Parameter name="Final Time Index"       type="int"    value="10000"/>
-        <Parameter name="Initial Time Step"      type="double" value="0.05"/>
+        <Parameter name="Initial Time Step"      type="double" value="0.2"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
@@ -96,6 +93,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
 
     </ParameterList>
 

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_ExplicitCD.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_ExplicitCD.xml
@@ -1,4 +1,4 @@
-<ParameterList name="Newmark_HarmonicOscillator">
+<ParameterList name="HHTAlpha_HarmonicOscillator">
   <ParameterList name="HarmonicOscillatorModel">
     <Parameter name="Damping coeff c" type="double" value="0.0"/>
     <Parameter name="Forcing coeff f" type="double" value="0.0"/>

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_FirstOrder.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_FirstOrder.xml
@@ -1,8 +1,9 @@
-<ParameterList name="Newmark_HarmonicOscillator">
+<ParameterList name="HHTAlpha_HarmonicOscillator">
   <ParameterList name="HarmonicOscillatorModel">
     <Parameter name="Damping coeff c" type="double" value="0.0"/>
-    <Parameter name="Forcing coeff f" type="double" value="-1.0"/>
-    <Parameter name="x coeff k" type="double" value="0.0"/>
+    <Parameter name="Forcing coeff f" type="double" value="0.0"/>
+    <!--We set sqrt(k) = 2*pi, so that the period of the solution is 1-->
+    <Parameter name="x coeff k" type="double" value="39.4784176"/>
     <Parameter name="Mass coeff m" type="double" value="1.0"/>
   </ParameterList>
   <ParameterList name="Tempus">
@@ -19,10 +20,12 @@
       </ParameterList>
       <ParameterList name="Time Step Control">
         <Parameter name="Initial Time"           type="double" value="0.0"/>
-        <Parameter name="Final Time"             type="double" value="2.0"/>
+        <!--Integrate for 2.2 periods.  We do not integrate an integer number of periods
+             to avoid having a 0 value of the solution at the final time.-->
+        <Parameter name="Final Time"             type="double" value="2.2"/>
         <Parameter name="Initial Time Index"     type="int"    value="0"/>
         <Parameter name="Final Time Index"       type="int"    value="10000"/>
-        <Parameter name="Initial Time Step"      type="double" value="0.2"/>
+        <Parameter name="Initial Time Step"      type="double" value="0.05"/>
         <Parameter name="Maximum Absolute Error" type="double" value="1.0e-8"/>
         <Parameter name="Maximum Relative Error" type="double" value="1.0e-8"/>
         <Parameter name="Integrator Step Type"  type="string" value="Constant"/>
@@ -39,7 +42,9 @@
 
       <Parameter name="Stepper Type"   type="string" value="HHT-Alpha"/>
       <ParameterList name="HHT-Alpha Parameters">
-        <Parameter name="Scheme Name"    type="string" value="Newmark Beta Average Acceleration"/>
+        <Parameter name="Scheme Name"    type="string" value="Newmark Beta"/>
+        <Parameter name="Beta"    type="double" value="0.25"/>
+        <Parameter name="Gamma"   type="double" value="0.33"/>
       </ParameterList>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
@@ -93,7 +98,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
 
     </ParameterList>
 

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_SecondOrder.xml
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlpha_SinCos_SecondOrder.xml
@@ -1,4 +1,4 @@
-<ParameterList name="Newmark_HarmonicOscillator">
+<ParameterList name="HHTAlpha_HarmonicOscillator">
   <ParameterList name="HarmonicOscillatorModel">
     <Parameter name="Damping coeff c" type="double" value="0.0"/>
     <Parameter name="Forcing coeff f" type="double" value="0.0"/>
@@ -42,9 +42,7 @@
 
       <Parameter name="Stepper Type"   type="string" value="HHT-Alpha"/>
       <ParameterList name="HHT-Alpha Parameters">
-        <Parameter name="Scheme Name"    type="string" value="Newmark Beta"/>
-        <Parameter name="Beta"    type="double" value="0.25"/>
-        <Parameter name="Gamma"   type="double" value="0.33"/>
+        <Parameter name="Scheme Name"    type="string" value="Newmark Beta Average Acceleration"/>
       </ParameterList>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -34,6 +34,12 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_VANDERPOL
+
+
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
@@ -74,6 +80,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -129,8 +136,10 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0),  1.810210, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), -0.754602, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
@@ -167,12 +176,16 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
     std::replace(stepperName.begin(), stepperName.end(), ' ', '_');
     std::replace(stepperName.begin(), stepperName.end(), '/', '.');
 
+    RCP<Tempus::IntegratorBasic<double> > integrator;
     std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+    std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
     std::vector<double> StepSize;
-    std::vector<double> ErrorNorm;
+    std::vector<double> xErrorNorm;
+    std::vector<double> xDotErrorNorm;
+
     const int nTimeStepSizes = 3;  // 6 for error plot
     double dt = stepperInitDt[m];
-    double order = 0.0;
+    double time = 0.0;
     for (int n=0; n<nTimeStepSizes; n++) {
 
       // Read params from .xml file
@@ -209,83 +222,58 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
-      RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(pl, model);
-      order = integrator->getStepper()->getOrder();
+      integrator = Tempus::integratorBasic<double>(pl, model);
 
       // Integrate to timeMax
       bool integratorStatus = integrator->advanceTime();
       TEST_ASSERT(integratorStatus)
 
       // Test if at 'Final Time'
-      double time = integrator->getTime();
+      time = integrator->getTime();
       double timeFinal =pl->sublist("Default Integrator")
         .sublist("Time Step Control").get<double>("Final Time");
       double tol = 100.0 * std::numeric_limits<double>::epsilon();
       TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
       // Store off the final solution and step size
+      StepSize.push_back(dt);
       auto solution = Thyra::createMember(model->get_x_space());
       Thyra::copy(*(integrator->getX()),solution.ptr());
       solutions.push_back(solution);
-      StepSize.push_back(dt);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
 
       // Output finest temporal solution for plotting
       // This only works for ONE MPI process
       if ((n == 0) or (n == nTimeStepSizes-1)) {
         std::string fname = "Tempus_"+stepperName+"_VanDerPol-Ref.dat";
         if (n == 0) fname = "Tempus_"+stepperName+"_VanDerPol.dat";
-        std::ofstream ftmp(fname);
         RCP<const SolutionHistory<double> > solutionHistory =
           integrator->getSolutionHistory();
-        int nStates = solutionHistory->getNumStates();
-        for (int i=0; i<nStates; i++) {
-          RCP<const SolutionState<double> > solutionState =
-            (*solutionHistory)[i];
-          RCP<const Thyra::VectorBase<double> > x = solutionState->getX();
-          double ttime = solutionState->getTime();
-          ftmp << ttime << "   " << get_ele(*x, 0) << "   " << get_ele(*x, 1)
-               << std::endl;
-        }
-        ftmp.close();
+        writeSolution(fname, solutionHistory);
       }
-    }
-
-    // Calculate the error - use the most temporally refined mesh for
-    // the reference solution.
-    auto ref_solution = solutions[solutions.size()-1];
-    std::vector<double> StepSizeCheck;
-    for (std::size_t i=0; i < (solutions.size()-1); ++i) {
-      auto tmp = solutions[i];
-      Thyra::Vp_StV(tmp.ptr(), -1.0, *ref_solution);
-      const double L2norm = Thyra::norm_2(*tmp);
-      StepSizeCheck.push_back(StepSize[i]);
-      ErrorNorm.push_back(L2norm);
     }
 
     // Check the order and intercept
-    double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-    std::cout << "  Stepper = " << stepperType << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Expected order: " << order << std::endl;
-    std::cout << "  Observed order: " << slope << std::endl;
-    std::cout << "  =========================" << std::endl;
-    TEST_FLOATING_EQUALITY( slope, stepperOrders[m], 0.02 );
-    TEST_FLOATING_EQUALITY( ErrorNorm[0], stepperErrors[m], 1.0e-4 );
+    double xSlope = 0.0;
+    //double xDotSlope = 0.0;
+    RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+    //double order = stepper->getOrder();
+    writeOrderError("Tempus_"+stepperName+"_VanDerPol-Error.dat",
+                    stepper, StepSize,
+                    solutions,    xErrorNorm,    xSlope); //,
+                    //solutionsDot, xDotErrorNorm, xDotSlope);
 
-    // Write error data
-    {
-      std::ofstream ftmp("Tempus_"+stepperName+"_VanDerPol-Error.dat");
-      double error0 = 0.8*ErrorNorm[0];
-      for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-        ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-             << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-      }
-      ftmp.close();
-    }
+    TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m],   0.02 );
+    TEST_FLOATING_EQUALITY( xErrorNorm[0], stepperErrors[m], 1.0e-4 );
+    //TEST_FLOATING_EQUALITY( xDotSlope,        1.74898, 0.10 );
+    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  1.0038, 1.0e-4 );
+
   }
-  Teuchos::TimeMonitor::summarize();
+  //Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_VANDERPOL
 
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -257,16 +257,17 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
 
     // Check the order and intercept
     double xSlope = 0.0;
-    //double xDotSlope = 0.0;
+    double xDotSlope = 0.0;
     RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
     //double order = stepper->getOrder();
     writeOrderError("Tempus_"+stepperName+"_VanDerPol-Error.dat",
                     stepper, StepSize,
-                    solutions,    xErrorNorm,    xSlope); //,
-                    //solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutions,    xErrorNorm,    xSlope,
+                    solutionsDot, xDotErrorNorm, xDotSlope);
 
     TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m],   0.02 );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], stepperErrors[m], 1.0e-4 );
+    // xDot not yet available for IMEX_RK.
     //TEST_FLOATING_EQUALITY( xDotSlope,        1.74898, 0.10 );
     //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  1.0038, 1.0e-4 );
 

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_VanDerPol.xml
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_VanDerPol.xml
@@ -113,6 +113,7 @@
   <ParameterList name="General IMEX RK">
 
       <Parameter name="Stepper Type" type="string" value="General IMEX RK"/>
+      <Parameter name="overall order" type="int" value="2"/>
       <ParameterList name ="IMEX-RK Explicit Stepper">
           <Parameter name="Stepper Type" type="string" value="General ERK"/>
           <ParameterList name="Tableau">

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -271,18 +271,19 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
 
     // Check the order and intercept
     double xSlope = 0.0;
-    //double xDotSlope = 0.0;
+    double xDotSlope = 0.0;
     RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
     //double order = stepper->getOrder();
     writeOrderError("Tempus_"+stepperName+"_VanDerPol-Error.dat",
                     stepper, StepSize,
-                    solutions,    xErrorNorm,    xSlope); //,
-                    //solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutions,    xErrorNorm,    xSlope,
+                    solutionsDot, xDotErrorNorm, xDotSlope);
 
-    TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m],   0.02 );
+    TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m], 0.02 );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], stepperErrors[m], 1.0e-4 );
-    //TEST_FLOATING_EQUALITY( xDotSlope,        1.74898, 0.10 );
-    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  1.0038, 1.0e-4 );
+    // xDot not yet available for IMEX_RK_Partitioned.
+    //TEST_FLOATING_EQUALITY( xDotSlope,              1.74898, 0.02 );
+    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],        1.0038, 1.0e-4 );
 
   }
   Teuchos::TimeMonitor::summarize();

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -35,7 +35,12 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_VANDERPOL
 
+
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
@@ -82,6 +87,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -137,8 +143,10 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0),  1.810210, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), -0.754602, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
@@ -175,12 +183,16 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
     std::replace(stepperName.begin(), stepperName.end(), ' ', '_');
     std::replace(stepperName.begin(), stepperName.end(), '/', '.');
 
+    RCP<Tempus::IntegratorBasic<double> > integrator;
     std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+    std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
     std::vector<double> StepSize;
-    std::vector<double> ErrorNorm;
+    std::vector<double> xErrorNorm;
+    std::vector<double> xDotErrorNorm;
+
     const int nTimeStepSizes = 3;  // 6 for error plot
     double dt = stepperInitDt[m];
-    double order = 0.0;
+    double time = 0.0;
     for (int n=0; n<nTimeStepSizes; n++) {
 
       // Read params from .xml file
@@ -224,83 +236,58 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
-      RCP<Tempus::IntegratorBasic<double> > integrator =
-        Tempus::integratorBasic<double>(pl, model);
-      order = integrator->getStepper()->getOrder();
+      integrator = Tempus::integratorBasic<double>(pl, model);
 
       // Integrate to timeMax
       bool integratorStatus = integrator->advanceTime();
       TEST_ASSERT(integratorStatus)
 
       // Test if at 'Final Time'
-      double time = integrator->getTime();
+      time = integrator->getTime();
       double timeFinal =pl->sublist("Default Integrator")
         .sublist("Time Step Control").get<double>("Final Time");
       double tol = 100.0 * std::numeric_limits<double>::epsilon();
       TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
       // Store off the final solution and step size
+      StepSize.push_back(dt);
       auto solution = Thyra::createMember(model->get_x_space());
       Thyra::copy(*(integrator->getX()),solution.ptr());
       solutions.push_back(solution);
-      StepSize.push_back(dt);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
 
       // Output finest temporal solution for plotting
       // This only works for ONE MPI process
       if ((n == 0) or (n == nTimeStepSizes-1)) {
         std::string fname = "Tempus_"+stepperName+"_VanDerPol-Ref.dat";
         if (n == 0) fname = "Tempus_"+stepperName+"_VanDerPol.dat";
-        std::ofstream ftmp(fname);
         RCP<const SolutionHistory<double> > solutionHistory =
           integrator->getSolutionHistory();
-        int nStates = solutionHistory->getNumStates();
-        for (int i=0; i<nStates; i++) {
-          RCP<const SolutionState<double> > solutionState =
-            (*solutionHistory)[i];
-          RCP<const Thyra::VectorBase<double> > x = solutionState->getX();
-          double ttime = solutionState->getTime();
-          ftmp << ttime << "   " << get_ele(*x, 0) << "   " << get_ele(*x, 1)
-               << std::endl;
-        }
-        ftmp.close();
+        writeSolution(fname, solutionHistory);
       }
-    }
-
-    // Calculate the error - use the most temporally refined mesh for
-    // the reference solution.
-    auto ref_solution = solutions[solutions.size()-1];
-    std::vector<double> StepSizeCheck;
-    for (std::size_t i=0; i < (solutions.size()-1); ++i) {
-      auto tmp = solutions[i];
-      Thyra::Vp_StV(tmp.ptr(), -1.0, *ref_solution);
-      const double L2norm = Thyra::norm_2(*tmp);
-      StepSizeCheck.push_back(StepSize[i]);
-      ErrorNorm.push_back(L2norm);
     }
 
     // Check the order and intercept
-    double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-    std::cout << "  Stepper = " << stepperType << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Expected order: " << order << std::endl;
-    std::cout << "  Observed order: " << slope << std::endl;
-    std::cout << "  =========================" << std::endl;
-    TEST_FLOATING_EQUALITY( slope, stepperOrders[m], 0.02 );
-    TEST_FLOATING_EQUALITY( ErrorNorm[0], stepperErrors[m], 1.0e-4 );
+    double xSlope = 0.0;
+    //double xDotSlope = 0.0;
+    RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+    //double order = stepper->getOrder();
+    writeOrderError("Tempus_"+stepperName+"_VanDerPol-Error.dat",
+                    stepper, StepSize,
+                    solutions,    xErrorNorm,    xSlope); //,
+                    //solutionsDot, xDotErrorNorm, xDotSlope);
 
-    // Write error data
-    {
-      std::ofstream ftmp("Tempus_"+stepperName+"_VanDerPol-Error.dat");
-      double error0 = 0.8*ErrorNorm[0];
-      for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-        ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-             << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-      }
-      ftmp.close();
-    }
+    TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m],   0.02 );
+    TEST_FLOATING_EQUALITY( xErrorNorm[0], stepperErrors[m], 1.0e-4 );
+    //TEST_FLOATING_EQUALITY( xDotSlope,        1.74898, 0.10 );
+    //TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  1.0038, 1.0e-4 );
+
   }
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_VANDERPOL
 
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_VanDerPol.xml
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_VanDerPol.xml
@@ -113,6 +113,7 @@
   <ParameterList name="General IMEX RK">
 
       <Parameter name="Stepper Type" type="string" value="General Partitioned IMEX RK"/>
+      <Parameter name="overall order" type="int" value="2"/>
       <ParameterList name ="IMEX-RK Explicit Stepper">
           <Parameter name="Stepper Type" type="string" value="General ERK"/>
           <ParameterList name="Tableau">

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -4,7 +4,7 @@
     <Parameter docString="" id="1" isDefault="false" isUsed="true" name="Integrator Type" type="string" value="Integrator Basic"/>
     <Parameter docString="" id="2" isDefault="false" isUsed="true" name="Stepper Name" type="string" value="Demo Stepper"/>
     <ParameterList id="5" name="Solution History">
-      <Parameter docString="" id="3" isDefault="true" isUsed="true" name="Storage Type" type="string" value="Unlimited"/>
+      <Parameter docString="" id="3" isDefault="true" isUsed="true" name="Storage Type" type="string" value="Undo"/>
       <Parameter docString="" id="4" isDefault="true" isUsed="true" name="Storage Limit" type="int" value="2"/>
       <ParameterList name="Interpolator">
         <Parameter name="Interpolator Type" type="string" value="Lagrange"/>
@@ -15,8 +15,8 @@
       <Parameter docString="" id="7" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.79769313486231571e+308"/>
       <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
       <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
-      <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="2.22044604925031308e-12"/>
-      <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="2.22044604925031308e-12"/>
+      <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
+      <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
       <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.79769313486231571e+308"/>
       <Parameter docString="" id="15" isDefault="true" isUsed="true" name="Minimum Order" type="int" value="1"/>
       <Parameter docString="" id="16" isDefault="true" isUsed="true" name="Initial Order" type="int" value="1"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -6,7 +6,7 @@
     <Parameter docString="Screen Output Index Interval (e.g., every 100 time steps" id="3" isDefault="false" isUsed="true" name="Screen Output Index Interval" type="int" value="1000000"/>
     <Parameter docString="'Stepper Name' selects the Stepper block to construct (Required)." id="4" isDefault="false" isUsed="true" name="Stepper Name" type="string" value="Demo Stepper"/>
     <ParameterList id="7" name="Solution History">
-      <Parameter docString="" id="5" isDefault="true" isUsed="true" name="Storage Type" type="string" value="Unlimited"/>
+      <Parameter docString="" id="5" isDefault="true" isUsed="true" name="Storage Type" type="string" value="Undo"/>
       <Parameter docString="" id="6" isDefault="true" isUsed="true" name="Storage Limit" type="int" value="2"/>
       <ParameterList name="Interpolator">
         <Parameter name="Interpolator Type" type="string" value="Lagrange"/>
@@ -17,8 +17,8 @@
       <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.79769313486231571e+308"/>
       <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
       <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
-      <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="2.22044604925031308e-12"/>
-      <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="2.22044604925031308e-12"/>
+      <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
+      <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
       <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.79769313486231571e+308"/>
       <Parameter docString="" id="17" isDefault="true" isUsed="true" name="Minimum Order" type="int" value="1"/>
       <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Initial Order" type="int" value="1"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -50,6 +50,9 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
   RCP<ParameterList> referencePL =
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref.xml");
 
+  //std::cout << std::endl;
+  //std::cout << "testPL      -------------- \n" << *testPL << std::endl;
+  //std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
   TEST_ASSERT(haveSameValues(*testPL,*referencePL))
 }
 
@@ -90,6 +93,9 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
   RCP<ParameterList> referencePL =
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref2.xml");
 
+  //std::cout << std::endl;
+  //std::cout << "testPL      -------------- \n" << *testPL << std::endl;
+  //std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
   TEST_ASSERT(haveSameValues(*testPL,*referencePL))
 }
 

--- a/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
+++ b/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
@@ -42,6 +42,13 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS
+
+
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
@@ -72,6 +79,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   using Teuchos::rcp_const_cast;
@@ -138,16 +146,22 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
   std::cout << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.167158, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_SINCOS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(Leapfrog, SinCos)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 9;
-  double order = 0.0;
+  double time = 0.0;
 
   // Read params from .xml file
   RCP<ParameterList> pList =
@@ -175,71 +189,77 @@ TEUCHOS_UNIT_TEST(Leapfrog, SinCos)
               << " (out of " << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-    // Time-integrated solution and the exact solution
-    RCP<Thyra::VectorBase<double> > x = integrator->getX();
-    RCP<const Thyra::VectorBase<double> > x_exact =
-      model->getExactSolution(time).get_x();
-
     // Plot sample solution and exact solution at most-refined resolution
     if (n == nTimeStepSizes-1) {
-      std::ofstream ftmp("Tempus_Leapfrog_SinCos.dat");
-      ftmp.precision(16);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      RCP<const Thyra::VectorBase<double> > x_exact_plot;
+      writeSolution("Tempus_Leapfrog_SinCos.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        double time = solutionState->getTime();
-        RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-        x_exact_plot = model->getExactSolution(time).get_x();
-        ftmp << time << "   "
-             << get_ele(*(x_plot), 0) << "   "
-             << get_ele(*(x_exact_plot), 0) << std::endl;
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
       }
-      ftmp.close();
+      writeSolution("Tempus_Leapfrog_SinCos-Ref.dat", solnHistExact);
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
+
+
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = Leapfrog" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.02 );
-  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0157928, 1.0e-4 );
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_Leapfrog_SinCos-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_Leapfrog-Error_SinCos.dat");
-  ftmp.precision(16);
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,               order, 0.02 );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0157928, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,          1.09387, 0.01   );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0],  0.563002, 1.0e-4 );
+
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_SINCOS
 
 }

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -44,7 +44,14 @@ using Tempus::IntegratorBasic;
 using Tempus::SolutionHistory;
 using Tempus::SolutionState;
 
+// Comment out any of the following tests to exclude from build/run.
+#define TEST_PARAMETERLIST
+#define TEST_CONSTRUCTING_FROM_DEFAULTS
+#define TEST_SINCOS
+#define TEST_VANDERPOL
 
+
+#ifdef TEST_PARAMETERLIST
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
@@ -83,8 +90,10 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
     TEST_ASSERT(haveSameValues(*stepperPL, *defaultPL, true))
   }
 }
+#endif // TEST_PARAMETERLIST
 
 
+#ifdef TEST_CONSTRUCTING_FROM_DEFAULTS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
@@ -124,6 +133,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
   timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
   timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
   timeStepControl->setInitTimeStep(dt);
+  timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
@@ -191,17 +201,23 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841021, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.541002, 1.0e-4 );
 }
+#endif // TEST_CONSTRUCTING_FROM_DEFAULTS
 
 
+#ifdef TEST_SINCOS
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 7;
   double dt = 0.2;
-  double order = 0.0;
+  double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -224,9 +240,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Initial Conditions
     // During the Integrator construction, the initial SolutionState
@@ -245,74 +259,84 @@ TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Default Integrator")
        .sublist("Time Step Control").get<double>("Final Time");
     TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-    // Time-integrated solution and the exact solution
-    RCP<Thyra::VectorBase<double> > x = integrator->getX();
-    RCP<const Thyra::VectorBase<double> > x_exact =
-      model->getExactSolution(time).get_x();
-
     // Plot sample solution and exact solution
     if (n == 0) {
-      std::ofstream ftmp("Tempus_Trapezoidal_SinCos.dat");
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      RCP<const Thyra::VectorBase<double> > x_exact_plot;
+      writeSolution("Tempus_Trapezoidal_SinCos.dat", solutionHistory);
+
+      RCP<Tempus::SolutionHistory<double> > solnHistExact =
+        Teuchos::rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        double time = solutionState->getTime();
-        RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-        x_exact_plot = model->getExactSolution(time).get_x();
-        ftmp << time << "   "
-             << get_ele(*(x_plot), 0) << "   "
-             << get_ele(*(x_plot), 1) << "   "
-             << get_ele(*(x_exact_plot), 0) << "   "
-             << get_ele(*(x_exact_plot), 1) << std::endl;
+        double time = (*solutionHistory)[i]->getTime();
+        RCP<Tempus::SolutionState<double> > state =
+          Teuchos::rcp(new Tempus::SolutionState<double>(
+            model->getExactSolution(time).get_x(),
+            model->getExactSolution(time).get_x_dot()));
+        state->setTime((*solutionHistory)[i]->getTime());
+        solnHistExact->addState(state);
       }
-      ftmp.close();
+      writeSolution("Tempus_Trapezoidal_SinCos-Ref.dat", solnHistExact);
     }
 
-    // Calculate the error
-    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Store off the final solution and step size
     StepSize.push_back(dt);
-    const double L2norm = Thyra::norm_2(*xdiff);
-    ErrorNorm.push_back(L2norm);
+    auto solution = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getX()),solution.ptr());
+    solutions.push_back(solution);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
+    if (n == nTimeStepSizes-1) {  // Add exact solution last in vector.
+      StepSize.push_back(0.0);
+      auto solution = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x()),solution.ptr());
+      solutions.push_back(solution);
+      auto solutionDot = Thyra::createMember(model->get_x_space());
+      Thyra::copy(*(model->getExactSolution(time).get_x_dot()),
+                  solutionDot.ptr());
+      solutionsDot.push_back(solutionDot);
+    }
   }
 
-  // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  std::cout << "  Stepper = Trapezoidal" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.01 );
-  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.000832086, 1.0e-4 );
+ double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_Trapezoidal_SinCos-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  std::ofstream ftmp("Tempus_Trapezoidal_SinCos-Error.dat");
-  double error0 = 0.8*ErrorNorm[0];
-  for (int n=0; n<nTimeStepSizes; n++) {
-    ftmp << StepSize[n]  << "   " << ErrorNorm[n] << "   "
-         << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-  }
-  ftmp.close();
+  TEST_FLOATING_EQUALITY( xSlope,                 order, 0.01   );
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.000832086, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotSlope,              order, 0.01   );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.000832086, 1.0e-4 );
+
+  Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_SINCOS
 
 
+#ifdef TEST_VANDERPOL
 // ************************************************************
 // ************************************************************
 TEUCHOS_UNIT_TEST(Trapezoidal, VanDerPol)
 {
+  RCP<Tempus::IntegratorBasic<double> > integrator;
   std::vector<RCP<Thyra::VectorBase<double>>> solutions;
+  std::vector<RCP<Thyra::VectorBase<double>>> solutionsDot;
   std::vector<double> StepSize;
-  std::vector<double> ErrorNorm;
+  std::vector<double> xErrorNorm;
+  std::vector<double> xDotErrorNorm;
   const int nTimeStepSizes = 4;
   double dt = 0.05;
-  double order = 0.0;
+  double time = 0.0;
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -332,83 +356,56 @@ TEUCHOS_UNIT_TEST(Trapezoidal, VanDerPol)
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
     pl->sublist("Demo Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
-    RCP<Tempus::IntegratorBasic<double> > integrator =
-      Tempus::integratorBasic<double>(pl, model);
-    order = integrator->getStepper()->getOrder();
+    integrator = Tempus::integratorBasic<double>(pl, model);
 
     // Integrate to timeMax
     bool integratorStatus = integrator->advanceTime();
     TEST_ASSERT(integratorStatus)
 
     // Test if at 'Final Time'
-    double time = integrator->getTime();
+    time = integrator->getTime();
     double timeFinal =pl->sublist("Demo Integrator")
       .sublist("Time Step Control").get<double>("Final Time");
     double tol = 100.0 * std::numeric_limits<double>::epsilon();
     TEST_FLOATING_EQUALITY(time, timeFinal, tol);
 
     // Store off the final solution and step size
+    StepSize.push_back(dt);
     auto solution = Thyra::createMember(model->get_x_space());
     Thyra::copy(*(integrator->getX()),solution.ptr());
     solutions.push_back(solution);
-    StepSize.push_back(dt);
+    auto solutionDot = Thyra::createMember(model->get_x_space());
+    Thyra::copy(*(integrator->getXdot()),solutionDot.ptr());
+    solutionsDot.push_back(solutionDot);
 
     // Output finest temporal solution for plotting
     // This only works for ONE MPI process
     if ((n == 0) or (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_Trapezoidal_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_Trapezoidal_VanDerPol.dat";
-      std::ofstream ftmp(fname);
       RCP<const SolutionHistory<double> > solutionHistory =
         integrator->getSolutionHistory();
-      int nStates = solutionHistory->getNumStates();
-      for (int i=0; i<nStates; i++) {
-        RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-        RCP<const Thyra::VectorBase<double> > x = solutionState->getX();
-        double ttime = solutionState->getTime();
-        ftmp << ttime << "   " << get_ele(*x, 0) << "   " << get_ele(*x, 1)
-             << std::endl;
-      }
-      ftmp.close();
+      writeSolution(fname, solutionHistory);
     }
   }
-
-  // Calculate the error - use the most temporally refined mesh for
-  // the reference solution.
-  auto ref_solution = solutions[solutions.size()-1];
-  std::vector<double> StepSizeCheck;
-  for (std::size_t i=0; i < (solutions.size()-1); ++i) {
-    auto tmp = solutions[i];
-    Thyra::Vp_StV(tmp.ptr(), -1.0, *ref_solution);
-    const double L2norm = Thyra::norm_2(*tmp);
-    StepSizeCheck.push_back(StepSize[i]);
-    ErrorNorm.push_back(L2norm);
-  }
-
   // Check the order and intercept
-  double slope = computeLinearRegressionLogLog<double>(StepSizeCheck,ErrorNorm);
-  std::cout << "  Stepper = Trapezoidal" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Expected order: " << order << std::endl;
-  std::cout << "  Observed order: " << slope << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.10 );
-  out << "\n\n ** Slope on Trapezoidal Method = " << slope
-      << "\n" << std::endl;
+  double xSlope = 0.0;
+  double xDotSlope = 0.0;
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  double order = stepper->getOrder();
+  writeOrderError("Tempus_Trapezoidal_VanDerPol-Error.dat",
+                  stepper, StepSize,
+                  solutions,    xErrorNorm,    xSlope,
+                  solutionsDot, xDotErrorNorm, xDotSlope);
 
-  // Write error data
-  {
-    std::ofstream ftmp("Tempus_Trapezoidal_VanDerPol-Error.dat");
-    double error0 = 0.8*ErrorNorm[0];
-    for (std::size_t n = 0; n < StepSizeCheck.size(); n++) {
-      ftmp << StepSizeCheck[n]  << "   " << ErrorNorm[n] << "   "
-           << error0*(pow(StepSize[n]/StepSize[0],order)) << std::endl;
-    }
-    ftmp.close();
-  }
+  TEST_FLOATING_EQUALITY( xSlope,            order, 0.10 );
+  TEST_FLOATING_EQUALITY( xDotSlope,         order, 0.10 );//=order at samll dt
+  TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.00085855, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.00120695, 1.0e-4 );
 
   Teuchos::TimeMonitor::summarize();
 }
+#endif // TEST_VANDERPOL
 
 
 } // namespace Tempus_Test


### PR DESCRIPTION
 * Added to the tests, the testing of xDot.  Previously no testing of
   the time derivative was done.
 * Cleaned up testing to use some common functions for writing the
   solution, reference solution, and order/error convergence data.
 * Fix many miss-named and miss-spelled variables and filenames.
 * Added Irina's #defines to all tests for each Teuchos unit test.
   This makes it easy to turn off unit tests while debugging.

Others
 * Change default SolutionHistory::StorageType from "Unlimited" to
 * "Undo".
   this better reflects the normal situation for applications.  For most
   Steppers, two SolutionStates are required for implicit solvers and
   setting the time derivative.
 * Added exceptions to Steppers to ensure that there is the minimum
   number of SolutionStates available in the SolutionHistory.  Most
   Steppers require at least two (the currentState, x_{n-1}, and the
   workingState, x_n).
 * BUG FIX - In SolutionHistory::initWorkingState(), the last State is
   removed and then the CurrentState is copied into the newState.
   However when the number of States was one, there is no State to copy
   from.
 * Added doxygen comments on TimeStepControlStrategy_BasicVS, describing
   the functionality, mathematical statements, and suggested settings.
   Changed the default eta's to reflect constant time step control.
   Made these changes also in the tests.
 * Separate the "Constant" and "Variable" output control in
   TimeStepControl::getNextTime().
 * Set min and max timestep to the initial time step for constant time
   step, and added an initialize() to reset values in TimeStepControl.

@trilinos/tempus 

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

