### PR TITLE
Epetra: Use v.data() instead of &v[0].

### DIFF
--- a/packages/epetra/src/Epetra_CrsGraph.cpp
+++ b/packages/epetra/src/Epetra_CrsGraph.cpp
@@ -176,7 +176,7 @@ int Epetra_CrsGraph::TAllocate(const int* numIndicesPerRow, int Inc, bool static
     // yet.
     Data.SortedEntries_[i].entries_.resize(NumIndices,
                  indexBaseMinusOne);
-    Data.Indices_[i] = NumIndices > 0 ? &Data.SortedEntries_[i].entries_[0]: NULL;
+    Data.Indices_[i] = NumIndices > 0 ? Data.SortedEntries_[i].entries_.data() : NULL;
     Data.SortedEntries_[i].entries_.resize(0);
   }
       }

--- a/packages/epetra/src/Epetra_CrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_CrsMatrix.cpp
@@ -4895,7 +4895,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
     Epetra_IntVector SourceDomain_pids(SourceMatrix.DomainMap(),true);
 
     SourcePids.resize(SourceMatrix.ColMap().NumMyElements(),0);
-    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? &SourcePids[0] : 0);
+    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? SourcePids.data() : 0);
     // SourceDomain_pids contains the restricted pids
     SourceDomain_pids.PutValue(MyPID);
 
@@ -4923,7 +4923,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
 
     // Associate SourcePids vector with non-rebalanced column map
     SourcePids.resize(SourceMatrix.ColMap().NumMyElements(),0);
-    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? &SourcePids[0] : 0);
+    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? SourcePids.data() : 0);
 
     // create an Import object between non-rebalanced (=source) and rebalanced domain map (=target)
     if(typeid(TransferType)==typeid(Epetra_Import) && DomainTransfer->TargetMap().SameBlockMapDataAs(*theDomainMap))
@@ -4943,7 +4943,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
     Epetra_IntVector TargetRow_pids(*theDomainMap,true);
     Epetra_IntVector SourceRow_pids(SourceMatrix.RowMap());
     SourcePids.resize(SourceMatrix.ColMap().NumMyElements(),0);
-    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? &SourcePids[0] : 0);
+    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? SourcePids.data() : 0);
 
     TargetRow_pids.PutValue(MyPID);
     if(typeid(TransferType)==typeid(Epetra_Import))
@@ -5027,7 +5027,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
 
   // Unpack into arrays
   if(UseLL)
-    Epetra_Import_Util::UnpackAndCombineIntoCrsArrays(SourceMatrix,NumSameIDs,NumRemoteIDs,RemoteLIDs,NumPermuteIDs,PermuteToLIDs,PermuteFromLIDs,LenImports_,Imports_,NumMyRows(),mynnz,MyPID,CSR_rowptr.Values(),CSR_colind_LL.size()?&CSR_colind_LL[0]:0,CSR_vals,SourcePids,TargetPids);
+    Epetra_Import_Util::UnpackAndCombineIntoCrsArrays(SourceMatrix,NumSameIDs,NumRemoteIDs,RemoteLIDs,NumPermuteIDs,PermuteToLIDs,PermuteFromLIDs,LenImports_,Imports_,NumMyRows(),mynnz,MyPID,CSR_rowptr.Values(),CSR_colind_LL.size()?CSR_colind_LL.data():0,CSR_vals,SourcePids,TargetPids);
   else
     Epetra_Import_Util::UnpackAndCombineIntoCrsArrays(SourceMatrix,NumSameIDs,NumRemoteIDs,RemoteLIDs,NumPermuteIDs,PermuteToLIDs,PermuteFromLIDs,LenImports_,Imports_,NumMyRows(),mynnz,MyPID,CSR_rowptr.Values(),CSR_colind.Values(),CSR_vals,SourcePids,TargetPids);
 
@@ -5067,10 +5067,10 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
   /**************************************************************/
   //Call an optimized version of MakeColMap that avoids the Directory lookups (since the importer knows who owns all the gids).
   std::vector<int> RemotePIDs;
