### PR TITLE
Teuchos: fix remainder fraction calculation in StackedTiimer

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -217,8 +217,8 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
       for (int l=0; l<=level; ++l)
         os << "|   ";
       os << "Remainder: " <<  sum_[i]/active_[i]- sub_time;
-      if ( options.output_fraction && parent_time > 0 )
-        os << " - "<< (sum_[i]/active_[i]- sub_time)/parent_time*100 << "%";
+      if ( options.output_fraction && (sum_[i]/active_[i] > 0.) )
+        os << " - "<< (sum_[i]/active_[i]- sub_time)/(sum_[i]/active_[i])*100 << "%";
       os <<std::endl;
     }
     total_time += sum_[i]/active_[i];
@@ -232,6 +232,12 @@ StackedTimer::report(std::ostream &os, Teuchos::RCP<const Teuchos::Comm<int> > c
   merge(comm);
   collectRemoteData(comm, options);
   if (rank(*comm) == 0 ) {
+    if (options.print_warnings) {
+      os << "*** Teuchos::StackedTimer::report() - Remainder for a block will be ***"
+         << "\n*** incorrect if a timer in the block does not exist on every rank  ***"
+         << "\n*** of the MPI Communicator.                                        ***"
+         << std::endl;
+    }
     if ( (options.max_levels != INT_MAX) && options.print_warnings) {
       os << "Teuchos::StackedTimer::report() - max_levels set to " << options.max_levels
          << ", to print more levels, increase value of OutputOptions::max_levels." << std::endl;

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -561,7 +561,7 @@ protected:
     * Recursive call to print a level of timer data.
     */
   double printLevel(std::string prefix, int level, std::ostream &os, std::vector<bool> &printed,
-      double parent_time, const OutputOptions &options);
+                    double parent_time, const OutputOptions &options);
 
 };  //StackedTimer
 


### PR DESCRIPTION
The fraction calculation for the "Remainder" of each block was using a parent_time from one level too high.

Also added a warning (that can be disabled) that discusses when a remainder calculation can be incorrect. This can happen when a timer does not exist on every MPI process in the communicator. A good example of this is for timing boundary condition operations. These timers might only be called if elements in the sideset exists on a particular MPI process.