### PR TITLE
Belos: Fix for Stokhos MagnitudeType (see PR #2677)

### DIFF
--- a/packages/belos/src/BelosBiCGStabSolMgr.hpp
+++ b/packages/belos/src/BelosBiCGStabSolMgr.hpp
@@ -271,7 +271,6 @@ namespace Belos {
     mutable Teuchos::RCP<const Teuchos::ParameterList> validParams_;
 
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool showMaxResNormOnly_default_ = false;
     static constexpr int verbosity_default_ = Belos::Errors;
@@ -301,7 +300,7 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 BiCGStabSolMgr<ScalarType,MV,OP>::BiCGStabSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -321,7 +320,7 @@ BiCGStabSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                      const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -446,7 +445,13 @@ void BiCGStabSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -568,7 +573,7 @@ BiCGStabSolMgr<ScalarType,MV,OP>::getValidParameters() const
 
     // The static_cast is to resolve an issue with older clang versions which
     // would cause the constexpr to link fail. With c++17 the problem is resolved.
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linera system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),

--- a/packages/belos/src/BelosBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosBlockCGSolMgr.hpp
@@ -213,12 +213,12 @@ namespace Belos {
      *                                         relative residual norm is printed if convergence
      *                                         information is printed. Default: false
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
-     *		\param pl [in] ParameterList with construction information
-     *			\htmlonly
-     *			<iframe src="belos_BlockCG.xml" width=100% scrolling="no" frameborder="0">
-     *			</iframe>
-     *			<hr />
-     *			\endhtmlonly
+     *          \param pl [in] ParameterList with construction information
+     *                  \htmlonly
+     *                  <iframe src="belos_BlockCG.xml" width=100% scrolling="no" frameborder="0">
+     *                  </iframe>
+     *                  <hr />
+     *                  \endhtmlonly
      */
     BlockCGSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                    const Teuchos::RCP<Teuchos::ParameterList> &pl );
@@ -357,8 +357,6 @@ namespace Belos {
     //
     // Default solver parameters.
     //
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
-    static constexpr MagnitudeType orthoKappa_default_ = -1.0;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool adaptiveBlockSize_default_ = true;
     static constexpr bool showMaxResNormOnly_default_ = false;
@@ -415,8 +413,8 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 BlockCGSolMgr<ScalarType,MV,OP,true>::BlockCGSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  orthoKappa_(orthoKappa_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  orthoKappa_(DefaultSolverParameters::orthoKappa),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -441,8 +439,8 @@ BlockCGSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
               const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
     outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  orthoKappa_(orthoKappa_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  orthoKappa_(DefaultSolverParameters::orthoKappa),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -563,7 +561,14 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 
   // Check which orthogonalization constant to use.
   if (params->isParameter("Orthogonalization Constant")) {
-    orthoKappa_ = params->get("Orthogonalization Constant",orthoKappa_default_);
+    if (params->isType<MagnitudeType> ("Orthogonalization Constant")) {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 static_cast<MagnitudeType> (DefaultSolverParameters::orthoKappa));
+    }
+    else {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 DefaultSolverParameters::orthoKappa);
+    }
 
     // Update parameter in our list.
     params_->set("Orthogonalization Constant",orthoKappa_);
@@ -634,7 +639,13 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -754,7 +765,7 @@ BlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
@@ -788,7 +799,7 @@ BlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
       "The string to use as a prefix for the timer labels.");
     pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, or IMGS.");
-    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(DefaultSolverParameters::orthoKappa),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL = pl;

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -156,12 +156,12 @@ public:
    *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
    *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
    *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms must reach to decide convergence. Default: 1e-8
-   *		\param pl [in] ParameterList with construction information
-   *			\htmlonly
-   *			<iframe src="belos_BlockGmres.xml" width=100% scrolling="no" frameborder="0">
-   *			</iframe>
-   *			<hr />
-   *			\endhtmlonly
+   *            \param pl [in] ParameterList with construction information
+   *                    \htmlonly
+   *                    <iframe src="belos_BlockGmres.xml" width=100% scrolling="no" frameborder="0">
+   *                    </iframe>
+   *                    <hr />
+   *                    \endhtmlonly
    */
   BlockGmresSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
     const Teuchos::RCP<Teuchos::ParameterList> &pl );
@@ -315,8 +315,6 @@ private:
   Teuchos::RCP<Teuchos::ParameterList> params_;
 
   // Default solver values.
-  static constexpr MagnitudeType convTol_default_ = 1e-8;
-  static constexpr MagnitudeType orthoKappa_default_ = -1.0;
   static constexpr int maxRestarts_default_ = 20;
   static constexpr int maxIters_default_ = 1000;
   static constexpr bool adaptiveBlockSize_default_ = true;
@@ -356,8 +354,8 @@ private:
 template<class ScalarType, class MV, class OP>
 BlockGmresSolMgr<ScalarType,MV,OP>::BlockGmresSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  orthoKappa_(orthoKappa_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  orthoKappa_(DefaultSolverParameters::orthoKappa),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxRestarts_(maxRestarts_default_),
   maxIters_(maxIters_default_),
@@ -388,8 +386,8 @@ BlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                   const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  orthoKappa_(orthoKappa_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  orthoKappa_(DefaultSolverParameters::orthoKappa),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxRestarts_(maxRestarts_default_),
   maxIters_(maxIters_default_),
@@ -432,7 +430,7 @@ BlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
 
     // The static_cast is to resolve an issue with older clang versions which
     // would cause the constexpr to link fail. With c++17 the problem is resolved.
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged." );
     pl->set("Maximum Restarts", static_cast<int>(maxRestarts_default_),
@@ -478,7 +476,7 @@ BlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "The string to use as a prefix for the timer labels.");
     pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, or IMGS.");
-    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(DefaultSolverParameters::orthoKappa),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL = pl;
@@ -604,7 +602,14 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
 
   // Check which orthogonalization constant to use.
   if (params->isParameter("Orthogonalization Constant")) {
-    orthoKappa_ = params->get("Orthogonalization Constant",orthoKappa_default_);
+    if (params->isType<MagnitudeType> ("Orthogonalization Constant")) {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 static_cast<MagnitudeType> (DefaultSolverParameters::orthoKappa));
+    }
+    else {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 DefaultSolverParameters::orthoKappa);
+    }
 
     // Update parameter in our list.
     params_->set("Orthogonalization Constant",orthoKappa_);
@@ -673,7 +678,13 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);

--- a/packages/belos/src/BelosFixedPointSolMgr.hpp
+++ b/packages/belos/src/BelosFixedPointSolMgr.hpp
@@ -75,10 +75,10 @@
  */
 
 namespace Belos {
-  
+
   //! @name FixedPointSolMgr Exceptions
   //@{
-  
+
   /** \brief FixedPointSolMgrLinearProblemFailure is thrown when the linear problem is
    * not setup (i.e. setProblem() was not called) when solve() is called.
    *
@@ -88,21 +88,21 @@ namespace Belos {
   class FixedPointSolMgrLinearProblemFailure : public BelosError {public:
     FixedPointSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   template<class ScalarType, class MV, class OP>
   class FixedPointSolMgr : public SolverManager<ScalarType,MV,OP> {
-    
+
   private:
     typedef MultiVecTraits<ScalarType,MV> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    
+
   public:
-    
+
     //! @name Constructors/Destructor
-    //@{ 
+    //@{
 
     /*! \brief Empty constructor for FixedPointSolMgr.
      * This constructor takes no arguments and sets the default values for the solver.
@@ -115,29 +115,29 @@ namespace Belos {
      *
      * This constructor accepts the LinearProblem to be solved in addition
      * to a parameter list of options for the solver manager. These options include the following:
-     *   - "Block Size" - an \c int specifying the block size to be used by the underlying block 
+     *   - "Block Size" - an \c int specifying the block size to be used by the underlying block
      *                    conjugate-gradient solver. Default: 1
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Output Stream" - a reference-counted pointer to the output stream where all
      *                       solver output is sent.  Default: Teuchos::rcp(&std::cout,false)
-     *   - "Output Frequency" - an \c int specifying how often convergence information should be 
+     *   - "Output Frequency" - an \c int specifying how often convergence information should be
      *                          outputted.  Default: -1 (never)
      *   - "Show Maximum Residual Norm Only" - a \c bool specifying whether that only the maximum
-     *                                         relative residual norm is printed if convergence 
+     *                                         relative residual norm is printed if convergence
      *                                         information is printed. Default: false
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
      */
     FixedPointSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-		   const Teuchos::RCP<Teuchos::ParameterList> &pl );
-    
+                   const Teuchos::RCP<Teuchos::ParameterList> &pl );
+
     //! Destructor.
     virtual ~FixedPointSolMgr() {};
     //@}
-    
+
     //! @name Accessor methods
-    //@{ 
-    
+    //@{
+
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
     }
@@ -145,12 +145,12 @@ namespace Belos {
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    
+
     /*! \brief Get a parameter list containing the current parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const { return params_; }
-    
-    /*! \brief Return the timers for this object. 
+
+    /*! \brief Return the timers for this object.
      *
      * The timers are ordered as follows:
      *   - time spent in solve() routine
@@ -160,7 +160,7 @@ namespace Belos {
     }
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -176,18 +176,18 @@ namespace Belos {
     /*! \brief Return whether a loss of accuracy was detected by this solver during the most current solve.
      */
     bool isLOADetected() const { return false; }
- 
+
     //@}
-    
+
     //! @name Set methods
     //@{
-   
-    //! Set the linear problem that needs to be solved. 
+
+    //! Set the linear problem that needs to be solved.
     void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) { problem_ = problem; }
-   
-    //! Set the parameters the solver manager should use to solve the linear problem. 
+
+    //! Set the parameters the solver manager should use to solve the linear problem.
     void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params );