-  int * pids_ptr = TargetPids.size() ? &TargetPids[0] : 0;
+  int * pids_ptr = TargetPids.size() ? TargetPids.data() : 0;
   if(UseLL) {
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
-    long long * CSR_colind_LL_ptr = CSR_colind_LL.size() ? &CSR_colind_LL[0] : 0;
+    long long * CSR_colind_LL_ptr = CSR_colind_LL.size() ? CSR_colind_LL.data() : 0;
     Epetra_Import_Util::LowCommunicationMakeColMapAndReindex(N,CSR_rowptr.Values(),CSR_colind.Values(),CSR_colind_LL_ptr,
                                                              *MyDomainMap,pids_ptr,
                                                              Graph_.CrsGraphData_->SortGhostsAssociatedWithEachProcessor_,RemotePIDs,
@@ -5103,7 +5103,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
   // Pre-build the importer using the existing PIDs
   Epetra_Import * MyImport=0;
   int NumRemotePIDs = RemotePIDs.size();
-  int *RemotePIDs_ptr = RemotePIDs.size() ? &RemotePIDs[0] : 0;
+  int *RemotePIDs_ptr = RemotePIDs.size() ? RemotePIDs.data() : 0;
   //  if(!RestrictCommunicator && !MyDomainMap->SameAs(ColMap()))
   if(!MyDomainMap->SameAs(ColMap()))
     MyImport = new Epetra_Import(ColMap(),*MyDomainMap,NumRemotePIDs,RemotePIDs_ptr);

--- a/packages/epetra/src/Epetra_Export.cpp
+++ b/packages/epetra/src/Epetra_Export.cpp
@@ -500,8 +500,8 @@ void Epetra_Export::Print(std::ostream & os) const
 
   if (sortIDs && NumExportIDs_ > 0) {
     int* intCompanions[1]; // Input for Epetra_Util::Sort().
-    intCompanions[0] = &exportLIDs[0];
-    Epetra_Util::Sort (true, NumExportIDs_, &exportPIDs[0],
+    intCompanions[0] = exportLIDs.data();
+    Epetra_Util::Sort (true, NumExportIDs_, exportPIDs.data(),
            0, (double**) NULL, 1, intCompanions, 0, 0);
   }
       }

--- a/packages/epetra/src/Epetra_FECrsGraph.cpp
+++ b/packages/epetra/src/Epetra_FECrsGraph.cpp
@@ -246,10 +246,10 @@ int Epetra_FECrsGraph::GlobalAssemble(const Epetra_Map& domain_map,
   for (nonlocalRows = nonlocalRowData_var.begin();
        nonlocalRows != nonlocalRowData_var.end(); ++nonlocalRows)
     allColumns.AddEntries((int) nonlocalRows->second.entries_.size(),
-       nonlocalRows->second.entries_.size() ? &nonlocalRows->second.entries_[0] : 0);
+       nonlocalRows->second.entries_.size() ? nonlocalRows->second.entries_.data() : 0);
 
   Epetra_Map* colMap = new Epetra_Map((int_type) -1, (int) allColumns.entries_.size(),
-             allColumns.entries_.size() ? &allColumns.entries_[0] : 0,
+             allColumns.entries_.size() ? allColumns.entries_.data() : 0,
                                       (int_type) Map().IndexBase64(), Map().Comm());
 
   //now we need to create a graph with sourceMap and colMap, and fill it with
@@ -281,7 +281,7 @@ int Epetra_FECrsGraph::GlobalAssemble(const Epetra_Map& domain_map,
        nonlocalRows != nonlocalRowData_var.end(); ++nonlocalRows)
     EPETRA_CHK_ERR( tempGrph->InsertGlobalIndices(nonlocalRows->first,
              (int) nonlocalRows->second.entries_.size(),
-             nonlocalRows->second.entries_.size() ? &nonlocalRows->second.entries_[0] : 0) );
+             nonlocalRows->second.entries_.size() ? nonlocalRows->second.entries_.data() : 0) );
 
 
   //Now we need to call FillComplete on our temp graph. We need to

--- a/packages/epetra/src/Epetra_FECrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_FECrsMatrix.cpp
@@ -925,7 +925,7 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
     //First build a map that describes our nonlocal data.
     //We'll use the arbitrary distribution constructor of Map.
 
