### PR TITLE
Anasazi:  Remove Unused Parameter Warning

### DIFF
--- a/packages/anasazi/epetra/util/ModeLaplace/BlockPCGSolver.h
+++ b/packages/anasazi/epetra/util/ModeLaplace/BlockPCGSolver.h
@@ -115,7 +115,7 @@ class ANASAZIEPETRA_MODELAPLACE_LIB_DLL_EXPORT BlockPCGSolver : public virtual E
     const char* Label() const { return "Epetra_Operator for Block PCG solver"; };
 
     bool UseTranspose() const { return (false); };
-    int SetUseTranspose(bool useTranspose) { return 0; };
+    int SetUseTranspose(bool /* useTranspose */) { return -1; };
 
     bool HasNormInf() const { return (false); };
     double NormInf() const  { return (-1.0); };


### PR DESCRIPTION
@trilinos/anasazi 

## Description
Remove `unused parameter` warning generated by `gcc-7.3.0`.

## Motivation and Context
Just working on a cleaner build.

## How Has This Been Tested?
Letting the @trilinos-autotester do its thing.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.