-    
+
     //! Set user-defined convergence status test.
     void replaceUserConvStatusTest( const Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP> > &userConvStatusTest )
     {
@@ -205,7 +205,7 @@ namespace Belos {
     }
 
     //@}
-   
+
     //! @name Reset methods
     //@{
     /*! \brief Performs a reset of the solver manager specified by the \c ResetType.  This informs the
@@ -214,21 +214,21 @@ namespace Belos {
      */
     void reset( const ResetType type ) { if ((type & Belos::Problem) && !Teuchos::is_null(problem_)) problem_->setProblem(); }
     //@}
- 
+
     //! @name Solver application methods
-    //@{ 
-    
-    /*! \brief This method performs possibly repeated calls to the underlying linear solver's 
-     *         iterate() routine until the problem has been solved (as decided by the solver manager) 
+    //@{
+
+    /*! \brief This method performs possibly repeated calls to the underlying linear solver's
+     *         iterate() routine until the problem has been solved (as decided by the solver manager)
      *         or the solver manager decides to quit.
      *
-     * This method calls FixedPointIter::iterate() or CGIter::iterate(), which will return either because a 
+     * This method calls FixedPointIter::iterate() or CGIter::iterate(), which will return either because a
      * specially constructed status test evaluates to ::Passed or an std::exception is thrown.
      *
      * A return from FixedPointIter::iterate() signifies one of the following scenarios:
-     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions 
+     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions
      *      to the linear system will be placed in the linear problem and return ::Unconverged.
-     *    - global convergence has been met. In this case, the current solutions to the linear system 
+     *    - global convergence has been met. In this case, the current solutions to the linear system
      *      will be placed in the linear problem and the solver manager will return ::Converged
      *
      * \returns ::ReturnType specifying:
@@ -236,22 +236,22 @@ namespace Belos {
      *     - ::Unconverged: the linear problem was not solved to the specification desired by the solver manager.
      */
     ReturnType solve();
-    
+
     //@}
-    
+
     /** \name Overridden from Teuchos::Describable */
     //@{
-    
+
     /** \brief Method to return description of the block CG solver manager */
     std::string description() const;
-    
+
     //@}
-    
+
   private:
 
     //! The linear problem to solve.
     Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
-    
+
     //! Output manager, that handles printing of different kinds of messages.
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
     //! Output stream to which the output manager prints.
@@ -274,11 +274,10 @@ namespace Belos {
 
     //! Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
-    
+
     //
     // Default solver parameters.
     //
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool showMaxResNormOnly_default_ = false;
     static constexpr int blockSize_default_ = 1;
@@ -296,7 +295,7 @@ namespace Belos {
     MagnitudeType convtol_;
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -310,7 +309,7 @@ namespace Belos {
 
     int blockSize_, verbosity_, outputStyle_, outputFreq_;
     bool showMaxResNormOnly_;
-    
+
     //! Prefix label for all the timers.
     std::string label_;
 
@@ -326,7 +325,7 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 FixedPointSolMgr<ScalarType,MV,OP>::FixedPointSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -344,10 +343,10 @@ FixedPointSolMgr<ScalarType,MV,OP>::FixedPointSolMgr() :
 template<class ScalarType, class MV, class OP>
 FixedPointSolMgr<ScalarType,MV,OP>::
 FixedPointSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-	      const Teuchos::RCP<Teuchos::ParameterList> &pl) : 
+              const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -359,19 +358,19 @@ FixedPointSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
   label_(label_default_),
   isSet_(false)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION(problem_.is_null(), std::invalid_argument, 
+  TEUCHOS_TEST_FOR_EXCEPTION(problem_.is_null(), std::invalid_argument,
     "FixedPointSolMgr's constructor requires a nonnull LinearProblem instance.");
 
   // If the user passed in a nonnull parameter list, set parameters.
   // Otherwise, the next solve() call will use default parameters,
   // unless the user calls setParameters() first.
   if (! pl.is_null()) {
-    setParameters (pl);  
+    setParameters (pl);
   }
 }
 
 template<class ScalarType, class MV, class OP>
-void 
+void
 FixedPointSolMgr<ScalarType,MV,OP>::
 setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 {
@@ -395,9 +394,9 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 
   // Check for blocksize
   if (params->isParameter("Block Size")) {
-    blockSize_ = params->get("Block Size",blockSize_default_);    
+    blockSize_ = params->get("Block Size",blockSize_default_);
     TEUCHOS_TEST_FOR_EXCEPTION(blockSize_ <= 0, std::invalid_argument,
-		       "Belos::FixedPointSolMgr: \"Block Size\" must be strictly positive.");
+                       "Belos::FixedPointSolMgr: \"Block Size\" must be strictly positive.");
 
     // Update parameter in our list.
     params_->set("Block Size", blockSize_);
@@ -470,22 +469,28 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
-  }  
-  
+  }
+
   // Convergence
   typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
   typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP>  StatusTestResNorm_t;
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
     if (convTest_ != Teuchos::null)
       convTest_->setTolerance( convtol_ );
   }
-  
+
   if (params->isParameter("Show Maximum Residual Norm Only")) {
     showMaxResNormOnly_ = Teuchos::getParameter<bool>(*params,"Show Maximum Residual Norm Only");
 
@@ -500,14 +505,14 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   // Basic test checks maximum iterations and native residual.
   if (maxIterTest_ == Teuchos::null)
     maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
-  
+
   // Implicit residual test, using the native residual to determine if convergence was achieved.
   if (convTest_ == Teuchos::null)
     convTest_ = Teuchos::rcp( new StatusTestResNorm_t( convtol_, 1 ) );
-  
+
   if (sTest_ == Teuchos::null)
     sTest_ = Teuchos::rcp( new StatusTestCombo_t( StatusTestCombo_t::OR, maxIterTest_, convTest_ ) );
-  
+
   if (outputTest_ == Teuchos::null) {
 
     // Create the status test output class.
@@ -533,20 +538,20 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   isSet_ = true;
 }
 
-    
+
 template<class ScalarType, class MV, class OP>
-Teuchos::RCP<const Teuchos::ParameterList> 
+Teuchos::RCP<const Teuchos::ParameterList>
 FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
-  
+
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
     // The static_cast is to resolve an issue with older clang versions which
     // would cause the constexpr to link fail. With c++17 the problem is resolved.
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
@@ -562,7 +567,7 @@ FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "to the output stream.");
     pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
-      "to the output stream.");  
+      "to the output stream.");
     pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
@@ -576,7 +581,7 @@ FixedPointSolMgr<ScalarType,MV,OP>::getValidParameters() const
   return validPL;
 }
 
-  
+
 // solve()
 template<class ScalarType, class MV, class OP>
 ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
@@ -595,8 +600,8 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
 
   Teuchos::BLAS<int,ScalarType> blas;
   Teuchos::LAPACK<int,ScalarType> lapack;
