### PR TITLE
TrilinosCouplings: adding guard in exmaple_maxwell.cpp

### DIFF
--- a/packages/trilinoscouplings/examples/scaling/example_Maxwell.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Maxwell.cpp
@@ -280,7 +280,7 @@ void TestMultiLevelPreconditioner_Stratimikos(char ProblemType[],
                                               double & TotalErrorResidual,
                                               double & TotalErrorExactSol);
 
-#if defined(HAVE_MUELU_EPETRA) and defined(HAVE_TRILINOSCOUPLINGS_MUELU)
+  #if defined(HAVE_MUELU_EPETRA) and defined(HAVE_TRILINOSCOUPLINGS_MUELU)
 /** \brief  MueLu Preconditioner
 
     \param  ProblemType        [in]    problem type
@@ -306,7 +306,7 @@ void TestMueLuMultiLevelPreconditioner_Stratimikos(char ProblemType[],
                                                    Epetra_MultiVector & b,
                                                    double & TotalErrorResidual,
                                                    double & TotalErrorExactSol);
-#endif
+  #endif
 #endif
 
 /**********************************************************************************/
@@ -2022,6 +2022,7 @@ int main(int argc, char *argv[]) {
 
   }
 
+#if defined(HAVE_MUELU_EPETRA) and defined(HAVE_TRILINOSCOUPLINGS_MUELU)
   if (solverName == "MueLu") {
     // MueLu RefMaxwell
     if(MyPID==0) {std::cout << "\n\nMueLu solve \n";}
@@ -2032,7 +2033,7 @@ int main(int argc, char *argv[]) {
                                               TotalErrorResidual, TotalErrorExactSol);
   }
 
-#ifdef HAVE_TRILINOSCOUPLINGS_STRATIMIKOS
+  #ifdef HAVE_TRILINOSCOUPLINGS_STRATIMIKOS
   if (solverName == "MueLu-Stratimikos") {
     if(MyPID==0) {std::cout << "\n\nMueLu Stratimikos solve \n";}
     TestMueLuMultiLevelPreconditioner_Stratimikos(probType,MueLuList,StiffMatrixC,
@@ -2041,6 +2042,7 @@ int main(int argc, char *argv[]) {
                                                   xh,rhsVector,
                                                   TotalErrorResidual, TotalErrorExactSol);
   }
+  #endif
 #endif
 
 

--- a/packages/trilinoscouplings/examples/scaling/example_Maxwell.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Maxwell.cpp
@@ -149,7 +149,9 @@
 
 // MueLu
 #include <MueLu_RefMaxwell.hpp>
+#ifdef HAVE_MUELU_EPETRA
 #include <MueLu_AztecEpetraOperator.hpp>
+#endif
 #include <MueLu_Exceptions.hpp>
 
 #endif


### PR DESCRIPTION
@trilinos/trilinoscouplings 

## Description
This guard makes sure that MueLu_Epetra is enabled before include the MueLu_AztecEpetraOperator.hpp header.

## Motivation and Context
This is will allow the new builds that set `MueLu_ENABLE_Epetra=OFF` to compile `TrilinosCouplings` without problems

## Related Issues

* Closes #2786 

## How Has This Been Tested?
I did a local build of the with the configure-testbed-jenkins configuration to check that everything compiles properly

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.