### PR TITLE
Switch to all-at-once approach for 'toss3' builds on 'serrano' (TRIL-200, #2699)

### DIFF
--- a/cmake/ctest/drivers/atdm/toss3/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/toss3/local-driver.sh
@@ -5,6 +5,10 @@ if [ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
   # This is just running tests, not the entire build!
 fi
 
+if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
+  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+fi
+
 set -x
 
 source $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver-config-build.sh


### PR DESCRIPTION
Now that the new testing-vm.sandia.gov site is sending out emails, I think
this is a safe thing to do.  I am hoping this will help to avoid timeouts in
the sbatch command running the tests on 'serrano'.

I did not test this.  But this was a copy-and-paste from the other driver scripts for 'white'/'ride' that was tested and it is an extremely safe change.  