-  
-  TEUCHOS_TEST_FOR_EXCEPTION( !problem_->isProblemSet(), 
+
+  TEUCHOS_TEST_FOR_EXCEPTION( !problem_->isProblemSet(),
     FixedPointSolMgrLinearProblemFailure,
     "Belos::FixedPointSolMgr::solve(): Linear problem is not ready, setProblem() "
     "has not been called.");
@@ -609,9 +614,9 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   std::vector<int> currIdx, currIdx2;
   currIdx.resize( blockSize_ );
   currIdx2.resize( blockSize_ );
-  for (int i=0; i<numCurrRHS; ++i) 
+  for (int i=0; i<numCurrRHS; ++i)
     { currIdx[i] = startPtr+i; currIdx2[i]=i; }
-  for (int i=numCurrRHS; i<blockSize_; ++i) 
+  for (int i=numCurrRHS; i<blockSize_; ++i)
     { currIdx[i] = -1; currIdx2[i] = i; }
 
   // Inform the linear problem of the current linear system to solve.
@@ -621,13 +626,13 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   // Set up the parameter list for the Iteration subclass.
   Teuchos::ParameterList plist;
   plist.set("Block Size",blockSize_);
-  
+
   // Reset the output status test (controls all the other status tests).
   outputTest_->reset();
 
   // Assume convergence is achieved, then let any failed convergence
   // set this to false.  "Innocent until proven guilty."
-  bool isConverged = true;	
+  bool isConverged = true;
 
   ////////////////////////////////////////////////////////////////////////////
   // Set up the FixedPoint Iteration subclass.
@@ -663,130 +668,130 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
       block_fp_iter->initializeFixedPoint(newstate);
 
       while(1) {
-	
-	// tell block_fp_iter to iterate
-	try {
-	  block_fp_iter->iterate();
-	  //
-	  // Check whether any of the linear systems converged.
-	  //
-	  if (convTest_->getStatus() == Passed) {
-	    // At least one of the linear system(s) converged.  
-	    //
-	    // Get the column indices of the linear systems that converged.
-	    std::vector<int> convIdx = convTest_->convIndices();
 
-	    // If the number of converged linear systems equals the
+        // tell block_fp_iter to iterate
+        try {
+          block_fp_iter->iterate();
+          //
+          // Check whether any of the linear systems converged.
+          //
+          if (convTest_->getStatus() == Passed) {
+            // At least one of the linear system(s) converged.
+            //
+            // Get the column indices of the linear systems that converged.
+            std::vector<int> convIdx = convTest_->convIndices();
+
+            // If the number of converged linear systems equals the
             // number of linear systems currently being solved, then
             // we are done with this block.
-	    if (convIdx.size() == currRHSIdx.size())
-	      break;  // break from while(1){block_fp_iter->iterate()}
+            if (convIdx.size() == currRHSIdx.size())
+              break;  // break from while(1){block_fp_iter->iterate()}
 
-	    // Inform the linear problem that we are finished with
-	    // this current linear system.
-	    problem_->setCurrLS();
+            // Inform the linear problem that we are finished with
+            // this current linear system.
+            problem_->setCurrLS();
 
-	    // Reset currRHSIdx to contain the right-hand sides that
-	    // are left to converge for this block.
-	    int have = 0;
+            // Reset currRHSIdx to contain the right-hand sides that
+            // are left to converge for this block.
+            int have = 0;
             std::vector<int> unconvIdx(currRHSIdx.size());
-	    for (unsigned int i=0; i<currRHSIdx.size(); ++i) {
-	      bool found = false;
-	      for (unsigned int j=0; j<convIdx.size(); ++j) {
-		if (currRHSIdx[i] == convIdx[j]) {
-		  found = true;
-		  break;
-		}
-	      }
-	      if (!found) {
+            for (unsigned int i=0; i<currRHSIdx.size(); ++i) {
+              bool found = false;
+              for (unsigned int j=0; j<convIdx.size(); ++j) {
+                if (currRHSIdx[i] == convIdx[j]) {
+                  found = true;
+                  break;
+                }
+              }
+              if (!found) {
                 currIdx2[have] = currIdx2[i];
-		currRHSIdx[have++] = currRHSIdx[i];
-	      }
+                currRHSIdx[have++] = currRHSIdx[i];
+              }
               else {
-              } 
-	    }
-	    currRHSIdx.resize(have);
-	    currIdx2.resize(have);
+              }
+            }
+            currRHSIdx.resize(have);
+            currIdx2.resize(have);
 
-	    // Set the remaining indices after deflation.
-	    problem_->setLSIndex( currRHSIdx );
+            // Set the remaining indices after deflation.
+            problem_->setLSIndex( currRHSIdx );
 
-	    // Get the current residual vector.
-	    std::vector<MagnitudeType> norms;
+            // Get the current residual vector.
+            std::vector<MagnitudeType> norms;
             R_0 = MVT::CloneCopy( *(block_fp_iter->getNativeResiduals(&norms)),currIdx2 );
-	    for (int i=0; i<have; ++i) { currIdx2[i] = i; }
+            for (int i=0; i<have; ++i) { currIdx2[i] = i; }
 
-	    // Set the new blocksize for the solver.
-	    block_fp_iter->setBlockSize( have );
+            // Set the new blocksize for the solver.
+            block_fp_iter->setBlockSize( have );
 
-	    // Set the new state and initialize the solver.
-	    FixedPointIterationState<ScalarType,MV> defstate;
-	    defstate.R = R_0;
-	    block_fp_iter->initializeFixedPoint(defstate);
-	  }
-	  //
-	  // None of the linear systems converged.  Check whether the
-	  // maximum iteration count was reached.
-	  //
-	  else if (maxIterTest_->getStatus() == Passed) {
-	    isConverged = false; // None of the linear systems converged.
-	    break;  // break from while(1){block_fp_iter->iterate()}
-	  }
-	  //
-	  // iterate() returned, but none of our status tests Passed.
-	  // This indicates a bug.
-	  //
-	  else {
-	    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
-	      "Belos::FixedPointSolMgr::solve(): Neither the convergence test nor "
-	      "the maximum iteration count test passed.  Please report this bug "
-	      "to the Belos developers.");
-	  }
-	}
-	catch (const std::exception &e) {
-	  std::ostream& err = printer_->stream (Errors);
-	  err << "Error! Caught std::exception in FixedPointIteration::iterate() at "
-	      << "iteration " << block_fp_iter->getNumIters() << std::endl 
-	      << e.what() << std::endl;
-	  throw;
-	}
+            // Set the new state and initialize the solver.
+            FixedPointIterationState<ScalarType,MV> defstate;
+            defstate.R = R_0;
+            block_fp_iter->initializeFixedPoint(defstate);
+          }
+          //
+          // None of the linear systems converged.  Check whether the
+          // maximum iteration count was reached.
+          //
+          else if (maxIterTest_->getStatus() == Passed) {
+            isConverged = false; // None of the linear systems converged.
+            break;  // break from while(1){block_fp_iter->iterate()}
+          }
+          //
+          // iterate() returned, but none of our status tests Passed.
+          // This indicates a bug.
+          //
+          else {
+            TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
+              "Belos::FixedPointSolMgr::solve(): Neither the convergence test nor "
+              "the maximum iteration count test passed.  Please report this bug "
+              "to the Belos developers.");
+          }
+        }
+        catch (const std::exception &e) {
+          std::ostream& err = printer_->stream (Errors);
+          err << "Error! Caught std::exception in FixedPointIteration::iterate() at "
+              << "iteration " << block_fp_iter->getNumIters() << std::endl
+              << e.what() << std::endl;
+          throw;
+        }
       }
-      
+
       // Inform the linear problem that we are finished with this
       // block linear system.
       problem_->setCurrLS();
-      
+
       // Update indices for the linear systems to be solved.
       startPtr += numCurrRHS;
       numRHS2Solve -= numCurrRHS;
       if ( numRHS2Solve > 0 ) {
-	numCurrRHS = ( numRHS2Solve < blockSize_) ? numRHS2Solve : blockSize_;
+        numCurrRHS = ( numRHS2Solve < blockSize_) ? numRHS2Solve : blockSize_;
 
-	
-	currIdx.resize( blockSize_ );
-	currIdx2.resize( blockSize_ );
-	for (int i=0; i<numCurrRHS; ++i) 
-	  { currIdx[i] = startPtr+i; currIdx2[i] = i; }
-	for (int i=numCurrRHS; i<blockSize_; ++i) 
-	  { currIdx[i] = -1; currIdx2[i] = i; }
 
-	// Set the next indices.
-	problem_->setLSIndex( currIdx );
+        currIdx.resize( blockSize_ );
+        currIdx2.resize( blockSize_ );
+        for (int i=0; i<numCurrRHS; ++i)
+          { currIdx[i] = startPtr+i; currIdx2[i] = i; }
+        for (int i=numCurrRHS; i<blockSize_; ++i)
+          { currIdx[i] = -1; currIdx2[i] = i; }
 
-	// Set the new blocksize for the solver.
-	block_fp_iter->setBlockSize( blockSize_ );	
+        // Set the next indices.
+        problem_->setLSIndex( currIdx );
+
+        // Set the new blocksize for the solver.
+        block_fp_iter->setBlockSize( blockSize_ );
       }
       else {
         currIdx.resize( numRHS2Solve );
       }
-      
+
     }// while ( numRHS2Solve > 0 )
-    
+
   }
 
   // print final summary
   sTest_->print( printer_->stream(FinalSummary) );
- 
+
   // print timing information
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   // Calling summarize() requires communication in general, so don't
@@ -797,7 +802,7 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
     Teuchos::TimeMonitor::summarize( printer_->stream(TimingDetails) );
   }
 #endif
- 
+
   // Save the iteration count for this solve.
   numIters_ = maxIterTest_->getNumIters();
 
@@ -805,11 +810,11 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
   {
     // testValues is nonnull and not persistent.
     const std::vector<MagnitudeType>* pTestValues = convTest_->getTestValue();
-    
+
     TEUCHOS_TEST_FOR_EXCEPTION(pTestValues == NULL, std::logic_error,
       "Belos::FixedPointSolMgr::solve(): The convergence test's getTestValue() "
       "method returned NULL.  Please report this bug to the Belos developers.");
-    
+
     TEUCHOS_TEST_FOR_EXCEPTION(pTestValues->size() < 1, std::logic_error,
       "Belos::FixedPointSolMgr::solve(): The convergence test's getTestValue() "
       "method returned a vector of length zero.  Please report this bug to the "
@@ -820,11 +825,11 @@ ReturnType FixedPointSolMgr<ScalarType,MV,OP>::solve() {
     // just for the vectors from the last deflation?
     achievedTol_ = *std::max_element (pTestValues->begin(), pTestValues->end());
   }
- 
+
   if (!isConverged) {
-    return Unconverged; // return from FixedPointSolMgr::solve() 
+    return Unconverged; // return from FixedPointSolMgr::solve()
   }
-  return Converged; // return from FixedPointSolMgr::solve() 
+  return Converged; // return from FixedPointSolMgr::solve()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
@@ -835,7 +840,7 @@ std::string FixedPointSolMgr<ScalarType,MV,OP>::description() const
   oss << "Belos::FixedPointSolMgr<...,"<<Teuchos::ScalarTraits<ScalarType>::name()<<">";
   return oss.str();
 }
-  
+
 } // end Belos namespace
 
 #endif /* BELOS_FIXEDPOINT_SOLMGR_HPP */

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -362,8 +362,6 @@ namespace Belos {
     Teuchos::RCP<Teuchos::ParameterList> params_;
 
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
-    static constexpr MagnitudeType orthoKappa_default_ = -1.0;
     static constexpr int maxIters_default_ = 1000;
     static constexpr int deflatedBlocks_default_ = 2;
     static constexpr int savedBlocks_default_ = 16;
@@ -415,8 +413,8 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 PCPGSolMgr<ScalarType,MV,OP,true>::PCPGSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  orthoKappa_(orthoKappa_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  orthoKappa_(DefaultSolverParameters::orthoKappa),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   numIters_(0),
   maxIters_(maxIters_default_),
@@ -440,8 +438,8 @@ PCPGSolMgr<ScalarType,MV,OP,true>::PCPGSolMgr(
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
 
-  convtol_(convTol_default_),
-  orthoKappa_(orthoKappa_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  orthoKappa_(DefaultSolverParameters::orthoKappa),
   achievedTol_(Teuchos::ScalarTraits<MagnitudeType>::zero()),
   numIters_(0),
   maxIters_(maxIters_default_),
@@ -563,7 +561,14 @@ void PCPGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teucho
 
   // Check which orthogonalization constant to use.
   if (params->isParameter("Orthogonalization Constant")) {
-    orthoKappa_ = params->get("Orthogonalization Constant",orthoKappa_default_);
+    if (params->isType<MagnitudeType> ("Orthogonalization Constant")) {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 static_cast<MagnitudeType> (DefaultSolverParameters::orthoKappa));
+    }
+    else {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 DefaultSolverParameters::orthoKappa);
+    }
 
     // Update parameter in our list.
     params_->set("Orthogonalization Constant",orthoKappa_);
@@ -634,7 +639,13 @@ void PCPGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teucho
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -708,7 +719,7 @@ PCPGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   if (is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     // Set all the valid parameters and their default values.
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
@@ -734,7 +745,7 @@ PCPGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
       "The string to use as a prefix for the timer labels.");
     pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
       "The type of orthogonalization to use: DGKS, ICGS, IMGS");
-    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(orthoKappa_default_),
+    pl->set("Orthogonalization Constant",static_cast<MagnitudeType>(DefaultSolverParameters::orthoKappa),
       "The constant used by DGKS orthogonalization to determine\n"
       "whether another step of classical Gram-Schmidt is necessary.");
     validPL = pl;

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -168,12 +168,12 @@ namespace Belos {
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms must reach to decide convergence.
-     *		\param pl [in] ParameterList with construction information
-     *			\htmlonly
-     *			<iframe src="belos_PseudoBlockCG.xml" width=100% scrolling="no" frameborder="0">
-     *			</iframe>
-     *			<hr />
-     *			\endhtmlonly   
+     *          \param pl [in] ParameterList with construction information
+     *                  \htmlonly
+     *                  <iframe src="belos_PseudoBlockCG.xml" width=100% scrolling="no" frameborder="0">
+     *                  </iframe>
+     *                  <hr />
+     *                  \endhtmlonly
      */
     PseudoBlockCGSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                          const Teuchos::RCP<Teuchos::ParameterList> &pl );
@@ -325,7 +325,6 @@ namespace Belos {
     mutable Teuchos::RCP<const Teuchos::ParameterList> validParams_;
 
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool assertPositiveDefiniteness_default_ = true;
     static constexpr bool showMaxResNormOnly_default_ = false;
@@ -360,7 +359,7 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::PseudoBlockCGSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -383,7 +382,7 @@ PseudoBlockCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &probl
                      const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -553,7 +552,13 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
   // Check for convergence tolerance
   if (params->isParameter ("Convergence Tolerance")) {
-    convtol_ = params->get ("Convergence Tolerance", convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set ("Convergence Tolerance", convtol_);
@@ -678,9 +683,9 @@ PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   if (validParams_.is_null()) {
     // Set all the valid parameters and their default values.
     RCP<ParameterList> pl = parameterList ();
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
-      "iterative solver in order for the linera system to be declared converged.");
+      "iterative solver in order for the linear system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
       "The maximum number of block iterations allowed for each\n"
       "set of RHS solved.");
@@ -776,10 +781,10 @@ ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
   Teuchos::RCP<CGIteration<ScalarType,MV,OP> > block_cg_iter;
   if (numRHS2Solve == 1) {
     block_cg_iter =
-      Teuchos::rcp (new CGIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, plist));                                           
+      Teuchos::rcp (new CGIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, plist));
   } else {
     block_cg_iter =
-      Teuchos::rcp (new PseudoBlockCGIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, plist));                                              
+      Teuchos::rcp (new PseudoBlockCGIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, plist));
   }
 
 

