### PR TITLE
Epetra: Add a utility function to get a std::vector's buffer.

### DIFF
--- a/packages/epetra/example/petra_power_method/cxx_main.cpp
+++ b/packages/epetra/example/petra_power_method/cxx_main.cpp
@@ -49,6 +49,7 @@
 #include "Epetra_Map.h"
 #include "Epetra_Time.h"
 #include "Epetra_MultiVector.h"
+#include "Epetra_Util.h"
 #include "Epetra_Vector.h"
 #include "Epetra_CrsMatrix.h"
 #ifdef EPETRA_MPI
@@ -211,10 +212,10 @@ int main(int argc, char *argv[])
     int numvals = A.NumGlobalEntries(0);
     std::vector<double> Rowvals(numvals);
     std::vector<int> Rowinds(numvals);
-    A.ExtractGlobalRowCopy(0, numvals, numvals, &Rowvals[0], &Rowinds[0]); // Get A[0,0]
+    A.ExtractGlobalRowCopy(0, numvals, numvals, Epetra_Util_data_ptr(Rowvals), Epetra_Util_data_ptr(Rowinds)); // Get A[0,0]
     for (i=0; i<numvals; i++) if (Rowinds[i] == 0) Rowvals[i] *= 10.0;
 
-    A.ReplaceGlobalValues(0, numvals, &Rowvals[0], &Rowinds[0]);
+    A.ReplaceGlobalValues(0, numvals, Epetra_Util_data_ptr(Rowvals), Epetra_Util_data_ptr(Rowinds));
   }
 
   // Iterate (again)

--- a/packages/epetra/src/Epetra_CrsGraph.cpp
+++ b/packages/epetra/src/Epetra_CrsGraph.cpp
@@ -176,12 +176,12 @@ int Epetra_CrsGraph::TAllocate(const int* numIndicesPerRow, int Inc, bool static
     // yet.
     Data.SortedEntries_[i].entries_.resize(NumIndices,
                  indexBaseMinusOne);
-    Data.Indices_[i] = NumIndices > 0 ? Data.SortedEntries_[i].entries_.data() : NULL;
+    Data.Indices_[i] = Epetra_Util_data_ptr(Data.SortedEntries_[i].entries_);
     Data.SortedEntries_[i].entries_.resize(0);
   }
       }
       else {
-  Data.Indices_[i] = 0;
+        Data.Indices_[i] = NULL;
       }
 
       CrsGraphData_->NumAllocatedIndicesPerRow_[i] = NumIndices;

--- a/packages/epetra/src/Epetra_CrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_CrsMatrix.cpp
@@ -4895,7 +4895,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
     Epetra_IntVector SourceDomain_pids(SourceMatrix.DomainMap(),true);
 
     SourcePids.resize(SourceMatrix.ColMap().NumMyElements(),0);
-    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? SourcePids.data() : 0);
+    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(), Epetra_Util_data_ptr(SourcePids));
     // SourceDomain_pids contains the restricted pids
     SourceDomain_pids.PutValue(MyPID);
 
@@ -4923,7 +4923,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
 
     // Associate SourcePids vector with non-rebalanced column map
     SourcePids.resize(SourceMatrix.ColMap().NumMyElements(),0);
-    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? SourcePids.data() : 0);
+    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(), Epetra_Util_data_ptr(SourcePids));
 
     // create an Import object between non-rebalanced (=source) and rebalanced domain map (=target)
     if(typeid(TransferType)==typeid(Epetra_Import) && DomainTransfer->TargetMap().SameBlockMapDataAs(*theDomainMap))
@@ -4943,7 +4943,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
     Epetra_IntVector TargetRow_pids(*theDomainMap,true);
     Epetra_IntVector SourceRow_pids(SourceMatrix.RowMap());
     SourcePids.resize(SourceMatrix.ColMap().NumMyElements(),0);
-    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(),SourcePids.size() ? SourcePids.data() : 0);
+    Epetra_IntVector SourceCol_pids(View,SourceMatrix.ColMap(), Epetra_Util_data_ptr(SourcePids));
 
     TargetRow_pids.PutValue(MyPID);
     if(typeid(TransferType)==typeid(Epetra_Import))
@@ -5027,7 +5027,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
 
   // Unpack into arrays
   if(UseLL)
