### PR TITLE
Switch all builds on 'white' and 'ride' to use all-at-oce approch (TRIL-198)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ride/local-driver.sh
@@ -4,6 +4,10 @@ if [ "${BSUB_CTEST_TIME_LIMIT}" == "" ] ; then
   export BSUB_CTEST_TIME_LIMIT=12:00
 fi
 
+if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
+  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+fi
+
 set -x
 
 bsub -x -Is -q rhel7F -n 16 -J $JOB_NAME -W $BSUB_CTEST_TIME_LIMIT \


### PR DESCRIPTION
Given data from past runs, this should result in less frequent crashing of the
'bsub' command.  This will also just speed up the build by about a factor of 2
and speed up running the tests by about 25%.

I tested this locally on 'white' with:

```

$ time env \
     JOB_NAME=Trilinos-atdm-white-ride-cuda-debug \
     WORKSPACE=$PWD \
     Trilinos_PACKAGES=Kokkos,Teuchos \
     CTEST_TEST_TYPE=Experimental \
     CTEST_DO_SUBMIT=OFF \
     CTEST_DO_UPDATES=OFF \
     CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=FALSE   ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
   &> console.out
```

and it showed that it used the all-at-once approach.
 