### PR TITLE
Use 'srun' and not 'salloc' on hansen/shiller

### DIFF
--- a/cmake/ctest/drivers/atdm/shiller/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/shiller/local-driver.sh
@@ -10,6 +10,6 @@ fi
 
 set -x
 
-salloc -N 1 --constraint=k80 -J $JOB_NAME \
+/usr/bin/srun -N 1 --constraint=k80 -J $JOB_NAME \
   --time=${SRUN_CTEST_TIME_LIMIT_MINUTES} \
   $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -40,7 +40,7 @@ $ cmake \
 
 $ make NP=16  # Uses ninja -j16
 
-$ ctest -j16  # Might need to be run with salloc or some other command, see below
+$ ctest -j16  # Might need to be run with srun or some other command, see below
 ```
 
 The command:
@@ -271,7 +271,7 @@ $ bsub -x -I -q rhel7F -n 16 \
 Once logged on to `hansen` (on the SON) or `shiller` (on the SRN), one can
 directly configure and build on the login node (being careful not to overload
 the node).  But to run the tests, one must run on the compute nodes using the
-`salloc` command.  For example, to configure, build and run the tests for say
+`srun` command.  For example, to configure, build and run the tests for say
 `MueLu` on `hansen`, (after cloning Trilinos on the `develop` branch) one
 would do:
 
@@ -289,7 +289,7 @@ $ cmake \
 
 $ make NP=16
 
-$ salloc ctest -j16
+$ srun ctest -j16
 ```
 
 Note that one can also run the same build a tests using the <a
@@ -298,7 +298,7 @@ href="#checkin-test-atdmsh">checkin-test-atdm.sh</a> script as:
 ```
 $ cd <some_build_dir>/
 $ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-sems.sh .
-$ salloc ./checkin-test-sems.sh intel-opt-openmp \
+$ srun ./checkin-test-sems.sh intel-opt-openmp \
   --enable-all-packages=off --no-enable-fwd-packages \
   --enable-packages=MueLu \
   --local-do-all
@@ -308,7 +308,7 @@ $ salloc ./checkin-test-sems.sh intel-opt-openmp \
 
 Once logged on to `chama` or `serrano`, one can directly configure and build
 on the login node (being careful not to overload the node).  But to run the
-tests, one must run on the compute nodes using the `salloc` command.  For
+tests, one must run on the compute nodes using the `srun` command.  For
 example, to configure, build and run the tests for say `MueLu` on `serrano`
 or `chama`, (after cloning Trilinos on the `develop` branch) one would do:
 

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -304,6 +304,15 @@ $ srun ./checkin-test-sems.sh intel-opt-openmp \
   --local-do-all
 ```
 
+WARNING: One must use `srun` and **not** `salloc` to allocate and run on a
+compute node.  The way that these machines are currently set up, running with
+`salloc` the command `squeue` will seem to show that the job is allocated and
+running on a compute node but the job is actually running on the login node!
+(Running `ps -AF | grep <script-name>` and `top` on the login node will
+clearly show that that the job is actually running on the login node and
+presumably the actual compute node is idle.)
+
+
 ### chama/serrano
 
 Once logged on to `chama` or `serrano`, one can directly configure and build


### PR DESCRIPTION
CC: @fryeguy52 

## Description

The commits and the updated text in the README.md file are self-explanatory but in short you need to allocate jobs on 'hansen' with `srun` and not `salloc`.

## Motivation and Context

If you use `salloc`, SLURM runs the jobs on the login node 'hansen01' but thinks it is running it on a compute node.  If you use `srun`, it runs the job correctly on a compute node.  Crazy.

This is what was likely causing all of the test timeouts and strange behavior that we have been seeing lately on 'hansen' documented in issues #2925, #2919 and #2913.

## How Has This Been Tested?

On 'hansen' I ran:

```
$ time env \
     JOB_NAME=Trilinos-atdm-hansen-shiller-gnu-debug-serial \
     WORKSPACE=$PWD \
     Trilinos_PACKAGES=Kokkos,Teuchos \
     CTEST_TEST_TYPE=Experimental \
     CTEST_DO_SUBMIT=OFF \
     CTEST_DO_UPDATES=OFF \
     CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=FALSE \
   ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
     &> console.out

real    66m37.153s
user    0m0.102s
sys     0m0.114s
```

The `console.out` file showed:

```
+ /usr/bin/srun -N 1 --constraint=k80 -J Trilinos-atdm-hansen-shiller-gnu-debug-serial --time=180 /ascldap/users/rabartl/Trilinos.base/BUILD/HANSEN/JENKINS_DRIVER/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
srun: job 1003128 queued and waiting for resources
srun: job 1003128 has been allocated resources

Starting processing .bash_profile


Skipping load of the dev env because /ascldap/users/rabartl/load_dev_env.sh does not exist!


Ending processing .bash_profile


Start: ctest-s-driver.sh

  ==> Wed Jun 13 18:21:21 MDT 2018

Loading env and running ctest -S comamnd to configure, build, and test ...
Current dir: /ascldap/users/rabartl/Trilinos.base/BUILD/HANSEN/JENKINS_DRIVER/SRC_AND_BUILD
Hostname 'hansen04' matches known ATDM host 'hansen' and system 'shiller'
ATDM_CONFIG_TRILNOS_DIR = /home/rabartl/Trilinos.base/Trilinos
Setting default compiler and build options for JOB_NAME='Trilinos-atdm-hansen-shiller-gnu-debug-serial'
Using hansen/shiller compiler stack GNU to build DEBUG code with Kokkos node type SERIAL
```

See, it showed:

```
Hostname 'hansen04' matches known ATDM host 'hansen' and system 'shiller'
```

That shows that it actually running on the compute node.

I also verified looking in the file `/SRC_AND_BUILD/BUILD/Testing/Temporary/LastConfigure_20180614-0021.log` that it shows:

```
-- Trilinos_HOSTNAME='hansen04'
```
