### PR TITLE
MueLu: overlapping aggregates

### DIFF
--- a/packages/muelu/src/Graph/MueLu_Aggregates_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_Aggregates_decl.hpp
@@ -49,6 +49,7 @@
 #include <Xpetra_Map_fwd.hpp>
 #include <Xpetra_Vector_fwd.hpp>
 #include <Xpetra_VectorFactory_fwd.hpp>
+#include <Xpetra_MultiVector_fwd.hpp>
 
 #include "MueLu_ConfigDefs.hpp"
 #include "MueLu_BaseClass.hpp"
@@ -143,7 +144,7 @@ namespace MueLu {
 
         For local node ID i, the corresponding vector entry v[i] is the local aggregate id to which i belongs on the current processor.
     */
-    RCP<LOVector> & GetVertex2AggIdNonConst()     { return vertex2AggId_;       }
+    RCP<LOMultiVector> & GetVertex2AggIdNonConst()     { return vertex2AggId_;       }
 
     /*! @brief Returns nonconsant vector that maps local node IDs to owning processor IDs.
 
@@ -154,7 +155,7 @@ namespace MueLu {
 
         For local node ID i, the corresponding vector entry v[i] is the local aggregate id to which i belongs on the current processor.
     */
-    const RCP<LOVector> & GetVertex2AggId() const { return vertex2AggId_;       }
+    const RCP<LOMultiVector> & GetVertex2AggId() const { return vertex2AggId_;       }
 
     /*! @brief Returns constant vector that maps local node IDs to owning processor IDs.
 
@@ -201,7 +202,7 @@ namespace MueLu {
      * local id k has been assigned. While k is the local id on my processor (MyPID),
      * vertex2AggId[k] is the local id on the processor which actually owns the aggregate.
      */
-    RCP<LOVector> vertex2AggId_;
+    RCP<LOMultiVector> vertex2AggId_;
 
     /*!
      * If k is the local id on my processor (MyPID), the owning processor has the

--- a/packages/muelu/src/Graph/MueLu_Aggregates_def.hpp
+++ b/packages/muelu/src/Graph/MueLu_Aggregates_def.hpp
@@ -48,9 +48,11 @@
 
 #include <Xpetra_Map.hpp>
 #include <Xpetra_Vector.hpp>
+#include <Xpetra_MultiVector.hpp>
 #include <Xpetra_BlockedMultiVector.hpp>
 #include <Xpetra_BlockedVector.hpp>
 #include <Xpetra_VectorFactory.hpp>
+#include <Xpetra_MultiVectorFactory.hpp>
 
 #include "MueLu_Aggregates_decl.hpp"
 #include "MueLu_Graph.hpp"
@@ -63,7 +65,7 @@ namespace MueLu {
   Aggregates<LocalOrdinal, GlobalOrdinal, Node>::Aggregates(const GraphBase & graph) {
     nAggregates_  = 0;
 
-    vertex2AggId_ = LOVectorFactory::Build(graph.GetImportMap());
+    vertex2AggId_ = LOMultiVectorFactory::Build(graph.GetImportMap(), 1);
     vertex2AggId_->putScalar(MUELU_UNAGGREGATED);
 
     procWinner_ = LOVectorFactory::Build(graph.GetImportMap());
@@ -80,7 +82,7 @@ namespace MueLu {
   Aggregates<LocalOrdinal, GlobalOrdinal, Node>::Aggregates(const RCP<const Map> & map) {
     nAggregates_ = 0;
 
-    vertex2AggId_ = LOVectorFactory::Build(map);
+    vertex2AggId_ = LOMultiVectorFactory::Build(map, 1);
     vertex2AggId_->putScalar(MUELU_UNAGGREGATED);
 
     procWinner_ = LOVectorFactory::Build(map);

--- a/packages/muelu/src/Graph/MueLu_CoupledAggregationCommHelper_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_CoupledAggregationCommHelper_decl.hpp
@@ -49,6 +49,7 @@
 #include <Xpetra_Import_fwd.hpp>
 #include <Xpetra_ImportFactory_fwd.hpp>
 #include <Xpetra_Vector_fwd.hpp>
+#include <Xpetra_MultiVector_fwd.hpp>
 
 #include "MueLu_ConfigDefs.hpp"
 #include "MueLu_BaseClass.hpp"
@@ -180,7 +181,7 @@ namespace MueLu {
                                         its MyPid, the corresponding companion
                                         is not altered.
     */
-    void ArbitrateAndCommunicate(Vector &weight, LOVector &procWinner, LOVector *companion, const bool perturb) const; //ArbitrateAndCommunicate(Vector&, LOVector &, LOVector *, const bool) const
+    void ArbitrateAndCommunicate(Vector &weight, LOVector &procWinner, LOMultiVector *companion, const bool perturb) const; //ArbitrateAndCommunicate(Vector&, LOVector &, LOMultiVector *, const bool) const
 
     /*!  @brief Redistribute data in source to dest where both source and dest might have multiple copies of the same global id across many processors.
 

--- a/packages/muelu/src/Graph/MueLu_CoupledAggregationCommHelper_def.hpp
+++ b/packages/muelu/src/Graph/MueLu_CoupledAggregationCommHelper_def.hpp
@@ -50,6 +50,7 @@
 #include <Xpetra_BlockedMultiVector.hpp>
 #include <Xpetra_BlockedVector.hpp>
 #include <Xpetra_VectorFactory.hpp>
+#include <Xpetra_MultiVectorFactory.hpp>
 #include <Xpetra_ImportFactory.hpp>
 #include <Xpetra_ExportFactory.hpp>
 
@@ -69,7 +70,7 @@ namespace MueLu {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void CoupledAggregationCommHelper<LocalOrdinal, GlobalOrdinal, Node>::ArbitrateAndCommunicate(Vector &weight_, LOVector &procWinner_, LOVector *companion, const bool perturb) const {
+  void CoupledAggregationCommHelper<LocalOrdinal, GlobalOrdinal, Node>::ArbitrateAndCommunicate(Vector &weight_, LOVector &procWinner_, LOMultiVector *companion, const bool perturb) const {
     const RCP<const Map> weightMap = weight_.getMap();
     const size_t nodeNumElements = weightMap->getNodeNumElements();
     const RCP<const Teuchos::Comm<int> > & comm = weightMap->getComm();
@@ -103,10 +104,10 @@ namespace MueLu {
       ArrayRCP<LO> procWinner = procWinner_.getDataNonConst(0);
       for (size_t i=0; i < nodeNumElements; ++i) in_procWinner[i] = procWinner[i];
     }
-    RCP<LOVector> in_companion;
+    RCP<LOMultiVector> in_companion;
     {
       if (companion != NULL) {
-        in_companion = LOVectorFactory::Build(companion->getMap());
+        in_companion = LOMultiVectorFactory::Build(companion->getMap(), companion->getNumVectors());
         ArrayRCP<LO> in_comp = in_companion->getDataNonConst(0);
         ArrayRCP<LO> comp = companion->getDataNonConst(0);
         for (size_t i=0; i < nodeNumElements; ++i) in_comp[i] = comp[i];
@@ -306,7 +307,7 @@ namespace MueLu {
       // Pull the Winners out of companion
       //     JustWinners <-- companion[Winners];
 
-      RCP<LOVector> justWinners = LOVectorFactory::Build(winnerMap_);
+      RCP<LOMultiVector> justWinners = LOMultiVectorFactory::Build(winnerMap_, companion->getNumVectors());
 
 #ifdef JG_DEBUG
       RCP<Teuchos::FancyOStream> out = rcp(new Teuchos::FancyOStream(rcp(&std::cout,false)));

--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
@@ -202,10 +202,10 @@ namespace MueLu {
       }
     }
     GetOStream(Runtime0) << "AggregationExportFactory: DofsPerNode: " << DofsPerNode << std::endl;
-    Teuchos::RCP<LocalOrdinalVector> vertex2AggId_vector = aggregates->GetVertex2AggId();
-    Teuchos::RCP<LocalOrdinalVector> procWinner_vector   = aggregates->GetProcWinner();
-    Teuchos::ArrayRCP<LocalOrdinal>  vertex2AggId        = aggregates->GetVertex2AggId()->getDataNonConst(0);
-    Teuchos::ArrayRCP<LocalOrdinal>  procWinner          = aggregates->GetProcWinner()->getDataNonConst(0);
+    Teuchos::RCP<LocalOrdinalMultiVector> vertex2AggId_vector = aggregates->GetVertex2AggId();
+    Teuchos::RCP<LocalOrdinalVector>      procWinner_vector   = aggregates->GetProcWinner();
+    Teuchos::ArrayRCP<LocalOrdinal>       vertex2AggId        = aggregates->GetVertex2AggId()->getDataNonConst(0);
+    Teuchos::ArrayRCP<LocalOrdinal>       procWinner          = aggregates->GetProcWinner()->getDataNonConst(0);
 
     vertex2AggId_ = vertex2AggId;
 

--- a/packages/xpetra/src/CMakeLists.txt
+++ b/packages/xpetra/src/CMakeLists.txt
@@ -29,6 +29,7 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
     Import/Xpetra_EpetraImport.cpp
     Export/Xpetra_EpetraExport.cpp
     MultiVector/Xpetra_EpetraMultiVector.cpp
+    MultiVector/Xpetra_EpetraIntMultiVector.cpp
     CrsGraph/Xpetra_EpetraCrsGraph.cpp
     CrsMatrix/Xpetra_EpetraCrsMatrix.cpp
     Vector/Xpetra_EpetraVector.cpp

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.cpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.cpp
@@ -1,0 +1,145 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//             Xpetra: A linear algebra interface package
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#include "Xpetra_EpetraIntMultiVector.hpp"
+#include "Xpetra_EpetraImport.hpp"
+#include "Xpetra_EpetraExport.hpp"
+
+namespace Xpetra {
+
+
+  // TODO: move that elsewhere
+  template<class GlobalOrdinal, class Node>
+  Epetra_IntMultiVector & toEpetra(MultiVector<int, int, GlobalOrdinal,Node> &x) {
+    XPETRA_DYNAMIC_CAST(      EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, x, tX, "toEpetra");
+    return *tX.getEpetra_IntMultiVector();
+  }
+
+  template<class GlobalOrdinal, class Node>
+  const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal, Node> &x) {
+    XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, x, tX, "toEpetra");
+    return *tX.getEpetra_IntMultiVector();
+  }
+  //
+
+#ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
+#ifdef HAVE_XPETRA_TPETRA
+#include "TpetraCore_config.h"
+#if ((defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_OPENMP)) || \
+    (!defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_SERIAL)))
+template class EpetraIntMultiVectorT<int, Xpetra::EpetraNode >;
+template Epetra_IntMultiVector & toEpetra<int,Xpetra::EpetraNode >(MultiVector<int, int, int, Xpetra::EpetraNode> &);
+template const Epetra_IntMultiVector & toEpetra<int, Xpetra::EpetraNode >(const MultiVector<int, int, int, Xpetra::EpetraNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_SERIAL
+template class EpetraIntMultiVectorT<int, Kokkos::Compat::KokkosSerialWrapperNode >;
+template Epetra_IntMultiVector & toEpetra<int,Kokkos::Compat::KokkosSerialWrapperNode >(MultiVector<int, int, int, Kokkos::Compat::KokkosSerialWrapperNode> &);
+template const Epetra_IntMultiVector & toEpetra<int, Kokkos::Compat::KokkosSerialWrapperNode >(const MultiVector<int, int, int, Kokkos::Compat::KokkosSerialWrapperNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_PTHREAD
+template class EpetraIntMultiVectorT<int, Kokkos::Compat::KokkosThreadsWrapperNode>;
+template Epetra_IntMultiVector & toEpetra<int,Kokkos::Compat::KokkosThreadsWrapperNode >(MultiVector<int, int, int, Kokkos::Compat::KokkosThreadsWrapperNode> &);
+template const Epetra_IntMultiVector & toEpetra<int, Kokkos::Compat::KokkosThreadsWrapperNode >(const MultiVector<int, int, int, Kokkos::Compat::KokkosThreadsWrapperNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_OPENMP
+template class EpetraIntMultiVectorT<int, Kokkos::Compat::KokkosOpenMPWrapperNode >;
+template Epetra_IntMultiVector & toEpetra<int,Kokkos::Compat::KokkosOpenMPWrapperNode >(MultiVector<int, int, int, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
+template const Epetra_IntMultiVector & toEpetra<int, Kokkos::Compat::KokkosOpenMPWrapperNode >(const MultiVector<int, int, int, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_CUDA
+typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraIntMultiVectorT<int, default_node_type >;
+template Epetra_IntMultiVector & toEpetra<int,default_node_type >(MultiVector<int, int, int, default_node_type> &);
+template const Epetra_IntMultiVector & toEpetra<int,default_node_type >(const MultiVector<int, int, int, default_node_type> &);
+#endif
+#else
+// Tpetra is disabled and Kokkos not available: use dummy node type
+typedef Xpetra::EpetraNode default_node_type;
+template class EpetraIntMultiVectorT<int, default_node_type >;
+template Epetra_IntMultiVector & toEpetra<int,default_node_type >(MultiVector<int, int, int, default_node_type> &);
+template const Epetra_IntMultiVector & toEpetra<int,default_node_type >(const MultiVector<int, int, int, default_node_type> &);
+#endif // HAVE_XPETRA_TPETRA
+#endif
+
+#ifndef XPETRA_EPETRA_NO_64BIT_GLOBAL_INDICES
+#ifdef HAVE_XPETRA_TPETRA
+#include "TpetraCore_config.h"
+#if ((defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_OPENMP)) || \
+    (!defined(EPETRA_HAVE_OMP) && !defined(HAVE_TPETRA_INST_SERIAL)))
+template class EpetraIntMultiVectorT<long long, Xpetra::EpetraNode >;
+template Epetra_IntMultiVector & toEpetra<long long,Xpetra::EpetraNode >(MultiVector<int, int, long long, Xpetra::EpetraNode> &);
+template const Epetra_IntMultiVector & toEpetra<long long, Xpetra::EpetraNode >(const MultiVector<int, int, long long, Xpetra::EpetraNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_SERIAL
+template class EpetraIntMultiVectorT<long long, Kokkos::Compat::KokkosSerialWrapperNode >;
+template Epetra_IntMultiVector & toEpetra<long long,Kokkos::Compat::KokkosSerialWrapperNode >(MultiVector<int, int, long long, Kokkos::Compat::KokkosSerialWrapperNode> &);
+template const Epetra_IntMultiVector & toEpetra<long long, Kokkos::Compat::KokkosSerialWrapperNode >(const MultiVector<int, int, long long, Kokkos::Compat::KokkosSerialWrapperNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_PTHREAD
+template class EpetraIntMultiVectorT<long long, Kokkos::Compat::KokkosThreadsWrapperNode>;
+template Epetra_IntMultiVector & toEpetra<long long,Kokkos::Compat::KokkosThreadsWrapperNode >(MultiVector<int, int, long long, Kokkos::Compat::KokkosThreadsWrapperNode> &);
+template const Epetra_IntMultiVector & toEpetra<long long, Kokkos::Compat::KokkosThreadsWrapperNode >(const MultiVector<int, int, long long, Kokkos::Compat::KokkosThreadsWrapperNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_OPENMP
+template class EpetraIntMultiVectorT<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >;
+template Epetra_IntMultiVector & toEpetra<long long,Kokkos::Compat::KokkosOpenMPWrapperNode >(MultiVector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
+template const Epetra_IntMultiVector & toEpetra<long long, Kokkos::Compat::KokkosOpenMPWrapperNode >(const MultiVector<int, int, long long, Kokkos::Compat::KokkosOpenMPWrapperNode> &);
+#endif
+#ifdef HAVE_TPETRA_INST_CUDA
+typedef Kokkos::Compat::KokkosCudaWrapperNode default_node_type;
+template class EpetraIntMultiVectorT<long long, default_node_type >;
+template Epetra_IntMultiVector & toEpetra<long long,default_node_type >(MultiVector<int, int, long long, default_node_type> &);
+template const Epetra_IntMultiVector & toEpetra<long long,default_node_type >(const MultiVector<int, int, long long, default_node_type> &);
+#endif
+#else
+// Tpetra is disabled and Kokkos not available: use dummy node type
+typedef Xpetra::EpetraNode default_node_type;
+template class EpetraIntMultiVectorT<long long, default_node_type >;
+template Epetra_IntMultiVector & toEpetra<long long,default_node_type >(MultiVector<int, int, long long, default_node_type> &);
+template const Epetra_IntMultiVector & toEpetra<long long,default_node_type >(const MultiVector<int, int, long long, default_node_type> &);
+#endif // HAVE_XPETRA_TPETRA
+#endif
+
+} // namespace Xpetra

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
@@ -1,0 +1,1247 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//             Xpetra: A linear algebra interface package
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#ifndef XPETRA_EPETRAINTMULTIVECTOR_HPP
+#define XPETRA_EPETRAINTMULTIVECTOR_HPP
+
+#include "Xpetra_EpetraConfigDefs.hpp"
+
+#include "Xpetra_ConfigDefs.hpp"
+#include "Xpetra_MultiVector.hpp"
+#include "Xpetra_Exceptions.hpp"
+
+#include "Xpetra_EpetraMap.hpp"
+#include "Xpetra_EpetraMultiVector.hpp"
+#include "Epetra_IntMultiVector.h"
+
+namespace Xpetra {
+
+// TODO: move that elsewhere
+template<class GlobalOrdinal, class Node>
+Epetra_IntMultiVector & toEpetra(MultiVector<int, int, GlobalOrdinal, Node> &);
+
+template<class GlobalOrdinal, class Node>
+const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal, Node> &);
+//
+
+  // stub implementation for EpetraIntVectorT
+  template<class EpetraGlobalOrdinal, class Node>
+  class EpetraIntMultiVectorT
+    : public MultiVector<int,int,EpetraGlobalOrdinal, Node>
+  {
+    typedef int Scalar;
+    typedef int LocalOrdinal;
+    typedef EpetraGlobalOrdinal GlobalOrdinal;
+
+  public:
+
+    //! @name Constructor/Destructor Methods
+    //@{
+
+    //! Sets all vector entries to zero.
+    explicit EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, bool zeroOut=true)  {  }
+
+    //! Destructor.
+    ~EpetraIntMultiVectorT() {  };
+
+    //@}
+
+    //! @name Mathematical methods
+    //@{
+
+    //! TODO missing comment
+    int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntMultiVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+
+    //! Return 1-norm of this Vector.
+    Teuchos::ScalarTraits<int>::magnitudeType norm1() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+
+    //! Compute 2-norm of this Vector.
+    Teuchos::ScalarTraits<int>::magnitudeType norm2() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+    //! Compute Inf-norm of this Vector.
+    Teuchos::ScalarTraits<int>::magnitudeType normInf() const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+    //! Compute mean (average) value of this Vector.
+    int meanValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+    //! Compute max value of this Vector.
+    int maxValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+
+    //@}
+
+    //! @name Post-construction modification routines
+    //@{
+
+    //! Replace current value at the specified location with specified value.
+    void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Adds specified value to existing value at the specified location.
+    void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Replace current value at the specified location with specified values.
+    void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Adds specified value to existing value at the specified location.
+    void sumIntoLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Initialize all values in a multi-vector with specified value.
+    void putScalar(const int &value) {  }
+
+    //! Set multi-vector values to random numbers.
+    void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+
+
+    //! Set seed for Random function.
+    /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
+    void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
+
+
+    //@}
+
+    //! @name Data Copy and View get methods
+    //@{
+
+    //! Return a Vector which is a const view of column j.
+    Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+       TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+     }
+
+    //! Return a Vector which is a nonconst view of column j.
+    Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
+
+    //! Const Local vector access function.
+    //! View of the local values in a particular vector of this multi-vector.
+    Teuchos::ArrayRCP<const int> getData(size_t j) const { return Teuchos::ArrayRCP<const int>();  }
+
+    //! Local vector access function.
+    //! View of the local values in a particular vector of this multi-vector.
+    Teuchos::ArrayRCP<int> getDataNonConst(size_t j) { return Teuchos::ArrayRCP<int>(); }
+
+    //@}
+
+    //! @name Mathematical methods
+    //@{
+    //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
+    void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const { }
+
+    //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
+    void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {  }
+
+    //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
+    void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {  }
+
+    //! Scale the current values of a multi-vector, this = alpha*this.
+    void scale(const int &alpha) {  }
+
+    //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
+    void scale (Teuchos::ArrayView< const int > alpha) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
+
+    //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
+    void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::update");
+
+      // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
+
+    //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
+    void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::update");
+
+      //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+      //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, B, eB, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
+
+    //! Compute 1-norm of each vector in multi-vector.
+    void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Compute 2-norm of each vector in multi-vector.
+    void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Compute Inf-norm of each vector in multi-vector.
+    void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Compute mean (average) value of each vector in multi-vector.
+    void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Compute max value of each vector in multi-vector.
+    void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
+    void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+
+    //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
+    void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::elementWiseMultiply");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
+      }
+
+    //@}
+
+    //! @name Post-construction modification routines
+    //@{
+
+    //! Replace value, using global (row) index.
+    void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Add value to existing value, using global (row) index.
+    void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Replace value, using local (row) index.
+    void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //! Add value to existing value, using local (row) index.
+    void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+    //@}
+
+    //! @name Attribute access functions
+    //@{
+
+    //! Returns the number of vectors in the multi-vector.
+    size_t getNumVectors() const { XPETRA_MONITOR("EpetraIntMultiVectorT::getNumVectors"); return 1; }
+
+
+    //! Returns the local vector length on the calling processor of vectors in the multi-vector.
+    size_t getLocalLength() const {  return 0; }
+
+    //! Returns the global vector length of vectors in the multi-vector.
+    global_size_t getGlobalLength() const {  return 0; }
+   
+    //! Checks to see if the local length, number of vectors and size of Scalar type match
+    bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { return false; }
+
+    //@}
+
+    //! @name Overridden from Teuchos::Describable
+    //@{
+
+    //! Return a simple one-line description of this object.
+    std::string description() const {
+      return std::string("");
+    }
+
+    //! Print the object with some verbosity level to an FancyOStream object.
+    void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const { }
+
+    //@}
+
+    RCP< Epetra_IntMultiVector > getEpetra_IntMultiVector() const {  return Teuchos::null; }
+
+    const RCP<const Comm<int> > getComm() const {
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO getComm Epetra MultiVector not implemented");
+    }
+
+    // Implementing DistObject
+    Teuchos::RCP<const Map<int, GlobalOrdinal, Node> > getMap () const {
+      return Teuchos::null;
+    }
+
+    void doImport(const DistObject<int, int, GlobalOrdinal, Node> &source,
+                                    const Import<int, GlobalOrdinal, Node> &importer, CombineMode CM) {  }
+
+    void doExport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &dest,
+                                   const Import<int, GlobalOrdinal, Node>& importer, CombineMode CM) {  }
+
+    void doImport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &source,
+                                   const Export<int, GlobalOrdinal, Node>& exporter, CombineMode CM) {  }
+
+    void doExport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &dest,
+                                   const Export<int, GlobalOrdinal, Node>& exporter, CombineMode CM) {  }
+
+    void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
+      // do nothing
+    }
+
+
+    //! @name Xpetra specific
+    //@{
+#ifdef HAVE_XPETRA_KOKKOS_REFACTOR
+    typedef typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
+
+    typename dual_view_type::t_host_um getHostLocalView () const {
+      throw std::runtime_error("EpetraIntVector does not support device views! Must be implemented extra...");
+#ifndef __NVCC__ //prevent nvcc warning
+      typename dual_view_type::t_host_um ret;
+#endif
+      TEUCHOS_UNREACHABLE_RETURN(ret);
+    }
+
+    typename dual_view_type::t_dev_um getDeviceLocalView() const {
+      throw std::runtime_error("Epetra does not support device views!");
+#ifndef __NVCC__ //prevent nvcc warning
+      typename dual_view_type::t_dev_um ret;
+#endif
+      TEUCHOS_UNREACHABLE_RETURN(ret);
+    }
+
+    /// \brief Return an unmanaged non-const view of the local data on a specific device.
+    /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
+    ///
+    /// \warning DO NOT USE THIS FUNCTION! There is no reason why you are working directly
+    ///          with the Xpetra::EpetraIntVector object. To write a code which is independent
+    ///          from the underlying linear algebra package you should always use the abstract class,
+    ///          i.e. Xpetra::Vector!
+    ///
+    /// \warning Be aware that the view on the vector data is non-persisting, i.e.
+    ///          only valid as long as the vector does not run of scope!
+    template<class TargetDeviceType>
+    typename Kokkos::Impl::if_c<
+      Kokkos::Impl::is_same<
+        typename dual_view_type::t_dev_um::execution_space::memory_space,
+        typename TargetDeviceType::memory_space>::value,
+        typename dual_view_type::t_dev_um,
+        typename dual_view_type::t_host_um>::type
+    getLocalView () const {
+      return this->MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::template getLocalView<TargetDeviceType>();
+    }
+#endif
+
+    //@}
+
+  protected:
+    /// \brief Implementation of the assignment operator (operator=);
+    ///   does a deep copy.
+    virtual void
+    assign (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& rhs)
+    {  }
+
+
+  private:
+    //! The Epetra_IntMultiVector which this class wraps.
+    //RCP< Epetra_IntMultiVector > vec_;
+
+  }; // class EpetraIntMultiVectorT
+
+  // specialization on GO=int and Node=Serial
+#ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
+  template<>
+  class EpetraIntMultiVectorT<int, EpetraNode>
+    : public virtual Vector<int,int,int,EpetraNode>
+  {
+      typedef int Scalar;
+      typedef int LocalOrdinal;
+      typedef int GlobalOrdinal;
+      typedef EpetraNode Node;
+
+    public:
+
+      //! @name Constructor/Destructor Methods
+      //@{
+
+      //! Sets all vector entries to zero.
+      explicit EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, bool zeroOut=true)
+      {
+        vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(map), zeroOut));
+      }
+
+      //! Destructor.
+      ~EpetraIntMultiVectorT() {  };
+
+      //@}
+
+      //! @name Mathematical methods
+      //@{
+
+      //! TODO missing comment
+      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntMultiVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+
+      //! Return 1-norm of this Vector.
+      Teuchos::ScalarTraits<int>::magnitudeType norm1() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+
+      //! Compute 2-norm of this Vector.
+      Teuchos::ScalarTraits<int>::magnitudeType norm2() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+      //! Compute Inf-norm of this Vector.
+      Teuchos::ScalarTraits<int>::magnitudeType normInf() const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+      //! Compute mean (average) value of this Vector.
+      int meanValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+
+      //! Compute max value of this Vector.
+      int maxValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); return vec_->MaxValue(); }
+
+
+      //@}
+
+      //! @name Post-construction modification routines
+      //@{
+
+      //! Replace current value at the specified location with specified value.
+      void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Adds specified value to existing value at the specified location.
+      void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Replace current value at the specified location with specified values.
+      void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue");(*vec_)[myRow] = value; }
+
+      //! Adds specified value to existing value at the specified location.
+      void sumIntoLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); (*vec_)[myRow] += value;}
+
+      //! Initialize all values in a multi-vector with specified value.
+      void putScalar(const int &value) {  vec_->PutValue(value); }
+
+      //! Set multi-vector values to random numbers.
+      void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+
+
+      //! Set seed for Random function.
+      /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
+      void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
+
+
+      //@}
+
+      //! @name Data Copy and View get methods
+      //@{
+
+      //! Return a Vector which is a const view of column j.
+      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+       }
+
+      //! Return a Vector which is a nonconst view of column j.
+      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Const Local vector access function.
+      //! View of the local values in a particular vector of this multi-vector.
+      Teuchos::ArrayRCP<const int> getData(size_t j) const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::getData");
+
+        int * data = vec_->Values();
+        int localLength = vec_->MyLength();
+
+        return ArrayRCP<int>(data, 0, localLength, false); // not ownership
+      }
+
+      //! Local vector access function.
+      //! View of the local values in a particular vector of this multi-vector.
+      Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::getDataNonConst");
+
+        int * data = vec_->Values();
+        int localLength = vec_->MyLength();
+
+        return ArrayRCP<int>(data, 0, localLength, false); // not ownership
+      }
+
+      //@}
+
+      //! @name Mathematical methods
+      //@{
+      //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::dot");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
+      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::abs");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
+      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::reciprocal");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Scale the current values of a multi-vector, this = alpha*this.
+      void scale(const int &alpha) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
+      void scale (Teuchos::ArrayView< const int > alpha) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
+      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::update");
+
+        // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
+      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::update");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, B, eB, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Compute 1-norm of each vector in multi-vector.
+      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute 2-norm of each vector in multi-vector.
+      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute Inf-norm of each vector in multi-vector.
+      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute mean (average) value of each vector in multi-vector.
+      void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute max value of each vector in multi-vector.
+      void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
+      void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+
+      //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
+      void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+          XPETRA_MONITOR("EpetraIntMultiVectorT::elementWiseMultiply");
+          TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
+        }
+
+      //@}
+
+      //! @name Post-construction modification routines
+      //@{
+
+      //! Replace value, using global (row) index.
+      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Add value to existing value, using global (row) index.
+      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Replace value, using local (row) index.
+      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Add value to existing value, using local (row) index.
+      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //@}
+
+      //! @name Attribute access functions
+      //@{
+
+      //! Returns the number of vectors in the multi-vector.
+      size_t getNumVectors() const { XPETRA_MONITOR("EpetraIntMultiVectorT::getNumVectors"); return 1; }
+
+
+      //! Returns the local vector length on the calling processor of vectors in the multi-vector.
+      size_t getLocalLength() const {  return vec_->MyLength(); }
+
+      //! Returns the global vector length of vectors in the multi-vector.
+      global_size_t getGlobalLength() const {  return vec_->GlobalLength64(); }
+
+      //! Checks to see if the local length, number of vectors and size of Scalar type match
+      bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
+        XPETRA_MONITOR("EpetraIntMultiVectorT::isSameSize"); 
+        const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> *asvec = dynamic_cast<const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> *>(&vec);
+        if(!asvec) return false;
+        auto vv = toEpetra(*asvec); 
+        return ( (vec_->MyLength() == vv.MyLength()) && (getNumVectors() == vec.getNumVectors()));
+      }
+
+      //@}
+
+      //! @name Overridden from Teuchos::Describable
+      //@{
+
+      //! Return a simple one-line description of this object.
+      std::string description() const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::description");
+
+        // This implementation come from Epetra_Vector_def.hpp (without modification)
+        std::ostringstream oss;
+        oss << Teuchos::Describable::description();
+        oss << "{length="<<this->getGlobalLength()
+            << "}";
+        return oss.str();
+      }
+
+      //! Print the object with some verbosity level to an FancyOStream object.
+      void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {
+         XPETRA_MONITOR("EpetraIntMultiVectorT::describe");
+
+         // This implementation come from Tpetra_Vector_def.hpp (without modification) // JG: true?
+         using std::endl;
+         using std::setw;
+         using Teuchos::VERB_DEFAULT;
+         using Teuchos::VERB_NONE;
+         using Teuchos::VERB_LOW;
+         using Teuchos::VERB_MEDIUM;
+         using Teuchos::VERB_HIGH;
+         using Teuchos::VERB_EXTREME;
+
+         if (verbLevel > Teuchos::VERB_NONE)
+           vec_->Print(out);
+       }
+
+      //@}
+
+      RCP< Epetra_IntMultiVector > getEpetra_IntMultiVector() const {  return vec_; }
+
+      const RCP<const Comm<int> > getComm() const {
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO getComm Epetra MultiVector not implemented");
+      }
+
+      // Implementing DistObject
+      Teuchos::RCP<const Map<int, GlobalOrdinal, Node> > getMap () const {
+        RCP<const Epetra_BlockMap> map = rcp(new Epetra_BlockMap(vec_->Map()));
+        return rcp (new Xpetra::EpetraMapT<GlobalOrdinal, Node>(map));
+      }
+
+      void doImport(const DistObject<int, int, GlobalOrdinal, Node> &source,
+                                      const Import<int, GlobalOrdinal, Node> &importer, CombineMode CM) {
+         XPETRA_MONITOR("EpetraIntMultiVectorT::doImport");
+
+         XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, source, tSource, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+         XPETRA_DYNAMIC_CAST(const EpetraImportT<GlobalOrdinal XPETRA_COMMA Node>, importer, tImporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+         const Epetra_IntMultiVector & v = *tSource.getEpetra_IntMultiVector();
+         int err = vec_->Import(v, *tImporter.getEpetra_Import(), toEpetra(CM));
+         TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+       }
+
+      void doExport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &dest,
+                                     const Import<int, GlobalOrdinal, Node>& importer, CombineMode CM) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::doExport");
+
+        XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, dest, tDest, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+        XPETRA_DYNAMIC_CAST(const EpetraImportT<GlobalOrdinal XPETRA_COMMA Node>, importer, tImporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+        const Epetra_IntMultiVector & v = *tDest.getEpetra_IntMultiVector();
+        int err = vec_->Import(v, *tImporter.getEpetra_Import(), toEpetra(CM));
+        TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+      }
+
+      void doImport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &source,
+                                     const Export<int, GlobalOrdinal, Node>& exporter, CombineMode CM) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::doImport");
+
+        XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, source, tSource, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+        XPETRA_DYNAMIC_CAST(const EpetraExportT<GlobalOrdinal XPETRA_COMMA Node>, exporter, tExporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+        const Epetra_IntMultiVector & v = *tSource.getEpetra_IntMultiVector();
+        int err = vec_->Import(v, *tExporter.getEpetra_Export(), toEpetra(CM));
+        TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+      }
+
+      void doExport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &dest,
+                                     const Export<int, GlobalOrdinal, Node>& exporter, CombineMode CM) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::doExport");
+
+        XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, dest, tDest, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+        XPETRA_DYNAMIC_CAST(const EpetraExportT<GlobalOrdinal XPETRA_COMMA Node>, exporter, tExporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+        const Epetra_IntMultiVector & v = *tDest.getEpetra_IntMultiVector();
+        int err = vec_->Export(v, *tExporter.getEpetra_Export(), toEpetra(CM));
+        TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+      }
+
+      void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
+        // do nothing
+      }
+
+
+      //! @name Xpetra specific
+      //@{
+  #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
+      typedef typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
+
+      typename dual_view_type::t_host_um getHostLocalView () const {
+        typedef Kokkos::View< typename dual_view_type::t_host::data_type ,
+                      Kokkos::LayoutLeft,
+                      typename dual_view_type::t_host::device_type ,
+                      Kokkos::MemoryUnmanaged> epetra_view_type;
+
+        // access Epetra vector data
+        int* data = NULL;
+        vec_->ExtractView(&data);
+        int localLength = vec_->MyLength();
+
+        // create view
+        epetra_view_type test = epetra_view_type(data, localLength,1);
+        typename dual_view_type::t_host_um ret = subview(test, Kokkos::ALL(), Kokkos::ALL());
+
+        return ret;
+      }
+
+      typename dual_view_type::t_dev_um getDeviceLocalView() const {
+        throw std::runtime_error("Epetra does not support device views!");
+#ifndef __NVCC__ //prevent nvcc warning
+        typename dual_view_type::t_dev_um ret;
+#endif
+        TEUCHOS_UNREACHABLE_RETURN(ret);
+      }
+
+      /// \brief Return an unmanaged non-const view of the local data on a specific device.
+      /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
+      ///
+      /// \warning DO NOT USE THIS FUNCTION! There is no reason why you are working directly
+      ///          with the Xpetra::EpetraIntVector object. To write a code which is independent
+      ///          from the underlying linear algebra package you should always use the abstract class,
+      ///          i.e. Xpetra::Vector!
+      ///
+      /// \warning Be aware that the view on the vector data is non-persisting, i.e.
+      ///          only valid as long as the vector does not run of scope!
+      template<class TargetDeviceType>
+      typename Kokkos::Impl::if_c<
+        Kokkos::Impl::is_same<
+          typename dual_view_type::t_dev_um::execution_space::memory_space,
+          typename TargetDeviceType::memory_space>::value,
+          typename dual_view_type::t_dev_um,
+          typename dual_view_type::t_host_um>::type
+      getLocalView () const {
+        return this->MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::template getLocalView<TargetDeviceType>();
+      }
+  #endif
+
+      //@}
+
+    protected:
+      /// \brief Implementation of the assignment operator (operator=);
+      ///   does a deep copy.
+      virtual void
+      assign (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& rhs)
+      {
+        typedef EpetraIntMultiVectorT<GlobalOrdinal, Node> this_type;
+        const this_type* rhsPtr = dynamic_cast<const this_type*> (&rhs);
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          rhsPtr == NULL, std::invalid_argument, "Xpetra::MultiVector::operator=: "
+          "The left-hand side (LHS) of the assignment has a different type than "
+          "the right-hand side (RHS).  The LHS has type Xpetra::EpetraIntMultiVectorT "
+          "(which means it wraps an Epetra_IntMultiVector), but the RHS has some "
+          "other type.  This probably means that the RHS wraps either an "
+          "Tpetra::MultiVector, or an Epetra_MultiVector.  Xpetra::MultiVector "
+          "does not currently implement assignment from a Tpetra object to an "
+          "Epetra object, though this could be added with sufficient interest.");
+
+        RCP<const Epetra_IntMultiVector> rhsImpl = rhsPtr->getEpetra_IntMultiVector ();
+        RCP<Epetra_IntMultiVector> lhsImpl = this->getEpetra_IntMultiVector ();
+
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          rhsImpl.is_null (), std::logic_error, "Xpetra::MultiVector::operator= "
+          "(in Xpetra::EpetraIntMultiVectorT::assign): *this (the right-hand side of "
+          "the assignment) has a null RCP<Epetra_IntMultiVector> inside.  Please "
+          "report this bug to the Xpetra developers.");
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          lhsImpl.is_null (), std::logic_error, "Xpetra::MultiVector::operator= "
+          "(in Xpetra::EpetraIntMultiVectorT::assign): The left-hand side of the "
+          "assignment has a null RCP<Epetra_IntMultiVector> inside.  Please report "
+          "this bug to the Xpetra developers.");
+
+        // Epetra_IntMultiVector's assignment operator does a deep copy.
+        *lhsImpl = *rhsImpl;
+      }
+
+
+    private:
+      //! The Epetra_IntMultiVector which this class wraps.
+      RCP< Epetra_IntMultiVector > vec_;
+  };
+#endif
+
+  // specialization on GO=long long and Node=Serial
+#ifndef XPETRA_EPETRA_NO_64BIT_GLOBAL_INDICES
+  template<>
+  class EpetraIntMultiVectorT<long long, EpetraNode>
+    : public virtual Vector<int,int,long long,EpetraNode>
+  {
+      typedef int Scalar;
+      typedef int LocalOrdinal;
+      typedef long long GlobalOrdinal;
+      typedef EpetraNode Node;
+
+    public:
+
+      //! @name Constructor/Destructor Methods
+      //@{
+
+      //! Sets all vector entries to zero.
+      explicit EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, bool zeroOut=true)
+      {
+        vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(map), zeroOut));
+      }
+
+      //! Destructor.
+      ~EpetraIntMultiVectorT() {  };
+
+      //@}
+
+      //! @name Mathematical methods
+      //@{
+
+      //! TODO missing comment
+      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntMultiVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
+
+
+      //! Return 1-norm of this Vector.
+      Teuchos::ScalarTraits<int>::magnitudeType norm1() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
+
+
+      //! Compute 2-norm of this Vector.
+      Teuchos::ScalarTraits<int>::magnitudeType norm2() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
+
+      //! Compute Inf-norm of this Vector.
+      Teuchos::ScalarTraits<int>::magnitudeType normInf() const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
+
+      //! Compute mean (average) value of this Vector.
+      int meanValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
+
+      //! Compute max value of this Vector.
+      int maxValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); return Teuchos::as<int>(vec_->MaxValue()); }
+
+      //@}
+
+      //! @name Post-construction modification routines
+      //@{
+
+      //! Replace current value at the specified location with specified value.
+      void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Adds specified value to existing value at the specified location.
+      void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Replace current value at the specified location with specified values.
+      void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue");(*vec_)[myRow] = value;}
+
+      //! Adds specified value to existing value at the specified location.
+      void sumIntoLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); (*vec_)[myRow] += value;}
+
+      //! Initialize all values in a multi-vector with specified value.
+      void putScalar(const int &value) {  vec_->PutValue(value); }
+
+      //! Set multi-vector values to random numbers.
+      void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+
+
+      //! Set seed for Random function.
+      /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
+      void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
+
+
+      //@}
+
+      //! @name Data Copy and View get methods
+      //@{
+
+      //! Return a Vector which is a const view of column j.
+      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+       }
+
+      //! Return a Vector which is a nonconst view of column j.
+      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Const Local vector access function.
+      //! View of the local values in a particular vector of this multi-vector.
+      Teuchos::ArrayRCP<const int> getData(size_t j) const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::getData");
+
+        int * data = vec_->Values();
+        int localLength = vec_->MyLength();
+
+        return ArrayRCP<int>(data, 0, localLength, false); // not ownership
+      }
+
+      //! Local vector access function.
+      //! View of the local values in a particular vector of this multi-vector.
+      Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::getDataNonConst");
+
+        int * data = vec_->Values();
+        int localLength = vec_->MyLength();
+
+        return ArrayRCP<int>(data, 0, localLength, false); // not ownership
+      }
+
+      //@}
+
+      //! @name Mathematical methods
+      //@{
+      //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::dot");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
+      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::abs");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
+      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::reciprocal");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Scale the current values of a multi-vector, this = alpha*this.
+      void scale(const int &alpha) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
+      void scale (Teuchos::ArrayView< const int > alpha) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
+      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::update");
+
+        // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
+      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::update");
+
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, B, eB, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      }
+
+      //! Compute 1-norm of each vector in multi-vector.
+      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute 2-norm of each vector in multi-vector.
+      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute Inf-norm of each vector in multi-vector.
+      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute mean (average) value of each vector in multi-vector.
+      void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Compute max value of each vector in multi-vector.
+      void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
+      void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+
+      //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
+      void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+          XPETRA_MONITOR("EpetraIntMultiVectorT::elementWiseMultiply");
+          TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
+        }
+
+      //@}
+
+      //! @name Post-construction modification routines
+      //@{
+
+      //! Replace value, using global (row) index.
+      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Add value to existing value, using global (row) index.
+      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Replace value, using local (row) index.
+      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //! Add value to existing value, using local (row) index.
+      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+
+      //@}
+
+      //! @name Attribute access functions
+      //@{
+
+      //! Returns the number of vectors in the multi-vector.
+      size_t getNumVectors() const { XPETRA_MONITOR("EpetraIntMultiVectorT::getNumVectors"); return 1; }
+
+
+      //! Returns the local vector length on the calling processor of vectors in the multi-vector.
+      size_t getLocalLength() const {  return vec_->MyLength(); }
+
+      //! Returns the global vector length of vectors in the multi-vector.
+      global_size_t getGlobalLength() const {  return vec_->GlobalLength64(); }
+
+
+      //! Checks to see if the local length, number of vectors and size of Scalar type match
+      bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
+        XPETRA_MONITOR("EpetraIntMultiVectorT::isSameSize"); 
+        const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>  *asvec = dynamic_cast<const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>* >(&vec);
+        if(!asvec) return false;
+        auto vv = toEpetra(*asvec); 
+        return ( (vec_->MyLength() == vv.MyLength()) && (getNumVectors() == vec.getNumVectors()));
+      }
+      //@}
+
+      //! @name Overridden from Teuchos::Describable
+      //@{
+
+      //! Return a simple one-line description of this object.
+      std::string description() const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::description");
+
+        // This implementation come from Epetra_Vector_def.hpp (without modification)
+        std::ostringstream oss;
+        oss << Teuchos::Describable::description();
+        oss << "{length="<<this->getGlobalLength()
+            << "}";
+        return oss.str();
+      }
+
+      //! Print the object with some verbosity level to an FancyOStream object.
+      void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {
+         XPETRA_MONITOR("EpetraIntMultiVectorT::describe");
+
+         // This implementation come from Tpetra_Vector_def.hpp (without modification) // JG: true?
+         using std::endl;
+         using std::setw;
+         using Teuchos::VERB_DEFAULT;
+         using Teuchos::VERB_NONE;
+         using Teuchos::VERB_LOW;
+         using Teuchos::VERB_MEDIUM;
+         using Teuchos::VERB_HIGH;
+         using Teuchos::VERB_EXTREME;
+
+         if (verbLevel > Teuchos::VERB_NONE)
+           vec_->Print(out);
+       }
+
+      //@}
+
+      RCP< Epetra_IntMultiVector > getEpetra_IntMultiVector() const {  return vec_; }
+
+      const RCP<const Comm<int> > getComm() const {
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO getComm Epetra MultiVector not implemented");
+      }
+
+      // Implementing DistObject
+      Teuchos::RCP<const Map<int, GlobalOrdinal, Node> > getMap () const {
+        RCP<const Epetra_BlockMap> map = rcp(new Epetra_BlockMap(vec_->Map()));
+        return rcp (new Xpetra::EpetraMapT<GlobalOrdinal, Node>(map));
+      }
+
+      void doImport(const DistObject<int, int, GlobalOrdinal, Node> &source,
+                                      const Import<int, GlobalOrdinal, Node> &importer, CombineMode CM) {
+         XPETRA_MONITOR("EpetraIntMultiVectorT::doImport");
+
+         XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, source, tSource, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+         XPETRA_DYNAMIC_CAST(const EpetraImportT<GlobalOrdinal XPETRA_COMMA Node>, importer, tImporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+         const Epetra_IntMultiVector & v = *tSource.getEpetra_IntMultiVector();
+         int err = vec_->Import(v, *tImporter.getEpetra_Import(), toEpetra(CM));
+         TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+       }
+
+      void doExport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &dest,
+                                     const Import<int, GlobalOrdinal, Node>& importer, CombineMode CM) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::doExport");
+
+        XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, dest, tDest, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+        XPETRA_DYNAMIC_CAST(const EpetraImportT<GlobalOrdinal XPETRA_COMMA Node>, importer, tImporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+        const Epetra_IntMultiVector & v = *tDest.getEpetra_IntMultiVector();
+        int err = vec_->Import(v, *tImporter.getEpetra_Import(), toEpetra(CM));
+        TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+      }
+
+      void doImport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &source,
+                                     const Export<int, GlobalOrdinal, Node>& exporter, CombineMode CM) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::doImport");
+
+        XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, source, tSource, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+        XPETRA_DYNAMIC_CAST(const EpetraExportT<GlobalOrdinal XPETRA_COMMA Node>, exporter, tExporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+        const Epetra_IntMultiVector & v = *tSource.getEpetra_IntMultiVector();
+        int err = vec_->Import(v, *tExporter.getEpetra_Export(), toEpetra(CM));
+        TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+      }
+
+      void doExport(const DistObject<int, LocalOrdinal, GlobalOrdinal, Node> &dest,
+                                     const Export<int, GlobalOrdinal, Node>& exporter, CombineMode CM) {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::doExport");
+
+        XPETRA_DYNAMIC_CAST(const EpetraIntMultiVectorT<GlobalOrdinal XPETRA_COMMA Node>, dest, tDest, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraIntMultiVectorT as input arguments.");
+        XPETRA_DYNAMIC_CAST(const EpetraExportT<GlobalOrdinal XPETRA_COMMA Node>, exporter, tExporter, "Xpetra::EpetraIntMultiVectorT::doImport only accept Xpetra::EpetraImportT as input arguments.");
+
+        const Epetra_IntMultiVector & v = *tDest.getEpetra_IntMultiVector();
+        int err = vec_->Export(v, *tExporter.getEpetra_Export(), toEpetra(CM));
+        TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
+      }
+
+      void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
+        // do nothing
+      }
+
+
+      //! @name Xpetra specific
+      //@{
+  #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
+      typedef typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
+
+      typename dual_view_type::t_host_um getHostLocalView () const {
+        typedef Kokkos::View< typename dual_view_type::t_host::data_type ,
+                      Kokkos::LayoutLeft,
+                      typename dual_view_type::t_host::device_type ,
+                      Kokkos::MemoryUnmanaged> epetra_view_type;
+
+        // access Epetra vector data
+        int* data = NULL;
+        vec_->ExtractView(&data);
+        int localLength = vec_->MyLength();
+
+        // create view
+        epetra_view_type test = epetra_view_type(data, localLength, 1);
+        typename dual_view_type::t_host_um ret = subview(test, Kokkos::ALL(), Kokkos::ALL());
+
+        return ret;
+      }
+
+      typename dual_view_type::t_dev_um getDeviceLocalView() const {
+        throw std::runtime_error("Epetra does not support device views!");
+#ifndef __NVCC__ //prevent nvcc warning
+        typename dual_view_type::t_dev_um ret;
+#endif
+        TEUCHOS_UNREACHABLE_RETURN(ret);
+      }
+
+      /// \brief Return an unmanaged non-const view of the local data on a specific device.
+      /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
+      ///
+      /// \warning DO NOT USE THIS FUNCTION! There is no reason why you are working directly
+      ///          with the Xpetra::EpetraIntVector object. To write a code which is independent
+      ///          from the underlying linear algebra package you should always use the abstract class,
+      ///          i.e. Xpetra::Vector!
+      ///
+      /// \warning Be aware that the view on the vector data is non-persisting, i.e.
+      ///          only valid as long as the vector does not run of scope!
+      template<class TargetDeviceType>
+      typename Kokkos::Impl::if_c<
+        Kokkos::Impl::is_same<
+          typename dual_view_type::t_dev_um::execution_space::memory_space,
+          typename TargetDeviceType::memory_space>::value,
+          typename dual_view_type::t_dev_um,
+          typename dual_view_type::t_host_um>::type
+      getLocalView () const {
+        return this->MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node >::template getLocalView<TargetDeviceType>();
+      }
+  #endif
+
+      //@}
+
+    protected:
+      /// \brief Implementation of the assignment operator (operator=);
+      ///   does a deep copy.
+      virtual void
+      assign (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& rhs)
+      {
+        typedef EpetraIntMultiVectorT<GlobalOrdinal, Node> this_type;
+        const this_type* rhsPtr = dynamic_cast<const this_type*> (&rhs);
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          rhsPtr == NULL, std::invalid_argument, "Xpetra::MultiVector::operator=: "
+          "The left-hand side (LHS) of the assignment has a different type than "
+          "the right-hand side (RHS).  The LHS has type Xpetra::EpetraIntMultiVectorT "
+          "(which means it wraps an Epetra_IntMultiVector), but the RHS has some "
+          "other type.  This probably means that the RHS wraps either an "
+          "Tpetra::MultiVector, or an Epetra_MultiVector.  Xpetra::MultiVector "
+          "does not currently implement assignment from a Tpetra object to an "
+          "Epetra object, though this could be added with sufficient interest.");
+
+        RCP<const Epetra_IntMultiVector> rhsImpl = rhsPtr->getEpetra_IntMultiVector ();
+        RCP<Epetra_IntMultiVector> lhsImpl = this->getEpetra_IntMultiVector ();
+
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          rhsImpl.is_null (), std::logic_error, "Xpetra::MultiVector::operator= "
+          "(in Xpetra::EpetraIntMultiVectorT::assign): *this (the right-hand side of "
+          "the assignment) has a null RCP<Epetra_IntMultiVector> inside.  Please "
+          "report this bug to the Xpetra developers.");
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          lhsImpl.is_null (), std::logic_error, "Xpetra::MultiVector::operator= "
+          "(in Xpetra::EpetraIntMultiVectorT::assign): The left-hand side of the "
+          "assignment has a null RCP<Epetra_IntMultiVector> inside.  Please report "
+          "this bug to the Xpetra developers.");
+
+        // Epetra_IntMultiVector's assignment operator does a deep copy.
+        *lhsImpl = *rhsImpl;
+      }
+
+
+    private:
+      //! The Epetra_IntMultiVector which this class wraps.
+      RCP< Epetra_IntMultiVector > vec_;
+  };
+#endif
+
+
+} // namespace Xpetra
+
+#endif // XPETRA_EPETRAINTMULTIVECTOR_HPP

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
@@ -66,7 +66,7 @@ template<class GlobalOrdinal, class Node>
 const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal, Node> &);
 //
 
-  // stub implementation for EpetraIntVectorT
+  // stub implementation for EpetraIntMultiVectorT
   template<class EpetraGlobalOrdinal, class Node>
   class EpetraIntMultiVectorT
     : public MultiVector<int,int,EpetraGlobalOrdinal, Node>
@@ -81,53 +81,30 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
     //@{
 
     //! Sets all vector entries to zero.
-    explicit EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, bool zeroOut=true)  {  }
+    EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, size_t NumVectors, bool zeroOut=true)  {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+        "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
+    }
+
+    //! MultiVector copy constructor.
+    EpetraIntMultiVectorT(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source) {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+        "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
+    }
+
+    //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
+    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+        "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
+    }
 
     //! Destructor.
     ~EpetraIntMultiVectorT() {  };
 
     //@}
 
-    //! @name Mathematical methods
-    //@{
-
-    //! TODO missing comment
-    int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntMultiVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-
-    //! Return 1-norm of this Vector.
-    Teuchos::ScalarTraits<int>::magnitudeType norm1() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-
-    //! Compute 2-norm of this Vector.
-    Teuchos::ScalarTraits<int>::magnitudeType norm2() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-    //! Compute Inf-norm of this Vector.
-    Teuchos::ScalarTraits<int>::magnitudeType normInf() const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-    //! Compute mean (average) value of this Vector.
-    int meanValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-    //! Compute max value of this Vector.
-    int maxValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-
-    //@}
-
     //! @name Post-construction modification routines
     //@{
-
-    //! Replace current value at the specified location with specified value.
-    void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-    //! Adds specified value to existing value at the specified location.
-    void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-    //! Replace current value at the specified location with specified values.
-    void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-    //! Adds specified value to existing value at the specified location.
-    void sumIntoLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
     //! Initialize all values in a multi-vector with specified value.
     void putScalar(const int &value) {  }
@@ -138,7 +115,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
     //! Set seed for Random function.
     /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
-    void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
+    void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
 
 
     //@}
@@ -148,34 +127,45 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
     //! Return a Vector which is a const view of column j.
     Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
-       TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      return Teuchos::null;
      }
 
     //! Return a Vector which is a nonconst view of column j.
     Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
-      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      return Teuchos::null;
     }
 
     //! Const Local vector access function.
     //! View of the local values in a particular vector of this multi-vector.
-    Teuchos::ArrayRCP<const int> getData(size_t j) const { return Teuchos::ArrayRCP<const int>();  }
+    Teuchos::ArrayRCP<const int> getData(size_t j) const {
+      return Teuchos::ArrayRCP<const int>();
+    }
 
     //! Local vector access function.
     //! View of the local values in a particular vector of this multi-vector.
-    Teuchos::ArrayRCP<int> getDataNonConst(size_t j) { return Teuchos::ArrayRCP<int>(); }
+    Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
+      return Teuchos::ArrayRCP<int>();
+    }
 
     //@}
 
     //! @name Mathematical methods
     //@{
     //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-    void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const { }
+    void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A,
+             const Teuchos::ArrayView<int> &dots) const {
+      TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented,
+                                 "This function is not implemented in Epetra_IntMultiVector");
+    }
 
     //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
     void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {  }
 
     //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
-    void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {  }
+    void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented,
+                                 "This function is not implemented in Epetra_IntMultiVector");
+    }
 
     //! Scale the current values of a multi-vector, this = alpha*this.
     void scale(const int &alpha) {  }
@@ -183,48 +173,69 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
     //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
     void scale (Teuchos::ArrayView< const int > alpha) {
       XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
-      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::scale(): Functionnality not available in Epetra");
     }
 
     //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
     void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
       XPETRA_MONITOR("EpetraIntMultiVectorT::update");
-
-      // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::update(): Functionnality not available in Epetra");
     }
 
     //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
     void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
       XPETRA_MONITOR("EpetraIntMultiVectorT::update");
-
-      //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-      //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, B, eB, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::update(): Functionnality not available in Epetra");
     }
 
     //! Compute 1-norm of each vector in multi-vector.
-    void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::norm1");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::norm1(): Functionnality not available in Epetra");
+    }
 
     //! Compute 2-norm of each vector in multi-vector.
-    void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::norm2");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::norm2(): Functionnality not available in Epetra"); }
 
     //! Compute Inf-norm of each vector in multi-vector.
-    void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::normInf");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::normInf(): Functionnality not available in Epetra"); }
 
     //! Compute mean (average) value of each vector in multi-vector.
-    void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void meanValue(const Teuchos::ArrayView<int> &means) const {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::meanValue(): Functionnality not available in Epetra");
+    }
 
     //! Compute max value of each vector in multi-vector.
-    void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void maxValue(const Teuchos::ArrayView<int> &maxs) const {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::maxValue(): Functionnality not available in Epetra");
+    }
 
     //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
-    void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+    void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::multiply");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                 "Xpetra::EpetraIntMultiVectorT::multiply(): Functionnality not available in Epetra");
+    }
 
     //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
     void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::elementWiseMultiply");
-        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                   "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
       }
 
     //@}
@@ -233,16 +244,28 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
     //@{
 
     //! Replace value, using global (row) index.
-    void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
 
     //! Add value to existing value, using global (row) index.
-    void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
 
     //! Replace value, using local (row) index.
-    void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
 
     //! Add value to existing value, using local (row) index.
-    void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+    void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+      XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue");
+      TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+    }
 
     //@}
 
@@ -368,7 +391,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
   template<>
   class EpetraIntMultiVectorT<int, EpetraNode>
-    : public virtual Vector<int,int,int,EpetraNode>
+    : public virtual MultiVector<int,int,int,EpetraNode>
   {
       typedef int Scalar;
       typedef int LocalOrdinal;
@@ -381,59 +404,35 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Sets all vector entries to zero.
-      explicit EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, bool zeroOut=true)
-      {
-        vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(map), zeroOut));
-      }
+    EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, size_t NumVectors, bool zeroOut=true) {
+      vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(map), NumVectors, zeroOut));
+    }
+
+    //! MultiVector copy constructor.
+    EpetraIntMultiVectorT(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source) {
+      vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(source)));
+    }
+
+    //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
+    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+        "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
+    }
 
       //! Destructor.
       ~EpetraIntMultiVectorT() {  };
 
       //@}
 
-      //! @name Mathematical methods
-      //@{
-
-      //! TODO missing comment
-      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntMultiVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-
-      //! Return 1-norm of this Vector.
-      Teuchos::ScalarTraits<int>::magnitudeType norm1() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-
-      //! Compute 2-norm of this Vector.
-      Teuchos::ScalarTraits<int>::magnitudeType norm2() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-      //! Compute Inf-norm of this Vector.
-      Teuchos::ScalarTraits<int>::magnitudeType normInf() const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-      //! Compute mean (average) value of this Vector.
-      int meanValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
-
-      //! Compute max value of this Vector.
-      int maxValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); return vec_->MaxValue(); }
-
-
-      //@}
-
       //! @name Post-construction modification routines
       //@{
 
-      //! Replace current value at the specified location with specified value.
-      void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-      //! Adds specified value to existing value at the specified location.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-      //! Replace current value at the specified location with specified values.
-      void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue");(*vec_)[myRow] = value; }
-
-      //! Adds specified value to existing value at the specified location.
-      void sumIntoLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); (*vec_)[myRow] += value;}
-
       //! Initialize all values in a multi-vector with specified value.
-      void putScalar(const int &value) {  vec_->PutValue(value); }
+      void putScalar(const int &value) {
+        int ierr = 0;
+        ierr = vec_->PutScalar(value);
+        TEUCHOS_TEST_FOR_EXCEPTION(ierr != 0, Xpetra::Exceptions::RuntimeError, "Epetra_IntMultiVector::PutScalar returned an error.")
+      }
 
       //! Set multi-vector values to random numbers.
       void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
@@ -464,7 +463,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       Teuchos::ArrayRCP<const int> getData(size_t j) const {
         XPETRA_MONITOR("EpetraIntMultiVectorT::getData");
 
-        int * data = vec_->Values();
+        int ** arrayOfPointers;
+        vec_->ExtractView(&arrayOfPointers);
+        int * data = arrayOfPointers[j];
         int localLength = vec_->MyLength();
 
         return ArrayRCP<int>(data, 0, localLength, false); // not ownership
@@ -475,7 +476,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::getDataNonConst");
 
-        int * data = vec_->Values();
+        int ** arrayOfPointers;
+        vec_->ExtractView(&arrayOfPointers);
+        int * data = arrayOfPointers[j];
         int localLength = vec_->MyLength();
 
         return ArrayRCP<int>(data, 0, localLength, false); // not ownership
@@ -486,19 +489,20 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //! @name Mathematical methods
       //@{
       //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const {
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A,
+               const Teuchos::ArrayView<int> &dots) const {
         XPETRA_MONITOR("EpetraIntMultiVectorT::dot");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                   "This function is not implemented in Epetra_IntMultiVector");
       }
 
       //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
       void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::abs");
-
-        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                   "This function is not available in Epetra_IntMultiVector");
       }
 
       //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
@@ -506,7 +510,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
         XPETRA_MONITOR("EpetraIntMultiVectorT::reciprocal");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::RuntimeError, "The reciprocal of an IntMultiVector is not defined!");
       }
 
       //! Scale the current values of a multi-vector, this = alpha*this.
@@ -568,16 +572,24 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Replace value, using global (row) index.
-      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+        vec_->ReplaceGlobalValue(globalRow, vectorIndex, value);
+      }
 
       //! Add value to existing value, using global (row) index.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+        vec_->SumIntoGlobalValue(globalRow, vectorIndex, value);
+      }
 
       //! Replace value, using local (row) index.
-      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+        vec_->ReplaceMyValue(myRow, vectorIndex, value);
+      }
 
       //! Add value to existing value, using local (row) index.
-      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+        vec_->SumIntoMyValue(myRow, vectorIndex, value);
+      }
 
       //@}
 
@@ -585,22 +597,25 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Returns the number of vectors in the multi-vector.
-      size_t getNumVectors() const { XPETRA_MONITOR("EpetraIntMultiVectorT::getNumVectors"); return 1; }
+      size_t getNumVectors() const {
+        return vec_->NumVectors();
+      }
 
 
       //! Returns the local vector length on the calling processor of vectors in the multi-vector.
-      size_t getLocalLength() const {  return vec_->MyLength(); }
+      size_t getLocalLength() const {
+        return vec_->MyLength();
+      }
 
       //! Returns the global vector length of vectors in the multi-vector.
       global_size_t getGlobalLength() const {  return vec_->GlobalLength64(); }
 
       //! Checks to see if the local length, number of vectors and size of Scalar type match
       bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
-        XPETRA_MONITOR("EpetraIntMultiVectorT::isSameSize"); 
-        const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> *asvec = dynamic_cast<const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> *>(&vec);
-        if(!asvec) return false;
-        auto vv = toEpetra(*asvec); 
-        return ( (vec_->MyLength() == vv.MyLength()) && (getNumVectors() == vec.getNumVectors()));
+        XPETRA_MONITOR("EpetraIntMultiVectorT::isSameSize");
+        auto vv = toEpetra<GlobalOrdinal,Node>(vec);
+        return ( (getLocalLength() == Teuchos::as<size_t>(vv.MyLength())) &&
+                 (getNumVectors() == Teuchos::as<size_t>(vv.NumVectors())));
       }
 
       //@}
@@ -701,7 +716,18 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
-        // do nothing
+      XPETRA_MONITOR("EpetraIntMultiVectorT::replaceMap");
+      int err = 0;
+      if (!map.is_null()) {
+        err = this->getEpetra_IntMultiVector()->ReplaceMap(toEpetra<GlobalOrdinal,Node>(map));
+
+      } else {
+        // Replace map with a dummy map to avoid potential hangs later
+        Epetra_SerialComm SComm;
+        Epetra_Map NewMap((GlobalOrdinal) vec_->MyLength(), (GlobalOrdinal) vec_->Map().IndexBase64(), SComm);
+        err = this->getEpetra_IntMultiVector()->ReplaceMap(NewMap);
+      }
+      TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
       }
 
 
@@ -807,7 +833,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 #ifndef XPETRA_EPETRA_NO_64BIT_GLOBAL_INDICES
   template<>
   class EpetraIntMultiVectorT<long long, EpetraNode>
-    : public virtual Vector<int,int,long long,EpetraNode>
+    : public virtual MultiVector<int,int,long long,EpetraNode>
   {
       typedef int Scalar;
       typedef int LocalOrdinal;
@@ -820,58 +846,35 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Sets all vector entries to zero.
-      explicit EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, bool zeroOut=true)
-      {
-        vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(map), zeroOut));
-      }
+    EpetraIntMultiVectorT(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, size_t NumVectors, bool zeroOut=true) {
+      vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(map), NumVectors, zeroOut));
+    }
+
+    //! MultiVector copy constructor.
+    EpetraIntMultiVectorT(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source) {
+      vec_ = rcp(new Epetra_IntMultiVector(toEpetra<GlobalOrdinal,Node>(source)));
+    }
+
+    //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
+    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+        "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
+    }
 
       //! Destructor.
       ~EpetraIntMultiVectorT() {  };
 
       //@}
 
-      //! @name Mathematical methods
-      //@{
-
-      //! TODO missing comment
-      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntMultiVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
-
-
-      //! Return 1-norm of this Vector.
-      Teuchos::ScalarTraits<int>::magnitudeType norm1() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
-
-
-      //! Compute 2-norm of this Vector.
-      Teuchos::ScalarTraits<int>::magnitudeType norm2() const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
-
-      //! Compute Inf-norm of this Vector.
-      Teuchos::ScalarTraits<int>::magnitudeType normInf() const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
-
-      //! Compute mean (average) value of this Vector.
-      int meanValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
-
-      //! Compute max value of this Vector.
-      int maxValue() const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); return Teuchos::as<int>(vec_->MaxValue()); }
-
-      //@}
-
       //! @name Post-construction modification routines
       //@{
 
-      //! Replace current value at the specified location with specified value.
-      void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-      //! Adds specified value to existing value at the specified location.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
-
-      //! Replace current value at the specified location with specified values.
-      void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue");(*vec_)[myRow] = value;}
-
-      //! Adds specified value to existing value at the specified location.
-      void sumIntoLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); (*vec_)[myRow] += value;}
-
       //! Initialize all values in a multi-vector with specified value.
-      void putScalar(const int &value) {  vec_->PutValue(value); }
+      void putScalar(const int &value) {
+        int ierr = 0;
+        ierr = vec_->PutScalar(value);
+        TEUCHOS_TEST_FOR_EXCEPTION(ierr != 0, Xpetra::Exceptions::RuntimeError, "Epetra_IntMultiVector::PutScalar returns a non zero error.");
+      }
 
       //! Set multi-vector values to random numbers.
       void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
@@ -902,7 +905,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       Teuchos::ArrayRCP<const int> getData(size_t j) const {
         XPETRA_MONITOR("EpetraIntMultiVectorT::getData");
 
-        int * data = vec_->Values();
+        int ** arrayOfPointers;
+        vec_->ExtractView(&arrayOfPointers);
+        int * data = arrayOfPointers[j];
         int localLength = vec_->MyLength();
 
         return ArrayRCP<int>(data, 0, localLength, false); // not ownership
@@ -913,7 +918,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::getDataNonConst");
 
-        int * data = vec_->Values();
+        int ** arrayOfPointers;
+        vec_->ExtractView(&arrayOfPointers);
+        int * data = arrayOfPointers[j];
         int localLength = vec_->MyLength();
 
         return ArrayRCP<int>(data, 0, localLength, false); // not ownership
@@ -924,7 +931,8 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //! @name Mathematical methods
       //@{
       //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const {
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A,
+               const Teuchos::ArrayView<int> &dots) const {
         XPETRA_MONITOR("EpetraIntMultiVectorT::dot");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -934,17 +942,15 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
       void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::abs");
-
-        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                   "This function is not available in Epetra_IntMultiVector");
       }
 
       //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
       void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::reciprocal");
-
-        //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
-        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
+        TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
+                                   "This function is not implemented in Epetra_IntMultiVector");
       }
 
       //! Scale the current values of a multi-vector, this = alpha*this.
@@ -1006,16 +1012,24 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Replace value, using global (row) index.
-      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+        vec_->ReplaceGlobalValue(globalRow, vectorIndex, value);
+      }
 
       //! Add value to existing value, using global (row) index.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+        vec_->SumIntoGlobalValue(globalRow, vectorIndex, value);
+      }
 
       //! Replace value, using local (row) index.
-      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+        vec_->ReplaceMyValue(myRow, vectorIndex, value);
+      }
 
       //! Add value to existing value, using local (row) index.
-      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntMultiVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+        vec_->SumIntoMyValue(myRow, vectorIndex, value);
+      }
 
       //@}
 
@@ -1023,7 +1037,9 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Returns the number of vectors in the multi-vector.
-      size_t getNumVectors() const { XPETRA_MONITOR("EpetraIntMultiVectorT::getNumVectors"); return 1; }
+      size_t getNumVectors() const {
+        return vec_->NumVectors();
+      }
 
 
       //! Returns the local vector length on the calling processor of vectors in the multi-vector.
@@ -1034,12 +1050,11 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
 
       //! Checks to see if the local length, number of vectors and size of Scalar type match
-      bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const { 
-        XPETRA_MONITOR("EpetraIntMultiVectorT::isSameSize"); 
-        const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>  *asvec = dynamic_cast<const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>* >(&vec);
-        if(!asvec) return false;
-        auto vv = toEpetra(*asvec); 
-        return ( (vec_->MyLength() == vv.MyLength()) && (getNumVectors() == vec.getNumVectors()));
+      bool isSameSize(const MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const {
+        XPETRA_MONITOR("EpetraIntMultiVectorT::isSameSize");
+        auto vv = toEpetra<GlobalOrdinal, Node>(vec);
+        return ( (getLocalLength() == Teuchos::as<size_t>(vv.MyLength())) &&
+                 (getNumVectors() == Teuchos::as<size_t>(vv.NumVectors())));
       }
       //@}
 
@@ -1139,7 +1154,18 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
-        // do nothing
+      XPETRA_MONITOR("EpetraIntMultiVectorT::replaceMap");
+      int err = 0;
+      if (!map.is_null()) {
+        err = this->getEpetra_IntMultiVector()->ReplaceMap(toEpetra<GlobalOrdinal,Node>(map));
+
+      } else {
+        // Replace map with a dummy map to avoid potential hangs later
+        Epetra_SerialComm SComm;
+        Epetra_Map NewMap((GlobalOrdinal) vec_->MyLength(), (GlobalOrdinal) vec_->Map().IndexBase64(), SComm);
+        err = this->getEpetra_IntMultiVector()->ReplaceMap(NewMap);
+      }
+      TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
       }
 
 

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVectorFactory.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVectorFactory.hpp
@@ -107,7 +107,10 @@ namespace Xpetra {
     }
 
     //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
-    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map,
+          const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs,
+          size_t NumVectors) {
       XPETRA_MONITOR("MultiVectorFactory::Build");
 
 #ifdef HAVE_XPETRA_TPETRA
@@ -143,7 +146,10 @@ namespace Xpetra {
 
   public:
 
-    static RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Build(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, size_t NumVectors, bool zeroOut=true) {
+    static RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
+          size_t NumVectors,
+          bool zeroOut=true) {
       XPETRA_MONITOR("MultiVectorFactory::Build");
 
       RCP<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> > bmap = Teuchos::rcp_dynamic_cast<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> >(map);
@@ -163,7 +169,66 @@ namespace Xpetra {
     }
 
     //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
-    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map,
+          const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs,
+          size_t NumVectors) {
+      XPETRA_MONITOR("MultiVectorFactory::Build");
+
+#ifdef HAVE_XPETRA_TPETRA
+      if (map->lib() == UseTpetra)
+        return rcp( new TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> (map, ArrayOfPtrs, NumVectors) );
+#endif
+
+      if (map->lib() == UseEpetra)
+        return rcp( new EpetraMultiVectorT<int,Node>(map, ArrayOfPtrs, NumVectors) );
+
+      XPETRA_FACTORY_END;
+    }
+
+  };
+
+  template <>
+  class MultiVectorFactory<int, int, int, EpetraNode> {
+
+    typedef int Scalar;
+    typedef int LocalOrdinal;
+    typedef int GlobalOrdinal;
+    typedef EpetraNode Node;
+
+  private:
+    //! Private constructor. This is a static class.
+    MultiVectorFactory() {}
+
+  public:
+
+    static RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
+          size_t NumVectors,
+          bool zeroOut=true) {
+      XPETRA_MONITOR("MultiVectorFactory::Build");
+
+      RCP<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> > bmap = Teuchos::rcp_dynamic_cast<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> >(map);
+      if(!bmap.is_null()) {
+        return rcp(new BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>(bmap, NumVectors, zeroOut));
+      }
+
+#ifdef HAVE_XPETRA_TPETRA
+      if (map->lib() == UseTpetra)
+        return rcp( new TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> (map, NumVectors, zeroOut) );
+#endif
+
+      if (map->lib() == UseEpetra)
+        return rcp( new EpetraMultiVectorT<int,Node>(map, NumVectors, zeroOut) );
+
+      XPETRA_FACTORY_END;
+    }
+
+    //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
+    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map,
+          const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs,
+          size_t NumVectors) {
       XPETRA_MONITOR("MultiVectorFactory::Build");
 
 #ifdef HAVE_XPETRA_TPETRA
@@ -196,7 +261,10 @@ namespace Xpetra {
 
   public:
 
-    static RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Build(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map, size_t NumVectors, bool zeroOut=true) {
+    static RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
+          size_t NumVectors,
+          bool zeroOut = true) {
       XPETRA_MONITOR("MultiVectorFactory::Build");
 
       RCP<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> > bmap = Teuchos::rcp_dynamic_cast<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> >(map);
@@ -216,7 +284,66 @@ namespace Xpetra {
     }
 
     //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
-    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map,
+          const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs,
+          size_t NumVectors) {
+      XPETRA_MONITOR("MultiVectorFactory::Build");
+
+#ifdef HAVE_XPETRA_TPETRA
+      if (map->lib() == UseTpetra)
+        return rcp( new TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> (map, ArrayOfPtrs, NumVectors) );
+#endif
+
+      if (map->lib() == UseEpetra)
+        return rcp( new EpetraMultiVectorT<long long,Node>(map, ArrayOfPtrs, NumVectors) );
+
+      XPETRA_FACTORY_END;
+    }
+
+  };
+
+  template <>
+  class MultiVectorFactory<int, int, long long, EpetraNode> {
+
+    typedef int Scalar;
+    typedef int LocalOrdinal;
+    typedef long long GlobalOrdinal;
+    typedef EpetraNode Node;
+
+  private:
+    //! Private constructor. This is a static class.
+    MultiVectorFactory() {}
+
+  public:
+
+    static RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
+          size_t NumVectors,
+          bool zeroOut = true) {
+      XPETRA_MONITOR("MultiVectorFactory::Build");
+
+      RCP<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> > bmap = Teuchos::rcp_dynamic_cast<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> >(map);
+      if(!bmap.is_null()) {
+        return rcp(new BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>(bmap, NumVectors, zeroOut));
+      }
+
+#ifdef HAVE_XPETRA_TPETRA
+      if (map->lib() == UseTpetra)
+        return rcp( new TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> (map, NumVectors, zeroOut) );
+#endif
+
+      if (map->lib() == UseEpetra)
+        return rcp( new EpetraMultiVectorT<long long,Node>(map, NumVectors, zeroOut) );
+
+      XPETRA_FACTORY_END;
+    }
+
+    //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
+    static Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+    Build(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map,
+          const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs,
+          size_t NumVectors) {
       XPETRA_MONITOR("MultiVectorFactory::Build");
 
 #ifdef HAVE_XPETRA_TPETRA

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVectorFactory.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVectorFactory.hpp
@@ -238,7 +238,7 @@ namespace Xpetra {
 #endif
 
       if (map->lib() == UseEpetra)
-        return rcp( new EpetraMultiVectorT<int,Node>(map, ArrayOfPtrs, NumVectors) );
+        return rcp( new EpetraIntMultiVectorT<int,Node>(map, ArrayOfPtrs, NumVectors) );
 
       XPETRA_FACTORY_END;
     }
@@ -353,7 +353,7 @@ namespace Xpetra {
 #endif
 
       if (map->lib() == UseEpetra)
-        return rcp( new EpetraMultiVectorT<long long,Node>(map, ArrayOfPtrs, NumVectors) );
+        return rcp( new EpetraIntMultiVectorT<long long,Node>(map, ArrayOfPtrs, NumVectors) );
 
       XPETRA_FACTORY_END;
     }

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVectorFactory.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVectorFactory.hpp
@@ -56,6 +56,7 @@
 
 #ifdef HAVE_XPETRA_EPETRA
 #include "Xpetra_EpetraMultiVector.hpp"
+#include "Xpetra_EpetraIntMultiVector.hpp"
 #endif
 
 #include "Xpetra_BlockedMap.hpp"
@@ -219,7 +220,7 @@ namespace Xpetra {
 #endif
 
       if (map->lib() == UseEpetra)
-        return rcp( new EpetraMultiVectorT<int,Node>(map, NumVectors, zeroOut) );
+        return rcp( new EpetraIntMultiVectorT<int,Node>(map, NumVectors, zeroOut) );
 
       XPETRA_FACTORY_END;
     }
@@ -334,7 +335,7 @@ namespace Xpetra {
 #endif
 
       if (map->lib() == UseEpetra)
-        return rcp( new EpetraMultiVectorT<long long,Node>(map, NumVectors, zeroOut) );
+        return rcp( new EpetraIntMultiVectorT<long long,Node>(map, NumVectors, zeroOut) );
 
       XPETRA_FACTORY_END;
     }


### PR DESCRIPTION
@trilinos/muelu @trilinos/xpetra 

## Description
Adding interface for IntMultiVector in Xpetra, this will be used in overlapping aggregates.

## Motivation and Context
This will allow structured aggregates to have sufficient data stored in case of piece-wise linear interpolation prolongator

## Related Issues

* Blocks #2687, #2577, #2230

## How Has This Been Tested?
The Xpetra unit test for MultiVector has been expended to test for `Scalar=int` and `Scalar=long long int` which tests the added interface.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.