-    int_type* nlr_ptr = nonlocalRows_var.size() > 0 ? &nonlocalRows_var[0] : 0;
+    int_type* nlr_ptr = nonlocalRows_var.size() > 0 ? nonlocalRows_var.data() : 0;
     if (sourceMap_ == NULL)
       sourceMap_ = new Epetra_Map((int_type) -1, (int) nonlocalRows_var.size(), nlr_ptr,
             (int_type) Map().IndexBase64(), Map().Comm());
@@ -962,7 +962,7 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
         }
       }
 
-      int_type* cols_ptr = cols.size() > 0 ? &cols[0] : 0;
+      int_type* cols_ptr = cols.size() > 0 ? cols.data() : 0;
 
       colMap_ = new Epetra_Map((int_type) -1, (int) cols.size(), cols_ptr,
                                (int_type) Map().IndexBase64(), Map().Comm());
@@ -975,7 +975,7 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
       nonlocalRowLengths[i] = (int) nonlocalCols_var[i].size();
     }
 
-    int* nlRLptr = nonlocalRowLengths.size()>0 ? &nonlocalRowLengths[0] : NULL;
+    int* nlRLptr = nonlocalRowLengths.size()>0 ? nonlocalRowLengths.data() : NULL;
     if ( first_time && tempMat_ == NULL )
       tempMat_ = new Epetra_CrsMatrix(Copy, *sourceMap_, *colMap_, nlRLptr);
     else
@@ -985,13 +985,13 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
       if ( first_time ) {
         EPETRA_CHK_ERR( tempMat_->InsertGlobalValues(nonlocalRows_var[i],
                                                     (int) nonlocalCols_var[i].size(),
-                                                    &nonlocalCoefs_[i][0],
-                                                    &nonlocalCols_var[i][0]) );
+                                                     nonlocalCoefs_[i].data(),
+                                                     nonlocalCols_var[i].data()) );
       } else {
         EPETRA_CHK_ERR( tempMat_->SumIntoGlobalValues(nonlocalRows_var[i],
                                                      (int) nonlocalCols_var[i].size(),
-                                                     &nonlocalCoefs_[i][0],
-                                                     &nonlocalCols_var[i][0]) );
+                                                      nonlocalCoefs_[i].data(),
+                                                      nonlocalCols_var[i].data()) );
       }
     }
 
@@ -1168,7 +1168,7 @@ int Epetra_FECrsMatrix::InputGlobalValues(int numRows, const int_type* rows,
 
     //If we get to here, the data is in column-major order.
 
-    double* valuesptr = &workData_[0];
+    double* valuesptr = workData_.data();
 
     //Since the data is in column-major order, then we copy the i-th row
     //of the values table into workData_, in order to have the row in
@@ -1209,7 +1209,7 @@ int Epetra_FECrsMatrix::InputGlobalValues(int numRows, const int_type* rows,
     for(int j=0; j<numCols; ++j) {
       workData_[j] = values[i+j*numRows];
     }
-    int err = InputGlobalValues_RowMajor(1, &rows[i], numCols, cols, &workData_[0], mode);
+    int err = InputGlobalValues_RowMajor(1, &rows[i], numCols, cols, workData_.data(), mode);
     if (err < 0) return err;
     returncode += err;
   }

--- a/packages/epetra/src/Epetra_Import.cpp
+++ b/packages/epetra/src/Epetra_Import.cpp
@@ -844,7 +844,7 @@ void Epetra_Import::Print(std::ostream & os) const
   if (sortIDs && NumExportIDs_ > 0) {
     int* intCompanions[1]; // Input for Epetra_Util::Sort().
     intCompanions[0] = &exportLIDs[0];
-    Epetra_Util::Sort (true, NumExportIDs_, &exportPIDs[0],
+    Epetra_Util::Sort (true, NumExportIDs_, exportPIDs.data(),
            0, (double**) NULL, 1, intCompanions, 0, 0);
   }
       }


### PR DESCRIPTION
These were caught by GLIBCXX's debug mode and the deal.II test suite.

Writing `&v[0]` when `v` is an empty `std::vector` is not permissible when running GCC in debug mode. Using `v.data()` provides the same result and avoids the issue. If I have understood the documentation correctly, Epetra requires C++11 so change should be okay. This fixes a lot of test failures in deal.II (with GCC debugging) where, for various reasons, our multigrid code deals with empty Epetra objects.

I ran the test suite on my workstation (albeit without all packages installed) with this patch and all tests passed.

See also dealii/dealii#6622.