### PR TITLE
Allow previously "ATDM" promoted builds on 'ride' to be demoted (TRIL-208)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-debug-panzer.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-debug-panzer.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-debug.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-opt-panzer.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-opt-panzer.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-debug-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-debug-openmp-panzer.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-opt-openmp-panzer.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh


### PR DESCRIPTION
Some random module failures on 'ride' require that we demote all of these
builds on 'ride' back to the "Specialized" CDash Track/Group so that they will
not spam Trilinos developers (and me) with CDash error emails.

By putting in an 'if' statement, I allow the Jenkins drivers on 'ride' to set:

  export Trilinos_TRACK=Specialized

but the builds on 'white' can still submit to the "ATDM" CDash Track/Group.

See:

* https://software-sandbox.sandia.gov/jira/browse/TRIL-208
