### PR TITLE
Phalanx:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/phalanx/src/Phalanx_DataLayout_DynamicLayout.cpp
+++ b/packages/phalanx/src/Phalanx_DataLayout_DynamicLayout.cpp
@@ -138,7 +138,7 @@ void PHX::Layout::names(std::vector<std::string>& names) const
 }
 
 //**********************************************************************
-void PHX::Layout::print(std::ostream& os, int offset) const
+void PHX::Layout::print(std::ostream& os, int /* offset */) const
 {
   os << m_identifier << "(";
   for (size_t i=0; i < m_extents.size(); ++i) {

--- a/packages/phalanx/src/Phalanx_DataLayout_MDALayout_Def.hpp
+++ b/packages/phalanx/src/Phalanx_DataLayout_MDALayout_Def.hpp
@@ -628,7 +628,7 @@ name(size_type ordinal) const
 template<typename Tag0, typename Tag1, typename Tag2, typename Tag3,
 	 typename Tag4, typename Tag5, typename Tag6, typename Tag7>
 void PHX::MDALayout<Tag0,Tag1,Tag2,Tag3,Tag4,Tag5,Tag6,Tag7>::
-print(std::ostream& os, int offset) const
+print(std::ostream& os, int /* offset */) const
 {
   os << m_identifier;
 }

--- a/packages/phalanx/src/Phalanx_DimTag.cpp
+++ b/packages/phalanx/src/Phalanx_DimTag.cpp
@@ -57,7 +57,7 @@ namespace PHX {
   DimTag::~DimTag() {}
   
   std::string
-  DimTag::to_string(DimTag::size_type n, DimTag::size_type i) const
+  DimTag::to_string(DimTag::size_type /* n */, DimTag::size_type i) const
   {
     //array_traits::check_range( i , n );
     std::ostringstream s ;
@@ -66,7 +66,7 @@ namespace PHX {
   }
 
   DimTag::size_type
-  DimTag::to_index( DimTag::size_type n , const std::string & s ) const
+  DimTag::to_index( DimTag::size_type /* n */, const std::string & s ) const
   {
     const int i = atoi( s.c_str() );
     //array_traits::check_range( i , n );

--- a/packages/phalanx/src/Phalanx_Evaluator_UnmanagedFieldDummy.hpp
+++ b/packages/phalanx/src/Phalanx_Evaluator_UnmanagedFieldDummy.hpp
@@ -63,7 +63,7 @@ public:
     this->addEvaluatedField(f);
     this->setName("UnmanageFieldDummy");
   }
-  void evaluateFields(typename Traits::EvalData workset) override {}
+  void evaluateFields(typename Traits::EvalData /* workset */) override {}
 };
 
 }

--- a/packages/phalanx/src/Phalanx_Evaluator_Utilities.hpp
+++ b/packages/phalanx/src/Phalanx_Evaluator_Utilities.hpp
@@ -83,9 +83,9 @@ namespace PHX {
     }
 
     template<typename DataT,typename... Props>
-    void setFieldData(const PHX::FieldTag& ft,
-                      Kokkos::View<DataT,Props...>& f,
-                      PHX::FieldManager<Traits>& fm)
+    void setFieldData(const PHX::FieldTag& /* ft */,
+                      Kokkos::View<DataT,Props...>& /* f */,
+                      PHX::FieldManager<Traits>& /* fm */)
     {
 
     }

--- a/packages/phalanx/src/Phalanx_Evaluator_WithBaseImpl_Def.hpp
+++ b/packages/phalanx/src/Phalanx_Evaluator_WithBaseImpl_Def.hpp
@@ -102,7 +102,7 @@ namespace PHX {
     DummyMemoryBinder& operator=(const DummyMemoryBinder& ) = default;
     DummyMemoryBinder(DummyMemoryBinder&& ) = default;
     DummyMemoryBinder& operator=(DummyMemoryBinder&& ) = default;
-    void operator()(const PHX::any& f) { /* DO NOTHING! */ }
+    void operator()(const PHX::any& /* f */) { /* DO NOTHING! */ }
   };
 
 } // namespace PHX
@@ -341,8 +341,8 @@ setName(const std::string& name)
 //**********************************************************************
 template<typename Traits>
 void PHX::EvaluatorWithBaseImpl<Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
-                      PHX::FieldManager<Traits>& vm)
+postRegistrationSetup(typename Traits::SetupData /* d */,
+                      PHX::FieldManager<Traits>& /* vm */)
 {}
 
 //**********************************************************************
@@ -392,13 +392,13 @@ taskSize() const
 //**********************************************************************
 template<typename Traits>
 void PHX::EvaluatorWithBaseImpl<Traits>::
