### PR TITLE
Switch default checkin-test-sems.sh build and post-push CI build to use updated GCC 4.8.4 + OpenMPI 1.10.1 + OpenMP configuration

### DIFF
--- a/cmake/ctest/drivers/sems_ci/ctest_linux_mpi_debug_shared_pt_ci.sems.cmake
+++ b/cmake/ctest/drivers/sems_ci/ctest_linux_mpi_debug_shared_pt_ci.sems.cmake
@@ -60,11 +60,12 @@ INCLUDE("${CTEST_SCRIPT_DIRECTORY}/TrilinosCTestDriverCore.sems.cmake")
 # Set the options specific to this build case
 #
 
-SET(BUILD_DIR_NAME MPI_RELEASE_DEBUG_SHARED_PT_CI)
+SET(BUILD_DIR_NAME MPI_RELEASE_DEBUG_SHARED_PT_OPENMP_CI)
 #SET(CTEST_TEST_TIMEOUT 900)
 
-#override the default number of processors to run on.
-SET( CTEST_BUILD_FLAGS "-j16 -i" )
+#override the default number of processors to run on and use Ninja
+SET( CTEST_CMAKE_GENERATOR Ninja )
+SET( CTEST_BUILD_FLAGS "-j16 -k 999999" )
 SET( CTEST_PARALLEL_LEVEL "16" )
 
 SET(Trilinos_ENABLE_SECONDARY_TESTED_CODE OFF)
@@ -76,13 +77,13 @@ SET(Trilinos_BRANCH develop)
 SET(EXTRA_EXCLUDE_PACKAGES)
 
 SET( EXTRA_CONFIGURE_OPTIONS
-  "-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/MpiReleaseDebugSharedPtSerial.cmake"
+  "-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake"
   "-DTrilinos_TEST_CATEGORIES=BASIC"
   "-DTrilinos_ENABLE_CONFIGURE_TIMING=ON"
   )
 # NOTE: That above must match *exactly* what is listed is listed in
 # project-checkin-test-config.py and produced by the checkin-test-sems.sh
-# --default-builds=MPI_RELEASE_DEBUG_SHARED_PT build!
+# --default-builds=MPI_RELEASE_DEBUG_SHARED_PT_OPENMP build!
 
 SET(CTEST_TEST_TYPE Continuous)
 

--- a/cmake/ctest/drivers/sems_ci/single_ci_iter.sh
+++ b/cmake/ctest/drivers/sems_ci/single_ci_iter.sh
@@ -9,8 +9,8 @@ TRILINOS_DIR=`readlink -f ${DRIVER_SCRIPT_DIR}/../../../..`
 echo "TRILINOS_DIR='${TRILINOS_DIR}'"
 
 source /etc/bashrc
-TRILINOS_SEMS_DEV_ENV_VERBOSE=1
-source $TRILINOS_DIR/cmake/load_sems_dev_env.sh
+source $TRILINOS_DIR/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
+module list
 
 export CTEST_DASHBOARD_ROOT=$PWD
 

--- a/cmake/std/sems/checkin-test-sems.sh
+++ b/cmake/std/sems/checkin-test-sems.sh
@@ -93,7 +93,7 @@ fi
 
 if [ "$TRILINOS_CHECKIN_TEST_SEMS_SKIP_MODULE_LOAD" == "" ] ; then
   export TRILINOS_SEMS_DEV_ENV_VERBOSE=1
-  source $TRILINOS_DIR/cmake/load_sems_dev_env.sh ""
+  source $TRILINOS_DIR/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
   # NOTE: Above, must pass empty arg "" or bash will pass in "$@" which is
   # bad!
 else
@@ -111,12 +111,10 @@ echo "
 " > COMMON.config
 
 # All of the options needed for the --default-builds
-# MPI_RELEASE_DEBUG_SHARED_PT are in project-checkin-test-config.py so no need
-# to set them here.  Also note that the SEMS env will be read in automatically
-# because load_sems_dev_env.sh was sourced above.
-
+# MPI_RELEASE_DEBUG_SHARED_PT_OPENMP are in project-checkin-test-config.py so
+# no need to set them here.
 echo "
-" > MPI_RELEASE_DEBUG_SHARED_PT.config
+" > MPI_RELEASE_DEBUG_SHARED_PT_OPENMP.config
 
 #
 # The following extra build configurations can be run using
