### PR TITLE
Selective disables of a few individaul unit tests in Kokkos and KokkosKernels for cuda-debug build on 'white' and 'ride'

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -225,11 +225,11 @@ the `checkin-test-atdm.sh` script is run.
 
 ### ride/white
 
-Once logged on to `white` (on the SON) or `shiller` (on the SRN), one can
+Once logged on to `white` (on the SON) or `ride` (on the SRN), one can
 directly configure and build on the login node (being careful not to overload
 the node).  But to run the tests, one must run on the compute nodes using the
 `bsub` command to run if using a CUDA build.  For example, to configure, build
-and run the tests for the `cuda-debug` build for say `MueuLu` on `white`,
+and run the tests for the `cuda-debug` build for say `MueLu` on `white`,
 (after cloning Trilinos on the `develop` branch) one would do:
 
 ```
@@ -272,7 +272,7 @@ Once logged on to `hansen` (on the SON) or `shiller` (on the SRN), one can
 directly configure and build on the login node (being careful not to overload
 the node).  But to run the tests, one must run on the compute nodes using the
 `salloc` command.  For example, to configure, build and run the tests for say
-`MueuLu` on `hansen`, (after cloning Trilinos on the `develop` branch) one
+`MueLu` on `hansen`, (after cloning Trilinos on the `develop` branch) one
 would do:
 
 
@@ -309,7 +309,7 @@ $ salloc ./checkin-test-sems.sh intel-opt-openmp \
 Once logged on to `chama` or `serrano`, one can directly configure and build
 on the login node (being careful not to overload the node).  But to run the
 tests, one must run on the compute nodes using the `salloc` command.  For
-example, to configure, build and run the tests for say `MueuLu` on `serrano`
+example, to configure, build and run the tests for say `MueLu` on `serrano`
 or `chama`, (after cloning Trilinos on the `develop` branch) one would do:
 
 
@@ -350,7 +350,7 @@ $ salloc -N1 --time=0:20:00 --account=<YOUR_WCID> \
 Once logged on to `mutrino`, one can directly configure and build
 on the login node (being careful not to overload the node).  But to run the
 tests, one must run on the compute nodes using the `salloc` command.  For
-example, to configure, build and run the tests for say `MueuLu` on `mutrino`, 
+example, to configure, build and run the tests for say `MueLu` on `mutrino`, 
 (after cloning Trilinos on the `develop` branch) one would:
 
 
@@ -373,7 +373,7 @@ $ salloc -N 1 -p standard -J $JOB_NAME ctest -j16
 
 Once logged on to a rhel6 machine with the sems NFS, one can directly
 configure, build, and run tests.  For example, to configure, build and run the
-tests for `MueuLu` one would clone Trilinos on the `develop` branch and then
+tests for `MueLu` one would clone Trilinos on the `develop` branch and then
 do the following:
 
 

--- a/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
@@ -6,4 +6,13 @@ ATDM_SET_ENABLE(TeuchosNumerics_LAPACK_test_MPI_1_DISABLE ON)
 # This test segfaults in the 'debug' builds on this system (#2466)
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
 
+# Disable some unit tests that run too slow in debug mode for this CUDA DEBUG
+# build (#2827)
+ATDM_SET_CACHE(KokkosContainers_UnitTest_Serial_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-serial.bitset:serial.scatterview"
+  CACHE STRING )
+ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_block_gauss_seidel_double_int_size_t_TestExecSpace"
+  CACHE STRING )
+
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")

--- a/cmake/tribits/core/package_arch/TribitsAddTest.cmake
+++ b/cmake/tribits/core/package_arch/TribitsAddTest.cmake
@@ -93,6 +93,7 @@ INCLUDE(TribitsAddTestHelpers)
 # * `Setting timeouts for tests (TRIBITS_ADD_TEST())`_
 # * `Debugging and Examining Test Generation (TRIBITS_ADD_TEST())`_
 # * `Disabling Tests Externally (TRIBITS_ADD_TEST())`_
+# * `Adding extra commandline arguments externally (TRIBITS_ADD_TEST())`_
 #
 # .. _Formal Arguments (TRIBITS_ADD_TEST()):
 #
@@ -723,6 +724,38 @@ INCLUDE(TribitsAddTestHelpers)
 # way, TriBITS will always print a warning to the ``cmake`` stdout at
 # configure time warning that the test is being disabled.
 #
+# .. _Adding extra commandline arguments externally (TRIBITS_ADD_TEST()):
+#
+# **Adding extra commandline arguments externally (TRIBITS_ADD_TEST())**
+#
+# One can add additional command-line arguments for any ctest test added using
+# this function.  In order to do so, set the CMake cache variable::
+#
+#   SET(<fullTestName>_EXTRA_ARGS  "<earg0>;<earg1>;<earg2>;..."
+#     CACHE  STRING  "Extra args")
+#
+# in a ``*.cmake`` configure options fragment file or::
+#
+#   -D <fullTestName>_EXTRA_ARGS="<earg0>;<earg1>;<earg2>;..."
+#
+# on the CMake command-line.
+#
+# These extra command-line arguments are added after any arguments passed in
+# through ``ARGS "<oarg0> <oarg1> ..."`` or ``POSTFIX_AND_ARGS_<IDX> <oarg0>
+# <oarg1> ...``.  This allows these extra arguments to override the ealier
+# arguments.
+#
+# The primary motivating use case for ``<fullTestName>_EXTRA_ARGS`` is to
+# allow one to alter how a test runs on a specific platform or build.  For
+# example, this allows one to disable specific individual unit tests for a
+# GTest executable such as with::
+#
+#   SET(<fullTestName>_EXTRA_ARGS "--gtest_filter=-<unittest0>:<unittest1>:..."
+#     CACHE  STRING  "Disable specific unit tests" )  
+#
+# For example, this would be an alternative to disabling an entire unit
+# testing executable using ``-D<fullTestName>_DISABLE=ON`` as described above.
+#
 FUNCTION(TRIBITS_ADD_TEST EXE_NAME)
 
   IF(${PROJECT_NAME}_VERBOSE_CONFIGURE)
@@ -911,7 +944,8 @@ FUNCTION(TRIBITS_ADD_TEST EXE_NAME)
       TRIBITS_ADD_TEST_ADD_TEST_ALL( ${TEST_NAME_INSTANCE}
         "${EXECUTABLE_PATH}" "${PARSE_CATEGORIES}"  "${NUM_PROCS_USED}"
         "${NUM_TOTAL_CORES_USED}"
-        ${PARSE_RUN_SERIAL}  ADDED_TEST_NAME  ${INARGS} )
+        ${PARSE_RUN_SERIAL}  ADDED_TEST_NAME  ${INARGS}
+	"${${TEST_NAME_INSTANCE}_EXTRA_ARGS}" )
       IF(PARSE_ADDED_TESTS_NAMES_OUT AND ADDED_TEST_NAME)
         LIST(APPEND ADDED_TESTS_NAMES_OUT ${ADDED_TEST_NAME})
       ENDIF()
@@ -943,9 +977,12 @@ FUNCTION(TRIBITS_ADD_TEST EXE_NAME)
       SET(TEST_NAME_INSTANCE "${TEST_NAME}_${POSTFIX}${MPI_NAME_POSTFIX}")
 
       TRIBITS_ADD_TEST_ADD_TEST_ALL( ${TEST_NAME_INSTANCE}
-        "${EXECUTABLE_PATH}" "${PARSE_CATEGORIES}" "${NUM_PROCS_USED}"  "${NUM_TOTAL_CORES_USED}"
+        "${EXECUTABLE_PATH}" "${PARSE_CATEGORIES}" "${NUM_PROCS_USED}" 
+        "${NUM_TOTAL_CORES_USED}"
         ${PARSE_CREATE_WORKING_DIR}
-        ${PARSE_RUN_SERIAL}   ADDED_TEST_NAME  ${INARGS} )
+        ${PARSE_RUN_SERIAL}   ADDED_TEST_NAME  ${INARGS}
+	"${${TEST_NAME_INSTANCE}_EXTRA_ARGS}"
+        )
       IF(PARSE_ADDED_TESTS_NAMES_OUT AND ADDED_TEST_NAME)
         LIST(APPEND ADDED_TESTS_NAMES_OUT ${ADDED_TEST_NAME})
       ENDIF()


### PR DESCRIPTION
CC: @trilinos/kokkos, @trilinos/kokkos-kernels, @fryeguy52 

## Description

This PR disables a couple of the more expensive individual unit tests for a Kokkos and KokkosKernels test for just the `cuda-debug` build on just 'white'/'ride'.  This addresses the last of the errors related to #2827.

As part of this, I extended TriBITS to support a [<fullTestName>_EXTRA_ARGS cache var](https://tribits.org/doc/TribitsDevelopersGuide.html#adding-extra-commandline-arguments-externally-tribits-add-test) that allows you to append arbitrary command-line arguments to specific tests added with [TRIBITS_ADD_TEST()](https://tribits.org/doc/TribitsDevelopersGuide.html#tribits-add-test).  I used this to add the `--gtest_filter` arguments to disable the specific unit tests.

I also included a commit fixing some typos in a README.md file.

## Motivation and Context

These tests were timing out at over 10 minutes for this build.

## How Has This Been Tested?

I tested this on `white` with:

```
$ bsub -x -Is -q rhel7F -n 16 \
  ./checkin-test-atdm.sh cuda-debug --enable-packages=Kokkos,KokkosKernels --local-do-all 
