### PR TITLE
MueLu: Build Kokkos version of factories from extended input format

### DIFF
--- a/packages/muelu/src/Interface/MueLu_FactoryFactory_decl.hpp
+++ b/packages/muelu/src/Interface/MueLu_FactoryFactory_decl.hpp
@@ -141,6 +141,16 @@
 #include "MueLu_ZoltanInterface.hpp"
 #include "MueLu_Zoltan2Interface.hpp"
 
+#ifdef HAVE_MUELU_KOKKOS_REFACTOR
+#include "MueLu_CoalesceDropFactory_kokkos.hpp"
+#include "MueLu_CoarseMapFactory_kokkos.hpp"
+#include "MueLu_CoordinatesTransferFactory_kokkos.hpp"
+#include "MueLu_NullspaceFactory_kokkos.hpp"
+#include "MueLu_SaPFactory_kokkos.hpp"
+#include "MueLu_TentativePFactory_kokkos.hpp"
+#include "MueLu_UncoupledAggregationFactory_kokkos.hpp"
+#endif
+
 #ifdef HAVE_MUELU_MATLAB
 // This is distasteful, but (sadly) neccesary due to peculiarities in MueLu's build system.
 #include "../matlab/src/MueLu_SingleLevelMatlabFactory_decl.hpp"
@@ -254,6 +264,15 @@ namespace MueLu {
       if (factoryName == "UserAggregationFactory")             return Build2<UserAggregationFactory>             (paramList, factoryMapIn, factoryManagersIn);
       if (factoryName == "UserPFactory")                       return Build2<UserPFactory>                       (paramList, factoryMapIn, factoryManagersIn);
       if (factoryName == "VariableDofLaplacianFactory")        return Build2<VariableDofLaplacianFactory>        (paramList, factoryMapIn, factoryManagersIn);
+#ifdef HAVE_MUELU_KOKKOS_REFACTOR
+      if (factoryName == "CoalesceDropFactory_kokkos")         return Build2<CoalesceDropFactory_kokkos>         (paramList, factoryMapIn, factoryManagersIn);
+      if (factoryName == "CoarseMapFactory_kokkos")            return Build2<CoarseMapFactory_kokkos>            (paramList, factoryMapIn, factoryManagersIn);
+      if (factoryName == "CoordinatesTransferFactory_kokkos")  return Build2<CoordinatesTransferFactory_kokkos>  (paramList, factoryMapIn, factoryManagersIn);
+      if (factoryName == "NullspaceFactory_kokkos")            return Build2<NullspaceFactory_kokkos>            (paramList, factoryMapIn, factoryManagersIn);
+      if (factoryName == "SaPFactory_kokkos")                  return Build2<SaPFactory_kokkos>                  (paramList, factoryMapIn, factoryManagersIn);
+      if (factoryName == "TentativePFactory_kokkos")           return Build2<TentativePFactory_kokkos>           (paramList, factoryMapIn, factoryManagersIn);
+      if (factoryName == "UncoupledAggregationFactory_kokkos") return Build2<UncoupledAggregationFactory_kokkos> (paramList, factoryMapIn, factoryManagersIn);
+#endif
 
       if (factoryName == "ZoltanInterface") {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
@@ -69,6 +69,15 @@
 #include "MueLu_UncoupledAggregationFactory_fwd.hpp"
 #include "MueLu_ZoltanInterface_fwd.hpp"
 
+#ifdef HAVE_MUELU_KOKKOS_REFACTOR
+#include "MueLu_CoalesceDropFactory_kokkos_fwd.hpp"
+#include "MueLu_CoarseMapFactory_kokkos_fwd.hpp"
+#include "MueLu_NullspaceFactory_kokkos_fwd.hpp"
+#include "MueLu_SaPFactory_kokkos_fwd.hpp"
+#include "MueLu_TentativePFactory_kokkos_fwd.hpp"
+#include "MueLu_UncoupledAggregationFactory_kokkos_fwd.hpp"
+#endif
+
 namespace MueLu {
 
   /*!

--- a/packages/muelu/utils/paramlist/convertToKokkos.py
+++ b/packages/muelu/utils/paramlist/convertToKokkos.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+import xml.etree.ElementTree as ET
+import argparse
+
+
+parser = argparse.ArgumentParser(description="Convert an extended xml input file to use Kokkos")
+parser.add_argument("-o", "--output", dest="output",
+                    default="out.xml", help="xml output file")
+parser.add_argument('xml', metavar='xml', type=str, nargs='+',
+                    help='an integer for the accumulator')
+
+options = parser.parse_args()
+
+if len(options.xml) > 1:
+    outfiles = options.xml
+else:
+    outfiles = [options.output]
+
+for fn, out in zip(options.xml, outfiles):
+    tree = ET.parse(fn)
+    root = tree.getroot()
+
+    factoryList = root.findall("*[@name='Factories']")
+    if len(factoryList) == 1:
+        # extended format
+        factoryList = factoryList[0]
+        factoriesToDelete = []
+        for factoryParams in factoryList.findall("ParameterList"):
+            factory = factoryParams.findall("*[@name='factory']")
+            assert len(factory) == 1
+            factory = factory[0]
+            factoryName = factory.attrib['value']
+            # rename factories to *_kokkos
+            if factoryName in ('CoalesceDropFactory',
+                               'CoarseMapFactory',
+                               'CoordinatesTransferFactory',
+                               'NullspaceFactory',
+                               'SaPFactory',
+                               'TentativePFactory',
+                               'UncoupledAggregationFactory'):
+                factory.attrib['value'] += '_kokkos'
+            # delete FilteredAFactory
+            if factoryName == 'FilteredAFactory':
+                factoriesToDelete.append(factoryParams.attrib['name'])
+                factoryList.remove(factoryParams)
+
+        # delete references to deleted factories
+        for factory in factoriesToDelete:
+            for el in root.findall(".//*[@value='{}']/..".format(factory)):
+                for el2 in el.findall(".//*[@value='{}']".format(factory)):
+                    el.remove(el2)
+    elif len(factoryList) == 0:
+        # simple format
+        useKokkos = ET.Element('Parameter')
+        useKokkos.set('name', 'use kokkos refactor')
+        useKokkos.set('type', 'bool')
+        useKokkos.set('value', 'true')
+        root.append(useKokkos)
+    else:
+        raise Exception("xml has wrong format.")
+
+    tree.write(out)


### PR DESCRIPTION
@trilinos/muelu 

## Description
Allows to build the `*_kokkos` factories from the extended interface. All factories are accesible by their full name, e.g. `NullspaceFactory_kokkos`. The script `convertToKokkos.py` is an attempt at converting xml input files to Kokkos.

Closes Issue #2663
