### PR TITLE
Teuchos: improve stacked timer output

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -179,7 +179,7 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
 
     // Output the data
     for (int l=0; l<level; ++l)
-      os << "    ";
+      os << "|   ";
     os << split_names.second << ": ";
     // output averge time
     os << sum_[i]/active_[i];
@@ -215,7 +215,7 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
     double sub_time = printLevel(flat_names_[i], level+1, os, printed, sum_[i]/active_[i], options);
     if (sub_time > 0 ) {
       for (int l=0; l<=level; ++l)
-        os << "    ";
+        os << "|   ";
       os << "Remainder: " <<  sum_[i]/active_[i]- sub_time;
       if ( options.output_fraction && parent_time > 0 )
         os << " - "<< (sum_[i]/active_[i]- sub_time)/parent_time*100 << "%";


### PR DESCRIPTION

This two character change significantly improves readability of stacked timer output when there are many nested levels present. Shamelessly lifted for @ibaned 's kokkos space time stack.