```

and it returned:

```
...
31/35 Test #29: KokkosKernels_sparse_cuda_MPI_1 ..................   Passed  235.92 sec
32/35 Test  #2: KokkosCore_UnitTest_Cuda_MPI_1 ...................   Passed  241.43 sec
33/35 Test #25: KokkosContainers_UnitTest_Serial_MPI_1 ...........   Passed  263.52 sec
34/35 Test #33: KokkosKernels_sparse_serial_MPI_1 ................   Passed  358.63 sec
35/35 Test #34: KokkosKernels_graph_serial_MPI_1 .................   Passed  408.13 sec

100% tests passed, 0 tests failed out of 35

Subproject Time Summary:
Kokkos           = 814.77 sec*proc (27 tests)
KokkosKernels    = 1282.89 sec*proc (8 tests)

Total Test time (real) = 408.15 sec
```

So that is now under the 600 sec (10 minute) time limit.

Before this change, these two tests timed out with:

```
...
34/35 Test #33: KokkosKernels_sparse_serial_MPI_1 ................***Timeout 600.07 sec
35/35 Test #25: KokkosContainers_UnitTest_Serial_MPI_1 ...........***Timeout 600.08 sec

94% tests passed, 2 tests failed out of 35

Subproject Time Summary:
Kokkos           = 1145.23 sec*proc (27 tests)
KokkosKernels    = 1516.06 sec*proc (8 tests)

Total Test time (real) = 600.12 sec

The following tests FAILED:
	 25 - KokkosContainers_UnitTest_Serial_MPI_1 (Timeout)
	 33 - KokkosKernels_sparse_serial_MPI_1 (Timeout)
Errors while running CTest
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