--- a/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
@@ -252,7 +252,6 @@ namespace Belos {
     mutable Teuchos::RCP<const Teuchos::ParameterList> validParams_;
 
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool assertPositiveDefiniteness_default_ = true;
     static constexpr bool showMaxResNormOnly_default_ = false;
@@ -288,7 +287,7 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::PseudoBlockStochasticCGSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -309,7 +308,7 @@ PseudoBlockStochasticCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP
                                const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
+  convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
   numIters_(0),
   verbosity_(verbosity_default_),
@@ -443,7 +442,13 @@ void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::setParameters( const Teuch
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -565,7 +570,7 @@ PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::getValidParameters() const
     // The static_cast is to resolve an issue with older clang versions which
     // would cause the constexpr to link fail. With c++17 the problem is resolved.
     RCP<ParameterList> pl = parameterList ();
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linera system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),

--- a/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRSolMgr.hpp
@@ -69,17 +69,17 @@
 /*! \class Belos::PseudoBlockTFQMRSolMgr
  *
  *  \brief The Belos::PseudoBlockTFQMRSolMgr provides a powerful and fully-featured solver manager over the pseudo-block TFQMR linear solver.
- 
+
  \ingroup belos_solver_framework
- 
+
  \author Heidi Thornquist
 */
 
 namespace Belos {
-  
+
   //! @name PseudoBlockTFQMRSolMgr Exceptions
   //@{
-  
+
   /** \brief PseudoBlockTFQMRSolMgrLinearProblemFailure is thrown when the linear problem is
    * not setup (i.e. setProblem() was not called) when solve() is called.
    *
@@ -89,7 +89,7 @@ namespace Belos {
   class PseudoBlockTFQMRSolMgrLinearProblemFailure : public BelosError {public:
     PseudoBlockTFQMRSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   /** \brief PseudoBlockTFQMRSolMgrOrthoFailure is thrown when the orthogonalization manager is
    * unable to generate orthonormal columns from the initial basis vectors.
    *
@@ -99,21 +99,21 @@ namespace Belos {
   class PseudoBlockTFQMRSolMgrOrthoFailure : public BelosError {public:
     PseudoBlockTFQMRSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   template<class ScalarType, class MV, class OP>
   class PseudoBlockTFQMRSolMgr : public SolverManager<ScalarType,MV,OP> {
-    
+
   private:
     typedef MultiVecTraits<ScalarType,MV> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    
+
   public:
-    
+
     //! @name Constructors/Destructor
-    //@{ 
+    //@{
 
     /*! \brief Empty constructor for PseudoBlockTFQMRSolMgr.
      * This constructor takes no arguments and sets the default values for the solver.
@@ -126,28 +126,28 @@ namespace Belos {
      *
      * This constructor accepts the LinearProblem to be solved in addition
      * to a parameter list of options for the solver manager. These options include the following:
-     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the 
+     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the
      *                            underlying solver is allowed to perform. Default: 1000
-     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms 
+     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms
      *                               must reach to decide convergence. Default: 1e-8.
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Output Stream" - a reference-counted pointer to the output stream where all
      *                       solver output is sent.  Default: Teuchos::rcp(&std::cout,false)
-     *   - "Output Frequency" - an \c int specifying how often convergence information should be 
+     *   - "Output Frequency" - an \c int specifying how often convergence information should be
      *                          outputted.  Default: -1 (never)
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
      */
     PseudoBlockTFQMRSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-		 const Teuchos::RCP<Teuchos::ParameterList> &pl );
-    
+                 const Teuchos::RCP<Teuchos::ParameterList> &pl );
+
     //! Destructor.
     virtual ~PseudoBlockTFQMRSolMgr() {};
     //@}
-    
+
     //! @name Accessor methods
-    //@{ 
-    
+    //@{
+
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
     }
@@ -155,12 +155,12 @@ namespace Belos {
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    
+
     /*! \brief Get a parameter list containing the current parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const { return params_; }
-    
-    /*! \brief Return the timers for this object. 
+
+    /*! \brief Return the timers for this object.
      *
      * The timers are ordered as follows:
      *   - time spent in solve() routine
@@ -170,7 +170,7 @@ namespace Belos {
     }
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -182,7 +182,7 @@ namespace Belos {
     int getNumIters() const {
       return numIters_;
     }
-    
+
     /// \brief Whether loss of accuracy was detected during the last \c solve() invocation.
     ///
     /// In solvers that can detect a loss of accuracy, this method
@@ -191,20 +191,20 @@ namespace Belos {
     /// not currently detect a loss of accuracy, so this method always
     /// returns false.
     bool isLOADetected() const { return false; }
-    
+
     //@}
-    
+
     //! @name Set methods
     //@{
-    
-    //! Set the linear problem that needs to be solved. 
+
+    //! Set the linear problem that needs to be solved.
     void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) { problem_ = problem; }
-    
-    //! Set the parameters the solver manager should use to solve the linear problem. 
+
+    //! Set the parameters the solver manager should use to solve the linear problem.
     void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params );
-    
+
     //@}
-    
+
     //! @name Reset methods
     //@{
     /*! \brief Performs a reset of the solver manager specified by the \c ResetType.  This informs the
@@ -213,21 +213,21 @@ namespace Belos {
      */
     void reset( const ResetType type ) { if ((type & Belos::Problem) && !Teuchos::is_null(problem_)) problem_->setProblem(); }
     //@}
-    
+
     //! @name Solver application methods
-    //@{ 
-    
-    /*! \brief This method performs possibly repeated calls to the underlying linear solver's 
-     *         iterate() routine until the problem has been solved (as decided by the solver manager) 
+    //@{
+
+    /*! \brief This method performs possibly repeated calls to the underlying linear solver's
+     *         iterate() routine until the problem has been solved (as decided by the solver manager)
      *         or the solver manager decides to quit.
      *
-     * This method calls PseudoBlockTFQMRIter::iterate(), which will return either because a 
+     * This method calls PseudoBlockTFQMRIter::iterate(), which will return either because a
      * specially constructed status test evaluates to ::Passed or an std::exception is thrown.
      *
      * A return from PseudoBlockTFQMRIter::iterate() signifies one of the following scenarios:
-     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions 
+     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions
      *      to the linear system will be placed in the linear problem and return ::Unconverged.
-     *    - global convergence has been met. In this case, the current solutions to the linear system 
+     *    - global convergence has been met. In this case, the current solutions to the linear system
      *      will be placed in the linear problem and the solver manager will return ::Converged
      *
      * \returns ::ReturnType specifying:
@@ -235,42 +235,40 @@ namespace Belos {
      *     - ::Unconverged: the linear problem was not solved to the specification desired by the solver manager.
      */
     ReturnType solve();
-    
+
     //@}
-    
+
     /** \name Overridden from Teuchos::Describable */
     //@{
-    
+
     /** \brief Method to return description of the pseudo-block TFQMR solver manager */
     std::string description() const;
-    
+
     //@}
-    
+
   private:
 
     // Method for checking current status test against defined linear problem.
     bool checkStatusTest();
-    
+
     // Linear problem.
     Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
-    
+
     // Output manager.
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
     Teuchos::RCP<std::ostream> outputStream_;
-    
+
     // Status test.
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
     Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > convTest_;
     Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > expConvTest_, impConvTest_;
     Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
-    
+
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
-    
+
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
-    static constexpr MagnitudeType impTolScale_default_ = 10.0;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool expResTest_default_ = false;
     static constexpr int verbosity_default_ = Belos::Errors;
@@ -288,7 +286,7 @@ namespace Belos {
     int verbosity_, outputStyle_, outputFreq_, defQuorum_;
     bool expResTest_;
     std::string impResScale_, expResScale_;
-    
+
     // Timers.
     std::string label_;
     Teuchos::RCP<Teuchos::Time> timerSolve_;
@@ -302,8 +300,8 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  impTolScale_(impTolScale_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  impTolScale_(DefaultSolverParameters::impTolScale),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -322,13 +320,13 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr() :
 
 // Basic Constructor
 template<class ScalarType, class MV, class OP>
-PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr( 
-					     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) : 
+PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr(
+                                             const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+                                             const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  impTolScale_(impTolScale_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  impTolScale_(DefaultSolverParameters::impTolScale),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -344,13 +342,13 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::PseudoBlockTFQMRSolMgr(
   isSTSet_(false)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null, std::invalid_argument, "Problem not given to solver manager.");
-  
+
   // If the parameter list pointer is null, then set the current parameters to the default parameter list.
   if ( !is_null(pl) ) {
-    setParameters( pl );  
+    setParameters( pl );
   }
 }
-  
+
 template<class ScalarType, class MV, class OP>
 void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
 {
@@ -439,19 +437,33 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
-  }  
-  
+  }
+
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
     isSTSet_ = false;
   }
- 
+
   if (params->isParameter("Implicit Tolerance Scale Factor")) {
-    impTolScale_ = params->get("Implicit Tolerance Scale Factor",impTolScale_default_);
+    if (params->isType<MagnitudeType> ("Implicit Tolerance Scale Factor")) {
+      impTolScale_ = params->get ("Implicit Tolerance Scale Factor",
+                                  static_cast<MagnitudeType> (DefaultSolverParameters::impTolScale));
+
+    }
+    else {
+      impTolScale_ = params->get ("Implicit Tolerance Scale Factor",
+                                  DefaultSolverParameters::impTolScale);
+    }
 
     // Update parameter in our list.
     params_->set("Implicit Tolerance Scale Factor", impTolScale_);
@@ -468,9 +480,9 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
       // Update parameter in our list.
       params_->set("Implicit Residual Scaling", impResScale_);
       isSTSet_ = false;
-    }      
+    }
   }
