### PR TITLE
Epetra: small change in CMakeList.txt for IntMultiVector_Distributed test

### DIFF
--- a/packages/epetra/test/IntMultiVectorDistributed/CMakeLists.txt
+++ b/packages/epetra/test/IntMultiVectorDistributed/CMakeLists.txt
@@ -3,7 +3,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   IntMultiVectorDistributed_test
   SOURCES cxx_main.cpp
   ARGS -v
-  COMM mpi serial
+  COMM mpi
   NUM_MPI_PROCS 4
   FAIL_REGULAR_EXPRESSION "tests FAILED"
   )


### PR DESCRIPTION
@trilinos/epetra 

## Description
This change requires that an MPI communicator be available to run the test.
This makes sense since the goal of the test is to check the behavior of
object when it is actually distributed among multiple ranks. Some of the
checks base on rank number would not make sense in serial.

## Motivation and Context
This fix is need to have a clean dashboard

## Related Issues

* Closes #2743

## How Has This Been Tested?
I compiled and ran the tests using the same configuration as the failing build.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.