### PR TITLE
Ifpack2 + Belos + equilibration demo

### DIFF
--- a/packages/ifpack2/example/RelaxationWithEquilibration.cpp
+++ b/packages/ifpack2/example/RelaxationWithEquilibration.cpp
@@ -3,12 +3,15 @@
 #include "BelosTpetraAdapter.hpp"
 #include "BelosSolverFactory.hpp"
 #include "MatrixMarket_Tpetra.hpp"
+#include "Tpetra_computeRowAndColumnOneNorms.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Core.hpp"
+#include "Tpetra_leftAndOrRightScaleCrsMatrix.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_ParameterList.hpp"
 //#include "Teuchos_ParameterXMLFileReader.hpp"
+#include "KokkosBlas1_abs.hpp"
 
 #include <algorithm> // std::transform
 #include <cctype> // std::toupper
@@ -16,6 +19,436 @@
 #include <functional>
 
 namespace { // (anonymous)
+
+template<class SC, class LO, class GO, class NT>
+Teuchos::RCP<Tpetra::CrsMatrix<SC, LO, GO, NT> >
+deepCopyFillCompleteCrsMatrix (const Tpetra::CrsMatrix<SC, LO, GO, NT>& A)
+{
+  using Teuchos::RCP;
+  using crs_matrix_type = Tpetra::CrsMatrix<SC, LO, GO, NT>;
+
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (! A.isFillComplete (), std::invalid_argument,
+     "deepCopyFillCompleteCrsMatrix: Input matrix A must be fillComplete.");
+  RCP<crs_matrix_type> A_copy (new crs_matrix_type (A.getCrsGraph ()));
+  auto A_copy_lcl = A_copy->getLocalMatrix ();
+  auto A_lcl = A.getLocalMatrix ();
+  Kokkos::deep_copy (A_copy_lcl.values, A_lcl.values);
+  A_copy->fillComplete (A.getDomainMap (), A.getRangeMap ());
+  return A_copy;
+}
+
+template<class ViewType1,
+         class ViewType2,
+         class IndexType,
+         const bool takeSquareRootsOfScalingFactors,
+         const bool takeAbsoluteValueOfScalingFactors =
+           ! std::is_same<
+               typename Kokkos::ArithTraits<
+                 typename ViewType1::non_const_value_type
+               >::mag_type,
+               typename ViewType2::non_const_value_type
+             >::value,
+         const int rank = ViewType1::Rank>
+class ElementWiseMultiply {};
+
+template<class ViewType1,
+         class ViewType2,
+         class IndexType,
+         const bool takeSquareRootsOfScalingFactors,
+         const bool takeAbsoluteValueOfScalingFactors>
+class ElementWiseMultiply<ViewType1,
+                          ViewType2,
+                          IndexType,
+                          takeSquareRootsOfScalingFactors,
+                          takeAbsoluteValueOfScalingFactors,
+                          1> {
+public:
+  static_assert (ViewType1::Rank == 1, "ViewType1 must be a rank-1 "
+                 "Kokkos::View in order to use this specialization.");
+
+  ElementWiseMultiply (const ViewType1& X,
+                       const ViewType2& scalingFactors) :
+    X_ (X),
+    scalingFactors_ (scalingFactors)
+  {}
+
+  KOKKOS_INLINE_FUNCTION void operator () (const IndexType i) const {
+    using val_type = typename ViewType2::non_const_value_type;
+    using KAT = Kokkos::ArithTraits<val_type>;
+    using mag_type = typename KAT::mag_type;
+    using KAM = Kokkos::ArithTraits<mag_type>;
+
+    if (takeAbsoluteValueOfScalingFactors) {
+      const mag_type scalFactAbs = KAT::abs (scalingFactors_(i));
+      const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+        KAM::sqrt (scalFactAbs) : scalFactAbs;
+      X_(i) = X_(i) * scalFinalVal;
+    }
+    else {
+      const val_type scalFact = scalingFactors_(i);
+      const val_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+        KAT::sqrt (scalFact) : scalFact;
+      X_(i) = X_(i) * scalFinalVal;
+    }
+  }
+
+private:
+  ViewType1 X_;
+  typename ViewType2::const_type scalingFactors_;
+};
+
+template<class ViewType1,
+         class ViewType2,
+         class IndexType,
+         const bool takeSquareRootsOfScalingFactors,
+         const bool takeAbsoluteValueOfScalingFactors>
+class ElementWiseMultiply<ViewType1,
+                          ViewType2,
+                          IndexType,
+                          takeSquareRootsOfScalingFactors,
+                          takeAbsoluteValueOfScalingFactors,
+                          2> {
+public:
+  static_assert (ViewType1::Rank == 2, "ViewType1 must be a rank-2 "
+                 "Kokkos::View in order to use this specialization.");
+
+  ElementWiseMultiply (const ViewType1& X,
+                       const ViewType2& scalingFactors) :
+    X_ (X),
+    scalingFactors_ (scalingFactors)
+  {}
+
+  KOKKOS_INLINE_FUNCTION void operator () (const IndexType i) const {
+    using val_type = typename ViewType2::non_const_value_type;
+    using KAT = Kokkos::ArithTraits<val_type>;
+    using mag_type = typename KAT::mag_type;
+    using KAM = Kokkos::ArithTraits<mag_type>;
+
+    for (IndexType j = 0; j < static_cast<IndexType> (X_.extent (1)); ++j) {
+      if (takeAbsoluteValueOfScalingFactors) {
+        const mag_type scalFactAbs = KAT::abs (scalingFactors_(i));
+        const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+          KAM::sqrt (scalFactAbs) : scalFactAbs;
+        X_(i,j) = X_(i,j) * scalFinalVal;
+      }
+      else {
+        const val_type scalFact = scalingFactors_(i);
+        const val_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+          KAT::sqrt (scalFact) : scalFact;
+        X_(i,j) = X_(i,j) * scalFinalVal;
+      }
+    }
+  }
+
+private:
+  ViewType1 X_;
+  typename ViewType2::const_type scalingFactors_;
+};
+
+template<class MultiVectorViewType,
+         class ScalingFactorsViewType,
+         class IndexType>
+void
+elementWiseMultiply (const MultiVectorViewType& X,
+                     const ScalingFactorsViewType& scalingFactors,
+                     const IndexType numRows,
+                     const bool takeSquareRootsOfScalingFactors,
+                     const bool takeAbsoluteValueOfScalingFactors =
+                       ! std::is_same<
+                           typename Kokkos::ArithTraits<
+                             typename MultiVectorViewType::non_const_value_type
+                           >::mag_type,
+                           typename ScalingFactorsViewType::non_const_value_type
+                         >::value)
+{
+  using execution_space = typename MultiVectorViewType::device_type::execution_space;
+  using range_type = Kokkos::RangePolicy<execution_space, IndexType>;
+
+  if (takeAbsoluteValueOfScalingFactors) {
+    constexpr bool takeAbsVal = true;
+    if (takeSquareRootsOfScalingFactors) {
+      constexpr bool takeSquareRoots = true;
+      using functor_type = ElementWiseMultiply<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseMultiply",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+    else {
+      constexpr bool takeSquareRoots = false;
+      using functor_type = ElementWiseMultiply<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseMultiply",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+  }
+  else {
+    constexpr bool takeAbsVal = false;
+    if (takeSquareRootsOfScalingFactors) {
+      constexpr bool takeSquareRoots = true;
+      using functor_type = ElementWiseMultiply<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseMultiply",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+    else {
+      constexpr bool takeSquareRoots = false;
+      using functor_type = ElementWiseMultiply<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseMultiply",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+  }
+}
+
+template<class MultiVectorType, class ScalingFactorsViewType>
+void
+elementWiseMultiplyMultiVector (MultiVectorType& X,
+                                const ScalingFactorsViewType& scalingFactors,
+                                const bool takeSquareRootsOfScalingFactors,
+                                const bool takeAbsoluteValueOfScalingFactors =
+                                  ! std::is_same<
+                                      typename Kokkos::ArithTraits<
+                                        typename MultiVectorType::scalar_type
+                                      >::mag_type,
+                                      typename ScalingFactorsViewType::non_const_value_type
+                                    >::value)
+{
+  using device_type = typename MultiVectorType::device_type;
+  using dev_memory_space = typename device_type::memory_space;
+  using index_type = typename MultiVectorType::local_ordinal_type;
+
+  const index_type lclNumRows = static_cast<index_type> (X.getLocalLength ());
+
+  if (X.template need_sync<dev_memory_space> ()) {
+    X.template sync<dev_memory_space> ();
+  }
+  X.template modify<dev_memory_space> ();
+
+  auto X_lcl = X.template getLocalView<dev_memory_space> ();
+  if (static_cast<std::size_t> (X.getNumVectors ()) == std::size_t (1)) {
+    using pair_type = Kokkos::pair<index_type, index_type>;
+    auto X_lcl_1d = Kokkos::subview (X_lcl, pair_type (0, lclNumRows), 0);
+    elementWiseMultiply (X_lcl_1d, scalingFactors, lclNumRows,
+                         takeSquareRootsOfScalingFactors,
+                         takeAbsoluteValueOfScalingFactors);
+  }
+  else {
+    elementWiseMultiply (X_lcl, scalingFactors, lclNumRows,
+                         takeSquareRootsOfScalingFactors,
+                         takeAbsoluteValueOfScalingFactors);
+  }
+}
+
+template<class ViewType1,
+         class ViewType2,
+         class IndexType,
+         const bool takeSquareRootsOfScalingFactors,
+         const bool takeAbsoluteValueOfScalingFactors =
+           ! std::is_same<
+               typename Kokkos::ArithTraits<
+                 typename ViewType1::non_const_value_type
+               >::mag_type,
+               typename ViewType2::non_const_value_type
+             >::value,
+         const int rank = ViewType1::Rank>
+class ElementWiseDivide {};
+
+template<class ViewType1,
+         class ViewType2,
+         class IndexType,
+         const bool takeSquareRootsOfScalingFactors,
+         const bool takeAbsoluteValueOfScalingFactors>
+class ElementWiseDivide<ViewType1,
+                        ViewType2,
+                        IndexType,
+                        takeSquareRootsOfScalingFactors,
+                        takeAbsoluteValueOfScalingFactors,
+                        1> {
+public:
+  static_assert (ViewType1::Rank == 1, "ViewType1 must be a rank-1 "
+                 "Kokkos::View in order to use this specialization.");
+
+  ElementWiseDivide (const ViewType1& X,
+                     const ViewType2& scalingFactors) :
+    X_ (X),
+    scalingFactors_ (scalingFactors)
+  {}
+
+  KOKKOS_INLINE_FUNCTION void operator () (const IndexType i) const {
+    using val_type = typename ViewType2::non_const_value_type;
+    using KAT = Kokkos::ArithTraits<val_type>;
+    using mag_type = typename KAT::mag_type;
+    using KAM = Kokkos::ArithTraits<mag_type>;
+
+    if (takeAbsoluteValueOfScalingFactors) {
+      const mag_type scalFactAbs = KAT::abs (scalingFactors_(i));
+      const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+        KAM::sqrt (scalFactAbs) : scalFactAbs;
+      X_(i) = X_(i) / scalFinalVal;
+    }
+    else {
+      const val_type scalFact = scalingFactors_(i);
+      const val_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+        KAT::sqrt (scalFact) : scalFact;
+      X_(i) = X_(i) / scalFinalVal;
+    }
+  }
+
+private:
+  ViewType1 X_;
+  typename ViewType2::const_type scalingFactors_;
+};
+
+template<class ViewType1,
+         class ViewType2,
+         class IndexType,
+         const bool takeSquareRootsOfScalingFactors,
+         const bool takeAbsoluteValueOfScalingFactors>
+class ElementWiseDivide<ViewType1,
+                        ViewType2,
+                        IndexType,
+                        takeSquareRootsOfScalingFactors,
+                        takeAbsoluteValueOfScalingFactors,
+                        2> {
+public:
+  static_assert (ViewType1::Rank == 2, "ViewType1 must be a rank-2 "
+                 "Kokkos::View in order to use this specialization.");
+
+  ElementWiseDivide (const ViewType1& X,
+                     const ViewType2& scalingFactors) :
+    X_ (X),
+    scalingFactors_ (scalingFactors)
+  {}
+
+  KOKKOS_INLINE_FUNCTION void operator () (const IndexType i) const {
+    using val_type = typename ViewType2::non_const_value_type;
+    using KAT = Kokkos::ArithTraits<val_type>;
+    using mag_type = typename KAT::mag_type;
+    using KAM = Kokkos::ArithTraits<mag_type>;
+
+    for (IndexType j = 0; j < static_cast<IndexType> (X_.extent (1)); ++j) {
+      if (takeAbsoluteValueOfScalingFactors) {
+        const mag_type scalFactAbs = KAT::abs (scalingFactors_(i));
+        const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+          KAM::sqrt (scalFactAbs) : scalFactAbs;
+        X_(i,j) = X_(i,j) / scalFinalVal;
+      }
+      else {
+        const val_type scalFact = scalingFactors_(i);
+        const val_type scalFinalVal = takeSquareRootsOfScalingFactors ?
+          KAT::sqrt (scalFact) : scalFact;
+        X_(i,j) = X_(i,j) / scalFinalVal;
+      }
+    }
+  }
+
+private:
+  ViewType1 X_;
+  typename ViewType2::const_type scalingFactors_;
+};
+
+template<class MultiVectorViewType,
+         class ScalingFactorsViewType,
+         class IndexType>
+void
+elementWiseDivide (const MultiVectorViewType& X,
+                   const ScalingFactorsViewType& scalingFactors,
+                   const IndexType numRows,
+                   const bool takeSquareRootsOfScalingFactors,
+                   const bool takeAbsoluteValueOfScalingFactors =
+                     ! std::is_same<
+                         typename Kokkos::ArithTraits<
+                           typename MultiVectorViewType::non_const_value_type
+                         >::mag_type,
+                         typename ScalingFactorsViewType::non_const_value_type
+                       >::value)
+{
+  using execution_space = typename MultiVectorViewType::device_type::execution_space;
+  using range_type = Kokkos::RangePolicy<execution_space, IndexType>;
+
+  if (takeAbsoluteValueOfScalingFactors) {
+    constexpr bool takeAbsVal = true;
+    if (takeSquareRootsOfScalingFactors) {
+      constexpr bool takeSquareRoots = true;
+      using functor_type = ElementWiseDivide<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseDivide",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+    else {
+      constexpr bool takeSquareRoots = false;
+      using functor_type = ElementWiseDivide<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseDivide",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+  }
+  else {
+    constexpr bool takeAbsVal = false;
+    if (takeSquareRootsOfScalingFactors) {
+      constexpr bool takeSquareRoots = true;
+      using functor_type = ElementWiseDivide<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseDivide",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+    else {
+      constexpr bool takeSquareRoots = false;
+      using functor_type = ElementWiseDivide<MultiVectorViewType,
+        ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for ("elementWiseDivide",
+                            range_type (0, numRows),
+                            functor_type (X, scalingFactors));
+    }
+  }
+}
+
+template<class MultiVectorType, class ScalingFactorsViewType>
+void
+elementWiseDivideMultiVector (MultiVectorType& X,
+                              const ScalingFactorsViewType& scalingFactors,
+                              const bool takeSquareRootsOfScalingFactors,
+                              const bool takeAbsoluteValueOfScalingFactors =
+                                ! std::is_same<
+                                    typename Kokkos::ArithTraits<
+                                      typename MultiVectorType::scalar_type
+                                    >::mag_type,
+                                    typename ScalingFactorsViewType::non_const_value_type
+                                  >::value)
+{
+  using device_type = typename MultiVectorType::device_type;
+  using dev_memory_space = typename device_type::memory_space;
+  using index_type = typename MultiVectorType::local_ordinal_type;
+
+  const index_type lclNumRows = static_cast<index_type> (X.getLocalLength ());
+
+  if (X.template need_sync<dev_memory_space> ()) {
+    X.template sync<dev_memory_space> ();
+  }
+  X.template modify<dev_memory_space> ();
+
+  auto X_lcl = X.template getLocalView<dev_memory_space> ();
+  if (static_cast<std::size_t> (X.getNumVectors ()) == std::size_t (1)) {
+    using pair_type = Kokkos::pair<index_type, index_type>;
+    auto X_lcl_1d = Kokkos::subview (X_lcl, pair_type (0, lclNumRows), 0);
+    elementWiseDivide (X_lcl_1d, scalingFactors, lclNumRows,
+                       takeSquareRootsOfScalingFactors,
+                       takeAbsoluteValueOfScalingFactors);
+  }
+  else {
+    elementWiseDivide (X_lcl, scalingFactors, lclNumRows,
+                       takeSquareRootsOfScalingFactors,
+                       takeAbsoluteValueOfScalingFactors);
+  }
+}
 
 // See example here:
 //
@@ -95,6 +528,11 @@ struct CmdLineArgs {
   std::string maxIterValues = "100";
   std::string restartLengthValues = "20";
   std::string preconditionerTypes = "RELAXATION";
+  bool solverVerbose = false;
+  bool equilibrate = false;
+  bool assumeSymmetric = false;
+  bool assumeZeroInitialGuess = true;
+  bool useDiagonalToEquilibrate = false;
 };
 
 // Read in values of command-line arguments.
@@ -125,6 +563,20 @@ getCmdLineArgs (CmdLineArgs& args, int argc, char* argv[])
   cmdp.setOption ("preconditionerTypes", &args.preconditionerTypes,
                   "One or more Ifpack2 preconditioner types, "
                   "separated by commas");
+  cmdp.setOption ("solverVerbose", "solverQuiet", &args.solverVerbose,
+                  "Whether the Belos solver should print verbose output");
+  cmdp.setOption ("equilibrate", "no-equilibrate", &args.equilibrate,
+                  "Whether to equilibrate the linear system before solving it");
+  cmdp.setOption ("assumeSymmetric", "no-assumeSymmetric",
+                  &args.assumeSymmetric, "Whether equilibration should assume "
+                  "that the matrix is symmetric");
+  cmdp.setOption ("assumeZeroInitialGuess", "assumeNonzeroInitialGuess",
+                  &args.assumeZeroInitialGuess, "Whether equilibration should "
+                  "assume that the initial guess (vector) is zero");
+  cmdp.setOption ("useDiagonalToEquilibrate", "useOneNorms",
+                  &args.useDiagonalToEquilibrate,
+                  "Whether equilibration should use the matrix's diagonal; "
+                  "default is to use row and column one norms");
 
   auto result = cmdp.parse (argc, argv);
   return result == Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL;
@@ -135,6 +587,7 @@ struct BelosSolverResult {
   typename Teuchos::ScalarTraits<ScalarType>::magnitudeType achievedTolerance;
   int numIters;
   bool converged;
+  bool lossOfAccuracy;
 };
 
 template<class CrsMatrixType>
@@ -156,9 +609,11 @@ private:
   void createPreconditioner ()
   {
     rightPrec_ = Teuchos::null; // destroy old one first, to reduce peak memory use
-    rightPrec_ =
-      Ifpack2::Factory::create<row_matrix_type> (precType_, A_);
-    rightPrec_->setParameters (* (precParams_));
+    if (precType_ != "NONE") {
+      rightPrec_ =
+        Ifpack2::Factory::create<row_matrix_type> (precType_, A_);
+      rightPrec_->setParameters (* (precParams_));
+    }
   }
 
   void createSolver ()
@@ -170,7 +625,7 @@ private:
 
   void setPreconditionerMatrix (const Teuchos::RCP<const row_matrix_type>& A)
   {
-    if (rightPrec_.get () != nullptr) {
+    if (precType_ != "NONE" && rightPrec_.get () != nullptr) {
       // Not all Ifpack2 preconditioners have a setMatrix method.  Use
       // it if it exists; otherwise, start over with a new instance.
       using can_change_matrix = Ifpack2::Details::CanChangeMatrix<row_matrix_type>;
@@ -186,30 +641,136 @@ private:
 
   void initializePreconditioner ()
   {
-    if (rightPrec_.get () == nullptr) {
-      createPreconditioner ();
+    if (precType_ != "NONE") {
+      if (rightPrec_.get () == nullptr) {
+        createPreconditioner ();
+      }
+      rightPrec_->initialize ();
     }
-    rightPrec_->initialize ();
   }
 
   void computePreconditioner ()
   {
-    if (rightPrec_.get () == nullptr) {
-      createPreconditioner ();
-      rightPrec_->initialize ();
+    if (precType_ != "NONE") {
+      if (rightPrec_.get () == nullptr) {
+        createPreconditioner ();
+        rightPrec_->initialize ();
+      }
+      rightPrec_->compute ();
     }
-    rightPrec_->compute ();
+  }
+
+  void equilibrateMatrix ()
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (A_.get () == nullptr, std::runtime_error, "Solver: You must call "
+       "setMatrix with a nonnull matrix before you may call compute.");
+    if (equilibrate_) {
+      using Tpetra::computeRowAndColumnOneNorms;
+      using Tpetra::leftAndOrRightScaleCrsMatrix;
+
+      equibResult_ = computeRowAndColumnOneNorms (*A_, assumeSymmetric_);
+      if (useDiagonalToEquilibrate_) {
+        using device_type = typename node_type::device_type;
+        using mag_type = typename Kokkos::ArithTraits<scalar_type>::mag_type;
+        using view_type = Kokkos::View<mag_type*, device_type>;
+
+        view_type rowDiagAbsVals ("rowDiagAbsVals",
+                                  equibResult_.rowDiagonalEntries.extent (0));
+        KokkosBlas::abs (rowDiagAbsVals, equibResult_.rowDiagonalEntries);
+        view_type colDiagAbsVals ("colDiagAbsVals",
+                                  equibResult_.colDiagonalEntries.extent (0));
+        KokkosBlas::abs (colDiagAbsVals, equibResult_.colDiagonalEntries);
+
+        leftAndOrRightScaleCrsMatrix (*A_, rowDiagAbsVals, colDiagAbsVals,
+                                      true, true, equibResult_.assumeSymmetric,
+                                      Tpetra::SCALING_DIVIDE);
+      }
+      else {
+        auto colScalingFactors = equibResult_.assumeSymmetric ?
+          equibResult_.colNorms :
+          equibResult_.rowScaledColNorms;
+        leftAndOrRightScaleCrsMatrix (*A_, equibResult_.rowNorms,
+                                      colScalingFactors, true, true,
+                                      equibResult_.assumeSymmetric,
+                                      Tpetra::SCALING_DIVIDE);
+      }
+    } // if equilibrate_
+  }
+
+  void
+  preScaleRightHandSides (Tpetra::MultiVector<scalar_type, local_ordinal_type,
+                            global_ordinal_type, node_type>& B) const
+  {
+    if (equilibrate_) {
+      if (useDiagonalToEquilibrate_) {
+        const bool takeSquareRootsOfScalingFactors = false; // just use the diagonal entries
+        elementWiseDivideMultiVector (B, equibResult_.rowDiagonalEntries,
+                                      takeSquareRootsOfScalingFactors);
+      }
+      else {
+        const bool takeSquareRootsOfScalingFactors = equibResult_.assumeSymmetric;
+        elementWiseDivideMultiVector (B, equibResult_.rowNorms,
+                                      takeSquareRootsOfScalingFactors);
+      }
+    }
+  }
+
+  void
+  preScaleInitialGuesses (Tpetra::MultiVector<scalar_type, local_ordinal_type,
+                            global_ordinal_type, node_type>& X) const
+  {
+    if (equilibrate_ && ! assumeZeroInitialGuess_) {
+      if (useDiagonalToEquilibrate_) {
+        const bool takeSquareRootsOfScalingFactors = false; // just use the diagonal entries
+        elementWiseMultiplyMultiVector (X, equibResult_.colDiagonalEntries,
+                                        takeSquareRootsOfScalingFactors);
+      }
+      else {
+        auto colScalingFactors = equibResult_.assumeSymmetric ?
+          equibResult_.colNorms :
+          equibResult_.rowScaledColNorms;
+        const bool takeSquareRootsOfScalingFactors =
+          equibResult_.assumeSymmetric;
+        elementWiseMultiplyMultiVector (X, colScalingFactors,
+                                        takeSquareRootsOfScalingFactors);
+      }
+    }
+  }
+
+  void
+  postScaleSolutionVectors (Tpetra::MultiVector<scalar_type, local_ordinal_type,
+                              global_ordinal_type, node_type>& X) const
+  {
+    if (equilibrate_) {
+      if (useDiagonalToEquilibrate_) {
+        const bool takeSquareRootsOfScalingFactors = false; // just use the diagonal entries
+        elementWiseDivideMultiVector (X, equibResult_.colDiagonalEntries,
+                                      takeSquareRootsOfScalingFactors);
+      }
+      else {
+        auto colScalingFactors = equibResult_.assumeSymmetric ?
+          equibResult_.colNorms :
+          equibResult_.rowScaledColNorms;
+        const bool takeSquareRootsOfScalingFactors =
+          equibResult_.assumeSymmetric;
+        elementWiseDivideMultiVector (X, colScalingFactors,
+                                      takeSquareRootsOfScalingFactors);
+      }
+    }
   }
 
 public:
   BelosIfpack2Solver () = default;
 
-  BelosIfpack2Solver (const Teuchos::RCP<const CrsMatrixType>& A,
+  BelosIfpack2Solver (const Teuchos::RCP<CrsMatrixType>& A,
                       const std::string& solverType = "GMRES",
-                      const std::string& precType = "RELAXATION") :
+                      const std::string& precType = "NONE") :
     A_ (A),
     solverType_ (solverType),
-    precType_ (precType)
+    precType_ (precType),
+    equilibrate_ (false),
+    useDiagonalToEquilibrate_ (false)
   {}
 
   void setMatrix (const Teuchos::RCP<const CrsMatrixType>& A)
@@ -240,7 +801,7 @@ public:
 
   void
   setSolverTypeAndParameters (const std::string& solverType,
-                              Teuchos::RCP<Teuchos::ParameterList>& params)
+                              const Teuchos::RCP<Teuchos::ParameterList>& params)
   {
     solverType_ = solverType;
     solverParams_ = params;
@@ -251,6 +812,19 @@ public:
       else {
         solver_->setParameters (params);
       }
+    }
+  }
+
+  void
+  setEquilibrationParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
+  {
+    if (params.get () != nullptr) {
+      equilibrate_ = params->get ("Equilibrate", equilibrate_);
+      assumeSymmetric_ = params->get ("Assume symmetric", assumeSymmetric_);
+      assumeZeroInitialGuess_ = params->get ("Assume zero initial guess",
+                                             assumeZeroInitialGuess_);
+      useDiagonalToEquilibrate_ = params->get ("Use diagonal to equilibrate",
+                                               useDiagonalToEquilibrate_);
     }
   }
 
@@ -271,13 +845,15 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION
       (A_.get () == nullptr, std::runtime_error, "Solver: You must call "
        "setMatrix with a nonnull matrix before you may call compute.");
+    equilibrateMatrix ();
+    // equilibration changes the matrix, so don't compute the
+    // preconditioner until after doing that.
     computePreconditioner ();
   }
 
-
   BelosSolverResult<scalar_type>
   solve (Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& X,
-         const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& B)
+         Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& B)
   {
     using Teuchos::RCP;
     using Teuchos::rcpFromRef;
@@ -291,6 +867,9 @@ public:
       computePreconditioner ();
     }
 
+    preScaleRightHandSides (B);
+    preScaleInitialGuesses (X);
+
     RCP<problem_type> problem (new problem_type (A_, rcpFromRef (X), rcpFromRef (B)));
     if (rightPrec_.get () != nullptr) {
       problem->setRightPrec (rightPrec_);
@@ -299,6 +878,8 @@ public:
     solver_->setProblem (problem);
     const Belos::ReturnType solveResult = solver_->solve ();
 
+    postScaleSolutionVectors (X);
+
     typename Teuchos::ScalarTraits<scalar_type>::magnitudeType tol {-1.0};
     try {
       tol = solver_->achievedTol ();
@@ -306,18 +887,26 @@ public:
     catch (...) {}
     const int numIters = solver_->getNumIters ();
     const bool converged = (solveResult == Belos::Converged);
-    return {tol, numIters, converged};
+    const bool lossOfAccuracy = solver_->isLOADetected ();
+    return {tol, numIters, converged, lossOfAccuracy};
   }
 
 private:
-  Teuchos::RCP<const CrsMatrixType> A_;
+  Teuchos::RCP<CrsMatrixType> A_;
   Teuchos::RCP<solver_type> solver_;
   Teuchos::RCP<preconditioner_type> rightPrec_;
+  using equilibration_result_type = decltype (Tpetra::computeRowAndColumnOneNorms (*A_, false));
+  equilibration_result_type equibResult_;
 
   std::string solverType_;
   Teuchos::RCP<Teuchos::ParameterList> solverParams_;
   std::string precType_;
   Teuchos::RCP<Teuchos::ParameterList> precParams_;
+
+  bool equilibrate_;
+  bool assumeSymmetric_;
+  bool assumeZeroInitialGuess_;
+  bool useDiagonalToEquilibrate_;
 };
 
 class TpetraInstance {
@@ -334,37 +923,96 @@ public:
 template<class CrsMatrixType, class MultiVectorType>
 void
 solveAndReport (BelosIfpack2Solver<CrsMatrixType>& solver,
+                const CrsMatrixType& A_original, // before scaling
                 MultiVectorType& X,
-                const MultiVectorType& B,
-                const int myRank,
+                MultiVectorType& B,
                 const std::string& solverType,
                 const std::string& precType,
-                const std::string& orthogonalizationMethod,
                 const typename MultiVectorType::mag_type convergenceTolerance,
+                const int maxIters,
                 const int restartLength,
-                const int maxIters)
+                const CmdLineArgs& args)
 {
   using Teuchos::ParameterList;
   using Teuchos::RCP;
 
-  RCP<ParameterList> solverParams (new ParameterList ("Belos"));
-  RCP<ParameterList> precParams (new ParameterList ("Ifpack2"));
+  X.putScalar (0.0);
 
+  RCP<ParameterList> solverParams (new ParameterList ("Belos"));
+  if (args.solverVerbose) {
+    solverParams->set ("Verbosity",
+                       Belos::IterationDetails |
+                       Belos::FinalSummary |
+                       Belos::StatusTestDetails);
+  }
   solverParams->set ("Convergence Tolerance", convergenceTolerance);
   solverParams->set ("Maximum Iterations", maxIters);
   if (solverType == "GMRES") {
     solverParams->set ("Num Blocks", restartLength);
     solverParams->set ("Maximum Restarts", restartLength * maxIters);
-    solverParams->set ("Orthogonalization", orthogonalizationMethod);
+    solverParams->set ("Orthogonalization", args.orthogonalizationMethod);
   }
+
+  RCP<ParameterList> precParams (new ParameterList ("Ifpack2"));
+  if (precType == "RELAXATION") {
+    precParams->set ("relaxation: type", "Symmetric Gauss-Seidel");
+  }
+
+  RCP<ParameterList> equibParams (new ParameterList ("Equilibration"));
+  equibParams->set ("Equilibrate", args.equilibrate);
+  equibParams->set ("Assume symmetric", args.assumeSymmetric);
+  equibParams->set ("Assume zero initial guess",
+                    args.assumeZeroInitialGuess);
+  equibParams->set ("Use diagonal to equilibrate",
+                    args.useDiagonalToEquilibrate);
+
   solver.setSolverTypeAndParameters (solverType, solverParams);
   solver.setPreconditionerTypeAndParameters (precType, precParams);
+  solver.setEquilibrationParameters (equibParams);
+
   solver.initialize ();
   solver.compute ();
+
+  // Keep this around for later computation of the explicit residual
+  // norm.  If the solver equilibrates, it will modify the original B.
+  MultiVectorType R (B, Teuchos::Copy);
+
+  // Compute ||B||_2.
+  using mag_type = typename MultiVectorType::mag_type;
+  Teuchos::Array<mag_type> norms (R.getNumVectors ());
+  R.norm2 (norms ());
+  mag_type B_norm2_max = Kokkos::ArithTraits<mag_type>::zero ();
+  for (std::size_t j = 0; j < B.getNumVectors (); ++j) {
+    // Any NaN will persist (since the first test will fail);
+    // this is what we want
+    B_norm2_max = norms[j] < B_norm2_max ? B_norm2_max : norms[j];
+  }
 
   // Solve the linear system AX=B.
   auto result = solver.solve (X, B);
 
+  // Compute the actual residual norm ||B - A*X||_2.
+  using scalar_type = typename MultiVectorType::scalar_type;
+  const scalar_type ONE = Teuchos::ScalarTraits<scalar_type>::one ();
+  A_original.apply (X, R, Teuchos::NO_TRANS, -ONE, ONE); // R := -A*X + B
+  R.norm2 (norms ());
+
+  mag_type R_norm2_max = Kokkos::ArithTraits<mag_type>::zero ();
+  for (std::size_t j = 0; j < R.getNumVectors (); ++j) {
+    // Any NaN will persist (since the first test will fail);
+    // this is what we want
+    R_norm2_max = norms[j] < R_norm2_max ? R_norm2_max : norms[j];
+  }
+
+  X.norm2 (norms ());
+  mag_type X_norm2_max = Kokkos::ArithTraits<mag_type>::zero ();
+  for (std::size_t j = 0; j < R.getNumVectors (); ++j) {
+    // Any NaN will persist (since the first test will fail);
+    // this is what we want
+    X_norm2_max = norms[j] < X_norm2_max ? X_norm2_max : norms[j];
+  }
+
+  const int myRank = X.getMap ()->getComm ()->getRank ();
   if (myRank == 0) {
     using std::cout;
     using std::endl;
@@ -375,13 +1023,21 @@ solveAndReport (BelosIfpack2Solver<CrsMatrixType>& solver,
          << "  Maximum number of iterations: " << maxIters << endl;
     if (solverType == "GMRES") {
       cout << "  Restart length: " << restartLength << endl
-           << "  Orthogonalization method: " << orthogonalizationMethod << endl;
+           << "  Orthogonalization method: " << args.orthogonalizationMethod << endl;
     }
     cout << "Results:" << endl
          << "  Converged: " << (result.converged ? "true" : "false") << endl
          << "  Number of iterations: " << result.numIters << endl
          << "  Achieved tolerance: " << result.achievedTolerance << endl
-         << endl;
+         << "  Loss of accuracy: " << result.lossOfAccuracy << endl
+         << "  ||B-A*X||_2: " << R_norm2_max << endl
+         << "  ||B||_2: " << B_norm2_max << endl
+         << "  ||X||_2: " << X_norm2_max << endl;
+    if (B_norm2_max != Kokkos::ArithTraits<mag_type>::zero ()) {
+      cout << "  ||B-A*X||_2 / ||B||_2: " << (R_norm2_max / B_norm2_max)
+           << endl;
+    }
+    cout << endl;
   }
 }
 
@@ -478,9 +1134,17 @@ main (int argc, char* argv[])
   if (args.rhsFilename == "") {
     B = Teuchos::rcp (new MV (A->getRangeMap (), 1));
     X = Teuchos::rcp (new MV (A->getDomainMap (), 1));
-    X->randomize ();
+    X->putScalar (1.0);
     A->apply (*X, *B);
     X->putScalar (0.0);
+
+    double norm {0.0};
+    using host_device_type = Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>;
+    Kokkos::View<double*, host_device_type> normView (&norm, B->getNumVectors ());
+    B->norm2 (normView);
+    if (norm != 0.0) {
+      B->scale (1.0 / norm);
+    }
   }
   else {
     auto map = A->getRangeMap ();
@@ -495,6 +1159,8 @@ main (int argc, char* argv[])
     X = Teuchos::rcp (new MV (A->getDomainMap (), B->getNumVectors ()));
   }
 
+  auto A_original = deepCopyFillCompleteCrsMatrix (*A);
+
   // Create the solver.
   BelosIfpack2Solver<crs_matrix_type> solver (A);
 
@@ -504,13 +1170,13 @@ main (int argc, char* argv[])
       for (int maxIters : maxIterValues) {
         for (int restartLength : restartLengthValues) {
           for (double convTol : convergenceToleranceValues) {
-            solveAndReport (solver, *X, *B, comm->getRank (),
+            solveAndReport (solver, *A_original, *X, *B,
                             solverType,
                             precType,
-                            args.orthogonalizationMethod,
                             convTol,
+                            maxIters,
                             restartLength,
-                            maxIters);
+                            args);
           }
         }
       }

--- a/packages/tpetra/core/src/Tpetra_Details_EquilibrationInfo.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_EquilibrationInfo.hpp
@@ -83,6 +83,8 @@ struct EquilibrationInfo {
   using host_device_type = typename Kokkos::View<mag_type*, device_type>::HostMirror::device_type;
   using HostMirror = EquilibrationInfo<val_type, host_device_type>;
 
+  EquilibrationInfo () = default;
+
   EquilibrationInfo (const std::size_t lclNumRows,
                      const std::size_t lclNumCols,
                      const bool assumeSymmetric_) :

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_decl.hpp
@@ -47,6 +47,7 @@
 
 #include "TpetraCore_config.h"
 #include "Kokkos_ArithTraits.hpp"
+#include "Tpetra_Details_EquilibrationInfo.hpp"
 
 namespace Tpetra {
 


### PR DESCRIPTION
Add an Ifpack2 example that demonstrates a complete linear solver:

  - Belos iterative solver
  - Ifpack2 preconditioner (optional)
  - Equilibration (optional), using new Tpetra capabilities I added recently

@trilinos/ifpack2 @trilinos/tpetra @trilinos/belos 

## Description

This is an example, not a new feature.  It's not clear where a feature would go in Trilinos.

## Motivation and Context

Sierra (specifically Fuego) really really needs row scaling.  It works great with their AztecOO solves.

## How Has This Been Tested?

Locally, with various command-line options.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
