### PR TITLE
Xpetra: fix 2905

### DIFF
--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
@@ -349,16 +349,6 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       TEUCHOS_UNREACHABLE_RETURN(ret);
     }
 
-    /// \brief Return an unmanaged non-const view of the local data on a specific device.
-    /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
-    ///
-    /// \warning DO NOT USE THIS FUNCTION! There is no reason why you are working directly
-    ///          with the Xpetra::EpetraIntVector object. To write a code which is independent
-    ///          from the underlying linear algebra package you should always use the abstract class,
-    ///          i.e. Xpetra::Vector!
-    ///
-    /// \warning Be aware that the view on the vector data is non-persisting, i.e.
-    ///          only valid as long as the vector does not run of scope!
     template<class TargetDeviceType>
     typename Kokkos::Impl::if_c<
       Kokkos::Impl::is_same<
@@ -744,11 +734,13 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
         // access Epetra vector data
         int* data = NULL;
-        vec_->ExtractView(&data);
+        int myLDA;
+        vec_->ExtractView(&data, &myLDA);
         int localLength = vec_->MyLength();
+        int numVectors  = vec_->NumVectors();
 
         // create view
-        epetra_view_type test = epetra_view_type(data, localLength,1);
+        epetra_view_type test = epetra_view_type(data, localLength, numVectors);
         typename dual_view_type::t_host_um ret = subview(test, Kokkos::ALL(), Kokkos::ALL());
 
         return ret;
@@ -1182,11 +1174,13 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
 
         // access Epetra vector data
         int* data = NULL;
-        vec_->ExtractView(&data);
+        int myLDA;
+        vec_->ExtractView(&data, &myLDA);
         int localLength = vec_->MyLength();
+        int numVectors  = vec_->NumVectors();
 
         // create view
-        epetra_view_type test = epetra_view_type(data, localLength, 1);
+        epetra_view_type test = epetra_view_type(data, localLength, numVectors);
         typename dual_view_type::t_host_um ret = subview(test, Kokkos::ALL(), Kokkos::ALL());
 
         return ret;


### PR DESCRIPTION
Adding the proper calls to extractView in the Xpetra_EpetraIntMultiVector
interface.


@trilinos/xpetra

## Description
Fixing the call to extractView in getLocalView from Xpetra_EpetraIntMultiVector

## Motivation and Context
This is a bug, it needs to be fixed for builds that have `Xpetra_ENABLE_kokkos_refactor=ON`

## Related Issues

* Closes #2905 

## How Has This Been Tested?
This fix locally builds with said configure flag turned on, I also ran Xpetra's unit tests and some tests in MueLu for good measure.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.