-    Epetra_Import_Util::UnpackAndCombineIntoCrsArrays(SourceMatrix,NumSameIDs,NumRemoteIDs,RemoteLIDs,NumPermuteIDs,PermuteToLIDs,PermuteFromLIDs,LenImports_,Imports_,NumMyRows(),mynnz,MyPID,CSR_rowptr.Values(),CSR_colind_LL.size()?CSR_colind_LL.data():0,CSR_vals,SourcePids,TargetPids);
+    Epetra_Import_Util::UnpackAndCombineIntoCrsArrays(SourceMatrix,NumSameIDs,NumRemoteIDs,RemoteLIDs,NumPermuteIDs,PermuteToLIDs,PermuteFromLIDs,LenImports_,Imports_,NumMyRows(),mynnz,MyPID,CSR_rowptr.Values(),Epetra_Util_data_ptr(CSR_colind_LL),CSR_vals,SourcePids,TargetPids);
   else
     Epetra_Import_Util::UnpackAndCombineIntoCrsArrays(SourceMatrix,NumSameIDs,NumRemoteIDs,RemoteLIDs,NumPermuteIDs,PermuteToLIDs,PermuteFromLIDs,LenImports_,Imports_,NumMyRows(),mynnz,MyPID,CSR_rowptr.Values(),CSR_colind.Values(),CSR_vals,SourcePids,TargetPids);
 
@@ -5067,10 +5067,10 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
   /**************************************************************/
   //Call an optimized version of MakeColMap that avoids the Directory lookups (since the importer knows who owns all the gids).
   std::vector<int> RemotePIDs;
-  int * pids_ptr = TargetPids.size() ? TargetPids.data() : 0;
+  int * pids_ptr = Epetra_Util_data_ptr(TargetPids);
   if(UseLL) {
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
-    long long * CSR_colind_LL_ptr = CSR_colind_LL.size() ? CSR_colind_LL.data() : 0;
+    long long * CSR_colind_LL_ptr = Epetra_Util_data_ptr(CSR_colind_LL);
     Epetra_Import_Util::LowCommunicationMakeColMapAndReindex(N,CSR_rowptr.Values(),CSR_colind.Values(),CSR_colind_LL_ptr,
                                                              *MyDomainMap,pids_ptr,
                                                              Graph_.CrsGraphData_->SortGhostsAssociatedWithEachProcessor_,RemotePIDs,
@@ -5103,7 +5103,7 @@ Epetra_CrsMatrix::FusedTransfer (const Epetra_CrsMatrix& SourceMatrix,
   // Pre-build the importer using the existing PIDs
   Epetra_Import * MyImport=0;
   int NumRemotePIDs = RemotePIDs.size();
-  int *RemotePIDs_ptr = RemotePIDs.size() ? RemotePIDs.data() : 0;
+  int *RemotePIDs_ptr = Epetra_Util_data_ptr(RemotePIDs);
   //  if(!RestrictCommunicator && !MyDomainMap->SameAs(ColMap()))
   if(!MyDomainMap->SameAs(ColMap()))
     MyImport = new Epetra_Import(ColMap(),*MyDomainMap,NumRemotePIDs,RemotePIDs_ptr);

--- a/packages/epetra/src/Epetra_Export.cpp
+++ b/packages/epetra/src/Epetra_Export.cpp
@@ -500,8 +500,8 @@ void Epetra_Export::Print(std::ostream & os) const
 
   if (sortIDs && NumExportIDs_ > 0) {
     int* intCompanions[1]; // Input for Epetra_Util::Sort().
-    intCompanions[0] = exportLIDs.data();
-    Epetra_Util::Sort (true, NumExportIDs_, exportPIDs.data(),
+    intCompanions[0] = Epetra_Util_data_ptr(exportLIDs);
+    Epetra_Util::Sort (true, NumExportIDs_, Epetra_Util_data_ptr(exportPIDs),
            0, (double**) NULL, 1, intCompanions, 0, 0);
   }
       }

--- a/packages/epetra/src/Epetra_FECrsGraph.cpp
+++ b/packages/epetra/src/Epetra_FECrsGraph.cpp
@@ -246,10 +246,10 @@ int Epetra_FECrsGraph::GlobalAssemble(const Epetra_Map& domain_map,
   for (nonlocalRows = nonlocalRowData_var.begin();
        nonlocalRows != nonlocalRowData_var.end(); ++nonlocalRows)
     allColumns.AddEntries((int) nonlocalRows->second.entries_.size(),
-       nonlocalRows->second.entries_.size() ? nonlocalRows->second.entries_.data() : 0);
+       Epetra_Util_data_ptr(nonlocalRows->second.entries_));
 
   Epetra_Map* colMap = new Epetra_Map((int_type) -1, (int) allColumns.entries_.size(),
-             allColumns.entries_.size() ? allColumns.entries_.data() : 0,
+                                      Epetra_Util_data_ptr(allColumns.entries_),
                                       (int_type) Map().IndexBase64(), Map().Comm());
 
   //now we need to create a graph with sourceMap and colMap, and fill it with
@@ -281,7 +281,7 @@ int Epetra_FECrsGraph::GlobalAssemble(const Epetra_Map& domain_map,
        nonlocalRows != nonlocalRowData_var.end(); ++nonlocalRows)
     EPETRA_CHK_ERR( tempGrph->InsertGlobalIndices(nonlocalRows->first,
              (int) nonlocalRows->second.entries_.size(),
-             nonlocalRows->second.entries_.size() ? nonlocalRows->second.entries_.data() : 0) );
+             Epetra_Util_data_ptr(nonlocalRows->second.entries_)) );
 
 
   //Now we need to call FillComplete on our temp graph. We need to

--- a/packages/epetra/src/Epetra_FECrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_FECrsMatrix.cpp
@@ -925,7 +925,7 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
     //First build a map that describes our nonlocal data.
     //We'll use the arbitrary distribution constructor of Map.
 
-    int_type* nlr_ptr = nonlocalRows_var.size() > 0 ? nonlocalRows_var.data() : 0;
+    int_type* nlr_ptr = Epetra_Util_data_ptr(nonlocalRows_var);
     if (sourceMap_ == NULL)
       sourceMap_ = new Epetra_Map((int_type) -1, (int) nonlocalRows_var.size(), nlr_ptr,
             (int_type) Map().IndexBase64(), Map().Comm());
@@ -962,7 +962,7 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
         }
       }
 
