### PR TITLE
Panzer: add kokkos accessors to dof-mgr for field offsets

### DIFF
--- a/packages/panzer/dof-mgr/src/Panzer_DOFManager.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_DOFManager.hpp
@@ -54,6 +54,7 @@
 #include "Panzer_UniqueGlobalIndexer.hpp"
 #include "Panzer_NodeType.hpp"
 #include "Panzer_FieldType.hpp"
+#include "Phalanx_KokkosDeviceTypes.hpp"
 
 #include "Teuchos_RCP.hpp"
 
@@ -213,6 +214,11 @@ public:
     * field in the GIDs array.
     */
   const std::vector<int> & getGIDFieldOffsets(const std::string & blockID, int fieldNum) const;
+
+  /** gets the field pattern so you can find a particular
+    * field in the GIDs array.
+    */
+  const Kokkos::View<const int*,PHX::Device> getGIDFieldOffsetsKokkos(const std::string & blockID, int fieldNum) const;
 
   //! get associated GIDs for a given local element
   void getElementGIDs(LO localElementID, std::vector<GO> & gids, const std::string & blockIdHint="") const;

--- a/packages/panzer/dof-mgr/src/Panzer_DOFManager_impl.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_DOFManager_impl.hpp
@@ -408,6 +408,23 @@ const std::vector<int> & DOFManager<LO,GO>::getGIDFieldOffsets(const std::string
 }
 
 template <typename LO, typename GO>
+const Kokkos::View<const int*,PHX::Device> DOFManager<LO,GO>::
+getGIDFieldOffsetsKokkos(const std::string & blockID, int fieldNum) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(!buildConnectivityRun_,std::logic_error, "DOFManager::getGIDFieldOffsets: cannot be called before "
+                                                                      "buildGlobalUnknowns has been called");
+  std::map<std::string,int>::const_iterator bitr = blockNameToID_.find(blockID);
+  if(bitr==blockNameToID_.end())
+    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"DOFManager::fieldInBlock: invalid block name");
+  int bid=bitr->second;
+  if(fa_fps_[bid]!=Teuchos::null)
+    return fa_fps_[bid]->localOffsetsKokkos(fieldNum);
+
+  static const Kokkos::View<int*,PHX::Device> empty("panzer::DOFManager::getGIDFieldOffsetsKokkos() empty",0);
+  return empty;
+}
+
+template <typename LO, typename GO>
 void DOFManager<LO,GO>::getElementGIDs(LO localElementID, std::vector<GO>& gids, const std::string& /* blockIdHint */) const
 {
   gids = elementGIDs_[localElementID];

--- a/packages/panzer/dof-mgr/src/Panzer_FieldAggPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_FieldAggPattern.cpp
@@ -286,6 +286,25 @@ const std::vector<int> & FieldAggPattern::localOffsets(int fieldId) const
    return offsets;
 }
 