-  
+
   if (params->isParameter("Explicit Residual Scaling")) {
     std::string tempExpResScale = Teuchos::getParameter<std::string>( *params, "Explicit Residual Scaling" );
 
@@ -481,7 +493,7 @@ void PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP
       // Update parameter in our list.
       params_->set("Explicit Residual Scaling", expResScale_);
       isSTSet_ = false;
-    }      
+    }
   }
 
   if (params->isParameter("Explicit Residual Test")) {
@@ -530,7 +542,7 @@ bool PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
 
   if (expResTest_) {
-   
+
     // Implicit residual test, using the native residual to determine if convergence was achieved.
     Teuchos::RCP<StatusTestGenResNorm_t> tmpImpConvTest =
       Teuchos::rcp( new StatusTestGenResNorm_t( impTolScale_*convtol_, defQuorum_ ) );
@@ -570,30 +582,30 @@ bool PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   std::string solverDesc = " Pseudo Block TFQMR ";
   outputTest_->setSolverDesc( solverDesc );
 
-  
+
   // The status test is now set.
   isSTSet_ = true;
 
   return false;
 }
 
-    
+
 template<class ScalarType, class MV, class OP>
-Teuchos::RCP<const Teuchos::ParameterList> 
+Teuchos::RCP<const Teuchos::ParameterList>
 PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
-  
+
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
     // The static_cast is to resolve an issue with older clang versions which
     // would cause the constexpr to link fail. With c++17 the problem is resolved.
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Implicit Tolerance Scale Factor", static_cast<MagnitudeType>(impTolScale_default_),
+    pl->set("Implicit Tolerance Scale Factor", static_cast<MagnitudeType>(DefaultSolverParameters::impTolScale),
       "The scale factor used by the implicit residual test when explicit residual\n"
       "testing is used.  May enable faster convergence when TFQMR bound is too loose.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
@@ -607,7 +619,7 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "to the output stream.");
     pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
-      "to the output stream.");  
+      "to the output stream.");
     pl->set("Deflation Quorum", static_cast<int>(defQuorum_default_),
       "The number of linear systems that need to converge before they are deflated.");
     pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
@@ -626,27 +638,27 @@ PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
   return validPL;
 }
 
-  
+
 // solve()
 template<class ScalarType, class MV, class OP>
 ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
 
   // Set the current parameters if they were not set before.
-  // NOTE:  This may occur if the user generated the solver manager with the default constructor and 
+  // NOTE:  This may occur if the user generated the solver manager with the default constructor and
   // then didn't set any parameters using setParameters().
   if (!isSet_) {
     setParameters(Teuchos::parameterList(*getValidParameters()));
   }
 
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null,PseudoBlockTFQMRSolMgrLinearProblemFailure,
-		     "Belos::PseudoBlockTFQMRSolMgr::solve(): Linear problem is not a valid object.");
+                     "Belos::PseudoBlockTFQMRSolMgr::solve(): Linear problem is not a valid object.");
 
   TEUCHOS_TEST_FOR_EXCEPTION(!problem_->isProblemSet(),PseudoBlockTFQMRSolMgrLinearProblemFailure,
                      "Belos::PseudoBlockTFQMRSolMgr::solve(): Linear problem is not ready, setProblem() has not been called.");
 
   if (!isSTSet_) {
     TEUCHOS_TEST_FOR_EXCEPTION( checkStatusTest(),PseudoBlockTFQMRSolMgrLinearProblemFailure,
-			"Belos::PseudoBlockTFQMRSolMgr::solve(): Linear problem and requested status tests are incompatible.");
+                        "Belos::PseudoBlockTFQMRSolMgr::solve(): Linear problem and requested status tests are incompatible.");
   }
 
   // Create indices for the linear systems to be solved.
@@ -665,17 +677,17 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // Parameter list
   Teuchos::ParameterList plist;
-  
-  // Reset the status test.  
+
+  // Reset the status test.
   outputTest_->reset();
 
   // Assume convergence is achieved, then let any failed convergence set this to false.
-  bool isConverged = true;	
+  bool isConverged = true;
 
   //////////////////////////////////////////////////////////////////////////////////////
   // TFQMR solver
 
-  Teuchos::RCP<PseudoBlockTFQMRIter<ScalarType,MV,OP> > block_tfqmr_iter = 
+  Teuchos::RCP<PseudoBlockTFQMRIter<ScalarType,MV,OP> > block_tfqmr_iter =
     Teuchos::rcp( new PseudoBlockTFQMRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations
@@ -706,17 +718,17 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
       block_tfqmr_iter->initializeTFQMR(newstate);
 
       while(1) {
-	
-	// tell block_tfqmr_iter to iterate
-	try {
-	  block_tfqmr_iter->iterate();
-	  
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  //
-	  // check convergence first
-	  //
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  if ( convTest_->getStatus() == Passed ) {
+
+        // tell block_tfqmr_iter to iterate
+        try {
+          block_tfqmr_iter->iterate();
+
+          ////////////////////////////////////////////////////////////////////////////////////
+          //
+          // check convergence first
+          //
+          ////////////////////////////////////////////////////////////////////////////////////
+          if ( convTest_->getStatus() == Passed ) {
 
             // Figure out which linear systems converged.
             std::vector<int> convIdx = expConvTest_->convIndices();
@@ -778,46 +790,46 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
               defstate.tau.push_back( currentState.tau[ *uIter ] );
               defstate.theta.push_back( currentState.theta[ *uIter ] );
             }
- 
+
             block_tfqmr_iter->initializeTFQMR(defstate);
-	  }
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  //
-	  // check for maximum iterations
-	  //
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  else if ( maxIterTest_->getStatus() == Passed ) {
-	    // we don't have convergence
-	    isConverged = false;
-	    break;  // break from while(1){block_tfqmr_iter->iterate()}
-	  }
+          }
+          ////////////////////////////////////////////////////////////////////////////////////
+          //
+          // check for maximum iterations
+          //
+          ////////////////////////////////////////////////////////////////////////////////////
+          else if ( maxIterTest_->getStatus() == Passed ) {
+            // we don't have convergence
+            isConverged = false;
+            break;  // break from while(1){block_tfqmr_iter->iterate()}
+          }
 
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  //
-	  // we returned from iterate(), but none of our status tests Passed.
-	  // something is wrong, and it is probably our fault.
-	  //
-	  ////////////////////////////////////////////////////////////////////////////////////
+          ////////////////////////////////////////////////////////////////////////////////////
+          //
+          // we returned from iterate(), but none of our status tests Passed.
+          // something is wrong, and it is probably our fault.
+          //
+          ////////////////////////////////////////////////////////////////////////////////////
 
-	  else {
-	    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
-			       "Belos::PseudoBlockTFQMRSolMgr::solve(): Invalid return from PseudoBlockTFQMRIter::iterate().");
-	  }
-	}
-	catch (const std::exception &e) {
-	  printer_->stream(Errors) << "Error! Caught std::exception in PseudoBlockTFQMRIter::iterate() at iteration " 
-				   << block_tfqmr_iter->getNumIters() << std::endl 
-				   << e.what() << std::endl;
-	  throw;
-	}
+          else {
+            TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
+                               "Belos::PseudoBlockTFQMRSolMgr::solve(): Invalid return from PseudoBlockTFQMRIter::iterate().");
+          }
+        }
+        catch (const std::exception &e) {
+          printer_->stream(Errors) << "Error! Caught std::exception in PseudoBlockTFQMRIter::iterate() at iteration "
+                                   << block_tfqmr_iter->getNumIters() << std::endl
+                                   << e.what() << std::endl;
+          throw;
+        }
       }
-     
+
       // Update the current solution with the update computed by the iteration object.
       problem_->updateSolution( block_tfqmr_iter->getCurrentUpdate(), true );