-      int_type* cols_ptr = cols.size() > 0 ? cols.data() : 0;
+      int_type* cols_ptr = Epetra_Util_data_ptr(cols);
 
       colMap_ = new Epetra_Map((int_type) -1, (int) cols.size(), cols_ptr,
                                (int_type) Map().IndexBase64(), Map().Comm());
@@ -975,7 +975,7 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
       nonlocalRowLengths[i] = (int) nonlocalCols_var[i].size();
     }
 
-    int* nlRLptr = nonlocalRowLengths.size()>0 ? nonlocalRowLengths.data() : NULL;
+    int* nlRLptr = Epetra_Util_data_ptr(nonlocalRowLengths);
     if ( first_time && tempMat_ == NULL )
       tempMat_ = new Epetra_CrsMatrix(Copy, *sourceMap_, *colMap_, nlRLptr);
     else
@@ -985,13 +985,13 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
       if ( first_time ) {
         EPETRA_CHK_ERR( tempMat_->InsertGlobalValues(nonlocalRows_var[i],
                                                     (int) nonlocalCols_var[i].size(),
-                                                     nonlocalCoefs_[i].data(),
-                                                     nonlocalCols_var[i].data()) );
+                                                     Epetra_Util_data_ptr(nonlocalCoefs_[i]),
+                                                     Epetra_Util_data_ptr(nonlocalCols_var[i])) );
       } else {
         EPETRA_CHK_ERR( tempMat_->SumIntoGlobalValues(nonlocalRows_var[i],
                                                      (int) nonlocalCols_var[i].size(),
-                                                      nonlocalCoefs_[i].data(),
-                                                      nonlocalCols_var[i].data()) );
+                                                      Epetra_Util_data_ptr(nonlocalCoefs_[i]),
+                                                      Epetra_Util_data_ptr(nonlocalCols_var[i])) );
       }
     }
 
