### PR TITLE
Move cmake-3.11.2 and ninja-1.8.2 to white-ride/ subdir (TRIL-209)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -71,7 +71,7 @@ if [ $? ]; then module load  yaml-cpp/20170104; fi
 
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
-export PATH=/ascldap/users/rabartl/install/cmake-3.11.2/bin:/ascldap/users/rabartl/install/ninja-1.8.2/bin:$PATH
+export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
 export MPICC=`which mpicc`


### PR DESCRIPTION
CC: @fryeguy52 

## Description

Since these executables only run on 'white' and 'ride', we needed to move
these into a subdir.

## Motivation and Context

Done because these only work on 'white' and 'ride', not other machines (see 03de0f3).  For more details, see [TRIL-209](https://software-sandbox.sandia.gov/jira/browse/TRIL-209).

## How Has This Been Tested?

I tested this locally on 'white' with the checkin-test-atdm.sh script:

```
$ bsub -x -Is -q rhel7F -n 16 \
  ./checkin-test-atdm.sh cuda-opt --enable-packages=Kokkos --local-do-all
```

and it returned:

```
Tue May 29 13:33:15 MDT 2018

Enabled Packages: Kokkos

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT => Test case MPI_RELEASE_DEBUG_SHARED_PT was not run! => Does not affect push readiness! (-1.00 min)
1) cuda-opt => passed: passed=27,notpassed=0 (4.64 min)
```

I tested this on 'ride' with:

```
$ cd ~/Trilinos.base/BUILDS/RIDE/JENKINS_DRIVER/

$ time env  \
     JOB_NAME=Trilinos-atdm-white-ride-cuda-debug \
     WORKSPACE=$PWD  \
     Trilinos_PACKAGES=Kokkos,Teuchos \
     CTEST_TEST_TYPE=Experimental \
     CTEST_DO_SUBMIT=OFF \
     CTEST_DO_UPDATES=OFF \
     CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
   ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
     &> console.out
```

That showed:

```
cmake in path:
/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin/cmake

ninja in path:
/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin/ninja
```

Now to test with a Jenkins job.  I reused the experimental job:

* https://jenkins-srn.sandia.gov/view/Trilinos%20ATDM/job/Trilinos-atdm-white-ride-cuda-debug-exp/

and just updated it to use the branch `tril-209-white-ride-move-cmake-3.11.2-ninja-1.8.2` in the outer and inner Trilinos clones of my Trilinos fork.  I ran the job and the output at:

* https://jenkins-srn.sandia.gov/view/Trilinos%20ATDM/job/Trilinos-atdm-white-ride-cuda-debug-exp/2/console

shows:

```
13:45:52 cmake in path:
13:45:52 /ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin/cmake
13:45:52 
13:45:52 ninja in path:
13:45:52 /ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin/ninja
```

So that means that the Jenkins entity account can access these executables, which is good.  And it submitted to:

* https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&parentid=3557524

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
