### PR TITLE
Fix setting CTEST_BUILD_FLAGS for ctest -S driver (TRIL-171)

### DIFF
--- a/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
+++ b/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
@@ -59,6 +59,9 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
     SET(CTEST_CMAKE_GENERATOR "Unix Makefiles")
     SET(CTEST_BUILD_FLAGS "-j$ENV{ATDM_CONFIG_BUILD_COUNT} -k")
   ENDIF()
+  ATDM_SET_CACHE(CTEST_BUILD_FLAGS "${CTEST_BUILD_FLAGS}" CACHE STRING)
+  # NOTE: Above, we need to set this as a cache var because this var is also
+  # set as a cache var in ATDMDevEnvSettings.cmake that gets included below.
   
   SET(EXTRA_CONFIGURE_OPTIONS)
   


### PR DESCRIPTION
This is needed so that the ctest -S drvier with ninja will have '-k 99999'
passed in to show all build errors, which we want for ctest -S builds and
submits to CDash.

See the comment in the file in the commit for more details.

This is needed so that ATDM Trilinos builds show all of their errors.

I tested this locally with the Jenkins driver and I say that the '-k 99999' argument is included.