@@ -1168,7 +1168,7 @@ int Epetra_FECrsMatrix::InputGlobalValues(int numRows, const int_type* rows,
 
     //If we get to here, the data is in column-major order.
 
-    double* valuesptr = workData_.data();
+    double* valuesptr = Epetra_Util_data_ptr(workData_);
 
     //Since the data is in column-major order, then we copy the i-th row
     //of the values table into workData_, in order to have the row in
@@ -1209,7 +1209,7 @@ int Epetra_FECrsMatrix::InputGlobalValues(int numRows, const int_type* rows,
     for(int j=0; j<numCols; ++j) {
       workData_[j] = values[i+j*numRows];
     }
-    int err = InputGlobalValues_RowMajor(1, &rows[i], numCols, cols, workData_.data(), mode);
+    int err = InputGlobalValues_RowMajor(1, &rows[i], numCols, cols, Epetra_Util_data_ptr(workData_), mode);
     if (err < 0) return err;
     returncode += err;
   }

--- a/packages/epetra/src/Epetra_FEVector.cpp
+++ b/packages/epetra/src/Epetra_FEVector.cpp
@@ -512,8 +512,8 @@ void Epetra_FEVector::createNonlocalMapAndExporter()
 {
   std::vector<int_type>& nonlocalIDs_var = nonlocalIDs<int_type>();
   delete nonlocalMap_;
-  int_type* nlIDptr = nonlocalIDs_var.size()>0 ? &nonlocalIDs_var[0] : NULL;
-  int* nlElSzptr = nonlocalElementSize_.size()>0 ? &nonlocalElementSize_[0] : NULL;
+  int_type* nlIDptr = Epetra_Util_data_ptr(nonlocalIDs_var);
+  int* nlElSzptr = Epetra_Util_data_ptr(nonlocalElementSize_);
   nonlocalMap_ = new Epetra_BlockMap ((int_type) -1, (int) nonlocalIDs_var.size(), nlIDptr,
                                       nlElSzptr, (int_type) Map().IndexBase64(), Map().Comm());
   delete exporter_;

--- a/packages/epetra/src/Epetra_Import.cpp
+++ b/packages/epetra/src/Epetra_Import.cpp
@@ -844,7 +844,7 @@ void Epetra_Import::Print(std::ostream & os) const
   if (sortIDs && NumExportIDs_ > 0) {
     int* intCompanions[1]; // Input for Epetra_Util::Sort().
     intCompanions[0] = &exportLIDs[0];
-    Epetra_Util::Sort (true, NumExportIDs_, exportPIDs.data(),
+    Epetra_Util::Sort (true, NumExportIDs_, Epetra_Util_data_ptr(exportPIDs),
            0, (double**) NULL, 1, intCompanions, 0, 0);
   }
       }

--- a/packages/epetra/src/Epetra_Import_Util.cpp
+++ b/packages/epetra/src/Epetra_Import_Util.cpp
@@ -50,6 +50,7 @@
 #include "Epetra_Import.h"
 #include "Epetra_CrsMatrix.h"
 #include "Epetra_HashTable.h"
+#include "Epetra_Util.h"
 
 #include <stdexcept>
 
@@ -133,7 +134,7 @@ int TPackAndPrepareWithOwningPIDs(const Epetra_CrsMatrix & A,
       intptr[0] = FromRow;
       values    = valptr;
       Indices   = intptr + 2;
-      EPETRA_CHK_ERR(A.ExtractMyRowCopy(ExportLIDs[i], maxNumEntries, NumEntries, values, MyIndices.size() ? &MyIndices[0] : 0));
+      EPETRA_CHK_ERR(A.ExtractMyRowCopy(ExportLIDs[i], maxNumEntries, NumEntries, values, Epetra_Util_data_ptr(MyIndices)));
       for (int j = 0; j < NumEntries; ++j) {
         Indices[2*j]   = (int_type) colMap.GID64(MyIndices[j]);   // convert to GIDs
         Indices[2*j+1] = pids[MyIndices[j]];                      // PID owning the entry.
@@ -581,7 +582,7 @@ int UnpackAndCombineIntoCrsArrays(const Epetra_CrsMatrix& SourceMatrix,
   int NumListsLL =0;
   int * IntSortLists[2];
   long long * LLSortLists[2];
-  int * RemotePermuteIDs_ptr = RemotePermuteIDs.size() ? &RemotePermuteIDs[0] : 0;
+  int * RemotePermuteIDs_ptr = Epetra_Util_data_ptr(RemotePermuteIDs);
   if(!UseLL) {
     // int version
     IntSortLists[0] = (int*) RemoteColIndices;
@@ -595,7 +596,7 @@ int UnpackAndCombineIntoCrsArrays(const Epetra_CrsMatrix& SourceMatrix,
     NumListsInt     = NumListsLL = 1;
   }
 
-  int * PIDList_ptr = PIDList.size() ? &PIDList[0] : 0;
+  int * PIDList_ptr = Epetra_Util_data_ptr(PIDList);
   Epetra_Util::Sort(true, NumRemoteColGIDs, PIDList_ptr, 0, 0, NumListsInt, IntSortLists,NumListsLL,LLSortLists);
 
   // Stash the RemotePIDs
@@ -638,7 +639,7 @@ int UnpackAndCombineIntoCrsArrays(const Epetra_CrsMatrix& SourceMatrix,
 
   if(NumLocalColGIDs == domainMap.NumMyElements()) {
     if(NumLocalColGIDs > 0) {
-      domainMap.MyGlobalElements(ColIndices.size() ? &ColIndices[0] : 0); // Load Global Indices into first numMyBlockCols elements column GID list
+      domainMap.MyGlobalElements(Epetra_Util_data_ptr(ColIndices)); // Load Global Indices into first numMyBlockCols elements column GID list
     }
   }
   else {
@@ -660,7 +661,7 @@ int UnpackAndCombineIntoCrsArrays(const Epetra_CrsMatrix& SourceMatrix,
   if (LocalGIDs!=0) delete [] LocalGIDs;
 
   // Make Column map with same element sizes as Domain map
-  int_type * ColIndices_ptr  = ColIndices.size() ? &ColIndices[0] : 0;
+  int_type * ColIndices_ptr  = Epetra_Util_data_ptr(ColIndices);
   MapType2 temp((int_type)(-1), numMyBlockCols, ColIndices_ptr, (int_type)domainMap.IndexBase64(), domainMap.Comm());
   NewColMap = temp;
 

--- a/packages/epetra/src/Epetra_Util.h
+++ b/packages/epetra/src/Epetra_Util.h
@@ -403,6 +403,36 @@ int Epetra_Util_insert(T item, int offset, T*& list,
   return(0);
 }
 
+/** Function that returns either a pointer to the first entry in the vector
+    or, if the vector is empty, the NULL pointer.
+
+    @param vec vector argument (may be empty)
+    @return Either NULL or a pointer to the first entry in @p vec
+ */
+template<class T>
+T* Epetra_Util_data_ptr(std::vector<T> &vec)
+{
+  if (!vec.empty()) {
+    return &vec.front();
+  }
+  return NULL;
+}
+
+/** Function that returns either a pointer to the first entry in the
+    vector or, if the vector is empty, the NULL pointer.
+
+    @param vec constant vector argument (may be empty)
+    @return Either NULL or a pointer to the first entry in @p vec
+ */
+template<class T>
+const T* Epetra_Util_data_ptr(const std::vector<T> &vec)
+{
+  if (!vec.empty()) {
+    return &vec.front();
+  }
+  return NULL;
+}
+
 //! Harwell-Boeing data extraction routine
 /*! This routine will extract data from an existing Epetra_Crs Matrix, and
     optionally from related rhs and lhs objects in a form that is compatible with

--- a/packages/epetra/test/FusedImportExport/cxx_main.cpp
+++ b/packages/epetra/test/FusedImportExport/cxx_main.cpp
@@ -45,6 +45,7 @@
 #include "Epetra_CrsMatrix.h"
 #include "Epetra_Import.h"
 #include "Epetra_Export.h"
+#include "Epetra_Util.h"
 #include "Epetra_Vector.h"
 #include "Epetra_Flops.h"
 
@@ -458,7 +459,7 @@ int main(int argc, char *argv[])
       }
 
     // New map
-    const int * MyGIDS_ptr = MyGIDS.size() ? &MyGIDS[0] : 0;
+    const int * MyGIDS_ptr = Epetra_Util_data_ptr(MyGIDS);
     Map1=new Epetra_Map(-1,num_local,MyGIDS_ptr,0,Comm);
 
 

--- a/packages/epetra/test/FusedImportExport_LL/cxx_main.cpp
+++ b/packages/epetra/test/FusedImportExport_LL/cxx_main.cpp
@@ -45,6 +45,7 @@
 #include "Epetra_CrsMatrix.h"
 #include "Epetra_Import.h"
 #include "Epetra_Export.h"
+#include "Epetra_Util.h"
 #include "Epetra_Vector.h"
 #include "Epetra_Flops.h"
 
@@ -436,7 +437,7 @@ int main(int argc, char *argv[])
       }
 
     // New map
-    const long long * MyGIDS_ptr = MyGIDS.size() ? &MyGIDS[0] : 0;
+    const long long * MyGIDS_ptr = Epetra_Util_data_ptr(MyGIDS);
     Map1=new Epetra_Map((long long)-1,num_local,MyGIDS_ptr,(long long)0,Comm);
 
     // Execute fused import constructor


### PR DESCRIPTION
Follow-up to #2783: we can get the same effect with a utility function instead of a new C++11 feature.

I verified that I can successfully run all Epetra tests with and without C++11. This also fixes the original problem with GCC's debug mode.

This was not too hard to put together (just a bit of search and replace).