### PR TITLE
Ifpack2,Tpetra: Fix #2869, & fix some #2630 deprecated warnings 

### DIFF
--- a/packages/ifpack2/src/CMakeLists.txt
+++ b/packages/ifpack2/src/CMakeLists.txt
@@ -367,5 +367,5 @@ TRIBITS_ADD_LIBRARY(
 
 #
 # Make a trivial change here if you want CMake to run, due to changes
-# you make to files in Ifpack2.
+# you make to files in Ifpack2.  Here is another such change.
 #

--- a/packages/ifpack2/src/Ifpack2_Details_OverlappingRowGraph_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_OverlappingRowGraph_decl.hpp
@@ -44,7 +44,7 @@
 #define IFPACK2_DETAILS_OVERLAPPINGROWGRAPH_DECL_HPP
 
 #include <Ifpack2_ConfigDefs.hpp>
-#include <Tpetra_RowGraph.hpp>
+#include "Ifpack2_Details_RowGraph.hpp"
 #include <Tpetra_Import_decl.hpp>
 #include <Tpetra_Export_decl.hpp>
 
@@ -63,9 +63,7 @@ namespace Details {
 ///   should not rely on its interface.
 template<class GraphType>
 class OverlappingRowGraph :
-    virtual public Tpetra::RowGraph<typename GraphType::local_ordinal_type,
-                                    typename GraphType::global_ordinal_type,
-                                    typename GraphType::node_type> {
+    virtual public Ifpack2::Details::RowGraph<GraphType> {
 public:
   //! \name Typedefs
   //@{
@@ -194,12 +192,6 @@ public:
   ///   entries in that row that are owned by the calling process.
   virtual size_t getNumEntriesInLocalRow (local_ordinal_type localRow) const;
 
-  //! The global number of diagonal entries.
-  virtual global_size_t getGlobalNumDiags () const;
-
-  //! The number of diagonal entries owned by the calling process.
-  virtual size_t getNodeNumDiags () const;
-
   //! The maximum number of entries in any row on any process.
   virtual size_t getGlobalMaxNumRowEntries () const;
 
@@ -208,12 +200,6 @@ public:
 
   //! Whether this graph has a column Map.
   virtual bool hasColMap() const;
-
-  //! Whether this graph is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! Whether this graph is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! Whether this graph is locally indexed.
   virtual bool isLocallyIndexed () const;

--- a/packages/ifpack2/src/Ifpack2_Details_OverlappingRowGraph_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_OverlappingRowGraph_def.hpp
@@ -226,20 +226,6 @@ getNumEntriesInLocalRow (local_ordinal_type localRow) const
   
 
 template<class GraphType>
-global_size_t OverlappingRowGraph<GraphType>::getGlobalNumDiags () const
-{
-  throw std::runtime_error("Ifpack2::OverlappingRowGraph::getGlobalNumDiags() not supported.");
-}
-  
-
-template<class GraphType>
-size_t OverlappingRowGraph<GraphType>::getNodeNumDiags() const
-{
-  return nonoverlappingGraph_->getNodeNumDiags();
-}
-  
-
-template<class GraphType>
 size_t OverlappingRowGraph<GraphType>::getGlobalMaxNumRowEntries () const
 {
   throw std::runtime_error("Ifpack2::OverlappingRowGraph::getGlobalMaxNumRowEntries() not supported.");
@@ -259,20 +245,6 @@ bool OverlappingRowGraph<GraphType>::hasColMap () const
   return true;
 }
   
-
-template<class GraphType>
-bool OverlappingRowGraph<GraphType>::isLowerTriangular () const
-{
-  return nonoverlappingGraph_->isLowerTriangular ();
-}
-  
-
-template<class GraphType>
-bool OverlappingRowGraph<GraphType>::isUpperTriangular() const
-{
-  return nonoverlappingGraph_->isUpperTriangular ();
-} 
-
 
 template<class GraphType>
 bool OverlappingRowGraph<GraphType>::isLocallyIndexed () const

--- a/packages/ifpack2/src/Ifpack2_Details_RowGraph.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_RowGraph.hpp
@@ -1,0 +1,129 @@
+/*@HEADER
+// ***********************************************************************
+//
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//@HEADER
+*/
+
+#ifndef IFPACK2_DETAILS_ROWGRAPH_HPP
+#define IFPACK2_DETAILS_ROWGRAPH_HPP
+
+#include "Ifpack2_ConfigDefs.hpp"
+#include "Tpetra_RowGraph.hpp"
+#include "Ifpack2_Details_throwBecauseDeprecated.hpp"
+
+namespace Ifpack2 {
+namespace Details {
+
+/// \class RowGraph
+/// \brief All Ifpack2 implementations of Tpetra::RowGraph must
+///   inherit from this class.
+/// \tparam GraphType Tpetra::RowGraph specialization.
+///
+/// \warning This class is an implementation detail of Ifpack2.  Users
+///   should not rely on its interface.
+///
+/// This class exists to facilitate Tpetra interface changes.  See
+/// e.g., GitHub Issue #2630.
+template<class GraphType>
+class RowGraph :
+    virtual public Tpetra::RowGraph<typename GraphType::local_ordinal_type,
+                                    typename GraphType::global_ordinal_type,
+                                    typename GraphType::node_type> {
+public:
+  //! \name Typedefs
+  //@{
+  typedef typename GraphType::local_ordinal_type local_ordinal_type;
+  typedef typename GraphType::global_ordinal_type global_ordinal_type;
+  typedef typename GraphType::node_type node_type;
+
+  //@}
+  //! \name Destructor
+  //@{
+
+  //! Destructor (virtual for memory safety of derived classes)
+  virtual ~RowGraph () {}
+
+  //@}
+  //! @name Work-around implementations of deprecated virtual methods
+  //@{
+
+  /// \brief The global number of diagonal entries.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  Tpetra::global_size_t IFPACK2_DEPRECATED
+  getGlobalNumDiags () const final
+  {
+    throwBecauseDeprecated ("getGlobalNumDiags");
+    return Tpetra::global_size_t (0);
+  }
+
+  /// \brief The local number of diagonal entries.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  std::size_t IFPACK2_DEPRECATED
+  getNodeNumDiags () const final
+  {
+    throwBecauseDeprecated ("getNodeNumDiags");
+    return std::size_t (0);
+  }
+
+  /// \brief Whether this graph is locally lower triangular.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  bool IFPACK2_DEPRECATED
+  isLowerTriangular () const final
+  {
+    throwBecauseDeprecated ("isLowerTriangular");    
+    return false;
+  }
+
+  /// \brief Whether this graph is locally upper triangular.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  bool IFPACK2_DEPRECATED isUpperTriangular() const final
+  {
+    throwBecauseDeprecated ("isUpperTriangular");    
+    return false;    
+  }
+};
+
+} // namespace Details
+} // namespace Ifpack2
+
+#endif // IFPACK2_DETAILS_ROWGRAPH_HPP

--- a/packages/ifpack2/src/Ifpack2_Details_RowMatrix.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_RowMatrix.hpp
@@ -1,0 +1,131 @@
+/*@HEADER
+// ***********************************************************************
+//
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//@HEADER
+*/
+
+#ifndef IFPACK2_DETAILS_ROWMATRIX_HPP
+#define IFPACK2_DETAILS_ROWMATRIX_HPP
+
+#include "Ifpack2_ConfigDefs.hpp"
+#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_throwBecauseDeprecated.hpp"
+
+namespace Ifpack2 {
+namespace Details {
+    
+/// \class RowMatrix
+/// \brief All Ifpack2 implementations of Tpetra::RowMatrix must
+///   inherit from this class.
+/// \tparam MatrixType Tpetra::RowMatrix specialization.
+///
+/// \warning This class is an implementation detail of Ifpack2.  Users
+///   should not rely on its interface.
+///
+/// This class exists to facilitate Tpetra interface changes.  See
+/// e.g., GitHub Issue #2630.
+template<class MatrixType>
+class RowMatrix :
+    public Tpetra::RowMatrix<typename MatrixType::scalar_type,
+			     typename MatrixType::local_ordinal_type,
+			     typename MatrixType::global_ordinal_type,
+			     typename MatrixType::node_type> {
+public:
+  //! \name Typedefs
+  //@{
+  typedef typename MatrixType::scalar_type scalar_type;
+  typedef typename MatrixType::local_ordinal_type local_ordinal_type;
+  typedef typename MatrixType::global_ordinal_type global_ordinal_type;
+  typedef typename MatrixType::node_type node_type;
+
+  //@}
+  //! \name Destructor
+  //@{
+
+  //! Destructor (virtual for memory safety of derived classes)
+  virtual ~RowMatrix () {}
+
+  //@}
+  //! @name Work-around implementations of deprecated virtual methods  
+  //@{
+
+  /// \brief The global number of diagonal entries.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  Tpetra::global_size_t IFPACK2_DEPRECATED
+  getGlobalNumDiags () const final
+  {
+    throwBecauseDeprecated ("getGlobalNumDiags");
+    return Tpetra::global_size_t (0);    
+  }
+
+  /// \brief The local number of diagonal entries.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  std::size_t IFPACK2_DEPRECATED
+  getNodeNumDiags () const final
+  {
+    throwBecauseDeprecated ("getNodeNumDiags");
+    return std::size_t (0);    
+  }
+
+  /// \brief Whether this graph is locally lower triangular.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  bool IFPACK2_DEPRECATED
+  isLowerTriangular () const final
+  {
+    throwBecauseDeprecated ("isLowerTriangular");
+    return false;
+  }
+
+  /// \brief Whether this graph is locally upper triangular.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
+  bool IFPACK2_DEPRECATED isUpperTriangular() const final
+  {
+    throwBecauseDeprecated ("isUpperTriangular");
+    return false;
+  }
+};
+
+} // namespace Details
+} // namespace Ifpack2
+
+#endif /* IFPACK2_DETAILS_ROWMATRIX_HPP */

--- a/packages/ifpack2/src/Ifpack2_Details_throwBecauseDeprecated.cpp
+++ b/packages/ifpack2/src/Ifpack2_Details_throwBecauseDeprecated.cpp
@@ -1,0 +1,59 @@
+/*@HEADER
+// ***********************************************************************
+//
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//@HEADER
+*/
+
+#include "Ifpack2_Details_throwBecauseDeprecated.hpp"
+#include "Teuchos_TestForException.hpp"
+#include <stdexcept>
+
+namespace Ifpack2 {
+namespace Details {
+
+void
+throwBecauseDeprecated (const char functionName[])
+{
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (true, std::logic_error, "\"" << functionName
+     << "\" is DEPRECATED and will be removed soon!");
+}
+
+} // namespace Details
+} // namespace Ifpack2

--- a/packages/ifpack2/src/Ifpack2_Details_throwBecauseDeprecated.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_throwBecauseDeprecated.hpp
@@ -1,0 +1,59 @@
+/*@HEADER
+// ***********************************************************************
+//
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//@HEADER
+*/
+
+#ifndef IFPACK2_DETAILS_THROWBECAUSEDEPRECATED_HPP
+#define IFPACK2_DETAILS_THROWBECAUSEDEPRECATED_HPP
+
+#include "Ifpack2_config.h"
+
+namespace Ifpack2 {
+namespace Details {
+
+/// \brief Call this in deprecated methods that will be removed soon;
+///   it will throw std::logic_error with a helpful message.
+void
+throwBecauseDeprecated (const char functionName[]);
+
+} // namespace Details
+} // namespace Ifpack2
+
+#endif // IFPACK2_DETAILS_THROWBECAUSEDEPRECATED_HPP

--- a/packages/ifpack2/src/Ifpack2_DiagonalFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_DiagonalFilter_decl.hpp
@@ -43,8 +43,7 @@
 #ifndef IFPACK2_DIAGONALFILTER_DECL_HPP
 #define IFPACK2_DIAGONALFILTER_DECL_HPP
 
-#include "Ifpack2_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include <type_traits>
 
 namespace Ifpack2 {
@@ -74,10 +73,7 @@ Note: This operation only really makes sense if the Thresholds are not complex.
 
 template<class MatrixType>
 class DiagonalFilter :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type> {
+    virtual public Ifpack2::Details::RowMatrix<MatrixType> {
 public:
   typedef typename MatrixType::scalar_type Scalar;
   typedef typename MatrixType::local_ordinal_type LocalOrdinal;
@@ -155,12 +151,6 @@ public:
   /*! Returns Teuchos::OrdinalTraits<size_t>::invalid() if the specified local row is not valid for this graph. */
   virtual size_t getNumEntriesInLocalRow(LocalOrdinal localRow) const;
 
-  //! \brief Returns the number of global diagonal entries, based on global row/column index comparisons.
-  virtual global_size_t getGlobalNumDiags() const;
-
-  //! \brief Returns the number of local diagonal entries, based on global row/column index comparisons.
-  virtual size_t getNodeNumDiags() const;
-
   //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
   virtual size_t getGlobalMaxNumRowEntries() const;
 
@@ -169,12 +159,6 @@ public:
 
   //! \brief Indicates whether this matrix has a well-defined column map.
   virtual bool hasColMap() const;
-
-  //! \brief Indicates whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! \brief Indicates whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! \brief If matrix indices are in the local range, this function returns true. Otherwise, this function returns false. */
   virtual bool isLocallyIndexed() const;

--- a/packages/ifpack2/src/Ifpack2_DiagonalFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_DiagonalFilter_def.hpp
@@ -207,18 +207,6 @@ size_t DiagonalFilter<MatrixType>::getNumEntriesInLocalRow(LocalOrdinal localRow
 }
 
 template<class MatrixType>
-global_size_t DiagonalFilter<MatrixType>::getGlobalNumDiags() const
-{
-  return A_->getGlobalNumDiags();
-}
-
-template<class MatrixType>
-size_t DiagonalFilter<MatrixType>::getNodeNumDiags() const
-{
-  return A_->getNodeNumDiags();
-}
-
-template<class MatrixType>
 size_t DiagonalFilter<MatrixType>::getGlobalMaxNumRowEntries() const
 {
   return A_->getGlobalMaxNumRowEntries();
@@ -234,18 +222,6 @@ template<class MatrixType>
 bool DiagonalFilter<MatrixType>::hasColMap() const
 {
   return A_->hasColMap();
-}
-
-template<class MatrixType>
-bool DiagonalFilter<MatrixType>::isLowerTriangular() const
-{
-  return A_->isLowerTriangular();
-}
-
-template<class MatrixType>
-bool DiagonalFilter<MatrixType>::isUpperTriangular() const
-{
-  return A_->isUpperTriangular();
 }
 
 template<class MatrixType>

--- a/packages/ifpack2/src/Ifpack2_DropFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_DropFilter_decl.hpp
@@ -45,7 +45,7 @@
 
 #include "Ifpack2_ConfigDefs.hpp"
 #include "Tpetra_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include "Teuchos_RefCountPtr.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include <type_traits>
@@ -75,10 +75,7 @@ namespace Ifpack2 {
 /// \endcode
 template<class MatrixType>
 class DropFilter :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type> {
+    virtual public Ifpack2::Details::RowMatrix<MatrixType> {
 public:
   typedef typename MatrixType::scalar_type Scalar;
   typedef typename MatrixType::local_ordinal_type LocalOrdinal;
@@ -154,12 +151,6 @@ public:
   /*! Returns Teuchos::OrdinalTraits<size_t>::invalid() if the specified local row is not valid for this graph. */
   virtual size_t getNumEntriesInLocalRow(LocalOrdinal localRow) const;
 
-  //! \brief Returns the number of global diagonal entries, based on global row/column index comparisons.
-  virtual global_size_t getGlobalNumDiags() const;
-
-  //! \brief Returns the number of local diagonal entries, based on global row/column index comparisons.
-  virtual size_t getNodeNumDiags() const;
-
   //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
   virtual size_t getGlobalMaxNumRowEntries() const;
 
@@ -168,12 +159,6 @@ public:
 
   //! \brief Indicates whether this matrix has a well-defined column map.
   virtual bool hasColMap() const;
-
-  //! \brief Indicates whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! \brief Indicates whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! \brief If matrix indices are in the local range, this function returns true. Otherwise, this function returns false. */
   virtual bool isLocallyIndexed() const;

--- a/packages/ifpack2/src/Ifpack2_DropFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_DropFilter_def.hpp
@@ -243,20 +243,6 @@ size_t DropFilter<MatrixType>::getNumEntriesInLocalRow(LocalOrdinal localRow) co
 
 //==========================================================================
 template<class MatrixType>
-global_size_t DropFilter<MatrixType>::getGlobalNumDiags() const
-{
-  return A_->getGlobalNumDiags();
-}
-
-//==========================================================================
-template<class MatrixType>
-size_t DropFilter<MatrixType>::getNodeNumDiags() const
-{
-  return A_->getNodeNumDiags();
-}
-
-//==========================================================================
-template<class MatrixType>
 size_t DropFilter<MatrixType>::getGlobalMaxNumRowEntries() const
 {
   return MaxNumEntries_;
@@ -274,20 +260,6 @@ template<class MatrixType>
 bool DropFilter<MatrixType>::hasColMap() const
 {
   return true;
-}
-
-//==========================================================================
-template<class MatrixType>
-bool DropFilter<MatrixType>::isLowerTriangular() const
-{
-  return A_->isLowerTriangular();
-}
-
-//==========================================================================
-template<class MatrixType>
-bool DropFilter<MatrixType>::isUpperTriangular() const
-{
-  return A_->isUpperTriangular();
 }
 
 //==========================================================================

--- a/packages/ifpack2/src/Ifpack2_LocalFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalFilter_decl.hpp
@@ -44,7 +44,7 @@
 #define IFPACK2_LOCALFILTER_DECL_HPP
 
 #include "Ifpack2_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include <type_traits>
 #include <vector>
 
@@ -158,10 +158,7 @@ namespace Ifpack2 {
 /// \endcode
 template<class MatrixType>
 class LocalFilter :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type>,
+    virtual public Ifpack2::Details::RowMatrix<MatrixType>,
     virtual public Teuchos::Describable
 {
 private:
@@ -296,12 +293,6 @@ public:
   ///   otherwise the number of entries in that row on this process.
   virtual size_t getNumEntriesInLocalRow (local_ordinal_type localRow) const;
 
-  //! The number of global diagonal entries, based on global row/column index comparisons.
-  virtual global_size_t getGlobalNumDiags() const;
-
-  //! The number of local diagonal entries, based on global row/column index comparisons.
-  virtual size_t getNodeNumDiags() const;
-
   //! The maximum number of entries across all rows/columns on all processes.
   virtual size_t getGlobalMaxNumRowEntries() const;
 
@@ -310,12 +301,6 @@ public:
 
   //! Whether this matrix has a well-defined column Map.
   virtual bool hasColMap() const;
-
-  //! Whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! Whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! Whether the underlying sparse matrix is locally (opposite of globally) indexed.
   virtual bool isLocallyIndexed() const;

--- a/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
@@ -389,20 +389,6 @@ getNumEntriesInLocalRow (local_ordinal_type localRow) const
 
 
 template<class MatrixType>
-global_size_t LocalFilter<MatrixType>::getGlobalNumDiags () const
-{
-  return A_->getGlobalNumDiags ();
-}
-
-
-template<class MatrixType>
-size_t LocalFilter<MatrixType>::getNodeNumDiags () const
-{
-  return A_->getNodeNumDiags ();
-}
-
-
-template<class MatrixType>
 size_t LocalFilter<MatrixType>::getGlobalMaxNumRowEntries () const
 {
   return MaxNumEntries_;
@@ -420,20 +406,6 @@ template<class MatrixType>
 bool LocalFilter<MatrixType>::hasColMap () const
 {
   return true;
-}
-
-
-template<class MatrixType>
-bool LocalFilter<MatrixType>::isLowerTriangular () const
-{
-  return A_->isLowerTriangular();
-}
-
-
-template<class MatrixType>
-bool LocalFilter<MatrixType>::isUpperTriangular () const
-{
-  return A_->isUpperTriangular();
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -383,7 +383,14 @@ initialize ()
     (! G->isFillComplete (), std::runtime_error, "If you call this method, "
      "the matrix's graph must be fill complete.  It is not.");
 
-  if (reverseStorage_ && A_crs_->isUpperTriangular() && htsImpl_.is_null()) {
+  // FIXME (mfh 01,02 Jun 2018) isUpperTriangular has been DEPRECATED.
+  // See GitHub Issue #2630.  I'm using isUpperTriangularImpl ONLY to
+  // avoid deprecated warnings.  Users may NOT call this method.
+  //
+  // FIXME (mfh 02 Jun 2018) Move the
+  // determineLocalTriangularStructure call above this test, so we can
+  // use that result, rather than the deprecated method.
+  if (reverseStorage_ && A_crs_->isUpperTriangularImpl() && htsImpl_.is_null()) {
     // Reverse the storage for an upper triangular matrix
     auto Alocal = A_crs_->getLocalMatrix();
     auto ptr    = Alocal.graph.row_map;

--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_decl.hpp
@@ -43,8 +43,7 @@
 #ifndef IFPACK2_OVERLAPPINGROWMATRIX_DECL_HPP
 #define IFPACK2_OVERLAPPINGROWMATRIX_DECL_HPP
 
-#include "Ifpack2_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include "Tpetra_CrsMatrix_decl.hpp" // only need the declaration here
 #include "Tpetra_Import.hpp"
 #include "Tpetra_Map.hpp"
@@ -57,10 +56,7 @@ namespace Ifpack2 {
 /// \tparam MatrixType Tpetra::RowMatrix specialization.
 template<class MatrixType>
 class OverlappingRowMatrix :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type> {
+    virtual public Ifpack2::Details::RowMatrix<MatrixType> {
 public:
   //! \name Typedefs
   //@{
@@ -177,12 +173,6 @@ public:
   ///   of entries in that row that are owned by the calling process.
   virtual size_t getNumEntriesInLocalRow (local_ordinal_type localRow) const;
 
-  //! The global number of diagonal entries.
-  virtual global_size_t getGlobalNumDiags () const;
-
-  //! The number of diagonal entries owned by the calling process.
-  virtual size_t getNodeNumDiags () const;
-
   //! The maximum number of entries in any row on any process.
   virtual size_t getGlobalMaxNumRowEntries () const;
 
@@ -191,12 +181,6 @@ public:
 
   //! Whether this matrix has a column Map.
   virtual bool hasColMap() const;
-
-  //! Whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! Whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! Whether this matrix is locally indexed.
   virtual bool isLocallyIndexed () const;

--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
@@ -376,20 +376,6 @@ getNumEntriesInLocalRow (local_ordinal_type localRow) const
 
 
 template<class MatrixType>
-global_size_t OverlappingRowMatrix<MatrixType>::getGlobalNumDiags() const
-{
-  throw std::runtime_error("Ifpack2::OverlappingRowMatrix::getGlobalNumDiags() not supported.");
-}
-
-
-template<class MatrixType>
-size_t OverlappingRowMatrix<MatrixType>::getNodeNumDiags() const
-{
-  return A_->getNodeNumDiags();
-}
-
-
-template<class MatrixType>
 size_t OverlappingRowMatrix<MatrixType>::getGlobalMaxNumRowEntries() const
 {
   throw std::runtime_error("Ifpack2::OverlappingRowMatrix::getGlobalMaxNumRowEntries() not supported.");
@@ -407,20 +393,6 @@ template<class MatrixType>
 bool OverlappingRowMatrix<MatrixType>::hasColMap() const
 {
   return true;
-}
-
-
-template<class MatrixType>
-bool OverlappingRowMatrix<MatrixType>::isLowerTriangular() const
-{
-  return A_->isLowerTriangular();
-}
-
-
-template<class MatrixType>
-bool OverlappingRowMatrix<MatrixType>::isUpperTriangular() const
-{
-  return A_->isUpperTriangular();
 }
 
 
@@ -772,7 +744,6 @@ void OverlappingRowMatrix<MatrixType>::describe(Teuchos::FancyOStream &out,
       }
       // O(1) globals, minus what was already printed by description()
       //if (isFillComplete() && myRank == 0) {
-      //  out << "Global number of diagonal entries: " << getGlobalNumDiags() << std::endl;
       //  out << "Global max number of entries in a row: " << getGlobalMaxNumRowEntries() << std::endl;
       //}
       // constituent objects
@@ -841,9 +812,6 @@ void OverlappingRowMatrix<MatrixType>::describe(Teuchos::FancyOStream &out,
           if (myRank == curRank) {
             out << "Process rank: " << curRank << std::endl;
             out << "  Number of entries: " << getNodeNumEntries() << std::endl;
-            if (isFillComplete()) {
-              out << "  Number of diagonal entries: " << getNodeNumDiags() << std::endl;
-            }
             out << "  Max number of entries per row: " << getNodeMaxNumRowEntries() << std::endl;
           }
           comm->barrier();

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -886,18 +886,6 @@ void RILUK<MatrixType>::compute ()
   L_->fillComplete (L_->getColMap (), A_local_->getRangeMap ());
   U_->fillComplete (A_local_->getDomainMap (), U_->getRowMap ());
 
-  // Validate that the L and U factors are actually lower and upper triangular
-
-  //18-Aug-2016 The following two Teuchos tests-for-exceptions were changed by Massimiliano Lupo Pasini
-  TEUCHOS_TEST_FOR_EXCEPTION(
-                             0 < L_->getNodeNumRows() &&
-                             ! L_->isLowerTriangular (), std::runtime_error,
-                             "Ifpack2::RILUK::compute: L isn't lower triangular.");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-                             0 < U_->getNodeNumRows() &&
-                             ! U_->isUpperTriangular (), std::runtime_error,
-                             "Ifpack2::RILUK::compute: U isn't lower triangular.");
-
   // If L_solver_ or U_solver store modified factors internally, we need to reset those
   L_solver_->setMatrix (L_);
   L_solver_->compute ();

--- a/packages/ifpack2/src/Ifpack2_ReorderFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_ReorderFilter_decl.hpp
@@ -44,7 +44,7 @@
 #define IFPACK2_REORDERFILTER_DECL_HPP
 
 #include "Ifpack2_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include <type_traits>
 
 namespace Ifpack2 {
@@ -67,10 +67,7 @@ whether the reordered matrix is lower/upper triangular or not).
 */
 template<class MatrixType>
 class ReorderFilter :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type> {
+    virtual public Ifpack2::Details::RowMatrix<MatrixType> {
 public:
   typedef typename MatrixType::scalar_type scalar_type;
   typedef typename MatrixType::local_ordinal_type local_ordinal_type;
@@ -177,12 +174,6 @@ public:
   ///   is not owned by the calling process.
   virtual size_t getNumEntriesInLocalRow (local_ordinal_type localRow) const;
 
-  //! \brief Returns the number of global diagonal entries, based on global row/column index comparisons.
-  virtual global_size_t getGlobalNumDiags() const;
-
-  //! \brief Returns the number of local diagonal entries, based on global row/column index comparisons.
-  virtual size_t getNodeNumDiags() const;
-
   //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
   virtual size_t getGlobalMaxNumRowEntries() const;
 
@@ -191,12 +182,6 @@ public:
 
   //! \brief Indicates whether this matrix has a well-defined column map.
   virtual bool hasColMap() const;
-
-  //! \brief Indicates whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! \brief Indicates whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! \brief If matrix indices are in the local range, this function returns true. Otherwise, this function returns false. */
   virtual bool isLocallyIndexed() const;

--- a/packages/ifpack2/src/Ifpack2_ReorderFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ReorderFilter_def.hpp
@@ -249,20 +249,6 @@ getNumEntriesInLocalRow (local_ordinal_type localRow) const
 
 
 template<class MatrixType>
-global_size_t ReorderFilter<MatrixType>::getGlobalNumDiags() const
-{
-  return A_->getGlobalNumDiags();
-}
-
-
-template<class MatrixType>
-size_t ReorderFilter<MatrixType>::getNodeNumDiags() const
-{
-  return A_->getNodeNumDiags();
-}
-
-
-template<class MatrixType>
 size_t ReorderFilter<MatrixType>::getGlobalMaxNumRowEntries() const
 {
   return A_->getGlobalMaxNumRowEntries();
@@ -280,20 +266,6 @@ template<class MatrixType>
 bool ReorderFilter<MatrixType>::hasColMap() const
 {
   return true;
-}
-
-
-template<class MatrixType>
-bool ReorderFilter<MatrixType>::isLowerTriangular() const
-{
-  return A_->isLowerTriangular();
-}
-
-
-template<class MatrixType>
-bool ReorderFilter<MatrixType>::isUpperTriangular() const
-{
-  return A_->isUpperTriangular();
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_SingletonFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_SingletonFilter_decl.hpp
@@ -45,7 +45,7 @@
 
 #include "Ifpack2_ConfigDefs.hpp"
 #include "Tpetra_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Teuchos_RefCountPtr.hpp"
 #include "Teuchos_ScalarTraits.hpp"
@@ -62,10 +62,7 @@ namespace Ifpack2 {
 /// \warning This is an implementation detail of Ifpack2.
 template<class MatrixType>
 class SingletonFilter :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type> {
+    virtual public Ifpack2::Details::RowMatrix<MatrixType> {
 public:
   typedef typename MatrixType::scalar_type Scalar;
   typedef typename MatrixType::local_ordinal_type LocalOrdinal;
@@ -141,12 +138,6 @@ public:
   /*! Returns Teuchos::OrdinalTraits<size_t>::invalid() if the specified local row is not valid for this graph. */
   virtual size_t getNumEntriesInLocalRow(LocalOrdinal localRow) const;
 
-  //! \brief Returns the number of global diagonal entries, based on global row/column index comparisons.
-  virtual global_size_t getGlobalNumDiags() const;
-
-  //! \brief Returns the number of local diagonal entries, based on global row/column index comparisons.
-  virtual size_t getNodeNumDiags() const;
-
   //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
   virtual size_t getGlobalMaxNumRowEntries() const;
 
@@ -155,12 +146,6 @@ public:
 
   //! \brief Indicates whether this matrix has a well-defined column map.
   virtual bool hasColMap() const;
-
-  //! \brief Indicates whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! \brief Indicates whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! \brief If matrix indices are in the local range, this function returns true. Otherwise, this function returns false. */
   virtual bool isLocallyIndexed() const;

--- a/packages/ifpack2/src/Ifpack2_SingletonFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SingletonFilter_def.hpp
@@ -52,7 +52,6 @@
 
 namespace Ifpack2 {
 
-//==========================================================================
 template<class MatrixType>
 SingletonFilter<MatrixType>::SingletonFilter(const Teuchos::RCP<const Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& Matrix):
   A_(Matrix),
@@ -140,11 +139,9 @@ SingletonFilter<MatrixType>::SingletonFilter(const Teuchos::RCP<const Tpetra::Ro
   }
 }
 
-//=========================================================================
 template<class MatrixType>
 SingletonFilter<MatrixType>::~SingletonFilter() { }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<const Teuchos::Comm<int> >
 SingletonFilter<MatrixType>::getComm() const
@@ -152,7 +149,6 @@ SingletonFilter<MatrixType>::getComm() const
   return A_->getComm();
 }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<typename MatrixType::node_type>
 SingletonFilter<MatrixType>::getNode() const
@@ -160,7 +156,6 @@ SingletonFilter<MatrixType>::getNode() const
   return A_->getNode();
 }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<const Tpetra::Map<typename MatrixType::local_ordinal_type,
                                typename MatrixType::global_ordinal_type,
@@ -170,7 +165,6 @@ SingletonFilter<MatrixType>::getRowMap() const
   return ReducedMap_;
 }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<const Tpetra::Map<typename MatrixType::local_ordinal_type,
                                typename MatrixType::global_ordinal_type,
@@ -180,7 +174,6 @@ SingletonFilter<MatrixType>::getColMap() const
   return ReducedMap_;
 }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<const Tpetra::Map<typename MatrixType::local_ordinal_type,
                                typename MatrixType::global_ordinal_type,
@@ -190,7 +183,6 @@ SingletonFilter<MatrixType>::getDomainMap() const
   return ReducedMap_;
 }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<const Tpetra::Map<typename MatrixType::local_ordinal_type,
                                typename MatrixType::global_ordinal_type,
@@ -200,7 +192,6 @@ SingletonFilter<MatrixType>::getRangeMap() const
   return ReducedMap_;
 }
 
-//==========================================================================
 template<class MatrixType>
 Teuchos::RCP<const Tpetra::RowGraph<typename MatrixType::local_ordinal_type,
                                      typename MatrixType::global_ordinal_type,
@@ -210,28 +201,23 @@ SingletonFilter<MatrixType>::getGraph() const
   throw std::runtime_error("Ifpack2::SingletonFilter: does not support getGraph.");
 }
 
-//==========================================================================
 template<class MatrixType>
 global_size_t SingletonFilter<MatrixType>::getGlobalNumRows() const
 {
   return NumRows_;
 }
 
-//==========================================================================
 template<class MatrixType>
 global_size_t SingletonFilter<MatrixType>::getGlobalNumCols() const
 {
   return NumRows_;
 }
 
-//==========================================================================
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getNodeNumRows() const
 {
   return NumRows_;
 }
-
-//==========================================================================
 
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getNodeNumCols() const
@@ -239,112 +225,72 @@ size_t SingletonFilter<MatrixType>::getNodeNumCols() const
   return NumRows_;
 }
 
-//==========================================================================
 template<class MatrixType>
 typename MatrixType::global_ordinal_type SingletonFilter<MatrixType>::getIndexBase() const
 {
   return A_->getIndexBase();
 }
 
-//==========================================================================
 template<class MatrixType>
 global_size_t SingletonFilter<MatrixType>::getGlobalNumEntries() const
 {
   return NumNonzeros_;
 }
 
-//==========================================================================
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getNodeNumEntries() const
 {
   return NumNonzeros_;
 }
 
-//==========================================================================
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal globalRow) const
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not implement getNumEntriesInGlobalRow.");
 }
 
-//==========================================================================
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getNumEntriesInLocalRow(LocalOrdinal localRow) const
 {
   return NumEntries_[localRow];
 }
 
-//==========================================================================
-template<class MatrixType>
-global_size_t SingletonFilter<MatrixType>::getGlobalNumDiags() const
-{
-  return A_->getGlobalNumDiags();
-}
-
-//==========================================================================
-template<class MatrixType>
-size_t SingletonFilter<MatrixType>::getNodeNumDiags() const
-{
-  return A_->getNodeNumDiags();
-}
-
-//==========================================================================
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getGlobalMaxNumRowEntries() const
 {
   return MaxNumEntries_;
 }
 
-//==========================================================================
 template<class MatrixType>
 size_t SingletonFilter<MatrixType>::getNodeMaxNumRowEntries() const
 {
   return MaxNumEntries_;
 }
 
-//==========================================================================
 template<class MatrixType>
 bool SingletonFilter<MatrixType>::hasColMap() const
 {
   return true;
 }
 
-//==========================================================================
-template<class MatrixType>
-bool SingletonFilter<MatrixType>::isLowerTriangular() const
-{
-  return A_->isLowerTriangular();
-}
-
-//==========================================================================
-template<class MatrixType>
-bool SingletonFilter<MatrixType>::isUpperTriangular() const
-{
-  return A_->isUpperTriangular();
-}
-
-//==========================================================================
 template<class MatrixType>
 bool SingletonFilter<MatrixType>::isLocallyIndexed() const
 {
   return A_->isLocallyIndexed();
 }
 
-//==========================================================================
 template<class MatrixType>
 bool SingletonFilter<MatrixType>::isGloballyIndexed() const
 {
   return A_->isGloballyIndexed();
 }
 
-//==========================================================================
 template<class MatrixType>
 bool SingletonFilter<MatrixType>::isFillComplete() const
 {
   return A_->isFillComplete();
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal GlobalRow,
                                                   const Teuchos::ArrayView<GlobalOrdinal> &Indices,
@@ -354,7 +300,6 @@ void SingletonFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal GlobalRow,
   throw std::runtime_error("Ifpack2::SingletonFilter does not implement getGlobalRowCopy.");
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::getLocalRowCopy(LocalOrdinal LocalRow,
                                               const Teuchos::ArrayView<LocalOrdinal> &Indices,
@@ -380,7 +325,6 @@ void SingletonFilter<MatrixType>::getLocalRowCopy(LocalOrdinal LocalRow,
 
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::getGlobalRowView(GlobalOrdinal GlobalRow,
                                                   Teuchos::ArrayView<const GlobalOrdinal> &indices,
@@ -389,7 +333,6 @@ void SingletonFilter<MatrixType>::getGlobalRowView(GlobalOrdinal GlobalRow,
   throw std::runtime_error("Ifpack2::SingletonFilter: does not support getGlobalRowView.");
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::getLocalRowView(LocalOrdinal LocalRow,
                                                  Teuchos::ArrayView<const LocalOrdinal> &indices,
@@ -398,7 +341,6 @@ void SingletonFilter<MatrixType>::getLocalRowView(LocalOrdinal LocalRow,
   throw std::runtime_error("Ifpack2::SingletonFilter: does not support getLocalRowView.");
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::getLocalDiagCopy(Tpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &diag) const
 {
@@ -406,21 +348,18 @@ void SingletonFilter<MatrixType>::getLocalDiagCopy(Tpetra::Vector<Scalar,LocalOr
   return A_->getLocalDiagCopy(diag);
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not support leftScale.");
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not support rightScale.");
 }
 
-//==========================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::apply(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &X,
                                        Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &Y,
@@ -466,22 +405,18 @@ void SingletonFilter<MatrixType>::apply(const Tpetra::MultiVector<Scalar,LocalOr
   }
 }
 
-
-//==========================================================================
 template<class MatrixType>
 bool SingletonFilter<MatrixType>::hasTransposeApply() const
 {
   return true;
 }
 
-//==========================================================================
 template<class MatrixType>
 bool SingletonFilter<MatrixType>::supportsRowViews() const
 {
   return false;
 }
 
-//==============================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::SolveSingletons(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& RHS,
                                                   Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& LHS)
@@ -489,7 +424,6 @@ void SingletonFilter<MatrixType>::SolveSingletons(const Tpetra::MultiVector<Scal
   this->template SolveSingletonsTempl<Scalar,Scalar>(RHS, LHS);
 }
 
-//==============================================================================
 template<class MatrixType>
 template<class DomainScalar, class RangeScalar>
 void SingletonFilter<MatrixType>::SolveSingletonsTempl(const Tpetra::MultiVector<DomainScalar,LocalOrdinal,GlobalOrdinal,Node>& RHS,
@@ -512,7 +446,6 @@ void SingletonFilter<MatrixType>::SolveSingletonsTempl(const Tpetra::MultiVector
   }
 }
 
-//==============================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::CreateReducedRHS(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& LHS,
                                                    const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& RHS,
@@ -521,7 +454,6 @@ void SingletonFilter<MatrixType>::CreateReducedRHS(const Tpetra::MultiVector<Sca
   this->template CreateReducedRHSTempl<Scalar,Scalar>(LHS, RHS, ReducedRHS);
 }
 
-//==============================================================================
 template<class MatrixType>
 template<class DomainScalar, class RangeScalar>
 void SingletonFilter<MatrixType>::CreateReducedRHSTempl(const Tpetra::MultiVector<DomainScalar,LocalOrdinal,GlobalOrdinal,Node>& LHS,
@@ -552,7 +484,6 @@ void SingletonFilter<MatrixType>::CreateReducedRHSTempl(const Tpetra::MultiVecto
   }
 }
 
-//==============================================================================
 template<class MatrixType>
 void SingletonFilter<MatrixType>::UpdateLHS(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& ReducedLHS,
                                             Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& LHS)
@@ -560,7 +491,6 @@ void SingletonFilter<MatrixType>::UpdateLHS(const Tpetra::MultiVector<Scalar,Loc
   this->template UpdateLHSTempl<Scalar,Scalar>(ReducedLHS, LHS);
 }
 
-//==============================================================================
 template<class MatrixType>
 template<class DomainScalar, class RangeScalar>
 void SingletonFilter<MatrixType>::UpdateLHSTempl(const Tpetra::MultiVector<DomainScalar,LocalOrdinal,GlobalOrdinal,Node>& ReducedLHS,
@@ -575,7 +505,6 @@ void SingletonFilter<MatrixType>::UpdateLHSTempl(const Tpetra::MultiVector<Domai
       LHS_ptr[k][InvReorder_[i]] = (RangeScalar)ReducedLHS_ptr[k][i];
 }
 
-//==========================================================================
 template<class MatrixType>
 typename SingletonFilter<MatrixType>::mag_type SingletonFilter<MatrixType>::getFrobeniusNorm() const
 {

--- a/packages/ifpack2/src/Ifpack2_SparsityFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparsityFilter_decl.hpp
@@ -44,7 +44,7 @@
 #define IFPACK2_SPARSITYFILTER_DECL_HPP
 
 #include "Ifpack2_ConfigDefs.hpp"
-#include "Tpetra_RowMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 
 namespace Ifpack2 {
@@ -80,10 +80,7 @@ namespace Ifpack2 {
 /// LocalFilter, that is, if the row and column Maps are the same.
 template<class MatrixType>
 class SparsityFilter :
-    virtual public Tpetra::RowMatrix<typename MatrixType::scalar_type,
-                                     typename MatrixType::local_ordinal_type,
-                                     typename MatrixType::global_ordinal_type,
-                                     typename MatrixType::node_type> {
+    virtual public Ifpack2::Details::RowMatrix<MatrixType> {
 public:
   typedef typename MatrixType::scalar_type Scalar;
   typedef typename MatrixType::local_ordinal_type LocalOrdinal;
@@ -160,12 +157,6 @@ public:
   /*! Returns Teuchos::OrdinalTraits<size_t>::invalid() if the specified local row is not valid for this graph. */
   virtual size_t getNumEntriesInLocalRow(LocalOrdinal localRow) const;
 
-  //! \brief Returns the number of global diagonal entries, based on global row/column index comparisons.
-  virtual global_size_t getGlobalNumDiags() const;
-
-  //! \brief Returns the number of local diagonal entries, based on global row/column index comparisons.
-  virtual size_t getNodeNumDiags() const;
-
   //! \brief Returns the maximum number of entries across all rows/columns on all nodes.
   virtual size_t getGlobalMaxNumRowEntries() const;
 
@@ -174,12 +165,6 @@ public:
 
   //! \brief Indicates whether this matrix has a well-defined column map.
   virtual bool hasColMap() const;
-
-  //! \brief Indicates whether this matrix is lower triangular.
-  virtual bool isLowerTriangular() const;
-
-  //! \brief Indicates whether this matrix is upper triangular.
-  virtual bool isUpperTriangular() const;
 
   //! \brief If matrix indices are in the local range, this function returns true. Otherwise, this function returns false. */
   virtual bool isLocallyIndexed() const;

--- a/packages/ifpack2/src/Ifpack2_SparsityFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparsityFilter_def.hpp
@@ -238,20 +238,6 @@ size_t SparsityFilter<MatrixType>::getNumEntriesInLocalRow(LocalOrdinal localRow
 
 //==========================================================================
 template<class MatrixType>
-global_size_t SparsityFilter<MatrixType>::getGlobalNumDiags() const
-{
-  return A_->getGlobalNumDiags();
-}
-
-//==========================================================================
-template<class MatrixType>
-size_t SparsityFilter<MatrixType>::getNodeNumDiags() const
-{
-  return A_->getNodeNumDiags();
-}
-
-//==========================================================================
-template<class MatrixType>
 size_t SparsityFilter<MatrixType>::getGlobalMaxNumRowEntries() const
 {
   return MaxNumEntries_;
@@ -269,20 +255,6 @@ template<class MatrixType>
 bool SparsityFilter<MatrixType>::hasColMap() const
 {
   return true;
-}
-
-//==========================================================================
-template<class MatrixType>
-bool SparsityFilter<MatrixType>::isLowerTriangular() const
-{
-  return A_->isLowerTriangular();
-}
-
-//==========================================================================
-template<class MatrixType>
-bool SparsityFilter<MatrixType>::isUpperTriangular() const
-{
-  return A_->isUpperTriangular();
 }
 
 //==========================================================================

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
@@ -47,6 +47,7 @@
 #include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_CrsMatrix.hpp"
+#include "Ifpack2_Details_RowMatrix.hpp"
 #include "Teuchos_Comm.hpp"
 #include "Teuchos_OrdinalTraits.hpp"
 #include "Teuchos_ScalarTraits.hpp"
@@ -877,7 +878,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
            class Node =
              typename Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal>::node_type>
   class NotCrsMatrix :
-    public Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> {
+    public Ifpack2::Details::RowMatrix<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > {
   public:
     NotCrsMatrix (Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& A) : A_(A){;}
     virtual ~NotCrsMatrix(){;}
@@ -902,13 +903,9 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
     virtual size_t getNodeNumEntries() const {return A_->getNodeNumEntries();}
     virtual size_t getNumEntriesInGlobalRow (GlobalOrdinal globalRow) const {return A_->getNumEntriesInGlobalRow(globalRow);}
     virtual size_t getNumEntriesInLocalRow(LocalOrdinal localRow) const {return A_->getNumEntriesInLocalRow(localRow);}
-    virtual global_size_t getGlobalNumDiags() const {return A_->getGlobalNumDiags();}
-    virtual size_t getNodeNumDiags() const {return A_->getNodeNumDiags();}
     virtual size_t getGlobalMaxNumRowEntries() const {return A_->getGlobalMaxNumRowEntries();}
     virtual size_t getNodeMaxNumRowEntries() const {return A_->getNodeMaxNumRowEntries();}
     virtual bool hasColMap() const {return A_->hasColMap();}
-    virtual bool isLowerTriangular() const {return A_->isLowerTriangular();}
-    virtual bool isUpperTriangular() const {return A_->isUpperTriangular();}
     virtual bool isLocallyIndexed() const {return A_->isLocallyIndexed();}
     virtual bool isGloballyIndexed() const {return A_->isGloballyIndexed();}
     virtual bool isFillComplete() const {return A_->isFillComplete();}

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -605,17 +605,19 @@ namespace Tpetra {
     }
 
     //! Destructor.
-    virtual ~CrsGraph();
+    virtual ~CrsGraph ();
 
     //@}
     //! @name Implementation of Teuchos::ParameterListAcceptor
     //@{
 
     //! Set the given list of parameters (must be nonnull).
-    void setParameterList (const Teuchos::RCP<Teuchos::ParameterList>& params);
+    void
+    setParameterList (const Teuchos::RCP<Teuchos::ParameterList>& params) override;
 
     //! Default parameter list suitable for validation.
-    Teuchos::RCP<const Teuchos::ParameterList> getValidParameters () const;
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getValidParameters () const override;
 
     //@}
     //! @name Insertion/Removal Methods
@@ -843,55 +845,55 @@ namespace Tpetra {
     //@{
 
     //! Returns the communicator.
-    Teuchos::RCP<const Teuchos::Comm<int> > getComm() const;
+    Teuchos::RCP<const Teuchos::Comm<int> > getComm() const override;
 
     //! Returns the underlying node.
-    Teuchos::RCP<node_type> getNode() const;
+    Teuchos::RCP<node_type> getNode() const override;
 
     //! Returns the Map that describes the row distribution in this graph.
-    Teuchos::RCP<const map_type> getRowMap () const;
+    Teuchos::RCP<const map_type> getRowMap () const override;
 
     //! \brief Returns the Map that describes the column distribution in this graph.
-    Teuchos::RCP<const map_type> getColMap () const;
+    Teuchos::RCP<const map_type> getColMap () const override;
 
     //! Returns the Map associated with the domain of this graph.
-    Teuchos::RCP<const map_type> getDomainMap () const;
+    Teuchos::RCP<const map_type> getDomainMap () const override;
 
     //! Returns the Map associated with the domain of this graph.
-    Teuchos::RCP<const map_type> getRangeMap () const;
+    Teuchos::RCP<const map_type> getRangeMap () const override;
 
     //! Returns the importer associated with this graph.
-    Teuchos::RCP<const import_type> getImporter () const;
+    Teuchos::RCP<const import_type> getImporter () const override;
 
     //! Returns the exporter associated with this graph.
-    Teuchos::RCP<const export_type> getExporter () const;
+    Teuchos::RCP<const export_type> getExporter () const override;
 
     //! Returns the number of global rows in the graph.
     /** Undefined if isFillActive().
      */
-    global_size_t getGlobalNumRows() const;
+    global_size_t getGlobalNumRows() const override;
 
     //! \brief Returns the number of global columns in the graph.
     /** Returns the number of entries in the domain map of the matrix.
         Undefined if isFillActive().
     */
-    global_size_t getGlobalNumCols() const;
+    global_size_t getGlobalNumCols() const override;
 
     //! Returns the number of graph rows owned on the calling node.
-    size_t getNodeNumRows() const;
+    size_t getNodeNumRows() const override;
 
     //! Returns the number of columns connected to the locally owned rows of this graph.
     /** Throws std::runtime_error if <tt>hasColMap() == false</tt>
      */
-    size_t getNodeNumCols() const;
+    size_t getNodeNumCols() const override;
 
     //! Returns the index base for global indices for this graph.
-    GlobalOrdinal getIndexBase() const;
+    GlobalOrdinal getIndexBase() const override;
 
     //! Returns the global number of entries in the graph.
     /** Undefined if isFillActive().
      */
-    global_size_t getGlobalNumEntries() const;
+    global_size_t getGlobalNumEntries() const override;
 
     /// \brief The local number of entries in the graph.
     ///
@@ -902,11 +904,12 @@ namespace Tpetra {
     ///   not store the number of entries as a separate integer field,
     ///   since doing so and keeping it updated would hinder
     ///   thread-parallel insertion of new entries.  See #1357.
-    size_t getNodeNumEntries() const;
+    size_t getNodeNumEntries() const override;
 
     //! \brief Returns the current number of entries on this node in the specified global row.
     /*! Returns OrdinalTraits<size_t>::invalid() if the specified global row does not belong to this graph. */
-    size_t getNumEntriesInGlobalRow(GlobalOrdinal globalRow) const;
+    size_t
+    getNumEntriesInGlobalRow (GlobalOrdinal globalRow) const override;
 
     /// \brief Get the number of entries in the given row (local index).
     ///
@@ -914,7 +917,8 @@ namespace Tpetra {
     ///   local index, on the calling MPI process.  If the specified
     ///   local row index is invalid on the calling process, return
     ///   <tt>Teuchos::OrdinalTraits<size_t>::invalid()</tt>.
-    size_t getNumEntriesInLocalRow (LocalOrdinal localRow) const;
+    size_t
+    getNumEntriesInLocalRow (LocalOrdinal localRow) const override;
 
     /// \brief The local number of indices allocated for the graph,
     ///   over all rows on the calling (MPI) process.
@@ -962,7 +966,7 @@ namespace Tpetra {
     ///
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
-    global_size_t TPETRA_DEPRECATED getGlobalNumDiags() const;
+    global_size_t TPETRA_DEPRECATED getGlobalNumDiags() const override;
 
     /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
     ///
@@ -983,7 +987,7 @@ namespace Tpetra {
     ///
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
-    size_t TPETRA_DEPRECATED getNodeNumDiags() const;
+    size_t TPETRA_DEPRECATED getNodeNumDiags() const override;
 
     /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
     ///
@@ -1011,13 +1015,13 @@ namespace Tpetra {
     ///   row.  This method only counts the number of entries in each
     ///   row that a process owns, not the total number of entries in
     ///   the row over all processes.
-    size_t getGlobalMaxNumRowEntries () const;
+    size_t getGlobalMaxNumRowEntries () const override;
 
     /// \brief Maximum number of entries in any row of the graph,
     ///   on this process.
     ///
     /// \pre <tt>! isFillActive()</tt>
-    size_t getNodeMaxNumRowEntries () const;
+    size_t getNodeMaxNumRowEntries () const override;
 
     /// \brief Whether the graph has a column Map.
     ///
@@ -1034,7 +1038,7 @@ namespace Tpetra {
     ///
     /// The latter is mainly useful for a graph associated with a
     /// CrsMatrix.
-    bool hasColMap () const;
+    bool hasColMap () const override;
 
     /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
     ///
@@ -1059,7 +1063,7 @@ namespace Tpetra {
     ///
     /// \note This is entirely a local property.  That means this
     ///   method may return different results on different processes.
-    bool TPETRA_DEPRECATED isLowerTriangular () const;
+    bool TPETRA_DEPRECATED isLowerTriangular () const override;
 
     /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
     ///
@@ -1084,16 +1088,16 @@ namespace Tpetra {
     ///
     /// \note This is entirely a local property.  That means this
     ///   method may return different results on different processes.
-    bool TPETRA_DEPRECATED isUpperTriangular () const;
+    bool TPETRA_DEPRECATED isUpperTriangular () const override;
 
     //! \brief If graph indices are in the local range, this function returns true. Otherwise, this function returns false. */
-    bool isLocallyIndexed() const;
+    bool isLocallyIndexed() const override;
 
     //! \brief If graph indices are in the global range, this function returns true. Otherwise, this function returns false. */
-    bool isGloballyIndexed() const;
+    bool isGloballyIndexed() const override;
 
     //! Returns \c true if fillComplete() has been called and the graph is in compute mode.
-    bool isFillComplete() const;
+    bool isFillComplete() const override;
 
     //! Returns \c true if resumeFill() has been called and the graph is in edit mode.
     bool isFillActive() const;
@@ -1127,7 +1131,7 @@ namespace Tpetra {
     void
     getGlobalRowCopy (GlobalOrdinal GlobalRow,
                       const Teuchos::ArrayView<GlobalOrdinal>& Indices,
-                      size_t& NumIndices) const;
+                      size_t& NumIndices) const override;
 
     /// \brief Get a copy of the given row, using local indices.
     ///
@@ -1139,7 +1143,7 @@ namespace Tpetra {
     void
     getLocalRowCopy (LocalOrdinal LocalRow,
                      const Teuchos::ArrayView<LocalOrdinal>& indices,
-                     size_t& NumIndices) const;
+                     size_t& NumIndices) const override;
 
     /// \brief Get a const, non-persisting view of the given global
     ///   row's global column indices, as a Teuchos::ArrayView.
@@ -1153,11 +1157,11 @@ namespace Tpetra {
     /// \post <tt>gblColInds.size() == getNumEntriesInGlobalRow(gblRow)</tt>
     void
     getGlobalRowView (const GlobalOrdinal gblRow,
-                      Teuchos::ArrayView<const GlobalOrdinal>& gblColInds) const;
+                      Teuchos::ArrayView<const GlobalOrdinal>& gblColInds) const override;
 
     /// \brief Whether this class implements getLocalRowView() and
     ///   getGlobalRowView() (it does).
-    bool supportsRowViews () const;
+    bool supportsRowViews () const override;
 
     /// \brief Get a const, non-persisting view of the given local
     ///   row's local column indices, as a Teuchos::ArrayView.
@@ -1171,33 +1175,34 @@ namespace Tpetra {
     /// \post <tt>lclColInds.size() == getNumEntriesInLocalRow(lclRow)</tt>
     void
     getLocalRowView (const LocalOrdinal lclRow,
-                     Teuchos::ArrayView<const LocalOrdinal>& lclColInds) const;
+                     Teuchos::ArrayView<const LocalOrdinal>& lclColInds) const override;
 
     //@}
     //! @name Overridden from Teuchos::Describable
     //@{
 
-    /** \brief Return a simple one-line description of this object. */
-    std::string description() const;
+    //! Return a one-line human-readable description of this object.
+    std::string description () const override;
 
-    //! Print the object to the given output stream with given verbosity level.
+    /// \brief Print this object to the given output stream with the
+    ///   given verbosity level.
     void
     describe (Teuchos::FancyOStream& out,
               const Teuchos::EVerbosityLevel verbLevel =
-              Teuchos::Describable::verbLevel_default) const;
+              Teuchos::Describable::verbLevel_default) const override;
 
     //@}
     //! \name Implementation of DistObject
     //@{
 
     virtual bool
-    checkSizes (const SrcDistObject& source);
+    checkSizes (const SrcDistObject& source) override;
 
     virtual void
     copyAndPermute (const SrcDistObject& source,
                     size_t numSameIDs,
                     const Teuchos::ArrayView<const LocalOrdinal> &permuteToLIDs,
-                    const Teuchos::ArrayView<const LocalOrdinal> &permuteFromLIDs);
+                    const Teuchos::ArrayView<const LocalOrdinal> &permuteFromLIDs) override;
 
     virtual void
     packAndPrepare (const SrcDistObject& source,
@@ -1205,14 +1210,14 @@ namespace Tpetra {
                     Teuchos::Array<GlobalOrdinal> &exports,
                     const Teuchos::ArrayView<size_t> & numPacketsPerLID,
                     size_t& constantNumPackets,
-                    Distributor &distor);
+                    Distributor &distor) override;
 
     virtual void
     pack (const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
           Teuchos::Array<GlobalOrdinal>& exports,
           const Teuchos::ArrayView<size_t>& numPacketsPerLID,
           size_t& constantNumPackets,
-          Distributor& distor) const;
+          Distributor& distor) const override;
 
     virtual void
     unpackAndCombine (const Teuchos::ArrayView<const LocalOrdinal> &importLIDs,
@@ -1220,7 +1225,7 @@ namespace Tpetra {
                       const Teuchos::ArrayView<size_t> &numPacketsPerLID,
                       size_t constantNumPackets,
                       Distributor &distor,
-                      CombineMode CM);
+                      CombineMode CM) override;
     //@}
     //! \name Advanced methods, at increased risk of deprecation.
     //@{
@@ -1429,7 +1434,7 @@ namespace Tpetra {
     /// method call should only fail on user error or failure to
     /// allocate memory.
     virtual void
-    removeEmptyProcessesInPlace (const Teuchos::RCP<const map_type>& newMap);
+    removeEmptyProcessesInPlace (const Teuchos::RCP<const map_type>& newMap) override;
     //@}
 
     template<class ViewType, class OffsetViewType >

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5498,10 +5498,8 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  checkSizes (const SrcDistObject& source)
+  checkSizes (const SrcDistObject& /* source */)
   {
-    (void) source; // forestall "unused variable" compiler warnings
-
     // It's not clear what kind of compatibility checks on sizes can
     // be performed here.  Epetra_CrsGraph doesn't check any sizes for
     // compatibility.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -189,7 +189,8 @@ namespace Tpetra {
             class Node = ::Tpetra::Details::DefaultTypes::node_type>
   class CrsMatrix :
     public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
-    public DistObject<char, LocalOrdinal, GlobalOrdinal, Node>
+    public DistObject<char, LocalOrdinal, GlobalOrdinal, Node>,
+    public Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers
   {
   public:
     //! @name Typedefs
@@ -2149,26 +2150,27 @@ namespace Tpetra {
     ///   is not, this method's behavior is undefined.  This pointer
     ///   will be null on excluded processes.
     virtual void
-    removeEmptyProcessesInPlace (const Teuchos::RCP<const map_type>& newMap);
+    removeEmptyProcessesInPlace (const Teuchos::RCP<const map_type>& newMap) override;
 
     //@}
     //! @name Methods implementing RowMatrix
     //@{
 
     //! The communicator over which the matrix is distributed.
-    Teuchos::RCP<const Teuchos::Comm<int> > getComm() const;
+    Teuchos::RCP<const Teuchos::Comm<int> > getComm() const override;
 
     //! The Kokkos Node instance.
-    Teuchos::RCP<node_type> getNode () const;
+    Teuchos::RCP<node_type> getNode () const override;
 
     //! The Map that describes the row distribution in this matrix.
-    Teuchos::RCP<const map_type> getRowMap () const;
+    Teuchos::RCP<const map_type> getRowMap () const override;
 
     //! The Map that describes the column distribution in this matrix.
-    Teuchos::RCP<const map_type> getColMap () const;
+    Teuchos::RCP<const map_type> getColMap () const override;
 
     //! This matrix's graph, as a RowGraph.
-    Teuchos::RCP<const RowGraph<LocalOrdinal, GlobalOrdinal, Node> > getGraph () const;
+    Teuchos::RCP<const RowGraph<LocalOrdinal, GlobalOrdinal, Node> >
+    getGraph () const override;
 
     //! This matrix's graph, as a CrsGraph.
     Teuchos::RCP<const crs_graph_type> getCrsGraph () const;
@@ -2217,14 +2219,14 @@ namespace Tpetra {
     ///
     /// \warning Undefined if isFillActive().
     ///
-    global_size_t getGlobalNumRows() const;
+    global_size_t getGlobalNumRows() const override;
 
     /// \brief The number of global columns in the matrix.
     ///
     /// This equals the number of entries in the matrix's domain Map.
     ///
     /// \warning Undefined if isFillActive().
-    global_size_t getGlobalNumCols() const;
+    global_size_t getGlobalNumCols() const override;
 
     /// \brief The number of matrix rows owned by the calling process.
     ///
@@ -2232,29 +2234,50 @@ namespace Tpetra {
     /// in the row Map's communicator does not necessarily equal the
     /// global number of rows in the matrix, if the row Map is
     /// overlapping.
-    size_t getNodeNumRows() const;
+    size_t getNodeNumRows() const override;
 
     /// \brief The number of columns connected to the locally owned rows of this matrix.
     ///
     /// Throws std::runtime_error if <tt>! hasColMap ()</tt>.
-    size_t getNodeNumCols() const;
+    size_t getNodeNumCols() const override;
 
     //! The index base for global indices for this matrix.
-    GlobalOrdinal getIndexBase() const;
+    GlobalOrdinal getIndexBase() const override;
 
     //! The global number of entries in this matrix.
-    global_size_t getGlobalNumEntries() const;
+    global_size_t getGlobalNumEntries() const override;
 
     //! The local number of entries in this matrix.
-    size_t getNodeNumEntries() const;
+    size_t getNodeNumEntries() const override;
 
-    //! \brief Returns the current number of entries on this node in the specified global row.
-    /*! Returns OrdinalTraits<size_t>::invalid() if the specified global row does not belong to this matrix. */
-    size_t getNumEntriesInGlobalRow (GlobalOrdinal globalRow) const;
+    /// \brief Number of entries in the sparse matrix in the given
+    ///   globa row, on the calling (MPI) process.
+    ///
+    /// \return <tt>OrdinalTraits<size_t>::invalid()</tt>if the
+    ///   specified global row index is invalid on the calling
+    ///   process, else the number of entries in the given row.
+    size_t getNumEntriesInGlobalRow (GlobalOrdinal globalRow) const override;
 
-    //! Returns the current number of entries on this node in the specified local row.
-    /*! Returns OrdinalTraits<size_t>::invalid() if the specified local row is not valid for this matrix. */
-    size_t getNumEntriesInLocalRow (LocalOrdinal localRow) const;
+    /// \brief Number of entries in the sparse matrix in the given
+    ///   local row, on the calling (MPI) process.
+    ///
+    /// \return <tt>OrdinalTraits<size_t>::invalid()</tt>if the
+    ///   specified local row index is invalid on the calling process,
+    ///   else the number of entries in the given row.
+    size_t getNumEntriesInLocalRow (LocalOrdinal localRow) const override;
+
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings.  We only want users to see deprecated warnings if
+    /// <i>they</i> call deprecated methods, not if <i>we</i> call
+    /// them.
+    global_size_t getGlobalNumDiagsImpl () const override;
 
     /// \brief Number of diagonal entries in the matrix's graph, over
     ///   all processes in the matrix's communicator.
@@ -2263,7 +2286,20 @@ namespace Tpetra {
     ///
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
-    global_size_t TPETRA_DEPRECATED getGlobalNumDiags () const;
+    global_size_t TPETRA_DEPRECATED getGlobalNumDiags () const override;
+
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings.  We only want users to see deprecated warnings if
+    /// <i>they</i> call deprecated methods, not if <i>we</i> call
+    /// them.
+    size_t getNodeNumDiagsImpl () const override;
 
     /// \brief Number of diagonal entries in the matrix's graph, on
     ///   the calling process.
@@ -2272,7 +2308,7 @@ namespace Tpetra {
     ///
     /// \warning This method is DEPRECATED.  DO NOT CALL IT.  It may
     ///   go away at any time.
-    size_t TPETRA_DEPRECATED getNodeNumDiags () const;
+    size_t TPETRA_DEPRECATED getNodeNumDiags () const override;
 
     /// \brief Maximum number of entries in any row of the matrix,
     ///   over all processes in the matrix's communicator.
@@ -2281,7 +2317,7 @@ namespace Tpetra {
     ///
     /// This method only uses the matrix's graph.  Explicitly stored
     /// zeros count as "entries."
-    size_t getGlobalMaxNumRowEntries () const;
+    size_t getGlobalMaxNumRowEntries () const override;
 
     /// \brief Maximum number of entries in any row of the matrix,
     ///   on this process.
@@ -2290,10 +2326,23 @@ namespace Tpetra {
     ///
     /// This method only uses the matrix's graph.  Explicitly stored
     /// zeros count as "entries."
-    size_t getNodeMaxNumRowEntries () const;
+    size_t getNodeMaxNumRowEntries () const override;
 
     //! Whether the matrix has a well-defined column Map.
-    bool hasColMap () const;
+    bool hasColMap () const override;
+
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings.  We only want users to see deprecated warnings if
+    /// <i>they</i> call deprecated methods, not if <i>we</i> call
+    /// them.
+    bool isLowerTriangularImpl () const override;
 
     /// \brief Whether the matrix is locally lower triangular.
     ///
@@ -2305,7 +2354,20 @@ namespace Tpetra {
     ///
     /// \note This is entirely a local property.  That means this
     ///   method may return different results on different processes.
-    bool TPETRA_DEPRECATED isLowerTriangular () const;
+    bool TPETRA_DEPRECATED isLowerTriangular () const override;
+
+    /// \brief DO NOT CALL THIS METHOD; THIS IS NOT FOR USERS.
+    ///
+    /// \warning DO NOT CALL THIS METHOD.  THIS IS AN IMPLEMENTATION
+    ///   DETAIL OF TPETRA DESIGNED TO PREVENT SPURIOUS BUILD
+    ///   WARNINGS.  DO NOT CALL THIS METHOD.  IT WILL GO AWAY VERY
+    ///   SOON PER #2630.
+    ///
+    /// This function exists only to prevent spurious deprecation
+    /// warnings.  We only want users to see deprecated warnings if
+    /// <i>they</i> call deprecated methods, not if <i>we</i> call
+    /// them.
+    bool isUpperTriangularImpl () const override;
 
     /// \brief Whether the matrix is locally upper triangular.
     ///
@@ -2317,9 +2379,10 @@ namespace Tpetra {
     ///
     /// \note This is entirely a local property.  That means this
     ///   method may return different results on different processes.
-    bool TPETRA_DEPRECATED isUpperTriangular () const;
+    bool TPETRA_DEPRECATED isUpperTriangular () const override;
 
-    /// \brief Whether the matrix is locally indexed on the calling process.
+    /// \brief Whether the matrix is locally indexed on the calling
+    ///   process.
     ///
     /// The matrix is locally indexed on the calling process if and
     /// only if all of the following hold:
@@ -2338,7 +2401,7 @@ namespace Tpetra {
     /// locally nor globally indexed, and some processes that are
     /// globally indexed.  The processes that are neither do not have
     /// any entries.
-    bool isLocallyIndexed() const;
+    bool isLocallyIndexed() const override;
 
     /// \brief Whether the matrix is globally indexed on the calling process.
     ///
@@ -2359,7 +2422,7 @@ namespace Tpetra {
     /// locally nor globally indexed, and some processes that are
     /// globally indexed.  The processes that are neither do not have
     /// any entries.
-    bool isGloballyIndexed() const;
+    bool isGloballyIndexed() const override;
 
     /// \brief Whether the matrix is fill complete.
     ///
@@ -2383,7 +2446,7 @@ namespace Tpetra {
     /// is called.  Some methods like clone() and some of the
     /// "nonmember constructors" (like importAndFillComplete() and
     /// exportAndFillComplete()) may return a fill-complete matrix.
-    bool isFillComplete() const;
+    bool isFillComplete() const override;
 
     /// \brief Whether the matrix is not fill complete.
     ///
@@ -2435,11 +2498,11 @@ namespace Tpetra {
     /// cached; the cache is cleared whenever resumeFill() is called.
     /// Otherwise, the value is computed every time the method is
     /// called.
-    mag_type getFrobeniusNorm () const;
+    mag_type getFrobeniusNorm () const override;
 
     /// \brief Return \c true if getLocalRowView() and
     ///   getGlobalRowView() are valid for this object.
-    virtual bool supportsRowViews () const;
+    virtual bool supportsRowViews () const override;
 
     /// \brief Fill given arrays with a deep copy of the locally owned
     ///   entries of the matrix in a given row, using global column
@@ -2493,7 +2556,7 @@ namespace Tpetra {
     getGlobalRowCopy (GlobalOrdinal GlobalRow,
                       const Teuchos::ArrayView<GlobalOrdinal>& Indices,
                       const Teuchos::ArrayView<Scalar>& Values,
-                      size_t& NumEntries) const;
+                      size_t& NumEntries) const override;
 
     /// \brief Fill given arrays with a deep copy of the locally owned
     ///   entries of the matrix in a given row, using local column
@@ -2516,7 +2579,7 @@ namespace Tpetra {
     getLocalRowCopy (LocalOrdinal localRow,
                      const Teuchos::ArrayView<LocalOrdinal>& colInds,
                      const Teuchos::ArrayView<Scalar>& vals,
-                     size_t& numEntries) const;
+                     size_t& numEntries) const override;
 
     /// \brief Get a constant, nonpersisting view of a row of this
     ///   matrix, using global row and column indices.
@@ -2534,7 +2597,7 @@ namespace Tpetra {
     void
     getGlobalRowView (GlobalOrdinal GlobalRow,
                       Teuchos::ArrayView<const GlobalOrdinal>& indices,
-                      Teuchos::ArrayView<const Scalar>& values) const;
+                      Teuchos::ArrayView<const Scalar>& values) const override;
 
     /// \brief Get a constant, nonpersisting view of a row of this
     ///   matrix, using local row and column indices.
@@ -2552,7 +2615,7 @@ namespace Tpetra {
     void
     getLocalRowView (LocalOrdinal LocalRow,
                      Teuchos::ArrayView<const LocalOrdinal>& indices,
-                     Teuchos::ArrayView<const Scalar>& values) const;
+                     Teuchos::ArrayView<const Scalar>& values) const override;
 
     /// \brief Get a constant, nonpersisting, locally indexed view of
     ///   the given row of the matrix, using "raw" pointers instead of
@@ -2584,7 +2647,7 @@ namespace Tpetra {
     getLocalRowViewRaw (const LocalOrdinal lclRow,
                         LocalOrdinal& numEnt,
                         const LocalOrdinal*& lclColInds,
-                        const Scalar*& vals) const;
+                        const Scalar*& vals) const override;
 
     /// \brief Get a constant, nonpersisting view of a row of this
     ///   matrix, using local row and column indices, with raw
@@ -2648,7 +2711,7 @@ namespace Tpetra {
     /// entries owned by the calling process. If the matrix has an empty
     /// row, the diagonal entry contains a zero.
     void
-    getLocalDiagCopy (Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& diag) const;
+    getLocalDiagCopy (Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& diag) const override;
 
     /// \brief Get offsets of the diagonal entries in the matrix.
     ///
@@ -2747,13 +2810,19 @@ namespace Tpetra {
     getLocalDiagCopy (Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& diag,
                       const Teuchos::ArrayView<const size_t>& offsets) const;
 
-    /** \brief . */
+    /// \brief Scale the matrix on the left with the given Vector.
+    ///
+    /// On return, for all entries i,j in the matrix,
+    /// \f$A(i,j) = x(i)*A(i,j)\f$.
     void
-    leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x);
+    leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) override;
 
-    /** \brief . */
+    /// \brief Scale the matrix on the right with the given Vector.
+    ///
+    /// On return, for all entries i,j in the matrix,
+    /// \f$A(i,j) = x(j)*A(i,j)\f$.
     void
-    rightScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x);
+    rightScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) override;
 
     //@}
     //! @name Advanced templated methods
@@ -3151,23 +3220,11 @@ namespace Tpetra {
     /// \brief Solves a linear system when the underlying matrix is
     ///   locally triangular.
     ///
-    /// X is required to be post-imported, i.e., described by the
-    /// column map of the matrix. Y is required to be pre-exported,
-    /// i.e., described by the row map of the matrix.
-    ///
-    /// This method is templated on the scalar type of MultiVector
-    /// objects, allowing this method to be applied to MultiVector
-    /// objects of arbitrary type. However, if you intend to use this
-    /// with template parameters not equal to Scalar, we recommend
-    /// that you wrap this matrix in a CrsMatrixSolveOp.  That class
-    /// will handle the Import/Export operations required to apply a
-    /// matrix with non-trivial communication needs.
-    ///
-    /// Both X and Y are required to have constant stride. However,
-    /// unlike multiply(), it is permissible for <tt>&X == &Y</tt>. No
-    /// run-time checking will be performed in a non-debug build.
+    /// \warning This method is DEPRECATED.  For comparable
+    ///   functionality with a better interface, please see
+    ///   Ifpack2::LocalSparseTriangularSolver.
     template <class DomainScalar, class RangeScalar>
-    void
+    void TPETRA_DEPRECATED
     localSolve (const MultiVector<RangeScalar, LocalOrdinal, GlobalOrdinal, Node>& Y,
                 MultiVector<DomainScalar, LocalOrdinal, GlobalOrdinal, Node>& X,
                 Teuchos::ETransp mode) const
@@ -3189,7 +3246,8 @@ namespace Tpetra {
          "X and Y must be constant stride.");
 
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        ( getNodeNumRows()>0 && ! isUpperTriangular () && ! isLowerTriangular (), std::runtime_error,
+        (getNodeNumRows () != 0 && ! isUpperTriangularImpl () &&
+	 ! isLowerTriangularImpl (), std::runtime_error,
          "The matrix is neither upper triangular or lower triangular.  "
          "You may only call this method if the matrix is triangular.  "
          "Remember that this is a local (per MPI process) property, and that "
@@ -3220,12 +3278,12 @@ namespace Tpetra {
       // this code should only assume an implicitly stored unit diagonal
       // if the matrix has _no_ explicitly stored diagonal entries.
 
-      const std::string uplo = isUpperTriangular () ? "U" :
-        (isLowerTriangular () ? "L" : "N");
+      const std::string uplo = isUpperTriangularImpl () ? "U" :
+        (isLowerTriangularImpl () ? "L" : "N");
       const std::string trans = (mode == Teuchos::CONJ_TRANS) ? "C" :
         (mode == Teuchos::TRANS ? "T" : "N");
       const std::string diag =
-        (getNodeNumDiags () < getNodeNumRows ()) ? "U" : "N";
+        (getNodeNumDiagsImpl () < getNodeNumRows ()) ? "U" : "N";
 
       local_matrix_type A_lcl = this->getLocalMatrix ();
 
@@ -3286,10 +3344,11 @@ namespace Tpetra {
            MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&Y,
            Teuchos::ETransp mode = Teuchos::NO_TRANS,
            Scalar alpha = Teuchos::ScalarTraits<Scalar>::one(),
-           Scalar beta = Teuchos::ScalarTraits<Scalar>::zero()) const;
+           Scalar beta = Teuchos::ScalarTraits<Scalar>::zero()) const override;
 
-    //! Whether apply() allows applying the transpose or conjugate transpose.
-    bool hasTransposeApply () const;
+    /// \brief Whether apply() allows applying the transpose or
+    ///   conjugate transpose.
+    bool hasTransposeApply () const override;
 
     /// \brief The domain Map of this matrix.
     ///
@@ -3297,7 +3356,7 @@ namespace Tpetra {
     /// has not yet been called at least once on this matrix, or if
     /// the matrix was not constructed with a domain Map, then this
     /// method returns Teuchos::null.
-    Teuchos::RCP<const map_type> getDomainMap () const;
+    Teuchos::RCP<const map_type> getDomainMap () const override;
 
     /// \brief The range Map of this matrix.
     ///
@@ -3305,7 +3364,7 @@ namespace Tpetra {
     /// has not yet been called at least once on this matrix, or if
     /// the matrix was not constructed with a domain Map, then this
     /// method returns Teuchos::null.
-    Teuchos::RCP<const map_type> getRangeMap () const;
+    Teuchos::RCP<const map_type> getRangeMap () const override;
 
     //@}
     //! @name Other "apply"-like methods
@@ -3550,20 +3609,21 @@ namespace Tpetra {
          const Scalar& beta,
          const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& domainMap,
          const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& rangeMap,
-         const Teuchos::RCP<Teuchos::ParameterList>& params) const;
+         const Teuchos::RCP<Teuchos::ParameterList>& params) const override;
 
     //@}
     //! @name Implementation of Teuchos::Describable interface
     //@{
 
     //! A one-line description of this object.
-    std::string description () const;
+    std::string description () const override;
 
-    //! Print the object with some verbosity level to an FancyOStream object.
+    /// \brief Print this object with the given verbosity level to the
+    ///   given output stream.
     void
-    describe (Teuchos::FancyOStream &out,
+    describe (Teuchos::FancyOStream& out,
               const Teuchos::EVerbosityLevel verbLevel =
-              Teuchos::Describable::verbLevel_default) const;
+              Teuchos::Describable::verbLevel_default) const override;
 
     //@}
     //! @name Implementation of DistObject interface
@@ -3577,7 +3637,7 @@ namespace Tpetra {
                                 Node>::buffer_device_type buffer_device_type;
 
     virtual bool
-    checkSizes (const SrcDistObject& source);
+    checkSizes (const SrcDistObject& source) override;
 
     /// \brief Whether the subclass implements the "old" or "new"
     ///   (Kokkos-friendly) interface.
@@ -3593,7 +3653,7 @@ namespace Tpetra {
     /// the "new" interface (by removing "New" from the methods'
     /// names), so that it becomes the only interface.
     virtual bool
-    useNewInterface ();
+    useNewInterface () override;
 
   private:
 
@@ -3609,7 +3669,7 @@ namespace Tpetra {
     copyAndPermuteNew (const SrcDistObject& source,
                        const size_t numSameIDs,
                        const Kokkos::DualView<const local_ordinal_type*, device_type>& permuteToLIDs,
-                       const Kokkos::DualView<const local_ordinal_type*, device_type>& permuteFromLIDs);
+                       const Kokkos::DualView<const local_ordinal_type*, device_type>& permuteFromLIDs) override;
 
     virtual void
     packAndPrepareNew (const SrcDistObject& source,
@@ -3617,7 +3677,7 @@ namespace Tpetra {
                        Kokkos::DualView<char*, buffer_device_type>& exports,
                        const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
                        size_t& constantNumPackets,
-                       Distributor& distor);
+                       Distributor& distor) override;
 
   private:
     /// \brief Unpack the imported column indices and values, and
@@ -3657,7 +3717,7 @@ namespace Tpetra {
                          const Kokkos::DualView<const size_t*, buffer_device_type>& numPacketsPerLID,
                          const size_t constantNumPackets,
                          Distributor& distor,
-                         const CombineMode CM);
+                         const CombineMode CM) override;
 
     /// \brief Pack this object's data for an Import or Export.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -728,19 +728,33 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   global_size_t
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  getGlobalNumDiags () const {
+  getGlobalNumDiagsImpl () const {
     const crs_graph_type& G = this->getCrsGraphRef ();
     using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
     return dynamic_cast<const HDM&> (G).getGlobalNumDiagsImpl ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  global_size_t
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  getGlobalNumDiags () const {
+    return this->getGlobalNumDiagsImpl ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   size_t
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  getNodeNumDiags () const {
+  getNodeNumDiagsImpl () const {
     const crs_graph_type& G = this->getCrsGraphRef ();
     using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
     return dynamic_cast<const HDM&> (G).getNodeNumDiagsImpl ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  size_t
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  getNodeNumDiags () const {
+    return this->getNodeNumDiags ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -848,7 +862,7 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  isLowerTriangular () const {
+  isLowerTriangularImpl () const {
     const crs_graph_type& G = this->getCrsGraphRef ();
     using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
     return dynamic_cast<const HDM&> (G).isLowerTriangularImpl ();
@@ -857,10 +871,24 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  isUpperTriangular () const {
+  isLowerTriangular () const {
+    return this->isLowerTriangularImpl ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  isUpperTriangularImpl () const {
     const crs_graph_type& G = this->getCrsGraphRef ();
     using HDM = Details::HasDeprecatedMethods2630_WarningThisClassIsNotForUsers;
     return dynamic_cast<const HDM&> (G).isUpperTriangularImpl ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  isUpperTriangular () const {
+    return this->isUpperTriangularImpl ();
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowGraph_decl.hpp
@@ -244,7 +244,7 @@ namespace Tpetra {
     /// If subclasses override the default (trivial) implementation of
     /// getLocalRowView() and getGlobalRowView(), then they need to
     /// override this method as well.
-    bool supportsRowViews () const {
+    virtual bool supportsRowViews () const {
       return false;
     }
 

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_decl.hpp
@@ -447,18 +447,16 @@ namespace Tpetra {
     //! \name Mathematical methods
     //@{
 
-    /**
-     * \brief Scale the RowMatrix on the left with the given Vector x.
-     *
-     * On return, for all entries i,j in the matrix, \f$A(i,j) = x(i)*A(i,j)\f$.
-     */
+    /// \brief Scale the matrix on the left with the given Vector.
+    ///
+    /// On return, for all entries i,j in the matrix,
+    /// \f$A(i,j) = x(i)*A(i,j)\f$.
     virtual void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) = 0;
 
-    /**
-     * \brief Scale the RowMatrix on the right with the given Vector x.
-     *
-     * On return, for all entries i,j in the matrix, \f$A(i,j) = x(j)*A(i,j)\f$.
-     */
+    /// \brief Scale the matrix on the right with the given Vector.
+    ///
+    /// On return, for all entries i,j in the matrix,
+    /// \f$A(i,j) = x(j)*A(i,j)\f$.
     virtual void rightScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) = 0;
 
     /// \brief The Frobenius norm of the matrix.


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/tpetra 

## Description

  - Fix #2869 (`Tpetra::RowGraph::supportsRowViews` was not marked virtual)
  - Fix some deprecated warnings relating to #2630 that show up in Ifpack2

## Motivation and Context

  - #2869 relates to host-only CrsGraph access code, that accesses CrsGraph through RowGraph virtual methods; fixing it could improve MueLu performance
  - @ibaned [reported Albany being swamped](https://github.com/trilinos/Trilinos/issues/2630#issuecomment-393869243) with deprecated warnings; this PR should reduce the number of warnings Albany and other applications see

## Related Issues

* Related to #2869 
* Part of #2630 

## How Has This Been Tested?

With Clang, on MacOS X

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

These changes do technically break backwards compatibility, in that users of Ifpack2 subclasses of `Tpetra::RowGraph` and `Tpetra::RowMatrix` may no longer call methods deprecated by #2630: `isLowerTriangular`, `isUpperTriangular`, `getNodeNumDiags`, and `getGlobalNumDiags`.  These methods still exist and build, but now always throw `std::logic_error`.  Ifpack2's subclasses of RowGraph and RowMatrix are really implementation details of Ifpack2; users would normally have no reason to rely on them.