### PR TITLE
Use manually installed cmake 3.11.2 ninja 1.8.2 on hansen/shiller

### DIFF
--- a/cmake/ctest/drivers/atdm/shiller/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/shiller/local-driver.sh
@@ -4,6 +4,10 @@ if [ "${SRUN_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
   SRUN_CTEST_TIME_LIMIT_MINUTES=180  # Default limit is 3 hours
 fi
 
+if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
+  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+fi
+
 set -x
 
 /usr/bin/srun -N 1 --constraint=k80 -J $JOB_NAME \

--- a/cmake/ctest/drivers/atdm/shiller/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/shiller/local-driver.sh
@@ -10,6 +10,6 @@ fi
 
 set -x
 
-/usr/bin/srun -N 1 --constraint=k80 -J $JOB_NAME \
+salloc -N 1 --constraint=k80 -J $JOB_NAME \
   --time=${SRUN_CTEST_TIME_LIMIT_MINUTES} \
   $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh

--- a/cmake/ctest/drivers/atdm/utils/setup_env.sh
+++ b/cmake/ctest/drivers/atdm/utils/setup_env.sh
@@ -10,6 +10,8 @@ which ninja
 echo
 echo "ATDM config env vars:"
 set | grep ATDM_CONFIG_
+echo
+echo "PATH=$PATH"
 
 if [ "${Trilinos_REPOSITORY_LOCATION}" == "" ] ; then
   export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -40,7 +40,7 @@ $ cmake \
 
 $ make NP=16  # Uses ninja -j16
 
-$ ctest -j16  # Might need to be run with srun or some other command, see below
+$ ctest -j16  # Might need to be run with salloc or some other command, see below
 ```
 
 The command:
@@ -271,7 +271,7 @@ $ bsub -x -I -q rhel7F -n 16 \
 Once logged on to `hansen` (on the SON) or `shiller` (on the SRN), one can
 directly configure and build on the login node (being careful not to overload
 the node).  But to run the tests, one must run on the compute nodes using the
-`srun` command.  For example, to configure, build and run the tests for say
+`salloc` command.  For example, to configure, build and run the tests for say
 `MueuLu` on `hansen`, (after cloning Trilinos on the `develop` branch) one
 would do:
 
@@ -289,7 +289,7 @@ $ cmake \
 
 $ make NP=16
 
-$ srun ctest -j16
+$ salloc ctest -j16
 ```
 
 Note that one can also run the same build a tests using the <a
@@ -298,7 +298,7 @@ href="#checkin-test-atdmsh">checkin-test-atdm.sh</a> script as:
 ```
 $ cd <some_build_dir>/
 $ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-sems.sh .
-$ srun ./checkin-test-sems.sh intel-opt-openmp \
+$ salloc ./checkin-test-sems.sh intel-opt-openmp \
   --enable-all-packages=off --no-enable-fwd-packages \
   --enable-packages=MueLu \
   --local-do-all
@@ -308,7 +308,7 @@ $ srun ./checkin-test-sems.sh intel-opt-openmp \
 
 Once logged on to `chama` or `serrano`, one can directly configure and build
 on the login node (being careful not to overload the node).  But to run the
-tests, one must run on the compute nodes using the `srun` command.  For
+tests, one must run on the compute nodes using the `salloc` command.  For
 example, to configure, build and run the tests for say `MueuLu` on `serrano`
 or `chama`, (after cloning Trilinos on the `develop` branch) one would do:
 

--- a/cmake/std/atdm/shiller/environment.sh
+++ b/cmake/std/atdm/shiller/environment.sh
@@ -17,8 +17,6 @@ export ATDM_CONFIG_BUILD_COUNT=32
 
 module purge
 
-module load ninja/1.7.2
-
 if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
   export OMP_NUM_THREADS=2
@@ -88,6 +86,9 @@ export ATDM_CONFIG_USE_HWLOC=OFF
 
 export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;-lhdf5_hl;-lhdf5;-lz;-ldl"
 export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${ATDM_CONFIG_HDF5_LIBS}"
+
+# Use manually installed cmake and ninja (see TRIL-209)
+export PATH=/ascldap/users/rabartl/install/hansen-shiller/cmake-3.11.2/bin:/ascldap/users/rabartl/install/hansen-shiller/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
 export MPICC=`which mpicc`


### PR DESCRIPTION
CC: @fryeguy52 

## Description

I installed CMake 3.11.2 and Fortran-capable Ninja 1.8.2 under my home dir on 'hansen' and 'shiller' and opened up permissions to allow anyone to use.  I then updated the ATDM Trilinos configuration on 'hansen' and 'shiller' to use these.

I then updated the Jenkins ctest -S driver to use the all-at-once approach on these machines.

I also had to switch to 'salloc' instead of 'srun' (see commit c9ccf7d).

## Motivation and Context

This allows using the all-at-once approach which should be much faster.  I am doing this primarily to reduce time running on 'hansen' which is now past capacity  and can't run all of the builds currently defined on it (after adding the CUDA 9.0 builds as part of #2706).

## How Has This Been Tested?

I tested this locally on 'hansen' and 'shiller' with the checkin-test-sems.sh script.  I tested the Jenkins driver on 'shiller' using:

```
$ time env  \
     JOB_NAME=Trilinos-atdm-hansen-shiller-gnu-debug-openmp \
     WORKSPACE=$PWD     Trilinos_PACKAGES=Kokkos,Teuchos \
     CTEST_TEST_TYPE=Experimental \
     CTEST_DO_SUBMIT=OFF \
     CTEST_DO_UPDATES=OFF \
     CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
   ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
     &> console.out
```

and it look okay.

I also tested this with a test Jenkins driver on 'shiller' for this branch in the build:

* https://jenkins-srn.sandia.gov/view/Trilinos%20ATDM/job/Trilinos-atdm-hansen-shiller-cuda-debug-exp/4/console

and it showed that the correct CMake and Ninja are being used:

```
09:23:05 cmake in path:
09:23:05 /ascldap/users/rabartl/install/hansen-shiller/cmake-3.11.2/bin/cmake
09:23:05 
09:23:05 ninja in path:
09:23:05 /ascldap/users/rabartl/install/hansen-shiller/ninja-1.8.2/bin/ninja
```

and it submitted to:

* https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&parentid=3557241

I could not test on 'hansen' with the Jenkins driver since all of the compute nodes are taken up all day.  I just hope that I have the permissions correct on 'hansen'.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
