### PR TITLE
Change all 'chama' builds to go to "Specialized" CDash Track/Group (TRIL-200)

### DIFF
--- a/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-debug-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-debug-openmp-panzer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:45:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=Specialized
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/chama/local-driver.sh

--- a/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-debug-openmp.sh
+++ b/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-debug-openmp.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/chama/local-driver.sh

--- a/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-opt-openmp-panzer.sh
+++ b/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-opt-openmp-panzer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
+  export Trilinos_TRACK=Specialized
 fi
 export SALLOC_CTEST_TIME_LIMIT_MINUTES=0:15:00
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/chama/local-driver.sh

--- a/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-opt-openmp.sh
+++ b/cmake/ctest/drivers/atdm/chama/drivers/Trilinos-atdm-chama-intel-opt-openmp.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 #export SALLOC_CTEST_TIME_LIMIT_MINUTES=1:00:00
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/chama/local-driver.sh


### PR DESCRIPTION
CC: @fryeguy52 

## Description

The 'panzer' builds whese were copy and pasted to go to the "ATDM" CDash
Track/Group but they are not passing so that is not right.

@fryeguy52, I did this before your PR #2284 posted.   The changes in this PR allow for overriding `Trilinos_TRACK` in the outer Jenkins job if needed short term.

## How Has This Been Tested?

I did not test this but the changes are very simple and I copy and pasted this from other working scripts.