-preEvaluate(typename Traits::PreEvalData d)
+preEvaluate(typename Traits::PreEvalData /* d */)
 { }
 
 //**********************************************************************
 template<typename Traits>
 void PHX::EvaluatorWithBaseImpl<Traits>::
-postEvaluate(typename Traits::PostEvalData d)
+postEvaluate(typename Traits::PostEvalData /* d */)
 { }
 
 //**********************************************************************
@@ -433,7 +433,7 @@ createDeviceEvaluator() const
 //**********************************************************************
 template<typename Traits>
 void
-PHX::EvaluatorWithBaseImpl<Traits>::rebuildDeviceEvaluator(PHX::DeviceEvaluator<Traits>* e) const
+PHX::EvaluatorWithBaseImpl<Traits>::rebuildDeviceEvaluator(PHX::DeviceEvaluator<Traits>* /* e */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                              "Error - The evalautor \""<< this->getName() <<"\" does not have a derived method for rebuildDeviceEvalautor() that is required when using Device DAG support.  Please implement the rebuildDeviceEvaluator() method in this Evalautor.");
@@ -442,7 +442,7 @@ PHX::EvaluatorWithBaseImpl<Traits>::rebuildDeviceEvaluator(PHX::DeviceEvaluator<
 //**********************************************************************
 template<typename Traits>
 void
-PHX::EvaluatorWithBaseImpl<Traits>::deleteDeviceEvaluator(PHX::DeviceEvaluator<Traits>* e) const
+PHX::EvaluatorWithBaseImpl<Traits>::deleteDeviceEvaluator(PHX::DeviceEvaluator<Traits>* /* e */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                              "Error - The evalautor \""<< this->getName() <<"\" does not have a derived method for deleteDeviceEvalautor() that is required when using Device DAG support.  Please implement the deleteDeviceEvaluator() method in this Evalautor.");

--- a/packages/phalanx/src/Phalanx_Print_Utilities.hpp
+++ b/packages/phalanx/src/Phalanx_Print_Utilities.hpp
@@ -60,7 +60,7 @@ namespace PHX {
   // Specialization for "void" types - the default value for Array parameters
   template<typename Array>
   struct PrintDimension<void,Array> {
-    void addName(std::vector<const char*>& names) { }
+    void addName(std::vector<const char*>& /* names */) { }
   };
 
 } 

--- a/packages/phalanx/test/AliasedFields/AliasedFields_TestEvaluators.hpp
+++ b/packages/phalanx/test/AliasedFields/AliasedFields_TestEvaluators.hpp
@@ -66,8 +66,8 @@ public:
     this->addDependentField(b);
   }
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                             PHX::FieldManager<Traits>& vm) override
+  void postRegistrationSetup(typename Traits::SetupData /* d */,
+                             PHX::FieldManager<Traits>& /* vm */) override
   {}
   
   void evaluateFields(typename Traits::EvalData ) override
@@ -92,8 +92,8 @@ public:
     this->addEvaluatedField(c);
   }
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                             PHX::FieldManager<Traits>& vm) override
+  void postRegistrationSetup(typename Traits::SetupData /* d */,
+                             PHX::FieldManager<Traits>& /* vm */) override
   {}
   
   void evaluateFields(typename Traits::EvalData ) override

--- a/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_Constant_Def.hpp
+++ b/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_Constant_Def.hpp
@@ -58,15 +58,15 @@ Constant<EvalT, Traits>::Constant(Teuchos::ParameterList& p) :
 //**********************************************************************
 template<typename EvalT, typename Traits>
 void Constant<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
-		      PHX::FieldManager<Traits>& vm)
+postRegistrationSetup(typename Traits::SetupData /* d */,
+		      PHX::FieldManager<Traits>& /* vm */)
 {
   constant.deep_copy(value);
 }
 
 //**********************************************************************
 template<typename EvalT, typename Traits>
-void Constant<EvalT, Traits>::evaluateFields(typename Traits::EvalData d)
+void Constant<EvalT, Traits>::evaluateFields(typename Traits::EvalData /* d */)
 { }
 
 //**********************************************************************

--- a/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_Density_Def.hpp
+++ b/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_Density_Def.hpp
@@ -56,8 +56,8 @@ Density(const Teuchos::ParameterList& p) :
 //**********************************************************************
 template<typename EvalT, typename Traits>
 void Density<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
-		      PHX::FieldManager<Traits>& vm)
+postRegistrationSetup(typename Traits::SetupData /* d */,
+		      PHX::FieldManager<Traits>& /* vm */)
 {
   cell_data_size = density.size() / density.dimension(0);
 }

