### PR TITLE
Use cmake 3.11 1 and ninja for RHEL ATDM Trilinos build

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -301,9 +301,10 @@ $ salloc -N1 --time=0:20:00 --account=<YOUR_WCID> \
 
 ### SEMS rhel6 environment
 
-Once logged on to a rhel6 machine with the sems NFS, one can
-directly configure, build, and run tests.  For example, to configure, build and run 
-the tests for `MueuLu` one would clone Trilinos on the `develop` branch and then do the following:
+Once logged on to a rhel6 machine with the sems NFS, one can directly
+configure, build, and run tests.  For example, to configure, build and run the
+tests for `MueuLu` one would clone Trilinos on the `develop` branch and then
+do the following:
 
 
 ```
@@ -312,11 +313,12 @@ $ cd <some_build_dir>/
 $ source $TRILINOS_DIR/cmake/std/atdm/load-env.sh intel-opt-openmp
 
 $ cmake \
+  -GNinja \
   -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
   -DTrilinos_ENABLE_TESTS=ON -DTrilinos_ENABLE_MueLu=ON \
   $TRILINOS_DIR
 
-$ make -j16
+$ make NP=16
 
 $ ctest -j16 \
 ```

--- a/cmake/std/atdm/checkin-test-atdm.sh
+++ b/cmake/std/atdm/checkin-test-atdm.sh
@@ -168,7 +168,24 @@ done
 # ToDo: Implement
 
 #
-# D) Loop over individual builds and run them
+# D) Write default local-checkin-test-defaults.py file
+#
+
+_LOCAL_CHECKIN_TEST_DEFAULTS=local-checkin-test-defaults.py
+if [ -f $_LOCAL_CHECKIN_TEST_DEFAULTS ] ; then
+  echo "File $_LOCAL_CHECKIN_TEST_DEFAULTS already exists, leaving it!"
+else
+  echo "Creating default file $_LOCAL_CHECKIN_TEST_DEFAULTS!"
+  echo "
+defaults = [
+  \"--enable-all-package=off\",
+  \"--no-enable-fwd-packages\",
+  ]
+  " > $_LOCAL_CHECKIN_TEST_DEFAULTS
+fi
+
+#
+# E) Loop over individual builds and run them
 #
 
 echo
@@ -205,7 +222,7 @@ for ATDM_JOB_NAME_KEYS in $ATDM_JOB_NAME_KEYS_LIST ; do
 done
 
 #
-# E) Collect the results from all the builds
+# F) Collect the results from all the builds
 #
 
 echo
@@ -226,7 +243,7 @@ ATDM_CHT_RETURN_CODE=$?
 # NOTE The return value will be 0 if everything passed!
 
 #
-# F) Print final status
+# G) Print final status
 #
 
 echo

--- a/cmake/std/atdm/rhel6/environment.sh
+++ b/cmake/std/atdm/rhel6/environment.sh
@@ -8,15 +8,16 @@
 
 echo "Using SEMS RHEL6 compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE"
 
-export ATDM_CONFIG_USE_NINJA=OFF
+export ATDM_CONFIG_USE_NINJA=ON
 export ATDM_CONFIG_BUILD_COUNT=32
 
 module purge
 module load sems-env
-module load sems-cmake/3.5.2
 module load sems-git/2.10.1
 
-#module load ninja/1.7.2
+module load atdm-env
+module load atdm-cmake/3.11.1
+module load atdm-ninja_fortran/1.7.2
 
 if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16


### PR DESCRIPTION
CC: @fryeguy52 

## Description

See the commits log messages.  Good stuff.

## How Has This Been Tested?

Locally on crf450 I ran:

```
$ ./checkin-test-atdm.sh gnu-opt-openmp --enable-packages=Teuchos --local-do-all
```

and it returned

```
PASSED (NOT READY TO PUSH): Trilinos: crf450.srn.sandia.gov

Thu May 10 16:55:41 MDT 2018

Enabled Packages: Teuchos

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) gnu-opt-openmp => passed: passed=131,notpassed=0 (0.92 min)
```

## Checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
