### PR TITLE
MueLu: add no-qr mode for kokkos version

### DIFF
--- a/packages/muelu/test/interface/kokkos/EasyParameterListInterpreter/CMakeLists.txt
+++ b/packages/muelu/test/interface/kokkos/EasyParameterListInterpreter/CMakeLists.txt
@@ -12,3 +12,4 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(ParameterList_EasyParameterListInterpreter_cp
   SOURCE_FILES ${xmlFiles}
   DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../EasyParameterListInterpreter/
   )
+# touch

--- a/packages/muelu/test/interface/kokkos/EasyParameterListInterpreter/unsmoothed2.xml
+++ b/packages/muelu/test/interface/kokkos/EasyParameterListInterpreter/unsmoothed2.xml
@@ -1,0 +1,4 @@
+<ParameterList name="MueLu">
+  <Parameter name="multigrid algorithm"     type="string"   value="unsmoothed"/>
+  <Parameter name="tentative: calculate qr" type="bool"     value="false"/>
+</ParameterList>

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -312,6 +316,7 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLemptyb_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -182,6 +184,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -251,6 +254,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg2b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -117,6 +118,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -190,6 +192,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -263,6 +266,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4b_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +177,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -241,6 +244,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -54,6 +54,20 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+
+*********************************************************************
+WARNING: Overlapping timers detected!
+A TimeMonitor timer was stopped before a nested subtimer was
+stopped. This is not allowed by the StackedTimer. This corner case
+typically occurs if the TimeMonitor is stored in an RCP and the RCP is
+assigned to a new timer. To disable this warning, either fix the
+ordering of timer creation and destuction or disable the StackedTimer
+support in the TimeMonitor by setting the StackedTimer to null
+with:
+Teuchos::TimeMonitor::setStackedTimer(Teuchos::null)
+*********************************************************************
+
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +145,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -312,6 +316,7 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -285,6 +288,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -362,6 +366,7 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -48,6 +48,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -111,6 +112,7 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -48,6 +48,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -48,6 +48,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_epetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_epetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -49,6 +49,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -155,6 +156,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -261,6 +263,7 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
@@ -49,6 +49,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -270,6 +272,7 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -49,6 +49,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -155,6 +156,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -261,6 +263,7 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
@@ -49,6 +49,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -270,6 +272,7 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +109,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +177,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +129,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +207,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +109,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +177,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +129,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +207,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +109,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +177,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +129,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +207,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +109,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +177,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +129,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +207,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -284,6 +286,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -388,6 +391,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -277,6 +279,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -381,6 +384,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -307,6 +309,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -421,6 +424,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -314,6 +316,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -428,6 +431,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -284,6 +286,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -388,6 +391,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -277,6 +279,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -381,6 +384,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -307,6 +309,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -421,6 +424,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -314,6 +316,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -428,6 +431,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -349,6 +351,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +152,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -342,6 +344,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -382,6 +384,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -389,6 +391,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -46,6 +46,7 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -143,6 +144,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -317,6 +319,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
@@ -46,6 +46,7 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -143,6 +144,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -310,6 +312,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -163,6 +164,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -350,6 +352,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -163,6 +164,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -357,6 +359,7 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_epetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +108,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_epetra.gold
@@ -49,6 +49,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -73,6 +73,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -169,6 +170,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_epetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +108,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -172,6 +174,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -237,6 +240,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -302,6 +306,7 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -48,6 +48,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -190,6 +192,7 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -261,6 +264,7 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -332,6 +336,7 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_epetra.gold
@@ -49,6 +49,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_epetra.gold
@@ -35,6 +35,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -93,6 +94,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -35,6 +35,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -93,6 +94,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_epetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +108,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -48,6 +48,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_epetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +108,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -42,6 +42,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +108,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_epetra.gold
@@ -49,6 +49,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +132,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +108,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +140,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_epetra.gold
@@ -43,6 +43,7 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -103,6 +104,7 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -53,6 +53,7 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -123,6 +124,7 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_epetra.gold
@@ -1,26 +1,20 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+ smoother ->
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 1   [unused]
+  relaxation: damping factor = 1   [unused]
+
 Level 1
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-    
+
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -28,7 +22,7 @@ Level 1
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-   
+
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -42,48 +36,46 @@ Level 1
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  
+
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-  
+
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-  
- tentative: calculate qr = 1   [default]
- matrixmatrix: kernel params -> 
+
+ tentative: calculate qr = 0
+ matrixmatrix: kernel params ->
   [empty list]
