### PR TITLE
Some selective disables and promotion of some ATDM T

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-opt.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-opt.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-#export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-opt-openmp.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-opt-openmp.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-#export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=ATDM
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-debug.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-opt.sh
+++ b/cmake/ctest/drivers/atdm/shiller/drivers/Trilinos-atdm-hansen-shiller-cuda-9.0-opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 export SRUN_CTEST_TIME_LIMIT_MINUTES=480 # 8 hour time limit
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/shiller/local-driver.sh

--- a/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA-DEBUG-CUDA.cmake
@@ -15,4 +15,8 @@ ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
   "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_block_gauss_seidel_double_int_size_t_TestExecSpace"
   CACHE STRING )
 
+# Disable randomly failing tests for this build (#2920)
+ATDM_SET_ENABLE(Belos_pseudo_stochastic_pcg_hb_0_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Belos_pseudo_stochastic_pcg_hb_1_MPI_4_DISABLE ON)
+
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/shiller/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/shiller/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -6,3 +6,6 @@ ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
 
 # Disable test takes a long time to complete for some reason (#2455)
 ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
+
+# Disable expensive test that started timing out (#2919)
+ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/GNU-DEBUG-SERIAL.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU-DEBUG-SERIAL.cmake
@@ -6,3 +6,6 @@ ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
 
 # Disable test that times out for some unkown reason (#2925)
 ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)
+
+# Disable expensive test that started timing out (#2919)
+ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/GNU-DEBUG-SERIAL.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU-DEBUG-SERIAL.cmake
@@ -3,3 +3,6 @@ ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
 
 # Disable test takes a long time to complete for some reason (#2455)
 ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
+
+# Disable test that times out for some unkown reason (#2925)
+ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-SERIAL.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-SERIAL.cmake
@@ -6,3 +6,6 @@ ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
 
 # This test fails consistently with a major numerical error (#2474)
 ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
+
+# Disable test that times out randomly for some unkown reason (#2925)
+ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-SERIAL.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-SERIAL.cmake
@@ -9,3 +9,6 @@ ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
 
 # Disable test that times out randomly for some unkown reason (#2925)
 ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)
+
+# Disable expensive test that started timing out (#2919)
+ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)


### PR DESCRIPTION
CC: @fryeguy52 

## Description

* Some selective disable of tests (see the commits)
* Promoting some passing builds (see the commits)

See: #2925, #2919, #2990, #2826, and [TRIL-198](https://software-sandbox.sandia.gov/jira/browse/TRIL-198)

## Motivation and Context

Clean up the ATDM Trilinos dashboard.

## How Has This Been Tested?

I ran configure on 'hansen' and 'white' for all of the builds using:

```
$ ./checkin-test-atdm.sh all --enable-packages=Stratimikos,Belos --configure
```

and verified that the correct tests were disabled for the correct builds.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