- 
+
       // Inform the linear problem that we are finished with this block linear system.
       problem_->setCurrLS();
-      
+
       // Update indices for the linear systems to be solved.
       startPtr += numCurrRHS;
       numRHS2Solve -= numCurrRHS;
@@ -843,12 +855,12 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
       }
 
     }// while ( numRHS2Solve > 0 )
-    
+
   }
 
   // print final summary
   sTest_->print( printer_->stream(FinalSummary) );
- 
+
   // print timing information
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   // Calling summarize() can be expensive, so don't call unless the
@@ -857,7 +869,7 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
   if (verbosity_ & TimingDetails)
     Teuchos::TimeMonitor::summarize( printer_->stream(TimingDetails) );
 #endif
- 
+
   // get iteration information for this solve
   numIters_ = maxIterTest_->getNumIters();
 
@@ -876,9 +888,9 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
     if (expResTest_) {
       pTestValues = expConvTest_->getTestValue();
       if (pTestValues == NULL || pTestValues->size() < 1) {
-	pTestValues = impConvTest_->getTestValue();
+        pTestValues = impConvTest_->getTestValue();
       }
-    } 
+    }
     else {
       // Only the implicit residual norm test is being used.
       pTestValues = impConvTest_->getTestValue();
@@ -897,11 +909,11 @@ ReturnType PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::solve() {
     // just for the vectors from the last deflation?
     achievedTol_ = *std::max_element (pTestValues->begin(), pTestValues->end());
   }
- 
+
   if (!isConverged) {
-    return Unconverged; // return from PseudoBlockTFQMRSolMgr::solve() 
+    return Unconverged; // return from PseudoBlockTFQMRSolMgr::solve()
   }
-  return Converged; // return from PseudoBlockTFQMRSolMgr::solve() 
+  return Converged; // return from PseudoBlockTFQMRSolMgr::solve()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
@@ -913,7 +925,7 @@ std::string PseudoBlockTFQMRSolMgr<ScalarType,MV,OP>::description() const
   oss << "{}";
   return oss.str();
 }
-  
+
 } // end Belos namespace
 
 #endif /* BELOS_PSEUDO_BLOCK_TFQMR_SOLMGR_HPP */

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -357,7 +357,6 @@ namespace Belos {
     Teuchos::RCP<Teuchos::ParameterList> params_;
 
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
     static constexpr int maxIters_default_ = 1000;
     static constexpr int blockSize_default_ = 1;
     static constexpr int numBlocks_default_ = 25;
@@ -496,7 +495,7 @@ template<class ScalarType, class MV, class OP>
 void RCGSolMgr<ScalarType,MV,OP,true>::init()
 {
   outputStream_ = Teuchos::rcp(outputStream_default_,false);
-  convtol_ = convTol_default_;
+  convtol_ = DefaultSolverParameters::convTol;
   maxIters_ = maxIters_default_;
   numBlocks_ = numBlocks_default_;
   recycleBlocks_ = recycleBlocks_default_;
@@ -662,7 +661,13 @@ void RCGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teuchos
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list and residual tests.
     params_->set("Convergence Tolerance", convtol_);
@@ -726,7 +731,7 @@ RCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),

--- a/packages/belos/src/BelosTFQMRSolMgr.hpp
+++ b/packages/belos/src/BelosTFQMRSolMgr.hpp
@@ -69,17 +69,17 @@
 /*! \class Belos::TFQMRSolMgr
  *
  *  \brief The Belos::TFQMRSolMgr provides a powerful and fully-featured solver manager over the TFQMR linear solver.
- 
+
  \ingroup belos_solver_framework
- 
+
  \author Heidi Thornquist
 */
 
 namespace Belos {
-  
+
   //! @name TFQMRSolMgr Exceptions
   //@{
-  
+
   /** \brief TFQMRSolMgrLinearProblemFailure is thrown when the linear problem is
    * not setup (i.e. setProblem() was not called) when solve() is called.
    *
@@ -89,7 +89,7 @@ namespace Belos {
   class TFQMRSolMgrLinearProblemFailure : public BelosError {public:
     TFQMRSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   /** \brief TFQMRSolMgrOrthoFailure is thrown when the orthogonalization manager is
    * unable to generate orthonormal columns from the initial basis vectors.
    *
@@ -99,21 +99,21 @@ namespace Belos {
   class TFQMRSolMgrOrthoFailure : public BelosError {public:
     TFQMRSolMgrOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   template<class ScalarType, class MV, class OP>
   class TFQMRSolMgr : public SolverManager<ScalarType,MV,OP> {
-    
+
   private:
     typedef MultiVecTraits<ScalarType,MV> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    
+
   public:
-    
+
     //! @name Constructors/Destructor
-    //@{ 
+    //@{
 
     /*! \brief Empty constructor for TFQMRSolMgr.
      * This constructor takes no arguments and sets the default values for the solver.
@@ -126,28 +126,28 @@ namespace Belos {
      *
      * This constructor accepts the LinearProblem to be solved in addition
      * to a parameter list of options for the solver manager. These options include the following:
-     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the 
+     *   - "Maximum Iterations" - an \c int specifying the maximum number of iterations the
      *                            underlying solver is allowed to perform. Default: 1000
-     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms 
+     *   - "Convergence Tolerance" - a \c MagnitudeType specifying the level that residual norms
      *                               must reach to decide convergence. Default: 1e-8.
      *   - "Verbosity" - a sum of MsgType specifying the verbosity. Default: Belos::Errors
      *   - "Output Style" - a OutputType specifying the style of output. Default: Belos::General
      *   - "Output Stream" - a reference-counted pointer to the output stream where all
      *                       solver output is sent.  Default: Teuchos::rcp(&std::cout,false)
-     *   - "Output Frequency" - an \c int specifying how often convergence information should be 
+     *   - "Output Frequency" - an \c int specifying how often convergence information should be
      *                          outputted.  Default: -1 (never)
      *   - "Timer Label" - a \c std::string to use as a prefix for the timer labels.  Default: "Belos"
      */
     TFQMRSolMgr( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-		 const Teuchos::RCP<Teuchos::ParameterList> &pl );
-    
+                 const Teuchos::RCP<Teuchos::ParameterList> &pl );
+
     //! Destructor.
     virtual ~TFQMRSolMgr() {};
     //@}
-    
+
     //! @name Accessor methods
-    //@{ 
-    
+    //@{
+
     const LinearProblem<ScalarType,MV,OP>& getProblem() const {
       return *problem_;
     }
@@ -155,12 +155,12 @@ namespace Belos {
     /*! \brief Get a parameter list containing the valid parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-    
+
     /*! \brief Get a parameter list containing the current parameters for this object.
      */
     Teuchos::RCP<const Teuchos::ParameterList> getCurrentParameters() const { return params_; }
-    
-    /*! \brief Return the timers for this object. 
+
+    /*! \brief Return the timers for this object.
      *
      * The timers are ordered as follows:
      *   - time spent in solve() routine
@@ -170,7 +170,7 @@ namespace Belos {
     }
 
     /// \brief Tolerance achieved by the last \c solve() invocation.
-    /// 
+    ///
     /// This is the maximum over all right-hand sides' achieved
     /// convergence tolerances, and is set whether or not the solve
     /// actually managed to achieve the desired convergence tolerance.
@@ -182,7 +182,7 @@ namespace Belos {
     int getNumIters() const {
       return numIters_;
     }
-    
+
     /// \brief Whether loss of accuracy was detected during the last \c solve() invocation.
     ///
     /// In solvers that can detect a loss of accuracy, this method
@@ -191,20 +191,20 @@ namespace Belos {
     /// not currently detect a loss of accuracy, so this method always
     /// returns false.
     bool isLOADetected() const { return false; }
-    
+
     //@}
-    
+
     //! @name Set methods
     //@{
-    
-    //! Set the linear problem that needs to be solved. 
+
+    //! Set the linear problem that needs to be solved.
     void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) { problem_ = problem; }
-    
-    //! Set the parameters the solver manager should use to solve the linear problem. 
+
+    //! Set the parameters the solver manager should use to solve the linear problem.
     void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params );
-    
+
     //@}
-    
+
     //! @name Reset methods
     //@{
     /*! \brief Performs a reset of the solver manager specified by the \c ResetType.  This informs the
@@ -213,21 +213,21 @@ namespace Belos {
      */
     void reset( const ResetType type ) { if ((type & Belos::Problem) && !Teuchos::is_null(problem_)) problem_->setProblem(); }
     //@}
-    
+
     //! @name Solver application methods
-    //@{ 
-    
-    /*! \brief This method performs possibly repeated calls to the underlying linear solver's 
-     *         iterate() routine until the problem has been solved (as decided by the solver manager) 
+    //@{
+
+    /*! \brief This method performs possibly repeated calls to the underlying linear solver's
+     *         iterate() routine until the problem has been solved (as decided by the solver manager)
      *         or the solver manager decides to quit.
      *
-     * This method calls TFQMRIter::iterate(), which will return either because a 
+     * This method calls TFQMRIter::iterate(), which will return either because a
      * specially constructed status test evaluates to ::Passed or an std::exception is thrown.
      *
      * A return from TFQMRIter::iterate() signifies one of the following scenarios:
-     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions 
+     *    - the maximum number of iterations has been exceeded. In this scenario, the current solutions
      *      to the linear system will be placed in the linear problem and return ::Unconverged.
-     *    - global convergence has been met. In this case, the current solutions to the linear system 
+     *    - global convergence has been met. In this case, the current solutions to the linear system
      *      will be placed in the linear problem and the solver manager will return ::Converged
      *
      * \returns ::ReturnType specifying:
@@ -235,42 +235,40 @@ namespace Belos {
      *     - ::Unconverged: the linear problem was not solved to the specification desired by the solver manager.
      */
     ReturnType solve();
-    
+
     //@}
-    
+
     /** \name Overridden from Teuchos::Describable */
     //@{
-    
+
     /** \brief Method to return description of the TFQMR solver manager */
     std::string description() const;
-    
+
     //@}
-    
+
   private:
 
     // Method for checking current status test against defined linear problem.
     bool checkStatusTest();
-    
+
     // Linear problem.
     Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > problem_;
-    
+
     // Output manager.
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
     Teuchos::RCP<std::ostream> outputStream_;
-    
+
     // Status test.
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
     Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
     Teuchos::RCP<StatusTest<ScalarType,MV,OP> > convTest_;
     Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > expConvTest_, impConvTest_;
     Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
-    
+
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
-    
+
     // Default solver values.
-    static constexpr MagnitudeType convTol_default_ = 1e-8;
-    static constexpr MagnitudeType impTolScale_default_ = 10;
     static constexpr int maxIters_default_ = 1000;
     static constexpr bool expResTest_default_ = false;
     static constexpr int verbosity_default_ = Belos::Errors;
@@ -288,7 +286,7 @@ namespace Belos {
     int blockSize_;
     bool expResTest_;
     std::string impResScale_, expResScale_;
-    
+
     // Timers.
     std::string label_;
     Teuchos::RCP<Teuchos::Time> timerSolve_;
@@ -302,8 +300,8 @@ namespace Belos {
 template<class ScalarType, class MV, class OP>
 TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr() :
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  impTolScale_(impTolScale_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  impTolScale_(DefaultSolverParameters::impTolScale),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -322,13 +320,13 @@ TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr() :
 
 // Basic Constructor
 template<class ScalarType, class MV, class OP>
-TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr( 
-					     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-					     const Teuchos::RCP<Teuchos::ParameterList> &pl ) : 
+TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr(
+                                             const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+                                             const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
   outputStream_(Teuchos::rcp(outputStream_default_,false)),
-  convtol_(convTol_default_),
-  impTolScale_(impTolScale_default_),
+  convtol_(DefaultSolverParameters::convTol),
+  impTolScale_(DefaultSolverParameters::impTolScale),
   achievedTol_(Teuchos::ScalarTraits<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>::zero()),
   maxIters_(maxIters_default_),
   numIters_(0),
@@ -344,13 +342,13 @@ TFQMRSolMgr<ScalarType,MV,OP>::TFQMRSolMgr(
   isSTSet_(false)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null, std::invalid_argument, "Problem not given to solver manager.");
-  
+
   // If the parameter list pointer is null, then set the current parameters to the default parameter list.
   if ( !is_null(pl) ) {
-    setParameters( pl );  
+    setParameters( pl );
   }
 }
-  
+
 template<class ScalarType, class MV, class OP>
 void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
 {
@@ -374,9 +372,9 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
 
   // Check for blocksize
   if (params->isParameter("Block Size")) {
-    blockSize_ = params->get("Block Size",1);    
+    blockSize_ = params->get("Block Size",1);
     TEUCHOS_TEST_FOR_EXCEPTION(blockSize_ != 1, std::invalid_argument,
-		       "Belos::TFQMRSolMgr: \"Block Size\" must be 1.");
+                       "Belos::TFQMRSolMgr: \"Block Size\" must be 1.");
 
     // Update parameter in our list.
     params_->set("Block Size", blockSize_);
@@ -449,20 +447,34 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
-  }  
-  
+  }
+
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
-    convtol_ = params->get("Convergence Tolerance",convTol_default_);
+    if (params->isType<MagnitudeType> ("Convergence Tolerance")) {
+      convtol_ = params->get ("Convergence Tolerance",
+                              static_cast<MagnitudeType> (DefaultSolverParameters::convTol));
+    }
+    else {
+      convtol_ = params->get ("Convergence Tolerance", DefaultSolverParameters::convTol);
+    }
 
     // Update parameter in our list.
     params_->set("Convergence Tolerance", convtol_);
     isSTSet_ = false;
   }
-  
+
   // Check for implicit residual scaling
   if (params->isParameter("Implicit Tolerance Scale Factor")) {
-    impTolScale_ = params->get("Implicit Tolerance Scale Factor",impTolScale_default_);
+    if (params->isType<MagnitudeType> ("Implicit Tolerance Scale Factor")) {
+      impTolScale_ = params->get ("Implicit Tolerance Scale Factor",
+                                  static_cast<MagnitudeType> (DefaultSolverParameters::impTolScale));
+
+    }
+    else {
+      impTolScale_ = params->get ("Implicit Tolerance Scale Factor",
+                                  DefaultSolverParameters::impTolScale);
+    }
 
     // Update parameter in our list.
     params_->set("Implicit Tolerance Scale Factor", impTolScale_);
@@ -482,9 +494,9 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
 
       // Make sure the convergence test gets constructed again.
       isSTSet_ = false;
-    }      
+    }
   }
-  
+
   if (params->isParameter("Explicit Residual Scaling")) {
     std::string tempExpResScale = Teuchos::getParameter<std::string>( *params, "Explicit Residual Scaling" );
 
@@ -497,7 +509,7 @@ void TFQMRSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::P
 
       // Make sure the convergence test gets constructed again.
       isSTSet_ = false;
-    }      
+    }
   }
 
   if (params->isParameter("Explicit Residual Test")) {
@@ -534,7 +546,7 @@ bool TFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
 
   if (expResTest_) {
-   
+
     // Implicit residual test, using the native residual to determine if convergence was achieved.
     Teuchos::RCP<StatusTestGenResNorm_t> tmpImpConvTest =
       Teuchos::rcp( new StatusTestGenResNorm_t( impTolScale_*convtol_ ) );
@@ -574,30 +586,30 @@ bool TFQMRSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   std::string solverDesc = " TFQMR ";
   outputTest_->setSolverDesc( solverDesc );
 
-  
+
   // The status test is now set.
   isSTSet_ = true;
 
   return false;
 }
 
-    
+
 template<class ScalarType, class MV, class OP>
-Teuchos::RCP<const Teuchos::ParameterList> 
+Teuchos::RCP<const Teuchos::ParameterList>
 TFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
-  
+
   // Set all the valid parameters and their default values.
   if(is_null(validPL)) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
     // The static_cast is to resolve an issue with older clang versions which
     // would cause the constexpr to link fail. With c++17 the problem is resolved.
-    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(convTol_default_),
+    pl->set("Convergence Tolerance", static_cast<MagnitudeType>(DefaultSolverParameters::convTol),
       "The relative residual tolerance that needs to be achieved by the\n"
       "iterative solver in order for the linear system to be declared converged.");
-    pl->set("Implicit Tolerance Scale Factor", static_cast<MagnitudeType>(impTolScale_default_),
+    pl->set("Implicit Tolerance Scale Factor", static_cast<MagnitudeType>(DefaultSolverParameters::impTolScale),
       "The scale factor used by the implicit residual test when explicit residual\n"
       "testing is used.  May enable faster convergence when TFQMR bound is too loose.");
     pl->set("Maximum Iterations", static_cast<int>(maxIters_default_),
@@ -611,7 +623,7 @@ TFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
       "to the output stream.");
     pl->set("Output Frequency", static_cast<int>(outputFreq_default_),
       "How often convergence information should be outputted\n"
-      "to the output stream.");  
+      "to the output stream.");
     pl->set("Output Stream", Teuchos::rcp(outputStream_default_,false),
       "A reference-counted pointer to the output stream where all\n"
       "solver output is sent.");
@@ -628,27 +640,27 @@ TFQMRSolMgr<ScalarType,MV,OP>::getValidParameters() const
   return validPL;
 }
 
