### PR TITLE
Some small 'serrano' updates for the ATDM Trilinos configuration

### DIFF
--- a/cmake/ctest/drivers/atdm/serrano/drivers/Trilinos-atdm-serrano-intel-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/serrano/drivers/Trilinos-atdm-serrano-intel-opt-openmp-panzer.sh
@@ -2,5 +2,5 @@
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=ATDM
 fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:15:00
+export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:30:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/serrano/local-driver.sh

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -172,6 +172,8 @@ function atdm_run_script_on_compute_node {
 
 }
 
+export -f atdm_run_script_on_compute_node
+
 # NOTE: The above function is implemented in this way using 'sbatch' so that
 # we can avoid using 'salloc' which is belived to cause ORTE errors.  But we
 # still want to see live ouput from the script so that we can report it on


### PR DESCRIPTION
CC: @fryeguy52 

The commits are self explanatory.

I tested that the exported function `atdm_run_script_on_compute_node` can be used in child process scripts.


