### PR TITLE
Tril 200 serrano fixups

### DIFF
--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp-panzer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:20:00
+export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:45:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh

--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=ATDM
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:20:00
+export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:15:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -272,11 +272,12 @@ $ cd <some_build_dir>/
 $ source $TRILINOS_DIR/cmake/std/atdm/load-env.sh intel-opt-openmp
 
 $ cmake \
+  -GNinja \
   -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
   -DTrilinos_ENABLE_TESTS=ON -DTrilinos_ENABLE_MueLu=ON \
   $TRILINOS_DIR
 
-$ make -j16
+$ make NP=16
 
 $ salloc -N1 --time=0:20:00 --account=<YOUR_WCID> ctest -j16
 ```
@@ -291,12 +292,10 @@ the configure and build as with:
 $ cd <some_build_dir>/
 $ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-sems.sh .
 $ ./checkin-test-sems.sh intel-opt-openmp \
-  --enable-all-packages=off --no-enable-fwd-packages --enable-packages=MueLu \
-  --allow-no-pull --configure --build
+  --enable-packages=MueLu --allow-no-pull --configure --build
 $ salloc -N1 --time=0:20:00 --account=<YOUR_WCID> \
   ./checkin-test-sems.sh intel-opt-openmp \
-  --enable-all-packages=off --no-enable-fwd-packages --enable-packages=MueLu \
-  --test
+  --enable-packages=MueLu --test
 ```
 
 ### SEMS rhel6 environment

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -8,16 +8,15 @@
 
 echo "Using toss3 compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE"
 
-# there does not appear to be a ninja module ontoss3 so turn off ninja
-export ATDM_CONFIG_USE_MAKEFILES=ON
+export ATDM_CONFIG_USE_NINJA=ON
 export ATDM_CONFIG_BUILD_COUNT=16
-export ATDM_CONFIG_USE_NINJA=OFF
 
 module purge
 . /projects/sems/modulefiles/utils/sems-modules-init.sh
 module load sems-env
 module load atdm-env
 module load atdm-cmake/3.10.1
+module load atdm-ninja_fortran/1.7.2
 
 
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -26,8 +26,8 @@ else
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
 fi
 
-#export Kokkos_Arch=BDW
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
+    export ATDM_CONFIG_KOKKOS_ARCH=BDW
     module load sems-python/2.7.9
     module load sems-intel/17.0.0
     module load sems-openmpi/1.10.5

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -66,7 +66,7 @@ export MPICC=`which mpicc`
 export MPICXX=`which mpicxx`
 export MPIF90=`which mpif90`
 
-export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;core;--npernode;36"
+export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;core;--npernode;36;--report-bindings"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=--n
 
 # Set the default compilers

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -66,7 +66,7 @@ export MPICC=`which mpicc`
 export MPICXX=`which mpicxx`
 export MPIF90=`which mpif90`
 
-export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;core;--npernode;36;--report-bindings"
+export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;socket;--report-bindings"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=--n
 
 # Set the default compilers

--- a/cmake/std/atdm/toss3/tweaks/INTEL-DEBUG-OPENMP.cmake
+++ b/cmake/std/atdm/toss3/tweaks/INTEL-DEBUG-OPENMP.cmake
@@ -1,0 +1,2 @@
+# Disable test that is failing or timing out in this build (see #2751)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)


### PR DESCRIPTION
@trilinos/<teamName>

## Description

This PR contains several fix-ups for the builds on 'serrano'.  See the set of commits for what the changes are.  There are good descriptions in the log messages in those.

However, the big things are:

* Disable the Panzer test `PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3` for intel-debug-openmp builds (#2751, commit 652a011)

* Try to fix failing tests by setting `KOKKOS_ARCH=BDW` (1a271e5) and switch to `mpiexec --bind-by socket` (e1944ed)  (#2699)

* Enabled the usage of Ninja (297cf26)

## Related Issues

* Related to: #2751, #2699 

## How Has This Been Tested?

I tested this locally on 'serrano' using:

```
$ ./checkin-test-atdm.sh intel-opt-openmp \
   --enable-packages=Kokkos,Panzer --allow-no-pull --configure --build --send-email-to=

$ salloc -N1 --time=0:20:00 --account=fy150090 \
  ./checkin-test-atdm.sh intel-opt-openmp \
 --enable-packages=Kokkos,Panzer --test
```

This gave the result:

```
PASSED (NOT READY TO PUSH): Trilinos: serrano-login5

Wed May 16 08:23:59 MDT 2018

Enabled Packages: Kokkos, Panzer

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) intel-opt-openmp => passed: passed=180,notpassed=0 (2.68 min)
```

Unfortunately, I can't currently test the `intel-debug-openmp` build because it takes too much disk space and there is a quote of 50G in my home space on 'serrano'.  I only have the disk space to test the `intel-opt-openmp` build.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