-  
+
 // solve()
 template<class ScalarType, class MV, class OP>
 ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
 
   // Set the current parameters if they were not set before.
-  // NOTE:  This may occur if the user generated the solver manager with the default constructor and 
+  // NOTE:  This may occur if the user generated the solver manager with the default constructor and
   // then didn't set any parameters using setParameters().
   if (!isSet_) {
     setParameters(Teuchos::parameterList(*getValidParameters()));
   }
 
   TEUCHOS_TEST_FOR_EXCEPTION(problem_ == Teuchos::null,TFQMRSolMgrLinearProblemFailure,
-		     "Belos::TFQMRSolMgr::solve(): Linear problem is not a valid object.");
+                     "Belos::TFQMRSolMgr::solve(): Linear problem is not a valid object.");
 
   TEUCHOS_TEST_FOR_EXCEPTION(!problem_->isProblemSet(),TFQMRSolMgrLinearProblemFailure,
                      "Belos::TFQMRSolMgr::solve(): Linear problem is not ready, setProblem() has not been called.");
 
   if (!isSTSet_) {
     TEUCHOS_TEST_FOR_EXCEPTION( checkStatusTest(),TFQMRSolMgrLinearProblemFailure,
-			"Belos::TFQMRSolMgr::solve(): Linear problem and requested status tests are incompatible.");
+                        "Belos::TFQMRSolMgr::solve(): Linear problem and requested status tests are incompatible.");
   }
 
   // Create indices for the linear systems to be solved.
@@ -661,7 +673,7 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
   //  The index set is generated that informs the linear problem that some linear systems are augmented.
   currIdx.resize( blockSize_ );
   currIdx2.resize( blockSize_ );
-  for (int i=0; i<numCurrRHS; ++i) 
+  for (int i=0; i<numCurrRHS; ++i)
     { currIdx[i] = startPtr+i; currIdx2[i]=i; }
 
   // Inform the linear problem of the current linear system to solve.
@@ -671,17 +683,17 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
   // Parameter list
   Teuchos::ParameterList plist;
   plist.set("Block Size",blockSize_);
-  
-  // Reset the status test.  
+
+  // Reset the status test.
   outputTest_->reset();
 
   // Assume convergence is achieved, then let any failed convergence set this to false.
-  bool isConverged = true;	
+  bool isConverged = true;
 
   //////////////////////////////////////////////////////////////////////////////////////
   // TFQMR solver
 
