### PR TITLE
AztecOO:  Remove Copy Constructor Compiler Warning

### DIFF
--- a/packages/aztecoo/src/Epetra_MsrMatrix.h
+++ b/packages/aztecoo/src/Epetra_MsrMatrix.h
@@ -413,6 +413,6 @@ class Epetra_MsrMatrix: public Epetra_Object, public Epetra_CompObject, public v
     
 
  //! Copy constructor (not accessible to users).
-  Epetra_MsrMatrix(const Epetra_MsrMatrix & Matrix) {(void)Matrix;}
+  Epetra_MsrMatrix(const Epetra_MsrMatrix & Matrix) : Epetra_Object(Matrix), Epetra_CompObject(Matrix) {}
 };
 #endif /* _EPETRA_MSRMATRIX_H_ */


### PR DESCRIPTION
@trilinos/aztecoo 

## Description
Remove compiler warning by explicitly calling base class copy constructors.

## Motivation and Context
Just hoping for a cleaner build.  In this case the way things were originally written left the meaning unclear, which is why `gcc-7.3.0` is warning about it.

## How Has This Been Tested?
@trilinos-autotester 

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.