### PR TITLE
Correct Intel configuration before I messed everyone up (hopefully)

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -175,7 +175,7 @@ ctest -S simple_testing.cmake \
   -Dskip_update_step=ON \
   -Ddashboard_model=Experimental \
   -Ddashboard_track="${CDASH_TRACK:?}" \
-  -DPARALLEL_LEVEL=13 \
+  -DPARALLEL_LEVEL=22 \
   -Dbuild_dir="${WORKSPACE:?}/pull_request_test" \
   -Dconfigure_script=../Trilinos/cmake/std/${CONFIG_SCRIPT:?} \
   -Dpackage_enables=../packageEnables.cmake \

--- a/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
@@ -1,207 +1,22 @@
-#!/bin/env bash
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
 
-export https_proxy=https://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
+# Usage: cmake -C PullRequestLinuxGCCTestingSettings.cmake 
 
-whoami
-which -a env
+# Misc options typically added by CI testing mode in TriBITS
 
-## Rather than do proper option handling right now I am just going to
-##  test that all these environment variables are set.  Because getopt ;->
-: ${TRILINOS_SOURCE_REPO:?}
-: ${TRILINOS_SOURCE_BRANCH:?}
-: ${TRILINOS_TARGET_REPO:?}
-: ${TRILINOS_TARGET_BRANCH:?}
-: ${TRILINOS_SOURCE_SHA:?}
-: ${PULLREQUESTNUM:?}
-: ${JOB_BASE_NAME:?}
-: ${BUILD_NUMBER:?}
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
 
