### PR TITLE
Sacado:  Remove use of deprecated Kokkos functions.

### DIFF
--- a/packages/sacado/example/view_example.cpp
+++ b/packages/sacado/example/view_example.cpp
@@ -65,7 +65,7 @@ public:
 
   MatVec(const ViewTypeA& A_, const ViewTypeB& b_, const ViewTypeC& c_) :
     A(A_), b(b_), c(c_),
-    m(A.dimension_0()), n(A.dimension_1())
+    m(A.extent(0)), n(A.extent(1))
   {
     typedef typename ViewTypeC::execution_space execution_space;
     Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0,m), *this);
@@ -102,7 +102,7 @@ public:
 
   MatVecDeriv(const ViewTypeA& A_, const ViewTypeB& b_, const ViewTypeC& c_) :
     A(A_), b(b_), c(c_),
-    m(A.dimension_0()), n(A.dimension_1()), p(A.dimension_2()-1)
+    m(A.extent(0)), n(A.extent(1)), p(A.extent(2)-1)
   {
     typedef typename ViewTypeC::execution_space execution_space;
     Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0,m), *this);

--- a/packages/sacado/example/view_factory_example.cpp
+++ b/packages/sacado/example/view_factory_example.cpp
@@ -64,8 +64,8 @@ my_func(const View1& v1, const View2& v2)
   static_assert( unsigned(View1::rank) == 2, "" );
   static_assert( unsigned(View2::rank) == 1, "" );
 