--- a/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_EnergyFlux_Fourier_Def.hpp
+++ b/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_EnergyFlux_Fourier_Def.hpp
@@ -66,8 +66,8 @@ Fourier(const Teuchos::ParameterList& p) :
 //**********************************************************************
 template<typename EvalT, typename Traits> 
 void Fourier<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
-		      PHX::FieldManager<Traits>& fm)
+postRegistrationSetup(typename Traits::SetupData /* d */,
+		      PHX::FieldManager<Traits>& /* fm */)
 {  
   num_qp = static_cast<PHX::index_size_type>(flux.extent(1));
   num_dim = static_cast<PHX::index_size_type>(flux.extent(2));

--- a/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_FEInterpolation_Def.hpp
+++ b/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_FEInterpolation_Def.hpp
@@ -71,7 +71,7 @@ FEInterpolation(const Teuchos::ParameterList& p) :
 //**********************************************************************
 template<typename EvalT, typename Traits> 
 void FEInterpolation<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
+postRegistrationSetup(typename Traits::SetupData /* d */,
 		      PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData(val_node,fm);

--- a/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_NonlinearSource_Def.hpp
+++ b/packages/phalanx/test/AssemblyHeatFluxFad/evaluators/Evaluator_NonlinearSource_Def.hpp
@@ -63,7 +63,7 @@ NonlinearSource(const Teuchos::ParameterList& p) :
 //**********************************************************************
 template<typename EvalT, typename Traits>
 void NonlinearSource<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
+postRegistrationSetup(typename Traits::SetupData /* d */,
 		      PHX::FieldManager<Traits>& vm)
 {
   // NOTE: We no longer need manually call setFieldData(). It happens
@@ -96,7 +96,7 @@ evaluateFields(typename Traits::EvalData d)
 //**********************************************************************
 template<typename EvalT, typename Traits>
 void NonlinearSource<EvalT, Traits>::
-preEvaluate(typename Traits::PreEvalData d)
+preEvaluate(typename Traits::PreEvalData /* d */)
 { 
   using namespace std;
   cout << "In Source Pre Op" << endl;
@@ -105,7 +105,7 @@ preEvaluate(typename Traits::PreEvalData d)
 //**********************************************************************
 template< typename EvalT, typename Traits>
 void NonlinearSource<EvalT, Traits>::
-postEvaluate(typename Traits::PostEvalData d)
+postEvaluate(typename Traits::PostEvalData /* d */)
 { 
   using namespace std;
   cout << "In Source Post Op" << endl;

--- a/packages/phalanx/test/UnmanagedFields/Field/Field_TestEvaluators_Def.hpp
+++ b/packages/phalanx/test/UnmanagedFields/Field/Field_TestEvaluators_Def.hpp
@@ -51,7 +51,7 @@ struct BASIS;
 
 namespace PHX {
 
-  PHX_EVALUATOR_CTOR(EvalUnmanaged,plist)
+  PHX_EVALUATOR_CTOR(EvalUnmanaged,/* plist */)
 
   {
     using Teuchos::RCP;
@@ -74,7 +74,7 @@ namespace PHX {
     this->addDependentField(d);
   }
 
-  PHX_POST_REGISTRATION_SETUP(EvalUnmanaged,data,fm)
+  PHX_POST_REGISTRATION_SETUP(EvalUnmanaged,/* data */,fm)
   {
     this->utils.setFieldData(a,fm);
     this->utils.setFieldData(b,fm);
@@ -82,13 +82,13 @@ namespace PHX {
     this->utils.setFieldData(d,fm);
   }
 
-  PHX_EVALUATE_FIELDS(EvalUnmanaged,data)
+  PHX_EVALUATE_FIELDS(EvalUnmanaged,/* data */)
   {
     a.deep_copy(b);
     c.deep_copy(d);
   }
 
-  PHX_EVALUATOR_CTOR(EvalDummy,plist)
+  PHX_EVALUATOR_CTOR(EvalDummy,/* plist */)
   {
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -106,13 +106,13 @@ namespace PHX {
     this->addEvaluatedField(d);
   }
 
-  PHX_POST_REGISTRATION_SETUP(EvalDummy,data,fm)
+  PHX_POST_REGISTRATION_SETUP(EvalDummy,/* data */,fm)
   {
     this->utils.setFieldData(b,fm);
     this->utils.setFieldData(d,fm);
   }
 
-  PHX_EVALUATE_FIELDS(EvalDummy,data)
+  PHX_EVALUATE_FIELDS(EvalDummy,/* data */)
   {
     // do nothing - they are unmanaged - data values are set by user
   }

--- a/packages/phalanx/test/UnmanagedFields/KokkosView/View_TestEvaluators_Def.hpp
+++ b/packages/phalanx/test/UnmanagedFields/KokkosView/View_TestEvaluators_Def.hpp
@@ -66,7 +66,7 @@ namespace PHX {
     this->addDependentField(tag_d,d);
   }
 
-  PHX_POST_REGISTRATION_SETUP(EvalUnmanaged,data,fm)
+  PHX_POST_REGISTRATION_SETUP(EvalUnmanaged,/* data */,fm)
   {
     this->utils.setFieldData(tag_a,a,fm);
     this->utils.setFieldData(tag_b,b,fm);
@@ -74,7 +74,7 @@ namespace PHX {
     this->utils.setFieldData(tag_d,d,fm);
   }
 
-  PHX_EVALUATE_FIELDS(EvalUnmanaged,data)
+  PHX_EVALUATE_FIELDS(EvalUnmanaged,/* data */)
   {
     Kokkos::deep_copy(a,b);
     Kokkos::deep_copy(c,d);
@@ -94,13 +94,13 @@ namespace PHX {
     this->addEvaluatedField(tag_d,d);
   }
 
-  PHX_POST_REGISTRATION_SETUP(EvalDummy,data,fm)
+  PHX_POST_REGISTRATION_SETUP(EvalDummy,/* data */,fm)
   {
     this->utils.setFieldData(tag_b,b,fm);
     this->utils.setFieldData(tag_d,d,fm);
   }
 
-  PHX_EVALUATE_FIELDS(EvalDummy,data)
+  PHX_EVALUATE_FIELDS(EvalDummy,/* data */)
   {
     // do nothing - they are unmanaged - data values are set by user
   }

--- a/packages/phalanx/test/UnmanagedFields/MDField/MDField_TestEvaluators_Def.hpp
+++ b/packages/phalanx/test/UnmanagedFields/MDField/MDField_TestEvaluators_Def.hpp
@@ -51,7 +51,7 @@ struct BASIS;
 
 namespace PHX {
 
-  PHX_EVALUATOR_CTOR(EvalUnmanaged,plist)
+  PHX_EVALUATOR_CTOR(EvalUnmanaged,/* plist */)
 
   {
     using Teuchos::RCP;
@@ -74,7 +74,7 @@ namespace PHX {
     this->addDependentField(d);
   }
 
-  PHX_POST_REGISTRATION_SETUP(EvalUnmanaged,data,fm)
+  PHX_POST_REGISTRATION_SETUP(EvalUnmanaged,/* data */,fm)
   {
     this->utils.setFieldData(a,fm);
     this->utils.setFieldData(b,fm);
@@ -82,13 +82,13 @@ namespace PHX {
     this->utils.setFieldData(d,fm);
   }
 
-  PHX_EVALUATE_FIELDS(EvalUnmanaged,data)
+  PHX_EVALUATE_FIELDS(EvalUnmanaged,/* data */)
   {
     a.deep_copy(b);
     c.deep_copy(d);
   }
 
-  PHX_EVALUATOR_CTOR(EvalDummy,plist)
+  PHX_EVALUATOR_CTOR(EvalDummy,/* plist */)
   {
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -106,13 +106,13 @@ namespace PHX {
     this->addEvaluatedField(d);
   }
 
-  PHX_POST_REGISTRATION_SETUP(EvalDummy,data,fm)
+  PHX_POST_REGISTRATION_SETUP(EvalDummy,/* data */,fm)
   {
     this->utils.setFieldData(b,fm);
     this->utils.setFieldData(d,fm);
   }
 
-  PHX_EVALUATE_FIELDS(EvalDummy,data)
+  PHX_EVALUATE_FIELDS(EvalDummy,/* data */)
   {
     // do nothing - they are unmanaged - data values are set by user
   }

--- a/packages/phalanx/test/Utilities/Evaluator_MockDAG_Def.hpp
+++ b/packages/phalanx/test/Utilities/Evaluator_MockDAG_Def.hpp
@@ -60,7 +60,7 @@ namespace PHX {
   }
 
   template<typename EvalT,typename Traits>
-  void MockDAG<EvalT,Traits>::evaluateFields(typename Traits::EvalData d){}
+  void MockDAG<EvalT,Traits>::evaluateFields(typename Traits::EvalData /* d */){}
 
   template<typename EvalT,typename Traits>
   void MockDAG<EvalT,Traits>::evaluates(const std::string& n)


### PR DESCRIPTION
@trilinos/phalanx 

## Description
Remove `unused parameter` warnings generated with `gcc-7.3.0`.

## Motivation and Context
Just wanting a clean build.  My head's really foggy with sickness today, but cleaning up warnings is something I can manage.

## How Has This Been Tested?
Just letting the @trilinos-autotester do its thing.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.