### PR TITLE
Tpetra: Deprecate is{Lower,Upper}Triangular per #2630; deprecate CrsMatrixSolveOp per #581; remove spurious warnings

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -998,9 +998,10 @@ namespace Tpetra {
     /// methods, not if <i>we</i> call them.
     size_t getNodeNumDiagsImpl () const override;
 
-    /// \brief Maximum number of entries in all rows over all processes.
+    /// \brief Maximum number of entries in any row of the graph,
+    ///   over all processes in the graph's communicator.
     ///
-    /// \note Undefined if isFillActive().
+    /// \pre <tt>! isFillActive()</tt>
     ///
     /// \note This is the same as the result of a global maximum of
     ///   getNodeMaxNumRowEntries() over all processes.  That may not
@@ -1010,12 +1011,13 @@ namespace Tpetra {
     ///   row.  This method only counts the number of entries in each
     ///   row that a process owns, not the total number of entries in
     ///   the row over all processes.
-    size_t getGlobalMaxNumRowEntries() const;
+    size_t getGlobalMaxNumRowEntries () const;
 
-    //! \brief Maximum number of entries in all rows owned by the calling process.
-    /** Undefined if isFillActive().
-     */
-    size_t getNodeMaxNumRowEntries() const;
+    /// \brief Maximum number of entries in any row of the graph,
+    ///   on this process.
+    ///
+    /// \pre <tt>! isFillActive()</tt>
+    size_t getNodeMaxNumRowEntries () const;
 
     /// \brief Whether the graph has a column Map.
     ///
@@ -1025,13 +1027,14 @@ namespace Tpetra {
     /// does not already have one.
     ///
     /// A column Map lets the graph
-    ///
-    ///   - use local indices for storing entries in each row, and
-    ///   - compute an Import from the domain Map to the column Map.
+    /// <ul>
+    /// <li> use local indices for storing entries in each row, and </li>
+    /// <li> compute an Import from the domain Map to the column Map. </li>
+    /// </ul>
     ///
     /// The latter is mainly useful for a graph associated with a
     /// CrsMatrix.
-    bool hasColMap() const;
+    bool hasColMap () const;
 
     /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -181,6 +181,22 @@ namespace Tpetra {
       STORAGE_1D_PACKED, //<! 1-D "packed" storage
       STORAGE_UB //<! Invalid value; upper bound on enum values
     };
+
+
+    /// \brief Mix-in to avoid spurious deprecation warnings due to #2630.
+    ///
+    /// CrsMatrix has methods deprecated by #2630, that need to call
+    /// CrsGraph methods also deprecated by #2630.  This results in
+    /// spurious deprecation warnings.  This mix-in class gives Tpetra
+    /// developers a work-around so that CrsMatrix's and
+    /// BlockCrsMatrix's deprecated methods can call CrsGraph's
+    /// deprecated methods without emitting spurious warnings.
+    class HasDeprecatedMethods2630_WarningThisClassIsNotForUsers {
+    public:
+      virtual ~HasDeprecatedMethods2630_WarningThisClassIsNotForUsers() {}
+      virtual size_t getGlobalNumDiagsImpl () const = 0;
+      virtual global_size_t getNodeNumDiagsImpl () const = 0;
+    };
   } // namespace Details
 
   /// \class CrsGraph
@@ -250,7 +266,8 @@ namespace Tpetra {
                       LocalOrdinal,
                       GlobalOrdinal,
                       Node>,
-    public Teuchos::ParameterListAcceptorDefaultBase
+    public Teuchos::ParameterListAcceptorDefaultBase,
+    public Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers
   {
     template <class S, class LO, class GO, class N>
     friend class CrsMatrix;
@@ -945,6 +962,19 @@ namespace Tpetra {
     ///   go away at any time.
     global_size_t TPETRA_DEPRECATED getGlobalNumDiags() const;
 
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings in CrsMatrix and BlockCrsMatrix.  We only want users
+    /// to see deprecated warnings if <i>they</i> call deprecated
+    /// methods, not if <i>we</i> call them.
+    global_size_t getGlobalNumDiagsImpl () const override;
+
     /// \brief Number of diagonal entries on the calling process.
     ///
     /// \pre <tt>! this->isFillActive()</tt>
@@ -952,6 +982,19 @@ namespace Tpetra {
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
     size_t TPETRA_DEPRECATED getNodeNumDiags() const;
+
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings in CrsMatrix and BlockCrsMatrix.  We only want users
+    /// to see deprecated warnings if <i>they</i> call deprecated
+    /// methods, not if <i>we</i> call them.
+    size_t getNodeNumDiagsImpl () const override;
 
     /// \brief Maximum number of entries in all rows over all processes.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -193,7 +193,9 @@ namespace Tpetra {
     /// deprecated methods without emitting spurious warnings.
     class HasDeprecatedMethods2630_WarningThisClassIsNotForUsers {
     public:
-      virtual ~HasDeprecatedMethods2630_WarningThisClassIsNotForUsers() {}
+      virtual ~HasDeprecatedMethods2630_WarningThisClassIsNotForUsers () {}
+      virtual bool isLowerTriangularImpl () const = 0;
+      virtual bool isUpperTriangularImpl () const = 0;
       virtual size_t getGlobalNumDiagsImpl () const = 0;
       virtual global_size_t getNodeNumDiagsImpl () const = 0;
     };
@@ -1031,23 +1033,55 @@ namespace Tpetra {
     /// CrsMatrix.
     bool hasColMap() const;
 
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings in CrsMatrix and BlockCrsMatrix.  We only want users
+    /// to see deprecated warnings if <i>they</i> call deprecated
+    /// methods, not if <i>we</i> call them.
+    bool isLowerTriangularImpl () const override;
+
     /// \brief Whether the graph is locally lower triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
     ///
     /// \pre <tt>! isFillActive()</tt>.
     ///   If fill is active, this method's behavior is undefined.
     ///
     /// \note This is entirely a local property.  That means this
     ///   method may return different results on different processes.
-    bool isLowerTriangular() const;
+    bool TPETRA_DEPRECATED isLowerTriangular () const;
+
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings in CrsMatrix and BlockCrsMatrix.  We only want users
+    /// to see deprecated warnings if <i>they</i> call deprecated
+    /// methods, not if <i>we</i> call them.
+    bool isUpperTriangularImpl () const override;
 
     /// \brief Whether the graph is locally upper triangular.
     ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
     /// \pre <tt>! isFillActive()</tt>.
     ///   If fill is active, this method's behavior is undefined.
     ///
     /// \note This is entirely a local property.  That means this
     ///   method may return different results on different processes.
-    bool isUpperTriangular() const;
+    bool TPETRA_DEPRECATED isUpperTriangular () const;
 
     //! \brief If graph indices are in the local range, this function returns true. Otherwise, this function returns false. */
     bool isLocallyIndexed() const;

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -848,16 +848,25 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   size_t
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  getNodeNumDiags () const
+  getNodeNumDiagsImpl () const
   {
     return nodeNumDiags_;
   }
 
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  size_t
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  getNodeNumDiags () const
+  {
+    return this->getNodeNumDiagsImpl ();
+  }
+
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
   global_size_t
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  getGlobalNumDiags () const
+  getGlobalNumDiagsImpl () const
   {
     const char tfecfFuncName[] = "getGlobalNumDiags: ";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -866,6 +875,15 @@ namespace Tpetra {
        "but the user has requested them.");
 
     return globalNumDiags_;
+  }
+
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  global_size_t
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  getGlobalNumDiags () const
+  {
+    return this->getGlobalNumDiagsImpl ();
   }
 
 

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1105,9 +1105,9 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  isUpperTriangular () const
+  isLowerTriangularImpl () const
   {
-    return upperTriangular_;
+    return this->lowerTriangular_;
   }
 
 
@@ -1116,7 +1116,25 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   isLowerTriangular () const
   {
-    return lowerTriangular_;
+    return this->isLowerTriangularImpl ();
+  }
+
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  isUpperTriangularImpl () const
+  {
+    return this->upperTriangular_;
+  }
+
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  isUpperTriangular () const
+  {
+    return this->isUpperTriangularImpl ();
   }
 
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrixSolveOp.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrixSolveOp.hpp
@@ -53,6 +53,8 @@ namespace Tpetra {
 
   /// \class CrsMatrixSolveOp
   /// \brief Wrap a CrsMatrix instance's triangular solve in an Operator.
+  /// \warning This class is DEPRECATED, along with CrsMatrix::localSolve.
+  ///   DO NOT USE IT ANY MORE!  It may disappear at any time.
   ///
   /// \tparam Scalar Same as the first template parameter of Operator.
   ///   The type of the entries of the MultiVector input and output of
@@ -90,7 +92,7 @@ namespace Tpetra {
             class LocalOrdinal = ::Tpetra::Details::DefaultTypes::local_ordinal_type,
             class GlobalOrdinal = ::Tpetra::Details::DefaultTypes::global_ordinal_type,
             class Node = ::Tpetra::Details::DefaultTypes::node_type>
-  class CrsMatrixSolveOp :
+  class CrsMatrixSolveOp TPETRA_DEPRECATED :
     public Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
   public:
     //! The specialization of CrsMatrix which this class wraps.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2274,28 +2274,49 @@ namespace Tpetra {
     ///   go away at any time.
     size_t TPETRA_DEPRECATED getNodeNumDiags() const;
 
-    //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
-    /** Undefined if isFillActive().
-     */
+    /// \brief Maximum number of entries in any row of the matrix,
+    ///   over all processes.
+    ///
+    /// \pre <tt>! isFillActive()</tt>
+    ///
+    /// This method only uses the matrix's graph.  Explicitly stored
+    /// zeros count as "entries."
     size_t getGlobalMaxNumRowEntries() const;
 
-    //! \brief Returns the maximum number of entries across all rows/columns on this node.
-    /** Undefined if isFillActive().
-     */
+    /// \brief Maximum number of entries in any row of the matrix on this process.
+    ///
+    /// \pre <tt>! isFillActive()</tt>
+    ///
+    /// This method only uses the matrix's graph.  Explicitly stored
+    /// zeros count as "entries."
     size_t getNodeMaxNumRowEntries() const;
 
-    //! \brief Indicates whether the matrix has a well-defined column map.
-    bool hasColMap() const;
+    //! Whether the matrix has a well-defined column Map.
+    bool hasColMap () const;
 
-    //! \brief Indicates whether the matrix is lower triangular.
-    /** Undefined if isFillActive().
-     */
-    bool isLowerTriangular() const;
+    /// \brief Whether the matrix is locally lower triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre <tt>! isFillActive()</tt>.
+    ///   If fill is active, this method's behavior is undefined.
+    ///
+    /// \note This is entirely a local property.  That means this
+    ///   method may return different results on different processes.
+    bool TPETRA_DEPRECATED isLowerTriangular () const;
 
-    //! \brief Indicates whether the matrix is upper triangular.
-    /** Undefined if isFillActive().
-     */
-    bool isUpperTriangular() const;
+    /// \brief Whether the matrix is locally upper triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre <tt>! isFillActive()</tt>.
+    ///   If fill is active, this method's behavior is undefined.
+    ///
+    /// \note This is entirely a local property.  That means this
+    ///   method may return different results on different processes.
+    bool TPETRA_DEPRECATED isUpperTriangular () const;
 
     /// \brief Whether the matrix is locally indexed on the calling process.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2263,7 +2263,7 @@ namespace Tpetra {
     ///
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
-    global_size_t TPETRA_DEPRECATED getGlobalNumDiags() const;
+    global_size_t TPETRA_DEPRECATED getGlobalNumDiags () const;
 
     /// \brief Number of diagonal entries in the matrix's graph, on
     ///   the calling process.
@@ -2272,24 +2272,25 @@ namespace Tpetra {
     ///
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
-    size_t TPETRA_DEPRECATED getNodeNumDiags() const;
+    size_t TPETRA_DEPRECATED getNodeNumDiags () const;
 
     /// \brief Maximum number of entries in any row of the matrix,
-    ///   over all processes.
+    ///   over all processes in the matrix's communicator.
     ///
     /// \pre <tt>! isFillActive()</tt>
     ///
     /// This method only uses the matrix's graph.  Explicitly stored
     /// zeros count as "entries."
-    size_t getGlobalMaxNumRowEntries() const;
+    size_t getGlobalMaxNumRowEntries () const;
 
-    /// \brief Maximum number of entries in any row of the matrix on this process.
+    /// \brief Maximum number of entries in any row of the matrix,
+    ///   on this process.
     ///
     /// \pre <tt>! isFillActive()</tt>
     ///
     /// This method only uses the matrix's graph.  Explicitly stored
     /// zeros count as "entries."
-    size_t getNodeMaxNumRowEntries() const;
+    size_t getNodeMaxNumRowEntries () const;
 
     //! Whether the matrix has a well-defined column Map.
     bool hasColMap () const;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -847,14 +847,18 @@ namespace Tpetra {
   bool
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   isLowerTriangular () const {
-    return getCrsGraphRef ().isLowerTriangular ();
+    const crs_graph_type& G = this->getCrsGraphRef ();
+    using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (G).isLowerTriangularImpl ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   isUpperTriangular () const {
-    return getCrsGraphRef ().isUpperTriangular ();
+    const crs_graph_type& G = this->getCrsGraphRef ();
+    using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (G).isUpperTriangularImpl ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -727,14 +727,18 @@ namespace Tpetra {
   global_size_t
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getGlobalNumDiags () const {
-    return getCrsGraphRef ().getGlobalNumDiags ();
+    const crs_graph_type& G = this->getCrsGraphRef ();
+    using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (G).getGlobalNumDiagsImpl ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   size_t
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getNodeNumDiags () const {
-    return getCrsGraphRef ().getNodeNumDiags ();
+    const crs_graph_type& G = this->getCrsGraphRef ();
+    using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (G).getNodeNumDiagsImpl ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -1117,11 +1117,29 @@ public:
   //! Whether this matrix has a well-defined column map.
   virtual bool hasColMap() const;
 
-  //! Whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
+  /// \brief Whether the matrix's graph is locally lower triangular.
+  ///
+  /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+  ///   and will DISAPPEAR VERY SOON per #2630.
+  ///
+  /// \pre <tt>! isFillActive()</tt>.
+  ///   If fill is active, this method's behavior is undefined.
+  ///
+  /// \note This is entirely a local property.  That means this
+  ///   method may return different results on different processes.
+  virtual bool TPETRA_DEPRECATED isLowerTriangular () const;
 
-  //! Whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
+  /// \brief Whether the matrix's graph is locally upper triangular.
+  ///
+  /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+  ///   and will DISAPPEAR VERY SOON per #2630.
+  ///
+  /// \pre <tt>! isFillActive()</tt>.
+  ///   If fill is active, this method's behavior is undefined.
+  ///
+  /// \note This is entirely a local property.  That means this
+  ///   method may return different results on different processes.
+  virtual bool TPETRA_DEPRECATED isUpperTriangular () const;
 
   /// \brief Whether matrix indices are locally indexed.
   ///

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -3611,7 +3611,8 @@ public:
   BlockCrsMatrix<Scalar, LO, GO, Node>::
   getGlobalNumDiags() const
   {
-    return graph_.getGlobalNumDiags();
+    using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (this->graph_).getGlobalNumDiagsImpl ();
   }
 
   template<class Scalar, class LO, class GO, class Node>
@@ -3619,7 +3620,8 @@ public:
   BlockCrsMatrix<Scalar, LO, GO, Node>::
   getNodeNumDiags() const
   {
-    return graph_.getNodeNumDiags();
+    using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (this->graph_).getNodeNumDiagsImpl ();
   }
 
   template<class Scalar, class LO, class GO, class Node>

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -3643,17 +3643,19 @@ public:
   template<class Scalar, class LO, class GO, class Node>
   bool
   BlockCrsMatrix<Scalar, LO, GO, Node>::
-  isLowerTriangular() const
+  isLowerTriangular () const
   {
-    return graph_.isLowerTriangular();
+    using HDM = ::Tpetra::Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (this->graph_).isLowerTriangularImpl ();
   }
 
   template<class Scalar, class LO, class GO, class Node>
   bool
   BlockCrsMatrix<Scalar, LO, GO, Node>::
-  isUpperTriangular() const
+  isUpperTriangular () const
   {
-    return graph_.isUpperTriangular();
+    using HDM = ::Tpetra::Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
+    return dynamic_cast<const HDM&> (this->graph_).isUpperTriangularImpl ();
   }
 
   template<class Scalar, class LO, class GO, class Node>

--- a/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
@@ -152,15 +152,15 @@ namespace Tpetra {
     /// \brief Number of diagonal entries over all processes in the
     ///   graph's communicator.
     ///
-    /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
-    ///   go away at any time.
-    virtual global_size_t TPETRA_DEPRECATED getGlobalNumDiags() const = 0;
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    virtual global_size_t TPETRA_DEPRECATED getGlobalNumDiags () const = 0;
 
     /// \brief Number of diagonal entries on the calling process.
     ///
-    /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
-    ///   go away at any time.
-    virtual size_t TPETRA_DEPRECATED getNodeNumDiags() const = 0;
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    virtual size_t TPETRA_DEPRECATED getNodeNumDiags () const = 0;
 
     //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
     virtual size_t getGlobalMaxNumRowEntries() const = 0;
@@ -168,14 +168,32 @@ namespace Tpetra {
     //! \brief Returns the maximum number of entries across all rows/columns on this node.
     virtual size_t getNodeMaxNumRowEntries() const = 0;
 
-    //! \brief Indicates whether the graph has a well-defined column map.
+    //! Whether the graph has a well-defined column Map.
     virtual bool hasColMap() const = 0;
 
-    //! \brief Indicates whether the graph is lower triangular.
-    virtual bool isLowerTriangular() const = 0;
+    /// \brief Whether the graph is locally lower triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    ///
+    /// \note This is entirely a local property.  That means this
+    ///   method may return different results on different processes.
+    virtual bool TPETRA_DEPRECATED isLowerTriangular () const = 0;
 
-    //! \brief Indicates whether the graph is upper triangular.
-    virtual bool isUpperTriangular() const = 0;
+    /// \brief Whether the graph is locally upper triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    ///
+    /// \note This is entirely a local property.  That means this
+    ///   method may return different results on different processes.
+    virtual bool TPETRA_DEPRECATED isUpperTriangular () const = 0;
 
     //! \brief If graph indices are in the local range, this function returns true. Otherwise, this function returns false. */
     virtual bool isLocallyIndexed() const = 0;

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
@@ -192,25 +192,45 @@ namespace Tpetra {
     /// \brief Number of diagonal entries in the matrix's graph, over
     ///   all processes in the matrix's communicator.
     ///
-    /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
-    ///   go away at any time.
-    virtual global_size_t TPETRA_DEPRECATED getGlobalNumDiags() const = 0;
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    virtual global_size_t TPETRA_DEPRECATED getGlobalNumDiags () const = 0;
 
     /// \brief Number of diagonal entries in the matrix's graph, on
     ///   the calling process.
     ///
-    /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
-    ///   go away at any time.
-    virtual size_t TPETRA_DEPRECATED getNodeNumDiags() const = 0;
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    virtual size_t TPETRA_DEPRECATED getNodeNumDiags () const = 0;
 
-    //! The maximum number of entries across all rows/columns on all nodes.
-    virtual size_t getGlobalMaxNumRowEntries() const = 0;
+    /// \brief Maximum number of entries in any row of the matrix,
+    ///   over all processes.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    ///
+    /// This method only uses the matrix's graph.  Explicitly stored
+    /// zeros count as "entries."
+    virtual size_t getGlobalMaxNumRowEntries () const = 0;
 
-    //! The maximum number of entries across all rows/columns on this node.
-    virtual size_t getNodeMaxNumRowEntries() const = 0;
+    /// \brief Maximum number of entries in any row of the matrix,
+    ///   on this process.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    ///
+    /// This method only uses the matrix's graph.  Explicitly stored
+    /// zeros count as "entries."
+    virtual size_t getNodeMaxNumRowEntries () const = 0;
 
-    //! Whether this matrix has a well-defined column map.
-    virtual bool hasColMap() const = 0;
+    //! Whether this matrix has a well-defined column Map.
+    virtual bool hasColMap () const = 0;
 
     /// \brief Whether the matrix is locally lower triangular.
     ///

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
@@ -212,11 +212,29 @@ namespace Tpetra {
     //! Whether this matrix has a well-defined column map.
     virtual bool hasColMap() const = 0;
 
-    //! Whether this matrix is lower triangular.
-    virtual bool isLowerTriangular() const = 0;
+    /// \brief Whether the matrix is locally lower triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    ///
+    /// \note This is entirely a local property.  That means this
+    ///   method may return different results on different processes.
+    virtual bool TPETRA_DEPRECATED isLowerTriangular () const = 0;
 
-    //! Whether this matrix is upper triangular.
-    virtual bool isUpperTriangular() const = 0;
+    /// \brief Whether the matrix is locally upper triangular.
+    ///
+    /// \warning DO NOT CALL THIS METHOD!  This method is DEPRECATED
+    ///   and will DISAPPEAR VERY SOON per #2630.
+    ///
+    /// \pre Subclasses reserve the right to impose preconditions on
+    ///   the matrix's state.
+    ///
+    /// \note This is entirely a local property.  That means this
+    ///   method may return different results on different processes.
+    virtual bool TPETRA_DEPRECATED isUpperTriangular () const = 0;
 
     /// \brief Whether matrix indices are locally indexed.
     ///

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -148,7 +148,6 @@ namespace { // (anonymous)
       MV mvbad(badmap,1);
 #ifdef HAVE_TPETRA_DEBUG
       const Scalar ONE = ST::one(), ZERO = ST::zero();
-      // tests in localSolve() and localMultiply() are only done in a debug build
       MV mvcol(zero->getColMap(),1);
       MV mvrow(zero->getRowMap(),1);
       TEST_THROW(zero->template localMultiply<Scalar>(mvcol,mvbad,  NO_TRANS,ONE,ZERO), std::runtime_error); // bad output map

--- a/packages/tpetra/core/test/CrsMatrix/Tpetra_Test_CrsMatrix_WithGraph.hpp
+++ b/packages/tpetra/core/test/CrsMatrix/Tpetra_Test_CrsMatrix_WithGraph.hpp
@@ -403,11 +403,10 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
         TEST_ASSERT( lclTri.couldBeUpperTriangular );
       }
 
-      // Bug verification:
-      // Tpetra::CrsMatrix constructed with a Optimized, Fill-Complete graph will not call fillLocalMatrix()
-      // in optimizeStorage(), because it returns early due to picking up the storage optimized bool from the graph.
-      // As a result, the local mat-vec and mat-solve operations are never initialized, and localMultiply() and localSolve()
-      // fail with a complaint regarding the initialization of these objects.
+      // Make sure that if you create a CrsMatrix with an optimized,
+      // fillComplete CrsGraph, that the resulting CrsMatrix is
+      // fillComplete, has optimized storage, and has a correctly
+      // initialized local sparse matrix-vector multiply.
 
       out << "Create a CrsMatrix with the diagonal CrsGraph" << endl;
       MAT matrix(rcpFromRef(diaggraph));
@@ -432,10 +431,6 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       out << "Call localMultiply (local mat-vec) on the CrsMatrix; "
         "it should not throw" << endl;
       TEST_NOTHROW( matrix.localMultiply(x,y,Teuchos::NO_TRANS,SONE,SZERO) );
-
-      out << "Call localSolve (local triangular solve) on the CrsMatrix; "
-        "it should not throw" << endl;
-      TEST_NOTHROW( matrix.localSolve(y,y,Teuchos::NO_TRANS) );
 
       ArrayRCP<const Scalar> x_view = x.get1dView();
       ArrayRCP<const Scalar> y_view = y.get1dView();


### PR DESCRIPTION
* Per #2630, deprecate isLowerTriangular and isUpperTriangular
* Per #581, deprecate CrsMatrixSolveOp and remove all `CrsMatrix::localSolve` calls from Tpetra's tests
* Remove spurious deprecation warnings due to #2630 deprecations, for when CrsMatrix's and BlockCrsMatrix's deprecated methods call CrsGraph's deprecated methods

@trilinos/tpetra 

## Related Issues

* Part of #581, #2630 

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