-  const size_type m = v1.dimension_0();
-  const size_type n = v1.dimension_1();
+  const size_type m = v1.extent(0);
+  const size_type n = v1.extent(1);
   ViewTmp vtmp = ViewFac::template create_view<ViewTmp>(v1,v2,"tmp",m);
 
   Kokkos::parallel_for(m, KOKKOS_LAMBDA (const size_type i) {
@@ -95,8 +95,8 @@ my_func_dynamic(const View1& v1, const View2& v2)
   TEUCHOS_ASSERT( v1.rank() == 2 );
   TEUCHOS_ASSERT( v2.rank() == 1 );
 
-  const size_type m = v1.dimension_0();
-  const size_type n = v1.dimension_1();
+  const size_type m = v1.extent(0);
+  const size_type n = v1.extent(1);
   ViewTmp vtmp = ViewFac::template create_view<ViewTmp>(v1,v2,"tmp",m);
 
   Kokkos::parallel_for(m, KOKKOS_LAMBDA (const size_type i) {

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -244,13 +244,13 @@ struct SacadoViewFill
   KOKKOS_INLINE_FUNCTION
   void operator()( const size_t i0 ) const
   {
-    const size_t n1 = output.dimension_1();
-    const size_t n2 = output.dimension_2();
-    const size_t n3 = output.dimension_3();
-    const size_t n4 = output.dimension_4();
-    const size_t n5 = output.dimension_5();
-    const size_t n6 = output.dimension_6();
-    const size_t n7 = output.dimension_7();
+    const size_t n1 = output.extent(1);
+    const size_t n2 = output.extent(2);
+    const size_t n3 = output.extent(3);
+    const size_t n4 = output.extent(4);
+    const size_t n5 = output.extent(5);
+    const size_t n6 = output.extent(6);
+    const size_t n7 = output.extent(7);
 
     for ( size_t i1 = 0 ; i1 < n1 ; ++i1 ) {
     for ( size_t i2 = 0 ; i2 < n2 ; ++i2 ) {
@@ -266,7 +266,7 @@ struct SacadoViewFill
   SacadoViewFill( const OutputView & arg_out , const_value_type & arg_in )
     : output( arg_out ), input( arg_in )
     {
-      const size_t n0 = output.dimension_0();
+      const size_t n0 = output.extent(0);
       Kokkos::RangePolicy<execution_space> policy( 0, n0 );
       Kokkos::parallel_for( policy, *this );
       execution_space::fence();

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -340,13 +340,13 @@ struct SacadoViewFill<
   {
     local_scalar_type input_stride = Sacado::partition_scalar<stride>(input);
 
-    const size_t n1 = output.dimension_1();
-    const size_t n2 = output.dimension_2();
-    const size_t n3 = output.dimension_3();
-    const size_t n4 = output.dimension_4();
-    const size_t n5 = output.dimension_5();
-    const size_t n6 = output.dimension_6();
-    const size_t n7 = output.dimension_7();
+    const size_t n1 = output.extent(1);
+    const size_t n2 = output.extent(2);
+    const size_t n3 = output.extent(3);
+    const size_t n4 = output.extent(4);
+    const size_t n5 = output.extent(5);
+    const size_t n6 = output.extent(6);
+    const size_t n7 = output.extent(7);
 
     for ( size_t i1 = 0 ; i1 < n1 ; ++i1 ) {
     for ( size_t i2 = 0 ; i2 < n2 ; ++i2 ) {
@@ -363,7 +363,7 @@ struct SacadoViewFill<
   void operator()( const team_handle& team ) const
   {
     const size_t i0 = team.league_rank()*team.team_size() + team.team_rank();
-    if (i0 < output.dimension_0())
+    if (i0 < output.extent(0))
       (*this)(i0);
   }
 
@@ -371,7 +371,7 @@ struct SacadoViewFill<
     : output( arg_out ), input( arg_in )
     {
       const size_t team_size = 256 / stride;
-      team_policy policy( (output.dimension_0()+team_size-1)/team_size ,
+      team_policy policy( (output.extent(0)+team_size-1)/team_size ,
                           team_size , stride );
       Kokkos::parallel_for( policy, *this );
       execution_space::fence();

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -907,7 +907,7 @@ void deep_copy
 //         dst.span_is_contiguous() && //will always fail - stride set to 0s
 //         src.span_is_contiguous() &&
          dst.span() == src.span() &&
-         dst.extent(0) == src.dimension_0() &&
+         dst.extent(0) == src.extent(0) &&
          dst.extent(1) == src.extent(1) &&
          dst.extent(2) == src.extent(2) &&
          dst.extent(3) == src.extent(3) &&

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -907,14 +907,14 @@ void deep_copy
 //         dst.span_is_contiguous() && //will always fail - stride set to 0s
 //         src.span_is_contiguous() &&
          dst.span() == src.span() &&
-         dst.dimension_0() == src.dimension_0() &&
-         dst.dimension_1() == src.dimension_1() &&
-         dst.dimension_2() == src.dimension_2() &&
-         dst.dimension_3() == src.dimension_3() &&
-         dst.dimension_4() == src.dimension_4() &&
-         dst.dimension_5() == src.dimension_5() &&
-         dst.dimension_6() == src.dimension_6() &&
-         dst.dimension_7() == src.dimension_7() ) {
+         dst.extent(0) == src.dimension_0() &&
+         dst.extent(1) == src.extent(1) &&
+         dst.extent(2) == src.extent(2) &&
+         dst.extent(3) == src.extent(3) &&
+         dst.extent(4) == src.extent(4) &&
+         dst.extent(5) == src.extent(5) &&
+         dst.extent(6) == src.extent(6) &&
+         dst.extent(7) == src.extent(7) ) {
 
 //      const size_t nbytes = sizeof(typename dst_type::value_type) * dst.span() * dimension_scalar(dst) ;
       //const size_t nbytes = sizeof(typename dst_type::scalar_array_type) * dst.span() ;
@@ -942,14 +942,14 @@ void deep_copy
 //         dst.span_is_contiguous() && //will always fail - stride set to 0s
 //         src.span_is_contiguous() &&
          dst.span() == src.span() &&
-         dst.dimension_0() == src.dimension_0() &&
-         dst.dimension_1() == src.dimension_1() &&
-         dst.dimension_2() == src.dimension_2() &&
-         dst.dimension_3() == src.dimension_3() &&
-         dst.dimension_4() == src.dimension_4() &&
-         dst.dimension_5() == src.dimension_5() &&
-         dst.dimension_6() == src.dimension_6() &&
-         dst.dimension_7() == src.dimension_7() &&
+         dst.extent(0) == src.extent(0) &&
+         dst.extent(1) == src.extent(1) &&
+         dst.extent(2) == src.extent(2) &&
+         dst.extent(3) == src.extent(3) &&
+         dst.extent(4) == src.extent(4) &&
+         dst.extent(5) == src.extent(5) &&
+         dst.extent(6) == src.extent(6) &&
+         dst.extent(7) == src.extent(7) &&
          dst.stride_0() == src.stride_0() &&
          dst.stride_1() == src.stride_1() &&
          dst.stride_2() == src.stride_2() &&

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -133,7 +133,7 @@ struct MultiplyKernel {
   void operator()( const team_handle& team ) const
   {
     const size_type i = team.league_rank()*team.team_size() + team.team_rank();
-    if (i < m_v1.dimension_0())
+    if (i < m_v1.extent(0))
       (*this)(i);
   }
 
@@ -142,7 +142,7 @@ struct MultiplyKernel {
                     const InputViewType2 v2,
                     const OutputViewType v3,
                     const bool update = false) {
-    const size_type nrow = v1.dimension_0();
+    const size_type nrow = v1.extent(0);
 
 #if defined (KOKKOS_HAVE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL)
     const size_type stride = Kokkos::ViewScalarStride<InputViewType1>::stride;
@@ -202,13 +202,13 @@ struct ScalarAssignKernel {
   void operator()( const team_handle& team ) const
   {
     const size_type i = team.league_rank()*team.team_size() + team.team_rank();
-    if (i < m_v.dimension_0())
+    if (i < m_v.extent(0))
       (*this)(i);
   }
 
   // Kernel launch
   static void apply(const ViewType& v, const ScalarType& s) {
-    const size_type nrow = v.dimension_0();
+    const size_type nrow = v.extent(0);
 
 #if defined (KOKKOS_HAVE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL)
     const bool use_team =
@@ -267,13 +267,13 @@ struct ValueAssignKernel {
   void operator()( const team_handle& team ) const
   {
     const size_type i = team.league_rank()*team.team_size() + team.team_rank();
-    if (i < m_v.dimension_0())
+    if (i < m_v.extent(0))
       (*this)(i);
   }
 
   // Kernel launch
   static void apply(const ViewType& v, const ValueType& s) {
-    const size_type nrow = v.dimension_0();
+    const size_type nrow = v.extent(0);
 
 #if defined (KOKKOS_HAVE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL)
     const bool use_team =
@@ -339,7 +339,7 @@ struct AssignRank2Rank1Kernel {
   void operator()( const team_handle& team ) const
   {
     const size_type i = team.league_rank()*team.team_size() + team.team_rank();
-    if (i < m_v1.dimension_0())
+    if (i < m_v1.extent(0))
       (*this)(i);
   }
 
@@ -347,7 +347,7 @@ struct AssignRank2Rank1Kernel {
   static void apply(const InputViewType v1,
                     const OutputViewType v2,
                     const size_type col) {
-    const size_type nrow = v1.dimension_0();
+    const size_type nrow = v1.extent(0);
 
 #if defined (KOKKOS_HAVE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL)
     const bool use_team =
@@ -968,7 +968,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos::deep_copy(h_v2, v2);
 
   // Check dimensions are correct
-  TEUCHOS_TEST_EQUALITY(v2.dimension_0(), num_rows, out, success);
+  TEUCHOS_TEST_EQUALITY(v2.extent(0), num_rows, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
   TEUCHOS_TEST_EQUALITY(v2.stride_0(), v1.stride_0(), out, success);
   TEUCHOS_TEST_EQUALITY(v2.stride_1(), v1.stride_1(), out, success);
@@ -1007,8 +1007,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos::deep_copy(h_v2, v2);
 
   // Check dimensions are correct
-  TEUCHOS_TEST_EQUALITY(v2.dimension_0(), num_rows, out, success);
-  TEUCHOS_TEST_EQUALITY(v2.dimension_1(), num_cols, out, success);
+  TEUCHOS_TEST_EQUALITY(v2.extent(0), num_rows, out, success);
+  TEUCHOS_TEST_EQUALITY(v2.extent(1), num_cols, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
   TEUCHOS_TEST_EQUALITY(v2.stride_0(), v1.stride_0(), out, success);
   TEUCHOS_TEST_EQUALITY(v2.stride_1(), v1.stride_1(), out, success);
@@ -1103,9 +1103,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   success = true;
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(s), fad_size+1, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(h_s), fad_size+1, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_0(), num_rows, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_1(), 1, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_7(), 1, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(0), num_rows, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(1), 1, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(7), 1, out, success);
 
   for (size_type i=0; i<num_rows; ++i) {
     FadType f = generate_fad<FadType>(num_rows, num_cols, fad_size, i, col);
@@ -1152,10 +1152,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   success = true;
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(s), fad_size+1, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(h_s), fad_size+1, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_0(), num_cols, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_1(), num_planes, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_2(), 1, out, success);
-  TEUCHOS_TEST_EQUALITY(h_s.dimension_7(), 1, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(0), num_cols, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(1), num_planes, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(2), 1, out, success);
+  TEUCHOS_TEST_EQUALITY(h_s.extent(7), 1, out, success);
 
   for (size_type j=0; j<num_cols; ++j) {
     FadType f = generate_fad<FadType>(num_rows, num_cols, fad_size, row, j);
@@ -1347,7 +1347,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos::deep_copy(v, h_v);
 
   // Create unmanaged view
-  FadViewType v_fad(v.ptr_on_device(), num_rows, num_cols, fad_size+1);
+  FadViewType v_fad(v.data(), num_rows, num_cols, fad_size+1);
 
   // Copy back -- can't use create_mirror_view() because v_fad is unmanaged
   fad_host_view_type h_v_fad("host_view_fad", num_rows, num_cols, fad_size+1);
@@ -1411,7 +1411,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos::deep_copy(v, h_v);
 
   // Create unmanaged view
-  FadViewType v_fad( v.ptr_on_device(), num_rows, num_cols, fad_size+1);
+  FadViewType v_fad( v.data(), num_rows, num_cols, fad_size+1);
 
   // Copy back -- can't use create_mirror_view() because v_fad is unmanaged
   fad_host_view_type h_v_fad("host_view_fad", num_rows, num_cols, fad_size+1);
@@ -1479,7 +1479,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
   // Create unmanaged view
   ConstFadViewType v_fad(
-    v_const.ptr_on_device(), num_rows, num_cols, fad_size+1);
+    v_const.data(), num_rows, num_cols, fad_size+1);
 
   // Copy back -- can't use create_mirror_view() because v_fad is unmanaged
   fad_host_view_type h_v_fad("host_view_fad", num_rows, num_cols, fad_size+1);
@@ -1545,7 +1545,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   ConstViewType v_const = v;
 
   // Create unmanaged view
-  ConstFadViewType v_fad(v_const.ptr_on_device(), num_rows, num_cols, fad_size+1);
+  ConstFadViewType v_fad(v_const.data(), num_rows, num_cols, fad_size+1);
 
   // Copy back -- can't use create_mirror_view() because v_fad is unmanaged
   fad_host_view_type h_v_fad("host_view_fad", num_rows, num_cols, fad_size+1);
@@ -1689,8 +1689,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
   // Check
   success = true;
-  TEUCHOS_TEST_EQUALITY(h_vs.dimension_0(), num_rows, out, success);
-  TEUCHOS_TEST_EQUALITY(h_vs.dimension_1(), num_cols, out, success);
+  TEUCHOS_TEST_EQUALITY(h_vs.extent(0), num_rows, out, success);
+  TEUCHOS_TEST_EQUALITY(h_vs.extent(1), num_cols, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(h_vs), fad_size+1, out, success);
   for (size_type i=0; i<num_rows; ++i) {
     for (size_type j=0; j<num_cols; ++j) {

--- a/packages/sacado/test/UnitTests/ViewFactoryTests.cpp
+++ b/packages/sacado/test/UnitTests/ViewFactoryTests.cpp
@@ -328,8 +328,8 @@ TEUCHOS_UNIT_TEST(view_factory, dyn_rank_views)
     Kokkos::View<double*> a("a",5*3);
     using b_type = Kokkos::View<double**,Kokkos::MemoryUnmanaged>;
     b_type b = createViewWithType<b_type>(a,a.data(),5,3);
-    TEST_EQUALITY(b.dimension_0(),5);
-    TEST_EQUALITY(b.dimension_1(),3);
+    TEST_EQUALITY(b.extent(0),5);
+    TEST_EQUALITY(b.extent(1),3);
     TEST_EQUALITY(dimension_scalar(b),0);
   }
 
@@ -338,8 +338,8 @@ TEUCHOS_UNIT_TEST(view_factory, dyn_rank_views)
     Kokkos::View<FadType*> a("a",5*3,derivative_dim_plus_one);
     using b_type = Kokkos::View<FadType**,Kokkos::MemoryUnmanaged>;
     b_type b = createViewWithType<b_type>(a,a.data(),5,3);
-    TEST_EQUALITY(b.dimension_0(),5);
-    TEST_EQUALITY(b.dimension_1(),3);
+    TEST_EQUALITY(b.extent(0),5);
+    TEST_EQUALITY(b.extent(1),3);
     TEST_EQUALITY(dimension_scalar(b),derivative_dim_plus_one);
   }
 
@@ -360,8 +360,8 @@ TEUCHOS_UNIT_TEST(view_factory, dyn_rank_views)
     TEST_EQUALITY(is_b_layout_stride,true);
     TEST_EQUALITY(is_c_default_layout,true);
     TEST_EQUALITY(c.rank(),2);
-    TEST_EQUALITY(c.dimension_0(),5);
-    TEST_EQUALITY(c.dimension_1(),3);
+    TEST_EQUALITY(c.extent(0),5);
+    TEST_EQUALITY(c.extent(1),3);
     TEST_EQUALITY(dimension_scalar(b),0);
   }
 
@@ -382,8 +382,8 @@ TEUCHOS_UNIT_TEST(view_factory, dyn_rank_views)
     TEST_EQUALITY(is_b_layout_stride,true);
     TEST_EQUALITY(is_c_default_layout,true);
     TEST_EQUALITY(c.rank(),2);
-    TEST_EQUALITY(c.dimension_0(),5);
-    TEST_EQUALITY(c.dimension_1(),3);
+    TEST_EQUALITY(c.extent(0),5);
+    TEST_EQUALITY(c.extent(1),3);
     TEST_EQUALITY(dimension_scalar(b),derivative_dim_plus_one);
   }
 

--- a/packages/sacado/test/performance/fad_kokkos_hierarchical.cpp
+++ b/packages/sacado/test/performance/fad_kokkos_hierarchical.cpp
@@ -65,10 +65,10 @@ struct AdvectionKernel {
     wbs(bs),
     residual_m_i(residual),
     coeff(c),
-    ncells(flux_m_i.dimension_0()),
-    num_basis(wgb.dimension_1()),
-    num_points(wgb.dimension_2()),
-    num_dim((wgb.dimension_3()))
+    ncells(flux_m_i.extent(0)),
+    num_basis(wgb.extent(1)),
+    num_points(wgb.extent(2)),
+    num_dim((wgb.extent(3)))
   {
   }
 
@@ -148,10 +148,10 @@ struct AdvectionKernel {
     wbs(bs),
     residual_m_i(residual),
     coeff(c),
-    ncells(flux_m_i.dimension_0()),
-    num_basis(wgb.dimension_1()),
-    num_points(wgb.dimension_2()),
-    num_dim((wgb.dimension_3()))
+    ncells(flux_m_i.extent(0)),
+    num_basis(wgb.extent(1)),
+    num_points(wgb.extent(2)),
+    num_dim((wgb.extent(3)))
   {
   }
 
@@ -230,10 +230,10 @@ struct AdvectionKernel {
     wbs(bs),
     residual_m_i(residual),
     coeff(c),
-    ncells(flux_m_i.dimension_0()),
-    num_basis(wgb.dimension_1()),
-    num_points(wgb.dimension_2()),
-    num_dim((wgb.dimension_3()))
+    ncells(flux_m_i.extent(0)),
+    num_basis(wgb.extent(1)),
+    num_points(wgb.extent(2)),
+    num_dim((wgb.extent(3)))
   {
   }
 
@@ -652,9 +652,9 @@ struct DrekarTest {
 
     typedef typename View1::value_type value_type;
 
-    const size_t n0 = v_gold_h.dimension_0();
-    const size_t n1 = v_gold_h.dimension_1();
-    const size_t n2 = v_gold_h.dimension_2();
+    const size_t n0 = v_gold_h.extent(0);
+    const size_t n1 = v_gold_h.extent(1);
+    const size_t n2 = v_gold_h.extent(2);
 
     bool success = true;
     for ( size_t i0 = 0 ; i0 < n0 ; ++i0 ) {
@@ -688,9 +688,9 @@ struct DrekarTest {
 
     typedef typename View1::value_type value_type;
 
-    const size_t n0 = v_gold_h.dimension_0();
-    const size_t n1 = v_gold_h.dimension_1();
-    const size_t n2 = v_gold_h.dimension_2();
+    const size_t n0 = v_gold_h.extent(0);
+    const size_t n1 = v_gold_h.extent(1);
+    const size_t n2 = v_gold_h.extent(2);
 
     bool success = true;
     for ( size_t i0 = 0 ; i0 < n0 ; ++i0 ) {

--- a/packages/sacado/test/performance/fad_kokkos_mat_vec_perf.cpp
+++ b/packages/sacado/test/performance/fad_kokkos_mat_vec_perf.cpp
@@ -54,8 +54,8 @@ void run_mat_vec(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c) {
   typedef typename ViewTypeC::value_type scalar_type;
   typedef typename ViewTypeC::execution_space execution_space;
 
-  const int m = A.dimension_0();
-  const int n = A.dimension_1();
+  const int m = A.extent(0);
+  const int n = A.extent(1);
   Kokkos::parallel_for(
     Kokkos::RangePolicy<execution_space>( 0,m ),
     KOKKOS_LAMBDA (const int i) {
@@ -83,8 +83,8 @@ void run_mat_vec_hierarchical(const ViewTypeA& A, const ViewTypeB& b,
   const unsigned vector_size = is_cuda ? 32 : 1;
   const unsigned team_size = is_cuda ? 128 / vector_size : 1;
 
-  const int m = A.dimension_0();
-  const int n = A.dimension_1();
+  const int m = A.extent(0);
+  const int n = A.extent(1);
   const int range = (m+team_size-1)/team_size;
 
   typedef Kokkos::TeamPolicy<execution_space> Policy;
@@ -119,8 +119,8 @@ void run_mat_vec_hierarchical(const ViewTypeA& A, const ViewTypeB& b,
   const unsigned vector_size = is_cuda ? 32 : 1;
   const unsigned team_size = is_cuda ? 128 / vector_size : 1;
 
-  const int m = A.dimension_0();
-  const int n = A.dimension_1();
+  const int m = A.extent(0);
+  const int n = A.extent(1);
   const int range = (m+team_size-1)/team_size;
 
   typedef Kokkos::TeamPolicy<execution_space> Policy;
@@ -155,8 +155,8 @@ void run_mat_vec_hierarchical(const ViewTypeA& A, const ViewTypeB& b,
   const unsigned vector_size = 1;
   const unsigned team_size = is_cuda ? 128 / vector_size : 1;
 
-  const int m = A.dimension_0();
-  const int n = A.dimension_1();
+  const int m = A.extent(0);
+  const int n = A.extent(1);
   const int range = (m+team_size-1)/team_size;
 
   typedef Kokkos::TeamPolicy<execution_space> Policy;
@@ -185,8 +185,8 @@ check_val(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
   typedef typename ViewTypeC::value_type value_type;
   typename ViewTypeC::HostMirror h_c = Kokkos::create_mirror_view(c);
   Kokkos::deep_copy(h_c, c);
-  const size_t m = A.dimension_0();
-  const size_t n = A.dimension_1();
+  const size_t m = A.extent(0);
+  const size_t n = A.extent(1);
   for (size_t i=0; i<m; ++i) {
     value_type t = n;
     if (std::abs(h_c(i)- t) > tol) {
@@ -204,8 +204,8 @@ check_deriv(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
   typedef typename ViewTypeC::value_type value_type;
   typename ViewTypeC::HostMirror h_c = Kokkos::create_mirror_view(c);
   Kokkos::deep_copy(h_c, c);
-  const size_t m = A.dimension_0();
-  const size_t n = A.dimension_1();
+  const size_t m = A.extent(0);
+  const size_t n = A.extent(1);
   const size_t p = Kokkos::dimension_scalar(A);
   for (size_t i=0; i<m; ++i) {
     for (size_t j=0; j<p; ++j) {

--- a/packages/sacado/test/performance/fad_kokkos_view.cpp
+++ b/packages/sacado/test/performance/fad_kokkos_view.cpp
@@ -68,7 +68,7 @@ struct MatVecFunctor {
   MatVecFunctor(const ViewTypeA& A_arg,
                 const ViewTypeB& b_arg,
                 const ViewTypeC& c_arg) :
-    A(A_arg), b(b_arg), c(c_arg), n(A.dimension_1())
+    A(A_arg), b(b_arg), c(c_arg), n(A.extent(1))
   {}
 
   // Function to compute matrix-vector product for a given row i
@@ -110,7 +110,7 @@ struct MatVecDerivFunctor {
   MatVecDerivFunctor(const ViewTypeA& A_arg,
                      const ViewTypeB& b_arg,
                      const ViewTypeC& c_arg) :
-    A(A_arg), b(b_arg), c(c_arg), n(A.dimension_1()), p(A.dimension_2()-1)
+    A(A_arg), b(b_arg), c(c_arg), n(A.extent(1)), p(A.extent(2)-1)
   {}
 
   KOKKOS_INLINE_FUNCTION
@@ -157,7 +157,7 @@ struct SLMatVecDerivFunctor {
   SLMatVecDerivFunctor(const ViewTypeA& A_arg,
                        const ViewTypeB& b_arg,
                        const ViewTypeC& c_arg) :
-    A(A_arg), b(b_arg), c(c_arg), n(A.dimension_1()), p(A.dimension_2()-1)
+    A(A_arg), b(b_arg), c(c_arg), n(A.extent(1)), p(A.extent(2)-1)
   {}
 
   KOKKOS_INLINE_FUNCTION
@@ -211,7 +211,7 @@ struct SMatVecDerivFunctor {
   SMatVecDerivFunctor(const ViewTypeA& A_arg,
                       const ViewTypeB& b_arg,
                       const ViewTypeC& c_arg) :
-    A(A_arg), b(b_arg), c(c_arg), n(A.dimension_1())
+    A(A_arg), b(b_arg), c(c_arg), n(A.extent(1))
   {}
 
   KOKKOS_INLINE_FUNCTION
@@ -251,7 +251,7 @@ void
 run_mat_vec(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
 {
   MatVecFunctor<ViewTypeA, ViewTypeB, ViewTypeC> f( A, b, c );
-  Kokkos::parallel_for( A.dimension_0(), f );
+  Kokkos::parallel_for( A.extent(0), f );
 }
 
 // Create a mat-vec derivative functor from given A, b, c
@@ -260,7 +260,7 @@ void
 run_mat_vec_deriv(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
 {
   MatVecDerivFunctor<ViewTypeA, ViewTypeB, ViewTypeC> f( A, b, c );
-  Kokkos::parallel_for( A.dimension_0(), f );
+  Kokkos::parallel_for( A.extent(0), f );
 }
 
 // Create a mat-vec derivative functor from given A, b, c
@@ -269,7 +269,7 @@ void
 run_mat_vec_deriv_sl(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
 {
   SLMatVecDerivFunctor<ViewTypeA, ViewTypeB, ViewTypeC, MaxP> f( A, b, c );
-  Kokkos::parallel_for( A.dimension_0(), f );
+  Kokkos::parallel_for( A.extent(0), f );
 }
 
 // Create a mat-vec derivative functor from given A, b, c
@@ -278,7 +278,7 @@ void
 run_mat_vec_deriv_s(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
 {
   SMatVecDerivFunctor<ViewTypeA, ViewTypeB, ViewTypeC, p> f( A, b, c );
-  Kokkos::parallel_for( A.dimension_0(), f );
+  Kokkos::parallel_for( A.extent(0), f );
 }
 
 template <typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
@@ -289,8 +289,8 @@ check_val(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
   typedef typename ViewTypeC::value_type value_type;
   typename ViewTypeC::HostMirror h_c = Kokkos::create_mirror_view(c);
   Kokkos::deep_copy(h_c, c);
-  const size_t m = A.dimension_0();
-  const size_t n = A.dimension_1();
+  const size_t m = A.extent(0);
+  const size_t n = A.extent(1);
   for (size_t i=0; i<m; ++i) {
     value_type t = n;
     if (std::abs(h_c(i)- t) > tol) {
@@ -308,9 +308,9 @@ check_deriv(const ViewTypeA& A, const ViewTypeB& b, const ViewTypeC& c)
   typedef typename ViewTypeC::value_type value_type;
   typename ViewTypeC::HostMirror h_c = Kokkos::create_mirror_view(c);
   Kokkos::deep_copy(h_c, c);
-  const size_t m = A.dimension_0();
-  const size_t n = A.dimension_1();
-  const size_t p = A.dimension_2();
+  const size_t m = A.extent(0);
+  const size_t n = A.extent(1);
+  const size_t p = A.extent(2);
   for (size_t i=0; i<m; ++i) {
     for (size_t j=0; j<p; ++j) {
       value_type t = (j == p-1 ? n : 2*n);

--- a/packages/sacado/test/performance/fenl_assembly/BoxElemFixture.hpp
+++ b/packages/sacado/test/performance/fenl_assembly/BoxElemFixture.hpp
@@ -155,7 +155,7 @@ public:
   typedef Kokkos::View< const unsigned *     , Device > send_nodeid_type ;
 
   KOKKOS_INLINE_FUNCTION
-  unsigned node_count() const { return m_node_grid.dimension_0(); }
+  unsigned node_count() const { return m_node_grid.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   unsigned node_count_owned() const { return m_box_part.owns_node_count(); }
@@ -164,7 +164,7 @@ public:
   unsigned node_count_global() const { return m_box_part.global_node_count(); }
 
   KOKKOS_INLINE_FUNCTION
-  unsigned elem_count() const { return m_elem_node.dimension_0(); }
+  unsigned elem_count() const { return m_elem_node.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   unsigned elem_count_global() const { return m_box_part.global_elem_count(); }
@@ -278,11 +278,11 @@ public:
     }
 
     const size_t nwork = 
-      std::max( m_recv_node.dimension_0() ,
-      std::max( m_send_node.dimension_0() ,
-      std::max( m_send_node_id.dimension_0() ,
-      std::max( m_node_grid.dimension_0() ,
-                m_elem_node.dimension_0() * m_elem_node.dimension_1() ))));
+      std::max( m_recv_node.extent(0) ,
+      std::max( m_send_node.extent(0) ,
+      std::max( m_send_node_id.extent(0) ,
+      std::max( m_node_grid.extent(0) ,
+                m_elem_node.extent(0) * m_elem_node.extent(1) ))));
 
     Kokkos::parallel_for( nwork , *this );
   }
@@ -293,7 +293,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t i ) const
   {
-    if ( i < m_elem_node.dimension_0() * m_elem_node.dimension_1() ) {
+    if ( i < m_elem_node.extent(0) * m_elem_node.extent(1) ) {
 
       const size_t ielem = i / ElemNode ;
       const size_t inode = i % ElemNode ;
@@ -313,7 +313,7 @@ public:
       m_elem_node(ielem,inode) = m_box_part.local_node_id( node_grid );
     }
 
-    if ( i < m_node_grid.dimension_0() ) {
+    if ( i < m_node_grid.extent(0) ) {
       unsigned node_grid[SpaceDim] ;
       m_box_part.local_node_coord( i , node_grid );
       m_node_grid(i,0) = node_grid[0] ;
@@ -328,17 +328,17 @@ public:
                    m_node_coord(i,2) );
     }
 
-    if ( i < m_recv_node.dimension_0() ) {
+    if ( i < m_recv_node.extent(0) ) {
       m_recv_node(i,0) = m_box_part.recv_node_rank(i);
       m_recv_node(i,1) = m_box_part.recv_node_count(i);
     }
 
-    if ( i < m_send_node.dimension_0() ) {
+    if ( i < m_send_node.extent(0) ) {
       m_send_node(i,0) = m_box_part.send_node_rank(i);
       m_send_node(i,1) = m_box_part.send_node_count(i);
     }
 
-    if ( i < m_send_node_id.dimension_0() ) {
+    if ( i < m_send_node_id.extent(0) ) {
       m_send_node_id(i) = m_box_part.send_node_id(i);
     }
   }

--- a/packages/sacado/test/performance/fenl_assembly/TestAssembly.hpp
+++ b/packages/sacado/test/performance/fenl_assembly/TestAssembly.hpp
@@ -214,15 +214,15 @@ bool check_assembly(const VectorType& analytic_residual,
 
   fbuf << test_name << ":" << std::endl;
 
-  if (host_analytic_residual.dimension_0() != host_fad_residual.dimension_0()) {
+  if (host_analytic_residual.extent(0) != host_fad_residual.extent(0)) {
     fbuf << "Analytic residual dimension "
-         << host_analytic_residual.dimension_0()
+         << host_analytic_residual.extent(0)
          << " does not match Fad residual dimension "
-         << host_fad_residual.dimension_0() << std::endl;
+         << host_fad_residual.extent(0) << std::endl;
     success = false;
   }
   else {
-    const size_t num_node = host_analytic_residual.dimension_0();
+    const size_t num_node = host_analytic_residual.extent(0);
     for (size_t i=0; i<num_node; ++i) {
       success = success && compareValues(
         host_analytic_residual(i), "analytic residual",
@@ -238,15 +238,15 @@ bool check_assembly(const VectorType& analytic_residual,
   Kokkos::deep_copy( host_analytic_jacobian, analytic_jacobian );
   Kokkos::deep_copy( host_fad_jacobian, fad_jacobian );
 
-  if (host_analytic_jacobian.dimension_0() != host_fad_jacobian.dimension_0()) {
+  if (host_analytic_jacobian.extent(0) != host_fad_jacobian.extent(0)) {
     fbuf << "Analytic Jacobian dimension "
-         << host_analytic_jacobian.dimension_0()
+         << host_analytic_jacobian.extent(0)
          << " does not match Fad Jacobian dimension "
-         << host_fad_jacobian.dimension_0() << std::endl;
+         << host_fad_jacobian.extent(0) << std::endl;
     success = false;
   }
   else {
-    const size_t num_entry = host_analytic_jacobian.dimension_0();
+    const size_t num_entry = host_analytic_jacobian.extent(0);
     for (size_t i=0; i<num_entry; ++i) {
       success = success && compareValues(
         host_analytic_jacobian(i), "analytic Jacobian",

--- a/packages/sacado/test/performance/fenl_assembly/fenl_functors.hpp
+++ b/packages/sacado/test/performance/fenl_assembly/fenl_functors.hpp
@@ -84,7 +84,7 @@ struct CrsMatrix {
 
   CrsMatrix( const StaticCrsGraphType & arg_graph )
     : graph( arg_graph )
-    , coeff( "crs_matrix_coeff" , arg_graph.entries.dimension_0() )
+    , coeff( "crs_matrix_coeff" , arg_graph.entries.extent(0) )
     {}
 };
 
@@ -175,7 +175,7 @@ public:
         // May be larger that requested:
         set_capacity = node_node_set.capacity();
 
-        Kokkos::parallel_reduce( Kokkos::RangePolicy<execution_space,TagFillNodeSet>(0,elem_node_id.dimension_0())
+        Kokkos::parallel_reduce( Kokkos::RangePolicy<execution_space,TagFillNodeSet>(0,elem_node_id.extent(0))
                                , *this
                                , failed_insert_count );
 
@@ -239,8 +239,8 @@ public:
       // Element-to-graph mapping:
       wall_clock.reset();
       phase = FILL_ELEMENT_GRAPH ;
-      elem_graph = ElemGraphType("elem_graph", elem_node_id.dimension_0() );
-      Kokkos::parallel_for( elem_node_id.dimension_0() , *this );
+      elem_graph = ElemGraphType("elem_graph", elem_node_id.extent(0) );
+      Kokkos::parallel_for( elem_node_id.extent(0) , *this );
 
       execution_space::fence();
       results.fill_element_graph = wall_clock.seconds();
@@ -253,17 +253,17 @@ public:
   void operator()( const TagFillNodeSet & , unsigned ielem , unsigned & count ) const
   {
     // Loop over element's (row_local_node,col_local_node) pairs:
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         // If either node is locally owned then insert the pair into the unordered map:
 
-        if ( row_node < row_count.dimension_0() || col_node < row_count.dimension_0() ) {
+        if ( row_node < row_count.extent(0) || col_node < row_count.extent(0) ) {
 
           const key_type key = (row_node < col_node) ? make_pair( row_node, col_node ) : make_pair( col_node, row_node ) ;
 
@@ -273,10 +273,10 @@ public:
           if ( result.success() ) {
 
             // If row node is owned then increment count
-            if ( row_node < row_count.dimension_0() ) { atomic_increment( & row_count( row_node ) ); }
+            if ( row_node < row_count.extent(0) ) { atomic_increment( & row_count( row_node ) ); }
 
             // If column node is owned and not equal to row node then increment count
-            if ( col_node < row_count.dimension_0() && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
           }
           else if ( result.failed() ) {
             ++count ;
@@ -296,13 +296,13 @@ public:
       const unsigned row_node = key.first ;
       const unsigned col_node = key.second ;
 
-      if ( row_node < row_count.dimension_0() ) {
+      if ( row_node < row_count.extent(0) ) {
         typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = col_node ;
       }
 
-      if ( col_node < row_count.dimension_0() && col_node != row_node ) {
+      if ( col_node < row_count.extent(0) && col_node != row_node ) {
         typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = row_node ;
@@ -328,17 +328,17 @@ public:
   KOKKOS_INLINE_FUNCTION
   void fill_elem_graph_map( const unsigned ielem ) const
   {
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         unsigned entry = ~0u ;
 
-        if ( row_node + 1 < graph.row_map.dimension_0() ) {
+        if ( row_node + 1 < graph.row_map.extent(0) ) {
 
           const unsigned entry_end = graph.row_map( row_node + 1 );
 
@@ -387,7 +387,7 @@ public:
     update += row_count( irow );
 
     if ( final ) {
-      if ( irow + 1 == row_count.dimension_0() ) {
+      if ( irow + 1 == row_count.extent(0) ) {
         row_map( irow + 1 ) = update ;
         row_total()         = update ;
       }
@@ -634,7 +634,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -672,7 +672,7 @@ public:
   {
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < this->residual.dimension_0() ) {
+      if ( row < this->residual.extent(0) ) {
         atomic_add( & this->residual( row ) , res[i] );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -825,7 +825,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -857,7 +857,7 @@ public:
   {
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < this->residual.dimension_0() ) {
+      if ( row < this->residual.extent(0) ) {
         atomic_add( & this->residual( row ) , res[i].val() );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -990,7 +990,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -1140,7 +1140,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 

--- a/packages/sacado/test/performance/fenl_assembly_view/BoxElemFixture.hpp
+++ b/packages/sacado/test/performance/fenl_assembly_view/BoxElemFixture.hpp
@@ -155,7 +155,7 @@ public:
   typedef Kokkos::View< const unsigned *     , Device > send_nodeid_type ;
 
   KOKKOS_INLINE_FUNCTION
-  unsigned node_count() const { return m_node_grid.dimension_0(); }
+  unsigned node_count() const { return m_node_grid.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   unsigned node_count_owned() const { return m_box_part.owns_node_count(); }
@@ -164,7 +164,7 @@ public:
   unsigned node_count_global() const { return m_box_part.global_node_count(); }
 
   KOKKOS_INLINE_FUNCTION
-  unsigned elem_count() const { return m_elem_node.dimension_0(); }
+  unsigned elem_count() const { return m_elem_node.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   unsigned elem_count_global() const { return m_box_part.global_elem_count(); }
@@ -278,11 +278,11 @@ public:
     }
 
     const size_t nwork = 
-      std::max( m_recv_node.dimension_0() ,
-      std::max( m_send_node.dimension_0() ,
-      std::max( m_send_node_id.dimension_0() ,
-      std::max( m_node_grid.dimension_0() ,
-                m_elem_node.dimension_0() * m_elem_node.dimension_1() ))));
+      std::max( m_recv_node.extent(0) ,
+      std::max( m_send_node.extent(0) ,
+      std::max( m_send_node_id.extent(0) ,
+      std::max( m_node_grid.extent(0) ,
+                m_elem_node.extent(0) * m_elem_node.extent(1) ))));
 
     Kokkos::parallel_for( nwork , *this );
   }
@@ -293,7 +293,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t i ) const
   {
-    if ( i < m_elem_node.dimension_0() * m_elem_node.dimension_1() ) {
+    if ( i < m_elem_node.extent(0) * m_elem_node.extent(1) ) {
 
       const size_t ielem = i / ElemNode ;
       const size_t inode = i % ElemNode ;
@@ -313,7 +313,7 @@ public:
       m_elem_node(ielem,inode) = m_box_part.local_node_id( node_grid );
     }
 
-    if ( i < m_node_grid.dimension_0() ) {
+    if ( i < m_node_grid.extent(0) ) {
       unsigned node_grid[SpaceDim] ;
       m_box_part.local_node_coord( i , node_grid );
       m_node_grid(i,0) = node_grid[0] ;
@@ -328,17 +328,17 @@ public:
                    m_node_coord(i,2) );
     }
 
-    if ( i < m_recv_node.dimension_0() ) {
+    if ( i < m_recv_node.extent(0) ) {
       m_recv_node(i,0) = m_box_part.recv_node_rank(i);
       m_recv_node(i,1) = m_box_part.recv_node_count(i);
     }
 
-    if ( i < m_send_node.dimension_0() ) {
+    if ( i < m_send_node.extent(0) ) {
       m_send_node(i,0) = m_box_part.send_node_rank(i);
       m_send_node(i,1) = m_box_part.send_node_count(i);
     }
 
-    if ( i < m_send_node_id.dimension_0() ) {
+    if ( i < m_send_node_id.extent(0) ) {
       m_send_node_id(i) = m_box_part.send_node_id(i);
     }
   }

--- a/packages/sacado/test/performance/fenl_assembly_view/TestAssembly.hpp
+++ b/packages/sacado/test/performance/fenl_assembly_view/TestAssembly.hpp
@@ -214,15 +214,15 @@ bool check_assembly(const VectorType& analytic_residual,
 
   fbuf << test_name << ":" << std::endl;
 
-  if (host_analytic_residual.dimension_0() != host_fad_residual.dimension_0()) {
+  if (host_analytic_residual.extent(0) != host_fad_residual.extent(0)) {
     fbuf << "Analytic residual dimension "
-         << host_analytic_residual.dimension_0()
+         << host_analytic_residual.extent(0)
          << " does not match Fad residual dimension "
-         << host_fad_residual.dimension_0() << std::endl;
+         << host_fad_residual.extent(0) << std::endl;
     success = false;
   }
   else {
-    const size_t num_node = host_analytic_residual.dimension_0();
+    const size_t num_node = host_analytic_residual.extent(0);
     for (size_t i=0; i<num_node; ++i) {
       success = success && compareValues(
         host_analytic_residual(i), "analytic residual",
@@ -238,15 +238,15 @@ bool check_assembly(const VectorType& analytic_residual,
   Kokkos::deep_copy( host_analytic_jacobian, analytic_jacobian );
   Kokkos::deep_copy( host_fad_jacobian, fad_jacobian );
 
-  if (host_analytic_jacobian.dimension_0() != host_fad_jacobian.dimension_0()) {
+  if (host_analytic_jacobian.extent(0) != host_fad_jacobian.extent(0)) {
     fbuf << "Analytic Jacobian dimension "
-         << host_analytic_jacobian.dimension_0()
+         << host_analytic_jacobian.extent(0)
          << " does not match Fad Jacobian dimension "
-         << host_fad_jacobian.dimension_0() << std::endl;
+         << host_fad_jacobian.extent(0) << std::endl;
     success = false;
   }
   else {
-    const size_t num_entry = host_analytic_jacobian.dimension_0();
+    const size_t num_entry = host_analytic_jacobian.extent(0);
     for (size_t i=0; i<num_entry; ++i) {
       success = success && compareValues(
         host_analytic_jacobian(i), "analytic Jacobian",

--- a/packages/sacado/test/performance/fenl_assembly_view/fenl_functors.hpp
+++ b/packages/sacado/test/performance/fenl_assembly_view/fenl_functors.hpp
@@ -84,7 +84,7 @@ struct CrsMatrix {
 
   CrsMatrix( const StaticCrsGraphType & arg_graph )
     : graph( arg_graph )
-    , coeff( "crs_matrix_coeff" , arg_graph.entries.dimension_0() )
+    , coeff( "crs_matrix_coeff" , arg_graph.entries.extent(0) )
     {}
 };
 
@@ -175,7 +175,7 @@ public:
         // May be larger that requested:
         set_capacity = node_node_set.capacity();
 
-        Kokkos::parallel_reduce( Kokkos::RangePolicy<execution_space,TagFillNodeSet>(0,elem_node_id.dimension_0())
+        Kokkos::parallel_reduce( Kokkos::RangePolicy<execution_space,TagFillNodeSet>(0,elem_node_id.extent(0))
                                , *this
                                , failed_insert_count );
 
@@ -239,8 +239,8 @@ public:
       // Element-to-graph mapping:
       wall_clock.reset();
       phase = FILL_ELEMENT_GRAPH ;
-      elem_graph = ElemGraphType("elem_graph", elem_node_id.dimension_0() );
-      Kokkos::parallel_for( elem_node_id.dimension_0() , *this );
+      elem_graph = ElemGraphType("elem_graph", elem_node_id.extent(0) );
+      Kokkos::parallel_for( elem_node_id.extent(0) , *this );
 
       execution_space::fence();
       results.fill_element_graph = wall_clock.seconds();
@@ -253,17 +253,17 @@ public:
   void operator()( const TagFillNodeSet & , unsigned ielem , unsigned & count ) const
   {
     // Loop over element's (row_local_node,col_local_node) pairs:
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         // If either node is locally owned then insert the pair into the unordered map:
 
-        if ( row_node < row_count.dimension_0() || col_node < row_count.dimension_0() ) {
+        if ( row_node < row_count.extent(0) || col_node < row_count.extent(0) ) {
 
           const key_type key = (row_node < col_node) ? make_pair( row_node, col_node ) : make_pair( col_node, row_node ) ;
 
@@ -273,10 +273,10 @@ public:
           if ( result.success() ) {
 
             // If row node is owned then increment count
-            if ( row_node < row_count.dimension_0() ) { atomic_increment( & row_count( row_node ) ); }
+            if ( row_node < row_count.extent(0) ) { atomic_increment( & row_count( row_node ) ); }
 
             // If column node is owned and not equal to row node then increment count
-            if ( col_node < row_count.dimension_0() && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
           }
           else if ( result.failed() ) {
             ++count ;
@@ -296,13 +296,13 @@ public:
       const unsigned row_node = key.first ;
       const unsigned col_node = key.second ;
 
-      if ( row_node < row_count.dimension_0() ) {
+      if ( row_node < row_count.extent(0) ) {
         typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = col_node ;
       }
 
-      if ( col_node < row_count.dimension_0() && col_node != row_node ) {
+      if ( col_node < row_count.extent(0) && col_node != row_node ) {
         typedef typename std::remove_reference< decltype( row_count(0) ) >::type atomic_incr_type;
         const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = row_node ;
@@ -328,17 +328,17 @@ public:
   KOKKOS_INLINE_FUNCTION
   void fill_elem_graph_map( const unsigned ielem ) const
   {
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         unsigned entry = ~0u ;
 
-        if ( row_node + 1 < graph.row_map.dimension_0() ) {
+        if ( row_node + 1 < graph.row_map.extent(0) ) {
 
           const unsigned entry_end = graph.row_map( row_node + 1 );
 
@@ -387,7 +387,7 @@ public:
     update += row_count( irow );
 
     if ( final ) {
-      if ( irow + 1 == row_count.dimension_0() ) {
+      if ( irow + 1 == row_count.extent(0) ) {
         row_map( irow + 1 ) = update ;
         row_total()         = update ;
       }
@@ -637,7 +637,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -675,7 +675,7 @@ public:
   {
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < this->residual.dimension_0() ) {
+      if ( row < this->residual.extent(0) ) {
         atomic_add( & this->residual( row ) , res(i) );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -831,7 +831,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -864,7 +864,7 @@ public:
   {
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < this->residual.dimension_0() ) {
+      if ( row < this->residual.extent(0) ) {
         atomic_add( & this->residual( row ) , res(i).val() );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -1001,7 +1001,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -1156,7 +1156,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_BlockCrsMatrix.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_BlockCrsMatrix.hpp
@@ -87,7 +87,7 @@ public:
   __device__
   void operator()(void) const
   {
-    const size_type blockCount = m_A.graph.row_map.dimension_0() - 1 ;
+    const size_type blockCount = m_A.graph.row_map.extent(0) - 1 ;
 
     for ( size_type iBlock = blockIdx.x ;
                     iBlock < blockCount ; iBlock += gridDim.x ) {
@@ -116,7 +116,7 @@ public:
     const size_type thread_max =
       Kokkos::Impl::cuda_internal_maximum_warp_count() * Kokkos::Impl::CudaTraits::WarpSize ;
 
-    const size_type row_count = A.graph.row_map.dimension_0() - 1 ;
+    const size_type row_count = A.graph.row_map.extent(0) - 1 ;
 
     const dim3 grid(
       std::min( row_count , Kokkos::Impl::cuda_internal_maximum_grid_count() ) , 1 , 1 );

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CooProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CooProductTensor.hpp
@@ -255,7 +255,7 @@ public:
                      const vector_type & x,
                      const vector_type & y )
   {
-    const size_type fem_rows = A.graph.row_map.dimension_0() - 1;
+    const size_type fem_rows = A.graph.row_map.extent(0) - 1;
     const size_type stoch_rows = A.block.dimension();
     const size_type stoch_entries = A.block.entry_count();
     const size_type warp_size = Kokkos::Impl::CudaTraits::WarpSize;
@@ -291,7 +291,7 @@ public:
 
 #if 0
     //std::cout << std::endl << A.block << std::endl;
-    const size_type fem_nnz = A.values.dimension_1();
+    const size_type fem_nnz = A.values.extent(1);
     std::cout << "Multiply< BlockCrsMatrix< CooProductTensor ... > >::apply"
               << std::endl
               << "  grid(" << dGrid.x << "," << dGrid.y << ")" << std::endl

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CrsMatrix.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CrsMatrix.hpp
@@ -120,8 +120,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const float alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
 
     cusparseStatus_t status =
       cusparseScsrmv( s.handle ,
@@ -129,12 +129,12 @@ public:
                       n , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      x.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      x.data() ,
                       &beta ,
-                      y.ptr_on_device() );
+                      y.data() );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseScsrmv " ) );
@@ -164,8 +164,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const double alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
 
     cusparseStatus_t status =
       cusparseDcsrmv( s.handle ,
@@ -173,12 +173,12 @@ public:
                       n , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      x.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      x.data() ,
                       &beta ,
-                      y.ptr_on_device() );
+                      y.data() );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
       throw std::runtime_error( std::string("ERROR - cusparseDcsrmv " ) );
@@ -210,8 +210,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const float alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
     const size_t ncol = col_indices.size();
 
     // Copy columns of x into a contiguous vector
@@ -233,13 +233,13 @@ public:
                       n , ncol , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      xx.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      xx.data() ,
                       n ,
                       &beta ,
-                      yy.ptr_on_device() ,
+                      yy.data() ,
                       n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
@@ -296,7 +296,7 @@ public:
     GatherTranspose( multi_vector_type& xt,
                      const multi_vector_type& x,
                      const Kokkos::View<Ordinal*,execution_space>& col ) :
-      m_xt(xt), m_x(x), m_col(col), m_ncol(col.dimension_0()) {}
+      m_xt(xt), m_x(x), m_col(col), m_ncol(col.extent(0)) {}
 
     __device__
     inline void operator() (size_type i) const {
@@ -307,7 +307,7 @@ public:
     static void apply( multi_vector_type& xt,
                        const multi_vector_type& x,
                        const Kokkos::View<Ordinal*,execution_space>& col ) {
-      const size_type n = x.dimension_0();
+      const size_type n = x.extent(0);
       Kokkos::parallel_for( n , GatherTranspose(xt,x,col) );
     }
   };
@@ -319,8 +319,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const double alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
     const size_t ncol = col_indices.size();
 
     // Copy col_indices to the device
@@ -349,13 +349,13 @@ public:
                        n , ncol , n , nz ,
                        &alpha ,
                        s.descra ,
-                       A.values.ptr_on_device() ,
-                       A.graph.row_map.ptr_on_device() ,
-                       A.graph.entries.ptr_on_device() ,
-                       xx.ptr_on_device() ,
+                       A.values.data() ,
+                       A.graph.row_map.data() ,
+                       A.graph.entries.data() ,
+                       xx.data() ,
                        ncol ,
                        &beta ,
-                       yy.ptr_on_device() ,
+                       yy.data() ,
                        n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
@@ -379,8 +379,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const double alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
     const size_t ncol = col_indices.size();
 
     // Copy columns of x into a contiguous vector
@@ -402,13 +402,13 @@ public:
                       n , ncol , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      xx.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      xx.data() ,
                       n ,
                       &beta ,
-                      yy.ptr_on_device() ,
+                      yy.data() ,
                       n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
@@ -449,9 +449,9 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const float alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
-    const size_t ncol = x.dimension_1();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
+    const size_t ncol = x.extent(1);
 
     // Sparse matrix-times-multivector
     cusparseStatus_t status =
@@ -460,13 +460,13 @@ public:
                       n , ncol , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      x.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      x.data() ,
                       n ,
                       &beta ,
-                      y.ptr_on_device() ,
+                      y.data() ,
                       n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
@@ -497,9 +497,9 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const double alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
-    const size_t ncol = x.dimension_1();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
+    const size_t ncol = x.extent(1);
 
     // Sparse matrix-times-multivector
     cusparseStatus_t status =
@@ -508,13 +508,13 @@ public:
                       n , ncol , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      x.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      x.data() ,
                       n ,
                       &beta ,
-                      y.ptr_on_device() ,
+                      y.data() ,
                       n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
@@ -556,7 +556,7 @@ public:
     m_x(x),
     m_y(y),
     m_col(col),
-    m_num_col(col.dimension_0()) {}
+    m_num_col(col.extent(0)) {}
 
   __device__
   inline void operator() ( const size_type iRow ) const {
@@ -593,7 +593,7 @@ public:
       col_indices_host(i) = col_indices[i];
     Kokkos::deep_copy(col_indices_dev, col_indices_host);
 
-    const size_t n = A.graph.row_map.dimension_0() - 1 ;
+    const size_t n = A.graph.row_map.extent(0) - 1 ;
     Kokkos::parallel_for( n , Multiply(A,x,y,col_indices_dev) );
   }
 };
@@ -622,8 +622,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const float alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
     const size_t ncol = x.size();
 
     // Copy columns of x into a contiguous vector
@@ -643,13 +643,13 @@ public:
                       n , ncol , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      xx.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      xx.data() ,
                       n ,
                       &beta ,
-                      yy.ptr_on_device() ,
+                      yy.data() ,
                       n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {
@@ -687,8 +687,8 @@ public:
   {
     CudaSparseSingleton & s = CudaSparseSingleton::singleton();
     const double alpha = 1 , beta = 0 ;
-    const int n = A.graph.row_map.dimension_0() - 1 ;
-    const int nz = A.graph.entries.dimension_0();
+    const int n = A.graph.row_map.extent(0) - 1 ;
+    const int nz = A.graph.entries.extent(0);
     const size_t ncol = x.size();
 
     // Copy columns of x into a contiguous vector
@@ -708,13 +708,13 @@ public:
                       n , ncol , n , nz ,
                       &alpha ,
                       s.descra ,
-                      A.values.ptr_on_device() ,
-                      A.graph.row_map.ptr_on_device() ,
-                      A.graph.entries.ptr_on_device() ,
-                      xx.ptr_on_device() ,
+                      A.values.data() ,
+                      A.graph.row_map.data() ,
+                      A.graph.entries.data() ,
+                      xx.data() ,
                       n ,
                       &beta ,
-                      yy.ptr_on_device() ,
+                      yy.data() ,
                       n );
 
     if ( CUSPARSE_STATUS_SUCCESS != status ) {

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CrsProductTensor.hpp
@@ -357,7 +357,7 @@ public:
                      const vector_type & x,
                      const vector_type & y )
   {
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = A.block.dimension();
     const size_type tensor_align = tensor_dimension;
     const size_type avg_tensor_entries_per_row = A.block.avg_entries_per_row();

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_LinearSparse3Tensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_LinearSparse3Tensor.hpp
@@ -113,7 +113,7 @@ public:
 
       // blockIdx.x == row in the deterministic (finite element) system
       const size_type row = blockIdx.x*blockDim.y + threadIdx.y;
-      if (row < m_A.graph.row_map.dimension_0()-1) {
+      if (row < m_A.graph.row_map.extent(0)-1) {
         const size_type colBeg = m_A.graph.row_map[ row ];
         const size_type colEnd = m_A.graph.row_map[ row + 1 ];
 
@@ -229,7 +229,7 @@ public:
 
       // blockIdx.x == row in the deterministic (finite element) system
       const size_type row = blockIdx.x*blockDim.y + threadIdx.y;
-      if (row < m_A.graph.row_map.dimension_0()-1) {
+      if (row < m_A.graph.row_map.extent(0)-1) {
         const size_type colBeg = m_A.graph.row_map[ row ];
         const size_type colEnd = m_A.graph.row_map[ row + 1 ];
 
@@ -321,7 +321,7 @@ public:
                      const vector_type & x,
                      const vector_type & y )
   {
-    const size_type num_spatial_rows = A.graph.row_map.dimension_0() - 1;
+    const size_type num_spatial_rows = A.graph.row_map.extent(0) - 1;
     const size_type num_stoch_rows = A.block.dimension();
 
     const size_type warp_size = Kokkos::Impl::CudaTraits::WarpSize;

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_SimpleTiledCrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_SimpleTiledCrsProductTensor.hpp
@@ -248,7 +248,7 @@ public:
                      const vector_type & x ,
                      const vector_type & y )
   {
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = A.block.dimension();
     const size_type i_tile_size = A.block.max_i_tile_size();
     const size_type jk_tile_size = A.block.max_jk_tile_size();
@@ -535,7 +535,7 @@ public:
                      const vector_type & x ,
                      const vector_type & y )
   {
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = A.block.dimension();
     const size_type tile_size = A.block.max_jk_tile_size();
     const size_type n_i_tile = A.block.num_i_tiles();

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_TiledCrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_TiledCrsProductTensor.hpp
@@ -236,7 +236,7 @@ public:
                      const vector_type & x ,
                      const vector_type & y )
   {
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = A.block.dimension();
     const size_type tile_size = A.block.tile_size();
     const size_type num_tiles = A.block.num_tiles();
@@ -465,7 +465,7 @@ public:
     typedef typename vector_type::execution_space execution_space;
     typedef typename execution_space::size_type size_type;
 
-    Zero( const vector_type & x ) : m_x( x ), m_d(x.dimension_0()) {}
+    Zero( const vector_type & x ) : m_x( x ), m_d(x.extent(0)) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator()( const size_type j ) const {
@@ -485,7 +485,7 @@ public:
                      const vector_type & x ,
                      const vector_type & y )
   {
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = A.block.dimension();
     const size_type tile_size = A.block.tile_size();
     const size_type num_tiles = A.block.num_tiles();
@@ -730,7 +730,7 @@ public:
                      const vector_type & x ,
                      const vector_type & y )
   {
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = A.block.dimension();
     const size_type tile_size = A.block.tile_size();
     const size_type num_tiles = A.block.num_tiles();

--- a/packages/stokhos/src/kokkos/OpenMP/Stokhos_OpenMP_MKL_CrsMatrix.hpp
+++ b/packages/stokhos/src/kokkos/OpenMP/Stokhos_OpenMP_MKL_CrsMatrix.hpp
@@ -82,7 +82,7 @@ namespace Impl {
     static void apply(const multi_vector_type & x,
                       const trans_multi_vector_type& xt,
                       const std::vector<ordinal_type> & indices) {
-      const size_t n = xt.dimension_1();
+      const size_t n = xt.extent(1);
       Kokkos::parallel_for( n, GatherTranspose(x,xt,indices) );
     }
   };
@@ -113,7 +113,7 @@ namespace Impl {
     static void apply(const multi_vector_type & x,
                       const trans_multi_vector_type& xt,
                       const std::vector<ordinal_type> & indices) {
-      const size_t n = xt.dimension_1();
+      const size_t n = xt.extent(1);
       Kokkos::parallel_for( n, ScatterTranspose(x,xt,indices) );
     }
   };
@@ -140,7 +140,7 @@ namespace Impl {
 
     static void apply(const std::vector<vector_type> & x,
                       const trans_multi_vector_type& xt) {
-      const size_t n = xt.dimension_1();
+      const size_t n = xt.extent(1);
       Kokkos::parallel_for( n, GatherVecTranspose(x,xt) );
     }
   };
@@ -167,7 +167,7 @@ namespace Impl {
 
     static void apply(const std::vector<vector_type> & x,
                       const trans_multi_vector_type& xt) {
-      const size_t n = xt.dimension_1();
+      const size_t n = xt.extent(1);
       Kokkos::parallel_for( n, ScatterVecTranspose(x,xt) );
     }
   };
@@ -182,18 +182,18 @@ void multiply(const CrsMatrix< double , Kokkos::OpenMP >& A,
               Kokkos::View< double* , Kokkos::OpenMP >& y,
               MKLMultiply tag)
 {
-  MKL_INT n = A.graph.row_map.dimension_0() - 1 ;
-  double *A_values = A.values.ptr_on_device() ;
-  MKL_INT *col_indices = A.graph.entries.ptr_on_device() ;
-  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.ptr_on_device()) ;
+  MKL_INT n = A.graph.row_map.extent(0) - 1 ;
+  double *A_values = A.values.data() ;
+  MKL_INT *col_indices = A.graph.entries.data() ;
+  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.data()) ;
   MKL_INT *row_end = row_beg+1;
   char matdescra[6] = { 'G', 'x', 'N', 'C', 'x', 'x' };
   char trans = 'N';
   double alpha = 1.0;
   double beta = 0.0;
 
-  double *x_values = x.ptr_on_device() ;
-  double *y_values = y.ptr_on_device() ;
+  double *x_values = x.data() ;
+  double *y_values = y.data() ;
 
   mkl_dcsrmv(&trans, &n, &n, &alpha, matdescra, A_values, col_indices,
              row_beg, row_end, x_values, &beta, y_values);
@@ -204,18 +204,18 @@ void multiply(const CrsMatrix< float , Kokkos::OpenMP >& A,
               Kokkos::View< float* , Kokkos::OpenMP >& y,
               MKLMultiply tag)
 {
-  MKL_INT n = A.graph.row_map.dimension_0() - 1 ;
-  float *A_values = A.values.ptr_on_device() ;
-  MKL_INT *col_indices = A.graph.entries.ptr_on_device() ;
-  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.ptr_on_device()) ;
+  MKL_INT n = A.graph.row_map.extent(0) - 1 ;
+  float *A_values = A.values.data() ;
+  MKL_INT *col_indices = A.graph.entries.data() ;
+  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.data()) ;
   MKL_INT *row_end = row_beg+1;
   char matdescra[6] = { 'G', 'x', 'N', 'C', 'x', 'x' };
   char trans = 'N';
   float alpha = 1.0;
   float beta = 0.0;
 
-  float *x_values = x.ptr_on_device() ;
-  float *y_values = y.ptr_on_device() ;
+  float *x_values = x.data() ;
+  float *y_values = y.data() ;
 
   mkl_scsrmv(&trans, &n, &n, &alpha, matdescra, A_values, col_indices,
              row_beg, row_end, x_values, &beta, y_values);
@@ -230,10 +230,10 @@ void multiply(const CrsMatrix< double , Kokkos::OpenMP >& A,
   typedef double value_type ;
   typedef Kokkos::View< double** , Kokkos::LayoutLeft, execution_space >  trans_multi_vector_type ;
 
-  MKL_INT n = A.graph.row_map.dimension_0() - 1 ;
-  double *A_values = A.values.ptr_on_device() ;
-  MKL_INT *col_indices = A.graph.entries.ptr_on_device() ;
-  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.ptr_on_device()) ;
+  MKL_INT n = A.graph.row_map.extent(0) - 1 ;
+  double *A_values = A.values.data() ;
+  MKL_INT *col_indices = A.graph.entries.data() ;
+  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.data()) ;
   MKL_INT *row_end = row_beg+1;
   char matdescra[6] = { 'G', 'x', 'N', 'C', 'x', 'x' };
   char trans = 'N';
@@ -245,8 +245,8 @@ void multiply(const CrsMatrix< double , Kokkos::OpenMP >& A,
   trans_multi_vector_type xx( "xx" , ncol , n );
   trans_multi_vector_type yy( "yy" , ncol , n );
   Impl::GatherVecTranspose<value_type,execution_space>::apply(x,xx);
-  double *x_values = xx.ptr_on_device() ;
-  double *y_values = yy.ptr_on_device() ;
+  double *x_values = xx.data() ;
+  double *y_values = yy.data() ;
 
   // Call MKLs CSR x multi-vector (row-based) multiply
   mkl_dcsrmm(&trans, &n, &ncol, &n, &alpha, matdescra, A_values, col_indices,
@@ -265,10 +265,10 @@ void multiply(const CrsMatrix< float , Kokkos::OpenMP >& A,
   typedef float value_type ;
   typedef Kokkos::View< float** , Kokkos::LayoutLeft, execution_space >  trans_multi_vector_type ;
 
-  MKL_INT n = A.graph.row_map.dimension_0() - 1 ;
-  float *A_values = A.values.ptr_on_device() ;
-  MKL_INT *col_indices = A.graph.entries.ptr_on_device() ;
-  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.ptr_on_device()) ;
+  MKL_INT n = A.graph.row_map.extent(0) - 1 ;
+  float *A_values = A.values.data() ;
+  MKL_INT *col_indices = A.graph.entries.data() ;
+  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.data()) ;
   MKL_INT *row_end = row_beg+1;
   char matdescra[6] = { 'G', 'x', 'N', 'C', 'x', 'x' };
   char trans = 'N';
@@ -280,8 +280,8 @@ void multiply(const CrsMatrix< float , Kokkos::OpenMP >& A,
   trans_multi_vector_type xx( "xx" , ncol , n );
   trans_multi_vector_type yy( "yy" , ncol , n );
   Impl::GatherVecTranspose<value_type,execution_space>::apply(x,xx);
-  float *x_values = xx.ptr_on_device() ;
-  float *y_values = yy.ptr_on_device() ;
+  float *x_values = xx.data() ;
+  float *y_values = yy.data() ;
 
   // Call MKLs CSR x multi-vector (row-based) multiply
   mkl_scsrmm(&trans, &n, &ncol, &n, &alpha, matdescra, A_values, col_indices,
@@ -303,10 +303,10 @@ void multiply(
   typedef double value_type ;
   typedef Kokkos::View< double** , Kokkos::LayoutLeft, execution_space >  trans_multi_vector_type ;
 
-  MKL_INT n = A.graph.row_map.dimension_0() - 1 ;
-  double *A_values = A.values.ptr_on_device() ;
-  MKL_INT *col_indices = A.graph.entries.ptr_on_device() ;
-  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.ptr_on_device()) ;
+  MKL_INT n = A.graph.row_map.extent(0) - 1 ;
+  double *A_values = A.values.data() ;
+  MKL_INT *col_indices = A.graph.entries.data() ;
+  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.data()) ;
   MKL_INT *row_end = row_beg+1;
   char matdescra[6] = { 'G', 'x', 'N', 'C', 'x', 'x' };
   char trans = 'N';
@@ -318,8 +318,8 @@ void multiply(
   trans_multi_vector_type xx( "xx" , ncol , n );
   trans_multi_vector_type yy( "yy" , ncol , n );
   Impl::GatherTranspose<value_type,ordinal_type,execution_space>::apply(x,xx,indices);
-  double *x_values = xx.ptr_on_device() ;
-  double *y_values = yy.ptr_on_device() ;
+  double *x_values = xx.data() ;
+  double *y_values = yy.data() ;
 
   // Call MKLs CSR x multi-vector (row-based) multiply
   mkl_dcsrmm(&trans, &n, &ncol, &n, &alpha, matdescra, A_values, col_indices,
@@ -341,10 +341,10 @@ void multiply(
   typedef float value_type ;
   typedef Kokkos::View< float** , Kokkos::LayoutLeft, execution_space >  trans_multi_vector_type ;
 
-  MKL_INT n = A.graph.row_map.dimension_0() - 1 ;
-  float *A_values = A.values.ptr_on_device() ;
-  MKL_INT *col_indices = A.graph.entries.ptr_on_device() ;
-  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.ptr_on_device()) ;
+  MKL_INT n = A.graph.row_map.extent(0) - 1 ;
+  float *A_values = A.values.data() ;
+  MKL_INT *col_indices = A.graph.entries.data() ;
+  MKL_INT *row_beg = const_cast<MKL_INT*>(A.graph.row_map.data()) ;
   MKL_INT *row_end = row_beg+1;
   char matdescra[6] = { 'G', 'x', 'N', 'C', 'x', 'x' };
   char trans = 'N';
@@ -356,8 +356,8 @@ void multiply(
   trans_multi_vector_type xx( "xx" , ncol , n );
   trans_multi_vector_type yy( "yy" , ncol , n );
   Impl::GatherTranspose<value_type,ordinal_type,execution_space>::apply(x,xx,indices);
-  float *x_values = xx.ptr_on_device() ;
-  float *y_values = yy.ptr_on_device() ;
+  float *x_values = xx.data() ;
+  float *y_values = yy.data() ;
 
   // Call MKLs CSR x multi-vector (row-based) multiply
   mkl_scsrmm(&trans, &n, &ncol, &n, &alpha, matdescra, A_values, col_indices,

--- a/packages/stokhos/src/kokkos/Stokhos_BlockCrsMatrix.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_BlockCrsMatrix.hpp
@@ -132,7 +132,7 @@ public:
                      const block_vector_type& x,
                      block_vector_type& y )
   {
-    const size_t row_count = A.graph.row_map.dimension_0() - 1;
+    const size_t row_count = A.graph.row_map.extent(0) - 1;
     Kokkos::parallel_for( row_count , Multiply(A,x,y) );
   }
 };

--- a/packages/stokhos/src/kokkos/Stokhos_CooProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_CooProductTensor.hpp
@@ -149,7 +149,7 @@ public:
 
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
-  size_type entry_count() const { return m_coord.dimension_0(); }
+  size_type entry_count() const { return m_coord.extent(0); }
 
   /** \brief  Get (i,j,k) coordinates of an entry */
   KOKKOS_INLINE_FUNCTION
@@ -165,7 +165,7 @@ public:
 
   /** \brief Number of non-zero's */
   KOKKOS_INLINE_FUNCTION
-  size_type num_non_zeros() const { return m_coord.dimension_0(); }
+  size_type num_non_zeros() const { return m_coord.extent(0); }
 
   /** \brief Number flop's per multiply-add */
   KOKKOS_INLINE_FUNCTION
@@ -332,7 +332,7 @@ public:
 
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
-  size_type entry_count() const { return m_coord.dimension_0(); }
+  size_type entry_count() const { return m_coord.extent(0); }
 
   /** \brief  Get (i,j,k) coordinates of an entry */
   KOKKOS_INLINE_FUNCTION
@@ -350,7 +350,7 @@ public:
 
   /** \brief Number of non-zero's */
   KOKKOS_INLINE_FUNCTION
-  size_type num_non_zeros() const { return m_coord.dimension_0(); }
+  size_type num_non_zeros() const { return m_coord.extent(0); }
 
   /** \brief Number flop's per multiply-add */
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_CrsMatrix.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_CrsMatrix.hpp
@@ -148,7 +148,7 @@ public:
                      const input_vector_type & x,
                      output_vector_type & y )
   {
-    const size_t row_count = A.graph.row_map.dimension_0() - 1;
+    const size_t row_count = A.graph.row_map.extent(0) - 1;
     Kokkos::parallel_for( row_count, Multiply(A,x,y) );
   }
 };
@@ -221,7 +221,7 @@ public:
                      output_multi_vector_type& y,
                      const column_indices_type& col )
   {
-    const size_t n = A.graph.row_map.dimension_0() - 1 ;
+    const size_t n = A.graph.row_map.extent(0) - 1 ;
     //Kokkos::parallel_for( n , Multiply(A,x,y,col) );
 
     const size_t block_size = 20;
@@ -280,8 +280,8 @@ public:
   : m_A( A )
   , m_x( x )
   , m_y( y )
-  , m_num_row( A.graph.row_map.dimension_0()-1 )
-  , m_num_col( m_y.dimension_1() )
+  , m_num_row( A.graph.row_map.extent(0)-1 )
+  , m_num_col( m_y.extent(1) )
   {
   }
 
@@ -334,7 +334,7 @@ public:
                      output_multi_vector_type& y )
   {
     // Parallelize over row blocks of size m_block_row_size
-    const size_type num_row = A.graph.row_map.dimension_0() - 1;
+    const size_type num_row = A.graph.row_map.extent(0) - 1;
     const size_type n = (num_row+m_block_row_size-1) / m_block_row_size;
     Kokkos::parallel_for( n , Multiply(A,x,y) );
   }
@@ -372,7 +372,7 @@ public:
   : m_A( A )
   , m_x( x )
   , m_y( y )
-  , m_num_vecs( m_y.dimension_1() )
+  , m_num_vecs( m_y.extent(1) )
   {}
 
   //--------------------------------------------------------------------------
@@ -401,7 +401,7 @@ public:
                      const input_multi_vector_type& x,
                      output_multi_vector_type& y )
   {
-    const size_t n = A.graph.row_map.dimension_0() - 1 ;
+    const size_t n = A.graph.row_map.extent(0) - 1 ;
     Kokkos::parallel_for( n , Multiply(A,x,y) );
 
     // const size_t block_size = 20;
@@ -460,7 +460,7 @@ public:
   : m_A( A )
   , m_x( x )
   , m_y( y )
-  , m_num_row( A.graph.row_map.dimension_0()-1 )
+  , m_num_row( A.graph.row_map.extent(0)-1 )
   , m_num_col( x.size() )
   {
   }
@@ -514,7 +514,7 @@ public:
                      output_multi_vector_type& y )
   {
     // Parallelize over row blocks of size m_block_row_size
-    const size_type num_row = A.graph.row_map.dimension_0() - 1;
+    const size_type num_row = A.graph.row_map.extent(0) - 1;
     const size_type n = (num_row+m_block_row_size-1) / m_block_row_size;
     Kokkos::parallel_for( n , Multiply(A,x,y) );
   }
@@ -582,7 +582,7 @@ public:
                      const input_multi_vector_type& x,
                      output_multi_vector_type& y )
   {
-    const size_t n = A.graph.row_map.dimension_0() - 1 ;
+    const size_t n = A.graph.row_map.extent(0) - 1 ;
     Kokkos::parallel_for( n , Multiply(A,x,y) );
 
     // const size_t block_size = 20;
@@ -710,11 +710,11 @@ public:
     typename matrix_type::HostMirror hA = Kokkos::create_mirror_view(A);
     Kokkos::deep_copy(hA, A);
 
-    const size_type nRow = hA.graph.row_map.dimension_0() - 1 ;
+    const size_type nRow = hA.graph.row_map.extent(0) - 1 ;
 
     // Write banner
     file << "%%MatrixMarket matrix coordinate real general" << std::endl;
-    file << nRow << " " << nRow << " " << hA.values.dimension_0() << std::endl;
+    file << nRow << " " << nRow << " " << hA.values.extent(0) << std::endl;
 
     for (size_type row=0; row<nRow; ++row) {
       size_type entryBegin = hA.graph.row_map(row);

--- a/packages/stokhos/src/kokkos/Stokhos_CrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_CrsProductTensor.hpp
@@ -211,7 +211,7 @@ public:
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
   size_type entry_count() const
-  { return m_coord.dimension_0(); }
+  { return m_coord.extent(0); }
 
   /** \brief  Maximum sparse entries for any coordinate */
   KOKKOS_INLINE_FUNCTION
@@ -840,7 +840,7 @@ public:
     const size_type iBlockRow = device.league_rank();
 
     // Check for valid row
-    const size_type row_count = m_A.graph.row_map.dimension_0()-1;
+    const size_type row_count = m_A.graph.row_map.extent(0)-1;
     if (iBlockRow >= row_count)
       return;
 
@@ -960,7 +960,7 @@ public:
     const size_type iBlockRow = device.league_rank();
 
     // Check for valid row
-    const size_type row_count = m_A.graph.row_map.dimension_0()-1;
+    const size_type row_count = m_A.graph.row_map.extent(0)-1;
     if (iBlockRow >= row_count)
       return;
 
@@ -1076,7 +1076,7 @@ public:
     const bool use_block_algorithm = false;
 #endif
 
-    const size_t row_count = A.graph.row_map.dimension_0() - 1 ;
+    const size_t row_count = A.graph.row_map.extent(0) - 1 ;
     if (use_block_algorithm) {
 #ifdef __MIC__
       const size_t team_size = 4;  // 4 hyperthreads for MIC

--- a/packages/stokhos/src/kokkos/Stokhos_FlatSparse3Tensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_FlatSparse3Tensor.hpp
@@ -129,12 +129,12 @@ public:
 
   /** \brief  Dimension of the tensor. */
   KOKKOS_INLINE_FUNCTION
-  size_type dimension() const { return m_k_row_map.dimension_0() - 1 ; }
+  size_type dimension() const { return m_k_row_map.extent(0) - 1 ; }
 
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
   size_type entry_count() const
-  { return m_j_coord.dimension_0(); }
+  { return m_j_coord.extent(0); }
 
   /** \brief  Begin k entries with a coordinate 'i' */
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_FlatSparse3Tensor_kji.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_FlatSparse3Tensor_kji.hpp
@@ -137,12 +137,12 @@ public:
 
   /** \brief  Number of k entries. */
   KOKKOS_INLINE_FUNCTION
-  size_type num_k() const { return m_j_row_map.dimension_0() - 1 ; }
+  size_type num_k() const { return m_j_row_map.extent(0) - 1 ; }
 
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
   size_type entry_count() const
-  { return m_i_coord.dimension_0(); }
+  { return m_i_coord.extent(0); }
 
   /** \brief  Begin j entries with a coordinate 'k' */
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_LexicographicBlockSparse3Tensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_LexicographicBlockSparse3Tensor.hpp
@@ -119,11 +119,11 @@ public:
 
   /** \brief  Number of coordinates. */
   KOKKOS_INLINE_FUNCTION
-  size_type num_coord() const { return m_coord.dimension_0(); }
+  size_type num_coord() const { return m_coord.extent(0); }
 
   /** \brief  Number of values. */
   KOKKOS_INLINE_FUNCTION
-  size_type num_value() const { return m_value.dimension_0(); }
+  size_type num_value() const { return m_value.extent(0); }
 
   /** \brief   */
   KOKKOS_INLINE_FUNCTION
@@ -174,7 +174,7 @@ public:
 
   /** \brief Number of non-zero's */
   KOKKOS_INLINE_FUNCTION
-  size_type num_non_zeros() const { return m_value.dimension_0(); }
+  size_type num_non_zeros() const { return m_value.extent(0); }
 
   /** \brief Number flop's per multiply-add */
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_LinearSparse3Tensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_LinearSparse3Tensor.hpp
@@ -125,7 +125,7 @@ public:
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
   size_type entry_count() const
-  { return m_value.dimension_0(); }
+  { return m_value.extent(0); }
 
   /** \brief Is tensor built from symmetric PDFs. */
    KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_SimpleTiledCrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_SimpleTiledCrsProductTensor.hpp
@@ -222,7 +222,7 @@ public:
 
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
-  size_type entry_count() const { return m_coord.dimension_0(); }
+  size_type entry_count() const { return m_coord.extent(0); }
 
   /** \brief Number i-tiles */
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_StochasticProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_StochasticProductTensor.hpp
@@ -162,9 +162,9 @@ public:
 
   void print( std::ostream & s ) const
   {
-    for ( unsigned i = 1 ; i < m_degree_map.dimension_0() ; ++i ) {
+    for ( unsigned i = 1 ; i < m_degree_map.extent(0) ; ++i ) {
       s << "  bases[" << i - 1 << "] (" ;
-      for ( unsigned j = 0 ; j < m_degree_map.dimension_1() ; ++j ) {
+      for ( unsigned j = 0 ; j < m_degree_map.extent(1) ; ++j ) {
         s << " " << m_degree_map(i,j);
       }
       s << " )" << std::endl ;

--- a/packages/stokhos/src/kokkos/Stokhos_TiledCrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_TiledCrsProductTensor.hpp
@@ -182,7 +182,7 @@ public:
   /** \brief  Number of sparse entries. */
   KOKKOS_INLINE_FUNCTION
   size_type entry_count() const
-  { return m_coord.dimension_0(); }
+  { return m_coord.extent(0); }
 
   /** \brief  Maximum sparse entries for any coordinate */
   KOKKOS_INLINE_FUNCTION
@@ -212,7 +212,7 @@ public:
    /** \brief  Return row_map ptr */
   KOKKOS_INLINE_FUNCTION
   const size_type* row_map_ptr() const
-  { return m_row_map.ptr_on_device(); }
+  { return m_row_map.data(); }
 
   /** \brief  Number of entries with a coordinate 'i' */
   KOKKOS_INLINE_FUNCTION
@@ -252,7 +252,7 @@ public:
   /** \brief Number tiles */
   KOKKOS_INLINE_FUNCTION
   size_type num_tiles() const
-  { return m_coord_offset.dimension_0(); }
+  { return m_coord_offset.extent(0); }
 
   /** \brief Coordinate offset */
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/kokkos/Stokhos_Update.hpp
+++ b/packages/stokhos/src/kokkos/Stokhos_Update.hpp
@@ -78,7 +78,7 @@ public:
   static void apply(const value_type& alpha, vector_type& x,
                     const value_type& beta,  const vector_type& y)
   {
-    const size_t row_count = x.dimension_0();
+    const size_t row_count = x.extent(0);
     Kokkos::parallel_for( row_count , Update(alpha,x,beta,y) );
   }
 };

--- a/packages/stokhos/src/sacado/kokkos/Kokkos_View_Utils.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Kokkos_View_Utils.hpp
@@ -299,13 +299,13 @@ struct StokhosViewFill
   KOKKOS_INLINE_FUNCTION
   void operator()( const size_t i0 ) const
   {
-    const size_t n1 = output.dimension_1();
-    const size_t n2 = output.dimension_2();
-    const size_t n3 = output.dimension_3();
-    const size_t n4 = output.dimension_4();
-    const size_t n5 = output.dimension_5();
-    const size_t n6 = output.dimension_6();
-    const size_t n7 = output.dimension_7();
+    const size_t n1 = output.extent(1);
+    const size_t n2 = output.extent(2);
+    const size_t n3 = output.extent(3);
+    const size_t n4 = output.extent(4);
+    const size_t n5 = output.extent(5);
+    const size_t n6 = output.extent(6);
+    const size_t n7 = output.extent(7);
 
     for ( size_t i1 = 0 ; i1 < n1 ; ++i1 ) {
     for ( size_t i2 = 0 ; i2 < n2 ; ++i2 ) {
@@ -321,7 +321,7 @@ struct StokhosViewFill
   StokhosViewFill( const OutputView & arg_out , const_value_type & arg_in )
     : output( arg_out ), input( arg_in )
     {
-      const size_t n0 = output.dimension_0();
+      const size_t n0 = output.extent(0);
       Kokkos::RangePolicy<execution_space> policy( 0, n0 );
       Kokkos::parallel_for( policy, *this );
       execution_space::fence();

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_Tpetra_Utilities.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_Tpetra_Utilities.hpp
@@ -60,7 +60,7 @@ namespace Stokhos {
     typedef typename ViewType::size_type size_type;
 
     GetMeanValsFunc(const ViewType& vals) {
-      mean_vals = ViewType("mean-values", vals.dimension_0());
+      mean_vals = ViewType("mean-values", vals.extent(0));
       Kokkos::deep_copy( mean_vals, vals );
     }
 
@@ -84,7 +84,7 @@ namespace Stokhos {
     typedef typename ViewType::size_type size_type;
 
     GetMeanValsFunc(const ViewType& vals_) : vals(vals_) {
-      const size_type nnz = vals.dimension_0();
+      const size_type nnz = vals.extent(0);
       typename Scalar::cijk_type mean_cijk =
         Stokhos::create_mean_based_product_tensor<execution_space, typename Storage::ordinal_type, typename Storage::value_type>();
       mean_vals = Kokkos::make_view<ViewType>("mean-values", mean_cijk, nnz, 1);
@@ -119,7 +119,7 @@ namespace Stokhos {
     GetMeanValsFunc(const ViewType& vals_) :
       vals(vals_), vec_size(Kokkos::dimension_scalar(vals))
     {
-      const size_type nnz = vals.dimension_0();
+      const size_type nnz = vals.extent(0);
       mean_vals = ViewType("mean-values", nnz, 1);
       Kokkos::parallel_for( nnz, *this );
     }
@@ -153,7 +153,7 @@ namespace Stokhos {
     typedef typename ViewType::size_type size_type;
 
     GetScalarMeanValsFunc(const ViewType& vals) {
-      mean_vals = ViewType("mean-values", vals.dimension_0());
+      mean_vals = ViewType("mean-values", vals.extent(0));
       Kokkos::deep_copy( mean_vals, vals );
     }
 
@@ -178,7 +178,7 @@ namespace Stokhos {
     typedef typename ViewType::size_type size_type;
 
     GetScalarMeanValsFunc(const ViewType& vals_) : vals(vals_) {
-      const size_type nnz = vals.dimension_0();
+      const size_type nnz = vals.extent(0);
       mean_vals = MeanViewType("mean-values", nnz, 1);
       Kokkos::parallel_for( nnz, *this );
     }
@@ -212,7 +212,7 @@ namespace Stokhos {
     GetScalarMeanValsFunc(const ViewType& vals_) :
       vals(vals_), vec_size(Kokkos::dimension_scalar(vals))
     {
-      const size_type nnz = vals.dimension_0();
+      const size_type nnz = vals.extent(0);
       mean_vals = ViewType("mean-values", nnz, 1);
       Kokkos::parallel_for( nnz, *this );
     }
@@ -324,8 +324,8 @@ namespace Stokhos {
     template <typename DstView, typename SrcView>
     void impl(const DstView& dst, const SrcView& src) {
       typedef typename SrcView::non_const_value_type Scalar;
-      const size_t m = src.dimension_0();
-      const size_t n = src.dimension_1();
+      const size_t m = src.extent(0);
+      const size_t n = src.extent(1);
       const size_t p = Kokkos::dimension_scalar(src);
       Kokkos::RangePolicy<exec_space> policy(0,m);
       Kokkos::parallel_for( policy, KOKKOS_LAMBDA(const size_t i)
@@ -353,8 +353,8 @@ namespace Stokhos {
     template <typename DstView, typename SrcView>
     void impl(const DstView& dst, const SrcView& src) {
       typedef typename DstView::non_const_value_type Scalar;
-      const size_t m = dst.dimension_0();
-      const size_t n = dst.dimension_1();
+      const size_t m = dst.extent(0);
+      const size_t n = dst.extent(1);
       const size_t p = Kokkos::dimension_scalar(dst);
 
       Kokkos::RangePolicy<exec_space> policy(0,m);
@@ -387,8 +387,8 @@ namespace Stokhos {
       typedef Kokkos::TeamPolicy<exec_space> Policy;
       typedef typename Policy::member_type Member;
 
-      const size_t m = src.dimension_0();
-      const size_t n = src.dimension_1();
+      const size_t m = src.extent(0);
+      const size_t n = src.extent(1);
       const size_t p = Kokkos::dimension_scalar(src);
 
       const size_t ChunkSize = 16;
@@ -444,8 +444,8 @@ namespace Stokhos {
       typedef Kokkos::TeamPolicy<exec_space> Policy;
       typedef typename Policy::member_type Member;
 
-      const size_t m = dst.dimension_0();
-      const size_t n = dst.dimension_1();
+      const size_t m = dst.extent(0);
+      const size_t n = dst.extent(1);
       const size_t p = Kokkos::dimension_scalar(dst);
 
       const size_t ChunkSize = 16;

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -186,20 +186,20 @@ struct DeepCopyNonContiguous
                          const InputView & arg_in ) :
     output( arg_out ), input( arg_in )
   {
-    parallel_for( output.dimension_0() , *this );
+    parallel_for( output.extent(0) , *this );
     execution_space::fence();
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator()( const size_type i0 ) const
   {
-    for ( size_type i1 = 0 ; i1 < output.dimension_1() ; ++i1 ) {
-    for ( size_type i2 = 0 ; i2 < output.dimension_2() ; ++i2 ) {
-    for ( size_type i3 = 0 ; i3 < output.dimension_3() ; ++i3 ) {
-    for ( size_type i4 = 0 ; i4 < output.dimension_4() ; ++i4 ) {
-    for ( size_type i5 = 0 ; i5 < output.dimension_5() ; ++i5 ) {
-    for ( size_type i6 = 0 ; i6 < output.dimension_6() ; ++i6 ) {
-    for ( size_type i7 = 0 ; i7 < output.dimension_7() ; ++i7 ) {
+    for ( size_type i1 = 0 ; i1 < output.extent(1) ; ++i1 ) {
+    for ( size_type i2 = 0 ; i2 < output.extent(2) ; ++i2 ) {
+    for ( size_type i3 = 0 ; i3 < output.extent(3) ; ++i3 ) {
+    for ( size_type i4 = 0 ; i4 < output.extent(4) ; ++i4 ) {
+    for ( size_type i5 = 0 ; i5 < output.extent(5) ; ++i5 ) {
+    for ( size_type i6 = 0 ; i6 < output.extent(6) ; ++i6 ) {
+    for ( size_type i7 = 0 ; i7 < output.extent(7) ; ++i7 ) {
       output(i0,i1,i2,i3,i4,i5,i6,i7) = input(i0,i1,i2,i3,i4,i5,i6,i7) ;
     }}}}}}}
   }
@@ -268,14 +268,14 @@ void deep_copy( const View<DT,DP...> & dst ,
            !is_allocation_contiguous(src) ) {
         size_t src_dims[8];
         //src.dimensions(src_dims);
-        src_dims[0] = src.dimension_0();
-        src_dims[1] = src.dimension_1();
-        src_dims[2] = src.dimension_2();
-        src_dims[3] = src.dimension_3();
-        src_dims[4] = src.dimension_4();
-        src_dims[5] = src.dimension_5();
-        src_dims[6] = src.dimension_6();
-        src_dims[7] = src.dimension_7();
+        src_dims[0] = src.extent(0);
+        src_dims[1] = src.extent(1);
+        src_dims[2] = src.extent(2);
+        src_dims[3] = src.extent(3);
+        src_dims[4] = src.extent(4);
+        src_dims[5] = src.extent(5);
+        src_dims[6] = src.extent(6);
+        src_dims[7] = src.extent(7);
         src_dims[src_type::Rank] = dimension_scalar(src);
         tmp_src_type src_tmp(
           view_alloc("src_tmp" , WithoutInitializing, cijk(src) ) ,
@@ -293,14 +293,14 @@ void deep_copy( const View<DT,DP...> & dst ,
                  is_allocation_contiguous(src) ) {
         size_t dst_dims[8];
         //dst.dimensions(dst_dims);
-        dst_dims[0] = dst.dimension_0();
-        dst_dims[1] = dst.dimension_1();
-        dst_dims[2] = dst.dimension_2();
-        dst_dims[3] = dst.dimension_3();
-        dst_dims[4] = dst.dimension_4();
-        dst_dims[5] = dst.dimension_5();
-        dst_dims[6] = dst.dimension_6();
-        dst_dims[7] = dst.dimension_7();
+        dst_dims[0] = dst.extent(0);
+        dst_dims[1] = dst.extent(1);
+        dst_dims[2] = dst.extent(2);
+        dst_dims[3] = dst.extent(3);
+        dst_dims[4] = dst.extent(4);
+        dst_dims[5] = dst.extent(5);
+        dst_dims[6] = dst.extent(6);
+        dst_dims[7] = dst.extent(7);
         dst_dims[dst_type::Rank] = dimension_scalar(dst);
         tmp_dst_type dst_tmp(
           view_alloc("dst_tmp" , WithoutInitializing, cijk(dst) ) ,
@@ -317,14 +317,14 @@ void deep_copy( const View<DT,DP...> & dst ,
       else {
         size_t src_dims[8];
         //src.dimensions(src_dims);
-        src_dims[0] = src.dimension_0();
-        src_dims[1] = src.dimension_1();
-        src_dims[2] = src.dimension_2();
-        src_dims[3] = src.dimension_3();
-        src_dims[4] = src.dimension_4();
-        src_dims[5] = src.dimension_5();
-        src_dims[6] = src.dimension_6();
-        src_dims[7] = src.dimension_7();
+        src_dims[0] = src.extent(0);
+        src_dims[1] = src.extent(1);
+        src_dims[2] = src.extent(2);
+        src_dims[3] = src.extent(3);
+        src_dims[4] = src.extent(4);
+        src_dims[5] = src.extent(5);
+        src_dims[6] = src.extent(6);
+        src_dims[7] = src.extent(7);
         src_dims[src_type::Rank] = dimension_scalar(src);
         tmp_src_type src_tmp(
           view_alloc("src_tmp" , WithoutInitializing, cijk(src) ) ,
@@ -333,14 +333,14 @@ void deep_copy( const View<DT,DP...> & dst ,
         Experimental::Impl::DeepCopyNonContiguous< tmp_src_type , src_type >( src_tmp , src );
         size_t dst_dims[8];
         //dst.dimensions(dst_dims);
-        dst_dims[0] = dst.dimension_0();
-        dst_dims[1] = dst.dimension_1();
-        dst_dims[2] = dst.dimension_2();
-        dst_dims[3] = dst.dimension_3();
-        dst_dims[4] = dst.dimension_4();
-        dst_dims[5] = dst.dimension_5();
-        dst_dims[6] = dst.dimension_6();
-        dst_dims[7] = dst.dimension_7();
+        dst_dims[0] = dst.extent(0);
+        dst_dims[1] = dst.extent(1);
+        dst_dims[2] = dst.extent(2);
+        dst_dims[3] = dst.extent(3);
+        dst_dims[4] = dst.extent(4);
+        dst_dims[5] = dst.extent(5);
+        dst_dims[6] = dst.extent(6);
+        dst_dims[7] = dst.extent(7);
         dst_dims[dst_type::Rank] = dimension_scalar(dst);
         tmp_dst_type dst_tmp(
           view_alloc("dst_tmp" , WithoutInitializing, cijk(dst) ) ,
@@ -1637,15 +1637,15 @@ struct StokhosViewFill< OutputView ,
       const size_type nvec = dimension_scalar(output);
 
       const size_type i0 = dev.league_rank() * nrow + tidy;
-      if ( i0 >= output.dimension_0() ) return;
+      if ( i0 >= output.extent(0) ) return;
 
-      for ( size_type i1 = 0 ; i1 < output.dimension_1() ; ++i1 ) {
-      for ( size_type i2 = 0 ; i2 < output.dimension_2() ; ++i2 ) {
-      for ( size_type i3 = 0 ; i3 < output.dimension_3() ; ++i3 ) {
-      for ( size_type i4 = 0 ; i4 < output.dimension_4() ; ++i4 ) {
-      for ( size_type i5 = 0 ; i5 < output.dimension_5() ; ++i5 ) {
-      for ( size_type i6 = 0 ; i6 < output.dimension_6() ; ++i6 ) {
-      for ( size_type i7 = 0 ; i7 < output.dimension_7() ; ++i7 ) {
+      for ( size_type i1 = 0 ; i1 < output.extent(1) ; ++i1 ) {
+      for ( size_type i2 = 0 ; i2 < output.extent(2) ; ++i2 ) {
+      for ( size_type i3 = 0 ; i3 < output.extent(3) ; ++i3 ) {
+      for ( size_type i4 = 0 ; i4 < output.extent(4) ; ++i4 ) {
+      for ( size_type i5 = 0 ; i5 < output.extent(5) ; ++i5 ) {
+      for ( size_type i6 = 0 ; i6 < output.extent(6) ; ++i6 ) {
+      for ( size_type i7 = 0 ; i7 < output.extent(7) ; ++i7 ) {
       for ( size_type is = tidx ; is < nvec ; is+=VectorLength ) {
         output(i0,i1,i2,i3,i4,i5,i6,i7).fastAccessCoeff(is) =
           input.fastAccessCoeff(is) ;
@@ -1672,15 +1672,15 @@ struct StokhosViewFill< OutputView ,
       const size_type npce = dimension_scalar(output);
 
       const size_type i0 = dev.league_rank() * nrow + tidy;
-      if ( i0 >= output.dimension_0() ) return;
+      if ( i0 >= output.extent(0) ) return;
 
-      for ( size_type i1 = 0 ; i1 < output.dimension_1() ; ++i1 ) {
-      for ( size_type i2 = 0 ; i2 < output.dimension_2() ; ++i2 ) {
-      for ( size_type i3 = 0 ; i3 < output.dimension_3() ; ++i3 ) {
-      for ( size_type i4 = 0 ; i4 < output.dimension_4() ; ++i4 ) {
-      for ( size_type i5 = 0 ; i5 < output.dimension_5() ; ++i5 ) {
-      for ( size_type i6 = 0 ; i6 < output.dimension_6() ; ++i6 ) {
-      for ( size_type i7 = 0 ; i7 < output.dimension_7() ; ++i7 ) {
+      for ( size_type i1 = 0 ; i1 < output.extent(1) ; ++i1 ) {
+      for ( size_type i2 = 0 ; i2 < output.extent(2) ; ++i2 ) {
+      for ( size_type i3 = 0 ; i3 < output.extent(3) ; ++i3 ) {
+      for ( size_type i4 = 0 ; i4 < output.extent(4) ; ++i4 ) {
+      for ( size_type i5 = 0 ; i5 < output.extent(5) ; ++i5 ) {
+      for ( size_type i6 = 0 ; i6 < output.extent(6) ; ++i6 ) {
+      for ( size_type i7 = 0 ; i7 < output.extent(7) ; ++i7 ) {
       for ( size_type is = tidx ; is < npce ; is+=VectorLength ) {
         output(i0,i1,i2,i3,i4,i5,i6,i7).fastAccessCoeff(is) =
           is == 0 ? input : scalar_type(0) ;
@@ -1699,7 +1699,7 @@ struct StokhosViewFill< OutputView ,
     const size_type block_size = 256;
 
     const size_type rows_per_block = block_size / vector_length;
-    const size_type n = output.dimension_0();
+    const size_type n = output.extent(0);
     const size_type league_size = ( n + rows_per_block-1 ) / rows_per_block;
     const size_type team_size = rows_per_block * vector_length;
     Kokkos::TeamPolicy< execution_space > config( league_size, team_size );
@@ -1727,7 +1727,7 @@ struct StokhosViewFill< OutputView ,
     const size_type block_size = 256;
 
     const size_type rows_per_block = block_size / vector_length;
-    const size_type n = output.dimension_0();
+    const size_type n = output.extent(0);
     const size_type league_size = ( n + rows_per_block-1 ) / rows_per_block;
     const size_type team_size = rows_per_block * vector_length;
     Kokkos::TeamPolicy< execution_space > config( league_size, team_size );

--- a/packages/stokhos/src/sacado/kokkos/pce/belos/Belos_TpetraAdapter_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/belos/Belos_TpetraAdapter_UQ_PCE.hpp
@@ -366,7 +366,7 @@ namespace Belos {
       typedef Kokkos::View<dot_type**, Kokkos::LayoutLeft, execution_space> b_view_type;
       typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, execution_space> b_1d_view_type;
       b_1d_view_type B_1d_view_dev(Kokkos::ViewAllocateWithoutInitializing("B"), strideB*numColsB);
-      b_view_type B_view_dev( B_1d_view_dev.ptr_on_device(), strideB, numColsB);
+      b_view_type B_view_dev( B_1d_view_dev.data(), strideB, numColsB);
       Kokkos::deep_copy(B_view_dev, B_view_host);
 
       // Do local multiply
@@ -473,7 +473,7 @@ namespace Belos {
       typedef Kokkos::View<dot_type**, Kokkos::LayoutLeft, execution_space> c_view_type;
       typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, execution_space> c_1d_view_type;
       c_1d_view_type C_1d_view_dev("C", strideC*numColsC);
-      c_view_type C_view_dev( C_1d_view_dev.ptr_on_device(), strideC, numColsC);
+      c_view_type C_view_dev( C_1d_view_dev.data(), strideC, numColsC);
 
       // Do local multiply
       ::Tpetra::Details::Blas::gemm ('C', 'N',
@@ -488,12 +488,12 @@ namespace Belos {
       else {
         typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, Kokkos::HostSpace> c_1d_host_view_type;
         c_1d_host_view_type C_1d_view_tmp(Kokkos::ViewAllocateWithoutInitializing("C_tmp"), strideC*numColsC);
-        c_host_view_type C_view_tmp( C_1d_view_tmp.ptr_on_device(),
+        c_host_view_type C_view_tmp( C_1d_view_tmp.data(),
                                      strideC, numColsC);
         Kokkos::deep_copy(C_view_tmp, C_view_dev);
         reduceAll<int> (*pcomm, REDUCE_SUM, strideC*numColsC,
-                        C_view_tmp.ptr_on_device(),
-                        C_view_host.ptr_on_device());
+                        C_view_tmp.data(),
+                        C_view_host.data());
       }
     }
 

--- a/packages/stokhos/src/sacado/kokkos/pce/ifpack2/Stokhos_Ifpack2_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/ifpack2/Stokhos_Ifpack2_UQ_PCE.hpp
@@ -123,7 +123,7 @@ struct LocalReciprocalThreshold<
     }
     else {
       V_ReciprocalThresholdSelfFunctor<XV, SizeType> op (X, minVal);
-      Kokkos::parallel_for( X.dimension_0(), op );
+      Kokkos::parallel_for( X.extent(0), op );
     }
   }
 };

--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_Blas1_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_Blas1_UQ_PCE.hpp
@@ -281,7 +281,7 @@ struct MV_Reciprocal_Functor<
   XMV X_;
 
   MV_Reciprocal_Functor (const RMV& R, const XMV& X) :
-    numCols (X.dimension_1 ()), R_ (R), X_ (X)
+    numCols (X.extent(1)), R_ (R), X_ (X)
   {
   }
 
@@ -312,7 +312,7 @@ struct MV_ReciprocalSelf_Functor<
   RMV R_;
 
   MV_ReciprocalSelf_Functor (const RMV& R) :
-    numCols (R.dimension_1 ()), R_ (R)
+    numCols (R.extent(1)), R_ (R)
   {
   }
 
@@ -454,7 +454,7 @@ struct MV_MultFunctor<
                   typename AV::const_value_type& ab,
                   const AV& A,
                   const BMV& B) :
-    m_n (C.dimension_1 ()),
+    m_n (C.extent(1)),
     m_pce (dimension_scalar(C)),
     m_c (c.coeff(0)), m_C (C), m_ab (ab.coeff(0)), m_A (A), m_B (B)
   {

--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
@@ -189,7 +189,7 @@ public:
     const size_type iBlockRow = device.league_rank();
 
     // Check for valid row
-    const size_type row_count = m_A_graph.row_map.dimension_0()-1;
+    const size_type row_count = m_A_graph.row_map.extent(0)-1;
     if (iBlockRow >= row_count)
       return;
 
@@ -318,7 +318,7 @@ public:
     const size_type iBlockRow = device.league_rank();
 
     // Check for valid row
-    const size_type row_count = m_A_graph.row_map.dimension_0()-1;
+    const size_type row_count = m_A_graph.row_map.extent(0)-1;
     if (iBlockRow >= row_count)
       return;
 
@@ -439,7 +439,7 @@ public:
     const bool use_block_algorithm = false;
 #endif
 
-    const size_t row_count = A.graph.row_map.dimension_0() - 1 ;
+    const size_t row_count = A.graph.row_map.extent(0) - 1 ;
     if (use_block_algorithm) {
 #ifdef __MIC__
       const size_t team_size = 4;  // 4 hyperthreads for MIC
@@ -547,7 +547,7 @@ public:
     const size_type iEntryBegin = m_A_graph.row_map[ iBlockRow ];
     const size_type iEntryEnd   = m_A_graph.row_map[ iBlockRow + 1 ];
 
-    const size_type num_col = m_y.dimension_2();
+    const size_type num_col = m_y.extent(2);
 
     // Leading dimension guaranteed contiguous for LayoutLeft
     if ( m_b == output_scalar(0) )
@@ -595,7 +595,7 @@ public:
     const size_type iBlockRow = device.league_rank();
 
     // Check for valid row
-    const size_type row_count = m_A_graph.row_map.dimension_0()-1;
+    const size_type row_count = m_A_graph.row_map.extent(0)-1;
     if (iBlockRow >= row_count)
       return;
 
@@ -605,7 +605,7 @@ public:
       details::compute_work_range<output_scalar>(
         device, m_tensor.dimension(), num_thread, thread_idx);
 
-    const size_type num_col = m_y.dimension_2();
+    const size_type num_col = m_y.extent(2);
 
     // Leading dimension guaranteed contiguous for LayoutLeft
     if ( m_b == output_scalar(0) )
@@ -733,7 +733,7 @@ public:
     const size_type iBlockRow = device.league_rank();
 
     // Check for valid row
-    const size_type row_count = m_A_graph.row_map.dimension_0()-1;
+    const size_type row_count = m_A_graph.row_map.extent(0)-1;
     if (iBlockRow >= row_count)
       return;
 
@@ -743,7 +743,7 @@ public:
       details::compute_work_range<output_scalar>(
         device, m_tensor.dimension(), num_thread, thread_idx);
 
-    const size_type num_col = m_y.dimension_2();
+    const size_type num_col = m_y.extent(2);
 
     // Leading dimension guaranteed contiguous for LayoutLeft
     if ( m_b == output_scalar(0) )
@@ -861,7 +861,7 @@ public:
     const bool use_block_algorithm = false;
 #endif
 
-    const size_t row_count = A.graph.row_map.dimension_0() - 1 ;
+    const size_t row_count = A.graph.row_map.extent(0) - 1 ;
     if (use_block_algorithm) {
 #ifdef __MIC__
       const size_t team_size = 4;  // 4 hyperthreads for MIC
@@ -1120,7 +1120,7 @@ public:
                      const input_scalar & a = input_scalar(1) ,
                      const output_scalar & b = output_scalar(0) )
   {
-    const size_t row_count = A.graph.row_map.dimension_0() - 1 ;
+    const size_t row_count = A.graph.row_map.extent(0) - 1 ;
     const size_type dim = Kokkos::dimension_scalar(x);
 
     // Choose block size appropriately for PCE dimension
@@ -1206,7 +1206,7 @@ public:
       OutputP... > output_vector_1d_type;
     typedef MeanMultiply<matrix_type,input_vector_1d_type,
       output_vector_1d_type> MeanMultiply1D;
-    const size_type num_col = x.dimension_1();
+    const size_type num_col = x.extent(1);
     for (size_type i=0; i<num_col; ++i) {
       input_vector_1d_type x_col =
         Kokkos::subview(x, Kokkos::ALL(), i);
@@ -1292,7 +1292,7 @@ spmv(
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for transposed or conjugated matrix-vector multiplies");
   }
-  if (y.dimension_1() == 1) {
+  if (y.extent(1) == 1) {
     auto y_1D = subview(y, Kokkos::ALL(), 0);
     auto x_1D = subview(x, Kokkos::ALL(), 0);
     spmv(mode, a, A, x_1D, b, y_1D, RANK_ONE());

--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE_Cuda.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE_Cuda.hpp
@@ -288,7 +288,7 @@ public:
                      const output_scalar & b = output_scalar(0) )
   {
     const tensor_type tensor = Kokkos::cijk(A.values);
-    const size_type row_count = A.graph.row_map.dimension_0() - 1;
+    const size_type row_count = A.graph.row_map.extent(0) - 1;
     const size_type tensor_dimension = tensor.dimension();
     const size_type tensor_align = tensor_dimension;
     const size_type avg_tensor_entries_per_row = tensor.avg_entries_per_row();
@@ -508,7 +508,7 @@ public:
     typedef Multiply< matrix_type, input_vector_type_1D,
       output_vector_type_1D > multiply_type_1D;
 
-    const size_type num_col = y.dimension_1();
+    const size_type num_col = y.extent(1);
     for (size_type col=0; col<num_col; ++col)
 
       multiply_type_1D::apply(
@@ -602,7 +602,7 @@ public:
       , v_x( x )
       , m_a( a )
       , m_b( b )
-      , m_row_count( A.graph.row_map.dimension_0()-1 )
+      , m_row_count( A.graph.row_map.extent(0)-1 )
       , dim( dimension_scalar(x) )
       {}
 
@@ -669,7 +669,7 @@ public:
                      const input_scalar & a = input_scalar(1) ,
                      const output_scalar & b = output_scalar(0) )
   {
-    const size_t row_count = A.graph.row_map.dimension_0() - 1;
+    const size_t row_count = A.graph.row_map.extent(0) - 1;
     const size_type dim = dimension_scalar(x);
 
     // Compute number of threads for PCE coefficients and number of
@@ -789,8 +789,8 @@ public:
       , v_x( x )
       , m_a( a )
       , m_b( b )
-      , m_row_count( A.graph.row_map.dimension_0()-1 )
-      , m_num_col( x.dimension_1() )
+      , m_row_count( A.graph.row_map.extent(0)-1 )
+      , m_num_col( x.extent(1) )
       , dim( dimension_scalar(x) )
       {}
 
@@ -861,7 +861,7 @@ public:
                      const input_scalar & a = input_scalar(1) ,
                      const output_scalar & b = output_scalar(0) )
   {
-    const size_t row_count = A.graph.row_map.dimension_0() - 1;
+    const size_t row_count = A.graph.row_map.extent(0) - 1;
     const size_type dim = dimension_scalar(x);
 
     // Compute number of threads for PCE coefficients and number of

--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_MV_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_MV_UQ_PCE.hpp
@@ -319,7 +319,7 @@ V_ElementWiseMultiply(
   typedef View< typename BVector::data_type, typename BVector::array_layout, typename BVector::execution_space, typename BVector::memory_traits > BView;
 
   V_ElementWiseMultiplyFunctor<CView,AView,BView> op(c,C,ab,A,B) ;
-  Kokkos::parallel_for( C.dimension_0() , op );
+  Kokkos::parallel_for( C.extent(0) , op );
   return C;
 }
 
@@ -366,8 +366,8 @@ MV_ElementWiseMultiply(
   typedef View< typename AVector::data_type, typename AVector::array_layout, typename AVector::execution_space, typename AVector::memory_traits > AView;
   typedef View< typename BVector::data_type, typename BVector::array_layout, typename BVector::execution_space, typename BVector::memory_traits > BView;
 
-  MV_ElementWiseMultiplyFunctor<CView,AView,BView> op(c,C,ab,A,B,C.dimension_1()) ;
-  Kokkos::parallel_for( C.dimension_0() , op );
+  MV_ElementWiseMultiplyFunctor<CView,AView,BView> op(c,C,ab,A,B,C.extent(1)) ;
+  Kokkos::parallel_for( C.extent(0) , op );
   return C;
 }
 

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_TsqrAdaptor_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_TsqrAdaptor_UQ_PCE.hpp
@@ -364,8 +364,8 @@ namespace Tpetra {
       view_type pce_mv = A.getDualView();
       flat_array_type flat_mv = pce_mv.d_view;
 
-      numRows = static_cast<ordinal_type> (flat_mv.dimension_0 ());
-      numCols = static_cast<ordinal_type> (flat_mv.dimension_1 ());
+      numRows = static_cast<ordinal_type> (flat_mv.extent(0));
+      numCols = static_cast<ordinal_type> (flat_mv.extent(1));
       A_ptr = flat_mv.ptr_on_device ();
 
       ordinal_type strides[2];

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -1493,15 +1493,15 @@ struct StokhosViewFill< OutputView ,
       const size_type nvec = dimension_scalar(output);
 
       const size_type i0 = dev.league_rank() * nrow + tidy;
-      if ( i0 >= output.dimension_0() ) return;
+      if ( i0 >= output.extent(0) ) return;
 
-      for ( size_type i1 = 0 ; i1 < output.dimension_1() ; ++i1 ) {
-      for ( size_type i2 = 0 ; i2 < output.dimension_2() ; ++i2 ) {
-      for ( size_type i3 = 0 ; i3 < output.dimension_3() ; ++i3 ) {
-      for ( size_type i4 = 0 ; i4 < output.dimension_4() ; ++i4 ) {
-      for ( size_type i5 = 0 ; i5 < output.dimension_5() ; ++i5 ) {
-      for ( size_type i6 = 0 ; i6 < output.dimension_6() ; ++i6 ) {
-      for ( size_type i7 = 0 ; i7 < output.dimension_7() ; ++i7 ) {
+      for ( size_type i1 = 0 ; i1 < output.extent(1) ; ++i1 ) {
+      for ( size_type i2 = 0 ; i2 < output.extent(2) ; ++i2 ) {
+      for ( size_type i3 = 0 ; i3 < output.extent(3) ; ++i3 ) {
+      for ( size_type i4 = 0 ; i4 < output.extent(4) ; ++i4 ) {
+      for ( size_type i5 = 0 ; i5 < output.extent(5) ; ++i5 ) {
+      for ( size_type i6 = 0 ; i6 < output.extent(6) ; ++i6 ) {
+      for ( size_type i7 = 0 ; i7 < output.extent(7) ; ++i7 ) {
       for ( size_type is = tidx ; is < nvec ; is+=VectorLength ) {
         output(i0,i1,i2,i3,i4,i5,i6,i7).fastAccessCoeff(is) =
           input.fastAccessCoeff(is) ;
@@ -1525,7 +1525,7 @@ struct StokhosViewFill< OutputView ,
       const size_type block_size = 256;
 
       const size_type rows_per_block = block_size / vector_length;
-      const size_type n = output.dimension_0();
+      const size_type n = output.extent(0);
       const size_type league_size = ( n + rows_per_block-1 ) / rows_per_block;
       const size_type team_size = rows_per_block * vector_length;
       Kokkos::TeamPolicy< execution_space > config( league_size, team_size );

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Interlaced.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Interlaced.hpp
@@ -817,7 +817,7 @@ public:
 
   KOKKOS_FORCEINLINE_FUNCTION
   typename traits::value_type::storage_type::value_type *
-    ptr_on_device() const { return m_ptr_on_device ; }
+    data() const { return m_ptr_on_device ; }
 
   // Stride of physical storage, dimensioned to at least Rank
   template< typename iType >
@@ -861,13 +861,13 @@ void deep_copy( const View<DT,DL,DD,DM,Impl::ViewMPVectorInterlaced> & dst ,
   typedef typename dst_type::memory_space  dst_memory_space ;
   typedef typename src_type::memory_space  src_memory_space ;
 
-  if ( dst.ptr_on_device() != src.ptr_on_device() ) {
+  if ( dst.data() != src.data() ) {
 
     Impl::assert_shapes_are_equal( dst.shape() , src.shape() );
 
-    const size_t nbytes = sizeof(typename dst_type::value_type::storage_type::value_type) * dst.capacity();
+    const size_t nbytes = sizeof(typename dst_type::value_type::storage_type::value_type) * dst.span();
 
-    Impl::DeepCopy< dst_memory_space , src_memory_space >( dst.ptr_on_device() , src.ptr_on_device() , nbytes );
+    Impl::DeepCopy< dst_memory_space , src_memory_space >( dst.data() , src.data() , nbytes );
   }
 }
 

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_TpetraAdapter_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_TpetraAdapter_MP_Vector.hpp
@@ -366,7 +366,7 @@ namespace Belos {
       typedef Kokkos::View<dot_type**, Kokkos::LayoutLeft, execution_space> b_view_type;
       typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, execution_space> b_1d_view_type;
       b_1d_view_type B_1d_view_dev(Kokkos::ViewAllocateWithoutInitializing("B"), strideB*numColsB);
-      b_view_type B_view_dev( B_1d_view_dev.ptr_on_device(), strideB, numColsB);
+      b_view_type B_view_dev( B_1d_view_dev.data(), strideB, numColsB);
       Kokkos::deep_copy(B_view_dev, B_view_host);
 
       // Do local multiply
@@ -474,7 +474,7 @@ namespace Belos {
       typedef Kokkos::View<dot_type**, Kokkos::LayoutLeft, execution_space> c_view_type;
       typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, execution_space> c_1d_view_type;
       c_1d_view_type C_1d_view_dev("C", strideC*numColsC);
-      c_view_type C_view_dev( C_1d_view_dev.ptr_on_device(), strideC, numColsC);
+      c_view_type C_view_dev( C_1d_view_dev.data(), strideC, numColsC);
 
       // Do local multiply
       ::Tpetra::Details::Blas::gemm(
@@ -490,12 +490,12 @@ namespace Belos {
       else {
         typedef Kokkos::View<dot_type*, Kokkos::LayoutLeft, Kokkos::HostSpace> c_1d_host_view_type;
         c_1d_host_view_type C_1d_view_tmp(Kokkos::ViewAllocateWithoutInitializing("C_tmp"), strideC*numColsC);
-        c_host_view_type C_view_tmp( C_1d_view_tmp.ptr_on_device(),
+        c_host_view_type C_view_tmp( C_1d_view_tmp.data(),
                                      strideC, numColsC);
         Kokkos::deep_copy(C_view_tmp, C_view_dev);
         reduceAll<int> (*pcomm, REDUCE_SUM, strideC*numColsC,
-                        C_view_tmp.ptr_on_device(),
-                        C_view_host.ptr_on_device());
+                        C_view_tmp.data(),
+                        C_view_host.data());
       }
     }
 

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
@@ -155,7 +155,7 @@ public:
                      const output_vector_type & y,
                      const update_type & update )
   {
-    const size_type row_count = A.graph.row_map.dimension_0()-1;
+    const size_type row_count = A.graph.row_map.extent(0)-1;
     Kokkos::parallel_for( row_count, MPMultiply(A,x,y,update) );
   }
 };
@@ -234,7 +234,7 @@ public:
   {
     scalar_type sum;
     // Loop over columns of x, y
-    const size_type num_col = m_y.dimension_1();
+    const size_type num_col = m_y.extent(1);
     for (size_type col=0; col<num_col; ++col) {
       // Compute mat-vec for this row
       const size_type iEntryBegin = m_A.graph.row_map[iRow];
@@ -255,7 +255,7 @@ public:
                      const output_vector_type & y,
                      const update_type & update )
   {
-    const size_type row_count = A.graph.row_map.dimension_0()-1;
+    const size_type row_count = A.graph.row_map.extent(0)-1;
     Kokkos::parallel_for( row_count, MPMultiply(A,x,y,update) );
   }
 };
@@ -481,7 +481,7 @@ spmv(
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for transposed or conjugated matrix-vector multiplies");
   }
-  if (y.dimension_1() == 1) {
+  if (y.extent(1) == 1) {
     auto y_1D = subview(y, Kokkos::ALL(), 0);
     auto x_1D = subview(x, Kokkos::ALL(), 0);
     spmv(mode, a, A, x_1D, b, y_1D, RANK_ONE());

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector_Cuda.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector_Cuda.hpp
@@ -146,7 +146,7 @@ public:
       , m_x( x )
       , m_y( y )
       , m_update( update )
-      , m_row_count( A.graph.row_map.dimension_0()-1 )
+      , m_row_count( A.graph.row_map.extent(0)-1 )
       {}
 
     __device__
@@ -235,7 +235,7 @@ public:
     size_type rows_per_block = A.dev_config.block_dim.y;
     if (rows_per_block == 0)
       rows_per_block = 256 / threads_per_vector;
-    const size_type row_count = A.graph.row_map.dimension_0()-1;
+    const size_type row_count = A.graph.row_map.extent(0)-1;
     const size_type num_blocks = (row_count+rows_per_block-1)/rows_per_block;
     const dim3 block( threads_per_vector, rows_per_block, 1 );
     const dim3 grid( num_blocks, 1 );
@@ -395,8 +395,8 @@ public:
       , m_x( x )
       , m_y( y )
       , m_update( update )
-      , m_row_count( A.graph.row_map.dimension_0()-1 )
-      , m_num_vec_cols( x.dimension_1() )
+      , m_row_count( A.graph.row_map.extent(0)-1 )
+      , m_num_vec_cols( x.extent(1) )
       {}
 
     __device__
@@ -493,7 +493,7 @@ public:
     size_type rows_per_block = A.dev_config.block_dim.y;
     if (rows_per_block == 0)
       rows_per_block = 256 / threads_per_vector;
-    const size_type row_count = A.graph.row_map.dimension_0()-1;
+    const size_type row_count = A.graph.row_map.extent(0)-1;
     const size_type num_blocks = (row_count+rows_per_block-1)/rows_per_block;
     const dim3 block( threads_per_vector, rows_per_block, 1 );
     const dim3 grid( num_blocks, 1 );

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_TsqrAdaptor_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_TsqrAdaptor_MP_Vector.hpp
@@ -364,8 +364,8 @@ namespace Tpetra {
       view_type mp_mv = A.getDualView();
       flat_array_type flat_mv = mp_mv.d_view;
 
-      numRows = static_cast<ordinal_type> (flat_mv.dimension_0 ());
-      numCols = static_cast<ordinal_type> (flat_mv.dimension_1 ());
+      numRows = static_cast<ordinal_type> (flat_mv.extent(0));
+      numCols = static_cast<ordinal_type> (flat_mv.extent(1));
       A_ptr = flat_mv.ptr_on_device ();
 
       ordinal_type strides[2];

--- a/packages/stokhos/test/Performance/FadMPAssembly/BoxElemFixture.hpp
+++ b/packages/stokhos/test/Performance/FadMPAssembly/BoxElemFixture.hpp
@@ -155,7 +155,7 @@ public:
   typedef Kokkos::View< const unsigned *     , Device > send_nodeid_type ;
 
   KOKKOS_INLINE_FUNCTION
-  unsigned node_count() const { return m_node_grid.dimension_0(); }
+  unsigned node_count() const { return m_node_grid.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   unsigned node_count_owned() const { return m_box_part.owns_node_count(); }
@@ -164,7 +164,7 @@ public:
   unsigned node_count_global() const { return m_box_part.global_node_count(); }
 
   KOKKOS_INLINE_FUNCTION
-  unsigned elem_count() const { return m_elem_node.dimension_0(); }
+  unsigned elem_count() const { return m_elem_node.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   unsigned elem_count_global() const { return m_box_part.global_elem_count(); }
@@ -278,11 +278,11 @@ public:
     }
 
     const size_t nwork = 
-      std::max( m_recv_node.dimension_0() ,
-      std::max( m_send_node.dimension_0() ,
-      std::max( m_send_node_id.dimension_0() ,
-      std::max( m_node_grid.dimension_0() ,
-                m_elem_node.dimension_0() * m_elem_node.dimension_1() ))));
+      std::max( m_recv_node.extent(0) ,
+      std::max( m_send_node.extent(0) ,
+      std::max( m_send_node_id.extent(0) ,
+      std::max( m_node_grid.extent(0) ,
+                m_elem_node.extent(0) * m_elem_node.extent(1) ))));
 
     Kokkos::parallel_for( nwork , *this );
   }
@@ -293,7 +293,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t i ) const
   {
-    if ( i < m_elem_node.dimension_0() * m_elem_node.dimension_1() ) {
+    if ( i < m_elem_node.extent(0) * m_elem_node.extent(1) ) {
 
       const size_t ielem = i / ElemNode ;
       const size_t inode = i % ElemNode ;
@@ -313,7 +313,7 @@ public:
       m_elem_node(ielem,inode) = m_box_part.local_node_id( node_grid );
     }
 
-    if ( i < m_node_grid.dimension_0() ) {
+    if ( i < m_node_grid.extent(0) ) {
       unsigned node_grid[SpaceDim] ;
       m_box_part.local_node_coord( i , node_grid );
       m_node_grid(i,0) = node_grid[0] ;
@@ -328,17 +328,17 @@ public:
                    m_node_coord(i,2) );
     }
 
-    if ( i < m_recv_node.dimension_0() ) {
+    if ( i < m_recv_node.extent(0) ) {
       m_recv_node(i,0) = m_box_part.recv_node_rank(i);
       m_recv_node(i,1) = m_box_part.recv_node_count(i);
     }
 
-    if ( i < m_send_node.dimension_0() ) {
+    if ( i < m_send_node.extent(0) ) {
       m_send_node(i,0) = m_box_part.send_node_rank(i);
       m_send_node(i,1) = m_box_part.send_node_count(i);
     }
 
-    if ( i < m_send_node_id.dimension_0() ) {
+    if ( i < m_send_node_id.extent(0) ) {
       m_send_node_id(i) = m_box_part.send_node_id(i);
     }
   }

--- a/packages/stokhos/test/Performance/FadMPAssembly/TestAssembly.hpp
+++ b/packages/stokhos/test/Performance/FadMPAssembly/TestAssembly.hpp
@@ -294,10 +294,10 @@ bool check_residuals(const ScalarViewType& scalar_residual,
   Kokkos::deep_copy( host_scalar_residual, scalar_residual );
   Kokkos::deep_copy( host_ensemble_residual, ensemble_residual );
 
-  TEUCHOS_TEST_EQUALITY( host_scalar_residual.dimension_0(),
-                         host_ensemble_residual.dimension_0(), fbuf, success );
+  TEUCHOS_TEST_EQUALITY( host_scalar_residual.extent(0),
+                         host_ensemble_residual.extent(0), fbuf, success );
 
-  const size_t num_node = host_scalar_residual.dimension_0();
+  const size_t num_node = host_scalar_residual.extent(0);
   const size_t num_ensemble = Kokkos::dimension_scalar(host_ensemble_residual);
   for (size_t i=0; i<num_node; ++i) {
     for (size_t j=0; j<num_ensemble; ++j) {

--- a/packages/stokhos/test/Performance/FadMPAssembly/VectorImport.hpp
+++ b/packages/stokhos/test/Performance/FadMPAssembly/VectorImport.hpp
@@ -157,7 +157,7 @@ public:
       , source( arg_source )
       , buffer( arg_buffer )
     {
-      Kokkos::parallel_for( index.dimension_0() , *this );
+      Kokkos::parallel_for( index.extent(0) , *this );
       execution_space::fence();
     }
   };
@@ -189,7 +189,7 @@ public:
       }
 
       unsigned send_count = 0 ;
-      for ( unsigned i = 0 ; i < send_msg.dimension_0() ; ++i ) { send_count += host_send_msg(i,1); }
+      for ( unsigned i = 0 ; i < send_msg.extent(0) ; ++i ) { send_count += host_send_msg(i,1); }
       send_buffer      = VectorType("send_buffer",send_count);
       host_send_buffer = Kokkos::create_mirror_view( send_buffer );
     }
@@ -205,19 +205,19 @@ public:
     MPI_Comm mpi_comm = * teuchos_mpi_comm.getRawMpiComm();
 
     const int mpi_tag = 42 ;
-    const unsigned chunk = v.dimension_1();
+    const unsigned chunk = v.extent(1);
 
     // Subvector for receives
     const std::pair<unsigned,unsigned> recv_range( count_owned , count_owned + count_receive );
     const VectorType recv_vector = Kokkos::subview( v , recv_range );
 
-    std::vector< MPI_Request > recv_request( recv_msg.dimension_0() , MPI_REQUEST_NULL );
+    std::vector< MPI_Request > recv_request( recv_msg.extent(0) , MPI_REQUEST_NULL );
 
     // Post receives
     if (ReceiveInPlace) {
-      scalar_type * ptr = recv_vector.ptr_on_device();
+      scalar_type * ptr = recv_vector.data();
 
-      for ( size_t i = 0 ; i < recv_msg.dimension_0() ; ++i ) {
+      for ( size_t i = 0 ; i < recv_msg.extent(0) ; ++i ) {
         const int proc  = host_recv_msg(i,0);
         const int count = host_recv_msg(i,1) * chunk ;
 
@@ -228,9 +228,9 @@ public:
       }
     }
     else {
-      host_scalar_type * ptr = host_recv_buffer.ptr_on_device();
+      host_scalar_type * ptr = host_recv_buffer.data();
 
-      for ( size_t i = 0 ; i < recv_msg.dimension_0() ; ++i ) {
+      for ( size_t i = 0 ; i < recv_msg.extent(0) ; ++i ) {
         const int proc  = host_recv_msg(i,0);
         const int count = host_recv_msg(i,1) * chunk ;
 
@@ -249,9 +249,9 @@ public:
 
       Kokkos::deep_copy( host_send_buffer , send_buffer );
 
-      host_scalar_type * ptr = host_send_buffer.ptr_on_device();
+      host_scalar_type * ptr = host_send_buffer.data();
 
-      for ( size_t i = 0 ; i < send_msg.dimension_0() ; ++i ) {
+      for ( size_t i = 0 ; i < send_msg.extent(0) ; ++i ) {
         const int proc  = host_send_msg(i,0);
         const int count = host_send_msg(i,1) * chunk ;
 
@@ -272,12 +272,12 @@ public:
 
     // Wait for receives and verify:
 
-    for ( size_t i = 0 ; i < recv_msg.dimension_0() ; ++i ) {
+    for ( size_t i = 0 ; i < recv_msg.extent(0) ; ++i ) {
       MPI_Status recv_status ;
       int recv_which = 0 ;
       int recv_size  = 0 ;
 
-      MPI_Waitany( recv_msg.dimension_0() , & recv_request[0] , & recv_which , & recv_status );
+      MPI_Waitany( recv_msg.extent(0) , & recv_request[0] , & recv_which , & recv_status );
 
       const int recv_proc = recv_status.MPI_SOURCE ;
 

--- a/packages/stokhos/test/Performance/FadMPAssembly/fenl_functors.hpp
+++ b/packages/stokhos/test/Performance/FadMPAssembly/fenl_functors.hpp
@@ -107,7 +107,7 @@ struct CrsMatrix {
 
   CrsMatrix( const StaticCrsGraphType & arg_graph )
     : graph( arg_graph )
-    , values( "crs_matrix_values" , arg_graph.entries.dimension_0() )
+    , values( "crs_matrix_values" , arg_graph.entries.extent(0) )
     {}
 };
 
@@ -268,7 +268,7 @@ public:
         // May be larger that requested:
         set_capacity = node_node_set.capacity();
 
-        Kokkos::parallel_for( elem_node_id.dimension_0() , *this );
+        Kokkos::parallel_for( elem_node_id.extent(0) , *this );
       }
 
       execution_space::fence();
@@ -329,8 +329,8 @@ public:
       // Element-to-graph mapping:
       wall_clock.reset();
       phase = FILL_ELEMENT_GRAPH ;
-      elem_graph = ElemGraphType("elem_graph", elem_node_id.dimension_0() );
-      Kokkos::parallel_for( elem_node_id.dimension_0() , *this );
+      elem_graph = ElemGraphType("elem_graph", elem_node_id.extent(0) );
+      Kokkos::parallel_for( elem_node_id.extent(0) , *this );
 
       execution_space::fence();
       results.fill_element_graph = wall_clock.seconds();
@@ -343,25 +343,25 @@ public:
   void fill_set( const unsigned ielem ) const
   {
     // Loop over element's (row_local_node,col_local_node) pairs:
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         // If either node is locally owned then insert the pair into the unordered map:
 
-        if ( row_node < row_count.dimension_0() || col_node < row_count.dimension_0() ) {
+        if ( row_node < row_count.extent(0) || col_node < row_count.extent(0) ) {
 
           const key_type key = (row_node < col_node) ? make_pair( row_node, col_node ) : make_pair( col_node, row_node ) ;
 
           const typename SetType::insert_result result = node_node_set.insert( key );
 
           if ( result.success() ) {
-            if ( row_node < row_count.dimension_0() ) { atomic_fetch_add( & row_count( row_node ) , (typename RowMapType::value_type)1 ); }
-            if ( col_node < row_count.dimension_0() && col_node != row_node ) { atomic_fetch_add( & row_count( col_node ) , (typename RowMapType::value_type)1 ); }
+            if ( row_node < row_count.extent(0) ) { atomic_fetch_add( & row_count( row_node ) , (typename RowMapType::value_type)1 ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_fetch_add( & row_count( col_node ) , (typename RowMapType::value_type)1 ); }
           }
         }
       }
@@ -376,12 +376,12 @@ public:
       const unsigned row_node = key.first ;
       const unsigned col_node = key.second ;
 
-      if ( row_node < row_count.dimension_0() ) {
+      if ( row_node < row_count.extent(0) ) {
         const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , (typename RowMapType::value_type)1 );
         graph.entries( offset ) = col_node ;
       }
 
-      if ( col_node < row_count.dimension_0() && col_node != row_node ) {
+      if ( col_node < row_count.extent(0) && col_node != row_node ) {
         const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , (typename RowMapType::value_type)1 );
         graph.entries( offset ) = row_node ;
       }
@@ -408,17 +408,17 @@ public:
   void fill_elem_graph_map( const unsigned ielem ) const
   {
     typedef typename CrsGraphType::data_type entry_type;
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         entry_type entry = 0 ;
 
-        if ( row_node + 1 < graph.row_map.dimension_0() ) {
+        if ( row_node + 1 < graph.row_map.extent(0) ) {
 
           const entry_type entry_end = static_cast<entry_type> (graph.row_map( row_node + 1 ));
 
@@ -465,7 +465,7 @@ public:
     update += row_count( irow );
 
     if ( final ) {
-      if ( irow + 1 == row_count.dimension_0() ) {
+      if ( irow + 1 == row_count.extent(0) ) {
         row_map( irow + 1 ) = update ;
         row_total()         = update ;
       }
@@ -809,7 +809,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -847,7 +847,7 @@ public:
   {
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < this->residual.dimension_0() ) {
+      if ( row < this->residual.extent(0) ) {
         atomic_add( & this->residual( row ) , res[i] );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -1024,7 +1024,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -1056,7 +1056,7 @@ public:
   {
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < this->residual.dimension_0() ) {
+      if ( row < this->residual.extent(0) ) {
         atomic_add( & this->residual( row ) , res[i].val() );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -1205,7 +1205,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -1371,7 +1371,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = this->elem_node_ids.dimension_0();
+    const size_t nelem = this->elem_node_ids.extent(0);
     parallel_for( nelem , *this );
   }
 
@@ -1597,7 +1597,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = elem_node_ids.dimension_0();
+    const size_t nelem = elem_node_ids.extent(0);
     if ( use_team ) {
       const size_t team_size = dev_config.block_dim.x * dev_config.block_dim.y;
       const size_t league_size =
@@ -1761,7 +1761,7 @@ public:
     const unsigned ielem =
       dev.league_rank() * num_element_threads + element_rank;
 
-    if (ielem >= elem_node_ids.dimension_0())
+    if (ielem >= elem_node_ids.extent(0))
       return;
 
     (*this)( ielem, ensemble_rank );
@@ -1851,7 +1851,7 @@ public:
 
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < residual.dimension_0() ) {
+      if ( row < residual.extent(0) ) {
         atomic_add( & local_residual( row ) , elem_vec[i] );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {

--- a/packages/stokhos/test/Performance/KokkosArraySPMVKernels/TestStochastic.hpp
+++ b/packages/stokhos/test/Performance/KokkosArraySPMVKernels/TestStochastic.hpp
@@ -470,7 +470,7 @@ test_product_flat_commuted_matrix(
   matrix.graph = Kokkos::create_staticcrsgraph<matrix_graph_type>(
     std::string("testing") , flat_graph );
 
-  const size_t flat_graph_length = matrix.graph.entries.dimension_0();
+  const size_t flat_graph_length = matrix.graph.entries.extent(0);
 
   matrix.values = matrix_values_type( Kokkos::ViewAllocateWithoutInitializing("matrix"), flat_graph_length );
 
@@ -625,7 +625,7 @@ test_product_flat_original_matrix(
 
   matrix.graph = Kokkos::create_staticcrsgraph<matrix_graph_type>( std::string("testing") , flat_graph );
 
-  const size_t flat_graph_length = matrix.graph.entries.dimension_0();
+  const size_t flat_graph_length = matrix.graph.entries.extent(0);
 
   matrix.values = matrix_values_type( Kokkos::ViewAllocateWithoutInitializing("matrix"), flat_graph_length );
 

--- a/packages/stokhos/test/Performance/MPAssembly/BoxElemFixture.hpp
+++ b/packages/stokhos/test/Performance/MPAssembly/BoxElemFixture.hpp
@@ -157,7 +157,7 @@ public:
   inline bool ok() const { return m_box_part.ok(); }
 
   KOKKOS_INLINE_FUNCTION
-  size_t node_count() const { return m_node_grid.dimension_0(); }
+  size_t node_count() const { return m_node_grid.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   size_t node_count_owned() const { return m_box_part.owns_node_count(); }
@@ -166,7 +166,7 @@ public:
   size_t node_count_global() const { return m_box_part.global_node_count(); }
 
   KOKKOS_INLINE_FUNCTION
-  size_t elem_count() const { return m_elem_node.dimension_0(); }
+  size_t elem_count() const { return m_elem_node.extent(0); }
 
   KOKKOS_INLINE_FUNCTION
   size_t elem_count_global() const { return m_box_part.global_elem_count(); }
@@ -280,11 +280,11 @@ public:
     }
 
     const size_t nwork =
-      std::max( m_recv_node.dimension_0() ,
-      std::max( m_send_node.dimension_0() ,
-      std::max( m_send_node_id.dimension_0() ,
-      std::max( m_node_grid.dimension_0() ,
-                m_elem_node.dimension_0() * m_elem_node.dimension_1() ))));
+      std::max( m_recv_node.extent(0) ,
+      std::max( m_send_node.extent(0) ,
+      std::max( m_send_node_id.extent(0) ,
+      std::max( m_node_grid.extent(0) ,
+                m_elem_node.extent(0) * m_elem_node.extent(1) ))));
 
     Kokkos::parallel_for( nwork , *this );
   }
@@ -295,7 +295,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t i ) const
   {
-    if ( i < m_elem_node.dimension_0() * m_elem_node.dimension_1() ) {
+    if ( i < m_elem_node.extent(0) * m_elem_node.extent(1) ) {
 
       const size_t ielem = i / ElemNode ;
       const size_t inode = i % ElemNode ;
@@ -315,7 +315,7 @@ public:
       m_elem_node(ielem,inode) = m_box_part.local_node_id( nodeGrid );
     }
 
-    if ( i < m_node_grid.dimension_0() ) {
+    if ( i < m_node_grid.extent(0) ) {
       size_t nodeGrid[SpaceDim] ;
       m_box_part.local_node_coord( i , nodeGrid );
       m_node_grid(i,0) = nodeGrid[0] ;
@@ -330,17 +330,17 @@ public:
                    m_node_coord(i,2) );
     }
 
-    if ( i < m_recv_node.dimension_0() ) {
+    if ( i < m_recv_node.extent(0) ) {
       m_recv_node(i,0) = m_box_part.recv_node_rank(i);
       m_recv_node(i,1) = m_box_part.recv_node_count(i);
     }
 
-    if ( i < m_send_node.dimension_0() ) {
+    if ( i < m_send_node.extent(0) ) {
       m_send_node(i,0) = m_box_part.send_node_rank(i);
       m_send_node(i,1) = m_box_part.send_node_count(i);
     }
 
-    if ( i < m_send_node_id.dimension_0() ) {
+    if ( i < m_send_node_id.extent(0) ) {
       m_send_node_id(i) = m_box_part.send_node_id(i);
     }
   }

--- a/packages/stokhos/test/Performance/MPAssembly/TestAssembly.hpp
+++ b/packages/stokhos/test/Performance/MPAssembly/TestAssembly.hpp
@@ -316,10 +316,10 @@ bool check_residuals(const ScalarViewType& scalar_residual,
   Kokkos::deep_copy( host_scalar_residual, scalar_residual );
   Kokkos::deep_copy( host_ensemble_residual, ensemble_residual );
 
-  TEUCHOS_TEST_EQUALITY( host_scalar_residual.dimension_0(),
-                         host_ensemble_residual.dimension_0(), fbuf, success );
+  TEUCHOS_TEST_EQUALITY( host_scalar_residual.extent(0),
+                         host_ensemble_residual.extent(0), fbuf, success );
 
-  const size_t num_node = host_scalar_residual.dimension_0();
+  const size_t num_node = host_scalar_residual.extent(0);
   const size_t num_ensemble = Kokkos::dimension_scalar(host_ensemble_residual);
   for (size_t i=0; i<num_node; ++i) {
     for (size_t j=0; j<num_ensemble; ++j) {

--- a/packages/stokhos/test/Performance/MPAssembly/VectorImport.hpp
+++ b/packages/stokhos/test/Performance/MPAssembly/VectorImport.hpp
@@ -157,7 +157,7 @@ public:
       , source( arg_source )
       , buffer( arg_buffer )
     {
-      Kokkos::parallel_for( index.dimension_0() , *this );
+      Kokkos::parallel_for( index.extent(0) , *this );
       execution_space::fence();
     }
   };
@@ -189,7 +189,7 @@ public:
       }
 
       unsigned send_count = 0 ;
-      for ( unsigned i = 0 ; i < send_msg.dimension_0() ; ++i ) { send_count += host_send_msg(i,1); }
+      for ( unsigned i = 0 ; i < send_msg.extent(0) ; ++i ) { send_count += host_send_msg(i,1); }
       send_buffer      = VectorType("send_buffer",send_count);
       host_send_buffer = Kokkos::create_mirror_view( send_buffer );
     }
@@ -205,19 +205,19 @@ public:
     MPI_Comm mpi_comm = * teuchos_mpi_comm.getRawMpiComm();
 
     const int mpi_tag = 42 ;
-    const unsigned chunk = v.dimension_1();
+    const unsigned chunk = v.extent(1);
 
     // Subvector for receives
     const std::pair<unsigned,unsigned> recv_range( count_owned , count_owned + count_receive );
     const VectorType recv_vector = Kokkos::subview( v , recv_range );
 
-    std::vector< MPI_Request > recv_request( recv_msg.dimension_0() , MPI_REQUEST_NULL );
+    std::vector< MPI_Request > recv_request( recv_msg.extent(0) , MPI_REQUEST_NULL );
 
     // Post receives
     if (ReceiveInPlace) {
-      scalar_type * ptr = recv_vector.ptr_on_device();
+      scalar_type * ptr = recv_vector.data();
 
-      for ( size_t i = 0 ; i < recv_msg.dimension_0() ; ++i ) {
+      for ( size_t i = 0 ; i < recv_msg.extent(0) ; ++i ) {
         const int proc  = host_recv_msg(i,0);
         const int count = host_recv_msg(i,1) * chunk ;
 
@@ -228,9 +228,9 @@ public:
       }
     }
     else {
-      host_scalar_type * ptr = host_recv_buffer.ptr_on_device();
+      host_scalar_type * ptr = host_recv_buffer.data();
 
-      for ( size_t i = 0 ; i < recv_msg.dimension_0() ; ++i ) {
+      for ( size_t i = 0 ; i < recv_msg.extent(0) ; ++i ) {
         const int proc  = host_recv_msg(i,0);
         const int count = host_recv_msg(i,1) * chunk ;
 
@@ -249,9 +249,9 @@ public:
 
       Kokkos::deep_copy( host_send_buffer , send_buffer );
 
-      host_scalar_type * ptr = host_send_buffer.ptr_on_device();
+      host_scalar_type * ptr = host_send_buffer.data();
 
-      for ( size_t i = 0 ; i < send_msg.dimension_0() ; ++i ) {
+      for ( size_t i = 0 ; i < send_msg.extent(0) ; ++i ) {
         const int proc  = host_send_msg(i,0);
         const int count = host_send_msg(i,1) * chunk ;
 
@@ -272,12 +272,12 @@ public:
 
     // Wait for receives and verify:
 
-    for ( size_t i = 0 ; i < recv_msg.dimension_0() ; ++i ) {
+    for ( size_t i = 0 ; i < recv_msg.extent(0) ; ++i ) {
       MPI_Status recv_status ;
       int recv_which = 0 ;
       int recv_size  = 0 ;
 
-      MPI_Waitany( recv_msg.dimension_0() , & recv_request[0] , & recv_which , & recv_status );
+      MPI_Waitany( recv_msg.extent(0) , & recv_request[0] , & recv_which , & recv_status );
 
       const int recv_proc = recv_status.MPI_SOURCE ;
 

--- a/packages/stokhos/test/Performance/MPAssembly/fenl_functors.hpp
+++ b/packages/stokhos/test/Performance/MPAssembly/fenl_functors.hpp
@@ -103,7 +103,7 @@ struct CrsMatrix {
 
   CrsMatrix( const StaticCrsGraphType & arg_graph )
     : graph( arg_graph )
-    , values( "crs_matrix_values" , arg_graph.entries.dimension_0() )
+    , values( "crs_matrix_values" , arg_graph.entries.extent(0) )
     {}
 };
 
@@ -264,7 +264,7 @@ public:
         // May be larger that requested:
         set_capacity = node_node_set.capacity();
 
-        Kokkos::parallel_for( elem_node_id.dimension_0() , *this );
+        Kokkos::parallel_for( elem_node_id.extent(0) , *this );
       }
 
       execution_space::fence();
@@ -325,8 +325,8 @@ public:
       // Element-to-graph mapping:
       wall_clock.reset();
       phase = FILL_ELEMENT_GRAPH ;
-      elem_graph = ElemGraphType("elem_graph", elem_node_id.dimension_0() );
-      Kokkos::parallel_for( elem_node_id.dimension_0() , *this );
+      elem_graph = ElemGraphType("elem_graph", elem_node_id.extent(0) );
+      Kokkos::parallel_for( elem_node_id.extent(0) , *this );
 
       execution_space::fence();
       results.fill_element_graph = wall_clock.seconds();
@@ -339,25 +339,25 @@ public:
   void fill_set( const unsigned ielem ) const
   {
     // Loop over element's (row_local_node,col_local_node) pairs:
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = row_local_node ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         // If either node is locally owned then insert the pair into the unordered map:
 
-        if ( row_node < row_count.dimension_0() || col_node < row_count.dimension_0() ) {
+        if ( row_node < row_count.extent(0) || col_node < row_count.extent(0) ) {
 
           const key_type key = (row_node < col_node) ? make_pair( row_node, col_node ) : make_pair( col_node, row_node ) ;
 
           const typename SetType::insert_result result = node_node_set.insert( key );
 
           if ( result.success() ) {
-            if ( row_node < row_count.dimension_0() ) { atomic_fetch_add( & row_count( row_node ) , (typename RowMapType::value_type)1 ); }
-            if ( col_node < row_count.dimension_0() && col_node != row_node ) { atomic_fetch_add( & row_count( col_node ) , (typename RowMapType::value_type)1 ); }
+            if ( row_node < row_count.extent(0) ) { atomic_fetch_add( & row_count( row_node ) , (typename RowMapType::value_type)1 ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_fetch_add( & row_count( col_node ) , (typename RowMapType::value_type)1 ); }
           }
         }
       }
@@ -372,12 +372,12 @@ public:
       const unsigned row_node = key.first ;
       const unsigned col_node = key.second ;
 
-      if ( row_node < row_count.dimension_0() ) {
+      if ( row_node < row_count.extent(0) ) {
         const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , (typename RowMapType::value_type)1 );
         graph.entries( offset ) = col_node ;
       }
 
-      if ( col_node < row_count.dimension_0() && col_node != row_node ) {
+      if ( col_node < row_count.extent(0) && col_node != row_node ) {
         const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , (typename RowMapType::value_type)1 );
         graph.entries( offset ) = row_node ;
       }
@@ -404,17 +404,17 @@ public:
   void fill_elem_graph_map( const unsigned ielem ) const
   {
     typedef typename CrsGraphType::data_type entry_type;
-    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.dimension_1() ; ++row_local_node ) {
+    for ( unsigned row_local_node = 0 ; row_local_node < elem_node_id.extent(1) ; ++row_local_node ) {
 
       const unsigned row_node = elem_node_id( ielem , row_local_node );
 
-      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.dimension_1() ; ++col_local_node ) {
+      for ( unsigned col_local_node = 0 ; col_local_node < elem_node_id.extent(1) ; ++col_local_node ) {
 
         const unsigned col_node = elem_node_id( ielem , col_local_node );
 
         entry_type entry = 0 ;
 
-        if ( row_node + 1 < graph.row_map.dimension_0() ) {
+        if ( row_node + 1 < graph.row_map.extent(0) ) {
 
           const entry_type entry_end = static_cast<entry_type> (graph.row_map( row_node + 1 ));
 
@@ -461,7 +461,7 @@ public:
     update += row_count( irow );
 
     if ( final ) {
-      if ( irow + 1 == row_count.dimension_0() ) {
+      if ( irow + 1 == row_count.extent(0) ) {
         row_map( irow + 1 ) = update ;
         row_total()         = update ;
       }
@@ -700,7 +700,7 @@ public:
 
   void apply() const
   {
-    const size_t nelem = elem_node_ids.dimension_0();
+    const size_t nelem = elem_node_ids.extent(0);
     if ( use_team ) {
       const size_t team_size = dev_config.block_dim.x * dev_config.block_dim.y;
       const size_t league_size =
@@ -864,7 +864,7 @@ public:
     const unsigned ielem =
       dev.league_rank() * num_element_threads + element_rank;
 
-    if (ielem >= elem_node_ids.dimension_0())
+    if (ielem >= elem_node_ids.extent(0))
       return;
 
     (*this)( ielem, ensemble_rank );
@@ -954,7 +954,7 @@ public:
 
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
-      if ( row < residual.dimension_0() ) {
+      if ( row < residual.extent(0) ) {
         atomic_add( & local_residual( row ) , elem_vec[i] );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
@@ -1177,7 +1177,7 @@ public:
   {
     value_type response = 0;
     //Kokkos::parallel_reduce( fixture.elem_count() , *this , response );
-    Kokkos::parallel_reduce( solution.dimension_0() , *this , response );
+    Kokkos::parallel_reduce( solution.extent(0) , *this , response );
     return response;
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosArrayKernelsUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosArrayKernelsUnitTest.hpp
@@ -997,7 +997,7 @@ test_crs_flat_commuted(const UnitTestSetup<Device>& setup,
   matrix.graph = Kokkos::create_staticcrsgraph<matrix_graph_type>(
     std::string("testing") , flat_graph );
 
-  const size_t flat_graph_length = matrix.graph.entries.dimension_0();
+  const size_t flat_graph_length = matrix.graph.entries.extent(0);
 
   matrix.values = matrix_values_type( "matrix" , flat_graph_length );
   {
@@ -1144,7 +1144,7 @@ test_crs_flat_original(const UnitTestSetup<Device>& setup,
 
   matrix.graph = Kokkos::create_staticcrsgraph<matrix_graph_type>( std::string("testing") , flat_graph );
 
-  const size_t flat_graph_length = matrix.graph.entries.dimension_0();
+  const size_t flat_graph_length = matrix.graph.entries.extent(0);
 
   matrix.values = matrix_values_type( "matrix" , flat_graph_length );
   {

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest.hpp
@@ -143,8 +143,8 @@ bool compare_rank_2_views(const array_type& y,
   Kokkos::deep_copy(hy, y);
   Kokkos::deep_copy(hy_exp, y_exp);
 
-  size_type num_rows = y.dimension_0();
-  size_type num_cols = y.dimension_1();
+  size_type num_rows = y.extent(0);
+  size_type num_cols = y.extent(1);
   bool success = true;
   for (size_type i=0; i<num_rows; ++i) {
     for (size_type j=0; j<num_cols; ++j) {

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixUQPCEUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixUQPCEUnitTest.hpp
@@ -179,8 +179,8 @@ bool compare_rank_2_views(const array_type& y,
   Kokkos::deep_copy(hy, y);
   Kokkos::deep_copy(hy_exp, y_exp);
 
-  size_type num_rows = y.dimension_0();
-  size_type num_cols = y.dimension_1();
+  size_type num_rows = y.extent(0);
+  size_type num_cols = y.extent(1);
   bool success = true;
   for (size_type i=0; i<num_rows; ++i) {
     for (size_type j=0; j<num_cols; ++j) {
@@ -216,7 +216,7 @@ bool compareRank1(const vector_type& y,
   Kokkos::deep_copy(hy, y);
   Kokkos::deep_copy(hy_exp, y_exp);
 
-  size_type num_rows = y.dimension_0();
+  size_type num_rows = y.extent(0);
   bool success = true;
   for (size_type i=0; i<num_rows; ++i) {
     for (size_type j=0; j<Kokkos::dimension_scalar(y); ++j) {
@@ -251,8 +251,8 @@ bool compareRank2(const vector_type& y,
   Kokkos::deep_copy(hy, y);
   Kokkos::deep_copy(hy_exp, y_exp);
 
-  size_type num_rows = y.dimension_0();
-  size_type num_cols = y.dimension_1();
+  size_type num_rows = y.extent(0);
+  size_type num_cols = y.extent(1);
   bool success = true;
 
  for (size_type col = 0; col < num_cols; ++col){

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest.hpp
@@ -92,12 +92,12 @@ checkVectorView(const ViewType& v,
   bool is_right = Kokkos::Impl::is_same< typename ViewType::array_layout,
                                          Kokkos::LayoutRight >::value;
   if (is_right || !view_type::is_contiguous) {
-    num_rows = h_a.dimension_0();
-    num_cols = h_a.dimension_1();
+    num_rows = h_a.extent(0);
+    num_cols = h_a.extent(1);
   }
   else {
-    num_rows = h_a.dimension_1();
-    num_cols = h_a.dimension_0();
+    num_rows = h_a.extent(1);
+    num_cols = h_a.extent(0);
   }
   bool success = true;
   if (is_right || !view_type::is_contiguous) {
@@ -142,7 +142,7 @@ checkConstantFadVectorView(const ViewType& view,
   host_view_type h_view = Kokkos::create_mirror_view(view);
   Kokkos::deep_copy(h_view, view);
 
-  const size_type num_rows = h_view.dimension_0();
+  const size_type num_rows = h_view.extent(0);
   const size_type num_fad = Kokkos::dimension_scalar(h_view)-1;
   const size_type num_ensemble = storage_type::static_size;
   bool success = true;
@@ -177,13 +177,13 @@ checkConstantFadVectorView2(const ViewType& view,
   bool success = true;
   const size_type num_fad = Kokkos::dimension_scalar(h_view)-1;
   const size_type num_ensemble = storage_type::static_size;
-  for (size_type i0=0; i0<h_view.dimension_0(); ++i0) {
-  for (size_type i1=0; i1<h_view.dimension_1(); ++i1) {
-  for (size_type i2=0; i2<h_view.dimension_2(); ++i2) {
-  for (size_type i3=0; i3<h_view.dimension_3(); ++i3) {
-  for (size_type i4=0; i4<h_view.dimension_4(); ++i4) {
-  for (size_type i5=0; i5<h_view.dimension_5(); ++i5) {
-  for (size_type i6=0; i6<h_view.dimension_6(); ++i6) {
+  for (size_type i0=0; i0<h_view.extent(0); ++i0) {
+  for (size_type i1=0; i1<h_view.extent(1); ++i1) {
+  for (size_type i2=0; i2<h_view.extent(2); ++i2) {
+  for (size_type i3=0; i3<h_view.extent(3); ++i3) {
+  for (size_type i4=0; i4<h_view.extent(4); ++i4) {
+  for (size_type i5=0; i5<h_view.extent(5); ++i5) {
+  for (size_type i6=0; i6<h_view.extent(6); ++i6) {
     for (size_type k=0; k<num_ensemble; ++k)
       TEUCHOS_TEST_EQUALITY(h_view(i0,i1,i2,i3,i4,i5,i6,0).val().coeff(k),
                             v.val().coeff(k), out, success);

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewMPVectorUnitTest.hpp
@@ -90,12 +90,12 @@ checkVectorView(const ViewType& v,
   bool is_right = Kokkos::Impl::is_same< typename ViewType::array_layout,
                                          Kokkos::LayoutRight >::value;
   if (is_right) {
-    num_rows = h_a.dimension_0();
-    num_cols = h_a.dimension_1();
+    num_rows = h_a.extent(0);
+    num_cols = h_a.extent(1);
   }
   else {
-    num_rows = h_a.dimension_1();
-    num_cols = h_a.dimension_0();
+    num_rows = h_a.extent(1);
+    num_cols = h_a.extent(0);
   }
   bool success = true;
   if (is_right) {
@@ -138,7 +138,7 @@ checkConstantVectorView(const ViewType& v,
   host_view_type h_v = Kokkos::create_mirror_view(v);
   Kokkos::deep_copy(h_v, v);
 
-  const size_type num_rows = h_v.dimension_0();
+  const size_type num_rows = h_v.extent(0);
   const size_type num_cols = Kokkos::dimension_scalar(h_v);
   bool success = true;
   for (size_type i=0; i<num_rows; ++i) {
@@ -417,7 +417,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Kokkos_View_MP, Unmanaged, Storage, Layout )
   Kokkos::deep_copy(v, h_v);
 
   // Create unmanaged view
-  ViewType v2(v.ptr_on_device(), num_rows, num_cols);
+  ViewType v2(v.data(), num_rows, num_cols);
 
   success = checkVectorView(v2, out);
 }
@@ -535,7 +535,7 @@ struct MPVectorAtomicFunctor {
 
   MPVectorAtomicFunctor( const ViewType & v , const scalar_type & s ) : m_v( v ), m_s( s )
   {
-    Kokkos::parallel_for( m_v.dimension_0() , *this );
+    Kokkos::parallel_for( m_v.extent(0) , *this );
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewUQPCEUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewUQPCEUnitTest.hpp
@@ -120,12 +120,12 @@ checkPCEView(const ViewType& v, Teuchos::FancyOStream& out) {
   bool is_right = Kokkos::Impl::is_same< typename ViewType::array_layout,
                                          Kokkos::LayoutRight >::value;
   if (is_right) {
-    num_rows = h_a.dimension_0();
-    num_cols = h_a.dimension_1();
+    num_rows = h_a.extent(0);
+    num_cols = h_a.extent(1);
   }
   else {
-    num_rows = h_a.dimension_1();
-    num_cols = h_a.dimension_0();
+    num_rows = h_a.extent(1);
+    num_cols = h_a.extent(0);
   }
   bool success = true;
   if (is_right) {
@@ -168,7 +168,7 @@ checkConstantPCEView(const ViewType& v,
   host_view_type h_v = Kokkos::create_mirror_view(v);
   Kokkos::deep_copy(h_v, v);
 
-  const size_type num_rows = h_v.dimension_0();
+  const size_type num_rows = h_v.extent(0);
   const size_type num_cols = Kokkos::dimension_scalar(h_v);
 
   bool success = true;
@@ -540,7 +540,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Kokkos_View_PCE, Unmanaged, Storage, Layout )
 
   // Create unmanaged view
   ViewType v2 =
-    Kokkos::make_view<ViewType>( v.ptr_on_device(), cijk, num_rows, num_cols );
+    Kokkos::make_view<ViewType>( v.data(), cijk, num_rows, num_cols );
 
   success = checkPCEView(v2, out);
 }
@@ -561,7 +561,7 @@ struct PCEAtomicFunctor {
   PCEAtomicFunctor( const ViewType & v , const scalar_type & s ) :
     m_v( v ), m_s( s )
   {
-    Kokkos::parallel_for( m_v.dimension_0() , *this );
+    Kokkos::parallel_for( m_v.extent(0) , *this );
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
For issue #2717.  This gets all the ones I can find.  Unfortunately I
can't test it gets all of them, because Kokkos itself does not compile
with deprecated functions disabled.