### PR TITLE
Move the mpiexec args before -np not after (#2699)

### DIFF
--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -67,7 +67,8 @@ export MPICC=`which mpicc`
 export MPICXX=`which mpicxx`
 export MPIF90=`which mpif90`
 
-export ATDM_CONFIG_MPI_POST_FLAG="--bind-to;core;--npernode;36"
+export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;core;--npernode;36"
+export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=--n
 
 # Set the default compilers
 export CC=mpicc


### PR DESCRIPTION
CC: @fryeguy52, @jmgate 

The instructions on the 'serrano' support page say that these arguments should
go before the -np argument, not after the --n arugment.  I am hoping this will fix
some of the failures we are seeing as described in #2699.

Also, I changed the -np argument to --n to match exactly what the 'serrano'
support page says to do.

## How Has This Been Tested?

On serrano, I ran:

```
$ ./checkin-test-atdm.sh intel-opt-openmp --enable-packages=Rythmos,MueLu --configure --build

$ salloc -N1 --time=00:20:00 --account=fy150090 \
  ./checkin-test-atdm.sh intel-opt-openmp --enable-packages=Rythmos,MueLu --test
```

That returned:

```
PASSED (NOT READY TO PUSH): Trilinos: serrano-login5

Thu May 10 17:30:21 MDT 2018

Enabled Packages: Rythmos, MueLu

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) intel-opt-openmp => passed: passed=125,notpassed=0 (1.06 min)
```

Now, all of the Rythmos tests were already passing for the `intel-opt-openmp` build.  But the fact there were no failing MueLu tests is hopeful.

NOTE: I could not run the `intel-debug-openmp` build because it takes up too much disk space and bombs out my 50G disk quota before it completes the build.  It would be nice to run that build because that is were we saw the most failures.


## Checklist

- [ ] All new and existing tests passed.