@@ -181,6 +179,7 @@ else
   echo "
 defaults = [
   \"-j4\",
+  \"--use-ninja\",
   \"--ctest-timeout=300\",
   \"--disable-packages=PyTrilinos,Claps,TriKota\",
   \"--skip-case-no-email\",

--- a/project-checkin-test-config.py
+++ b/project-checkin-test-config.py
@@ -31,8 +31,8 @@ configuration = {
         # developers prefer one case to fail earlier than another).
         'default-builds': [
 
-            ('MPI_RELEASE_DEBUG_SHARED_PT', [
-                '-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/MpiReleaseDebugSharedPtSerial.cmake',
+            ('MPI_RELEASE_DEBUG_SHARED_PT_OPENMP', [
+                '-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake',
                 ]),
 
             ], # default-builds


### PR DESCRIPTION
CC: @trilinos/framework, @fryeguy52, @mhoemmen, @ibaned

## Description

Switches the default checkin-test-sems.sh build and post-push CI build to use updated GCC 4.8.4 + OpenMPI 1.10.1 + OpenMP configuration.

## Motivation and Context

This enables OpenMP for the GCC 4.8.4 and this matches the GCC 4.8.4 we agreed to for the auto PR build in #2317.

## Related Issues

* Related to: #2317, #2462

## How Has This Been Tested?

I ran the full CI build on my machine 'crf450' with:

```
$ ./checkin-test-sems.sh --enable-all-packages=on --local-do-all
```

That returned:

```
  Enabled Packages: 
  Disabled Packages: PyTrilinos,Claps,TriKota
  Enabled all Packages
  Hostname: crf450.srn.sandia.gov
  Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /home/rabartl/Trilinos.base/BUILDS/CHECKIN/MPI_RELEASE_DEBUG_SHARED_PT_OPENMP
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=BASIC -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=300.0 -DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON -DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=ON -DTrilinos_ENABLE_PyTrilinos:BOOL=OFF -DTrilinos_ENABLE_Claps:BOOL=OFF -DTrilinos_ENABLE_TriKota:BOOL=OFF
  CTest Options: -j16
  
  Pull: Not Performed
  Configure: Passed (1.80 min)
  Build: Passed (73.70 min)
  Test: Passed (12.07 min)
  
  100% tests passed, 0 tests failed out of 2722
  
  Subproject Time Summary:
  Amesos               =  18.98 sec*proc (14 tests)
  Amesos2              =   8.78 sec*proc (8 tests)
  Anasazi              = 142.27 sec*proc (74 tests)
  AztecOO              =   9.20 sec*proc (17 tests)
  Belos                = 123.17 sec*proc (72 tests)
  Domi                 = 134.58 sec*proc (125 tests)
  Epetra               =  27.91 sec*proc (63 tests)
  EpetraExt            =  13.18 sec*proc (11 tests)
  FEI                  =  29.25 sec*proc (43 tests)
  Galeri               =   5.08 sec*proc (9 tests)
  GlobiPack            =   0.89 sec*proc (6 tests)
  Ifpack               =  65.01 sec*proc (48 tests)
  Ifpack2              =  73.73 sec*proc (37 tests)
  Intrepid             = 178.03 sec*proc (143 tests)
  Intrepid2            = 126.73 sec*proc (240 tests)
  Isorropia            =   6.14 sec*proc (6 tests)
  Kokkos               = 119.02 sec*proc (27 tests)
  KokkosKernels        = 213.59 sec*proc (8 tests)
  ML                   =  49.45 sec*proc (34 tests)
  MiniTensor           =   0.87 sec*proc (2 tests)
  MueLu                = 768.01 sec*proc (82 tests)
  NOX                  = 222.63 sec*proc (106 tests)
  OptiPack             =   8.65 sec*proc (5 tests)
  Panzer               = 1790.05 sec*proc (154 tests)
  Phalanx              =  11.37 sec*proc (27 tests)
  Pike                 =   0.88 sec*proc (7 tests)
  Piro                 =  88.70 sec*proc (12 tests)
  ROL                  = 3062.24 sec*proc (162 tests)
  RTOp                 =   5.79 sec*proc (24 tests)
  Rythmos              = 167.37 sec*proc (83 tests)
  SEACAS               =  22.67 sec*proc (14 tests)
  STK                  =  48.09 sec*proc (12 tests)
  Sacado               =  42.53 sec*proc (296 tests)
  Shards               =   0.58 sec*proc (4 tests)
  ShyLU_DD             =   6.47 sec*proc (2 tests)
  ShyLU_Node           =  13.32 sec*proc (5 tests)
  Stokhos              =  95.38 sec*proc (79 tests)
  Stratimikos          =  47.14 sec*proc (40 tests)
  Teko                 = 109.47 sec*proc (19 tests)
  Tempus               = 2452.52 sec*proc (36 tests)
  Teuchos              =  71.32 sec*proc (138 tests)
  ThreadPool           =  24.41 sec*proc (10 tests)
  Thyra                =  36.31 sec*proc (81 tests)
  Tpetra               = 132.16 sec*proc (167 tests)
  TrilinosCouplings    =  70.64 sec*proc (24 tests)
  Triutils             =   1.33 sec*proc (2 tests)
  Xpetra               = 108.22 sec*proc (18 tests)
  Zoltan               =  89.79 sec*proc (19 tests)
  Zoltan2              = 158.25 sec*proc (107 tests)
  
  Total Test time (real) = 723.76 sec
  
  Total time for MPI_RELEASE_DEBUG_SHARED_PT_OPENMP = 87.57 min
```

I verified that this is using the right env with GCC 4.8.4, OpenMPI 1.10.1 and OpenMP enabled because in the `configure.out` file I saw:

```
-- Reading in configuration options from cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake ...
-- Setting Trilinos_ENABLE_OpenMP='ON' by default
-- Setting MPI_EXEC_PRE_NUMPROCS_FLAGS='--bind-to;none' by default
[...]
-- MPI_EXEC='/projects/sems/install/rhel6-x86_64/sems/compiler/gcc/4.8.4/openmpi/1.10.1/bin/mpiexec'
-- The C compiler identification is GNU 4.8.4
-- Check for working C compiler: /projects/sems/install/rhel6-x86_64/sems/compiler/gcc/4.8.4/openmpi/1.10.1/bin/mpicc
-- Check for working C compiler: /projects/sems/install/rhel6-x86_64/sems/compiler/gcc/4.8.4/openmpi/1.10.1/bin/mpicc -- works
[...]

[...]
-- KokkosCore_UnitTest_OpenMP_MPI_1: Added test (BASIC, NUM_MPI_PROCS=1, PROCESSORS=1)!
-- KokkosCore_UnitTest_OpenMPInterOp_MPI_1: Added test (BASIC, NUM_MPI_PROCS=1, PROCESSORS=1)!
[...]
-- KokkosContainers_UnitTest_OpenMP_MPI_1: Added test (BASIC, NUM_MPI_PROCS=1, PROCESSORS=1)!
```

I ran the full post-push CI build with:

```
$ env  CTEST_DASHBOARD_ROOT=$PWD \
     CI_FIRST_ITERATION=1 \
     CTEST_TEST_TYPE=Experimental \
     CTEST_DO_SUBMIT=OFF \
     CTEST_DO_UPDATES=OFF \
     CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=OFF \
   ~/Trilinos.base/Trilinos/cmake/ctest/drivers/sems_ci/single_ci_iter.sh \
     &> console.out
```

In the `console.out` file I saw:

```
Currently Loaded Modulefiles:
  1) sems-env
  2) atdm-env
  3) sems-python/2.7.9
  4) atdm-cmake/3.11.1
  5) sems-git/2.10.1
  6) atdm-ninja_fortran/1.7.2
  7) sems-gcc/4.8.4
  8) sems-openmpi/1.10.1
  9) sems-boost/1.63.0/base
 10) sems-zlib/1.2.8/base
 11) sems-hdf5/1.8.12/parallel
 12) sems-netcdf/4.4.1/exo_parallel
 13) sems-parmetis/4.0.3/parallel
 14) sems-scotch/6.0.3/nopthread_64bit_parallel
 15) sems-superlu/4.3/base
...
-- CTEST_DASHBOARD_ROOT='/ascldap/users/rabartl/Trilinos.base/BUILDS/GCC-4.8.4/MOCK_MPI_RELEASE_DEBUG_SHARED_PT_OPENMP_CI'
...
CONFIGURE_OPTIONS = '...;-DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake;...'
```

The configure XML files under `BUILD/Testing/Temporary/` showed:

```
-- CMAKE_VERSION='3.11.1'
-- CMAKE_GENERATOR='Ninja'
-- Reading in configuration options from cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake ...
...
-- Leaving current CMAKE_CXX_COMPILER=/projects/sems/install/rhel6-x86_64/sems/compiler/gcc/4.8.4/openmpi/1.10.1/bin/mpicxx since it is already set!
...
-- MPI_EXEC='/projects/sems/install/rhel6-x86_64/sems/compiler/gcc/4.8.4/openmpi/1.10.1/bin/mpiexec'
...
```

This resulted in:

```
  Build Name: Linux-GCC-4.8.4-MPI_RELEASE_DEBUG_SHARED_PT_OPENMP_CI
at:
  http://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project

TRIBITS_CTEST_DRIVER: OVERALL: ALL PASSSED
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
