### PR TITLE
Teuchos: add max levels to StackedTimer output options

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -171,7 +171,7 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
     if (printed[i])
       continue;
     int level = std::count(flat_names_[i].begin(), flat_names_[i].end(), '@');
-    if ( (level != print_level) || (level > options.max_levels) )
+    if ( (level != print_level) || (level >= options.max_levels) )
       continue;
     auto split_names = getPrefix(flat_names_[i]);
     if ( prefix != split_names.first)
@@ -232,6 +232,10 @@ StackedTimer::report(std::ostream &os, Teuchos::RCP<const Teuchos::Comm<int> > c
   merge(comm);
   collectRemoteData(comm, options);
   if (rank(*comm) == 0 ) {
+    if ( (options.max_levels != INT_MAX) && options.print_warnings) {
+      os << "Teuchos::StackedTimer::report() - max_levels set to " << options.max_levels
+         << ", to print more levels, increase value of OutputOptions::max_levels." << std::endl;
+    }
     std::vector<bool> printed(flat_names_.size(), false);
     printLevel("", 0, os, printed, 0., options);
   }

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -171,7 +171,7 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
     if (printed[i])
       continue;
     int level = std::count(flat_names_[i].begin(), flat_names_[i].end(), '@');
-    if (level != print_level)
+    if ( (level != print_level) || (level > options.max_levels) )
       continue;
     auto split_names = getPrefix(flat_names_[i]);
     if ( prefix != split_names.first)

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -506,12 +506,13 @@ public:
   /// Struct for controlling output options like histograms
   struct OutputOptions {
     OutputOptions() : output_fraction(false), output_total_updates(false), output_histogram(false),
-        output_minmax(false), num_histogram(10) {}
+                      output_minmax(false), num_histogram(10), max_levels(10000) {}
     bool output_fraction;
     bool output_total_updates;
     bool output_histogram;
     bool output_minmax;
     int num_histogram;
+    int max_levels;
   };
 
   /**

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 #include <cassert>
 #include <chrono>
-
+#include <climits>
 
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
 namespace Kokkos {
@@ -506,13 +506,15 @@ public:
   /// Struct for controlling output options like histograms
   struct OutputOptions {
     OutputOptions() : output_fraction(false), output_total_updates(false), output_histogram(false),
-                      output_minmax(false), num_histogram(10), max_levels(10000) {}
+                      output_minmax(false), num_histogram(10), max_levels(INT_MAX),
+                      print_warnings(true) {}
     bool output_fraction;
     bool output_total_updates;
     bool output_histogram;
     bool output_minmax;
     int num_histogram;
     int max_levels;
+    bool print_warnings;
   };
 
   /**


### PR DESCRIPTION
Add a max_levels flag to limit the depth of timer levels printed in report() for StackedTimer output