-source /projects/sems/modulefiles/utils/sems-modules-init.sh
+set (MueLu_UnitTestsEpetra_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (MueLu_UnitTestsEpetra_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (MueLu_UnitTestsTpetra_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (MueLu_UnitTestsTpetra_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (Zoltan2_simplePamgenTest_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 
-declare -i ierror=0
-#Have to keep loading git
-module load sems-git/2.10.1
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxGCCTestingSettings.cmake")
 
-ls
-cd Trilinos
-
-#------------------------------
-# Doing merge of pull request
-#------------------------------
-
-
-# Check for existence of source_remote and remove if it exists
-git_remote_text=`git remote -v | grep "source_remote"`
-if [[ "$git_remote_text" != "" ]]; then
-  echo "git remote exists, removing it."
-  git remote rm source_remote
-fi
-
-#Add the necessary remote
-git remote add source_remote ${TRILINOS_SOURCE_REPO:?}
-ierror=$?
-if [[ $ierror != 0 ]]; then
-echo "There was a problem adding the remote for the source repo. The error code was: $ierror"
-#just in case somehow a previously defined source_remote caused this failure
-#would be better to check prior to the add. Don't want to issue command that will be known to fail typically.
-#git remote rm source_remote
-exit $ierror
-fi
-
-git fetch source_remote
-ierror=$?
-if [[ $ierror != 0 ]]; then
-echo "Source remote fetch failed. The error code was: $ierror"
-#git remote rm source_remote
-exit $ierror
-fi
-
-git remote -v
-
-git merge source_remote/${TRILINOS_SOURCE_BRANCH:?}
-ierror=$?
-if [[ $ierror != 0 ]]; then
-echo "There was an issue merging changes from ${TRILINOS_SOURCE_REPO:?} ${TRILINOS_SOURCE_BRANCH:?} onto ${TRILINOS_TARGET_REPO:?} ${TRILINOS_TARGET_BRANCH:?}. The error code was: $ierror"
-#git remote rm source_remote
-exit $ierror
-fi
-
-#Need to compare expected SOURCE SHA to actual SHA! This will prevent a security hole.
-#first get the most recent SHA on the source branch
-declare source_sha=$(git rev-parse source_remote/${TRILINOS_SOURCE_BRANCH:?})
-echo "The most recent SHA for repo: ${TRILINOS_SOURCE_REPO:?} on branch: ${TRILINOS_SOURCE_BRANCH:?} is: $source_sha"
-#Now see if the two shas match, unless TRILINOS_SOURCE_SHA is the default value of ABC
-if [[ ABC != ${TRILINOS_SOURCE_SHA:?} ]]; then
-  if [[ $source_sha != ${TRILINOS_SOURCE_SHA:?} ]]; then
-    echo "The SHA ($source_sha) for the last commit on branch ${TRILINOS_SOURCE_BRANCH:?} in repo ${TRILINOS_SOURCE_REPO:?} is different than the expected SHA, which is: ${TRILINOS_SOURCE_SHA:?}. The error code was: $ierror"
-    #git remote rm source_remote
-  exit -1
-  fi
-fi
-
-# may eventually want to verify the same target SHA too, but there would be
-# advantages to testing newer versions of target instead of older if
-# not all test jobs kick off right away
-
-#------------------------------
-# Doing setup for build
-#------------------------------
-
-
-git status
-git diff origin/${TRILINOS_TARGET_BRANCH:?} --numstat > ../gitchanges.txt
-ierror=$?
-if [[ $ierror != 0 ]]; then
-echo "There was an issue getting the list of changed files. The error code was: $ierror"
-
-exit $ierror
-fi
-
-cd ../
-#process list of changes here with script and save to 'packageEnables'
-declare packageEnables=$(bash Trilinos/commonTools/test/utilities/changedPackages.bash)
-ierror=$?
-if [[ $ierror != 0 ]]; then
-echo "There was an issue creating the list of package enables. The error code was: $ierror"
-exit $ierror
-fi
-echo "List of package enables is: $packageEnables"
-
-# Set up the full environment for the build
-if [ "Trilinos_pullrequest_gcc_4.8.4" == "${JOB_BASE_NAME:?}" ]
-then
-  source Trilinos/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
-  ierror=$?
-  if [[ $ierror != 0 ]]; then
-    echo "There was an issue loading the gcc environment. The error code was: $ierror"
-    exit $ierror
-  fi
-elif [ "Trilinos_pullrequest_gcc_4.9.3" == "${JOB_BASE_NAME:?}" ]
-then
-  source Trilinos/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
-  ierror=$?
-  if [[ $ierror != 0 ]]; then
-    echo "There was an issue loading the gcc environment. The error code was: $ierror"
-    exit $ierror
-  fi
-elif [ "Trilinos_pullrequest_intel_17.0.1" == "${JOB_BASE_NAME:?}" ]
-then
-  source Trilinos/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
-  ierror=$?
-  if [[ $ierror != 0 ]]; then
-    echo "There was an issue loading the intel environment. The error code was: $ierror"
-    exit $ierror
-  fi
-else
-  ierror=42
-  echo "There was an issue loading the proper environment. The error code was: $ierror"
-  exit $ierror
-fi
-
-# The single submit requires at least cmake 3.10.*
-cmake --version
-
-module list
-
-echo "MPI type = sems-${SEMS_MPI_NAME:?}/${SEMS_MPI_VERSION:?}"
-
-# CDASH_TRACK="Pull Request"
-CDASH_TRACK="Experimental"
-echo "CDash Track = ${CDASH_TRACK:?}"
-
-
-#-------------------------------------
-# Doing configure/build/test/submit
-#-------------------------------------
-echo $packageEnables | sed -e "s/-D\([^= ]*\)=\([^ ]*\)/set(\1 \2 CACHE BOOL \"Enabled by PR package enable file.\")^/g" | tr "^" "\n" > packageEnables.cmake
-
-build_name="PR-$PULLREQUESTNUM-test-$JOB_BASE_NAME-$BUILD_NUMBER"
-
-#This should be runnable from anywhere, but all the tests so far have been from the 
-#same dir the simple_testing.cmake file was in.
-cd TFW_testing_single_configure_prototype
-
-if [ "icc" == ${CC:?} ]
-then
-  CONFIG_SCRIPT=PullRequestLinuxIntelTestingSettings.cmake
-else
-  CONFIG_SCRIPT=PullRequestLinuxGCCTestingSettings.cmake
-fi
-
-ctest -S simple_testing.cmake \
-  -Dbuild_name=${build_name:?} \
-  -Dskip_by_parts_submit=OFF \
-  -Dskip_update_step=ON \
-  -Ddashboard_model=Experimental \
-  -Ddashboard_track="${CDASH_TRACK:?}" \
-  -DPARALLEL_LEVEL=13 \
-  -Dbuild_dir="${WORKSPACE:?}/pull_request_test" \
-  -Dconfigure_script=../Trilinos/cmake/std/${CONFIG_SCRIPT:?} \
-  -Dpackage_enables=../packageEnables.cmake \
-  -DMueLu_UnitTestsEpetra_MPI_1_DISABLE:BOOL=ON \
-  -DMueLu_UnitTestsEpetra_MPI_4_DISABLE:BOOL=ON \
-  -DMueLu_UnitTestsTpetra_MPI_1_DISABLE:BOOL=ON \
-  -DMueLu_UnitTestsTpetra_MPI_4_DISABLE:BOOL=ON \
-  -DKokkosCore_UnitTest_Serial_MPI_1_DISABLE:BOOL=ON \
-  -DZoltan2_simplePamgenTest_MPI_3_DISABLE:BOOL=ON \
-  -Dsubprojects_file=../TFW_single_configure_support_scripts/package_subproject_list.cmake
-
-ierror=$?
-
-if [[ $ierror != 0 ]]; then
-echo "Single configure/build/test failed. The error code was: $ierror"
-exit $ierror
-fi
-
-
-ierror=$?
-if [[ $ierror != 0 ]]; then
-echo "There was an error removing the source remote. The error code was: $ierror"
-exit $ierror
-fi
-
-#NEED TO MAKE SURE THE REPOS ARE CLEAN FOR NEW PULL REQUESTS!
-
-#pushd Trilinos/cmake/ctest/drivers/parameterized
-#ctest -S ctest_linux_nightly_generic.cmake


### PR DESCRIPTION
@trilinos/framework 

## Description
Testing revealed I had copied and modified the driver script instead of the configuration make file.  That was a mess when attempting to re-create a build for testing.  This seems better and also does not duplicate the info in the GCC base configuration.

## How Has This Been Tested?
Teted by following the PR build recreation steps.  I need this to verify that all the failing tests are covered as well.

