### PR TITLE
Temp disable three ShyLU_DD tests for this OpenMP build (#2691)

### DIFF
--- a/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake
+++ b/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake
@@ -26,6 +26,11 @@ TRIL_SET_CACHE_VAR(MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none"
 # Disable just one Teko sub-unit test that fails with GCC 4.8.4 + OpenMP (#2712)
 TRIL_SET_BOOL_CACHE_VAR(Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D TRUE)
 
+# Disable these tests until they can get fixed (#2691)
+TRIL_SET_BOOL_CACHE_VAR(ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE TRUE)
+TRIL_SET_BOOL_CACHE_VAR(ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE TRUE)
+TRIL_SET_BOOL_CACHE_VAR(ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE TRUE)
+
 # NOTE: The order of these includes matters!
 
 include("${CMAKE_CURRENT_LIST_DIR}/MpiReleaseDebugSharedPtSettings.cmake")


### PR DESCRIPTION
CC: @trilinos/shylu, @trilinos/framework 

## Description

The addresses #2691.

These disables will allows this build to be promoted to the CI build and an
auto PR build (see #2462).

## Motivation and Context

ShyLU developers have not been able to reproduce and fix yet.  Temporarily disabling in this one (and only this one) build is the best option.  The GCC 4.9.3 serial Kokkos auto PR build will still run these tests.

## Related Issues

* Addresses: #2691,
* Related to: #2462, #2317 

## How Has This Been Tested?

While on this branch, I tested this as described in the "Steps to Reproduce" section in #2691 on my CEE LAN machine 'ceerws1113' and the configure output showed:

```
Processing enabled package: ShyLU_DD (FROSch, Tests, Examples)
-- ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4: NOT added test because ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE='TRUE'!
-- ShyLU_DDFROSch_test_frosch_laplacian_epetra_3d_gdsw: NOT added test because NUM_MPI_PROCS='8' > MPI_EXEC_MAX_NUMPROCS='4'!
-- ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4: NOT added test because ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE='TRUE'!
-- ShyLU_DDFROSch_test_frosch_laplacian_epetra_3d_rgdsw: NOT added test because NUM_MPI_PROCS='8' > MPI_EXEC_MAX_NUMPROCS='4'!
-- ShyLU_DDFROSch_test_frosch_laplacian_tpetra_2d_gdsw_MPI_4: Added test (BASIC, NUM_MPI_PROCS=4, PROCESSORS=4)!
-- ShyLU_DDFROSch_test_frosch_laplacian_tpetra_3d_gdsw: NOT added test because NUM_MPI_PROCS='8' > MPI_EXEC_MAX_NUMPROCS='4'!
-- ShyLU_DDFROSch_test_frosch_laplacian_tpetra_2d_rgdsw_MPI_4: Added test (BASIC, NUM_MPI_PROCS=4, PROCESSORS=4)!
-- ShyLU_DDFROSch_test_frosch_laplacian_tpetra_3d_rgdsw: NOT added test because NUM_MPI_PROCS='8' > MPI_EXEC_MAX_NUMPROCS='4'!
-- ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4: NOT added test because ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE='TRUE'!
-- ShyLU_DDFROSch_test_frosch_interfacesets_3D: NOT added test because NUM_MPI_PROCS='8' > MPI_EXEC_MAX_NUMPROCS='4'!
```

and the test output showed:

```
Test project /scratch/rabartl/Trilinos.base/BUILDS/GCC-4.8.4/MPI_RELEASE_DEBUG_SHARED_PT_OPENMP
    Start 1: ShyLU_DDFROSch_test_frosch_laplacian_tpetra_2d_gdsw_MPI_4
    Start 2: ShyLU_DDFROSch_test_frosch_laplacian_tpetra_2d_rgdsw_MPI_4
1/2 Test #1: ShyLU_DDFROSch_test_frosch_laplacian_tpetra_2d_gdsw_MPI_4 ....   Passed    0.88 sec
2/2 Test #2: ShyLU_DDFROSch_test_frosch_laplacian_tpetra_2d_rgdsw_MPI_4 ...   Passed    0.89 sec

100% tests passed, 0 tests failed out of 2

Subproject Time Summary:
ShyLU_DD    =   7.10 sec*proc (2 tests)

Total Test time (real) =   0.90 sec
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
