### PR TITLE
Promote Trilinos-atdm-toss3-intel-opt-openmp-panzer to "ATDM" CDash Track/Group (TRIL-200)

### DIFF
--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+export Trilinos_TRACK=ATDM
 export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:20:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh


### PR DESCRIPTION
This build has been 100% clean and passing all Panzer tests the last 5 days, including today.
