### PR TITLE
Allow Trilinos_TRACK to be overridden in Jenkins driver (TRIL-200)

### DIFF
--- a/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/toss3/drivers/Trilinos-atdm-toss3-intel-opt-openmp-panzer.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:15:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/toss3/local-driver.sh


### PR DESCRIPTION
This is so that we can set up Jenkins builds on 'chama' to submit to
'Specialized' CDash group at first, even though these builds may be going to
the "ATDM" CDash group on 'serrano'.

This was not tested but it is super safe and was copied from another tested script.