### PR TITLE
MueLu, Xpetra: Kokkos refactor, RefMaxwell, IO

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -131,7 +131,7 @@ namespace MueLu {
     if (parameterList_.get<bool>("refmaxwell: cuda profile setup", false)) cudaProfilerStart();
 #endif
 
-    RCP<Teuchos::TimeMonitor> tmCompute = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: compute")));
+    Teuchos::TimeMonitor tmCompute(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: compute"));
 
     bool defaultFilter = false;
 
@@ -318,7 +318,7 @@ namespace MueLu {
       GetOStream(Runtime0) << "RefMaxwell::compute(): building MG for (2,2)-block" << std::endl;
 
       { // build fine grid operator for (2,2)-block, D0* SM D0  (aka TMT)
-        RCP<Teuchos::TimeMonitor> tm = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build A22")));
+        Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build A22"));
 
         Level fineLevel, coarseLevel;
         fineLevel.SetFactoryManager(Teuchos::null);
@@ -945,7 +945,7 @@ namespace MueLu {
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::formCoarseMatrix() {
-    RCP<Teuchos::TimeMonitor> tm = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build coarse (1,1) matrix")));
+    Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build coarse (1,1) matrix"));
     
     // coarse matrix for P11* (M1 + D1* M2 D1) P11
     Teuchos::RCP<Matrix> Matrix1 = MatrixFactory::Build(P11_->getDomainMap(),0);
@@ -965,7 +965,7 @@ namespace MueLu {
       AH_=Matrix1;
     }
     else {
-      RCP<Teuchos::TimeMonitor> tmAddon = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build coarse addon matrix")));
+      Teuchos::TimeMonitor tmAddon(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build coarse addon matrix"));
       // catch a failure
       TEUCHOS_TEST_FOR_EXCEPTION(M0inv_Matrix_==Teuchos::null,std::invalid_argument,
                                  "MueLu::RefMaxwell::formCoarseMatrix(): Inverse of "
@@ -1133,6 +1133,8 @@ namespace MueLu {
                                                                   Teuchos::ETransp mode,
                                                                   Scalar alpha,
                                                                   Scalar beta) const {
+
+    Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLuRefmaxwell: Solve"));
 
     // make sure that we have enough temporary memory
     if (X.getNumVectors() != P11res_->getNumVectors()) {

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -454,6 +454,18 @@ namespace MueLu {
       std::copy(BCrows_.begin(), BCrows_.end(), std::ostream_iterator<LO>(outBCrows, "\n"));
       std::ofstream outBCcols("BCcols.mat");
       std::copy(BCcols_.begin(), BCcols_.end(), std::ostream_iterator<LO>(outBCcols, "\n"));
+#else
+      std::ofstream outBCrows("BCrows.mat");
+      auto BCrows = Kokkos::create_mirror_view (BCrows_);
+      Kokkos::deep_copy(BCrows , BCrows_);
+      for (size_t i = 0; i < BCrows.size(); i++)
+        outBCrows << BCrows[i] << "\n";
+
+      std::ofstream outBCcols("BCcols.mat");
+      auto BCcols = Kokkos::create_mirror_view (BCcols_);
+      Kokkos::deep_copy(BCcols , BCcols_);
+      for (size_t i = 0; i < BCcols.size(); i++)
+        outBCcols << BCcols[i] << "\n";
 #endif
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("nullspace.mat"), *Nullspace_);
       if (Coords_ != Teuchos::null)

--- a/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
+++ b/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
@@ -284,6 +284,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       // Use an ML-style parameter list for variety
       Teuchos::ParameterList MLList;
       MLList.set("ML output", 10);
+      MLList.set("use kokkos refactor", false);
       MLList.set("coarse: type","Amesos-Superlu");
 #ifdef HAVE_AMESOS2_KLU2
       MLList.set("coarse: type","Amesos-KLU");
@@ -321,11 +322,13 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       // Start w/ an ML-style parameter list
       Teuchos::ParameterList MLList;
       MLList.set("ML output", 10);
+      MLList.set("use kokkos refactor", false);
       MLList.set("coarse: type","Amesos-Superlu");
 #ifdef HAVE_AMESOS2_KLU2
       MLList.set("coarse: type","Amesos-KLU");
 #endif
       FactoryManager M1;
+      M1.SetKokkosRefactor(false);
       M1.SetFactory("A",        MueLu::NoFactory::getRCP());
       M1.SetFactory("P",        MueLu::NoFactory::getRCP());
       M1.SetFactory("R",        MueLu::NoFactory::getRCP());
@@ -360,11 +363,13 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       // Start w/ an ML-style parameter list
       Teuchos::ParameterList MLList;
       MLList.set("ML output", 10);
+      MLList.set("use kokkos refactor", false);
       MLList.set("coarse: type","Amesos-Superlu");
 #ifdef HAVE_AMESOS2_KLU2
       MLList.set("coarse: type","Amesos-KLU");
 #endif
       FactoryManager M1;
+      M1.SetKokkosRefactor(false);
       M1.SetFactory("P",        MueLu::NoFactory::getRCP());
       M1.SetFactory("R",        MueLu::NoFactory::getRCP());
 

--- a/packages/muelu/example/advanced/multiplesolve/FixedMatrixPattern.cpp
+++ b/packages/muelu/example/advanced/multiplesolve/FixedMatrixPattern.cpp
@@ -126,6 +126,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     //
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
 
     Hierarchy H(A1);
 

--- a/packages/muelu/src/Interface/MueLu_MLParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_MLParameterListInterpreter_def.hpp
@@ -183,6 +183,15 @@ namespace MueLu {
     MueLu::CreateSublists(paramList, paramListWithSubList);
     paramList = paramListWithSubList; // swap
 
+    // pull out "use kokkos refactor"
+    bool setKokkosRefactor = false;
+    bool useKokkosRefactor = false;
+    if (paramList.isType<bool>("use kokkos refactor")) {
+      useKokkosRefactor = paramList.get<bool>("use kokkos refactor");
+      setKokkosRefactor = true;
+      paramList.remove("use kokkos refactor");
+    }
+
     //
     // Validate parameter list
     //
@@ -427,6 +436,8 @@ namespace MueLu {
       //
 
       RCP<FactoryManager> manager = rcp(new FactoryManager());
+      if (setKokkosRefactor)
+        manager->SetKokkosRefactor(useKokkosRefactor);
 
       //
       // Smoothers

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1618,6 +1618,7 @@ namespace MueLu {
 #undef MUELU_TEST_AND_SET_VAR
 #undef MUELU_TEST_AND_SET_PARAM_2LIST
 #undef MUELU_TEST_PARAM_2LIST
+#undef MUELU_KOKKOS_FACTORY
 
   size_t LevenshteinDistance(const char* s, size_t len_s, const char* t, size_t len_t);
 
@@ -1867,7 +1868,9 @@ namespace MueLu {
           FactoryMap levelFactoryMap;
           BuildFactoryMap(levelList, factoryMap, levelFactoryMap, factoryManagers);
 
-          RCP<FactoryManagerBase> m = rcp(new FactoryManager(levelFactoryMap));
+          RCP<FactoryManager> m = rcp(new FactoryManager(levelFactoryMap));
+          if (hieraList.isParameter("use kokkos refactor"))
+            m->SetKokkosRefactor(hieraList.get<bool>("use kokkos refactor"));
 
           if (startLevel >= 0)
             this->AddFactoryManager(startLevel, numDesiredLevel, m);

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
@@ -112,12 +112,22 @@ namespace MueLu {
     //! @brief Constructor.
     FactoryManager() {
       SetIgnoreUserData(false); // set IgnorUserData flag to false (default behaviour)
+#if defined(HAVE_MUELU_KOKKOS_REFACTOR) && defined(HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT)
+      useKokkos_ = true;
+#else
+      useKokkos_ = false;
+#endif
     }
 
     //! Constructor used by HierarchyFactory (temporary, will be removed)
     FactoryManager(const std::map<std::string, RCP<const FactoryBase> >& factoryTable) {
       factoryTable_ = factoryTable;
       SetIgnoreUserData(false); // set IgnorUserData flag to false (default behaviour) //TODO: use parent class constructor instead
+#if defined(HAVE_MUELU_KOKKOS_REFACTOR) && defined(HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT)
+      useKokkos_ = true;
+#else
+      useKokkos_ = false;
+#endif
     }
 
     //! Destructor.
@@ -159,6 +169,10 @@ namespace MueLu {
     //!
     const RCP<const FactoryBase> GetDefaultFactory(const std::string& varName) const;
 
+    void SetKokkosRefactor(const bool useKokkos) {
+      useKokkos_ = useKokkos;
+    }
+
     //@}
 
     void Clean() const { defaultFactoryTable_.clear(); }
@@ -199,6 +213,9 @@ namespace MueLu {
     */
     mutable
     std::map<std::string, RCP<const FactoryBase> > defaultFactoryTable_;
+
+    //! Whether or not to use kokkos factories.
+    bool useKokkos_;
 
   }; // class
 

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_def.hpp
@@ -89,8 +89,8 @@ namespace MueLu {
   SetAndReturnDefaultFactory(varName, rcp(new oldFactory()));
 #else
 #define MUELU_KOKKOS_FACTORY(varName, oldFactory, newFactory)   \
-  (!useKokkos) ? SetAndReturnDefaultFactory(varName, rcp(new oldFactory())) : \
-                 SetAndReturnDefaultFactory(varName, rcp(new newFactory()));
+  (!useKokkos_) ? SetAndReturnDefaultFactory(varName, rcp(new oldFactory())) : \
+                  SetAndReturnDefaultFactory(varName, rcp(new newFactory()));
 #endif
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -127,13 +127,6 @@ namespace MueLu {
       return defaultFactoryTable_.find(varName)->second;
 
     } else {
-      bool useKokkos;
-#if defined(HAVE_MUELU_KOKKOS_REFACTOR) && defined(HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT)
-      useKokkos = true;
-#else
-      useKokkos = false;
-#endif
-
       // No factory was created for this name, but we may know which one to create
       if (varName == "A")                               return SetAndReturnDefaultFactory(varName, rcp(new RAPFactory()));
       if (varName == "RAP Pattern")                     return GetFactory("A");
@@ -143,7 +136,7 @@ namespace MueLu {
         // GetFactory("Ptent"): we need to use the same factory instance for both "P" and "Nullspace"
         RCP<Factory> factory;
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
-        if (useKokkos)
+        if (useKokkos_)
           factory = rcp(new SaPFactory_kokkos());
         else
 #endif
@@ -155,7 +148,7 @@ namespace MueLu {
         // GetFactory("Ptent"): we need to use the same factory instance for both "P" and "Nullspace"
         RCP<Factory> factory;
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
-        if (useKokkos)
+        if (useKokkos_)
           factory = rcp(new NullspaceFactory_kokkos());
         else
 #endif
@@ -267,6 +260,9 @@ namespace MueLu {
         it->second->ResetDebugData();
   }
 #endif
+
+
+#undef MUELU_KOKKOS_FACTORY
 
 } // namespace MueLu
 

--- a/packages/muelu/test/blockedtransfer/BlockedTransfer.cpp
+++ b/packages/muelu/test/blockedtransfer/BlockedTransfer.cpp
@@ -295,6 +295,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     RCP<SmootherFactory> Smoo22Fact = rcp( new SmootherFactory(smoProto22) );
 
     RCP<FactoryManager> M11 = rcp(new FactoryManager());
+    M11->SetKokkosRefactor(false);
     M11->SetFactory("A", A11Fact);
     M11->SetFactory("P", P11Fact);
     M11->SetFactory("Ptent", P11Fact); //for Nullspace
@@ -303,6 +304,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     M11->SetIgnoreUserData(true);
 
     RCP<FactoryManager> M22 = rcp(new FactoryManager());
+    M22->SetKokkosRefactor(false);
     M22->SetFactory("A", A22Fact);
     M22->SetFactory("P", P22Fact);
     M22->SetFactory("R", R22Fact);

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -376,6 +376,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 #include "MueLu_Test_ETI.hpp"
 
 int main(int argc, char *argv[]) {
+  Teuchos::TimeMonitor::setStackedTimer(Teuchos::null);
   return Automatic_Test_ETI(argc,argv);
 }
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -54,19 +54,6 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
-
-*********************************************************************
-WARNING: Overlapping timers detected!
-A TimeMonitor timer was stopped before a nested subtimer was
-stopped. This is not allowed by the StackedTimer. This corner case
-typically occurs if the TimeMonitor is stored in an RCP and the RCP is
-assigned to a new timer. To disable this warning, either fix the
-ordering of timer creation and destuction or disable the StackedTimer
-support in the TimeMonitor by setting the StackedTimer to null
-with:
-Teuchos::TimeMonitor::setStackedTimer(Teuchos::null)
-*********************************************************************
-
   tentative: calculate qr = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]

--- a/packages/muelu/test/profiling/Aggregation.cpp
+++ b/packages/muelu/test/profiling/Aggregation.cpp
@@ -151,7 +151,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     Finest.SetLevelID(0);  // must be level 0 for NullspaceFactory
     Finest.Set("A", A);
 
-    Finest.SetFactoryManager( rcp( new FactoryManager() ));
+    RCP<FactoryManager> factMngr = rcp( new FactoryManager() );
+    factMngr->SetKokkosRefactor(false);
+    Finest.SetFactoryManager(factMngr);
 
     CoupledAggregationFactory CoupledAggFact;
     Finest.Request(CoupledAggFact);

--- a/packages/muelu/test/scaling/conchas_milestone_zoltan2.xml
+++ b/packages/muelu/test/scaling/conchas_milestone_zoltan2.xml
@@ -99,7 +99,7 @@
       <Parameter name="repartition: max imbalance"          type="double" value="1.327"/>
       <Parameter name="repartition: start level"            type="int"    value="1"/>
     </ParameterList>
-    
+
     <ParameterList name="myZoltanInterface">
       <Parameter name="factory"                             type="string" value="Zoltan2Interface"/>
       <Parameter name="A"                                   type="string" value="myRAPFact"/>
@@ -192,6 +192,7 @@
     <Parameter name="max levels"                            type="int"      value="10"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="1000"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/> <!--None, Low, Medium, High, Extreme -->
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <!-- to specify which level's matrices to write to file -->
     <!--

--- a/packages/muelu/test/toggletransfer/parameters_sa_tent.xml
+++ b/packages/muelu/test/toggletransfer/parameters_sa_tent.xml
@@ -101,6 +101,7 @@
     <Parameter name="max levels"                            type="int"      value="8"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="10"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>

--- a/packages/muelu/test/toggletransfer/parameters_semi_tent.xml
+++ b/packages/muelu/test/toggletransfer/parameters_semi_tent.xml
@@ -82,6 +82,7 @@
     <Parameter name="max levels"                            type="int"      value="8"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="10"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>

--- a/packages/muelu/test/toggletransfer/parameters_semi_tent_line.xml
+++ b/packages/muelu/test/toggletransfer/parameters_semi_tent_line.xml
@@ -87,6 +87,7 @@
     <Parameter name="max levels"                            type="int"      value="8"/>
     <Parameter name="coarse: max size"                      type="int"      value="10"/>
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>

--- a/packages/muelu/test/toggletransfer/parameters_tent_tent.xml
+++ b/packages/muelu/test/toggletransfer/parameters_tent_tent.xml
@@ -103,6 +103,7 @@
     <Parameter name="max levels"                            type="int"      value="5"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="10"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="Smoother"                            type="string"   value="myJacobi"/>

--- a/packages/muelu/test/unit_tests/Adapters/test.xml
+++ b/packages/muelu/test/unit_tests/Adapters/test.xml
@@ -29,6 +29,7 @@
     <Parameter name="max levels"                            type="int"      value="10"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="500"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="startLevel"                          type="int"      value="0"/>

--- a/packages/muelu/test/unit_tests/Adapters/testPDE.xml
+++ b/packages/muelu/test/unit_tests/Adapters/testPDE.xml
@@ -176,6 +176,8 @@
     <Parameter name="max levels"                            type="int"      value="10"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="500"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
+
 
     <ParameterList name="All">
       <Parameter name="startLevel"                          type="int"      value="0"/>

--- a/packages/muelu/test/unit_tests/Adapters/testWithRebalance.xml
+++ b/packages/muelu/test/unit_tests/Adapters/testWithRebalance.xml
@@ -192,6 +192,7 @@
     <Parameter name="max levels"                            type="int"      value="10"/> <!-- Max number of levels -->
     <Parameter name="coarse: max size"                      type="int"      value="500"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="startLevel"                          type="int"      value="0"/>

--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -192,6 +192,7 @@ namespace MueLuTests {
 
     RCP<CoupledAggregationFactory> CoupledAggFact = rcp(new CoupledAggregationFactory());
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("Aggregates", CoupledAggFact);
     M.SetFactory("Smoother", Teuchos::null);
     M.SetFactory("CoarseSolver", Teuchos::null);
@@ -263,6 +264,7 @@ namespace MueLuTests {
     int maxLevels = 5;
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("A", Acfact);
@@ -359,6 +361,7 @@ namespace MueLuTests {
     int maxLevels = 5;
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("A", Acfact);
@@ -418,6 +421,7 @@ namespace MueLuTests {
 
     // Multigrid setup phase (using default parameters)
     FactoryManager M0; // how to build aggregates and smoother of the first level
+    M0.SetKokkosRefactor(false);
 
     bool r = H.Setup(0, Teuchos::null, rcpFromRef(M0), Teuchos::null); TEST_EQUALITY(r, true); // cf. Teuchos Bug 5214
 
@@ -463,6 +467,7 @@ namespace MueLuTests {
 
     // Multigrid setup phase (using default parameters)
     FactoryManager M0; // how to build aggregates and smoother of the first level
+    M0.SetKokkosRefactor(false);
 
     H.Setup(M0, 0, 1);
 
@@ -506,12 +511,15 @@ namespace MueLuTests {
 
     // Multigrid setup phase (using default parameters)
     FactoryManager M0; // how to build aggregates and smoother of the first level
+    M0.SetKokkosRefactor(false);
 
     FactoryManager M1; // first coarse level (Plain aggregation)
+    M1.SetKokkosRefactor(false);
     M1.SetFactory("A", rcp(new RAPFactory()));
     M1.SetFactory("P", rcp(new TentativePFactory()));
 
     FactoryManager M2; // last level (SA)
+    M2.SetKokkosRefactor(false);
     M2.SetFactory("A", rcp(new RAPFactory()));
     M2.SetFactory("P", rcp(new SaPFactory()));
 
@@ -580,14 +588,17 @@ namespace MueLuTests {
 
     // Multigrid setup phase (using default parameters)
     FactoryManager M0; // how to build aggregates and smoother of the first level
+    M0.SetKokkosRefactor(false);
 
     FactoryManager M1; // first coarse level (Plain aggregation)
+    M1.SetKokkosRefactor(false);
     M1.SetFactory("A", rcp(new RAPFactory()));
     RCP<FactoryBase> P = rcp(new TentativePFactory());
     M1.SetFactory("P", P);
     M1.SetFactory("Ptent", P); //FIXME: can it be done automatically in FactoryManager?
 
     FactoryManager M2; // last level (SA)
+    M2.SetKokkosRefactor(false);
     M2.SetFactory("A", rcp(new RAPFactory()));
     M2.SetFactory("P", rcp(new SaPFactory()));
 
@@ -687,9 +698,11 @@ namespace MueLuTests {
 
     // Multigrid setup phase (using default parameters)
     FactoryManager M0; // how to build aggregates and smoother of the first level
+    M0.SetKokkosRefactor(false);
     M0.SetFactory("Smoother", preSmooFact);
 
     FactoryManager M1; // first coarse level (Plain aggregation)
+    M1.SetKokkosRefactor(false);
     M1.SetFactory("A", rcp(new RAPFactory()));
     RCP<FactoryBase> PFact = rcp(new TentativePFactory());
     M1.SetFactory("P", PFact);
@@ -697,6 +710,7 @@ namespace MueLuTests {
     M1.SetFactory("Smoother", postSmooFact);
 
     FactoryManager M2; // last level (SA)
+    M2.SetKokkosRefactor(false);
     M2.SetFactory("A", rcp(new RAPFactory()));
     M2.SetFactory("P", rcp(new SaPFactory()));
 
@@ -777,8 +791,10 @@ namespace MueLuTests {
 
     // Multigrid setup phase (using default parameters)
     FactoryManager M0; // how to build aggregates and smoother of the first level
+    M0.SetKokkosRefactor(false);
 
     FactoryManager M1; // first coarse level (Plain aggregation)
+    M1.SetKokkosRefactor(false);
     M1.SetFactory("A", rcp(new RAPFactory()));
     M1.SetFactory("P", rcp(new TentativePFactory()));
 
@@ -823,6 +839,7 @@ namespace MueLuTests {
     H.SetDefaultVerbLevel(MueLu::Low);
     H.SetMaxCoarseSize(29);
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("Smoother", Teuchos::null);
     M.SetFactory("CoarseSolver", Teuchos::null);
     H.Setup(M, 0, 2);
@@ -922,6 +939,7 @@ namespace MueLuTests {
     Haux.SetDefaultVerbLevel(MueLu::None);
 
     FactoryManager Maux;
+    Maux.SetKokkosRefactor(false);
     const FactoryBase* nullFactory = Maux.GetFactory("Nullspace").get();
 
     Haux.Keep("Nullspace", nullFactory);
@@ -946,10 +964,13 @@ namespace MueLuTests {
     // fix proposed here is to simply set corresponding fatories to NoFactory, so
     // they would fetch user data.
     FactoryManager M0, M1, M2;
+    M0.SetKokkosRefactor(false);
     M0.SetFactory("Smoother", SmooFact);
+    M1.SetKokkosRefactor(false);
     M1.SetFactory("A",        MueLu::NoFactory::getRCP());
     M1.SetFactory("P",        MueLu::NoFactory::getRCP());
     M1.SetFactory("R",        MueLu::NoFactory::getRCP());
+    M2.SetKokkosRefactor(false);
 
     out << "===== Setting up mixed hierarchy =====" << std::endl;
 

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
@@ -800,7 +800,8 @@ namespace MueLuTests {
       // Needed to initialize correctly a level used for testing SingleLevel factory Build() methods.
       // This method initializes LevelID and linked list of level
       static void createSingleLevelHierarchy(Level& currentLevel) {
-        RCP<MueLu::FactoryManagerBase> factoryHandler = rcp(new FactoryManager());
+        RCP<FactoryManager> factoryHandler = rcp(new FactoryManager());
+        factoryHandler->SetKokkosRefactor(false);
         currentLevel.SetFactoryManager(factoryHandler);
 
         currentLevel.SetLevelID(0);
@@ -809,7 +810,8 @@ namespace MueLuTests {
       // Needed to initialize correctly levels used for testing TwoLevel factory Build() methods.
       // This method initializes LevelID and linked list of level
       static void createTwoLevelHierarchy(Level& fineLevel, Level& coarseLevel) {
-        RCP<MueLu::FactoryManagerBase> factoryHandler = rcp(new FactoryManager());
+        RCP<FactoryManager> factoryHandler = rcp(new FactoryManager());
+        factoryHandler->SetKokkosRefactor(false);
         fineLevel.SetFactoryManager(factoryHandler);
         coarseLevel.SetFactoryManager(factoryHandler);
 

--- a/packages/muelu/test/unit_tests/MultiVectorTransferFactory.cpp
+++ b/packages/muelu/test/unit_tests/MultiVectorTransferFactory.cpp
@@ -112,6 +112,7 @@ namespace MueLuTests {
     RCP<TransPFactory>        RFact = rcp(new TransPFactory());
 
     RCP<FactoryManager> M = rcp(new FactoryManager());
+    M->SetKokkosRefactor(false);
     M->SetFactory("P", TentativePFact);
     M->SetFactory("Ptent", TentativePFact);
     M->SetFactory("R", RFact);
@@ -185,6 +186,7 @@ namespace MueLuTests {
     AcFact->setVerbLevel(Teuchos::VERB_HIGH);
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("Aggregates", CoupledAggFact);
     M.SetFactory("P", PFact);
     M.SetFactory("Ptent", PFact); // for nullspace

--- a/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Smoothed-Aggregation.xml
+++ b/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Smoothed-Aggregation.xml
@@ -5,6 +5,8 @@
 
     <Parameter name="max levels" type="int" value="10"/>
     <Parameter name="coarse: max size"   type="int" value="50"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
+
 
     <ParameterList name="FineLevel">
       <Parameter name="startLevel" type="int" value="0"/>

--- a/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Smoothed-Aggregation2.xml
+++ b/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Smoothed-Aggregation2.xml
@@ -17,6 +17,8 @@
 
     <Parameter name="max levels"                     type="int"     value="10"/>
     <Parameter name="coarse: max size"               type="int"     value="50"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
+
 
     <ParameterList name="FineLevel">
       <Parameter name="startLevel"                   type="int"     value="0"/>

--- a/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Smoothed-Aggregation3.xml
+++ b/packages/muelu/test/unit_tests/ParameterList/ParameterListInterpreter/Smoothed-Aggregation3.xml
@@ -17,6 +17,8 @@
 
     <Parameter name="max levels"        type="int"      value="10"/>
     <Parameter name="coarse: max size"  type="int"      value="50"/>
+    <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
+
 
     <ParameterList name="FineLevel">
       <Parameter name="startLevel"      type="int"      value="0"/>

--- a/packages/muelu/test/unit_tests/PgPFactory.cpp
+++ b/packages/muelu/test/unit_tests/PgPFactory.cpp
@@ -160,6 +160,7 @@ namespace MueLuTests {
     RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("A", Acfact);
@@ -382,6 +383,7 @@ namespace MueLuTests {
     Acfact->setVerbLevel(Teuchos::VERB_HIGH);
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("A", Acfact);
@@ -706,6 +708,7 @@ namespace MueLuTests {
     RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P",             Pfact);
     M.SetFactory("R",             Rfact);
     M.SetFactory("A",             Acfact);
@@ -881,6 +884,7 @@ namespace MueLuTests {
     RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("A", Acfact);
@@ -1066,6 +1070,7 @@ namespace MueLuTests {
         RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
         FactoryManager M;
+        M.SetKokkosRefactor(false);
         M.SetFactory("P", Pfact);
         M.SetFactory("R", Rfact);
         M.SetFactory("A", Acfact);

--- a/packages/muelu/test/unit_tests/RAPFactory.cpp
+++ b/packages/muelu/test/unit_tests/RAPFactory.cpp
@@ -168,6 +168,7 @@ namespace MueLuTests {
 
     // build test-specific default factory manager
     RCP<FactoryManager> defManager = rcp(new FactoryManager());
+    defManager->SetKokkosRefactor(false);
     defManager->SetFactory("A", rcp(MueLu::NoFactory::get(),false));         // dummy factory for A
     defManager->SetFactory("Nullspace", rcp(new NullspaceFactory()));        // real null space factory for Ptent
     defManager->SetFactory("Graph", rcp(new CoalesceDropFactory()));         // real graph factory for Ptent

--- a/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
+++ b/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
@@ -177,6 +177,7 @@ namespace MueLuTests {
 
     // build test-specific default factory manager
     RCP<FactoryManager> defManager = rcp(new FactoryManager());
+    defManager->SetKokkosRefactor(false);
     defManager->SetFactory("A", rcp(MueLu::NoFactory::get(),false));         // dummy factory for A
     defManager->SetFactory("Nullspace", rcp(new NullspaceFactory()));        // real null space factory for Ptent
     defManager->SetFactory("Graph", rcp(new CoalesceDropFactory()));         // real graph factory for Ptent
@@ -299,6 +300,7 @@ namespace MueLuTests {
 "   <Parameter name=\"max levels\"                            type=\"int\"      value=\"10\"/>"
 "   <Parameter name=\"coarse: max size\"                      type=\"int\"      value=\"1000\"/>"
 "   <Parameter name=\"verbosity\"                             type=\"string\"   value=\"None\"/>"
+"   <Parameter name=\"use kokkos refactor\"                   type=\"bool\"     value=\"false\"/>"
 "   <ParameterList name=\"All\">"
 "     <Parameter name=\"startLevel\"                          type=\"int\"      value=\"0\"/>"
 "     <Parameter name=\"Smoother\"                            type=\"string\"   value=\"mySmoo\"/>"
@@ -381,6 +383,7 @@ namespace MueLuTests {
     Params->set("rap: shift",1.0);
     Params->set("coarse: max size",1000);
     Params->set("verbosity","none");
+    Params->set("use kokkos refactor",false);
 
     Teuchos::ParameterList & pLevel0 = Params->sublist("level 0");
     pLevel0.set("K",A);

--- a/packages/muelu/test/unit_tests/SaPFactory.cpp
+++ b/packages/muelu/test/unit_tests/SaPFactory.cpp
@@ -161,6 +161,7 @@ namespace MueLuTests {
         RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
         FactoryManager M;
+        M.SetKokkosRefactor(false);
         M.SetFactory("P", Pfact);
         M.SetFactory("R", Rfact);
         M.SetFactory("A", Acfact);

--- a/packages/muelu/test/unit_tests/TentativePFactory.cpp
+++ b/packages/muelu/test/unit_tests/TentativePFactory.cpp
@@ -528,6 +528,7 @@ namespace MueLuTests {
     Acfact->setVerbLevel(Teuchos::VERB_HIGH);
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("A", Acfact);
@@ -675,6 +676,7 @@ namespace MueLuTests {
         RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
         FactoryManager M;
+        M.SetKokkosRefactor(false);
         M.SetFactory("P", Pfact);
         M.SetFactory("R", Rfact);
         M.SetFactory("A", Acfact);

--- a/packages/muelu/test/unit_tests/UnsmooshFactory.cpp
+++ b/packages/muelu/test/unit_tests/UnsmooshFactory.cpp
@@ -143,6 +143,7 @@ namespace MueLuTests {
     TentativePFactory Pfact;
     UnsmooshFactory unsmooFact;
     FactoryManager innerFactManager;
+    innerFactManager.SetKokkosRefactor(false);
     innerFactManager.SetFactory("A", Teuchos::rcpFromRef(lapFact));
     innerFactManager.SetFactory("UnAmalgamationInfo", Teuchos::rcpFromRef(amalgFact));
     innerFactManager.SetFactory("Graph", Teuchos::rcpFromRef(coalFact));

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -173,7 +173,7 @@ void KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpen
 
     // Grab the  Kokkos::SparseCrsMatrices
     const KCRS & Ak = Aview.origMatrix->getLocalMatrix();
-    const KCRS & Bk = Bview.origMatrix->getLocalMatrix();
+    // const KCRS & Bk = Bview.origMatrix->getLocalMatrix();
 
     // Get the algorithm mode
     std::string alg = nodename+std::string(" algorithm");

--- a/packages/xpetra/sup/Utils/Xpetra_IO.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_IO.hpp
@@ -93,6 +93,8 @@
 #include "Xpetra_MapExtractor.hpp"
 #include "Xpetra_MatrixFactory.hpp"
 
+#include <Teuchos_MatrixMarket_Raw_Writer.hpp>
+#include <string>
 
 
 namespace Xpetra {
@@ -309,6 +311,35 @@ namespace Xpetra {
 
       throw Exceptions::BadCast("Could not cast to EpetraCrsMatrix or TpetraCrsMatrix in matrix writing");
     } //Write
+
+
+    /*! @brief Save local parts of matrix to files in Matrix Market format. */
+    static void WriteLocal(const std::string& fileName, const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & Op) {
+      const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>& crsOp =
+          dynamic_cast<const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>&>(Op);
+      RCP<const Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > tmp_CrsMtx = crsOp.getCrsMatrix();
+
+      ArrayRCP<const size_t> rowptr_RCP;
+      ArrayRCP<LocalOrdinal>           rowptr2_RCP;
+      ArrayRCP<const LocalOrdinal>     colind_RCP;
+      ArrayRCP<const Scalar>     vals_RCP;
+      tmp_CrsMtx->getAllValues(rowptr_RCP, colind_RCP, vals_RCP);
+
+      ArrayView<const size_t> rowptr = rowptr_RCP();
+      ArrayView<const LocalOrdinal>     colind = colind_RCP();
+      ArrayView<const Scalar>     vals = vals_RCP();
+
+      rowptr2_RCP.resize(rowptr.size());
+      ArrayView<LocalOrdinal> rowptr2 = rowptr2_RCP();
+      for (size_t j = 0; j<rowptr.size(); j++)
+        rowptr2[j] = rowptr[j];
+
+      Teuchos::MatrixMarket::Raw::Writer<Scalar,LocalOrdinal> writer;
+      writer.writeFile(fileName + "." + std::to_string(Op.getRowMap()->getComm()->getSize()) + "." + std::to_string(Op.getRowMap()->getComm()->getRank()),
+                       rowptr2,colind,vals,
+                       rowptr.size()-1,Op.getColMap()->getNodeNumElements());
+    } //WriteLocal
+
 
     /*! @brief Save matrix to file in Matrix Market format. */
     static void WriteBlockedCrsMatrix(const std::string& fileName, const Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & Op) {
@@ -861,6 +892,34 @@ namespace Xpetra {
 
       throw Exceptions::BadCast("Could not cast to EpetraCrsMatrix or TpetraCrsMatrix in matrix writing");
     } //Write
+
+
+    /*! @brief Save local parts of matrix to files in Matrix Market format. */
+    static void WriteLocal(const std::string& fileName, const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & Op) {
+      const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>& crsOp =
+          dynamic_cast<const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>&>(Op);
+      RCP<const Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > tmp_CrsMtx = crsOp.getCrsMatrix();
+
+      ArrayRCP<const size_t> rowptr_RCP;
+      ArrayRCP<LocalOrdinal>           rowptr2_RCP;
+      ArrayRCP<const LocalOrdinal>     colind_RCP;
+      ArrayRCP<const Scalar>     vals_RCP;
+      tmp_CrsMtx->getAllValues(rowptr_RCP, colind_RCP, vals_RCP);
+
+      ArrayView<const size_t> rowptr = rowptr_RCP();
+      ArrayView<const LocalOrdinal>     colind = colind_RCP();
+      ArrayView<const Scalar>     vals = vals_RCP();
+
+      rowptr2_RCP.resize(rowptr.size());
+      ArrayView<LocalOrdinal> rowptr2 = rowptr2_RCP();
+      for (size_t j = 0; j<rowptr.size(); j++)
+        rowptr2[j] = rowptr[j];
+
+      Teuchos::MatrixMarket::Raw::Writer<Scalar,LocalOrdinal> writer;
+      writer.writeFile(fileName + "." + std::to_string(Op.getRowMap()->getComm()->getSize()) + "." + std::to_string(Op.getRowMap()->getComm()->getRank()),
+                       rowptr2,colind,vals,
+                       rowptr.size()-1,Op.getColMap()->getNodeNumElements());
+    } //WriteLocal
 
     /*! @brief Save matrix to file in Matrix Market format. */
     static void WriteBlockedCrsMatrix(const std::string& fileName, const Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & Op) {


### PR DESCRIPTION
@trilinos/muelu 
@trilinos/xpetra 

## Description
- Add `SetKokkosRefactor` to FactoryManager: Determines whether or not Kokkos factories are built by default. 
- Read "use kokkos refactor" from factory format xml.
- Fix non-kokkosified tests that error out when run with `MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT`.
- Add function to `Xpetra_IO` that writes out local parts of a CRS matrix.
- RefMaxwell timers and debug information.

Addresses #2926 