-  Teuchos::RCP<TFQMRIter<ScalarType,MV,OP> > tfqmr_iter = 
+  Teuchos::RCP<TFQMRIter<ScalarType,MV,OP> > tfqmr_iter =
     Teuchos::rcp( new TFQMRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations
@@ -712,84 +724,84 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
       tfqmr_iter->initializeTFQMR(newstate);
 
       while(1) {
-	
-	// tell tfqmr_iter to iterate
-	try {
-	  tfqmr_iter->iterate();
-	  
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  //
-	  // check convergence first
-	  //
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  if ( convTest_->getStatus() == Passed ) {
-	    // We have convergence of the linear system.
-	    break;  // break from while(1){tfqmr_iter->iterate()}
-	  }
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  //
-	  // check for maximum iterations
-	  //
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  else if ( maxIterTest_->getStatus() == Passed ) {
-	    // we don't have convergence
-	    isConverged = false;
-	    break;  // break from while(1){tfqmr_iter->iterate()}
-	  }
 
-	  ////////////////////////////////////////////////////////////////////////////////////
-	  //
-	  // we returned from iterate(), but none of our status tests Passed.
-	  // something is wrong, and it is probably our fault.
-	  //
-	  ////////////////////////////////////////////////////////////////////////////////////
+        // tell tfqmr_iter to iterate
+        try {
+          tfqmr_iter->iterate();
 
-	  else {
-	    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
-			       "Belos::TFQMRSolMgr::solve(): Invalid return from TFQMRIter::iterate().");
-	  }
-	}
-	catch (const std::exception &e) {
-	  printer_->stream(Errors) << "Error! Caught std::exception in TFQMRIter::iterate() at iteration " 
-				   << tfqmr_iter->getNumIters() << std::endl 
-				   << e.what() << std::endl;
-	  throw;
-	}
+          ////////////////////////////////////////////////////////////////////////////////////
+          //
+          // check convergence first
+          //
+          ////////////////////////////////////////////////////////////////////////////////////
+          if ( convTest_->getStatus() == Passed ) {
+            // We have convergence of the linear system.
+            break;  // break from while(1){tfqmr_iter->iterate()}
+          }
+          ////////////////////////////////////////////////////////////////////////////////////
+          //
+          // check for maximum iterations
+          //
+          ////////////////////////////////////////////////////////////////////////////////////
+          else if ( maxIterTest_->getStatus() == Passed ) {
+            // we don't have convergence
+            isConverged = false;
+            break;  // break from while(1){tfqmr_iter->iterate()}
+          }
+
+          ////////////////////////////////////////////////////////////////////////////////////
+          //
+          // we returned from iterate(), but none of our status tests Passed.
+          // something is wrong, and it is probably our fault.
+          //
+          ////////////////////////////////////////////////////////////////////////////////////
+
+          else {
+            TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
+                               "Belos::TFQMRSolMgr::solve(): Invalid return from TFQMRIter::iterate().");
+          }
+        }
+        catch (const std::exception &e) {
+          printer_->stream(Errors) << "Error! Caught std::exception in TFQMRIter::iterate() at iteration "
+                                   << tfqmr_iter->getNumIters() << std::endl
+                                   << e.what() << std::endl;
+          throw;
+        }
       }
 
       // Update the current solution with the update computed by the iteration object.
       problem_->updateSolution( tfqmr_iter->getCurrentUpdate(), true );
-      
+
       // Inform the linear problem that we are finished with this block linear system.
       problem_->setCurrLS();
-      
+
       // Update indices for the linear systems to be solved.
       startPtr += numCurrRHS;
       numRHS2Solve -= numCurrRHS;
       if ( numRHS2Solve > 0 ) {
-	numCurrRHS = blockSize_;
+        numCurrRHS = blockSize_;
 
-	currIdx.resize( blockSize_ );
-	currIdx2.resize( blockSize_ );
-	for (int i=0; i<numCurrRHS; ++i) 
-	  { currIdx[i] = startPtr+i; currIdx2[i] = i; }
-	// Set the next indices.
-	problem_->setLSIndex( currIdx );
+        currIdx.resize( blockSize_ );
+        currIdx2.resize( blockSize_ );
+        for (int i=0; i<numCurrRHS; ++i)
+          { currIdx[i] = startPtr+i; currIdx2[i] = i; }
+        // Set the next indices.
+        problem_->setLSIndex( currIdx );
 
-	// Set the new blocksize for the solver.
-	tfqmr_iter->setBlockSize( blockSize_ );	
+        // Set the new blocksize for the solver.
+        tfqmr_iter->setBlockSize( blockSize_ );
       }
       else {
         currIdx.resize( numRHS2Solve );
       }
-      
+
     }// while ( numRHS2Solve > 0 )
-    
+
   }
 
   // print final summary
   sTest_->print( printer_->stream(FinalSummary) );
- 
+
   // print timing information
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
   // Calling summarize() can be expensive, so don't call unless the
@@ -798,7 +810,7 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
   if (verbosity_ & TimingDetails)
     Teuchos::TimeMonitor::summarize( printer_->stream(TimingDetails) );
 #endif
- 
+
   // get iteration information for this solve
   numIters_ = maxIterTest_->getNumIters();
 
@@ -817,9 +829,9 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
     if (expResTest_) {
       pTestValues = expConvTest_->getTestValue();
       if (pTestValues == NULL || pTestValues->size() < 1) {
-	pTestValues = impConvTest_->getTestValue();
+        pTestValues = impConvTest_->getTestValue();
       }
-    } 
+    }
     else {
       // Only the implicit residual norm test is being used.
       pTestValues = impConvTest_->getTestValue();
@@ -838,11 +850,11 @@ ReturnType TFQMRSolMgr<ScalarType,MV,OP>::solve() {
     // just for the vectors from the last deflation?
     achievedTol_ = *std::max_element (pTestValues->begin(), pTestValues->end());
   }
- 
+
   if (!isConverged) {
-    return Unconverged; // return from TFQMRSolMgr::solve() 
+    return Unconverged; // return from TFQMRSolMgr::solve()
   }
-  return Converged; // return from TFQMRSolMgr::solve() 
+  return Converged; // return from TFQMRSolMgr::solve()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
@@ -854,7 +866,7 @@ std::string TFQMRSolMgr<ScalarType,MV,OP>::description() const
   oss << "{}";
   return oss.str();
 }
-  
+
 } // end Belos namespace
 
 #endif /* BELOS_TFQMR_SOLMGR_HPP */

--- a/packages/belos/src/BelosTypes.hpp
+++ b/packages/belos/src/BelosTypes.hpp
@@ -78,9 +78,9 @@ namespace Belos {
   /// \note This enum is useful to you only if you are specializing
   ///   OperatorTraits, implementing Operator, or implementing a Belos
   ///   solver.
-  enum ETrans     {	NOTRANS = 0,  /*!< The operator should not be transposed during this application. */
-			TRANS = 1,    /*!< Apply the transpose of the operator. */
-			CONJTRANS = 2 /*!< Apply the conjugate transpose of the operator. */
+  enum ETrans     {     NOTRANS = 0,  /*!< The operator should not be transposed during this application. */
+                        TRANS = 1,    /*!< Apply the transpose of the operator. */
+                        CONJTRANS = 2 /*!< Apply the conjugate transpose of the operator. */
   };
 
   /// \enum NormType
@@ -95,8 +95,8 @@ namespace Belos {
   ///   MultiVecTraits, implementing MultiVec, or implementing a Belos
   ///   solver.
   enum NormType {   OneNorm,       /*!< Compute the one-norm \f$\sum_{i=1}^{n}(|x_i w_i|)\f$ for each vector. */
-		    TwoNorm,       /*!< Compute the two-norm \f$\sqrt(\sum_{i=1}^{n}((x_i w_i)^2))\f$ for each vector. */
-		    InfNorm        /*!< Compute the infinity-norm \f$\max_{i=1}^{n}\{|x_i w_i|\}\f$ for each vector. */
+                    TwoNorm,       /*!< Compute the two-norm \f$\sqrt(\sum_{i=1}^{n}((x_i w_i)^2))\f$ for each vector. */
+                    InfNorm        /*!< Compute the infinity-norm \f$\max_{i=1}^{n}\{|x_i w_i|\}\f$ for each vector. */
   };
 
   /// \enum ScaleType
@@ -277,6 +277,35 @@ namespace Belos {
   /// for debugging.
   std::string
   convertMsgTypeToString (const MsgType msgType);
+
+  /// \brief Default parameters common to most Belos solvers
+  ///
+  /// Both Belos solvers and users may override these defaults.  Real
+  /// floating-point values are deliberately double, in order to avoid
+  /// issues with constexpr construction of certain MagnitudeTypes.
+  struct DefaultSolverParameters {
+    /// \brief Default convergence tolerance
+    ///
+    /// This assumes that implicit conversion from double to
+    /// Teuchos::ScalarTraits<Scalar>::magnitudeType always works, but
+    /// Belos already assumed that.  See discussion starting here:
+    ///
+    /// https://github.com/trilinos/Trilinos/pull/2677#issuecomment-395453521
+    static constexpr double convTol = 1.0e-8;
+
+    //! Relative residual tolerance for matrix polynomial construction
+    static constexpr double polyTol = 1.0e-12;
+
+    //! DGKS orthogonalization constant
+    static constexpr double orthoKappa = -1.0;
+
+    //! User-defined residual scaling factor
+    static constexpr double resScaleFactor = 1.0;
+
+    //! "Implicit Tolerance Scale Factor"
+    static constexpr double impTolScale = 10.0;
+  };
+
 
 } // end Belos namespace
 


### PR DESCRIPTION
@trilinos/belos @trilinos/stokhos

## Description

Fix Belos for the case when MagnitudeType isn't possible to construct as a `constexpr`.  This implements the proposal here: https://github.com/trilinos/Trilinos/pull/2677#issuecomment-395467589

I took care to ensure that solvers accept the relevant parameters (from the input ParameterList) either as `MagnitudeType` or as `double`.

## Motivation and Context

Stokhos needs this for a nondefault configure-time option to build correctly, as @etphipp explains here: https://github.com/trilinos/Trilinos/pull/2677#issuecomment-395241635

## Related Issues

* Related to #2483

## How Has This Been Tested?

Locally.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->