### PR TITLE
Add OpenMP to the 4.8.4 build

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -16,6 +16,7 @@ which -a env
 : ${PULLREQUESTNUM:?}
 : ${JOB_BASE_NAME:?}
 : ${BUILD_NUMBER:?}
+: ${WORKSPACE:?}
 
 source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
@@ -165,7 +166,13 @@ if [ "icc" == ${CC:?} ]
 then
   CONFIG_SCRIPT=PullRequestLinuxIntelTestingSettings.cmake
 else
-  CONFIG_SCRIPT=PullRequestLinuxGCCTestingSettings.cmake
+  if [ "Trilinos_pullrequest_gcc_4.8.4" == "${JOB_BASE_NAME:?}" ]
+  then
+    CONFIG_SCRIPT=PullRequestLinuxGCC4.8.4TestingSettings.cmake
+  elif [ "Trilinos_pullrequest_gcc_4.9.3" == "${JOB_BASE_NAME:?}" ]
+  then
+    CONFIG_SCRIPT=PullRequestLinuxGCC4.9.3TestingSettings.cmake
+  fi
 fi
 
 ctest -S simple_testing.cmake \

--- a/cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake
@@ -1,0 +1,23 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC 4.8.4 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxGCC4.8.4TestingSettings.cmake 
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+set (Trilinos_ENABLE_OpenMP ON CACHE BOOL "Set by default for PR testing")
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+ 
+# Disable just one Teko sub-unit test that fails with GCC 4.8.4 + OpenMP (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxGCCTestingSettings.cmake")
+

--- a/cmake/std/PullRequestLinuxGCC4.9.3TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.9.3TestingSettings.cmake
@@ -1,0 +1,1 @@
+PullRequestLinuxGCCTestingSettings.cmake

--- a/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
@@ -1,10 +1,10 @@
 # This file contains the options needed to both run the pull request testing
-# for Trilinos for the Linux GCC pull request testing builds, and to reproduce
+# for Trilinos for the Linux Intel 17 pull request testing builds, and to reproduce
 # the errors reported by those builds. Prior to using this this file, the
 # appropriate set of SEMS modules must be loaded and accessible through the
 # SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
 
-# Usage: cmake -C PullRequestLinuxGCCTestingSettings.cmake 
+# Usage: cmake -C PullRequestLinuxIntelTestingSettings.cmake 
 
 # Misc options typically added by CI testing mode in TriBITS
 

--- a/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
@@ -31,3 +31,6 @@ module load sems-superlu/4.3/base
 module load atdm-env
 module load atdm-cmake/3.11.1
 module load atdm-ninja_fortran/1.7.2
+
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2


### PR DESCRIPTION
This takes in the existing cmake GCC scripts and changes them to depend
on a single default and simply add changes as needed.  Right now the
4.9.3 does no additional setup and the 4.8.4 adds OpenMP requirements.
I also added the OPENMP_NUM_THREAD variable to the 4.8.4 environment
setup and changed the driver script to use those changes.

Note that the new builds will not actually be enabled until the Jenkins jobs are modified to the same driver script we currently use for the Intel job.

@trilinos/framework 

## Related Issues

* Closes #2788 

## Checklist

- [ x ] My commit messages mention the appropriate GitHub issue numbers.
- [ x ] My code follows the code style of the affected package(s).
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

I will change the wiki documentation when we Merge this - I don't want the mismatch to last more than a half-hour or so.