+const Kokkos::View<const int*,PHX::Device> FieldAggPattern::localOffsetsKokkos(int fieldId) const
+{
+   // lazy evaluation
+   std::map<int,Kokkos::View<int*,PHX::Device> >::const_iterator itr = fieldOffsetsKokkos_.find(fieldId);
+   if(itr!=fieldOffsetsKokkos_.end())
+      return itr->second;
+
+   const auto hostOffsetsStdVector = this->localOffsets(fieldId);
+   Kokkos::View<int*,PHX::Device> offsets("panzer::FieldAggPattern::localOffsetsKokkos",hostOffsetsStdVector.size());
+   auto hostOffsets = Kokkos::create_mirror_view(offsets);
+   for (size_t i=0; i < hostOffsetsStdVector.size(); ++i)
+     hostOffsets(i) = hostOffsetsStdVector[i];
+   Kokkos::deep_copy(offsets,hostOffsets);
+   PHX::Device::fence();
+
+   fieldOffsetsKokkos_[fieldId] = offsets;
+   return offsets;
+}
+
 bool FieldAggPattern::LessThan::operator()(const Teuchos::Tuple<int,3> & a,const Teuchos::Tuple<int,3> & b) const
 {
    if(a[0] < b[0]) return true;

--- a/packages/panzer/dof-mgr/src/Panzer_FieldAggPattern.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_FieldAggPattern.hpp
@@ -52,6 +52,7 @@
 
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_Tuple.hpp"
+#include "Phalanx_KokkosDeviceTypes.hpp"
 
 namespace panzer {
 
@@ -147,6 +148,25 @@ public:
      *                  required order of the basis functions
      */
    const std::vector<int> & localOffsets(int fieldId) const;
+
+  /** This function produces a map between the ordering specified by
+     * this pattern and an ordering required by the pattern associated with
+     * <code>fieldId</code>. 
+     *
+     * For instance if you have a vector called <code>GIDs</code>
+     * of length <code>this->numberIds()</code> and you want the GIDs
+     * associated with <code>fieldId = 0 </code>. Simply take the <code>offsets</code>
+     * vector and index it into the <code>GIDs</code> vector:
+     * <code>GIDs[offsets[*]]</code>.
+     *
+     * \param[in] fieldId Field to look up
+     *
+     * \returns offsets Offsets into global IDs vector. The order of this vector 
+     *                  is defined by the underlying FieldPattern defining the requested
+     *                  field. For the Intrepid2FieldPattern this will correspond to the 
+     *                  required order of the basis functions
+     */
+   const Kokkos::View<const int*,PHX::Device> localOffsetsKokkos(int fieldId) const;
      
    /** Returns a pair of vectors. The first is the offsets into the global ID 
      * array for the field and subcell specified. This will be the
@@ -232,6 +252,9 @@ protected:
 
    //! Stores the Field offsets for the fieldId key. Note that the key is the fieldId, not the index into the patterns_.
    mutable std::map<int, std::vector<int> > fieldOffsets_;
+
+   //! Stores the Field offsets for the fieldId key. Note that the key is the fieldId, not the index into the patterns_.
+   mutable std::map<int, Kokkos::View<int*,PHX::Device> > fieldOffsetsKokkos_;
 
    struct LessThan  
    { bool operator()(const Teuchos::Tuple<int,3> & a,const Teuchos::Tuple<int,3> & b) const; };

--- a/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_DynRankView.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_DynRankView.cpp
@@ -317,6 +317,26 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_DynRankView, threed)
         TEST_EQUALITY(gid_sub_r[i],gid_remote[i]);
     }
   }
+
+  // Test the kokkos version of field offsets
+  {
+    const int fieldNumber = dofManager->getFieldNum("B");
+    std::vector<std::string> elementBlockNames;
+    dofManager->getElementBlockIds(elementBlockNames);
+    TEST_ASSERT(elementBlockNames.size() > 0);
+    TEST_ASSERT(fieldNumber >= 0);
+    const auto& hostOffsetsStdVector = dofManager->getGIDFieldOffsets(elementBlockNames[0],fieldNumber);
+    TEST_EQUALITY(hostOffsetsStdVector.size(),6);
+    const auto kokkosOffsets = dofManager->getGIDFieldOffsetsKokkos(elementBlockNames[0],fieldNumber);
+    const auto hostKokkosOffsets = Kokkos::create_mirror_view(kokkosOffsets);
+    Kokkos::deep_copy(hostKokkosOffsets,kokkosOffsets);
+    PHX::Device::fence();
+
+    TEST_EQUALITY(hostOffsetsStdVector.size(),hostKokkosOffsets.size());
+    for (size_t i=0; i < hostOffsetsStdVector.size(); ++i) {
+      TEST_EQUALITY(hostOffsetsStdVector[i],hostKokkosOffsets(i));
+    }
+  }
     
 }
 

--- a/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianTop.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianTop.cpp
@@ -77,7 +77,7 @@ RCP<const panzer::FieldPattern> buildFieldPattern()
   return pattern;
 }
 
-// test that you can correctly compute a rank index from a grobal processor id
+// test that you can correctly compute a rank index from a global processor id
 TEUCHOS_UNIT_TEST(tCartesianTop, computeMyRankTriplet)
 {
   typedef CartesianConnManager<int,Ordinal64> CCM;


### PR DESCRIPTION
Adds kokkos version of offset accessors to dof manager. This will allow for reduction in memory use in Tpetra gather/scatter objects.

@trilinos/panzer 