### PR TITLE
Send CUDA 9.0 builds to "Specialized" CDash Track/Group and remove old var (#2706)

### DIFF
--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-8.0-debug.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-8.0-debug.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=ATDM
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
-export ATDM_CONFIG_USE_MAKEFILES=ON
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-8.0-opt.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-8.0-opt.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=ATDM
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
-export ATDM_CONFIG_USE_MAKEFILES=ON
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-debug.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-debug.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
-export ATDM_CONFIG_USE_MAKEFILES=ON
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-opt.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-opt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
-export ATDM_CONFIG_USE_MAKEFILES=ON
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-debug-panzer.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-debug-panzer.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=ATDM
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
-export ATDM_CONFIG_USE_MAKEFILES=ON
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-opt-panzer.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-opt-panzer.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 export Trilinos_TRACK=ATDM
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
-export ATDM_CONFIG_USE_MAKEFILES=ON
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh


### PR DESCRIPTION
CC: @fryeguy52 

## Description

From a copy-and-paste these were hard-coded to send to the "ATDM" CDash
Track/Group.  But these should not be promoted yet so I had the Jenkins jobs
set CTEST_TEST_TYPE=Experimental which overrides that.  Now these will go to
"Specializezd" by default, unless overridden in the Jenkins job.

I also got rid of 'export ATDM_CONFIG_USE_MAKEFILES=ON' which is a non-op
since the var name was changed to ATDM_CONFIG_USE_NINJA a while ago.

## Related Issues

* Part of: #2706  

## How Has This Been Tested?

I did not test this, but this was a copy and pasted from a script that was tested.  And this change is very simple with almost zero chance of breaking anything.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