- 
+
+ Transpose P (MueLu::TransPFactory)
+ matrixmatrix: kernel params ->
+  [empty list]
+
  Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
+ transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
+ matrixmatrix: kernel params ->
   [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+
+ Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+ smoother ->
+  relaxation: type = symmetric Gauss-Seidel   [unused]
+  relaxation: sweeps = 1   [unused]
+  relaxation: damping factor = 1   [unused]
+
 Level 2
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-    
+
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -91,7 +83,7 @@ Level 2
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-   
+
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -105,33 +97,37 @@ Level 2
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  
+
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-  
+
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-  
- tentative: calculate qr = 1   [default]
- matrixmatrix: kernel params -> 
+
+ tentative: calculate qr = 0
+ matrixmatrix: kernel params ->
   [empty list]
- 
+
+ Transpose P (MueLu::TransPFactory)
+ matrixmatrix: kernel params ->
+  [empty list]
+
  Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
+ transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
+ matrixmatrix: kernel params ->
   [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+
+ Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
+ presmoother ->
   [empty list]
- 
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -146,10 +142,10 @@ level  rows    nnz  nnz/row  c ratio  procs
   1    3333   9997     3.00     3.00      1
   2    1111   3331     3.00     3.00      1
 
-Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}}}
+Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 1) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [3333, 3333], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [3333, 3333], Global nnz: 9997, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [3333, 3333]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [3333, 3333]}}}}
+Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 2) pre  : <Direct> solver interface
+Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -1,26 +1,30 @@
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+ smoother ->
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 1
+  relaxation: damping factor = 1
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-    
+
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -28,7 +32,7 @@ Level 1
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-   
+
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -42,48 +46,56 @@ Level 1
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  
+
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-  
+
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-  
- tentative: calculate qr = 1   [default]
- matrixmatrix: kernel params -> 
+
+ tentative: calculate qr = 0
+ matrixmatrix: kernel params ->
   [empty list]
- 
+
+ Transpose P (MueLu::TransPFactory)
+ matrixmatrix: kernel params ->
+  [empty list]
+
  Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
+ transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
+ matrixmatrix: kernel params ->
   [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+
+ Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+ smoother ->
+  relaxation: type = Symmetric Gauss-Seidel
+  relaxation: sweeps = 1
+  relaxation: damping factor = 1
+  relaxation: zero starting solution = 1   [default]
+  relaxation: backward mode = 0   [default]
+  relaxation: use l1 = 0   [default]
+  relaxation: l1 eta = 1.5   [default]
+  relaxation: min diagonal value = 0   [default]
+  relaxation: fix tiny diagonal entries = 0   [default]
+  relaxation: check diagonal entries = 0   [default]
+  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+  relaxation: symmetric matrix structure = 0   [default]
+  relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-    
+
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -91,7 +103,7 @@ Level 2
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-   
+
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -105,40 +117,44 @@ Level 2
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  
+
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-  
+
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-  
- tentative: calculate qr = 1   [default]
- matrixmatrix: kernel params -> 
+
+ tentative: calculate qr = 0
+ matrixmatrix: kernel params ->
   [empty list]
- 
+
+ Transpose P (MueLu::TransPFactory)
+ matrixmatrix: kernel params ->
+  [empty list]
+
  Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
+ transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
+ matrixmatrix: kernel params ->
   [empty list]
- 
+
  Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
+ presmoother ->
   [empty list]
- 
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 0.00
+Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows    nnz  nnz/row  c ratio  procs
@@ -146,9 +162,9 @@ level  rows    nnz  nnz/row  c ratio  procs
   1    3333   9997     3.00     3.00      1
   2    1111   3331     3.00     3.00      1
 
-Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}}}
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [3333, 3333], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [3333, 3333], Global nnz: 9997, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [3333, 3333]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [3333, 3333]}}}}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother


### PR DESCRIPTION
@trilinos/muelu 

## Description
Add "skip QR" mode to Kokkos variant of TentativePFactory. For now, only for scalar problems.

## Motivation and Context
Exawind input decks use noqr.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
