### PR TITLE
Tril 198 cmake 3.11.2 ninja 1.8.2

### DIFF
--- a/cmake/ctest/drivers/atdm/ctest-s-driver-config-build.sh
+++ b/cmake/ctest/drivers/atdm/ctest-s-driver-config-build.sh
@@ -12,12 +12,7 @@ echo "Loading env and running ctest -S comamnd to update, configure and build ..
 
 source ${WORKSPACE}/Trilinos/cmake/ctest/drivers/atdm/utils/create-src-and-build-dir.sh
 
-source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
-echo
-module list
-set | grep ATDM_CONFIG_
-
-export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git
+source ${WORKSPACE}/Trilinos/cmake/ctest/drivers/atdm/utils/setup_env.sh
 
 CTEST_S_CMND=env CTEST_DO_TEST=OFF ctest -V -S $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-driver.cmake
 

--- a/cmake/ctest/drivers/atdm/ctest-s-driver.sh
+++ b/cmake/ctest/drivers/atdm/ctest-s-driver.sh
@@ -12,12 +12,7 @@ echo "Loading env and running ctest -S comamnd to configure, build, and test ...
 
 source ${WORKSPACE}/Trilinos/cmake/ctest/drivers/atdm/utils/create-src-and-build-dir.sh
 
-source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
-echo
-module list
-set | grep ATDM_CONFIG_
-
-export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git
+source ${WORKSPACE}/Trilinos/cmake/ctest/drivers/atdm/utils/setup_env.sh
 
 echo
 echo "Running: ctest -V -S $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-driver.cmake ..."

--- a/cmake/ctest/drivers/atdm/utils/setup_env.sh
+++ b/cmake/ctest/drivers/atdm/utils/setup_env.sh
@@ -11,4 +11,6 @@ echo
 echo "ATDM config env vars:"
 set | grep ATDM_CONFIG_
 
-export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git
+if [ "${Trilinos_REPOSITORY_LOCATION}" == "" ] ; then
+  export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git
+fi

--- a/cmake/ctest/drivers/atdm/utils/setup_env.sh
+++ b/cmake/ctest/drivers/atdm/utils/setup_env.sh
@@ -1,0 +1,14 @@
+source ${WORKSPACE}/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
+echo
+module list
+echo
+echo "cmake in path:"
+which cmake
+echo
+echo "ninja in path:"
+which ninja
+echo
+echo "ATDM config env vars:"
+set | grep ATDM_CONFIG_
+
+export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git

--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -19,8 +19,6 @@ export ATDM_CONFIG_BUILD_COUNT=128
 
 module purge
 
-module load ninja/1.7.2
-
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
   export OMP_NUM_THREADS=2
@@ -68,10 +66,12 @@ export ATDM_CONFIG_USE_HWLOC=OFF
 export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
 export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
 
-module swap cmake/3.6.2 cmake/3.10.2
-
 module swap yamlcpp/0.3.0 yaml-cpp/20170104 
 if [ $? ]; then module load  yaml-cpp/20170104; fi
+
+# Use manually installed cmake and ninja to try to avoid module loading
+# problems (see TRIL-208)
+export PATH=/ascldap/users/rabartl/install/cmake-3.11.2/bin:/ascldap/users/rabartl/install/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
 export MPICC=`which mpicc`


### PR DESCRIPTION
CC: @fryeguy52 

## Description

Updated ATDM Trilinos builds on 'white' and 'ride' to use manually installed CMake 3.11.2 and Ninja 1.8.2 (which supports CMake Fortran builds).  I also did some refactoring to remove duplication.   See the commit log messages and diffs.  There are not many changes here.

## Motivation and Context

There is hope that this will address several issues.

* The ninja module load failures in the Jenkins builds on 'ride' (see [TRIL-208](https://software-sandbox.sandia.gov/jira/browse/TRIL-208)). 
* Crashing of 'bsub' on 'white' and 'ride' (see [TRIL-198](https://software-sandbox.sandia.gov/jira/browse/TRIL-198)). (Hoping the new libuv implementation of the ctest test job runner may magically fix the problems with 'bsub' crashing while running tests with ctest -S.)

## How Has This Been Tested?

I did quite a bit of manual testing for these changes.  I think this is pretty solid.

* Do local testing on 'white':
  - checkin-test-atdm.sh [Done]
  - Jenkins driver [Done]

* Set up experimental Jenkins job 'Trilinos-atdm-white-ride-cuda-opt' on jenkins-son.sandia.gov that runs a build on branch tril-198-cmake-3.11.2-ninja-1.8.2 of my fork. => See [Jenkins log[(https://jenkins-son.sandia.gov/view/Trilinos%20ATDM/job/Trilinos-atdm-white-ride-cuda-opt/9/console) and [CDash build](https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&parentid=3546221).

* Do local testing on 'ride':
  - checkin-test-atdm.sh [Done]
  - Jenkins driver [Done]

* Set up experimental Jenkins jobs on jenkins-srn.sandia.gov that runs build on branch tril-198-cmake-3.11.2-ninja-1.8.2 => See [Jenkins log](https://jenkins-srn.sandia.gov/view/Trilinos%20ATDM/job/Trilinos-atdm-white-ride-cuda-debug-exp/1/console) and [CDash build](https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&parentid=3546254).

* Do local testing on 'serrano' (to test change in split Jenkins driver):
  - checkin-test-atdm.sh [Done]
  - Jenkins driver [Done]

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
