### PR TITLE
Amesos2:  Remove Build Warnings

### DIFF
--- a/packages/amesos2/src/Amesos2_EpetraCrsMatrix_MatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraCrsMatrix_MatrixAdapter_def.hpp
@@ -60,7 +60,7 @@ namespace Amesos2 {
     {}
 
   Teuchos::RCP<const MatrixAdapter<Epetra_CrsMatrix> >
-  ConcreteMatrixAdapter<Epetra_CrsMatrix>::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution distribution) const
+  ConcreteMatrixAdapter<Epetra_CrsMatrix>::get_impl(const Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,global_ordinal_t,node_t> > map, EDistribution /* distribution */) const
     {
       using Teuchos::as;
       using Teuchos::rcp;

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_def.hpp
@@ -216,7 +216,7 @@ void MultiVecAdapter<Epetra_MultiVector>::get1dCopy(
     const Tpetra::Map<MultiVecAdapter<Epetra_MultiVector>::local_ordinal_t,
                       MultiVecAdapter<Epetra_MultiVector>::global_ordinal_t,
                       MultiVecAdapter<Epetra_MultiVector>::node_t> > distribution_map,
-                      EDistribution distribution) const
+                      EDistribution /* distribution */) const
 {
   using Teuchos::rcpFromPtr;
   using Teuchos::as;
@@ -320,7 +320,7 @@ MultiVecAdapter<Epetra_MultiVector>::put1dData(
     const Tpetra::Map<MultiVecAdapter<Epetra_MultiVector>::local_ordinal_t,
                       MultiVecAdapter<Epetra_MultiVector>::global_ordinal_t,
                       MultiVecAdapter<Epetra_MultiVector>::node_t> > source_map,
-                      EDistribution distribution )
+                      EDistribution /* distribution */)
 {
   using Teuchos::rcpFromPtr;
   using Teuchos::as;

--- a/packages/amesos2/src/Amesos2_SolverCore_def.hpp
+++ b/packages/amesos2/src/Amesos2_SolverCore_def.hpp
@@ -256,12 +256,16 @@ SolverCore<ConcreteSolver,Matrix,Vector>::setA( const Teuchos::RCP<const Matrix>
   switch( status_.last_phase_ ){
   case CLEAN:
     status_.numPreOrder_ = 0;
+    // Intentional fallthrough.
   case PREORDERING:
     status_.numSymbolicFact_ = 0;
+    // Intentional fallthrough.
   case SYMBFACT:
     status_.numNumericFact_ = 0;
+    // Intentional fallthrough.
   case NUMFACT:                 // probably won't ever happen by itself
     status_.numSolve_ = 0;
+    // Intentional fallthrough.
   case SOLVE:                   // probably won't ever happen
     break;
   }


### PR DESCRIPTION
@trilinos/amesos2 

## Description
Remove warnings generated when building with `gcc-7.3.0`.  Specifically:
* Unused parameters.
* Intentional fallthrough in a `switch` statement.

## Motivation and Context
Just hoping for a cleaner build.

## How Has This Been Tested?
Letting the @trilinos-autotester do its thing.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.