### PR TITLE
Set KOKKOS_ARCH differently for chama and serrano in ATDM config

### DIFF
--- a/cmake/std/atdm/chama/environment.sh
+++ b/cmake/std/atdm/chama/environment.sh
@@ -10,4 +10,6 @@
 # sourced script below will impact jobs on both of those
 # machines. please be mindful of this when making changes
 
+export ATDM_CONFIG_KOKKOS_ARCH=SNB
 source $ATDM_SCRIPT_DIR/toss3/environment.sh
+

--- a/cmake/std/atdm/serrano/environment.sh
+++ b/cmake/std/atdm/serrano/environment.sh
@@ -10,4 +10,5 @@
 # sourced script below will impact jobs on both of those
 # machines. please be mindful of this when making changes
 
+export ATDM_CONFIG_KOKKOS_ARCH=BDW
 source $ATDM_SCRIPT_DIR/toss3/environment.sh

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -33,7 +33,6 @@ else
 fi
 
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
-    export ATDM_CONFIG_KOKKOS_ARCH=BDW
     module load sems-python/2.7.9
     module load sems-intel/17.0.0
     module load sems-openmpi/1.10.5


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
The toss3/environment.sh script was setting 
```
export ATDM_CONFIG_KOKKOS_ARCH=BDW
```
which is correct for serrano but not for chama.  `ATDM_CONFIG_KOKKOS_ARCH` is now set in the serrano/environment.sh and chama/environment.sh scripts

## Motivation and Context
This fixes illegal instruction errors on `chama` when I do local builds of various packages.  

## How Has This Been Tested?
Previously all tests would fail due to illegal instruction error, with this change the tests pass again.  I tested this with a build of Kokkos and a build of Thyra

```
  cd BUILD_DIR/
  export TRILINOS_DIR=/gscratch/jfrye/Trilinos
  source $TRILINOS_DIR/cmake/std/atdm/load-env.sh $JOB_NAME

  cmake \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Thyra=ON \
  $TRILINOS_DIR

  make -j16
  ctest -j16 -VV
```

```
100% tests passed, 0 tests failed out of 81

Subproject Time Summary:
Thyra    = 332.77 sec*proc (81 tests)

Total Test time (real) =  23.33 sec
```