### PR TITLE
Promote 100% passing Trilinos-atdm-toss3-intel-debug-openmp-panzer build (TRIL-200)

### DIFF
--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-debug-openmp-panzer.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:45:00
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh


### PR DESCRIPTION
CC: @fryeguy52, @jmgate 

This build was 100% passing today on 'serrano' as shown at:

* https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&parentid=3525281

and therefore is being promoted to the "ATDM" CDash Track/Group.
