### PR TITLE
[WIP] clean up of Matlab interface

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/doc/doc.tex
+++ b/packages/muelu/research/mmayr/composite_to_regions/doc/doc.tex
@@ -721,114 +721,20 @@ and {\sf composite2Region()} when performing matvecs within the Krylov solver.
 \appendix
 
 \section{Matlab interaction}
-To test Trilinos functionality, a combination of Matlab and a Trilinos
-C++ driver was constructed. The basic idea is to use Matlab for ``hard''
-things that do not ultimately affect Trilinos-like design decisions while
-restricting the C++ code to aspects that do affect the Trilinos-like design.
-The way this is implemented is that one first runs the Matlab program in the source folder.
-Then, establish a symbolic link to the C++ executable, but execute it also in the source
-folder, since it relies on files written to the source folder by Matlab.
 
-The Matlab program creates a series of myData\_k files where $ 0 \le k < nProcs$.
-The file should contain a basic command and optionally some data associated
-with that command. After the Matlab program has created a set of these
-myData\_k files it waits (loops with a sleep) until they are removed by
-the C++ program before proceeding. One executes the C++ via mpirun across
-multiple procs. The program first opens a myData\_k file. This very first
-myData\_k file should contain three entries separated by a single space
-corresponding to {\sf maxRegPerGID}, {\sf maxRegPerProc}, and {\sf whichCase}.
-The last entry is a string that should be either {\sf RegionsSpanProcs} or
-{\sf MultipleRegionsPerProc}. The myData\_k file is deleted (so that Matlab
-knows
-to proceed) and then the program enters a big infinite while loop. This loop
-opens a myData\_k file and executes one command per loop iteration.
-Specifically, each loop iteration waits (inner loop with a sleep) for the
-new myData\_k file.  Once it sees this file, it reads the command header.
-The body of the main loop basically has a bunch of `if statements'
-corresponding to the
-different commands and so {\sf myRank} reads the rest of the data and
-performs the associated task. The C++ file never needs to communicate
-any data back to the Matlab program, but it indicates that it is finished
-with the file by deleting it (signaling Matlab to proceed). Not sure if there
-is some chance that the C++ program starts reading a myData\_k file before
-the Matlab program has finished writing to it. This hasn't happened in my
-tests. Some of the myData\_k commands are
-\vskip .1in
+As of May 22, 2018, the Matlab interface has been redesigned.
+The last commit with the old interface is \texttt{commit 657d5544cee8dbb8bf8bfed5a8e93fb64a51eff3}.
 
-\optionbox{LoadCompositeMap}{load the composite GIDs and the non-ghosted portion of {\sf regionsPerGID}. Each line that follows the command line corresponds to one entry of the composite GID. Later communication will be employed in the C++ program so that myRank has ghosted version of this information.}
+To run the region code, two steps are required:
+\begin{enumerate}
+ \item Run the Matlab script {\sf createInput.m} to create the problem and write it to the disk.
+ \item Run the executable {\sf /packages/muelu/research/mmayr/composite\_to\_regions/src/MueLu\_composite\_to\_region\_driver.exe} from the source directory.
+\end{enumerate}
 
-\optionbox{LoadAndCommRegAssignments}{load non-ghosted portion of {\sf regionsPerGID}. Each jth line that follows the command line corresponds to all the regions in  the jth row of {\sf regionsPerGID} separated by spaces. The C++ program performs communication so that it has the ghosted version of this information.}
+The Matlab program creates a series of {\sf my*\_k} files where $ 0 \le k < nProcs$.
+These files contain various input information about the problem, the region layout, etc.
 
-\optionbox{ReadMatrix}{read the file Amat.mm that contains the composite matrix}
-
-\optionbox{LoadRegions}{load the {\sf myRegions} list which appears
-                    immediately after the command (one region per line).}
-
-\optionbox{MakeGrpRegRowMaps}{directs C++ program to make the new row maps.}
-
-\optionbox{MakeGrpRegColMaps}{directs C++ program to make the new col maps.}
-
-\optionbox{MakeExtendedRegGrpMaps}{directs C++ program to make the extended form of the domain and column maps. This extended form includes new GID numbers to address the replication of shared nodes in multiple regions.}
-
-\optionbox{MakeQuasiRegionMatrices}{directs C++ program to extract regional matrices from the composite matrix. Results in correct data, but wrong maps.}
-
-\optionbox{MakeRegMatrices}{directs C++ program to call expertStaticFillComplete on the extended region matrices in order to 'insert' correct range/domain maps into region matrices.}
-
-\optionbox{LoadAppDataForLIDregion()}{loads data associated with the minimum and maximum nodes that myRank will own for each region. Here, `will own' refers to nodes that will be owned by myRank in the regional form of the matrices. However, the min/max values correspond to composite GIDs  Specifically, the $k$th line following the command line provides two numbers. The first number is the minimum associated with {\sf myRegions[~k~]} while the second number is the maximum.}
-
-\optionbox{ComputeMatVecs}{direct C++ program to perform matrix-vector-multiplication in composite and regional form and to compare the results.}
-
-\optionbox{PrintGrpRegRowMaps}{direct C++ program to print new row maps.}
-
-\optionbox{PrintGrpRegColMaps}{directs C++ program to print new col maps.}
-
-\optionbox{PrintGrpRegDomMaps}{directs C++ program to print new extended domain maps.}
-
-\optionbox{PrintRevisedColMaps}{directs C++ program to print new extended col maps.}
-
-\optionbox{PrintQuasiRegionMatrices}{directs C++ program to print quasiRegional matrices.}
-
-\optionbox{PrintRegionMatrices}{directs C++ program to print regional matrices.}
-
-\optionbox{PrintRegionMatrixRowMap}{directs C++ programm to print row map of region matrices.}
-
-\optionbox{PrintRegionMatrixColMap}{directs C++ programm to print col map of region matrices.}
-
-\optionbox{PrintRegionMatrixRangeMap}{directs C++ programm to print range map of region matrices.}
-
-\optionbox{PrintRegionMatrixDomainMap}{directs C++ programm to print domain map of region matrices.}
-
-\optionbox{PrintCompositeMap}{directs C++ program to print composite map.}
-
-\optionbox{PrintRegionAssignments}{directs C++ program to print {\sf regionsPerGID}.}
-
-\optionbox{PrintCompositeVectorX}{directs C++ program to print the composite input vector.}
-
-\optionbox{PrintCompositeVectorY}{directs C++ program to print the composite result vector.}
-
-\optionbox{PrintQuasiRegVectorX}{directs C++ program to print the quasiRegion input vector.}
-
-\optionbox{PrintQuasiRegVectorY}{directs C++ program to print the quasiRegion result vector.}
-
-\optionbox{PrintRegVectorX}{directs C++ program to print the region input vector.}
-
-\optionbox{PrintRegVectorY}{directs C++ program to print the region result vector.}
-
-\optionbox{PrintRegVectorYComp}{directs C++ program to print the composite result vector that is reconstructed from the region result vector.}
-
-\optionbox{Terminate}{C++ program exits.}
-
-For some of the `Make*' commands, the Matlab program is also able to construct the same information and so this can be compared with the C++ program.
-The original intention was that there would be some additional commands to
-initialize vectors, convert from composite to regional views, and do matvecs ...but this is not done right now.
-\REMOVE{Some of these commands appeared in an earlier
-version (that was based on a different composite/region philosophy that
-was deemed not scalable).
-}
-
-
-
-
+The executable reads these files, creates matrices and a MueLu hierarchy and runs a V-cycle.
 
 \end{document}
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/createInput.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/createInput.m
@@ -1,0 +1,107 @@
+% createInput.m
+%
+% Create input files with composite matrix and region information and write to
+% disk. This will be used as starting point for the c++-based driver.
+%
+
+!rm -f compX.mm map_compX.mm
+!rm -f myRegionsInfo*_ myAppData_* myCompositeMap_* myRegionAssignment_* myProblemLayout_* myRegions_*
+
+nDims = 1; file='caseTen'; 
+% nDims = 2; file='caseTwenty'; 
+
+if (nDims == 2)
+  [globalDims,localDims,relcorners,abscorners]=mk2DRegionFile(file);
+elseif (nDims == 1) && ...
+    ((strcmp(file,'caseOne') == false) && (strcmp(file,'caseTwo')) == false && ...
+    (strcmp(file,'caseThree') == false) && (strcmp(file,'caseFour') == false))
+  
+  mk1DRegionFile(file);
+end
+
+%
+%  read in some of header type information 
+fp = fopen(file,'r'); fgetl(fp); 
+t = fscanf(fp,'%d'); nNodes = t(1); nProcs = t(3); 
+whichCase = fgets(fp,16); fclose(fp);
+
+%
+% make a global tridiagonal matrix corresponding to the discretization
+%
+% A = spdiags(rand(nNodes,3), -1:1, nNodes, nNodes);
+% A = spdiags(-1*ones(nNodes,3), -1:1, nNodes, nNodes);
+if (nDims == 1)
+  A = oneDimensionalLaplace(nNodes);
+elseif (nDims == 2)
+  A = twoDimensionalLaplace(nNodes);
+else
+  error('nDims is wrong\n');
+end
+
+% Each 'processor' reads regional file. 
+for myRank=0:nProcs-1
+   eval(sprintf('myNodes%d = readRegionalFile(file,myRank);',myRank));
+   eval(sprintf('RegionToProc%d=regionToProcMap(myNodes%d,myRank,file);',...
+               myRank,myRank));
+end
+
+maxRegPerProc = 0;
+maxRegPerGID = 0;
+for myRank=0:nProcs-1
+  eval(sprintf('allMyNodes{%d} = myNodes%d;',myRank+1,myRank));
+  eval(sprintf('allMyRegions{%d} = RegionToProc%d;',myRank+1,myRank));
+  if length(allMyRegions{myRank+1}.myRegions) > maxRegPerProc 
+    maxRegPerProc = length(allMyRegions{myRank+1}.myRegions);
+  end
+  for k=1:length(allMyNodes{myRank+1})
+    if length(allMyNodes{myRank+1}(k).gRegions) > maxRegPerGID 
+      maxRegPerGID = length(allMyNodes{myRank+1}(k).gRegions);
+    end
+  end
+end
+
+% send header to C++
+for myRank=0:nProcs-1
+  fp=fopen(sprintf('myRegionInfo_%d',myRank),'w');
+  if (nDims == 1)
+    fprintf(fp,'%d %d %d %d %s\n',maxRegPerGID,maxRegPerProc, nNodes, 1, whichCase);
+  elseif (nDims == 2)
+    fprintf(fp,'%d %d %d %d %s\n',maxRegPerGID,maxRegPerProc,sqrt(nNodes),sqrt(nNodes),whichCase);
+  else
+    error("Problems of spatial dimension %d are not implemented, yet.", nDims);
+  end
+  fclose(fp); 
+end
+
+% make and send composite map to C++
+for myRank=0:nProcs-1
+  eval(sprintf('mkCompositeMap(myNodes%d,%d);',myRank,myRank));
+end
+
+% write matrix to file using MatrixMarket format
+mkMatrixFile(A);
+
+for myRank=0:nProcs-1
+  eval(sprintf('mkRegionsPerGID(myNodes%d,%d,maxRegPerGID);',myRank,myRank));
+end
+
+for myRank=0:nProcs-1
+  fp=fopen(sprintf('myRegions_%d',myRank),'w');
+%   fprintf(fp,'LoadRegions\n');
+  for j=1:length(allMyRegions{myRank+1}.myRegions)
+    fprintf(fp,'%d\n', allMyRegions{myRank+1}.myRegions(j));
+  end
+  fclose(fp); 
+end
+
+if (nDims == 1)
+  mkAppData(allMyNodes,allMyRegions,nProcs,whichCase);
+elseif (nDims == 2)
+  mk2DAppData(allMyNodes,allMyRegions,nProcs,whichCase,globalDims,localDims,relcorners,abscorners);
+else
+  error("Problems of spatial dimension %d are not implemented, yet.", nDims);
+end
+
+str = sprintf('Run now with #procs = %d', nProcs);
+disp(str);
+

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -1,3 +1,47 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//        MueLu: A package for multigrid based preconditioning
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -72,9 +116,6 @@ struct widget {
    int        nx;
 int myRank;
 };
-
-void stripTrailingJunk(char *command);
-void printGrpMaps(std::vector<Teuchos::RCP<Epetra_Map> > &mapPerGrp, int maxRegPerProc, char *str);
 
 /*! \brief Transform composite vector to regional layout
  */
@@ -490,11 +531,13 @@ void vCycle(const int l, ///< ID of current level
   return;
 }
 
-// Interact with a Matlab program through a bunch of myData_procID files.
-// Basically, the matlab program issues a bunch of commands associated with
-// either composite or regional things (via the files). This program reads
-// those files and performs the commands. See unpublished latex document
-// ``Using Trilinos Capabilities to Facilitate Composite-Regional Transitions''
+/* To run the region MG sovler, first run the Matlab program 'createInput.m'
+ * to write a bunch of files with region information to the disk.
+ * Then start this executable with the appropriate number of MPI ranks.
+ * See unpublished latex document
+ * ``Using Trilinos Capabilities to Facilitate Composite-Regional Transitions''
+ * for further information.
+ */
 
 int main(int argc, char *argv[]) {
 
@@ -516,15 +559,12 @@ int main(int argc, char *argv[]) {
 
   myRank = Comm.MyPID();
 
-  if (myRank == 0)
-    std::cout << "Trying to sync with Matlab..." << std::endl
-        << "If you're stuck here, check whether numProcs in Matlab and C-executable match" << std::endl;
-
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::ParameterList;
   using Teuchos::Array;
 
+  Comm.Barrier();
 
   // read maxRegPerGID (maximum # of regions shared by any one node) and
   //      maxRegPerProc (maximum # of partial regions owned by any proc)
@@ -534,7 +574,7 @@ int main(int argc, char *argv[]) {
   //                                but regions may span across many procs
 
   int maxRegPerGID, maxRegPerProc, whichCase, iii = 0;
-  sprintf(fileName,"myData_%d",myRank);
+  sprintf(fileName,"myRegionInfo_%d",myRank);
   while ( (fp = fopen(fileName,"r") ) == NULL) sleep(1);
   fgets(command,80,fp);
   sscanf(command,"%d",&maxRegPerGID);
@@ -551,7 +591,9 @@ int main(int argc, char *argv[]) {
   if      (command[iii+1] == 'M') whichCase = MultipleRegionsPerProc;
   else if (command[iii+1] == 'R') whichCase = RegionsSpanProcs;
   else {fprintf(stderr,"%d: head messed up %s\n",myRank,command); exit(1);}
-  sprintf(command,"/bin/rm -f myData_%d",myRank); system(command); sleep(1);
+//  sprintf(command,"/bin/rm -f myData_%d",myRank); system(command); sleep(1);
+
+  Comm.Barrier();
 
   // check for 1D or 2D problem
   if (globalNy == 1)
@@ -660,1666 +702,1330 @@ int main(int argc, char *argv[]) {
   Array<std::vector<std::vector<int> > > interfaceLIDs; // local IDs of interface nodes on each level in each group
   Array<std::vector<std::vector<std::vector<int> > > > interfaceGIDPairs; // pairs of GIDs of interface nodes on each level in each group
 
-  // loop forever (or until the matlab program issues a terminate command
-  //               which causes exit() to be invoked).
+  /* The actual computations start here. It's a sequence of operations to
+   * - read region data from files
+   * - create composite and region matrices
+   * - create a region multigrid hierarchy
+   * - run a region-type V-cycle
+   */
 
-  while ( 1 == 1 ) {
-    Comm.Barrier();
+  Comm.Barrier();
 
-    // wait for file from Matlab program
-    while ((fp = fopen(fileName, "r")) == NULL)
-      sleep(1);
+  // Load composite map
+  {
+    std::cout << myRank << " | Loading composite map ..." << std::endl;
 
-    fgets(command,40,fp); stripTrailingJunk(command);
+    std::stringstream fileNameSS;
+    fileNameSS << "myCompositeMap_" << myRank;
+    fp = fopen(fileNameSS.str().c_str(), "r");
+    if (fp != NULL)
+      std::cout << std::endl << ">>> Check number of MPI ranks!" << std::endl << std::endl;
+    TEUCHOS_ASSERT(fp!=NULL);
 
-    printf("%d: Matlab command is __%s__\n",myRank,command);
-    if (strcmp(command,"LoadCompositeMap") == 0) {
+    std::vector<int> fileData; // composite GIDs
+    int i;
+    while (fscanf(fp, "%d", &i) != EOF)
+      fileData.push_back(i);
 
-      std::vector<int> fileData;        // composite GIDs
+    mapComp = Teuchos::rcp(new Epetra_Map(-1, (int) fileData.size(), fileData.data(), 0, Comm));
+//    mapComp->Print(std::cout);
+  }
+
+  Comm.Barrier();
+
+  // Read matrix from file
+  {
+    std::cout << myRank << " | Reading matrix from file ..." << std::endl;
+
+    Epetra_CrsMatrix* ACompPtr;
+    EpetraExt::MatrixMarketFileToCrsMatrix("Amat.mm", *mapComp, ACompPtr);
+    AComp = Teuchos::rcp(new Epetra_CrsMatrix(*ACompPtr));
+//    AComp->Print(std::cout);
+  }
+
+  Comm.Barrier();
+
+  // Load and communicate region assignments
+  {
+    std::cout << myRank << " | Loading and communicating region assignments ..." << std::endl;
+
+    regionsPerGID = Teuchos::rcp(new Epetra_MultiVector(AComp->RowMap(),maxRegPerGID));
+
+    std::stringstream fileNameSS;
+    fileNameSS << "myRegionAssignment_" << myRank;
+    fp = fopen(fileNameSS.str().c_str(), "r");
+    TEUCHOS_ASSERT(fp!=NULL);
+
+    int k;
+    double *jthRegions; // pointer to jth column in regionsPerGID
+    for (int i = 0; i < mapComp->NumMyElements(); i++) {
+      for (int j = 0; j < maxRegPerGID; j++) {
+        jthRegions = (*regionsPerGID)[j];
+
+        if (fscanf(fp, "%d", &k) == EOF) {
+          fprintf(stderr, "not enough region assignments\n");
+          exit(1);
+        }
+        jthRegions[i] = (double) k;
+
+        // identify interface DOFs. An interface DOF is assigned to at least two regions.
+        if (j > 0 and k != -1)
+          intIDs.push_back(i);
+      }
+    }
+
+    // make extended Region Assignments
+    Epetra_Import Importer(AComp->ColMap(), *mapComp);
+    regionsPerGIDWithGhosts = Teuchos::rcp(new Epetra_MultiVector(AComp->ColMap(),maxRegPerGID));
+    regionsPerGIDWithGhosts->Import(*regionsPerGID, Importer, Insert);
+//    regionsPerGIDWithGhosts->Print(std::cout);
+  }
+
+  Comm.Barrier();
+
+  // Load Regions
+  {
+    std::cout << myRank << " | Loading regions ..." << std::endl;
+
+    std::stringstream fileNameSS;
+    fileNameSS << "myRegions_" << myRank;
+    fp = fopen(fileNameSS.str().c_str(), "r");
+    TEUCHOS_ASSERT(fp!=NULL);
+
+    while (fgets(command, 80, fp) != NULL) {
       int i;
-      while ( fscanf(fp,"%d",&i) != EOF) fileData.push_back(i);
+      sscanf(command, "%d", &i);
+      myRegions.push_back(i);
+    }
+  }
 
-      mapComp = Teuchos::rcp(new Epetra_Map(-1,(int) fileData.size(),fileData.data(),0,Comm));
+  Comm.Barrier();
+
+  // Load AppData for LID region
+  {
+    std::stringstream fileNameSS;
+    fileNameSS << "myAppData_" << myRank;
+    fp = fopen(fileNameSS.str().c_str(), "r");
+    TEUCHOS_ASSERT(fp!=NULL);
+
+    if (doing1D) {
+      int minGID, maxGID;
+      for (int i = 0; i < (int) myRegions.size(); i++) {
+        fscanf(fp,"%d%d",&minGID,&maxGID);
+        minGIDComp[i] = minGID;
+        maxGIDComp[i] = maxGID;
+      }
+      appData.gDim = (int *) malloc(sizeof(int)*3*myRegions.size());
+      appData.lDim = (int *) malloc(sizeof(int)*3*myRegions.size());
+      appData.lowInd= (int *) malloc(sizeof(int)*3*myRegions.size());
+      for (int i = 0; i < (int) myRegions.size(); i++) {
+        fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
+        fscanf(fp,"%d%d%d",&(appData.lDim[3*i]),&(appData.lDim[3*i+1]),&(appData.lDim[3*i+2]));
+        fscanf(fp,"%d%d%d",&(appData.lowInd[3*i]),&(appData.lowInd[3*i+1]),&(appData.lowInd[3*i+2]));
+      }
+      appData.minGIDComp = minGIDComp.data();
+      appData.maxGIDComp = maxGIDComp.data();
     }
-    else if (strcmp(command,"PrintCompositeMap") == 0) {
-       sleep(myRank);
-       if (AComp == Teuchos::null) {
-         printf("%d: printing owned part of composite map\n",myRank);
-         const int *rowGIDs = mapComp->MyGlobalElements();
-         for (int i = 0; i < mapComp->NumMyElements(); i++)
-           printf("%d: compMap(%d) = %d\n",myRank,i,rowGIDs[i]);
-       }
-       else {
-         printf("%d: printing extended composite map\n",myRank);
-         const int *colGIDs= AComp->ColMap().MyGlobalElements();
-         for (int i = 0; i < AComp->ColMap().NumMyElements(); i++)
-           printf("%d: compMap(%d) = %d\n",myRank,i,colGIDs[i]);
-       }
-    }
-    else if (strcmp(command,"LoadRegions") == 0) {
-      while ( fgets(command,80,fp) != NULL ) {
-        int i;
-        sscanf(command,"%d",&i);
-        myRegions.push_back(i);
+    else {
+      appData.nx = globalNx;
+      appData.gDim = (int *) malloc(sizeof(int)*3*myRegions.size());
+      appData.lDimx= (int *) malloc(sizeof(int)*myRegions.size());
+      appData.lDimy= (int *) malloc(sizeof(int)*myRegions.size());
+      appData.trueCornerx= (int *) malloc(sizeof(int)*myRegions.size());
+      appData.trueCornery= (int *) malloc(sizeof(int)*myRegions.size());
+      appData.relcornerx= (int *) malloc(sizeof(int)*myRegions.size());
+      appData.relcornery= (int *) malloc(sizeof(int)*myRegions.size());
+      int garbage;
+      for (int i = 0; i < (int) myRegions.size(); i++) {
+        fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
+        fscanf(fp,"%d%d%d",&(appData.lDimx[i]),&(appData.lDimy[i]),&garbage);
+        fscanf(fp,"%d%d%d",&(appData.relcornerx[i]),&(appData.relcornery[i]),&garbage);
+        fscanf(fp,"%d%d%d",&(appData.trueCornerx[i]),&(appData.trueCornery[i]),&garbage);
       }
     }
-    else if (strcmp(command,"ReadMatrix") == 0) {
-      Epetra_CrsMatrix* ACompPtr;
-      EpetraExt::MatrixMarketFileToCrsMatrix("Amat.mm", *mapComp, ACompPtr);
-      AComp = Teuchos::rcp(new Epetra_CrsMatrix(*ACompPtr));
-    }
-    else if (strcmp(command,"PrintCompositeMatrix") == 0) {
-      AComp->Print(std::cout);
-    }
-    else if (strcmp(command,"LoadAndCommRegAssignments") == 0) {
 
-      regionsPerGID = Teuchos::rcp(new Epetra_MultiVector(AComp->RowMap(),maxRegPerGID));
+    appData.maxRegPerGID = maxRegPerGID;
+    appData.myRegions = myRegions.data();
+    appData.colMap = (Epetra_Map *) &(AComp->ColMap());
+    appData.regionsPerGIDWithGhosts = regionsPerGIDWithGhosts;
+    appData.myRank = myRank;
+  }
 
-      int k;
-      double *jthRegions; // pointer to jth column in regionsPerGID
-      for (int i = 0; i < mapComp->NumMyElements(); i++) {
-        for (int j = 0; j < maxRegPerGID; j++) {
-          jthRegions = (*regionsPerGID)[j];
+  Comm.Barrier();
 
-          if ( fscanf(fp,"%d",&k) == EOF) {
-            fprintf(stderr,"not enough region assignments\n"); exit(1);
-          }
-          jthRegions[i] = (double) k;
+  // Make group region row maps
+  {
+    std::cout << myRank << " | Creating region group row maps ..." << std::endl;
 
-          // identify interface DOFs. An interface DOF is assinged to at least two regions.
-          if (j > 0 and k != -1)
-            intIDs.push_back(i);
-        }
-      }
-
-      // make extended Region Assignments
-      Epetra_Import Importer(AComp->ColMap(), *mapComp);
-      regionsPerGIDWithGhosts = Teuchos::rcp(new Epetra_MultiVector(AComp->ColMap(),maxRegPerGID));
-      regionsPerGIDWithGhosts->Import(*regionsPerGID, Importer, Insert);
-    }
-    else if (strcmp(command,"PrintRegionAssignments") == 0) {
-      double *jthRegions;
-      sleep(myRank);
-      printf("%d: printing out extended regionsPerGID\n",myRank);
-      const int *colGIDsComp = AComp->ColMap().MyGlobalElements();
+    std::vector<int> rowGIDsReg;
+    int *colGIDsComp = AComp->ColMap().MyGlobalElements();
+    for (int k = 0; k < (int) myRegions.size(); k++) {
+      rowGIDsReg.resize(0);
+      std::vector<int> tempRegIDs(AComp->ColMap().NumMyElements());
       for (int i = 0; i < AComp->ColMap().NumMyElements(); i++) {
-        printf("compGID(%d,%d) = %d:",myRank,i,colGIDsComp[i]);
-        for (int j = 0; j <  maxRegPerGID; j++) {
-          jthRegions = (*regionsPerGIDWithGhosts)[j];
-          printf("%d ",(int) jthRegions[i]);
+        if (doing1D) tempRegIDs[i] = LIDregion(&appData, i, k);
+        else tempRegIDs[i] = LID2Dregion(&appData, i, k);
+      }
+
+      std::cout << myRank << " | k = " << k << std::endl;
+
+      std::vector<int> idx(tempRegIDs.size());
+      std::iota(idx.begin(), idx.end(), 0);
+      sort(idx.begin(), idx.end(), [tempRegIDs](int i1,int i2) { return tempRegIDs[i1] < tempRegIDs[i2];});
+
+      for (int i = 0; i < AComp->ColMap().NumMyElements(); i++) {
+        if (tempRegIDs[idx[i]] != -1)
+          rowGIDsReg.push_back(colGIDsComp[idx[i]]);
+      }
+      rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1, (int) rowGIDsReg.size(),
+          rowGIDsReg.data(), 0, Comm));
+    }
+
+    for (int k=(int) myRegions.size(); k < maxRegPerProc; k++) {
+      rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+    }
+  }
+
+  Comm.Barrier();
+
+  // Make group region column maps
+  {
+    std::cout << myRank << " | Creating region group column maps ..." << std::endl;
+
+    if (whichCase == MultipleRegionsPerProc) {
+      // clone rowMap
+      for (int j=0; j < maxRegPerProc; j++) {
+        if (j < (int) myRegions.size()) {
+          colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1,
+              rowMapPerGrp[j]->NumMyElements(),
+              rowMapPerGrp[j]->MyGlobalElements(), 0, Comm));
         }
-        printf("\n");
+        else colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
       }
     }
-    else if (strcmp(command,"LoadAppDataForLIDregion()") == 0) {
-      if (doing1D) {
-        int minGID,maxGID;
-        for (int i = 0; i < (int) myRegions.size(); i++) {
-          fscanf(fp,"%d%d",&minGID,&maxGID);
-          minGIDComp[i] = minGID;
-          maxGIDComp[i] = maxGID;
-        }
-        appData.gDim = (int *) malloc(sizeof(int)*3*myRegions.size());
-        appData.lDim = (int *) malloc(sizeof(int)*3*myRegions.size());
-        appData.lowInd= (int *) malloc(sizeof(int)*3*myRegions.size());
-        for (int i = 0; i < (int) myRegions.size(); i++) {
-          fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
-          fscanf(fp,"%d%d%d",&(appData.lDim[3*i]),&(appData.lDim[3*i+1]),&(appData.lDim[3*i+2]));
-          fscanf(fp,"%d%d%d",&(appData.lowInd[3*i]),&(appData.lowInd[3*i+1]),&(appData.lowInd[3*i+2]));
-        }
-        appData.minGIDComp   = minGIDComp.data();
-        appData.maxGIDComp   = maxGIDComp.data();
-      }
-      else {
-        appData.nx = globalNx;
-        appData.gDim = (int *) malloc(sizeof(int)*3*myRegions.size());
-        appData.lDimx= (int *) malloc(sizeof(int)*myRegions.size());
-        appData.lDimy= (int *) malloc(sizeof(int)*myRegions.size());
-        appData.trueCornerx= (int *) malloc(sizeof(int)*myRegions.size());
-        appData.trueCornery= (int *) malloc(sizeof(int)*myRegions.size());
-        appData.relcornerx= (int *) malloc(sizeof(int)*myRegions.size());
-        appData.relcornery= (int *) malloc(sizeof(int)*myRegions.size());
-        int garbage;
-        for (int i = 0; i < (int) myRegions.size(); i++) {
-          fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
-          fscanf(fp,"%d%d%d",&(appData.lDimx[i]),&(appData.lDimy[i]),&garbage);
-          fscanf(fp,"%d%d%d",&(appData.relcornerx[i]),&(appData.relcornery[i]),&garbage);
-          fscanf(fp,"%d%d%d",&(appData.trueCornerx[i]),&(appData.trueCornery[i]),&garbage);
-        }
-      }
-      appData.maxRegPerGID = maxRegPerGID;
-      appData.myRegions    = myRegions.data();
-      appData.colMap       = (Epetra_Map *) &(AComp->ColMap());
-      appData.regionsPerGIDWithGhosts = regionsPerGIDWithGhosts;
-      appData.myRank = myRank;
-    }
-    else if (strcmp(command,"MakeGrpRegColMaps") == 0) {
-      if (whichCase == MultipleRegionsPerProc) {
-        // clone rowMap
-        for (int j=0; j < maxRegPerProc; j++) {
-          if (j < (int) myRegions.size()) {
-            colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1,
-                rowMapPerGrp[j]->NumMyElements(),
-                rowMapPerGrp[j]->MyGlobalElements(), 0, Comm));
-          }
-          else colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
-        }
-      }
-      else if (whichCase == RegionsSpanProcs) {//so maxRegPerProc = 1
-        std::vector<int> colIDsReg;
+    else if (whichCase == RegionsSpanProcs) {//so maxRegPerProc = 1
+      std::vector<int> colIDsReg;
 
-        // copy the rowmap
-        int *rowGIDsReg = rowMapPerGrp[0]->MyGlobalElements();
-        for (int i = 0; i < rowMapPerGrp[0]->NumMyElements(); i++)
-          colIDsReg.push_back(rowGIDsReg[i]);
+      // copy the rowmap
+      int *rowGIDsReg = rowMapPerGrp[0]->MyGlobalElements();
+      for (int i = 0; i < rowMapPerGrp[0]->NumMyElements(); i++)
+        colIDsReg.push_back(rowGIDsReg[i]);
 
-        // append additional ghosts who are in my region and
-        // for whom I have a LID
-        int LID;
-        double *jthRegions;
-        int *colGIDsComp =  AComp->ColMap().MyGlobalElements();
-        for (int i = 0; i < AComp->ColMap().NumMyElements(); i++) {
-          if (doing1D) LID = LIDregion(&appData, i, 0);
-          else LID = LID2Dregion(&appData, i, 0);
-          if (LID == -1) {
-            for (int j = 0; j < maxRegPerGID; j++) {
-              jthRegions = (*regionsPerGIDWithGhosts)[j];
-              if  ( ((int) jthRegions[i]) == myRegions[0]) {
-                colIDsReg.push_back(colGIDsComp[i]);
-                break;
-              }
+      // append additional ghosts who are in my region and
+      // for whom I have a LID
+      int LID;
+      double *jthRegions;
+      int *colGIDsComp =  AComp->ColMap().MyGlobalElements();
+      for (int i = 0; i < AComp->ColMap().NumMyElements(); i++) {
+        if (doing1D) LID = LIDregion(&appData, i, 0);
+        else LID = LID2Dregion(&appData, i, 0);
+        if (LID == -1) {
+          for (int j = 0; j < maxRegPerGID; j++) {
+            jthRegions = (*regionsPerGIDWithGhosts)[j];
+            if  ( ((int) jthRegions[i]) == myRegions[0]) {
+              colIDsReg.push_back(colGIDsComp[i]);
+              break;
             }
           }
         }
-        if ((int) myRegions.size() > 0) {
-         colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(-1, (int) colIDsReg.size(),
-             colIDsReg.data(), 0, Comm));
-        }
-        else colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
       }
-      else { fprintf(stderr,"whichCase not set properly\n"); exit(1); }
+      if ((int) myRegions.size() > 0) {
+       colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(-1, (int) colIDsReg.size(),
+           colIDsReg.data(), 0, Comm));
+      }
+      else colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
     }
-    else if (strcmp(command,"PrintGrpRegColMaps") == 0) {
-      sleep(myRank);
-      char str[80]; sprintf(str,"%d: colMap ",myRank);
-      printGrpMaps(colMapPerGrp, maxRegPerProc, str);
+    else { fprintf(stderr,"whichCase not set properly\n"); exit(1); }
+  }
+
+  Comm.Barrier();
+
+  // Make extended group region maps
+  {
+    std::cout << myRank << " | Creating extended group region maps ..." << std::endl;
+
+    int nLocal   = AComp->RowMap().NumMyElements();
+    int nExtended= AComp->ColMap().NumMyElements();
+    int nTotal = 0;
+    Comm.SumAll(&nLocal,&nTotal,1);
+
+    // first step of NewGID calculation just counts the number of NewGIDs
+    // and sets firstNewGID[k] such that it is equal to the number of
+    // NewGIDs that have already been counted in (0:k-1) that myRank
+    // is responsible for.
+
+    Epetra_Vector firstNewGID(*mapComp);
+    firstNewGID[0] = 0.;
+    double *jthRegions = NULL;
+    for (int k = 0; k < nLocal-1; k++) {
+      firstNewGID[k+1] = firstNewGID[k]-1.;
+      for (int j = 0; j < maxRegPerGID; j++) {
+        jthRegions = (*regionsPerGIDWithGhosts)[j];
+        if (jthRegions[k] != -1) (firstNewGID[k+1]) += 1.;
+      }
     }
-    else if (strcmp(command,"MakeExtendedGrpRegMaps") == 0) {
-      int nLocal   = AComp->RowMap().NumMyElements();
-      int nExtended= AComp->ColMap().NumMyElements();
-      int nTotal = 0;
-      Comm.SumAll(&nLocal,&nTotal,1);
+    // So firstNewGID[nLocal-1] is number of NewGIDs up to nLocal-2
+    // To account for newGIDs associated with nLocal-1, we'll just
+    // use an upper bound (to avoid the little loop above).
+    // By adding maxRegPerGID-1 we account for the maximum
+    // number of possible newGIDs due to last composite id
+    int upperBndNumNewGIDs = (int) firstNewGID[nLocal-1] + maxRegPerGID-1;
+    int upperBndNumNewGIDsAllProcs;
+    Comm.MaxAll(&upperBndNumNewGIDs,&upperBndNumNewGIDsAllProcs,1);
 
-      // first step of NewGID calculation just counts the number of NewGIDs
-      // and sets firstNewGID[k] such that it is equal to the number of
-      // NewGIDs that have already been counted in (0:k-1) that myRank
-      // is responsible for.
+    // Now that we have an upper bound on the maximum number of
+    // NewGIDs over all procs, we sweep through firstNewGID again
+    // to assign ids to the first NewGID associated with each row of
+    // regionsPerGIDWithGhosts (by adding an offset)
+    for (int k = 0; k < nLocal; k++)
+      firstNewGID[k] += upperBndNumNewGIDsAllProcs*myRank+nTotal;
 
-      Epetra_Vector firstNewGID(*mapComp);
-      firstNewGID[0] = 0.;
-      double *jthRegions = NULL;
-      for (int k = 0; k < nLocal-1; k++) {
-        firstNewGID[k+1] = firstNewGID[k]-1.;
-        for (int j = 0; j < maxRegPerGID; j++) {
-          jthRegions = (*regionsPerGIDWithGhosts)[j];
-          if (jthRegions[k] != -1) (firstNewGID[k+1]) += 1.;
+    Epetra_Import Importer(AComp->ColMap(), *mapComp);
+    Epetra_Vector firstNewGIDWithGhost(AComp->ColMap());
+    firstNewGIDWithGhost.Import(firstNewGID, Importer, Insert);
+
+    std::vector<int> revisedGIDs;
+
+    for (int k = 0; k < (int) myRegions.size(); k++) {
+      revisedGIDs.resize(0);
+      int curRegion = myRegions[k];
+      int *colGIDsComp =  AComp->ColMap().MyGlobalElements();
+      std::vector<int> tempRegIDs(nExtended);
+
+      // must put revisedGIDs in application-provided order by
+      // invoking LIDregion() and sorting
+      for (int i = 0; i < nExtended; i++) {
+        if (doing1D)
+          tempRegIDs[i] = LIDregion(&appData, i, k);
+        else
+          tempRegIDs[i] = LID2Dregion(&appData, i, k);
+      }
+      std::vector<int> idx(tempRegIDs.size());
+      std::iota(idx.begin(),idx.end(),0);
+      sort(idx.begin(),idx.end(),[tempRegIDs](int i1,int i2){return tempRegIDs[i1] < tempRegIDs[i2];});
+
+      // Now sweep through regionsPerGIDWithGhosts looking for those
+      // associated with curRegion and record the revisedGID
+      int j;
+      for (int i = 0; i < nExtended; i++) {
+
+        if (tempRegIDs[idx[i]] != -1) {// if a valid LID for this region
+          for (j = 0; j < maxRegPerGID; j++) {
+            jthRegions = (*regionsPerGIDWithGhosts)[j];
+            if (((int) jthRegions[idx[i]]) == curRegion) break;
+          }
+
+          // (*regionsPerGIDWithGhosts)[0] entries keep original GID
+          // while others use firstNewGID to determine NewGID
+
+          if (j == 0) revisedGIDs.push_back(colGIDsComp[idx[i]]);
+          else if (j < maxRegPerGID) {
+             revisedGIDs.push_back((int) firstNewGIDWithGhost[idx[i]]+j-1);
+          }
+
+          // add entry to listDulicatedGIDs
         }
       }
-      // So firstNewGID[nLocal-1] is number of NewGIDs up to nLocal-2
-      // To account for newGIDs associated with nLocal-1, we'll just
-      // use an upper bound (to avoid the little loop above).
-      // By adding maxRegPerGID-1 we account for the maximum
-      // number of possible newGIDs due to last composite id
-      int upperBndNumNewGIDs = (int) firstNewGID[nLocal-1] + maxRegPerGID-1;
-      int upperBndNumNewGIDsAllProcs;
-      Comm.MaxAll(&upperBndNumNewGIDs,&upperBndNumNewGIDsAllProcs,1);
 
-      // Now that we have an upper bound on the maximum number of
-      // NewGIDs over all procs, we sweep through firstNewGID again
-      // to assign ids to the first NewGID associated with each row of
-      // regionsPerGIDWithGhosts (by adding an offset)
-      for (int k = 0; k < nLocal; k++)
-        firstNewGID[k] += upperBndNumNewGIDsAllProcs*myRank+nTotal;
+      revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,(int) revisedGIDs.size(),
+                                          revisedGIDs.data(),0,Comm));
+      // now append more stuff to handle ghosts ... needed for
+      // revised version of column map
 
-      Epetra_Import Importer(AComp->ColMap(), *mapComp);
-      Epetra_Vector firstNewGIDWithGhost(AComp->ColMap());
-      firstNewGIDWithGhost.Import(firstNewGID, Importer, Insert);
+      for (int i = 0; i < nExtended; i++) {
+        if (tempRegIDs[i] == -1) {// only in revised col map
+                   // note: since sorting not used when making the
+                   // original regional colmap, we can't use
+                   // it here either ... so no idx[]'s.
+          for (j = 0; j < maxRegPerGID; j++) {
+            jthRegions = (*regionsPerGIDWithGhosts)[j];
+            if  ( ((int) jthRegions[i]) == curRegion) break;
+          }
+          // (*regionsPerGIDWithGhosts)[0] entries keep original GID
+          // while others use firstNewGID to determine NewGID
 
-      std::vector<int> revisedGIDs;
-
-      for (int k = 0; k < (int) myRegions.size(); k++) {
-        revisedGIDs.resize(0);
-        int curRegion = myRegions[k];
-        int *colGIDsComp =  AComp->ColMap().MyGlobalElements();
-        std::vector<int> tempRegIDs(nExtended);
-
-        // must put revisedGIDs in application-provided order by
-        // invoking LIDregion() and sorting
-        for (int i = 0; i < nExtended; i++) {
-          if (doing1D)
-            tempRegIDs[i] = LIDregion(&appData, i, k);
-          else
-            tempRegIDs[i] = LID2Dregion(&appData, i, k);
-        }
-        std::vector<int> idx(tempRegIDs.size());
-        std::iota(idx.begin(),idx.end(),0);
-        sort(idx.begin(),idx.end(),[tempRegIDs](int i1,int i2){return tempRegIDs[i1] < tempRegIDs[i2];});
-
-        // Now sweep through regionsPerGIDWithGhosts looking for those
-        // associated with curRegion and record the revisedGID
-        int j;
-        for (int i = 0; i < nExtended; i++) {
-
-          if (tempRegIDs[idx[i]] != -1) {// if a valid LID for this region
-            for (j = 0; j < maxRegPerGID; j++) {
-              jthRegions = (*regionsPerGIDWithGhosts)[j];
-              if (((int) jthRegions[idx[i]]) == curRegion) break;
-            }
-
-            // (*regionsPerGIDWithGhosts)[0] entries keep original GID
-            // while others use firstNewGID to determine NewGID
-
-            if (j == 0) revisedGIDs.push_back(colGIDsComp[idx[i]]);
-            else if (j < maxRegPerGID) {
-               revisedGIDs.push_back((int) firstNewGIDWithGhost[idx[i]]+j-1);
-            }
-
-            // add entry to listDulicatedGIDs
+          if (j == 0) revisedGIDs.push_back(colGIDsComp[i]);
+          else if (j < maxRegPerGID) {
+            revisedGIDs.push_back((int) firstNewGIDWithGhost[i]+j-1);
           }
         }
+      }
+      revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1, (int) revisedGIDs.size(),
+          revisedGIDs.data(), 0, Comm));
+    }
+    for (int k = (int) myRegions.size(); k < maxRegPerProc; k++) {
+      revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+      revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+    }
 
-        revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,(int) revisedGIDs.size(),
-                                            revisedGIDs.data(),0,Comm));
-        // now append more stuff to handle ghosts ... needed for
-        // revised version of column map
+    // Setup importers
+    for (int j = 0; j < maxRegPerProc; j++) {
+      rowImportPerGrp[j] = Teuchos::rcp(new Epetra_Import(*(rowMapPerGrp[j]), *mapComp));
+      colImportPerGrp[j] = Teuchos::rcp(new Epetra_Import(*(colMapPerGrp[j]), *mapComp));
+    }
+  }
 
-        for (int i = 0; i < nExtended; i++) {
-          if (tempRegIDs[i] == -1) {// only in revised col map
-                     // note: since sorting not used when making the
-                     // original regional colmap, we can't use
-                     // it here either ... so no idx[]'s.
-            for (j = 0; j < maxRegPerGID; j++) {
-              jthRegions = (*regionsPerGIDWithGhosts)[j];
-              if  ( ((int) jthRegions[i]) == curRegion) break;
-            }
-            // (*regionsPerGIDWithGhosts)[0] entries keep original GID
-            // while others use firstNewGID to determine NewGID
+//  printRegionalMap("revisedRowMapPerGrp", revisedRowMapPerGrp, myRank);
+//  sleep(2);
+//  printRegionalMap("revisedColMapPerGrp", revisedColMapPerGrp, myRank);
 
-            if (j == 0) revisedGIDs.push_back(colGIDsComp[i]);
-            else if (j < maxRegPerGID) {
-              revisedGIDs.push_back((int) firstNewGIDWithGhost[i]+j-1);
-            }
-          }
+  Comm.Barrier();
+
+  // Make quasiRegion matrices
+  {
+    std::cout << myRank << " | Forming quasiRegion matrices ..." << std::endl;
+
+    /* We use the edge-based splitting, i.e. we first modify off-diagonal
+     * entries in the composite matrix, then decompose it into region matrices
+     * and finally take care of diagonal entries by enforcing the nullspace
+     * preservation constraint.
+     */
+
+    // copy and modify the composite matrix
+    ACompSplit = Teuchos::rcp(new Epetra_CrsMatrix(*AComp));
+
+    for (int row = 0; row < ACompSplit->NumMyRows(); ++row) { // loop over local rows of composite matrix
+      int rowGID = ACompSplit->RowMap().GID(row);
+      int numEntries; // number of nnz
+      double* vals; // non-zeros in this row
+      int* inds; // local column indices
+      int err = ACompSplit->ExtractMyRowView(row, numEntries, vals, inds);
+      TEUCHOS_ASSERT(err == 0);
+
+      for (int c = 0; c < numEntries; ++c) { // loop over all entries in this row
+        int col = inds[c];
+        int colGID = ACompSplit->ColMap().GID(col);
+        std::vector<int> commonRegions;
+        if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
+          commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
         }
-        revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1, (int) revisedGIDs.size(),
-            revisedGIDs.data(), 0, Comm));
-      }
-      for (int k = (int) myRegions.size(); k < maxRegPerProc; k++) {
-        revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
-        revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
-      }
 
-      // Setup importers
+        if (commonRegions.size() > 1) {
+          vals[c] *= 0.5;
+        }
+      }
+    }
+
+    // Import data from ACompSplit into the quasiRegion matrices
+    for (int j = 0; j < maxRegPerProc; j++) {
+      quasiRegionGrpMats[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *(rowMapPerGrp[j]),
+          *(colMapPerGrp[j]), -1));
+      quasiRegionGrpMats[j]->Import(*ACompSplit, *(rowImportPerGrp[j]), Insert);
+      quasiRegionGrpMats[j]->FillComplete();
+    }
+  }
+
+  Comm.Barrier();
+
+  // Make region matrices
+  {
+    std::cout << myRank << " | Forming region matrices ..." << std::endl;
+
+    // Copy data from quasiRegionGrpMats, but into new map layout
+    {
       for (int j = 0; j < maxRegPerProc; j++) {
-        rowImportPerGrp[j] = Teuchos::rcp(new Epetra_Import(*(rowMapPerGrp[j]), *mapComp));
-        colImportPerGrp[j] = Teuchos::rcp(new Epetra_Import(*(colMapPerGrp[j]), *mapComp));
-      }
+        // create empty matrix with correct row and column map
+        regionGrpMats[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *(revisedRowMapPerGrp[j]), *(revisedColMapPerGrp[j]), 3));
 
-    }
-    else if (strcmp(command,"MakeGrpRegRowMaps") == 0) {
-      std::vector<int> rowGIDsReg;
-      int *colGIDsComp = AComp->ColMap().MyGlobalElements();
-      for (int k = 0; k < (int) myRegions.size(); k++) {
-        rowGIDsReg.resize(0);
-        std::vector<int> tempRegIDs(AComp->ColMap().NumMyElements());
-        for (int i = 0; i < AComp->ColMap().NumMyElements(); i++) {
-          if (doing1D) tempRegIDs[i] = LIDregion(&appData, i, k);
-          else tempRegIDs[i] = LID2Dregion(&appData, i, k);
+        // extract pointers to crs arrays from quasiRegion matrix
+        Epetra_IntSerialDenseVector & qRowPtr = quasiRegionGrpMats[j]->ExpertExtractIndexOffset();
+        Epetra_IntSerialDenseVector & qColInd = quasiRegionGrpMats[j]->ExpertExtractIndices();
+        double *& qVals = quasiRegionGrpMats[j]->ExpertExtractValues();
+
+        // extract pointers to crs arrays from region matrix
+        Epetra_IntSerialDenseVector & rowPtr = regionGrpMats[j]->ExpertExtractIndexOffset();
+        Epetra_IntSerialDenseVector & colInd = regionGrpMats[j]->ExpertExtractIndices();
+        double *& vals = regionGrpMats[j]->ExpertExtractValues();
+
+        // assign array values from quasiRegional to regional matrices
+        rowPtr.Resize(qRowPtr.Length());
+        colInd.Resize(qColInd.Length());
+        delete [] vals;
+        vals = new double[colInd.Length()];
+        for (int i = 0; i < rowPtr.Length(); ++i) rowPtr[i] = qRowPtr[i];
+        for (int i = 0; i < colInd.Length(); ++i) {
+          colInd[i] = qColInd[i];
+          vals[i] = qVals[i];
         }
-
-        std::vector<int> idx(tempRegIDs.size());
-        std::iota(idx.begin(), idx.end(), 0);
-        sort(idx.begin(), idx.end(), [tempRegIDs](int i1,int i2) { return tempRegIDs[i1] < tempRegIDs[i2];});
-
-        for (int i = 0; i < AComp->ColMap().NumMyElements(); i++) {
-          if (tempRegIDs[idx[i]] != -1)
-            rowGIDsReg.push_back(colGIDsComp[idx[i]]);
-        }
-        rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1, (int) rowGIDsReg.size(),
-            rowGIDsReg.data(), 0, Comm));
       }
 
-      for (int k=(int) myRegions.size(); k < maxRegPerProc; k++) {
-        rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
-      }
-    }
-    else if (strcmp(command,"PrintRevisedRowMaps") == 0) {
-      sleep(myRank);
-      char str[80]; sprintf(str,"%d: revisedRowMap ",myRank);
-      printGrpMaps(revisedRowMapPerGrp, maxRegPerProc, str);
-    }
-    else if (strcmp(command,"PrintRevisedColMaps") == 0) {
-      sleep(myRank);
-      char str[80]; sprintf(str,"%d: revisedColMap ",myRank);
-      printGrpMaps(revisedColMapPerGrp, maxRegPerProc, str);
-    }
-    else if (strcmp(command,"PrintGrpRegDomMaps") == 0) {
-      sleep(myRank);
-      char str[80]; sprintf(str,"%d: domMap ",myRank);
-      printGrpMaps(revisedRowMapPerGrp, maxRegPerProc, str);
-    }
-    else if (strcmp(command,"PrintGrpRegRowMaps") == 0) {
-      sleep(myRank);
-      char str[80]; sprintf(str,"%d: rowMap ",myRank);
-      printGrpMaps(rowMapPerGrp, maxRegPerProc, str);
-    }
-    else if (strcmp(command,"TestRegionalToComposite") == 0) {
-      /* Create a random vector in regional layout and use both regionalToComposite
-       * modes (with automatic and manual ADD of local values). Compare results.
+      /* add domain and range map to region matrices (pass in revisedRowMap, since
+       * we assume that row map = range map = domain map)
        */
-
-      Teuchos::RCP<Epetra_Vector> startVec = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      startVec->Random();
-
-      std::vector<Teuchos::RCP<Epetra_Vector> > regStartVec(maxRegPerProc);
-      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegStartVec(maxRegPerProc);
-      compositeToRegional(startVec, quasiRegStartVec, regStartVec, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-
-      // use automatic ADD of local values via Export()
-      Teuchos::RCP<Epetra_Vector> autoCompVec = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      regionalToComposite(regStartVec, autoCompVec, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Epetra_AddLocalAlso, false);
-
-      Teuchos::RCP<Epetra_Vector> manCompVec = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      regionalToComposite(regStartVec, manCompVec, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Add, true);
-
-      // check for difference in result
-      {
-        Teuchos::RCP<Epetra_Vector> diff = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-        int err = diff->Update(1.0, *autoCompVec, -1.0, *manCompVec, 0.0);
-        TEUCHOS_ASSERT( err == 0);
-        double diffNorm2 = 0.0;
-        diff->Norm2(&diffNorm2);
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(diffNorm2 > 1.0e-15, "regionalToComposite() delivers "
-            "different results for adding local values via Export() combine mode or manually.");
+      for (int j = 0; j < maxRegPerProc; j++) {
+        regionGrpMats[j]->ExpertStaticFillComplete(*(revisedRowMapPerGrp[j]),*(revisedRowMapPerGrp[j]));
       }
     }
-    else if (strcmp(command,"MakeQuasiRegionMatrices") == 0) {
-      /* We use the edge-based splitting, i.e. we first modify off-diagonal
-       * entries in the composite matrix, then decompose it into region matrices
-       * and finally take care of diagonal entries by enforcing the nullspace
-       * preservation constraint.
+
+    // enforce nullspace constraint
+    {
+      // compute violation of nullspace property close to DBCs
+      Teuchos::RCP<Epetra_Vector> nspVec = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+      nspVec->PutScalar(1.0);
+      nspViolation = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+      int err = AComp->Apply(*nspVec, *nspViolation);
+      TEUCHOS_ASSERT(err == 0);
+
+      // move to regional layout
+      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegNspViolation(maxRegPerProc);
+      createRegionalVector(quasiRegNspViolation, maxRegPerProc, rowMapPerGrp);
+      createRegionalVector(regNspViolation, maxRegPerProc, revisedRowMapPerGrp);
+      compositeToRegional(nspViolation, quasiRegNspViolation, regNspViolation,
+          maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+
+      /* The nullspace violation computed in the composite layout needs to be
+       * transfered to the regional layout. Since we use this to compute
+       * the splitting of the diagonal values, we need to split the nullspace
+       * violation. We'd like to use the 'regInterfaceScaling', though this is
+       * not setup at this point. So, let's compute it right now.
+       *
+       * ToDo: Move setup of 'regInterfaceScaling' up front to use it here.
        */
-
-      // copy and modify the composite matrix
-      ACompSplit = Teuchos::rcp(new Epetra_CrsMatrix(*AComp));
-
-      for (int row = 0; row < ACompSplit->NumMyRows(); ++row) { // loop over local rows of composite matrix
-        int rowGID = ACompSplit->RowMap().GID(row);
-        int numEntries; // number of nnz
-        double* vals; // non-zeros in this row
-        int* inds; // local column indices
-        int err = ACompSplit->ExtractMyRowView(row, numEntries, vals, inds);
-        TEUCHOS_ASSERT(err == 0);
-
-        for (int c = 0; c < numEntries; ++c) { // loop over all entries in this row
-          int col = inds[c];
-          int colGID = ACompSplit->ColMap().GID(col);
-          std::vector<int> commonRegions;
-          if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
-            commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
-          }
-
-          if (commonRegions.size() > 1) {
-            vals[c] *= 0.5;
-          }
-        }
-      }
-
-      // Import data from ACompSplit into the quasiRegion matrices
-      for (int j = 0; j < maxRegPerProc; j++) {
-        quasiRegionGrpMats[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *(rowMapPerGrp[j]),
-            *(colMapPerGrp[j]), -1));
-        quasiRegionGrpMats[j]->Import(*ACompSplit, *(rowImportPerGrp[j]), Insert);
-        quasiRegionGrpMats[j]->FillComplete();
-      }
-    }
-    else if (strcmp(command,"PrintQuasiRegionMatrices") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: Matrix in Grp %d\n",myRank,j);
-        std::cout << *(quasiRegionGrpMats[j]) << std::endl;
-      }
-    }
-    else if (strcmp(command,"MakeInterfaceScalingFactorsRecursively") == 0) {
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!numLevels>0, "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
-
-      for (int l = 0; l < numLevels; l++)
       {
         // initialize region vector with all ones.
+        std::vector<Teuchos::RCP<Epetra_Vector> > interfaceScaling(maxRegPerProc);
         for (int j = 0; j < maxRegPerProc; j++) {
-          regInterfaceScalings[l][j] = rcp(new Epetra_Vector(*regRowMaps[l][j], true));
-          regInterfaceScalings[l][j]->PutScalar(1.0);
-        }
-
-        // transform to composite layout while adding interface values via the Export() combine mode
-        RCP<Epetra_Vector> compInterfaceScalingSum = rcp(new Epetra_Vector(*compMaps[l], true));
-        regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, maxRegPerProc, quasiRegRowMaps[l], regRowImporters[l], Add, true);
-
-        /* transform composite layout back to regional layout. Now, GIDs associated
-         * with region interface should carry a scaling factor (!= 1).
-         */
-        std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegInterfaceScaling(maxRegPerProc);
-        compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-            regInterfaceScalings[l], maxRegPerProc, quasiRegRowMaps[l],
-            regRowMaps[l], regRowImporters[l]);
-      }
-    }
-    else if (strcmp(command,"MakeInterfaceScalingFactors") == 0) {
-      // Fine level
-      {
-        // initialize region vector with all ones.
-        for (int j = 0; j < maxRegPerProc; j++) {
-          regionInterfaceScaling[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-          regionInterfaceScaling[j]->PutScalar(1.0);
+          interfaceScaling[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
+          interfaceScaling[j]->PutScalar(1.0);
         }
 
         // transform to composite layout while adding interface values via the Export() combine mode
         Teuchos::RCP<Epetra_Vector> compInterfaceScalingSum = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-        regionalToComposite(regionInterfaceScaling, compInterfaceScalingSum,
-              maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Add, true);
+        regionalToComposite(interfaceScaling, compInterfaceScalingSum,
+            maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Epetra_AddLocalAlso, false);
 
         /* transform composite layout back to regional layout. Now, GIDs associated
          * with region interface should carry a scaling factor (!= 1).
          */
         std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegInterfaceScaling(maxRegPerProc);
         compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-            regionInterfaceScaling, maxRegPerProc, rowMapPerGrp,
+            interfaceScaling, maxRegPerProc, rowMapPerGrp,
             revisedRowMapPerGrp, rowImportPerGrp);
-      }
 
-      // Coarse level
-      {
-        // initialize region vector with all ones.
+        // modify its interface entries
         for (int j = 0; j < maxRegPerProc; j++) {
-          coarseRegionInterfaceScaling[j] = Teuchos::rcp(new Epetra_Vector(*coarseRowMapPerGrp[j], true));
-          coarseRegionInterfaceScaling[j]->PutScalar(1.0);
-        }
-
-        // transform to composite layout while adding interface values via the Export() combine mode
-        Teuchos::RCP<Epetra_Vector> compInterfaceScalingSum = Teuchos::rcp(new Epetra_Vector(*coarseCompRowMap, true));
-        regionalToComposite(coarseRegionInterfaceScaling, compInterfaceScalingSum,
-            maxRegPerProc, coarseQuasiRowMapPerGrp, coarseRowImportPerGrp, Add, true);
-
-        /* transform composite layout back to regional layout. Now, GIDs associated
-         * with region interface should carry a scaling factor (!= 1).
-         */
-        std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegInterfaceScaling(maxRegPerProc);
-        compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-            coarseRegionInterfaceScaling, maxRegPerProc, coarseQuasiRowMapPerGrp,
-            coarseRowMapPerGrp, coarseRowImportPerGrp);
-      }
-    }
-    else if (strcmp(command,"MakeRegionMatrices") == 0) {
-
-      // Copy data from quasiRegionGrpMats, but into new map layout
-      {
-        for (int j = 0; j < maxRegPerProc; j++) {
-          // create empty matrix with correct row and column map
-          regionGrpMats[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *(revisedRowMapPerGrp[j]), *(revisedColMapPerGrp[j]), 3));
-
-          // extract pointers to crs arrays from quasiRegion matrix
-          Epetra_IntSerialDenseVector & qRowPtr = quasiRegionGrpMats[j]->ExpertExtractIndexOffset();
-          Epetra_IntSerialDenseVector & qColInd = quasiRegionGrpMats[j]->ExpertExtractIndices();
-          double *& qVals = quasiRegionGrpMats[j]->ExpertExtractValues();
-
-          // extract pointers to crs arrays from region matrix
-          Epetra_IntSerialDenseVector & rowPtr = regionGrpMats[j]->ExpertExtractIndexOffset();
-          Epetra_IntSerialDenseVector & colInd = regionGrpMats[j]->ExpertExtractIndices();
-          double *& vals = regionGrpMats[j]->ExpertExtractValues();
-
-          // assign array values from quasiRegional to regional matrices
-          rowPtr.Resize(qRowPtr.Length());
-          colInd.Resize(qColInd.Length());
-          delete [] vals;
-          vals = qVals;
-          for (int i = 0; i < rowPtr.Length(); ++i) rowPtr[i] = qRowPtr[i];
-          for (int i = 0; i < colInd.Length(); ++i) colInd[i] = qColInd[i];
-        }
-
-        /* add domain and range map to region matrices (pass in revisedRowMap, since
-         * we assume that row map = range map = domain map)
-         */
-        for (int j = 0; j < maxRegPerProc; j++) {
-          regionGrpMats[j]->ExpertStaticFillComplete(*(revisedRowMapPerGrp[j]),*(revisedRowMapPerGrp[j]));
-        }
-      }
-
-      // enforce nullspace constraint
-      {
-        // compute violation of nullspace property close to DBCs
-        Teuchos::RCP<Epetra_Vector> nspVec = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-        nspVec->PutScalar(1.0);
-        nspViolation = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-        int err = AComp->Apply(*nspVec, *nspViolation);
-        TEUCHOS_ASSERT(err == 0);
-
-        // move to regional layout
-        std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegNspViolation(maxRegPerProc);
-        createRegionalVector(quasiRegNspViolation, maxRegPerProc, rowMapPerGrp);
-        createRegionalVector(regNspViolation, maxRegPerProc, revisedRowMapPerGrp);
-        compositeToRegional(nspViolation, quasiRegNspViolation, regNspViolation,
-            maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-
-        /* The nullspace violation computed in the composite layout needs to be
-         * transfered to the regional layout. Since we use this to compute
-         * the splitting of the diagonal values, we need to split the nullspace
-         * violation. We'd like to use the 'regInterfaceScaling', though this is
-         * not setup at this point. So, let's compute it right now.
-         *
-         * ToDo: Move setup of 'regInterfaceScaling' up front to use it here.
-         */
-        {
-          // initialize region vector with all ones.
-          std::vector<Teuchos::RCP<Epetra_Vector> > interfaceScaling(maxRegPerProc);
-          for (int j = 0; j < maxRegPerProc; j++) {
-            interfaceScaling[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-            interfaceScaling[j]->PutScalar(1.0);
-          }
-
-          // transform to composite layout while adding interface values via the Export() combine mode
-          Teuchos::RCP<Epetra_Vector> compInterfaceScalingSum = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-          regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-              maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Epetra_AddLocalAlso, false);
-
-          /* transform composite layout back to regional layout. Now, GIDs associated
-           * with region interface should carry a scaling factor (!= 1).
-           */
-          std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegInterfaceScaling(maxRegPerProc);
-          compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-              interfaceScaling, maxRegPerProc, rowMapPerGrp,
-              revisedRowMapPerGrp, rowImportPerGrp);
-
-          // modify its interface entries
-          for (int j = 0; j < maxRegPerProc; j++) {
-            for (int i = 0; i < regNspViolation[j]->MyLength(); ++i) {
-              (*regNspViolation[j])[i] /= (*interfaceScaling[j])[i];
-            }
+          for (int i = 0; i < regNspViolation[j]->MyLength(); ++i) {
+            (*regNspViolation[j])[i] /= (*interfaceScaling[j])[i];
           }
         }
       }
-
-      std::vector<Teuchos::RCP<Epetra_Vector> > regNsp(maxRegPerProc);
-      std::vector<Teuchos::RCP<Epetra_Vector> > regCorrection(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        regNsp[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-        regNsp[j]->PutScalar(1.0);
-
-        regCorrection[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-        int err = regionGrpMats[j]->Apply(*regNsp[j], *regCorrection[j]);
-        TEUCHOS_ASSERT(err == 0);
-      }
-
-
-      std::vector<Teuchos::RCP<Epetra_Vector> > regDiag(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        regDiag[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-        int err = regionGrpMats[j]->ExtractDiagonalCopy(*regDiag[j]);
-        TEUCHOS_ASSERT(err == 0);
-        err = regDiag[j]->Update(-1.0, *regCorrection[j], 1.0, *regNspViolation[j], 1.0);
-        TEUCHOS_ASSERT(err == 0);
-
-        err = regionGrpMats[j]->ReplaceDiagonalValues(*regDiag[j]);
-        TEUCHOS_ASSERT(err == 0);
-      }
     }
-    else if (strcmp(command,"PrintRegionMatrices") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: Matrix in Grp %d\n",myRank,j);
-        std::cout << myRank << *(regionGrpMats[j]) << std::endl;
-      }
+
+    std::vector<Teuchos::RCP<Epetra_Vector> > regNsp(maxRegPerProc);
+    std::vector<Teuchos::RCP<Epetra_Vector> > regCorrection(maxRegPerProc);
+    for (int j = 0; j < maxRegPerProc; j++) {
+      regNsp[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
+      regNsp[j]->PutScalar(1.0);
+
+      regCorrection[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
+      int err = regionGrpMats[j]->Apply(*regNsp[j], *regCorrection[j]);
+      TEUCHOS_ASSERT(err == 0);
     }
-    else if (strcmp(command,"PrintRegionMatrixRowMap") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: Row Map Grp %d\n", myRank, j);
-        regionGrpMats[j]->RowMap().Print(std::cout);
-      }
+
+    std::vector<Teuchos::RCP<Epetra_Vector> > regDiag(maxRegPerProc);
+    for (int j = 0; j < maxRegPerProc; j++) {
+      regDiag[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
+      int err = regionGrpMats[j]->ExtractDiagonalCopy(*regDiag[j]);
+      TEUCHOS_ASSERT(err == 0);
+      err = regDiag[j]->Update(-1.0, *regCorrection[j], 1.0, *regNspViolation[j], 1.0);
+      TEUCHOS_ASSERT(err == 0);
+
+      err = regionGrpMats[j]->ReplaceDiagonalValues(*regDiag[j]);
+      TEUCHOS_ASSERT(err == 0);
     }
-    else if (strcmp(command,"PrintRegionMatrixColMap") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: Col Map Grp %d\n", myRank, j);
-        regionGrpMats[j]->ColMap().Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"PrintRegionMatrixRangeMap") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: Range Map Grp %d\n", myRank, j);
-        regionGrpMats[j]->OperatorRangeMap().Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"PrintRegionMatrixDomainMap") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: Domain Map Grp %d\n", myRank, j);
-        regionGrpMats[j]->OperatorDomainMap().Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"ComputeMatVecs") == 0) {
-      // create input and result vector in composite layout
-      compX = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      compY = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      compX->Random();
-//      compX->PutScalar(myRank);
+  }
 
-      // perform matvec in composite layout
-      {
-        int err = AComp->Apply(*compX, *compY);
-        TEUCHOS_ASSERT(err == 0);
-      }
+  Comm.Barrier();
 
-      // transform composite vector to regional layout
-      compositeToRegional(compX, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
-          revisedRowMapPerGrp, rowImportPerGrp);
-      createRegionalVector(regY, maxRegPerProc, revisedRowMapPerGrp);
+  // Make MueLu transfer operators
+  {
+    std::cout << myRank << " | Setting up MueLu hierarchies ..." << std::endl;
 
-      // perform matvec in regional layout
-      for (int j = 0; j < maxRegPerProc; j++) {
-        int err = regionGrpMats[j]->Apply(*(regX[j]), *(regY[j]));
-        TEUCHOS_ASSERT(err == 0);
-      }
-
-      // transform regY back to composite layout
-      regYComp = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      regionalToComposite(regY, regYComp, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Epetra_AddLocalAlso, false);
-
-      Teuchos::RCP<Epetra_Vector> diffY = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      diffY->Update(1.0, *compY, -1.0, *regYComp, 0.0);
-
-//      diffY->Print(std::cout);
-
-      sleep(8);
-
-      double diffNormTwo = 0.0;
-      double diffNormInf = 0.0;
-      diffY->Norm2(&diffNormTwo);
-      diffY->NormInf(&diffNormInf);
-      std::cout << myRank << ": diffNormTwo: " << diffNormTwo << "\tdiffNormInf: " << diffNormInf << std::endl;
-
-    }
-    else if (strcmp(command,"MakeMueLuTransferOperators") == 0) {
-
-//      printRegionalMap("rowMapPerGrp", rowMapPerGrp, myRank);
+//    printRegionalMap("rowMapPerGrp", rowMapPerGrp, myRank);
 //
-//      sleep(3);
+//    sleep(3);
 //
-//      printRegionalMap("revisedRowMapPerGrp", revisedRowMapPerGrp, myRank);
+//    printRegionalMap("revisedRowMapPerGrp", revisedRowMapPerGrp, myRank);
 
-      typedef MueLu::HierarchyManager<double,int,int,Xpetra::EpetraNode> HierarchyManager;
-      typedef MueLu::Hierarchy<double,int,int,Xpetra::EpetraNode> Hierarchy;
-      typedef MueLu::ParameterListInterpreter<double,int,int,Xpetra::EpetraNode> ParameterListInterpreter;
-      typedef MueLu::Aggregates<int,int,Xpetra::EpetraNode> Aggregates;
-      typedef MueLu::FactoryManagerBase FactoryManagerBase;
-      typedef MueLu::Utilities<double,int,int,Xpetra::EpetraNode> Utilities;
-      typedef Xpetra::Map<int,int,Xpetra::EpetraNode> Map;
-      typedef Xpetra::MultiVector<double,int,int,Xpetra::EpetraNode> MultiVector;
-      typedef Xpetra::MultiVectorFactory<double,int,int,Xpetra::EpetraNode> MultiVectorFactory;
-      typedef Xpetra::Matrix<double,int,int,Xpetra::EpetraNode> Matrix;
+    typedef MueLu::HierarchyManager<double,int,int,Xpetra::EpetraNode> HierarchyManager;
+    typedef MueLu::Hierarchy<double,int,int,Xpetra::EpetraNode> Hierarchy;
+    typedef MueLu::ParameterListInterpreter<double,int,int,Xpetra::EpetraNode> ParameterListInterpreter;
+    typedef MueLu::Aggregates<int,int,Xpetra::EpetraNode> Aggregates;
+    typedef MueLu::FactoryManagerBase FactoryManagerBase;
+    typedef MueLu::Utilities<double,int,int,Xpetra::EpetraNode> Utilities;
+    typedef Xpetra::Map<int,int,Xpetra::EpetraNode> Map;
+    typedef Xpetra::MultiVector<double,int,int,Xpetra::EpetraNode> MultiVector;
+    typedef Xpetra::MultiVectorFactory<double,int,int,Xpetra::EpetraNode> MultiVectorFactory;
+    typedef Xpetra::Matrix<double,int,int,Xpetra::EpetraNode> Matrix;
 
-      using Teuchos::RCP; using Teuchos::rcp; using Teuchos::ParameterList;
+    using Teuchos::RCP; using Teuchos::rcp; using Teuchos::ParameterList;
 
-      Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::rcp(new Teuchos::FancyOStream(Teuchos::rcp(&std::cout,false)));
+    Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::rcp(new Teuchos::FancyOStream(Teuchos::rcp(&std::cout,false)));
 
-      // convert Epetra region matrices to Xpetra
-      std::vector<RCP<Matrix> > regionGrpXMats(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        regionGrpXMats[j] = MueLu::EpetraCrs_To_XpetraMatrix<double,int,int,Xpetra::EpetraNode>(regionGrpMats[j]);
-      }
+    // convert Epetra region matrices to Xpetra
+    std::vector<RCP<Matrix> > regionGrpXMats(maxRegPerProc);
+    for (int j = 0; j < maxRegPerProc; j++) {
+      regionGrpXMats[j] = MueLu::EpetraCrs_To_XpetraMatrix<double,int,int,Xpetra::EpetraNode>(regionGrpMats[j]);
+    }
 
-      std::vector<RCP<Hierarchy> > regGrpHierarchy(maxRegPerProc);
-      std::vector<RCP<HierarchyManager> > regMueLuFactory(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) {
+    std::vector<RCP<Hierarchy> > regGrpHierarchy(maxRegPerProc);
+    std::vector<RCP<HierarchyManager> > regMueLuFactory(maxRegPerProc);
+    for (int j = 0; j < maxRegPerProc; j++) {
 
-        // create nullspace vector
-        RCP<const Map> map = regionGrpXMats[j]->getRowMap();
-        RCP<MultiVector> nullspace = MultiVectorFactory::Build(map, 1);
-        nullspace->putScalar(1.0);
+      // create nullspace vector
+      RCP<const Map> map = regionGrpXMats[j]->getRowMap();
+      RCP<MultiVector> nullspace = MultiVectorFactory::Build(map, 1);
+      nullspace->putScalar(1.0);
 
-        // create dummy coordinates vector
-        RCP<MultiVector> coordinates = MultiVectorFactory::Build(map, 3);
-        coordinates->putScalar(1.0);
+      // create dummy coordinates vector
+      RCP<MultiVector> coordinates = MultiVectorFactory::Build(map, 3);
+      coordinates->putScalar(1.0);
 
 //        const std::string xmlFileName = "/home/mmayr/wdir/codes/mayrmt-trilinos/Trilinos/packages/muelu/research/mmayr/composite_to_regions/src/muelu_expert.xml";
 //        const std::string xmlFileName = "/home/mmayr/wdir/codes/mayrmt-trilinos/Trilinos/packages/muelu/research/mmayr/composite_to_regions/src/muelu_simple.xml";
-        const std::string xmlFileName = "/home/mmayr/wdir/codes/mayrmt-trilinos/Trilinos/packages/muelu/research/mmayr/composite_to_regions/src/muelu_structured.xml";
-        RCP<const Teuchos::Comm<int> > teuchosComm = Teuchos::DefaultComm<int>::getComm();
-        Teuchos::ParameterList paramList;
-        Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *teuchosComm);
+      const std::string xmlFileName = "/home/mmayr/wdir/codes/mayrmt-trilinos/Trilinos/packages/muelu/research/mmayr/composite_to_regions/src/muelu_structured.xml";
+      RCP<const Teuchos::Comm<int> > teuchosComm = Teuchos::DefaultComm<int>::getComm();
+      Teuchos::ParameterList paramList;
+      Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *teuchosComm);
 
-        regMueLuFactory[j] = rcp(new ParameterListInterpreter(paramList));
-        regGrpHierarchy[j] = regMueLuFactory[j]->CreateHierarchy();
-        regGrpHierarchy[j]->GetLevel(0)->Set("A", regionGrpXMats[j]);
-        regGrpHierarchy[j]->GetLevel(0)->Set("Nullspace", nullspace);
-        regGrpHierarchy[j]->GetLevel(0)->Set("Coordinates", coordinates);
+      regMueLuFactory[j] = rcp(new ParameterListInterpreter(paramList));
+      regGrpHierarchy[j] = regMueLuFactory[j]->CreateHierarchy();
+      regGrpHierarchy[j]->GetLevel(0)->Set("A", regionGrpXMats[j]);
+      regGrpHierarchy[j]->GetLevel(0)->Set("Nullspace", nullspace);
+      regGrpHierarchy[j]->GetLevel(0)->Set("Coordinates", coordinates);
 
-        // For structured aggregation
+      // For structured aggregation
+      {
+        Array<int> gNodesPerDim(3);
+        for (int i = 0; i < gNodesPerDim.size(); ++i)
+          gNodesPerDim[i] = -1;
+
+        Array<int> lNodesPerDim(3);
+        // One-dimensional problems
         {
-          Array<int> gNodesPerDim(3);
-          for (int i = 0; i < gNodesPerDim.size(); ++i)
-            gNodesPerDim[i] = -1;
+          lNodesPerDim[0] = revisedRowMapPerGrp[j]->NumMyElements();
+          lNodesPerDim[1] = 1;
+          lNodesPerDim[2] = 1;
+        }
 
-          Array<int> lNodesPerDim(3);
-          // One-dimensional problems
-          {
-//            lNodesPerDim[0] = revisedRowMapPerGrp[j]->NumMyElements();
-//            lNodesPerDim[1] = 1;
+        // Two-dimensional problems
+        {
+//          // caseFifteen
+//          {
+//            lNodesPerDim[0] = 4;
+//            lNodesPerDim[1] = 4;
 //            lNodesPerDim[2] = 1;
+//          }
+
+//          // caseSixteen
+//          {
+//            lNodesPerDim[0] = 7;
+//            lNodesPerDim[1] = 7;
+//            lNodesPerDim[2] = 1;
+//          }
+
+//          // caseSeventeen
+//          {
+//            lNodesPerDim[0] = 31;
+//            lNodesPerDim[1] = 31;
+//            lNodesPerDim[2] = 1;
+//          }
+
+//          // caseEightteen / caseNineteen
+//          {
+//            lNodesPerDim[0] = 16;
+//            lNodesPerDim[1] = 16;
+//            lNodesPerDim[2] = 1;
+//          }
+
+//          // caseTwenty
+//          {
+//            lNodesPerDim[0] = 10;
+//            lNodesPerDim[1] = 10;
+//            lNodesPerDim[2] = 1;
+//          }
+        }
+
+        regGrpHierarchy[j]->GetLevel(0)->Set("gNodesPerDim", gNodesPerDim);
+        regGrpHierarchy[j]->GetLevel(0)->Set("lNodesPerDim", lNodesPerDim);
+      }
+
+      regMueLuFactory[j]->SetupHierarchy(*regGrpHierarchy[j]);
+
+    }
+
+    // resize Arrays and vectors
+    {
+      // resize level containers
+      numLevels = regGrpHierarchy[0]->GetNumLevels();
+      compMaps.resize(numLevels);
+      regRowMaps.resize(numLevels);
+      quasiRegRowMaps.resize(numLevels);
+      regMatrices.resize(numLevels);
+      regProlong.resize(numLevels);
+      regRowImporters.resize(numLevels);
+      regInterfaceScalings.resize(numLevels);
+
+      // resize group containers on each level
+      for (int l = 0; l < numLevels; ++l) {
+        regRowMaps[l].resize(maxRegPerProc);
+        quasiRegRowMaps[l].resize(maxRegPerProc);
+        regMatrices[l].resize(maxRegPerProc);
+        regProlong[l].resize(maxRegPerProc);
+        regRowImporters[l].resize(maxRegPerProc);
+        regInterfaceScalings[l].resize(maxRegPerProc);
+      }
+    }
+
+    // Fill fine level with our data
+    {
+      compMaps[0] = mapComp;
+      quasiRegRowMaps[0] = rowMapPerGrp;
+      regRowMaps[0] = revisedRowMapPerGrp;
+      regRowImporters[0] = rowImportPerGrp;
+      regMatrices[0] = regionGrpMats;
+
+      /* MueLu stores prolongator on coarse level, so there is no prolongator
+       * on the fine level. To have level containers of the same size, let's
+       * just put in dummy data
+       */
+      std::vector<RCP<Epetra_CrsMatrix> > fineLevelProlong(maxRegPerProc);
+      for (int j = 0; j < maxRegPerProc; ++j)
+        fineLevelProlong[j] = Teuchos::null;
+      regProlong[0] = fineLevelProlong;
+    }
+
+    // Get coarse level matrices and prolongators from MueLu hierarchy (Note: fine level has been dealt with previously)
+    for (int l = 1; l < numLevels; ++l) { // Note: we start at level 1 (which is the first coarse level)
+      for (int j = 0; j < maxRegPerProc; ++j) {
+        RCP<MueLu::Level> level = regGrpHierarchy[j]->GetLevel(l);
+
+        RCP<Matrix> regPXpetra = level->Get<RCP<Matrix> >("P", MueLu::NoFactory::get());
+        regProlong[l][j] = Utilities::Op2NonConstEpetraCrs(regPXpetra);
+
+        RCP<Matrix> regRAPXpetra = level->Get<RCP<Matrix> >("A", MueLu::NoFactory::get());
+        regMatrices[l][j] = Utilities::Op2NonConstEpetraCrs(regRAPXpetra);
+
+        regRowMaps[l][j] = Teuchos::rcp(new Epetra_Map(regMatrices[l][j]->RowMap())); // ToDo (mayr.mt) Do not copy!
+      }
+    }
+
+    /* Reconstruct coarse-level maps
+     *
+     * We know the regional map on the coarse levels since they are just the
+     * row maps of the coarse level operators. Though, we need to re-construct
+     * the quasiRegional and composite maps ourselves.
+     */
+
+    {
+      /* General strategy to create coarse level maps:
+       * =============================================
+       *
+       * We need three maps on the next coarser level:
+       * - regional map: just extract the RowMap() from the prolongator
+       * - quasiRegional map: needs to be formed manually
+       * - composite map: needs to be formed manually
+       *
+       * After extracting the RowMap() from the prolongator to be used as the
+       * coarse level's regional map, we need to identify pairs/sets of GIDs
+       * that represent the same (duplicated) DOF at a region interface in
+       * order to form the quasiRegional and composite map for the next
+       * coarser level.
+       *
+       * Identifying this pairs consists of several steps:
+       * 1. Identify GIDs that represent the same (duplicated) DOF at a region
+       *   interface on the current level
+       * 2. Identify GIDs that represent the same (duplicated) DOF at a region
+       *   interface on the next coarser level
+       *
+       * To form the quasiRegional map, we loop over the regional map and
+       * - copy each GID that's associated with an interior DOF away from a
+       *   region interface.
+       * - replace each GID that's associated with an interface DOF by its
+       *   quasiRegional counterpart.
+       *
+       * Note: We choose the quasiRegional (and composite) GID of an interface
+       * DOF to be the std::min of all GIDs that represent that same
+       * duplicated DOF.
+       *
+       * To form the composite map, we loop over the quasiRegional map and
+       * - every proc accepts every GID that it owns.
+       * - every proc ignores every GID that it doesn't own.
+       */
+
+      int err = 0;
+
+      ////////////////////////////////////////////////////////////////////////
+      // IDENTIFY DUPLICATED GIDS ON FINE LEVEL
+      ////////////////////////////////////////////////////////////////////////
+
+      RCP<Epetra_CrsMatrix> summedDuplicateMatrix = Teuchos::null;
+
+      // Find lists of duplicated GIDs locally
+      interfaceLIDs.resize(numLevels);
+      interfaceGIDPairs.resize(numLevels);
+      for (int l = 0; l < numLevels; ++l) {
+        interfaceLIDs[l].resize(maxRegPerProc);
+        interfaceGIDPairs[l].resize(maxRegPerProc);
+      }
+
+      for (int l = 0; l < numLevels - 1; ++l) {
+//        Comm.Barrier();
+//        if (Comm.MyPID() == 0) {
+//          std::cout << std::endl << std::endl
+//              << "Processing GID pairs on level " << l
+//              << std::endl << std::endl;
+//        }
+//        Comm.Barrier();
+
+//        sleep(1);
+//        std::cout << "Prolongator" << std::endl;
+//        regProlong[l+1][0]->Print(std::cout);
+
+        // create list of LIDs per group
+        for (int j = 0; j < maxRegPerProc; j++) {
+          for (int i = 0; i < regRowMaps[l][j]->NumMyElements(); ++i) {
+            if (regRowMaps[l][j]->GID(i) != quasiRegRowMaps[l][j]->GID(i)) {
+              // This is an interface node
+              interfaceLIDs[l][j].push_back(i);
+            }
           }
+        }
 
-          // Two-dimensional problems
-          {
-//            // caseFifteen
-//            {
-//              lNodesPerDim[0] = 4;
-//              lNodesPerDim[1] = 4;
-//              lNodesPerDim[2] = 1;
-//            }
+//        for (int j = 0; j < maxRegPerProc; j++) {
+//          std::cout << myRank << " | group = " << j << " | LIDs = ";
+//          for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
+//            std::cout << interfaceLIDs[l][j][i] << ", ";
+//          std::cout << std::endl;
+//        }
 
-//            // caseSixteen
-//            {
-//              lNodesPerDim[0] = 7;
-//              lNodesPerDim[1] = 7;
-//              lNodesPerDim[2] = 1;
-//            }
+        for (int j = 0; j < maxRegPerProc; j++)
+          interfaceGIDPairs[l][j].resize(interfaceLIDs[l][j].size());
 
-//            // caseSeventeen
-//            {
-//              lNodesPerDim[0] = 31;
-//              lNodesPerDim[1] = 31;
-//              lNodesPerDim[2] = 1;
-//            }
+        // create list of LIDPairs per group
+        for (int j = 0; j < maxRegPerProc; j++)
+          for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
+            interfaceGIDPairs[l][j][i].push_back(quasiRegRowMaps[l][j]->GID(interfaceLIDs[l][j][i]));
+        for (int j = 0; j < maxRegPerProc; j++)
+          for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
+            if (regRowMaps[l][j]->GID(interfaceLIDs[l][j][i]) != quasiRegRowMaps[l][j]->GID(interfaceLIDs[l][j][i]))
+              interfaceGIDPairs[l][j][i].push_back(regRowMaps[l][j]->GID(interfaceLIDs[l][j][i]));
 
-//            // caseEightteen / caseNineteen
-//            {
-//              lNodesPerDim[0] = 16;
-//              lNodesPerDim[1] = 16;
-//              lNodesPerDim[2] = 1;
-//            }
+//        std::cout << myRank << " | Print interfaceGIDPairs:" << std::endl;
+//        for (int j = 0; j < maxRegPerProc; j++) {
+//          std::cout << myRank << " | " << "Level " << l <<" | Group " << j << ":" << std::endl;
+//          for (std::size_t i = 0; i < interfaceGIDPairs[l][j].size(); ++i) {
+//            std::cout << "   " << myRank << " | ";
+//            for (std::size_t k = 0; k < interfaceGIDPairs[l][j][i].size(); ++k)
+//              std::cout << interfaceGIDPairs[l][j][i][k] << ", ";
+//            std::cout << std::endl;
+//          }
+//        }
 
-            // caseTwenty
-            {
-              lNodesPerDim[0] = 10;
-              lNodesPerDim[1] = 10;
-              lNodesPerDim[2] = 1;
+        std::vector<RCP<Epetra_Vector> > regDupGIDVec(maxRegPerProc); // Vector with zeros everywhere, but ones at duplicated GID spots
+        std::vector<RCP<Epetra_Vector> > quasiRegDupGIDVec(maxRegPerProc); // Vector with zeros everywhere, but ones at duplicated GID spots
+        for (int j = 0; j < maxRegPerProc; ++j) {
+          regDupGIDVec[j] = rcp(new Epetra_Vector(*regRowMaps[l][j], true));
+          quasiRegDupGIDVec[j] = rcp(new Epetra_Vector(*quasiRegRowMaps[l][j], true));
+
+          for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
+            (*regDupGIDVec[j])[interfaceLIDs[l][j][i]] = 1.0;
+        }
+
+        RCP<Epetra_Vector> compDupGIDVec = rcp(new Epetra_Vector(*compMaps[l]), true);
+        regionalToComposite(regDupGIDVec, compDupGIDVec, maxRegPerProc,
+            quasiRegRowMaps[l], regRowImporters[l], Add, true);
+
+        compositeToRegional(compDupGIDVec, quasiRegDupGIDVec, regDupGIDVec,
+            maxRegPerProc, quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
+
+        // create row/range/domain map for fine level duplicates mapping matrix
+        RCP<Epetra_Map> duplicateMap = Teuchos::null;
+        {
+          std::vector<int> myIntGIDs;
+          for (int j = 0; j < maxRegPerProc; j++) {
+            for (std::size_t i = 0; i < interfaceGIDPairs[l][j].size(); ++i) {
+              for (std::size_t k = 0; k < interfaceGIDPairs[l][j][i].size(); ++k) {
+                if (regRowMaps[l][j]->MyGID(interfaceGIDPairs[l][j][i][k]))
+                  myIntGIDs.push_back(interfaceGIDPairs[l][j][i][k]);
+              }
             }
           }
 
-          regGrpHierarchy[j]->GetLevel(0)->Set("gNodesPerDim", gNodesPerDim);
-          regGrpHierarchy[j]->GetLevel(0)->Set("lNodesPerDim", lNodesPerDim);
-        }
-
-        regMueLuFactory[j]->SetupHierarchy(*regGrpHierarchy[j]);
-
-      }
-
-      // resize Arrays and vectors
-      {
-        // resize level containers
-        numLevels = regGrpHierarchy[0]->GetNumLevels();
-        compMaps.resize(numLevels);
-        regRowMaps.resize(numLevels);
-        quasiRegRowMaps.resize(numLevels);
-        regMatrices.resize(numLevels);
-        regProlong.resize(numLevels);
-        regRowImporters.resize(numLevels);
-        regInterfaceScalings.resize(numLevels);
-
-        // resize group containers on each level
-        for (int l = 0; l < numLevels; ++l) {
-          regRowMaps[l].resize(maxRegPerProc);
-          quasiRegRowMaps[l].resize(maxRegPerProc);
-          regMatrices[l].resize(maxRegPerProc);
-          regProlong[l].resize(maxRegPerProc);
-          regRowImporters[l].resize(maxRegPerProc);
-          regInterfaceScalings[l].resize(maxRegPerProc);
-        }
-      }
-
-      // Fill fine level with our data
-      {
-        compMaps[0] = mapComp;
-        quasiRegRowMaps[0] = rowMapPerGrp;
-        regRowMaps[0] = revisedRowMapPerGrp;
-        regRowImporters[0] = rowImportPerGrp;
-        regMatrices[0] = regionGrpMats;
-
-        /* MueLu stores prolongator on coarse level, so there is no prolongator
-         * on the fine level. To have level containers of the same size, let's
-         * just put in dummy data
-         */
-        std::vector<RCP<Epetra_CrsMatrix> > fineLevelProlong(maxRegPerProc);
-        for (int j = 0; j < maxRegPerProc; ++j)
-          fineLevelProlong[j] = Teuchos::null;
-        regProlong[0] = fineLevelProlong;
-      }
-
-      // Get coarse level matrices and prolongators from MueLu hierarchy (Note: fine level has been dealt with previously)
-      for (int l = 1; l < numLevels; ++l) { // Note: we start at level 1 (which is the first coarse level)
-        for (int j = 0; j < maxRegPerProc; ++j) {
-          RCP<MueLu::Level> level = regGrpHierarchy[j]->GetLevel(l);
-
-          RCP<Matrix> regPXpetra = level->Get<RCP<Matrix> >("P", MueLu::NoFactory::get());
-          regProlong[l][j] = Utilities::Op2NonConstEpetraCrs(regPXpetra);
-
-          RCP<Matrix> regRAPXpetra = level->Get<RCP<Matrix> >("A", MueLu::NoFactory::get());
-          regMatrices[l][j] = Utilities::Op2NonConstEpetraCrs(regRAPXpetra);
-
-          regRowMaps[l][j] = Teuchos::rcp(new Epetra_Map(regMatrices[l][j]->RowMap())); // ToDo (mayr.mt) Do not copy!
-        }
-      }
-
-      /* Reconstruct coarse-level maps
-       *
-       * We know the regional map on the coarse levels since they are just the
-       * row maps of the coarse level operators. Though, we need to re-construct
-       * the quasiRegional and composite maps ourselves.
-       */
-
-      {
-        /* General strategy to create coarse level maps:
-         * =============================================
-         *
-         * We need three maps on the next coarser level:
-         * - regional map: just extract the RowMap() from the prolongator
-         * - quasiRegional map: needs to be formed manually
-         * - composite map: needs to be formed manually
-         *
-         * After extracting the RowMap() from the prolongator to be used as the
-         * coarse level's regional map, we need to identify pairs/sets of GIDs
-         * that represent the same (duplicated) DOF at a region interface in
-         * order to form the quasiRegional and composite map for the next
-         * coarser level.
-         *
-         * Identifying this pairs consists of several steps:
-         * 1. Identify GIDs that represent the same (duplicated) DOF at a region
-         *   interface on the current level
-         * 2. Identify GIDs that represent the same (duplicated) DOF at a region
-         *   interface on the next coarser level
-         *
-         * To form the quasiRegional map, we loop over the regional map and
-         * - copy each GID that's associated with an interior DOF away from a
-         *   region interface.
-         * - replace each GID that's associated with an interface DOF by its
-         *   quasiRegional counterpart.
-         *
-         * Note: We choose the quasiRegional (and composite) GID of an interface
-         * DOF to be the std::min of all GIDs that represent that same
-         * duplicated DOF.
-         *
-         * To form the composite map, we loop over the quasiRegional map and
-         * - every proc accepts every GID that it owns.
-         * - every proc ignores every GID that it doesn't own.
-         */
-
-        int err = 0;
-
-        ////////////////////////////////////////////////////////////////////////
-        // IDENTIFY DUPLICATED GIDS ON FINE LEVEL
-        ////////////////////////////////////////////////////////////////////////
-
-        RCP<Epetra_CrsMatrix> summedDuplicateMatrix = Teuchos::null;
-
-        // Find lists of duplicated GIDs locally
-        interfaceLIDs.resize(numLevels);
-        interfaceGIDPairs.resize(numLevels);
-        for (int l = 0; l < numLevels; ++l) {
-          interfaceLIDs[l].resize(maxRegPerProc);
-          interfaceGIDPairs[l].resize(maxRegPerProc);
-        }
-
-        for (int l = 0; l < numLevels - 1; ++l) {
-          Comm.Barrier();
-          if (Comm.MyPID() == 0) {
-            std::cout << std::endl << std::endl
-                << "Processing GID pairs on level " << l
-                << std::endl << std::endl;
-          }
-          Comm.Barrier();
+          duplicateMap = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myIntGIDs.size(), myIntGIDs.data(), 0, Comm));
 
 //          sleep(1);
-//          std::cout << "Prolongator" << std::endl;
-//          regProlong[l+1][0]->Print(std::cout);
+//          Comm.Barrier();
+//          std::cout << myRank << " | duplicateMap:" << std::endl;
+//          duplicateMap->Print(std::cout);
+        }
 
-          // create list of LIDs per group
-          for (int j = 0; j < maxRegPerProc; j++) {
-            for (int i = 0; i < regRowMaps[l][j]->NumMyElements(); ++i) {
-              if (regRowMaps[l][j]->GID(i) != quasiRegRowMaps[l][j]->GID(i)) {
-                // This is an interface node
-                interfaceLIDs[l][j].push_back(i);
-              }
-            }
+        // create row/range/domain map for the transpose of the fine level duplicates mapping matrix
+        RCP<Epetra_Map> fullDuplicateMap = Teuchos::null;
+        {
+          std::vector<int> myIntGIDs;
+          for (int i = 0; i < regRowMaps[l][0]->NumMyElements(); ++i) {
+            if ((*regDupGIDVec[0])[i] != 0)
+              myIntGIDs.push_back(regRowMaps[l][0]->GID(i));
           }
 
-//          for (int j = 0; j < maxRegPerProc; j++) {
-//            std::cout << myRank << " | group = " << j << " | LIDs = ";
-//            for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
-//              std::cout << interfaceLIDs[l][j][i] << ", ";
-//            std::cout << std::endl;
-//          }
+//          std::cout << myRank << " | myIntGIDs = ";
+//          for (auto gid : myIntGIDs)
+//            std::cout << gid << ", ";
+//          std::cout << std::endl;
 
-          for (int j = 0; j < maxRegPerProc; j++)
-            interfaceGIDPairs[l][j].resize(interfaceLIDs[l][j].size());
+          fullDuplicateMap = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myIntGIDs.size(), myIntGIDs.data(), 0, Comm));
 
-          // create list of LIDPairs per group
-          for (int j = 0; j < maxRegPerProc; j++)
-            for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
-              interfaceGIDPairs[l][j][i].push_back(quasiRegRowMaps[l][j]->GID(interfaceLIDs[l][j][i]));
-          for (int j = 0; j < maxRegPerProc; j++)
-            for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
-              if (regRowMaps[l][j]->GID(interfaceLIDs[l][j][i]) != quasiRegRowMaps[l][j]->GID(interfaceLIDs[l][j][i]))
-                interfaceGIDPairs[l][j][i].push_back(regRowMaps[l][j]->GID(interfaceLIDs[l][j][i]));
+//          sleep(1);
+//          Comm.Barrier();
+//          std::cout << myRank << " | fullDuplicateMap:" << std::endl;
+//          fullDuplicateMap->Print(std::cout);
+        }
 
-  //          std::cout << myRank << " | Print interfaceGIDPairs:" << std::endl;
-  //          for (int j = 0; j < maxRegPerProc; j++) {
-  //            std::cout << myRank << " | " << "Level " << l <<" | Group " << j << ":" << std::endl;
-  //            for (std::size_t i = 0; i < interfaceGIDPairs[l][j].size(); ++i) {
-  //              std::cout << "   " << myRank << " | ";
-  //              for (std::size_t k = 0; k < interfaceGIDPairs[l][j][i].size(); ++k)
-  //                std::cout << interfaceGIDPairs[l][j][i][k] << ", ";
-  //              std::cout << std::endl;
-  //            }
-  //          }
+        // Create and fill matrix
+        RCP<Epetra_CrsMatrix> duplicateMatrix = rcp(new Epetra_CrsMatrix(Copy, *fullDuplicateMap, 2));
+        {
+          // Fill diagonal
+          for (int i = 0; i < fullDuplicateMap->NumMyElements(); ++i) {
+            int globalRow = fullDuplicateMap->GID(i);
+            double vals[1];
+            int inds[1];
+            vals[0] = globalRow;
+            inds[0] = globalRow;
 
-          std::vector<RCP<Epetra_Vector> > regDupGIDVec(maxRegPerProc); // Vector with zeros everywhere, but ones at duplicated GID spots
-          std::vector<RCP<Epetra_Vector> > quasiRegDupGIDVec(maxRegPerProc); // Vector with zeros everywhere, but ones at duplicated GID spots
-          for (int j = 0; j < maxRegPerProc; ++j) {
-            regDupGIDVec[j] = rcp(new Epetra_Vector(*regRowMaps[l][j], true));
-            quasiRegDupGIDVec[j] = rcp(new Epetra_Vector(*quasiRegRowMaps[l][j], true));
-
-            for (std::size_t i = 0; i < interfaceLIDs[l][j].size(); ++i)
-              (*regDupGIDVec[j])[interfaceLIDs[l][j][i]] = 1.0;
+            err = duplicateMatrix->InsertGlobalValues(globalRow, 1, &*vals, &*inds);
+            TEUCHOS_ASSERT(err >= 0);
           }
 
-          RCP<Epetra_Vector> compDupGIDVec = rcp(new Epetra_Vector(*compMaps[l]), true);
-          regionalToComposite(regDupGIDVec, compDupGIDVec, maxRegPerProc,
-              quasiRegRowMaps[l], regRowImporters[l], Add, true);
-
-          compositeToRegional(compDupGIDVec, quasiRegDupGIDVec, regDupGIDVec,
-              maxRegPerProc, quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
-
-          // create row/range/domain map for fine level duplicates mapping matrix
-          RCP<Epetra_Map> duplicateMap = Teuchos::null;
-          {
-            std::vector<int> myIntGIDs;
-            for (int j = 0; j < maxRegPerProc; j++) {
-              for (std::size_t i = 0; i < interfaceGIDPairs[l][j].size(); ++i) {
-                for (std::size_t k = 0; k < interfaceGIDPairs[l][j][i].size(); ++k) {
-                  if (regRowMaps[l][j]->MyGID(interfaceGIDPairs[l][j][i][k]))
-                    myIntGIDs.push_back(interfaceGIDPairs[l][j][i][k]);
-                }
-              }
+          // Fill off-diagonals (if known)
+          for (int i = 0; i < duplicateMap->NumMyElements(); ++i) {
+            int globalRow = duplicateMap->GID(i);
+            double vals[2];
+            int inds[2];
+            for (std::size_t k = 0; k < interfaceGIDPairs[l][0][i].size(); ++k) {
+              vals[k] = globalRow;
+              inds[k] = interfaceGIDPairs[l][0][i][k];
             }
 
-            duplicateMap = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myIntGIDs.size(), myIntGIDs.data(), 0, Comm));
-
-  //            sleep(1);
-  //            Comm.Barrier();
-  //            std::cout << myRank << " | duplicateMap:" << std::endl;
-  //            duplicateMap->Print(std::cout);
+            err = duplicateMatrix->InsertGlobalValues(globalRow, 2, &*vals, &*inds);
+            TEUCHOS_ASSERT(err >= 0);
           }
+        }
 
-          // create row/range/domain map for the transpose of the fine level duplicates mapping matrix
-          RCP<Epetra_Map> fullDuplicateMap = Teuchos::null;
-          {
-            std::vector<int> myIntGIDs;
-            for (int i = 0; i < regRowMaps[l][0]->NumMyElements(); ++i) {
-              if ((*regDupGIDVec[0])[i] != 0)
-                myIntGIDs.push_back(regRowMaps[l][0]->GID(i));
-            }
+        err = duplicateMatrix->FillComplete();
+        TEUCHOS_ASSERT(err == 0);
 
-  //              std::cout << myRank << " | myIntGIDs = ";
-  //              for (auto gid : myIntGIDs)
-  //                std::cout << gid << ", ";
-  //              std::cout << std::endl;
+//        sleep(1);
+//        Comm.Barrier();
+//        std::cout << myRank << " | duplicateMatrix:" << std::endl;
+//        duplicateMatrix->Print(std::cout);
+//
+//        sleep(1);
+//        Comm.Barrier();
+//        std::cout << myRank << " | duplicateMatrix->RangeMap():" << std::endl;
+//        duplicateMatrix->OperatorRangeMap().Print(std::cout);
+//
+//        sleep(1);
+//        Comm.Barrier();
+//        std::cout << myRank << " | duplicateMatrix->DomainMap():" << std::endl;
+//        duplicateMatrix->OperatorDomainMap().Print(std::cout);
+//
+//        sleep(1);
+//        Comm.Barrier();
+//        std::cout << myRank << " | duplicateMatrix->ColMap():" << std::endl;
+//        duplicateMatrix->ColMap().Print(std::cout);
 
-            fullDuplicateMap = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myIntGIDs.size(), myIntGIDs.data(), 0, Comm));
+        {
+          EpetraExt::RowMatrix_Transpose transposer;
+          RCP<Epetra_CrsMatrix> transDuplicateMatrix =
+              rcp(new Epetra_CrsMatrix(dynamic_cast<Epetra_CrsMatrix&>(transposer(*duplicateMatrix))));
 
-  //            sleep(1);
-  //            Comm.Barrier();
-  //            std::cout << myRank << " | fullDuplicateMap:" << std::endl;
-  //            fullDuplicateMap->Print(std::cout);
-          }
+          TEUCHOS_ASSERT(!transDuplicateMatrix.is_null());
 
-          // Create and fill matrix
-          RCP<Epetra_CrsMatrix> duplicateMatrix = rcp(new Epetra_CrsMatrix(Copy, *fullDuplicateMap, 2));
-          {
-            // Fill diagonal
-            for (int i = 0; i < fullDuplicateMap->NumMyElements(); ++i) {
-              int globalRow = fullDuplicateMap->GID(i);
-              double vals[1];
-              int inds[1];
-              vals[0] = globalRow;
-              inds[0] = globalRow;
-
-              err = duplicateMatrix->InsertGlobalValues(globalRow, 1, &*vals, &*inds);
-              TEUCHOS_ASSERT(err >= 0);
-            }
-
-            // Fill off-diagonals (if known)
-            for (int i = 0; i < duplicateMap->NumMyElements(); ++i) {
-              int globalRow = duplicateMap->GID(i);
-              double vals[2];
-              int inds[2];
-              for (std::size_t k = 0; k < interfaceGIDPairs[l][0][i].size(); ++k) {
-                vals[k] = globalRow;
-                inds[k] = interfaceGIDPairs[l][0][i][k];
-              }
-
-              err = duplicateMatrix->InsertGlobalValues(globalRow, 2, &*vals, &*inds);
-              TEUCHOS_ASSERT(err >= 0);
-            }
-          }
-
-          err = duplicateMatrix->FillComplete();
+          err = transDuplicateMatrix->FillComplete();
           TEUCHOS_ASSERT(err == 0);
 
-  //          sleep(1);
-  //          Comm.Barrier();
-  //          std::cout << myRank << " | duplicateMatrix:" << std::endl;
-  //          duplicateMatrix->Print(std::cout);
-  //
-  //          sleep(1);
-  //          Comm.Barrier();
-  //          std::cout << myRank << " | duplicateMatrix->RangeMap():" << std::endl;
-  //          duplicateMatrix->OperatorRangeMap().Print(std::cout);
-  //
-  //          sleep(1);
-  //          Comm.Barrier();
-  //          std::cout << myRank << " | duplicateMatrix->DomainMap():" << std::endl;
-  //          duplicateMatrix->OperatorDomainMap().Print(std::cout);
-  //
-  //          sleep(1);
-  //          Comm.Barrier();
-  //          std::cout << myRank << " | duplicateMatrix->ColMap():" << std::endl;
-  //          duplicateMatrix->ColMap().Print(std::cout);
-
-          {
-            EpetraExt::RowMatrix_Transpose transposer;
-            RCP<Epetra_CrsMatrix> transDuplicateMatrix =
-                rcp(new Epetra_CrsMatrix(dynamic_cast<Epetra_CrsMatrix&>(transposer(*duplicateMatrix))));
-
-            TEUCHOS_ASSERT(!transDuplicateMatrix.is_null());
-
-            err = transDuplicateMatrix->FillComplete();
-            TEUCHOS_ASSERT(err == 0);
-
-    //          sleep(1);
-    //          Comm.Barrier();
-    //          std::cout << myRank << " | transDuplicateMatrix:" << std::endl;
-    //          transDuplicateMatrix->Print(std::cout);
+//          sleep(1);
+//          Comm.Barrier();
+//          std::cout << myRank << " | transDuplicateMatrix:" << std::endl;
+//          transDuplicateMatrix->Print(std::cout);
 
 
-            summedDuplicateMatrix = rcp(new Epetra_CrsMatrix(Copy, *fullDuplicateMap, 2));
-            Epetra_CrsMatrix* summedDuplicateMatrix_ptr = summedDuplicateMatrix.get();
-            err = EpetraExt::MatrixMatrix::Add(*transDuplicateMatrix, false, 1.0, *duplicateMatrix, false, 1.0, summedDuplicateMatrix_ptr);
-            TEUCHOS_ASSERT(err == 0);
-          }
+          summedDuplicateMatrix = rcp(new Epetra_CrsMatrix(Copy, *fullDuplicateMap, 2));
+          Epetra_CrsMatrix* summedDuplicateMatrix_ptr = summedDuplicateMatrix.get();
+          err = EpetraExt::MatrixMatrix::Add(*transDuplicateMatrix, false, 1.0, *duplicateMatrix, false, 1.0, summedDuplicateMatrix_ptr);
+          TEUCHOS_ASSERT(err == 0);
+        }
 
-          err = summedDuplicateMatrix->FillComplete(*fullDuplicateMap, *fullDuplicateMap);
-  //          err = summedDuplicateMatrix->FillComplete();
+        err = summedDuplicateMatrix->FillComplete(*fullDuplicateMap, *fullDuplicateMap);
+//        err = summedDuplicateMatrix->FillComplete();
+        TEUCHOS_ASSERT(err == 0);
+
+//        sleep(1);
+//        Comm.Barrier();
+//        std::cout << myRank << " | summedDuplicateMatrix:" << std::endl;
+//        summedDuplicateMatrix->Print(std::cout);
+
+        std::vector<std::vector<int> > myDuplicates; // pairs of duplicates with locally owned GID listed first.
+        myDuplicates.resize(summedDuplicateMatrix->NumMyRows());
+        for (int i = 0; i < summedDuplicateMatrix->NumMyRows(); ++i) {
+          int numEntries = 0;
+          double* vals;
+          int* inds;
+//          std::cout << myRank << " | Extracting my row " << i << ", global row " << summedDuplicateMatrix->RowMap().GID(i) << std::endl;
+          err = summedDuplicateMatrix->ExtractMyRowView(i, numEntries, vals, inds);
           TEUCHOS_ASSERT(err == 0);
 
-  //          sleep(1);
-  //          Comm.Barrier();
-  //          std::cout << myRank << " | summedDuplicateMatrix:" << std::endl;
-  //          summedDuplicateMatrix->Print(std::cout);
-
-          std::vector<std::vector<int> > myDuplicates; // pairs of duplicates with locally owned GID listed first.
-          myDuplicates.resize(summedDuplicateMatrix->NumMyRows());
-          for (int i = 0; i < summedDuplicateMatrix->NumMyRows(); ++i) {
-            int numEntries = 0;
-            double* vals;
-            int* inds;
-  //          std::cout << myRank << " | Extracting my row " << i << ", global row " << summedDuplicateMatrix->RowMap().GID(i) << std::endl;
-            err = summedDuplicateMatrix->ExtractMyRowView(i, numEntries, vals, inds);
-            TEUCHOS_ASSERT(err == 0);
-
-            std::vector<int> gidsToSort;
-            for (int k = 0; k < numEntries; ++k) {
-  //            std::cout << myRank << " | inds[" << k << "] = " << inds[k] << std::endl;
-              gidsToSort.push_back(summedDuplicateMatrix->ColMap().GID(inds[k]));
-            }
-
-            /* Note: At intersections of more than two regions, i.e. at interior
-             * vertices of the regional interface, the list of gidsToSort is not
-             * identical on all procs. In particular, only the proc owning the
-             * original GID of this vertex knows the full list of all duplicated
-             * GIDs. Those procs, that own a duplicated GID, only know about the
-             * two-member pair of their duplicate and the original GID, but not
-             * about the duplicated GIDs of all other procs.
-             *
-             * However, this does not matter since we are only looking for the
-             * mapping of each proc's duplicated GID to the original GID, which
-             * every proc knows about.
-             *
-             * Bottom line, this should be sufficient.
-             */
-
-  //          sleep(1);
-  //          std::cout << myRank << " | gidsToSort:" << std::endl << "  ";
-  //          for (auto gid : gidsToSort)
-  //             std::cout << gid << ", ";
-  //           std::cout << std::endl;
-  //           sleep(1);
-
-            /* sort s.t. my GID is first
-             *
-             * 1. Find index of the one GID that I own
-             * 2. Insert this GID at the beginning of the vector
-             * 3. Erase this GID from its initial position in the vector
-             *
-             * ToDo (mayr.mt) Is this really necessary?
-             */
-            {
-  //            int indOfMyGID = -1;
-  //            for (std::size_t k = 0; k < gidsToSort.size(); ++k) {
-  //              if (regRowMaps[l][0]->MyGID(gidsToSort[k])) {
-  //                indOfMyGID = k;
-  //                break;
-  //              }
-  //            }
-  //            TEUCHOS_ASSERT(indOfMyGID >= 0);
-  //
-  //            int tmpIndex = gidsToSort[indOfMyGID];
-  //            gidsToSort.erase(gidsToSort.begin() + indOfMyGID);
-  //            gidsToSort.insert(gidsToSort.begin(), tmpIndex);
-
-  //            for (std::size_t k = 0; i < gidsToSort.size(); ++k)
-  //              myDuplicates[i].push_back(gidsToSort[i]);
-
-              myDuplicates[i] = gidsToSort;
-            }
+          std::vector<int> gidsToSort;
+          for (int k = 0; k < numEntries; ++k) {
+//            std::cout << myRank << " | inds[" << k << "] = " << inds[k] << std::endl;
+            gidsToSort.push_back(summedDuplicateMatrix->ColMap().GID(inds[k]));
           }
 
-//          sleep(myRank);
-//          std::cout << std::endl << std::endl << std::endl << std::endl;
-//          for (std::size_t i = 0; i < myDuplicates.size(); ++i) {
-//            std::cout << myRank << " | myDuplicates:" << std::endl << "  ";
-//            for (std::size_t k = 0; k < myDuplicates[i].size(); ++k)
-//              std::cout << myDuplicates[i][k] << ", ";
-//            std::cout << std::endl;
-//          }
-//          std::cout << std::endl << std::endl << std::endl << std::endl;
-
-          ////////////////////////////////////////////////////////////////////////
-          // IDENTIFY DUPLICATED GIDS ON COARSE LEVEL
-          ////////////////////////////////////////////////////////////////////////
-
-          std::vector<std::vector<int> > myCoarseDuplicates; // pairs of duplicates with locally owned GID listed first on coarse level.
-          myCoarseDuplicates.resize(myDuplicates.size());
-
-          std::vector<int> myCoarseInterfaceGIDs;
-          for (std::size_t i = 0; i < myDuplicates.size(); ++i) {
-            const int rowGID = myDuplicates[i][0];
-            const int rowLID = regProlong[l+1][0]->RowMap().LID(rowGID);
-            int numEntries;
-            double* vals;
-            int* inds;
-            err = regProlong[l+1][0]->ExtractMyRowView(rowLID, numEntries, vals, inds);
-  //          std::cout << myRank << " | ExtractMyRowView err = " << err << std::endl;
-            TEUCHOS_ASSERT(err == 0);
-            TEUCHOS_ASSERT(numEntries == 1); // tentative P: only one entry per row
-
-            myCoarseInterfaceGIDs.push_back(regProlong[l+1][0]->ColMap().GID(inds[0]));
-          }
-
-  //        std::cout << "myCoarseInterfaceGIDs on proc " << myRank << ": ";
-  //        for (auto gid : myCoarseInterfaceGIDs) {
-  //          std::cout << gid << ", ";
-  //        }
-  //        std::cout << std::endl;
-
-          // Build row/range/domain map of duplicate mapping matrix
-          RCP<Epetra_Map> interfaceMap = Teuchos::null;
-          {
-            std::vector<int> interfaceMapGIDs(myDuplicates.size());
-            for (std::size_t i = 0; i < myDuplicates.size(); ++i) {
-              interfaceMapGIDs[i] = myDuplicates[i][0];
-            }
-
-  //          std::cout << "interfaceMapGIDs on proc " << myRank << ":      ";
-  //          for (auto gid : interfaceMapGIDs) {
-  //            std::cout << gid << ", ";
-  //          }
-  //          std::cout << std::endl;
-
-            interfaceMap = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), interfaceMapGIDs.size(), interfaceMapGIDs.data(), 0, Comm));
-          }
-
-          RCP<Epetra_CrsMatrix> duplicateMapping = rcp(new Epetra_CrsMatrix(Copy, *interfaceMap, 2));
-
-          // Fill the matrix
-          RCP<Epetra_CrsMatrix> transDuplicateMapping = Teuchos::null;
-          {
-            int numRows = myDuplicates.size();
-            std::vector<int> rowPtr(numRows);
-            std::vector<std::vector<double> > vals(numRows);
-            std::vector<std::vector<int> > colInds(numRows);
-
-            for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-              rowPtr[rowIdx] = myDuplicates[rowIdx][0];
-              for (std::size_t k = 0; k < myDuplicates[rowIdx].size(); ++k) {
-                vals[rowIdx].push_back(myCoarseInterfaceGIDs[rowIdx]);
-                colInds[rowIdx].push_back(myDuplicates[rowIdx][k]);
-              }
-            }
-
-  //          for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-  //            std::cout << myRank << " | rowIdx = " << rowIdx << ", rowGID = " << rowPtr[rowIdx] << ":";
-  //            for (std::size_t i = 0; i < vals[rowIdx].size(); ++i)
-  //              std::cout << "(" << colInds[rowIdx][i] << "|" << vals[rowIdx][i] << "), ";
-  //            std::cout << std::endl;
-  //          }
-
-            // local dummy insertion
-            for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-              err = duplicateMapping->InsertGlobalValues(rowPtr[rowIdx], colInds[rowIdx].size(), vals[rowIdx].data(), colInds[rowIdx].data());
-              TEUCHOS_ASSERT(err >= 0);
-            }
-
-            err = duplicateMapping->FillComplete();
-            TEUCHOS_ASSERT(err == 0);
-
-  //          sleep(1);
-  //          Comm.Barrier();
-  //          duplicateMapping->Print(std::cout);
-
-            EpetraExt::RowMatrix_Transpose transposer;
-            transDuplicateMapping = rcp(new Epetra_CrsMatrix(dynamic_cast<Epetra_CrsMatrix&>(transposer(*duplicateMapping))));
-
-            TEUCHOS_ASSERT(!transDuplicateMapping.is_null());
-
-            err = transDuplicateMapping->FillComplete();
-            TEUCHOS_ASSERT(err == 0);
-
-  //          sleep(1);
-  //          std::cout << myRank << " | Printing the tranpose ..." << std::endl;
-  //          Comm.Barrier();
-  //          transDuplicateMapping->Print(std::cout);
-          }
-
-          sleep(1);
-
-          /* Extract coarse level duplicates from transDuplicateMapping
+          /* Note: At intersections of more than two regions, i.e. at interior
+           * vertices of the regional interface, the list of gidsToSort is not
+           * identical on all procs. In particular, only the proc owning the
+           * original GID of this vertex knows the full list of all duplicated
+           * GIDs. Those procs, that own a duplicated GID, only know about the
+           * two-member pair of their duplicate and the original GID, but not
+           * about the duplicated GIDs of all other procs.
            *
-           * Note: In 2D, there will be duplicates which need to be removed.
-           * One could maybe use something along the lines of:
-           *    sort( vec.begin(), vec.end() );
-           *    vec.erase( unique( vec.begin(), vec.end() ), vec.end() );
+           * However, this does not matter since we are only looking for the
+           * mapping of each proc's duplicated GID to the original GID, which
+           * every proc knows about.
            *
+           * Bottom line, this should be sufficient.
            */
-          std::vector<std::vector<double> > myCoarseInterfaceDuplicates(transDuplicateMapping->NumMyRows());
+
+//          sleep(1);
+//          std::cout << myRank << " | gidsToSort:" << std::endl << "  ";
+//          for (auto gid : gidsToSort)
+//             std::cout << gid << ", ";
+//           std::cout << std::endl;
+//           sleep(1);
+
+          /* sort s.t. my GID is first
+           *
+           * 1. Find index of the one GID that I own
+           * 2. Insert this GID at the beginning of the vector
+           * 3. Erase this GID from its initial position in the vector
+           *
+           * ToDo (mayr.mt) Is this really necessary?
+           */
           {
-            for (int i = 0; i < transDuplicateMapping->NumMyRows(); ++i) {
-              int numEntries;
-              double* myVals;
-              int* myInds;
-              err = transDuplicateMapping->ExtractMyRowView(i, numEntries, myVals, myInds);
-              TEUCHOS_ASSERT(err == 0);
+//            int indOfMyGID = -1;
+//            for (std::size_t k = 0; k < gidsToSort.size(); ++k) {
+//              if (regRowMaps[l][0]->MyGID(gidsToSort[k])) {
+//                indOfMyGID = k;
+//                break;
+//              }
+//            }
+//            TEUCHOS_ASSERT(indOfMyGID >= 0);
+//
+//            int tmpIndex = gidsToSort[indOfMyGID];
+//            gidsToSort.erase(gidsToSort.begin() + indOfMyGID);
+//            gidsToSort.insert(gidsToSort.begin(), tmpIndex);
 
-              myCoarseInterfaceDuplicates[i].resize(numEntries);
-              myCoarseInterfaceDuplicates[i].assign(myVals, myVals+numEntries);
+//            for (std::size_t k = 0; i < gidsToSort.size(); ++k)
+//              myDuplicates[i].push_back(gidsToSort[i]);
 
-//              std::cout << myRank << " | myCoarseInterfaceDuplicates[" << i << "] = ";
-//              for (auto id : myCoarseInterfaceDuplicates[i])
-//                std::cout << id << ", ";
-//              std::cout << std::endl;
-            }
+            myDuplicates[i] = gidsToSort;
+          }
+        }
 
+//        sleep(myRank);
+//        std::cout << std::endl << std::endl << std::endl << std::endl;
+//        for (std::size_t i = 0; i < myDuplicates.size(); ++i) {
+//          std::cout << myRank << " | myDuplicates:" << std::endl << "  ";
+//          for (std::size_t k = 0; k < myDuplicates[i].size(); ++k)
+//            std::cout << myDuplicates[i][k] << ", ";
+//          std::cout << std::endl;
+//        }
+//        std::cout << std::endl << std::endl << std::endl << std::endl;
+
+        ////////////////////////////////////////////////////////////////////////
+        // IDENTIFY DUPLICATED GIDS ON COARSE LEVEL
+        ////////////////////////////////////////////////////////////////////////
+
+        std::vector<std::vector<int> > myCoarseDuplicates; // pairs of duplicates with locally owned GID listed first on coarse level.
+        myCoarseDuplicates.resize(myDuplicates.size());
+
+        std::vector<int> myCoarseInterfaceGIDs;
+        for (std::size_t i = 0; i < myDuplicates.size(); ++i) {
+          const int rowGID = myDuplicates[i][0];
+          const int rowLID = regProlong[l+1][0]->RowMap().LID(rowGID);
+          int numEntries;
+          double* vals;
+          int* inds;
+          err = regProlong[l+1][0]->ExtractMyRowView(rowLID, numEntries, vals, inds);
+//          std::cout << myRank << " | ExtractMyRowView err = " << err << std::endl;
+          TEUCHOS_ASSERT(err == 0);
+          TEUCHOS_ASSERT(numEntries == 1); // tentative P: only one entry per row
+
+          myCoarseInterfaceGIDs.push_back(regProlong[l+1][0]->ColMap().GID(inds[0]));
+        }
+
+//        std::cout << "myCoarseInterfaceGIDs on proc " << myRank << ": ";
+//        for (auto gid : myCoarseInterfaceGIDs) {
+//          std::cout << gid << ", ";
+//        }
+//        std::cout << std::endl;
+
+        // Build row/range/domain map of duplicate mapping matrix
+        RCP<Epetra_Map> interfaceMap = Teuchos::null;
+        {
+          std::vector<int> interfaceMapGIDs(myDuplicates.size());
+          for (std::size_t i = 0; i < myDuplicates.size(); ++i) {
+            interfaceMapGIDs[i] = myDuplicates[i][0];
           }
 
-          ////////////////////////////////////////////////////////////////////////
-          // CREATE COARSE LEVEL MAPS
-          ////////////////////////////////////////////////////////////////////////
+//          std::cout << "interfaceMapGIDs on proc " << myRank << ":      ";
+//          for (auto gid : interfaceMapGIDs) {
+//            std::cout << gid << ", ";
+//          }
+//          std::cout << std::endl;
+
+          interfaceMap = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), interfaceMapGIDs.size(), interfaceMapGIDs.data(), 0, Comm));
+        }
+
+        RCP<Epetra_CrsMatrix> duplicateMapping = rcp(new Epetra_CrsMatrix(Copy, *interfaceMap, 2));
+
+        // Fill the matrix
+        RCP<Epetra_CrsMatrix> transDuplicateMapping = Teuchos::null;
+        {
+          int numRows = myDuplicates.size();
+          std::vector<int> rowPtr(numRows);
+          std::vector<std::vector<double> > vals(numRows);
+          std::vector<std::vector<int> > colInds(numRows);
+
+          for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+            rowPtr[rowIdx] = myDuplicates[rowIdx][0];
+            for (std::size_t k = 0; k < myDuplicates[rowIdx].size(); ++k) {
+              vals[rowIdx].push_back(myCoarseInterfaceGIDs[rowIdx]);
+              colInds[rowIdx].push_back(myDuplicates[rowIdx][k]);
+            }
+          }
+
+//          for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+//            std::cout << myRank << " | rowIdx = " << rowIdx << ", rowGID = " << rowPtr[rowIdx] << ":";
+//            for (std::size_t i = 0; i < vals[rowIdx].size(); ++i)
+//              std::cout << "(" << colInds[rowIdx][i] << "|" << vals[rowIdx][i] << "), ";
+//            std::cout << std::endl;
+//          }
+
+          // local dummy insertion
+          for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+            err = duplicateMapping->InsertGlobalValues(rowPtr[rowIdx], colInds[rowIdx].size(), vals[rowIdx].data(), colInds[rowIdx].data());
+            TEUCHOS_ASSERT(err >= 0);
+          }
+
+          err = duplicateMapping->FillComplete();
+          TEUCHOS_ASSERT(err == 0);
+
+//          sleep(1);
+//          Comm.Barrier();
+//          duplicateMapping->Print(std::cout);
+
+          EpetraExt::RowMatrix_Transpose transposer;
+          transDuplicateMapping = rcp(new Epetra_CrsMatrix(dynamic_cast<Epetra_CrsMatrix&>(transposer(*duplicateMapping))));
+
+          TEUCHOS_ASSERT(!transDuplicateMapping.is_null());
+
+          err = transDuplicateMapping->FillComplete();
+          TEUCHOS_ASSERT(err == 0);
+
+//          sleep(1);
+//          std::cout << myRank << " | Printing the tranpose ..." << std::endl;
+//          Comm.Barrier();
+//          transDuplicateMapping->Print(std::cout);
+        }
+
+        sleep(1);
+
+        /* Extract coarse level duplicates from transDuplicateMapping
+         *
+         * Note: In 2D, there will be duplicates which need to be removed.
+         * One could maybe use something along the lines of:
+         *    sort( vec.begin(), vec.end() );
+         *    vec.erase( unique( vec.begin(), vec.end() ), vec.end() );
+         *
+         */
+        std::vector<std::vector<double> > myCoarseInterfaceDuplicates(transDuplicateMapping->NumMyRows());
+        {
+          for (int i = 0; i < transDuplicateMapping->NumMyRows(); ++i) {
+            int numEntries;
+            double* myVals;
+            int* myInds;
+            err = transDuplicateMapping->ExtractMyRowView(i, numEntries, myVals, myInds);
+            TEUCHOS_ASSERT(err == 0);
+
+            myCoarseInterfaceDuplicates[i].resize(numEntries);
+            myCoarseInterfaceDuplicates[i].assign(myVals, myVals+numEntries);
+
+//            std::cout << myRank << " | myCoarseInterfaceDuplicates[" << i << "] = ";
+//            for (auto id : myCoarseInterfaceDuplicates[i])
+//              std::cout << id << ", ";
+//            std::cout << std::endl;
+          }
+
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        // CREATE COARSE LEVEL MAPS
+        ////////////////////////////////////////////////////////////////////////
+        {
+//          sleep(1);
+//          std::cout << myRank << " | Printing regRowMaps[" << l+1 << "][0] ..." << std::endl;
+//          Comm.Barrier();
+//          regRowMaps[l+1][0]->Print(std::cout);
+//          sleep(2);
+
+          // create quasiRegional map
           {
-            sleep(1);
-            std::cout << myRank << " | Printing regRowMaps[" << l+1 << "][0] ..." << std::endl;
-            Comm.Barrier();
-            regRowMaps[l+1][0]->Print(std::cout);
-            sleep(2);
+            std::vector<int> myQuasiRegGIDs;
 
-            // create quasiRegional map
-            {
-              std::vector<int> myQuasiRegGIDs;
+            for (int i = 0; i < regRowMaps[l+1][0]->NumMyElements(); ++i) {
+              // grab current regional GID to be processed
+              int currGID = regRowMaps[l+1][0]->GID(i);
+              int quasiGID = currGID; // assign dummy value
 
-              for (int i = 0; i < regRowMaps[l+1][0]->NumMyElements(); ++i) {
-                // grab current regional GID to be processed
-                int currGID = regRowMaps[l+1][0]->GID(i);
-                int quasiGID = currGID; // assign dummy value
+              // find quasiRegional counterpart
+              {
+                // Is this an interface GID?
+                bool isInterface = false;
+                for (std::size_t k = 0; k < myCoarseInterfaceDuplicates.size(); ++k) {
+                  for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk) {
+                    if (currGID == myCoarseInterfaceDuplicates[k][kk])
+                      isInterface = true;
+                  }
+                }
 
-                // find quasiRegional counterpart
-                {
-                  // Is this an interface GID?
-                  bool isInterface = false;
+                if (isInterface) {
                   for (std::size_t k = 0; k < myCoarseInterfaceDuplicates.size(); ++k) {
+                    bool found = false;
                     for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk) {
                       if (currGID == myCoarseInterfaceDuplicates[k][kk])
-                        isInterface = true;
+                        found = true;
                     }
-                  }
 
-                  if (isInterface) {
-                    for (std::size_t k = 0; k < myCoarseInterfaceDuplicates.size(); ++k) {
-                      bool found = false;
-                      for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk) {
-                        if (currGID == myCoarseInterfaceDuplicates[k][kk])
-                          found = true;
-                      }
+                    if (found) {
+                      for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk)
+                        quasiGID = std::min(quasiGID, Teuchos::as<int>(myCoarseInterfaceDuplicates[k][kk]));
 
-                      if (found) {
-                        for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk)
-                          quasiGID = std::min(quasiGID, Teuchos::as<int>(myCoarseInterfaceDuplicates[k][kk]));
-
-  //                      std::cout << myRank << " | Interface GID " << currGID << " is replaced by quasiGID " << quasiGID << std::endl;
-                        break;
-                      }
+//                      std::cout << myRank << " | Interface GID " << currGID << " is replaced by quasiGID " << quasiGID << std::endl;
+                      break;
                     }
-                  }
-                  else { // interior node --> take GID from regional map
-                    quasiGID = currGID;
                   }
                 }
-
-                TEUCHOS_ASSERT(quasiGID>=0);
-                myQuasiRegGIDs.push_back(quasiGID);
-              }
-
-              quasiRegRowMaps[l+1][0] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myQuasiRegGIDs.size(), myQuasiRegGIDs.data(), 0, Comm));
-              TEUCHOS_ASSERT(!quasiRegRowMaps[l+1][0].is_null());
-
-              sleep(1);
-              std::cout << myRank << " | Printing quasiRegRowMaps[" << l+1 << "][0] ..." << std::endl;
-              Comm.Barrier();
-              quasiRegRowMaps[l+1][0]->Print(std::cout);
-
-            }
-
-            // create composite map
-            {
-              std::vector<int> myCompGIDs;
-              for (int j = 0; j < maxRegPerProc; j++) {
-                for (int i = 0; i < quasiRegRowMaps[l+1][j]->NumMyElements(); ++i) {
-                  const int trialGID = quasiRegRowMaps[l+1][j]->GID(i);
-
-                  if (regRowMaps[l+1][j]->MyGID(trialGID))
-                    myCompGIDs.push_back(trialGID);
+                else { // interior node --> take GID from regional map
+                  quasiGID = currGID;
                 }
               }
 
-              compMaps[l+1] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myCompGIDs.size(), myCompGIDs.data(), 0, Comm));
-              TEUCHOS_ASSERT(!compMaps[l+1].is_null());
-
-              sleep(1);
-              std::cout << myRank << " | Printing compMaps["<< l+1 << "] ..." << std::endl;
-              Comm.Barrier();
-              compMaps[l+1]->Print(std::cout);
+              TEUCHOS_ASSERT(quasiGID>=0);
+              myQuasiRegGIDs.push_back(quasiGID);
             }
 
-            // create regRowImporter
-            for (int j = 0; j < maxRegPerProc; ++j) {
-              regRowImporters[l+1][j] =
-                  rcp(new Epetra_Import(*quasiRegRowMaps[l+1][j], *compMaps[l+1]));
-              TEUCHOS_ASSERT(!regRowImporters[l+1][j].is_null());
+            quasiRegRowMaps[l+1][0] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myQuasiRegGIDs.size(), myQuasiRegGIDs.data(), 0, Comm));
+            TEUCHOS_ASSERT(!quasiRegRowMaps[l+1][0].is_null());
+
+//            sleep(1);
+//            std::cout << myRank << " | Printing quasiRegRowMaps[" << l+1 << "][0] ..." << std::endl;
+//            Comm.Barrier();
+//            quasiRegRowMaps[l+1][0]->Print(std::cout);
+
+          }
+
+          // create composite map
+          {
+            std::vector<int> myCompGIDs;
+            for (int j = 0; j < maxRegPerProc; j++) {
+              for (int i = 0; i < quasiRegRowMaps[l+1][j]->NumMyElements(); ++i) {
+                const int trialGID = quasiRegRowMaps[l+1][j]->GID(i);
+
+                if (regRowMaps[l+1][j]->MyGID(trialGID))
+                  myCompGIDs.push_back(trialGID);
+              }
             }
+
+            compMaps[l+1] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myCompGIDs.size(), myCompGIDs.data(), 0, Comm));
+            TEUCHOS_ASSERT(!compMaps[l+1].is_null());
+
+//            sleep(1);
+//            std::cout << myRank << " | Printing compMaps["<< l+1 << "] ..." << std::endl;
+//            Comm.Barrier();
+//            compMaps[l+1]->Print(std::cout);
+          }
+
+          // create regRowImporter
+          for (int j = 0; j < maxRegPerProc; ++j) {
+            regRowImporters[l+1][j] =
+                rcp(new Epetra_Import(*quasiRegRowMaps[l+1][j], *compMaps[l+1]));
+            TEUCHOS_ASSERT(!regRowImporters[l+1][j].is_null());
           }
         }
       }
     }
-    else if (strcmp(command,"MakeRegionTransferOperators") == 0) {
-      /* Populate a fine grid vector with 1 at coarse nodes and 0 at fine nodes.
-       * Then, transform to regional layout and find GIDs with entry 1
+  }
+
+  Comm.Barrier();
+
+  // Make interface scaling factors recursively
+  {
+    std::cout << myRank << " | Computing interface scaling factors ..." << std::endl;
+
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(!numLevels>0, "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
+
+    for (int l = 0; l < numLevels; l++)
+    {
+      // initialize region vector with all ones.
+      for (int j = 0; j < maxRegPerProc; j++) {
+        regInterfaceScalings[l][j] = rcp(new Epetra_Vector(*regRowMaps[l][j], true));
+        regInterfaceScalings[l][j]->PutScalar(1.0);
+      }
+
+      // transform to composite layout while adding interface values via the Export() combine mode
+      RCP<Epetra_Vector> compInterfaceScalingSum = rcp(new Epetra_Vector(*compMaps[l], true));
+      regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, maxRegPerProc, quasiRegRowMaps[l], regRowImporters[l], Add, true);
+
+      /* transform composite layout back to regional layout. Now, GIDs associated
+       * with region interface should carry a scaling factor (!= 1).
        */
-      int numNodes = mapComp->NumGlobalPoints() / 3 + 1;
-      std::vector<double> vals(numNodes);
-      std::vector<int> ind(numNodes);
-      for (int i = 0; i < numNodes; ++i)
-      {
-        vals[i] = 1.0;
-        ind[i] = 3*i;
-      }
-      Teuchos::RCP<Epetra_Vector> coarseGridToggle = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      coarseGridToggle->ReplaceGlobalValues(numNodes, vals.data(), ind.data());
-
-      // compute coarse composite row map
-      {
-        std::vector<int> coarseGIDs;
-        for (int i = 0; i < coarseGridToggle->MyLength(); ++i) {
-          if ((*coarseGridToggle)[i] != 0)
-            coarseGIDs.push_back(coarseGridToggle->Map().GID(i));
-        }
-        coarseCompRowMap = Teuchos::rcp(new Epetra_Map(-1, coarseGIDs.size(), coarseGIDs.data(), 0, Comm));
-      }
-
-      // transform composite vector to regional layout
-      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegCoarseGridToggle(maxRegPerProc);
-      std::vector<Teuchos::RCP<Epetra_Vector> > regCoarseGridToggle(maxRegPerProc);
-      compositeToRegional(coarseGridToggle, quasiRegCoarseGridToggle,
-          regCoarseGridToggle, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp,
-          rowImportPerGrp);
-
-      // create coarse grid row maps in region layout
-      for (int j = 0; j < maxRegPerProc; j++) {
-        std::vector<int> coarseRowGIDsReg;
-        std::vector<int> coarseQuasiRowGIDsReg;
-        for (int i = 0; i < regCoarseGridToggle[j]->Map().NumMyElements(); ++i) {
-          if ((*regCoarseGridToggle[j])[i] == 1.0) {
-            coarseQuasiRowGIDsReg.push_back(quasiRegCoarseGridToggle[j]->Map().GID(i));
-            coarseRowGIDsReg.push_back(regCoarseGridToggle[j]->Map().GID(i));
-          }
-        }
-
-        coarseQuasiRowMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1, coarseQuasiRowGIDsReg.size(), coarseQuasiRowGIDsReg.data(), 0, Comm));
-        coarseRowMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1, coarseRowGIDsReg.size(), coarseRowGIDsReg.data(), 0, Comm));
-      }
-
-      // setup coarse level row importer
-      for (int j = 0; j < maxRegPerProc; j++) {
-        coarseRowImportPerGrp[j] = Teuchos::rcp(new Epetra_Import(*(coarseQuasiRowMapPerGrp[j]),
-            *coarseCompRowMap));
-      }
-
-      // create coarse grid column map
-      Teuchos::RCP<Epetra_Vector> compGIDVec = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      for (int i = 0; i < mapComp->NumMyElements(); ++i)
-      {
-        int myGID = mapComp->GID(i);
-        if (myGID % 3 == 0) // that is the coarse point
-          (*compGIDVec)[i] = myGID;
-        else if (myGID % 3 == 1) // this node is right of a coarse point
-          (*compGIDVec)[i] = myGID - 1;
-        else if (myGID % 3 == 2) // this node is left of a coarse point
-          (*compGIDVec)[i] = myGID + 1;
-        else
-          TEUCHOS_ASSERT(false);
-      }
-
-      // transform composite vector to regional layout
-      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegGIDVec(maxRegPerProc);
-      std::vector<Teuchos::RCP<Epetra_Vector> > regGIDVec(maxRegPerProc);
-      compositeToRegional(compGIDVec, quasiRegGIDVec, regGIDVec, maxRegPerProc,
-          rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-
-      // deal with duplicated nodes and replace with new GID when necessary
-      for (int j = 0; j < maxRegPerProc; j++) {
-        for (int i = 0; i < regGIDVec[j]->MyLength(); ++i) {
-          if (regGIDVec[j]->Map().GID(i) >= mapComp->NumGlobalElements()) {
-            // replace 'aggregate ID' with duplicated 'aggregate ID'
-            (*regGIDVec[j])[i] = (revisedRowMapPerGrp[j])->GID(i);
-
-            // look for other nodes with the same fine grid aggregate ID that needs to be replaced with the duplicated one
-            for (int k = 0; k < regGIDVec[j]->MyLength(); ++k) {
-              if ((*regGIDVec[j])[k] == (rowMapPerGrp[j])->GID(i))
-                (*regGIDVec[j])[k] = (revisedRowMapPerGrp[j])->GID(i);
-            }
-          }
-        }
-      }
-
-      for (int j = 0; j < maxRegPerProc; j++) {
-        std::vector<int> regColGIDs;
-        for (int i = 0; i < revisedRowMapPerGrp[j]->NumMyElements(); ++i) {
-          const int currGID = revisedRowMapPerGrp[j]->GID(i);
-
-          // loop over existing regColGIDs and see if current GID is already in that list
-          bool found = false;
-          for (std::size_t k = 0; k < regColGIDs.size(); ++k) {
-            if ((*regGIDVec[j])[regGIDVec[j]->Map().LID(currGID)] == regColGIDs[k]) {
-              found = true;
-              break;
-            }
-          }
-
-          if (not found)
-            regColGIDs.push_back((*regGIDVec[j])[regGIDVec[j]->Map().LID(currGID)]);
-        }
-
-        coarseColMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1, regColGIDs.size(), regColGIDs.data(), 0, Comm));
-      }
-
-      for (int j = 0; j < maxRegPerProc; j++) {
-        std::vector<int> regAltColGIDs;
-        int *colGIDs = regionGrpMats[j]->ColMap().MyGlobalElements();
-        if (regionGrpMats[j]->ColMap().NumMyElements() > 0) {
-
-          // check if leftmost point is next to a cpt to the left in which case 1st ghost point is a cpt
-          if ( (appData.lowInd[3*j]%3) == 1 ) {
-           int NIOwn = regionGrpMats[j]->RowMap().NumMyElements();
-           regAltColGIDs.push_back(colGIDs[NIOwn]);
-          }
-          int start = 3 - (appData.lowInd[3*j]%3);
-          if (start == 3) start = 0;
-          for (int i = start; i < appData.lDim[3*j] ; i += 3)
-            regAltColGIDs.push_back(colGIDs[i]);
-
-          // check if pt to the right of rightmost point is is cpt, i.e. last ghost is a cpt
-          if ( ((appData.lowInd[3*j]+appData.lDim[3*j])%3) == 0 ) {
-            int NLast = regionGrpMats[j]->ColMap().NumMyElements()-1;
-            regAltColGIDs.push_back(colGIDs[NLast]);
-          }
-        }
-        coarseAltColMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1, regAltColGIDs.size(), regAltColGIDs.data(), 0, Comm));
-      }
-
-      // Build the actual prolongator
-      for (int j = 0; j < maxRegPerProc; j++) {
-        regionGrpProlong[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *revisedRowMapPerGrp[j], *coarseColMapPerGrp[j], 1, false));
-        for (int c = 0; c < regionGrpProlong[j]->NumMyCols(); ++c) {
-          for (int r = 0; r < regionGrpProlong[j]->NumMyRows(); ++r) {
-            if (regionGrpProlong[j]->ColMap().GID(c) == (*regGIDVec[j])[r]) {
-              double myVals[1];
-              int inds[1];
-              myVals[0] = 1.0; //1.0/sqrt(3.0); //1.0; // use all ones of the prolongator
-              inds[0] = c;
-              regionGrpProlong[j]->InsertMyValues(r, 1, &*myVals, &*inds);
-            }
-          }
-        }
-        int err = regionGrpProlong[j]->FillComplete(*coarseRowMapPerGrp[j], *revisedRowMapPerGrp[j]);
-        TEUCHOS_ASSERT(err == 0);
-//        regionGrpProlong[j]->Print(std::cout);
-      }
-
-      for (int j = 0; j < maxRegPerProc; j++) {
-        double myVals[1];
-        int inds[1];
-        myVals[0] = 1.0/3.0;
-        regionAltGrpProlong[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *revisedRowMapPerGrp[j], *coarseAltColMapPerGrp[j], 1, false));
-//        int *coarseCol = coarseAltColMapPerGrp[j]->MyGlobalElements();
-        int NccSize    = coarseAltColMapPerGrp[j]->NumMyElements();
-//        int *fineRow   = revisedRowMapPerGrp[j]->MyGlobalElements();
-        int NfrSize    = revisedRowMapPerGrp[j]->NumMyElements();
-        if (NfrSize > 0) {
-          int fstart = 3 - (appData.lowInd[3*j]%3);
-          if (fstart == 3) fstart = 0;
-          int cstart = 0;
-          if (fstart == 2) cstart = 1;
-
-          // need to add 1st prolongator row as this is not addressed by loop below
-          if (cstart == 1) {
-            inds[0] = 0;
-            regionAltGrpProlong[j]->InsertMyValues(0, 1, &*myVals, &*inds);
-          }
-          int i;
-          for (i = fstart; i < appData.lDim[3*j] ; i += 3) {
-            inds[0] = cstart;
-            regionAltGrpProlong[j]->InsertMyValues(i, 1, &*myVals, &*inds);
-            if (i > 0)         regionAltGrpProlong[j]->InsertMyValues(i-1, 1, &*myVals, &*inds);
-            if (i < NfrSize-1) regionAltGrpProlong[j]->InsertMyValues(i+1, 1, &*myVals, &*inds);
-            cstart++;
-          }
-          // last cpoint hasn't been addressed because someone else owns it
-          if (cstart < NccSize) {
-            inds[0] = cstart;
-            regionAltGrpProlong[j]->InsertMyValues(NfrSize-1, 1, &*myVals, &*inds);
-          }
-        }
-        regionAltGrpProlong[j]->FillComplete(*coarseRowMapPerGrp[j], *revisedRowMapPerGrp[j]); // ToDo: test this
-//        regionAltGrpProlong[j]->Print(std::cout);
-      }
+      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegInterfaceScaling(maxRegPerProc);
+      compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
+          regInterfaceScalings[l], maxRegPerProc, quasiRegRowMaps[l],
+          regRowMaps[l], regRowImporters[l]);
     }
-    else if (strcmp(command,"PrintRegProlongatorPerGrp") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        regionGrpProlong[j]->Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"MakeCoarseLevelOperator") == 0) {
+  }
 
-      std::vector<Teuchos::RCP<Epetra_CrsMatrix> > regAP(maxRegPerProc); // store intermediate result A*P
-      for (int j = 0; j < maxRegPerProc; j++) {
-        // Compute A*P
-        {
-          regAP[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *revisedRowMapPerGrp[j], 3, false));
+  Comm.Barrier();
 
-          int err = EpetraExt::MatrixMatrix::Multiply(*regionGrpMats[j], false, *regionGrpProlong[j], false, *regAP[j], false);
-          TEUCHOS_ASSERT(err == 0);
-          err = regAP[j]->FillComplete();
-          TEUCHOS_ASSERT(err == 0);
-        }
+  // Run V-cycle
+  {
+    std::cout << myRank << " | Running V-cycle ..." << std::endl;
 
-        // Compute R*(AP) = P'*(AP)
-        {
-          regCoarseMatPerGrp[j] = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *coarseRowMapPerGrp[j], 3, false));
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(!numLevels>0, "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
 
-          int err = EpetraExt::MatrixMatrix::Multiply(*regionGrpProlong[j], true, *regAP[j], false, *regCoarseMatPerGrp[j], false);
-          TEUCHOS_ASSERT(err == 0);
-          err = regCoarseMatPerGrp[j]->FillComplete();
-          TEUCHOS_ASSERT(err == 0);
-        }
-      }
+    /* We first use the non-level container variables to setup the fine grid problem.
+     * This is ok since the initial setup just mimics the application and the outer
+     * Krylov method.
+     *
+     * We switch to using the level container variables as soon as we enter the
+     * recursive part of the algorithm.
+     */
 
-//      for (int j = 0; j < maxRegPerProc; j++) {
-//          regAP[j]->Print(std::cout);
-//      }
-    }
-    else if (strcmp(command,"PrintRegCoarseMatPerGrp") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        regCoarseMatPerGrp[j]->Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"RunTwoLevelMethod") == 0) {
-      // initial guess for solution
-      compX = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+    // initial guess for solution
+    compX = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
 
 // debugging using shadow.m
 //double *z;
 //compX->ExtractView(&z); for (int kk = 0; kk < compX->MyLength(); kk++) z[kk] = (double) kk*kk;
 //compX->Print(std::cout);
-      // forcing vector
-      Teuchos::RCP<Epetra_Vector> compB = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+    // forcing vector
+    Teuchos::RCP<Epetra_Vector> compB = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+
+    // 1D
+    {
       {
         compB->ReplaceGlobalValue(compB->GlobalLength() - 1, 0, 1.0e-3);
       }
@@ -2333,321 +2039,118 @@ int main(int argc, char *argv[]) {
 //      {
 //        compB->ReplaceGlobalValue(16, 0, 1.0);
 //      }
+    }
 
-      // residual vector
-      Teuchos::RCP<Epetra_Vector> compRes = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+    std::vector<int> dirichletGIDs;
+
+    // 2D
+    {
+      const int nx = 19; // global number of nodes in x-direction
+      for (int i = 0; i < nx; ++i)
+        dirichletGIDs.push_back(i);
+      for (int i = 0; i < nx; ++i) {
+        dirichletGIDs.push_back(i*nx);
+        dirichletGIDs.push_back((i+1)*nx - 1);
+      }
+      for (int i = 0; i < nx; ++i)
+        dirichletGIDs.push_back((nx*(nx-1) + i));
+    }
+
+//    for (auto gid : dirichletGIDs)
+//      std::cout << gid << ", ";
+//    std::cout << std::endl;
+
+    {
+      compB->PutScalar(1.0e-3);
+      for (std::size_t i = 0; i < dirichletGIDs.size(); ++i)
+        compB->ReplaceGlobalValue(dirichletGIDs[i], 0, 0.0);
+    }
+
+    // residual vector
+    Teuchos::RCP<Epetra_Vector> compRes = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+    {
+      int err = AComp->Multiply(false, *compX, *compRes);
+      TEUCHOS_ASSERT(err == 0);
+      err = compRes->Update(1.0, *compB, -1.0);
+      TEUCHOS_ASSERT(err == 0);
+    }
+
+    // transform composite vectors to regional layout
+    compositeToRegional(compX, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
+        revisedRowMapPerGrp, rowImportPerGrp);
+
+    std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegB(maxRegPerProc);
+    std::vector<Teuchos::RCP<Epetra_Vector> > regB(maxRegPerProc);
+    compositeToRegional(compB, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
+        revisedRowMapPerGrp, rowImportPerGrp);
+
+    std::vector<Teuchos::RCP<Epetra_Vector> > regRes(maxRegPerProc);
+    for (int j = 0; j < maxRegPerProc; j++) { // step 1
+      regRes[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    // SWITCH TO RECURSIVE STYLE --> USE LEVEL CONTAINER VARIABLES
+    /////////////////////////////////////////////////////////////////////////
+
+    // define max iteration counts
+    const int maxVCycle = 200;
+    const int maxFineIter = 20;
+    const int maxCoarseIter = 100;
+    const double omega = 0.67;
+
+    // Richardson iterations
+    for (int cycle = 0; cycle < maxVCycle; ++cycle) {
+
+      vCycle(0, numLevels, maxFineIter, maxCoarseIter, omega, maxRegPerProc, regX, regB, regMatrices,
+          regProlong, compMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
+          regInterfaceScalings);
+
+      ////////////////////////////////////////////////////////////////////////
+      // SWITCH BACK TO NON-LEVEL VARIABLES
+      ////////////////////////////////////////////////////////////////////////
+
+      // check for convergence
       {
-        int err = AComp->Multiply(false, *compX, *compRes);
-        TEUCHOS_ASSERT(err == 0);
-        err = compRes->Update(1.0, *compB, -1.0);
-        TEUCHOS_ASSERT(err == 0);
-      }
+        computeResidual(regRes, regX, regB, regionGrpMats, mapComp,
+            rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
 
-      // transform composite vectors to regional layout
-      compositeToRegional(compX, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
-          revisedRowMapPerGrp, rowImportPerGrp);
+        compRes = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
+        regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
+            rowImportPerGrp, Add, true);
+        double normRes = 0.0;
+        compRes->Norm2(&normRes);
 
-      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegB(maxRegPerProc);
-      std::vector<Teuchos::RCP<Epetra_Vector> > regB(maxRegPerProc);
-      compositeToRegional(compB, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
-          revisedRowMapPerGrp, rowImportPerGrp);
-
-      std::vector<Teuchos::RCP<Epetra_Vector> > regRes(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) { // step 1
-        regRes[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-      }
-
-      // define max iteration counts
-      const int maxVCycle = 2;
-      const int maxFineIter = 10;
-      const int maxCoarseIter = 100;
-      const double omega = 0.67;
-
-      // Richardson iterations
-      for (int cycle = 0; cycle < maxVCycle; ++cycle) {
-
-        // a single 2-level V-Cycle
-        {
-          // -----------------------------------------------------------------------
-          // pre-smoothing on fine level
-          // -----------------------------------------------------------------------
-          jacobiIterate(maxFineIter, omega, regX, regB, regionGrpMats,
-              regionInterfaceScaling, maxRegPerProc, mapComp, rowMapPerGrp,
-              revisedRowMapPerGrp, rowImportPerGrp);
-
-          computeResidual(regRes, regX, regB, regionGrpMats, mapComp,
-              rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-
-          // -----------------------------------------------------------------------
-          // Transfer to coarse level
-          // -----------------------------------------------------------------------
-          std::vector<Teuchos::RCP<Epetra_Vector> > coarseRegX(maxRegPerProc);
-          std::vector<Teuchos::RCP<Epetra_Vector> > coarseRegB(maxRegPerProc);
-          for (int j = 0; j < maxRegPerProc; j++) {
-            coarseRegX[j] = Teuchos::rcp(new Epetra_Vector(regionGrpProlong[j]->DomainMap(), true));
-            coarseRegB[j] = Teuchos::rcp(new Epetra_Vector(regionGrpProlong[j]->DomainMap(), true));
-
-            for (int i = 0; i < regRes[j]->MyLength(); ++i)
-              (*regRes[j])[i] /= (*regionInterfaceScaling[j])[i];
-
-            int err = regionGrpProlong[j]->Multiply(true, *regRes[j], *coarseRegB[j]);
-            TEUCHOS_ASSERT(err == 0);
-            TEUCHOS_ASSERT(regionGrpProlong[j]->RangeMap().PointSameAs(regRes[j]->Map()));
-            TEUCHOS_ASSERT(regionGrpProlong[j]->DomainMap().PointSameAs(coarseRegB[j]->Map()));
-          }
-
-          sumInterfaceValues(coarseRegB, coarseCompRowMap, maxRegPerProc,
-              coarseQuasiRowMapPerGrp, coarseRowMapPerGrp,
-              coarseRowImportPerGrp);
-
-          // -----------------------------------------------------------------------
-          // Perform region-wise Jacobi on coarse level
-          // -----------------------------------------------------------------------
-          jacobiIterate(maxCoarseIter, omega, coarseRegX, coarseRegB, regCoarseMatPerGrp,
-              coarseRegionInterfaceScaling, maxRegPerProc, coarseCompRowMap, coarseQuasiRowMapPerGrp,
-              coarseRowMapPerGrp, coarseRowImportPerGrp);
-
-          // -----------------------------------------------------------------------
-          // Transfer to fine level
-          // -----------------------------------------------------------------------
-          std::vector<Teuchos::RCP<Epetra_Vector> > regCorrection(maxRegPerProc);
-          for (int j = 0; j < maxRegPerProc; j++) {
-            regCorrection[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-            int err = regionGrpProlong[j]->Multiply(false, *coarseRegX[j], *regCorrection[j]);
-            TEUCHOS_ASSERT(err == 0);
-            TEUCHOS_ASSERT(regionGrpProlong[j]->DomainMap().PointSameAs(coarseRegX[j]->Map()));
-            TEUCHOS_ASSERT(regionGrpProlong[j]->RangeMap().PointSameAs(regCorrection[j]->Map()));
-          }
-
-          // apply coarse grid correction
-          for (int j = 0; j < maxRegPerProc; j++) {
-            int err = regX[j]->Update(1.0, *regCorrection[j], 1.0);
-            TEUCHOS_ASSERT(err == 0);
-          }
-
-          // -----------------------------------------------------------------------
-          // post-smoothing on fine level
-          // -----------------------------------------------------------------------
-          jacobiIterate(maxFineIter, omega, regX, regB, regionGrpMats,
-              regionInterfaceScaling, maxRegPerProc, mapComp, rowMapPerGrp,
-              revisedRowMapPerGrp, rowImportPerGrp);
-        }
-
-        // check for convergence
-        {
-          computeResidual(regRes, regX, regB, regionGrpMats, mapComp,
-              rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-
-          compRes = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-          regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
-              rowImportPerGrp, Add, true);
-          double normRes = 0.0;
-          compRes->Norm2(&normRes);
-
-          if (normRes < 1.0e-12)
-            break;
-        }
-      }
-
-      // -----------------------------------------------------------------------
-      // Print fine-level solution
-      // -----------------------------------------------------------------------
-
-      compX->Comm().Barrier();
-      sleep(1);
-
-      regionalToComposite(regX, compX, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Zero, false);
-      std::cout << "compX after V-cycle" << std::endl;
-      compX->Print(std::cout);
-      sleep(2);
-    }
-    else if (strcmp(command,"RunVCycle") == 0) {
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!numLevels>0, "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
-
-      /* We first use the non-level container variables to setup the fine grid problem.
-       * This is ok since the initial setup just mimics the application and the outer
-       * Krylov method.
-       *
-       * We switch to using the level container variables as soon as we enter the
-       * recursive part of the algorithm.
-       */
-
-      // initial guess for solution
-      compX = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-
-// debugging using shadow.m
-//double *z;
-//compX->ExtractView(&z); for (int kk = 0; kk < compX->MyLength(); kk++) z[kk] = (double) kk*kk;
-//compX->Print(std::cout);
-      // forcing vector
-      Teuchos::RCP<Epetra_Vector> compB = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-
-      // 1D
-      {
-        {
-          compB->ReplaceGlobalValue(compB->GlobalLength() - 1, 0, 1.0e-3);
-        }
-//        {
-//        compB->PutScalar(1.0);
-//        compB->ReplaceGlobalValue(0, 0, 0.0);
-//        }
-//        {
-//          compB->ReplaceGlobalValue(15, 0, 1.0);
-//        }
-//        {
-//          compB->ReplaceGlobalValue(16, 0, 1.0);
-//        }
-      }
-
-      std::vector<int> dirichletGIDs;
-
-      // 2D
-      {
-        const int nx = 19; // global number of nodes in x-direction
-        for (int i = 0; i < nx; ++i)
-          dirichletGIDs.push_back(i);
-        for (int i = 0; i < nx; ++i) {
-          dirichletGIDs.push_back(i*nx);
-          dirichletGIDs.push_back((i+1)*nx - 1);
-        }
-        for (int i = 0; i < nx; ++i)
-          dirichletGIDs.push_back((nx*(nx-1) + i));
-      }
-
-//      for (auto gid : dirichletGIDs)
-//        std::cout << gid << ", ";
-//      std::cout << std::endl;
-
-      {
-        compB->PutScalar(1.0e-3);
-        for (std::size_t i = 0; i < dirichletGIDs.size(); ++i)
-          compB->ReplaceGlobalValue(dirichletGIDs[i], 0, 0.0);
-      }
-
-      // residual vector
-      Teuchos::RCP<Epetra_Vector> compRes = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-      {
-        int err = AComp->Multiply(false, *compX, *compRes);
-        TEUCHOS_ASSERT(err == 0);
-        err = compRes->Update(1.0, *compB, -1.0);
-        TEUCHOS_ASSERT(err == 0);
-      }
-
-      // transform composite vectors to regional layout
-      compositeToRegional(compX, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
-          revisedRowMapPerGrp, rowImportPerGrp);
-
-      std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegB(maxRegPerProc);
-      std::vector<Teuchos::RCP<Epetra_Vector> > regB(maxRegPerProc);
-      compositeToRegional(compB, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
-          revisedRowMapPerGrp, rowImportPerGrp);
-
-      std::vector<Teuchos::RCP<Epetra_Vector> > regRes(maxRegPerProc);
-      for (int j = 0; j < maxRegPerProc; j++) { // step 1
-        regRes[j] = Teuchos::rcp(new Epetra_Vector(*revisedRowMapPerGrp[j], true));
-      }
-
-      /////////////////////////////////////////////////////////////////////////
-      // SWITCH TO RECURSIVE STYLE --> USE LEVEL CONTAINER VARIABLES
-      /////////////////////////////////////////////////////////////////////////
-
-      // define max iteration counts
-      const int maxVCycle = 200;
-      const int maxFineIter = 20;
-      const int maxCoarseIter = 100;
-      const double omega = 0.67;
-
-      // Richardson iterations
-      for (int cycle = 0; cycle < maxVCycle; ++cycle) {
-
-        vCycle(0, numLevels, maxFineIter, maxCoarseIter, omega, maxRegPerProc, regX, regB, regMatrices,
-            regProlong, compMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
-            regInterfaceScalings);
-
-        ////////////////////////////////////////////////////////////////////////
-        // SWITCH BACK TO NON-LEVEL VARIABLES
-        ////////////////////////////////////////////////////////////////////////
-
-        // check for convergence
-        {
-          computeResidual(regRes, regX, regB, regionGrpMats, mapComp,
-              rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-
-          compRes = Teuchos::rcp(new Epetra_Vector(*mapComp, true));
-          regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
-              rowImportPerGrp, Add, true);
-          double normRes = 0.0;
-          compRes->Norm2(&normRes);
-
-          if (normRes < 1.0e-12)
-            break;
-        }
-      }
-
-      // -----------------------------------------------------------------------
-      // Print fine-level solution
-      // -----------------------------------------------------------------------
-
-      compX->Comm().Barrier();
-      sleep(1);
-
-      regionalToComposite(regX, compX, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Zero, false);
-
-      std::cout << myRank << " | compX after V-cycle" << std::endl;
-      sleep(1);
-      compX->Print(std::cout);
-      sleep(2);
-
-      // Write solution to file for printing
-      std::string outFileName = "compX.mm";
-      Xpetra::IO<double,int,int,Xpetra::EpetraNode>::Write(outFileName, *Xpetra::toXpetra<int,Xpetra::EpetraNode>(compX));
-    }
-    else if (strcmp(command,"PrintCompositeVectorX") == 0) {
-      sleep(myRank);
-      compX->Print(std::cout);
-    }
-    else if (strcmp(command,"PrintCompositeVectorY") == 0) {
-      sleep(myRank);
-      compY->Print(std::cout);
-    }
-    else if (strcmp(command,"PrintQuasiRegVectorX") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: quasiRegion vector X Grp %d\n", myRank, j);
-        quasiRegX[j]->Print(std::cout);
+        if (normRes < 1.0e-12)
+          break;
       }
     }
-    else if (strcmp(command,"PrintRegVectorX") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: region vector X Grp %d\n", myRank, j);
-        regX[j]->Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"PrintRegVectorY") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: region vector Y Grp %d\n", myRank, j);
-        regY[j]->Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"PrintRegVectorYComp") == 0) {
-      sleep(myRank);
-      regYComp->Print(std::cout);
-    }
-    else if (strcmp(command,"PrintRegVectorInterfaceScaling") == 0) {
-      sleep(myRank);
-      for (int j = 0; j < maxRegPerProc; j++) {
-        printf("%d: region vector regionInterfaceScaling Grp %d\n", myRank, j);
-        regionInterfaceScaling[j]->Print(std::cout);
-      }
-    }
-    else if (strcmp(command,"Terminate") == 0) {
-      sprintf(command,"/bin/rm -f %s",fileName); system(command); exit(1);
-    }
-    else { printf("%d: Command (%s) not recognized !\n",myRank,command);  exit(1); }
-    sprintf(command,"/bin/rm -f myData_%d",myRank); system(command); sleep(1);
+
+    // -----------------------------------------------------------------------
+    // Print fine-level solution
+    // -----------------------------------------------------------------------
+
+    compX->Comm().Barrier();
+    sleep(1);
+
+    regionalToComposite(regX, compX, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Zero, false);
+
+    std::cout << myRank << " | compX after V-cycle" << std::endl;
+    sleep(1);
+    compX->Print(std::cout);
+    sleep(2);
+
+    // Write solution to file for printing
+    std::string outFileName = "compX.mm";
+    Xpetra::IO<double,int,int,Xpetra::EpetraNode>::Write(outFileName, *Xpetra::toXpetra<int,Xpetra::EpetraNode>(compX));
   }
+
+  Comm.Barrier();
+
+#ifdef HAVE_MPI
+  MPI_Finalize();
+#endif
+
 }
 
 // returns local ID (within region curRegion) for the LIDcomp^th composite grid
@@ -2733,30 +2236,4 @@ int LID2Dregion(void *ptr, int LIDcomp, int whichGrp)
 
    return(
     (yGIDComp - relcornery[whichGrp]-trueCornery[whichGrp])*lDimx[whichGrp]+ (xGIDComp - relcornerx[whichGrp]-trueCornerx[whichGrp]));
-}
-
-
-
-// just some junk code to remove things like space and newlines when we
-// read strings from files ... so that strcmp() works properly
-void stripTrailingJunk(char *command)
-{
-   int i  = strlen(command)-1;
-   while ( (command[i] == ' ') || (command[i] == '\n')) {
-      command[i] = '\0';
-      i--;
-   }
-}
-// prints Grp-style maps
-void printGrpMaps(std::vector <Teuchos::RCP<Epetra_Map> > &mapPerGrp, int maxRegPerProc, char *str)
-{
-   for (int j = 0; j < maxRegPerProc; j++) {
-      printf("%s in grp(%d):",str,j);
-      Teuchos::RCP<Epetra_Map> jthMap = mapPerGrp[j];
-      const int *GIDsReg = jthMap->MyGlobalElements();
-      for (int i = 0; i < mapPerGrp[j]->NumMyElements(); i++) {
-         printf("%d ",GIDsReg[i]);
-      }
-      printf("\n");
-   }
 }

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mk1DRegionFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mk1DRegionFile.m
@@ -18,7 +18,8 @@ function [] = mk1DRegionFile(filename)
 %% User-defined cases
 
 if (strcmp(filename, 'caseTen') == true)
-  nNodesPerRegion = [4 7 4];
+%   nNodesPerRegion = [4 7 4];
+  nNodesPerRegion = [7 7 7];
 elseif (strcmp(filename, 'caseEleven') == true)
   nNodesPerRegion = [7 4 7 4 4 7];
 elseif (strcmp(filename, 'caseTwelve') == true)

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mk2DAppData.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mk2DAppData.m
@@ -5,31 +5,31 @@ function [] = mk2DAppData(allMyNodes,allMyRegions,nProcs,whichCase,...
 % here we basically need to just print it.
 %
 
-for myRank=0:nProcs-1,
-   if exist(sprintf('myData_%d',myRank),'file'),
-      fprintf('mkAppData: myData_%d already exists\n',myRank);
-      keyboard;
-   end;
-   fp = fopen(sprintf('myData_%d',myRank),'w');
-   if fp == -1,
-      fprintf('mkAppData: cannot open myData_%d\n',myRank);
-      keyboard;
-   end;
-   fprintf(fp,'LoadAppDataForLIDregion()\n');
+for myRank=0:nProcs-1
+   % open file
+   fp = fopen(sprintf('myAppData_%d',myRank),'w');
+   if fp == -1
+     error('mkAppData: cannot open myAppData_%d\n',myRank);
+   end
+   
+   % write to file
+%    fprintf(fp,'LoadAppDataForLIDregion()\n');
 
    curRegionList = allMyRegions{myRank+1}.myRegions;
 
    nRegions = length(curRegionList);
    gDim   = ones(3,nRegions);
    for k=1:nRegions
-      reg = curRegionList(k)+1;
-      if localDims(reg,myRank+1,1) ~= -1, 
-         fprintf(fp,'%d %d 1  %d %d 1  %d %d 0 %d %d 0\n',...
-             globalDims(reg,1),globalDims(reg,2),...
-             localDims(reg,myRank+1,1),localDims(reg,myRank+1,2),...
-             relcorners(reg,myRank+1,1),relcorners(reg,myRank+1,2),...
-             abscorners(reg,1),abscorners(reg,2));
-       end
+     reg = curRegionList(k)+1;
+     if localDims(reg,myRank+1,1) ~= -1
+       fprintf(fp,'%d %d 1  %d %d 1  %d %d 0 %d %d 0\n',...
+           globalDims(reg,1),globalDims(reg,2),...
+           localDims(reg,myRank+1,1),localDims(reg,myRank+1,2),...
+           relcorners(reg,myRank+1,1),relcorners(reg,myRank+1,2),...
+           abscorners(reg,1),abscorners(reg,2));
+     end
    end
+   
+   % close file
    fclose(fp);
-end;
+end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkAppData.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkAppData.m
@@ -1,66 +1,65 @@
 function [] = mkAppData(allMyNodes,allMyRegions,nProcs,whichCase)
 
-for myRank=0:nProcs-1,
-   if exist(sprintf('myData_%d',myRank),'file'),
-      fprintf('mkAppData: myData_%d already exists\n',myRank);
-      keyboard;
-   end;
-   fp = fopen(sprintf('myData_%d',myRank),'w');
-   if fp == -1,
-      fprintf('mkAppData: cannot open myData_%d\n',myRank);
-      keyboard;
-   end;
-   fprintf(fp,'LoadAppDataForLIDregion()\n');
+for myRank=0:nProcs-1
+   
+   % open file
+   fp = fopen(sprintf('myAppData_%d',myRank),'w');
+   if fp == -1
+     error('mkAppData: cannot open myAppData_%d\n',myRank);
+   end
+%    fprintf(fp,'LoadAppDataForLIDregion()\n');
 
    curRegionList = allMyRegions{myRank+1}.myRegions;
 
    nRegions = length(curRegionList);
    gDim   = ones(3,nRegions);
    for k=1:nRegions
-      maxGID = -1; minGID = 10000000;
-      curRegion = curRegionList(k);
+     maxGID = -1; minGID = 10000000;
+     curRegion = curRegionList(k);
 
-      % go through all GIDs on all procs looking for curRegion,
+     % go through all GIDs on all procs looking for curRegion,
 
-      for j=1:length(allMyNodes{myRank+1}),
-         if ~isempty(find(curRegion == allMyNodes{myRank+1}(j).gRegions)),
-            theID = allMyNodes{myRank+1}(j).ID;
-            if theID < minGID, minGID = theID; end;
-            if theID > maxGID, maxGID = theID; end;
-         end
-      end
-      gDim(1,k) = maxGID - minGID + 1;
-      fprintf(fp,'%d %d\n',minGID,maxGID);
-   end;
+     for j=1:length(allMyNodes{myRank+1})
+       if ~isempty(find(curRegion == allMyNodes{myRank+1}(j).gRegions))
+         theID = allMyNodes{myRank+1}(j).ID;
+         if theID < minGID, minGID = theID; end
+         if theID > maxGID, maxGID = theID; end
+       end
+     end
+     gDim(1,k) = maxGID - minGID + 1;
+     fprintf(fp,'%d %d\n',minGID,maxGID);
+   end
       
    lDim   = ones(3,nRegions);
    lowInd = zeros(3,nRegions);
-   if whichCase(1) == 'M',
-      lDim = gDim;
-   elseif whichCase(1) == 'R',
-       temp = allMyNodes{myRank+1};
-       maxi = 0; mini = temp(1).ID;
-       lowerCorner = mini;
-       for i=1:length(allMyNodes),
-          temp = allMyNodes{i};
-          for j=1:length(temp), 
-             if find(temp(j).gRegions == allMyRegions{myRank+1}.myRegions),
-                if temp(j).ID > maxi, maxi = temp(j).ID; end;
-                if temp(j).ID < mini, mini = temp(j).ID; end;
-                 if (i==myRank+1) && (temp(j).ID < lowerCorner), lowerCorner = temp(j).ID; end;
-             end
-          end
+   if whichCase(1) == 'M'
+     lDim = gDim;
+   elseif whichCase(1) == 'R'
+     temp = allMyNodes{myRank+1};
+     maxi = 0; mini = temp(1).ID;
+     lowerCorner = mini;
+     for i=1:length(allMyNodes)
+       temp = allMyNodes{i};
+       for j=1:length(temp)
+         if find(temp(j).gRegions == allMyRegions{myRank+1}.myRegions)
+           if temp(j).ID > maxi, maxi = temp(j).ID; end;
+           if temp(j).ID < mini, mini = temp(j).ID; end;
+           if (i==myRank+1) && (temp(j).ID < lowerCorner), lowerCorner = temp(j).ID; end;
+         end
        end
-       gDim(1,1) = maxi-mini+1;
-       lDim(1,1) = length(allMyNodes{myRank+1});
-       lowInd(1,1) = lowerCorner-mini;
+     end
+     gDim(1,1) = maxi-mini+1;
+     lDim(1,1) = length(allMyNodes{myRank+1});
+     lowInd(1,1) = lowerCorner-mini;
    else
-       fprintf('whichCase not right\n'); keyboard;
+     fprintf('whichCase not right\n'); keyboard;
    end
-   for ii=1:nRegions,
-       fprintf(fp,'%d %d %d    %d %d %d   %d %d %d\n',gDim(1,ii),gDim(2,ii),gDim(3,ii),...
-                                                   lDim(1,ii),lDim(2,ii),lDim(3,ii),...
-                                                   lowInd(1,ii),lowInd(2,ii),lowInd(3,ii));
+   for ii=1:nRegions
+     fprintf(fp,'%d %d %d    %d %d %d   %d %d %d\n',gDim(1,ii),gDim(2,ii),gDim(3,ii),...
+                                                 lDim(1,ii),lDim(2,ii),lDim(3,ii),...
+                                                 lowInd(1,ii),lowInd(2,ii),lowInd(3,ii));
    end
+   
+   % close file
    fclose(fp);
-end;
+end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkCompositeMap.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkCompositeMap.m
@@ -1,18 +1,20 @@
-function [] = mkCompositeMap(myNodes,myRank,maxRegPerGID)
+function [] = mkCompositeMap(myNodes,myRank)
 
-   if exist(sprintf('myData_%d',myRank),'file'),
-      fprintf('mkCompositeMap: myData_%d already exists\n',myRank);
-      keyboard;
-   end;
-   fp = fopen(sprintf('myData_%d',myRank),'w');
-   if fp == -1,
-      fprintf('mkCompositeMap: cannot open myData_%d\n',myRank);
-      keyboard;
-   end;
-   fprintf(fp,'LoadCompositeMap\n');
-   myGIDs = getCompositeIDs(myNodes,myRank);
-   count = 1;
-   for i=1:length(myGIDs)
-      fprintf(fp,'%d\n',myGIDs(i));
-   end;
-   fclose(fp);
+  % open file
+  filename = 'myCompositeMap_';
+  fp = fopen(sprintf('%s%d',filename,myRank),'w');
+  if fp == -1
+    error('mkCompositeMap: cannot open myData_%d\n',myRank);
+  end
+  
+  % write to file
+%   fprintf(fp,'LoadCompositeMap\n');
+  myGIDs = getCompositeIDs(myNodes,myRank);
+  for i=1:length(myGIDs)
+    fprintf(fp,'%d\n',myGIDs(i));
+  end
+  
+  % close file
+  fclose(fp);
+  
+end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkMatrixFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkMatrixFile.m
@@ -1,0 +1,54 @@
+% writeMatrixFile
+%
+% Write matrix to file
+%
+
+% now send matrix to C++
+
+function [] = writeMatrixFile(A)
+
+% open file
+fp = fopen('Amat.mm','w');
+if (fp == -1)
+  error('Cannot open file.');
+end
+
+% write to file
+fprintf(fp,'%%%%MatrixMarket matrix coordinate real general\n');
+fprintf(fp,'%d %d %d\n',size(A,1),size(A,2),nnz(A));
+[aaa,bbb,ccc] = find(A);
+[~,ii] = sort(aaa);
+aaa = aaa(ii); bbb = bbb(ii); ccc = ccc(ii);
+row = aaa(1);
+startRow = 1;  endRow = startRow;
+for i=2:length(aaa)
+  if aaa(i) ~= row % sort and print out the previous row
+    aa = aaa(startRow:i-1);
+    bb = bbb(startRow:i-1);
+    cc = ccc(startRow:i-1);
+    [~,ii] = sort(bb);
+    aa = aa(ii);
+    bb = bb(ii);
+    cc = cc(ii);
+    for k=1:length(aa)
+      fprintf(fp,'%d %d %20.13e\n',aa(k),bb(k),cc(k));
+    end
+    startRow=i;   % indicates that we are now storing a new row
+  end
+end
+% print the last row
+aa = aaa(startRow:end);
+bb = bbb(startRow:end);
+cc = ccc(startRow:end);
+[~,ii] = sort(bb);
+aa = aa(ii);
+bb = bb(ii);
+cc = cc(ii);
+for k=1:length(aa)
+  fprintf(fp,'%d %d %20.13e\n',aa(k),bb(k),cc(k));
+end
+
+% close file
+fclose(fp);
+
+end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkRegionsPerGID.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkRegionsPerGID.m
@@ -1,15 +1,10 @@
 function [] = mkRegionsPerGID(myNodes,myRank,maxRegPerGID)
 
-   if exist(sprintf('myData_%d',myRank),'file'),
-      fprintf('mkRegionsPerGID: myData_%d already exists\n',myRank);
-      keyboard;
-   end;
-   fp = fopen(sprintf('myData_%d',myRank),'w');
-   if fp == -1,
-      fprintf('mkRegionsPerGID: cannot open myData_%d\n',myRank);
-      keyboard;
-   end;
-   fprintf(fp,'LoadAndCommRegAssignments\n');
+   fp = fopen(sprintf('myRegionAssignment_%d',myRank),'w');
+   if fp == -1
+      error('mkRegionsPerGID: cannot open myRegAssignment_%d\n',myRank);
+   end
+%    fprintf(fp,'LoadAndCommRegAssignments\n');
    myGIDs = getCompositeIDs(myNodes,myRank);
    count = 1;
    for i=1:length(myGIDs)
@@ -18,5 +13,5 @@ function [] = mkRegionsPerGID(myNodes,myRank,maxRegPerGID)
       temp(1:length(myNodes(count).gRegions)) = myNodes(count).gRegions;
       fprintf(fp,'%d ',temp);
       fprintf(fp,'\n');
-   end;
+   end
    fclose(fp);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/readRegionalFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/readRegionalFile.m
@@ -17,11 +17,11 @@ function [myNodes] = readRegionFile(filename,myRank)
 
 
 fp = fopen(filename,'r');
-if fp == -1, fprintf('Cannot read %s \n',filename); keyboard; end;
+if (fp == -1)
+  error('Cannot read %s \n',filename);
+end
 
-%
 % read header information 
-%
 fgetl(fp);   % read heading line
 temp = fscanf(fp,'%d');
 nNodes   = temp(1);
@@ -30,11 +30,9 @@ nProcs   = temp(3);
 fgetl(fp);   % read rest of 2nd line
 fgetl(fp);   % read heading line
 
-%
 %  read each line of the file and only retain those things that I own
 %  this includes recording all other procs and region ids correspond
 %  to interface nodes that I own
-%
 newLine = 'dummy';
 iOwnIt = 0;
 myNodes = [];

--- a/packages/muelu/research/mmayr/composite_to_regions/src/regionToProcMap.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/regionToProcMap.m
@@ -50,11 +50,11 @@ regionList = sort(regionList);
 % figure things out in a slow clumsy way.
 
 fp = fopen(filename,'r');
-if fp == -1, fprintf('Cannot read %s \n',filename); keyboard; end;
+if (fp == -1)
+  error('Cannot read %s \n',filename);
+end
 
-%
 % read header information 
-%
 fgetl(fp);   % read heading line
 temp = fscanf(fp,'%d');
 nNodes   = temp(1);


### PR DESCRIPTION
@trilinos/muelu 

## Description
The interplay between the Matlab and the C++ driver has been redesigned. In brief, matlab is only used for preprocessing now, but not for controlling the solver anymore. Updated documentation accordingly.

## Motivation and Context
The interplay with Matlab was very slow and not super stable at numRegions > 4. Redesign was necessary.

For the old Matlab/C++ interaction, roll back to commit 657d5544cee8dbb8bf8bfed5a8e93fb64a51eff3.

## Related Issues
* Closes #2709 

## How Has This Been Tested?
I ran our 1D and 2D examples locally.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.