### PR TITLE
Tpetra: make column map arg in 4 map constructor non-default

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -561,7 +561,7 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const local_graph_type& lclGraph,
               const Teuchos::RCP<const map_type>& rowMap,
-              const Teuchos::RCP<const map_type>& colMap = Teuchos::null,
+              const Teuchos::RCP<const map_type>& colMap,
               const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
               const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -504,7 +504,7 @@ namespace Tpetra {
     ///   default values.
     CrsMatrix (const local_matrix_type& lclMatrix,
                const Teuchos::RCP<const map_type>& rowMap,
-               const Teuchos::RCP<const map_type>& colMap = Teuchos::null,
+               const Teuchos::RCP<const map_type>& colMap,
                const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
                const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);


### PR DESCRIPTION
@trilinos/tpetra 
## Description
Remove `Teuchos::null` default for the Tpetra constructor taking in local matrix and 4 maps

## Motivation and Context
It is unclear how to construct a matrix if column map is missing. In addition, there is a hard check in `CrsGraph` pertaining to that column map is non-zero which also means a user provided it.