### PR TITLE
Tpetra: Fix #2968

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_EquilibrationInfo.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_EquilibrationInfo.hpp
@@ -86,7 +86,8 @@ struct EquilibrationInfo {
   EquilibrationInfo () :
     foundInf (false),
     foundNan (false),
-    foundZeroDiag (false)
+    foundZeroDiag (false),
+    foundZeroRowNorm (false)
   {}
 
   EquilibrationInfo (const std::size_t lclNumRows,
@@ -106,7 +107,8 @@ struct EquilibrationInfo {
     assumeSymmetric (assumeSymmetric_),
     foundInf (false),
     foundNan (false),
-    foundZeroDiag (false)
+    foundZeroDiag (false),
+    foundZeroRowNorm (false)
   {}
 
   EquilibrationInfo (const Kokkos::View<mag_type*, device_type>& rowNorms_,
@@ -117,7 +119,8 @@ struct EquilibrationInfo {
                      const bool assumeSymmetric_,
                      const bool foundInf_,
                      const bool foundNan_,
-                     const bool foundZeroDiag_) :
+                     const bool foundZeroDiag_,
+                     const bool foundZeroRowNorm_) :
     rowNorms (rowNorms_),
     rowDiagonalEntries (rowDiagonalEntries_),
     colNorms (colNorms_),
@@ -126,7 +129,8 @@ struct EquilibrationInfo {
     assumeSymmetric (assumeSymmetric_),
     foundInf (foundInf_),
     foundNan (foundNan_),
-    foundZeroDiag (foundZeroDiag_)
+    foundZeroDiag (foundZeroDiag_),
+    foundZeroRowNorm (foundZeroRowNorm_)
   {}
 
   //! Deep-copy src into *this.
@@ -156,6 +160,7 @@ struct EquilibrationInfo {
     foundInf = src.foundInf;
     foundNan = src.foundNan;
     foundZeroDiag = src.foundZeroDiag;
+    foundZeroRowNorm = src.foundZeroRowNorm;
   }
 
   typename EquilibrationInfo<val_type, device_type>::HostMirror
@@ -169,7 +174,7 @@ struct EquilibrationInfo {
 
     return HostMirror {rowNorms_h, rowDiagonalEntries_h, colNorms_h,
         colDiagonalEntries_h, rowScaledColNorms_h, assumeSymmetric,
-        foundInf, foundNan, foundZeroDiag};
+        foundInf, foundNan, foundZeroDiag, foundZeroRowNorm};
   }
 
   // We call a row a "diagonally dominant row" if the absolute value
@@ -222,6 +227,9 @@ struct EquilibrationInfo {
 
   //! Found a zero diagonal entry somewhere in the matrix.
   bool foundZeroDiag;
+
+  //! At least one row of the matrix has a zero norm.
+  bool foundZeroRowNorm;
 };
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -57,6 +57,7 @@
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_RowMatrix.hpp"
 #include "Kokkos_Core.hpp"
+#include "Teuchos_CommHelpers.hpp"
 #include <memory>
 
 namespace Tpetra {
@@ -177,8 +178,16 @@ computeLocalRowAndColumnOneNorms_RowMatrix (const Tpetra::RowMatrix<SC, LO, GO, 
       const GO gblRow = rowMap.getGlobalElement (lclRow);
       // OK if invalid(); then we simply won't find the diagonal entry.
       const GO lclDiagColInd = colMap.getLocalElement (gblRow);
+
       for (std::size_t k = 0; k < numEnt; ++k) {
-        const mag_type matrixAbsVal = KAT::abs (val[k]);
+        const val_type matrixVal = val[k];
+        if (KAT::isInf (matrixVal)) {
+          result_h.foundInf = true;
+        }
+        if (KAT::isNan (matrixVal)) {
+          result_h.foundNan = true;
+        }
+        const mag_type matrixAbsVal = KAT::abs (matrixVal);
         rowNorm += matrixAbsVal;
         const LO lclCol = ind[k];
         if (lclCol == lclDiagColInd) {
@@ -187,13 +196,17 @@ computeLocalRowAndColumnOneNorms_RowMatrix (const Tpetra::RowMatrix<SC, LO, GO, 
         if (! assumeSymmetric) {
           result_h.colNorms[lclCol] += matrixAbsVal;
         }
-      }
+      } // for each entry in row
 
+      // This is a local result.  If the matrix has an overlapping
+      // row Map, then the global result might differ.
+      if (diagVal == KAT::zero ()) {
+        result_h.foundZeroDiag = true;
+      }
       // NOTE (mfh 24 May 2018) We could actually compute local
       // rowScaledColNorms in situ at this point, if ! assumeSymmetric
       // and row Map is the same as range Map (so that the local row
       // norms are the same as the global row norms).
-
       result_h.rowDiagonalEntries[lclRow] += diagVal;
       result_h.rowNorms[lclRow] = rowNorm;
       if (! assumeSymmetric &&
@@ -302,30 +315,48 @@ computeLocalRowScaledColumnNorms (EquilibrationInfo<typename Kokkos::ArithTraits
   }
 }
 
+// Kokkos::parallel_reduce functor that is part of the implementation
+// of computeLocalRowAndColumnOneNorms_CrsMatrix.
 template<class SC, class LO, class GO, class NT>
 class ComputeLocalRowAndColumnOneNorms {
 public:
-  using crs_matrix_type = ::Tpetra::CrsMatrix<SC, LO, GO, NT>;
   using val_type = typename Kokkos::ArithTraits<SC>::val_type;
-  using result_type = EquilibrationInfo<val_type, typename NT::device_type>;
+  using equib_info_type = EquilibrationInfo<val_type, typename NT::device_type>;
+  using local_matrix_type = typename ::Tpetra::CrsMatrix<SC, LO, GO, NT>::local_matrix_type;
+  using local_map_type = typename ::Tpetra::Map<LO, GO, NT>::local_map_type;
 
 public:
-  ComputeLocalRowAndColumnOneNorms (const crs_matrix_type& A,
-                                    const bool assumeSymmetric) :
-    A_lcl_ (A.getLocalMatrix ()),
-    rowMap_ (A.getRowMap ()->getLocalMap ()),
-    colMap_ (A.getColMap ()->getLocalMap ()),
-    result_ (result_type (static_cast<LO> (rowMap_.getNodeNumElements ()),
-                          static_cast<LO> (colMap_.getNodeNumElements ()),
-                          assumeSymmetric))
+  ComputeLocalRowAndColumnOneNorms (const equib_info_type& equib,   // in/out
+                                    const local_matrix_type& A_lcl, // in
+                                    const local_map_type& rowMap,   // in
+                                    const local_map_type& colMap) : // in
+    equib_ (equib),
+    A_lcl_ (A_lcl),
+    rowMap_ (rowMap),
+    colMap_ (colMap)
   {}
 
-  result_type getResult () const
+  // (result & 1) != 0 means "found Inf."
+  // (result & 2) != 0 means "found NaN."
+  // (result & 4) != 0 means "found zero diag."
+  // Pack into a single int so the reduction is cheaper,
+  // esp. on GPU.
+  using value_type = int;
+
+  KOKKOS_INLINE_FUNCTION void init (value_type& dst) const
   {
-    return result_;
+    dst = 0;
   }
 
-  KOKKOS_INLINE_FUNCTION void operator () (const LO lclRow) const
+  KOKKOS_INLINE_FUNCTION void
+  join (volatile value_type& dst,
+        const volatile value_type& src) const
+  {
+    dst |= src;
+  }
+
+  KOKKOS_INLINE_FUNCTION void
+  operator () (const LO lclRow, value_type& dst) const
   {
     using KAT = Kokkos::ArithTraits<val_type>;
     using mag_type = typename KAT::mag_type;
@@ -336,46 +367,54 @@ public:
 
     const auto curRow = A_lcl_.rowConst (lclRow);
     const LO numEnt = curRow.length;
-    const bool assumeSymmetric = result_.assumeSymmetric;
+    const bool assumeSymmetric = equib_.assumeSymmetric;
 
     mag_type rowNorm {0.0};
     val_type diagVal {0.0};
+
     for (LO k = 0; k < numEnt; ++k) {
-      const mag_type matrixAbsVal = KAT::abs (curRow.value (k));
+      const val_type matrixVal = curRow.value (k);
+      if (KAT::isInf (matrixVal)) {
+        dst |= 1;
+      }
+      if (KAT::isNan (matrixVal)) {
+        dst |= 2;
+      }
+      const mag_type matrixAbsVal = KAT::abs (matrixVal);
       rowNorm += matrixAbsVal;
       const LO lclCol = curRow.colidx (k);
       if (lclCol == lclDiagColInd) {
         diagVal = curRow.value (k); // assume no repeats
       }
       if (! assumeSymmetric) {
-        Kokkos::atomic_add (&(result_.colNorms[lclCol]), matrixAbsVal);
+        Kokkos::atomic_add (&(equib_.colNorms[lclCol]), matrixAbsVal);
       }
-    }
+    } // for each entry in row
 
+    // This is a local result.  If the matrix has an overlapping
+    // row Map, then the global result might differ.
+    if (diagVal == KAT::zero ()) {
+      dst |= 4;
+    }
     // NOTE (mfh 24 May 2018) We could actually compute local
     // rowScaledColNorms in situ at this point, if ! assumeSymmetric
     // and row Map is the same as range Map (so that the local row
     // norms are the same as the global row norms).
-
-    result_.rowDiagonalEntries[lclRow] = diagVal;
-    result_.rowNorms[lclRow] = rowNorm;
+    equib_.rowDiagonalEntries[lclRow] = diagVal;
+    equib_.rowNorms[lclRow] = rowNorm;
     if (! assumeSymmetric &&
         lclDiagColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
       // Don't need an atomic update here, since this lclDiagColInd is
       // a one-to-one function of lclRow.
-      result_.colDiagonalEntries[lclDiagColInd] += diagVal;
+      equib_.colDiagonalEntries[lclDiagColInd] += diagVal;
     }
   }
 
 private:
-  using local_matrix_type = typename crs_matrix_type::local_matrix_type;
+  equib_info_type equib_;
   local_matrix_type A_lcl_;
-
-  using local_map_type = typename ::Tpetra::Map<LO, GO, NT>::local_map_type;
   local_map_type rowMap_;
   local_map_type colMap_;
-
-  result_type result_;
 };
 
 /// \brief Implementation of computeLocalRowAndColumnOneNorms for a
@@ -388,12 +427,25 @@ computeLocalRowAndColumnOneNorms_CrsMatrix (const Tpetra::CrsMatrix<SC, LO, GO, 
   using execution_space = typename NT::device_type::execution_space;
   using range_type = Kokkos::RangePolicy<execution_space, LO>;
   using functor_type = ComputeLocalRowAndColumnOneNorms<SC, LO, GO, NT>;
+  using val_type = typename Kokkos::ArithTraits<SC>::val_type;
+  using device_type = typename NT::device_type;
+  using equib_info_type = EquilibrationInfo<val_type, device_type>;
 
-  functor_type functor (A, assumeSymmetric);
   const LO lclNumRows = static_cast<LO> (A.getRowMap ()->getNodeNumElements ());
-  Kokkos::parallel_for ("computeLocalRowAndColumnOneNorms",
-                        range_type (0, lclNumRows), functor);
-  return functor.getResult ();
+  const LO lclNumCols = static_cast<LO> (A.getColMap ()->getNodeNumElements ());
+  equib_info_type equib (lclNumRows, lclNumCols, assumeSymmetric);
+
+  functor_type functor (equib, A.getLocalMatrix (),
+                        A.getRowMap ()->getLocalMap (),
+                        A.getColMap ()->getLocalMap ());
+  int result = 0;
+  Kokkos::parallel_reduce ("computeLocalRowAndColumnOneNorms",
+                           range_type (0, lclNumRows), functor,
+                           result);
+  equib.foundInf = (result & 1) != 0;
+  equib.foundNan = (result & 2) != 0;
+  equib.foundZeroDiag = (result & 4) != 0;
+  return equib;
 }
 
 /// \brief Compute LOCAL row and column one-norms ("row sums" etc.) of
@@ -479,6 +531,41 @@ copyMultiVectorColumnInto1DView (const Kokkos::View<ViewValueType*, typename NT:
   Tpetra::Details::copyConvert (view, X_lcl);
 }
 
+template<class OneDViewType, class IndexType>
+class FindZero {
+public:
+  static_assert (OneDViewType::Rank == 1,
+                 "OneDViewType must be a rank-1 Kokkos::View.");
+  static_assert (std::is_integral<IndexType>::value,
+                 "IndexType must be a built-in integer type.");
+  FindZero (const OneDViewType& x) : x_ (x) {}
+  // Kokkos historically didn't like bool reduction results on CUDA,
+  // so we use int as the reduction result type.
+  KOKKOS_INLINE_FUNCTION void
+  operator () (const IndexType i, int& result) const {
+    using val_type = typename OneDViewType::non_const_value_type;
+    result = (x_(i) == Kokkos::ArithTraits<val_type>::zero ()) ? 1 : result;
+  }
+private:
+  OneDViewType x_;
+};
+
+template<class OneDViewType>
+bool findZero (const OneDViewType& x)
+{
+  using view_type = typename OneDViewType::const_type;
+  using execution_space = typename view_type::execution_space;
+  using size_type = typename view_type::size_type;
+  using functor_type = FindZero<view_type, size_type>;
+
+  Kokkos::RangePolicy<execution_space, size_type> range (0, x.extent (0));
+  range.set (Kokkos::ChunkSize (500)); // adjust as needed
+
+  int foundZero = 0;
+  Kokkos::parallel_reduce ("findZero", range, functor_type (x), foundZero);
+  return foundZero == 1;
+}
+
 template<class SC, class LO, class GO, class NT>
 void
 globalizeRowOneNorms (EquilibrationInfo<typename Kokkos::ArithTraits<SC>::val_type,
@@ -518,7 +605,30 @@ globalizeRowOneNorms (EquilibrationInfo<typename Kokkos::ArithTraits<SC>::val_ty
     }
     copyMultiVectorColumnInto1DView (equib.rowNorms, rowMapMV, 0);
     copyMultiVectorColumnInto1DView (equib.rowDiagonalEntries, rowMapMV, 1);
+
+    // It's not common for users to solve linear systems with a
+    // nontrival Export, so it's OK for this to cost an additional
+    // pass over rowDiagonalEntries.
+    equib.foundZeroDiag = findZero (equib.rowDiagonalEntries);
   }
+
+  constexpr int allReduceCount = 3;
+  int lclNaughtyMatrix[allReduceCount];
+  lclNaughtyMatrix[0] = equib.foundInf ? 1 : 0;
+  lclNaughtyMatrix[1] = equib.foundNan ? 1 : 0;
+  lclNaughtyMatrix[2] = equib.foundZeroDiag ? 1 : 0;
+
+  using Teuchos::outArg;
+  using Teuchos::REDUCE_MAX;
+  using Teuchos::reduceAll;
+  auto comm = G->getComm ();
+  int gblNaughtyMatrix[allReduceCount];
+  reduceAll<int, int> (*comm, REDUCE_MAX, allReduceCount,
+                       lclNaughtyMatrix, gblNaughtyMatrix);
+
+  equib.foundInf = gblNaughtyMatrix[0] == 1;
+  equib.foundNan = gblNaughtyMatrix[1] == 1;
+  equib.foundZeroDiag = gblNaughtyMatrix[2] == 1;
 }
 
 template<class SC, class LO, class GO, class NT>
@@ -536,11 +646,11 @@ globalizeColumnOneNorms (EquilibrationInfo<typename Kokkos::ArithTraits<SC>::val
   auto G = A.getGraph ();
   TEUCHOS_TEST_FOR_EXCEPTION
     (G.get () == nullptr, std::invalid_argument,
-     "globalizeRowOneNorms: Input RowMatrix A must have a nonnull graph "
+     "globalizeColumnOneNorms: Input RowMatrix A must have a nonnull graph "
      "(that is, getGraph() must return nonnull).");
   TEUCHOS_TEST_FOR_EXCEPTION
     (! G->isFillComplete (), std::invalid_argument,
-     "globalizeRowOneNorms: Input CrsGraph G must be fillComplete.");
+     "globalizeColumnOneNorms: Input CrsGraph G must be fillComplete.");
 
   auto imp = G->getImporter ();
   if (assumeSymmetric) {

--- a/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
@@ -57,9 +57,44 @@
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "Teuchos_CommHelpers.hpp"
+#include <array>
+#include <functional>
 #include <type_traits>
 
 namespace { // (anonymous)
+
+template<class SC, const bool isComplex = Kokkos::ArithTraits<SC>::is_complex>
+struct NaughtyValues {
+  static SC infinity ();
+  static SC quiet_NaN ();
+};
+
+template<class SC>
+struct NaughtyValues<SC, false> {
+  static SC infinity () {
+    return std::numeric_limits<SC>::infinity ();
+  }
+  static SC quiet_NaN () {
+    return std::numeric_limits<SC>::quiet_NaN ();
+  }
+};
+
+// mfh 15 Jun 2018: std::numeric_limits' infinity() and quiet_NaN()
+// methods don't seem to worki right for std::complex or
+// Kokkos::complex.  The code below works around that.  This test
+// passes whether just the real part is (Inf or NaN), or whether both
+// real and imaginary parts are (Inf or NaN).
+template<class SC>
+struct NaughtyValues<SC, true> {
+  using mag_type = typename Kokkos::ArithTraits<SC>::mag_type;
+
+  static SC infinity () {
+    return SC (std::numeric_limits<mag_type>::infinity (), 0.0);
+  }
+  static SC quiet_NaN () {
+    return SC (std::numeric_limits<mag_type>::quiet_NaN (), 0.0);
+  }
+};
 
 template<class SC, class LO, class GO, class NT>
 Tpetra::Vector<SC, LO, GO, NT>
@@ -85,9 +120,21 @@ near (const ValueType& x,
       const ValueType& y,
       const typename Kokkos::ArithTraits<ValueType>::mag_type& factor)
 {
-  const auto eps = Kokkos::ArithTraits<ValueType>::eps ();
-  const auto absDiff = Kokkos::ArithTraits<ValueType>::abs (x - y);
-  return absDiff <= factor * eps;
+  using KAT = Kokkos::ArithTraits<ValueType>;
+
+  if (KAT::isNan (x) && KAT::isNan (y)) {
+    // Any comparison involving a NaN will fail, so we need a special case.
+    return true;
+  }
+  else if (KAT::isInf (x) && KAT::isInf (y)) {
+    // Inf - Inf -> NaN, so we need a special case.
+    return true;
+  }
+  else {
+    const auto eps = KAT::eps ();
+    const auto absDiff = KAT::abs (x - y);
+    return absDiff <= factor * eps;
+  }
 }
 
 template<class SC, class LO, class GO, class NT>
@@ -194,6 +241,12 @@ struct EquilibrationTest {
   std::vector<mag_type> gblRowScaledColNorms;
   Teuchos::RCP<crs_matrix_type> A_leftScaled;
   Teuchos::RCP<crs_matrix_type> A_rightScaled;
+  bool lclFoundInf;
+  bool lclFoundNan;
+  bool lclFoundZeroDiag;
+  bool gblFoundInf;
+  bool gblFoundNan;
+  bool gblFoundZeroDiag;
 };
 
 template<class SC, class LO, class GO, class NT>
@@ -231,6 +284,15 @@ testEquilibration (Teuchos::FancyOStream& out,
     out << "Test computeLocalRowAndColumnOneNorms (CrsMatrix)" << endl;
     Teuchos::OSTab tab2 (out);
     auto result0 = Tpetra::Details::computeLocalRowAndColumnOneNorms (* (test.A), assumeSymmetric);
+
+    {
+      out << "Test detection of local error conditions" << endl;
+      Teuchos::OSTab tab3 (out);
+
+      TEST_EQUALITY( test.lclFoundInf, result0.foundInf );
+      TEST_EQUALITY( test.lclFoundNan, result0.foundNan );
+      TEST_EQUALITY( test.lclFoundZeroDiag, result0.foundZeroDiag );
+    }
 
     {
       out << "Test local row norms" << endl;
@@ -384,6 +446,15 @@ testEquilibration (Teuchos::FancyOStream& out,
 
     out << "Test globalizing row one norms" << endl;
     Tpetra::Details::globalizeRowOneNorms (result0, * (test.A));
+
+    {
+      out << "Test detection of global error conditions" << endl;
+      Teuchos::OSTab tab3 (out);
+
+      TEST_EQUALITY( test.gblFoundInf, result0.foundInf );
+      TEST_EQUALITY( test.gblFoundNan, result0.foundNan );
+      TEST_EQUALITY( test.gblFoundZeroDiag, result0.foundZeroDiag );
+    }
 
     {
       out << "Test global row norms" << endl;
@@ -554,6 +625,16 @@ testEquilibration (Teuchos::FancyOStream& out,
     using Tpetra::Details::computeLocalRowAndColumnOneNorms_RowMatrix;
     auto result1 =
       computeLocalRowAndColumnOneNorms_RowMatrix (* (test.A), assumeSymmetric);
+
+    {
+      out << "Test detection of local error conditions" << endl;
+      Teuchos::OSTab tab3 (out);
+
+      TEST_EQUALITY( test.lclFoundInf, result1.foundInf );
+      TEST_EQUALITY( test.lclFoundNan, result1.foundNan );
+      TEST_EQUALITY( test.lclFoundZeroDiag, result1.foundZeroDiag );
+    }
+
     {
       out << "Test local row norms" << endl;
       Teuchos::OSTab tab3 (out);
@@ -669,6 +750,15 @@ testEquilibration (Teuchos::FancyOStream& out,
       out << "Test whether assumeSymmetric got communicated" << endl;
       Teuchos::OSTab tab3 (out);
       TEST_EQUALITY( assumeSymmetric, result2.assumeSymmetric );
+    }
+
+    {
+      out << "Test detection of global error conditions" << endl;
+      Teuchos::OSTab tab3 (out);
+
+      TEST_EQUALITY( test.gblFoundInf, result2.foundInf );
+      TEST_EQUALITY( test.gblFoundNan, result2.foundNan );
+      TEST_EQUALITY( test.gblFoundZeroDiag, result2.foundZeroDiag );
     }
 
     {
@@ -1031,24 +1121,38 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
         const LO diagLclColInd = colMap->getLocalElement (gblCol);
         const LO rightLclColInd = colMap->getLocalElement (gblCol + GO (1));
 
-        lclRowScaledColNorms[diagLclColInd] += diagAbsVal / gblRowNorms[lclRow];
-        lclRowScaledColNorms[rightLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
+        if (diagLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[diagLclColInd] += diagAbsVal / gblRowNorms[lclRow];
+        }
+        if (rightLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[rightLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
+        }
       }
       else if (gblRow == rowMap->getMaxAllGlobalIndex ()) {
         const LO leftLclColInd = colMap->getLocalElement (gblCol - GO (1));
         const LO diagLclColInd = colMap->getLocalElement (gblCol);
 
-        lclRowScaledColNorms[leftLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
-        lclRowScaledColNorms[diagLclColInd] += diagAbsVal / gblRowNorms[lclRow];
+        if (leftLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[leftLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
+        }
+        if (diagLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[diagLclColInd] += diagAbsVal / gblRowNorms[lclRow];
+        }
       }
       else {
         const LO leftLclColInd = colMap->getLocalElement (gblCol - GO (1));
         const LO diagLclColInd = colMap->getLocalElement (gblCol);
         const LO rightLclColInd = colMap->getLocalElement (gblCol + GO (1));
 
-        lclRowScaledColNorms[leftLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
-        lclRowScaledColNorms[diagLclColInd] += diagAbsVal / gblRowNorms[lclRow];
-        lclRowScaledColNorms[rightLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
+        if (leftLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[leftLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
+        }
+        if (diagLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[diagLclColInd] += diagAbsVal / gblRowNorms[lclRow];
+        }
+        if (rightLclColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+          lclRowScaledColNorms[rightLclColInd] += offDiagAbsVal / gblRowNorms[lclRow];
+        }
       }
     }
   } // ! assumeSymmetric
@@ -1083,7 +1187,6 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
 
     for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
       const GO gblCol = colMap->getGlobalElement (lclCol);
-
       if (gblCol == gblMinGblCol || gblCol == gblMaxGblCol) {
         gblRowScaledColNorms[lclCol] = 11.0 / 12.0; // 2/3 + 1/4
       }
@@ -1094,6 +1197,240 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
       else {
         gblRowScaledColNorms[lclCol] = 1.0; // 1/4 + 1/2 + 1/4
       }
+    }
+  }
+
+  out << "Compute right-scaled matrix" << endl;
+  Teuchos::RCP<crs_matrix_type> A_rightScaled = [&] () {
+    Teuchos::RCP<crs_matrix_type> A_copy = deepCopyFillCompleteCrsMatrix (*A);
+    A_copy->resumeFill ();
+
+    auto A_lcl = A_copy->getLocalMatrix ();
+    auto val_h = Kokkos::create_mirror_view (A_lcl.values);
+    Kokkos::deep_copy (val_h, A_lcl.values);
+    auto ptr_h = Kokkos::create_mirror_view (A_lcl.graph.row_map);
+    Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
+    auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
+    Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      using size_type = typename decltype (A_lcl.graph)::size_type;
+      for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
+        const LO lclCol = ind_h[k];
+        const mag_type colNorm = assumeSymmetric ?
+          gblColNorms[lclCol] : gblRowScaledColNorms[lclCol];
+        // const mag_type rowScalingFactor = assumeSymmetric ?
+        //   KAM::sqrt (gblRowNorms[lclRow]) : gblRowNorms[lclRow];
+        const mag_type colScalingFactor = assumeSymmetric ?
+          KAM::sqrt (colNorm) : colNorm;
+        // const mag_type scalingFactor = rowScalingFactor * colScalingFactor;
+        const mag_type scalingFactor = colScalingFactor;
+        val_h[k] = val_h[k] / scalingFactor;
+      }
+    }
+    Kokkos::deep_copy (A_lcl.values, val_h);
+    A_copy->fillComplete (A_copy->getDomainMap (), A_copy->getRangeMap ());
+    return A_copy;
+  } ();
+
+  const bool lclFoundInf = false;
+  const bool lclFoundNan = false;
+  const bool lclFoundZeroDiag = false;
+  const bool gblFoundInf = false;
+  const bool gblFoundNan = false;
+  const bool gblFoundZeroDiag = false;
+
+  return EquilibrationTest<SC, LO, GO, NT> {
+    A,
+    lclRowNorms,
+    lclRowDiagonalEntries,
+    lclColNorms,
+    lclColDiagonalEntries,
+    lclRowScaledColNorms,
+    gblRowNorms,
+    gblColNorms,
+    gblRowScaledColNorms,
+    A_leftScaled,
+    A_rightScaled,
+    lclFoundInf,
+    lclFoundNan,
+    lclFoundZeroDiag,
+    gblFoundInf,
+    gblFoundNan,
+    gblFoundZeroDiag
+  };
+}
+
+// NOTE (mfh 23 May 2018) This function is only for the test.
+template<class SC, class LO, class GO, class NT>
+EquilibrationTest<SC, LO, GO, NT>
+makeMatrixTestWithExplicitZeroDiag (Teuchos::FancyOStream& out,
+                                    const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                    const bool assumeSymmetric)
+{
+  using Teuchos::RCP;
+  using std::endl;
+  using GST = Tpetra::global_size_t;
+  using map_type = Tpetra::Map<LO, GO, NT>;
+  using crs_graph_type = Tpetra::CrsGraph<LO, GO, NT>;
+  using crs_matrix_type = Tpetra::CrsMatrix<SC, LO, GO, NT>;
+  using KAT = Kokkos::ArithTraits<SC>;
+  using val_type = typename KAT::val_type;
+  using mag_type = typename Kokkos::ArithTraits<val_type>::mag_type;
+  using KAM = Kokkos::ArithTraits<mag_type>;
+
+  const int myRank = comm->getRank ();
+  const int numProcs = comm->getSize ();
+
+  const LO lclNumRows = 1;
+  const GO gblNumRows = GO (numProcs) * GO (lclNumRows);
+  const GO indexBase = 0;
+
+  out << "Create diagonal matrix problem with explicit zero "
+    "diagonal entry on one process, not Process 0" << endl;
+  Teuchos::OSTab tab0 (out);
+
+  out << "Create Maps" << endl;
+  RCP<const map_type> rowMap =
+    rcp (new map_type (GST (gblNumRows), std::size_t (lclNumRows),
+                       indexBase, comm));
+  RCP<const map_type> domMap = rowMap;
+  RCP<const map_type> ranMap = rowMap;
+
+  out << "Create CrsGraph" << endl;
+  const size_t maxNumEntPerRow = 1;
+  RCP<crs_graph_type> G =
+    rcp (new crs_graph_type (rowMap, maxNumEntPerRow, Tpetra::StaticProfile));
+  std::vector<GO> globalIndices (maxNumEntPerRow);
+
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    const GO gblRow = rowMap->getGlobalElement (lclRow);
+    const LO numEnt = 1;
+    globalIndices[0] = gblRow;
+    G->insertGlobalIndices (gblRow, numEnt, globalIndices.data ());
+  }
+  G->fillComplete (domMap, ranMap);
+
+  out << "Create test CrsMatrix" << endl;
+  RCP<crs_matrix_type> A = rcp (new crs_matrix_type (G));
+  std::vector<SC> values (maxNumEntPerRow);
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    const GO gblRow = rowMap->getGlobalElement (lclRow);
+
+    const LO numEnt = 1;
+    globalIndices[0] = gblRow;
+    if (myRank == 1) {
+      values[0] = 0.0; // explicitly stored zero diagonal
+    }
+    else {
+      values[0] = 1.0;
+    }
+    A->replaceGlobalValues (gblRow, numEnt, values.data (), globalIndices.data ());
+  }
+  A->fillComplete (domMap, ranMap);
+
+  RCP<const map_type> colMap = G->getColMap ();
+  const LO lclNumCols = static_cast<LO> (colMap->getNodeNumElements ());
+
+  out << "Compute local row norms and diagonal entries" << endl;
+  std::vector<val_type> lclRowDiagonalEntries (lclNumRows);
+  std::vector<mag_type> lclRowNorms (lclNumRows);
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    const mag_type expectedRowNorm = myRank == 1 ? 0.0 : 1.0;
+    lclRowDiagonalEntries[lclRow] = myRank == 1 ? 0.0 : 1.0;
+    lclRowNorms[lclRow] = expectedRowNorm;
+  }
+
+  // For this matrix, the global row norms are the same as the local
+  // row norms, since the matrix's row Map and range Map are the same.
+  // This may not be the case for matrices with an overlapping or
+  // permuted row Map.
+  out << "Compute global row norms" << endl;
+  std::vector<mag_type> gblRowNorms (lclRowNorms.begin (), lclRowNorms.end ());
+
+  Teuchos::RCP<crs_matrix_type> A_leftScaled = [&] () {
+    Teuchos::RCP<crs_matrix_type> A_copy = deepCopyFillCompleteCrsMatrix (*A);
+    A_copy->resumeFill ();
+
+    auto A_lcl = A_copy->getLocalMatrix ();
+    auto val_h = Kokkos::create_mirror_view (A_lcl.values);
+    Kokkos::deep_copy (val_h, A_lcl.values);
+    auto ptr_h = Kokkos::create_mirror_view (A_lcl.graph.row_map);
+    Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
+    auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
+    Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      using size_type = typename decltype (A_lcl.graph)::size_type;
+      for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
+        const val_type expectedUnscaledVal = myRank == 1 ? 0.0 : 1.0;
+        const mag_type rowNorm = gblRowNorms[lclRow];
+        const mag_type scalingFactor = assumeSymmetric ?
+          KAM::sqrt (rowNorm) : rowNorm;
+        val_h[k] = expectedUnscaledVal / scalingFactor; // may be NaN in this case
+      }
+    }
+    Kokkos::deep_copy (A_lcl.values, val_h);
+    A_copy->fillComplete (A_copy->getDomainMap (), A_copy->getRangeMap ());
+    return A_copy;
+  } ();
+
+  if (assumeSymmetric) {
+    out << "assumeSymmetric=true: Skip local (column norms, "
+      "diagonal entries, and row-scaled column norms)" << endl;
+  }
+  else {
+    out << "assumeSymmetric=false: Compute local (column norms, "
+      "diagonal entries, and row-scaled column norms)" << endl;
+  }
+
+  std::vector<mag_type> lclColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  std::vector<val_type> lclColDiagonalEntries
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  std::vector<mag_type> lclRowScaledColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+
+  if (! assumeSymmetric) {
+    // Columns are a little more complicated, since in the usual
+    // distributed case, the local column norms may not be the same as
+    // the global column norms.
+    for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+      lclColNorms[lclCol] = myRank == 1 ? 0.0 : 1.0;
+      lclColDiagonalEntries[lclCol] = myRank == 1 ? 0.0 : 1.0;
+    } // for each local column
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      const GO gblRow = rowMap->getGlobalElement (lclRow);
+      const GO gblCol = gblRow;
+      const LO lclCol = colMap->getLocalElement (gblCol);
+      mag_type lclRowScaledColNorm {0.0};
+
+      const mag_type matrixAbsVal = myRank == 1 ? 0.0 : 1.0;
+      lclRowScaledColNorms[lclCol] = myRank == 1 ?
+        NaughtyValues<mag_type>::quiet_NaN () : 1.0;
+    }
+  } // ! assumeSymmetric
+
+  out << "Compute global column norms" << endl;
+  std::vector<mag_type> gblColNorms (lclNumCols);
+  // The matrix is symmetric, so this holds regardless of assumeSymmetric.
+  for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+    gblColNorms[lclCol] = myRank == 1 ? 0.0 : 1.0;
+  }
+
+  if (assumeSymmetric) {
+    out << "Skip global row-scaled column norms" << endl;
+  }
+  else {
+    out << "Compute global row-scaled column norms" << endl;
+  }
+  std::vector<mag_type> gblRowScaledColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  if (! assumeSymmetric && colMap->getGlobalNumElements () != 0) {
+    for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+      gblRowScaledColNorms[lclCol] = myRank == 1 ?
+        NaughtyValues<mag_type>::quiet_NaN () : 1.0;
     }
   }
 
@@ -1129,6 +1466,13 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
     return A_copy;
   } ();
 
+  const bool lclFoundInf = false;
+  const bool lclFoundNan = false;
+  const bool lclFoundZeroDiag = myRank == 1 ? true : false;
+  const bool gblFoundInf = false;
+  const bool gblFoundNan = false;
+  const bool gblFoundZeroDiag = numProcs == 1 ? false : true;
+
   return EquilibrationTest<SC, LO, GO, NT> {
     A,
     lclRowNorms,
@@ -1140,7 +1484,528 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
     gblColNorms,
     gblRowScaledColNorms,
     A_leftScaled,
-    A_rightScaled
+    A_rightScaled,
+    lclFoundInf,
+    lclFoundNan,
+    lclFoundZeroDiag,
+    gblFoundInf,
+    gblFoundNan,
+    gblFoundZeroDiag
+  };
+}
+
+// NOTE (mfh 14 Jun 2018) This function is only for the test.
+template<class SC, class LO, class GO, class NT>
+EquilibrationTest<SC, LO, GO, NT>
+makeMatrixTestWithImplicitZeroDiag (Teuchos::FancyOStream& out,
+                                    const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                    const bool assumeSymmetric)
+{
+  using Teuchos::RCP;
+  using std::endl;
+  using GST = Tpetra::global_size_t;
+  using map_type = Tpetra::Map<LO, GO, NT>;
+  using crs_graph_type = Tpetra::CrsGraph<LO, GO, NT>;
+  using crs_matrix_type = Tpetra::CrsMatrix<SC, LO, GO, NT>;
+  using KAT = Kokkos::ArithTraits<SC>;
+  using val_type = typename KAT::val_type;
+  using mag_type = typename Kokkos::ArithTraits<val_type>::mag_type;
+  using KAM = Kokkos::ArithTraits<mag_type>;
+
+  const int myRank = comm->getRank ();
+  const int numProcs = comm->getSize ();
+
+  const LO lclNumRows = 1;
+  const GO gblNumRows = GO (numProcs) * GO (lclNumRows);
+  const GO indexBase = 0;
+
+  out << "Create diagonal matrix problem with implicit zero "
+    "diagonal entry on one process, not Process 0" << endl;
+  Teuchos::OSTab tab0 (out);
+
+  out << "Create Maps" << endl;
+  RCP<const map_type> rowMap =
+    rcp (new map_type (GST (gblNumRows), std::size_t (lclNumRows),
+                       indexBase, comm));
+  RCP<const map_type> domMap = rowMap;
+  RCP<const map_type> ranMap = rowMap;
+
+  out << "Create CrsGraph" << endl;
+  const size_t maxNumEntPerRow = 1;
+  RCP<crs_graph_type> G =
+    rcp (new crs_graph_type (rowMap, maxNumEntPerRow, Tpetra::StaticProfile));
+
+  // Process 1 gets an implicit zero diagonal entry.
+  std::vector<GO> globalIndices (maxNumEntPerRow);
+  if (myRank != 1) {
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      const GO gblRow = rowMap->getGlobalElement (lclRow);
+      const LO numEnt = 1;
+      globalIndices[0] = gblRow;
+      G->insertGlobalIndices (gblRow, numEnt, globalIndices.data ());
+    }
+  }
+  G->fillComplete (domMap, ranMap);
+
+  out << "Create test CrsMatrix" << endl;
+  RCP<crs_matrix_type> A = rcp (new crs_matrix_type (G));
+
+  std::vector<SC> values (maxNumEntPerRow);
+  if (myRank != 1) {
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      const GO gblRow = rowMap->getGlobalElement (lclRow);
+      const LO numEnt = 1;
+      globalIndices[0] = gblRow;
+      values[0] = 1.0;
+      A->replaceGlobalValues (gblRow, numEnt, values.data (), globalIndices.data ());
+    }
+  }
+  A->fillComplete (domMap, ranMap);
+
+  RCP<const map_type> colMap = G->getColMap ();
+  const LO lclNumCols = static_cast<LO> (colMap->getNodeNumElements ());
+
+  out << "Compute local row norms and diagonal entries" << endl;
+  std::vector<val_type> lclRowDiagonalEntries (lclNumRows);
+  std::vector<mag_type> lclRowNorms (lclNumRows);
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    const mag_type expectedRowNorm = myRank == 1 ? 0.0 : 1.0;
+    lclRowDiagonalEntries[lclRow] = myRank == 1 ? 0.0 : 1.0;
+    lclRowNorms[lclRow] = expectedRowNorm;
+  }
+
+  // For this matrix, the global row norms are the same as the local
+  // row norms, since the matrix's row Map and range Map are the same.
+  // This may not be the case for matrices with an overlapping or
+  // permuted row Map.
+  out << "Compute global row norms" << endl;
+  std::vector<mag_type> gblRowNorms (lclRowNorms.begin (), lclRowNorms.end ());
+
+  Teuchos::RCP<crs_matrix_type> A_leftScaled = [&] () {
+    Teuchos::RCP<crs_matrix_type> A_copy = deepCopyFillCompleteCrsMatrix (*A);
+    A_copy->resumeFill ();
+
+    auto A_lcl = A_copy->getLocalMatrix ();
+    auto val_h = Kokkos::create_mirror_view (A_lcl.values);
+    Kokkos::deep_copy (val_h, A_lcl.values);
+    auto ptr_h = Kokkos::create_mirror_view (A_lcl.graph.row_map);
+    Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
+    auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
+    Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      using size_type = typename decltype (A_lcl.graph)::size_type;
+      for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
+        const val_type expectedUnscaledVal = 1.0; // Proc 1 simply has no entry here
+        const mag_type rowNorm = gblRowNorms[lclRow];
+        const mag_type scalingFactor = assumeSymmetric ?
+          KAM::sqrt (rowNorm) : rowNorm;
+        val_h[k] = expectedUnscaledVal / scalingFactor;
+      }
+    }
+    Kokkos::deep_copy (A_lcl.values, val_h);
+    A_copy->fillComplete (A_copy->getDomainMap (), A_copy->getRangeMap ());
+    return A_copy;
+  } ();
+
+  if (assumeSymmetric) {
+    out << "assumeSymmetric=true: Skip local (column norms, "
+      "diagonal entries, and row-scaled column norms)" << endl;
+  }
+  else {
+    out << "assumeSymmetric=false: Compute local (column norms, "
+      "diagonal entries, and row-scaled column norms)" << endl;
+  }
+
+  std::vector<mag_type> lclColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  std::vector<val_type> lclColDiagonalEntries
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  std::vector<mag_type> lclRowScaledColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+
+  if (! assumeSymmetric) {
+    // Columns are a little more complicated, since in the usual
+    // distributed case, the local column norms may not be the same as
+    // the global column norms.
+    for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+      lclColNorms[lclCol] = myRank == 1 ? 0.0 : 1.0;
+      lclColDiagonalEntries[lclCol] = myRank == 1 ? 0.0 : 1.0;
+    } // for each local column
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      const GO gblRow = rowMap->getGlobalElement (lclRow);
+      const GO gblCol = gblRow;
+      const LO lclCol = colMap->getLocalElement (gblCol);
+      if (lclCol != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
+        mag_type lclRowScaledColNorm {0.0};
+
+        const mag_type matrixAbsVal = myRank == 1 ? 0.0 : 1.0;
+        lclRowScaledColNorms[lclCol] = myRank == 1 ?
+          NaughtyValues<mag_type>::quiet_NaN () : 1.0;
+      }
+    }
+  } // ! assumeSymmetric
+
+  out << "Compute global column norms" << endl;
+  std::vector<mag_type> gblColNorms (lclNumCols);
+  // The matrix is symmetric, so this holds regardless of assumeSymmetric.
+  for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+    gblColNorms[lclCol] = myRank == 1 ? 0.0 : 1.0;
+  }
+
+  if (assumeSymmetric) {
+    out << "Skip global row-scaled column norms" << endl;
+  }
+  else {
+    out << "Compute global row-scaled column norms" << endl;
+  }
+  std::vector<mag_type> gblRowScaledColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  if (! assumeSymmetric && colMap->getGlobalNumElements () != 0) {
+    for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+      gblRowScaledColNorms[lclCol] = myRank == 1 ?
+        NaughtyValues<mag_type>::quiet_NaN () : 1.0;
+    }
+  }
+
+  out << "Compute right-scaled matrix" << endl;
+  Teuchos::RCP<crs_matrix_type> A_rightScaled = [&] () {
+    Teuchos::RCP<crs_matrix_type> A_copy = deepCopyFillCompleteCrsMatrix (*A);
+    A_copy->resumeFill ();
+
+    auto A_lcl = A_copy->getLocalMatrix ();
+    auto val_h = Kokkos::create_mirror_view (A_lcl.values);
+    Kokkos::deep_copy (val_h, A_lcl.values);
+    auto ptr_h = Kokkos::create_mirror_view (A_lcl.graph.row_map);
+    Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
+    auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
+    Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      using size_type = typename decltype (A_lcl.graph)::size_type;
+      for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
+        const LO lclCol = ind_h[k];
+        const mag_type colNorm = assumeSymmetric ?
+          gblColNorms[lclCol] : gblRowScaledColNorms[lclCol];
+        // const mag_type rowScalingFactor = assumeSymmetric ?
+        //   KAM::sqrt (gblRowNorms[lclRow]) : gblRowNorms[lclRow];
+        const mag_type colScalingFactor = assumeSymmetric ?
+          KAM::sqrt (colNorm) : colNorm;
+        // const mag_type scalingFactor = rowScalingFactor * colScalingFactor;
+        const mag_type scalingFactor = colScalingFactor;
+        val_h[k] = val_h[k] / scalingFactor;
+      }
+    }
+    Kokkos::deep_copy (A_lcl.values, val_h);
+    A_copy->fillComplete (A_copy->getDomainMap (), A_copy->getRangeMap ());
+    return A_copy;
+  } ();
+
+  const bool lclFoundInf = false;
+  const bool lclFoundNan = false;
+  const bool lclFoundZeroDiag = myRank == 1 ? true : false;
+  const bool gblFoundInf = false;
+  const bool gblFoundNan = false;
+  const bool gblFoundZeroDiag = numProcs == 1 ? false : true;
+
+  return EquilibrationTest<SC, LO, GO, NT> {
+    A,
+    lclRowNorms,
+    lclRowDiagonalEntries,
+    lclColNorms,
+    lclColDiagonalEntries,
+    lclRowScaledColNorms,
+    gblRowNorms,
+    gblColNorms,
+    gblRowScaledColNorms,
+    A_leftScaled,
+    A_rightScaled,
+    lclFoundInf,
+    lclFoundNan,
+    lclFoundZeroDiag,
+    gblFoundInf,
+    gblFoundNan,
+    gblFoundZeroDiag
+  };
+}
+
+// NOTE (mfh 23 May 2018) This function is only for the test.
+template<class SC, class LO, class GO, class NT>
+EquilibrationTest<SC, LO, GO, NT>
+makeMatrixTestWithExplicitInfAndNan (Teuchos::FancyOStream& out,
+                                     const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                     const bool assumeSymmetric)
+{
+  using Teuchos::RCP;
+  using std::endl;
+  using GST = Tpetra::global_size_t;
+  using map_type = Tpetra::Map<LO, GO, NT>;
+  using crs_graph_type = Tpetra::CrsGraph<LO, GO, NT>;
+  using crs_matrix_type = Tpetra::CrsMatrix<SC, LO, GO, NT>;
+  using KAT = Kokkos::ArithTraits<SC>;
+  using val_type = typename KAT::val_type;
+  using mag_type = typename Kokkos::ArithTraits<val_type>::mag_type;
+  using KAM = Kokkos::ArithTraits<mag_type>;
+
+  const int myRank = comm->getRank ();
+  const int numProcs = comm->getSize ();
+
+  const LO lclNumRows = 1;
+  const GO gblNumRows = GO (numProcs) * GO (lclNumRows);
+  const GO indexBase = 0;
+
+  out << "Create diagonal matrix problem with an explicit Inf entry on "
+    "one process, and an explicit NaN entry on another process" << endl;
+  Teuchos::OSTab tab0 (out);
+
+  out << "Create Maps" << endl;
+  RCP<const map_type> rowMap =
+    rcp (new map_type (GST (gblNumRows), std::size_t (lclNumRows),
+                       indexBase, comm));
+  RCP<const map_type> domMap = rowMap;
+  RCP<const map_type> ranMap = rowMap;
+
+  out << "Create CrsGraph" << endl;
+  const size_t maxNumEntPerRow = 1;
+  RCP<crs_graph_type> G =
+    rcp (new crs_graph_type (rowMap, maxNumEntPerRow, Tpetra::StaticProfile));
+  std::vector<GO> globalIndices (maxNumEntPerRow);
+
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    const GO gblRow = rowMap->getGlobalElement (lclRow);
+    const LO numEnt = 1;
+    globalIndices[0] = gblRow;
+    G->insertGlobalIndices (gblRow, numEnt, globalIndices.data ());
+  }
+  G->fillComplete (domMap, ranMap);
+
+  out << "Create test CrsMatrix" << endl;
+  RCP<crs_matrix_type> A = rcp (new crs_matrix_type (G));
+  std::vector<SC> values (maxNumEntPerRow);
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    const GO gblRow = rowMap->getGlobalElement (lclRow);
+
+    const LO numEnt = 1;
+    globalIndices[0] = gblRow;
+    if (myRank == 1) {
+      values[0] = NaughtyValues<SC>::infinity ();
+    }
+    else if (myRank == 2) {
+      values[0] = NaughtyValues<SC>::quiet_NaN ();
+    }
+    else {
+      values[0] = 1.0;
+    }
+    A->replaceGlobalValues (gblRow, numEnt, values.data (), globalIndices.data ());
+  }
+  A->fillComplete (domMap, ranMap);
+
+  RCP<const map_type> colMap = G->getColMap ();
+  const LO lclNumCols = static_cast<LO> (colMap->getNodeNumElements ());
+
+  out << "Compute local row norms and diagonal entries" << endl;
+  std::vector<val_type> lclRowDiagonalEntries (lclNumRows);
+  std::vector<mag_type> lclRowNorms (lclNumRows);
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    mag_type expectedRowNorm = 1.0;
+    val_type diagEnt = 1.0;
+    if (myRank == 1) {
+      expectedRowNorm = NaughtyValues<mag_type>::infinity ();
+      diagEnt = NaughtyValues<val_type>::infinity ();
+    }
+    else if (myRank == 2) {
+      expectedRowNorm = NaughtyValues<mag_type>::quiet_NaN ();
+      diagEnt = NaughtyValues<val_type>::quiet_NaN ();
+    }
+    lclRowDiagonalEntries[lclRow] = diagEnt;
+    lclRowNorms[lclRow] = expectedRowNorm;
+  }
+
+  // For this matrix, the global row norms are the same as the local
+  // row norms, since the matrix's row Map and range Map are the same.
+  // This may not be the case for matrices with an overlapping or
+  // permuted row Map.
+  out << "Compute global row norms" << endl;
+  std::vector<mag_type> gblRowNorms (lclRowNorms.begin (), lclRowNorms.end ());
+
+  Teuchos::RCP<crs_matrix_type> A_leftScaled = [&] () {
+    Teuchos::RCP<crs_matrix_type> A_copy = deepCopyFillCompleteCrsMatrix (*A);
+    A_copy->resumeFill ();
+
+    auto A_lcl = A_copy->getLocalMatrix ();
+    auto val_h = Kokkos::create_mirror_view (A_lcl.values);
+    Kokkos::deep_copy (val_h, A_lcl.values);
+    auto ptr_h = Kokkos::create_mirror_view (A_lcl.graph.row_map);
+    Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
+    auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
+    Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      using size_type = typename decltype (A_lcl.graph)::size_type;
+      for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
+        val_type expectedUnscaledVal = 1.0;
+        if (myRank == 1) {
+          expectedUnscaledVal = NaughtyValues<val_type>::infinity ();
+        }
+        else if (myRank == 2) {
+          expectedUnscaledVal = NaughtyValues<val_type>::quiet_NaN ();
+        }
+        const mag_type rowNorm = gblRowNorms[lclRow];
+        const mag_type scalingFactor = assumeSymmetric ?
+          KAM::sqrt (rowNorm) : rowNorm;
+        val_h[k] = expectedUnscaledVal / scalingFactor;
+      }
+    }
+    Kokkos::deep_copy (A_lcl.values, val_h);
+    A_copy->fillComplete (A_copy->getDomainMap (), A_copy->getRangeMap ());
+    return A_copy;
+  } ();
+
+  if (assumeSymmetric) {
+    out << "assumeSymmetric=true: Skip local (column norms, "
+      "diagonal entries, and row-scaled column norms)" << endl;
+  }
+  else {
+    out << "assumeSymmetric=false: Compute local (column norms, "
+      "diagonal entries, and row-scaled column norms)" << endl;
+  }
+
+  std::vector<mag_type> lclColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  std::vector<val_type> lclColDiagonalEntries
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  std::vector<mag_type> lclRowScaledColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+
+  if (! assumeSymmetric) {
+    // Columns are a little more complicated, since in the usual
+    // distributed case, the local column norms may not be the same as
+    // the global column norms.
+    for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+      mag_type expectedNorm = 1.0;
+      val_type diagEnt = 1.0;
+      if (myRank == 1) {
+        expectedNorm = NaughtyValues<mag_type>::infinity ();
+        diagEnt = NaughtyValues<val_type>::infinity ();
+      }
+      else if (myRank == 2) {
+        expectedNorm = NaughtyValues<mag_type>::quiet_NaN ();
+        diagEnt = NaughtyValues<val_type>::quiet_NaN ();
+      }
+      lclColNorms[lclCol] = expectedNorm;
+      lclColDiagonalEntries[lclCol] = diagEnt;
+    } // for each local column
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      const GO gblRow = rowMap->getGlobalElement (lclRow);
+      const GO gblCol = gblRow;
+      const LO lclCol = colMap->getLocalElement (gblCol);
+      mag_type lclRowScaledColNorm {0.0};
+
+      mag_type matrixAbsVal = 1.0;
+      if (myRank == 1) {
+        matrixAbsVal = NaughtyValues<mag_type>::infinity ();
+      }
+      else if (myRank == 2) {
+        matrixAbsVal = NaughtyValues<mag_type>::quiet_NaN ();
+      }
+      lclRowScaledColNorms[lclCol] = matrixAbsVal / gblRowNorms[lclRow];
+    }
+  } // ! assumeSymmetric
+
+  out << "Compute global column norms" << endl;
+  std::vector<mag_type> gblColNorms (lclNumCols);
+  // The matrix is symmetric, so this holds regardless of assumeSymmetric.
+  for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+    mag_type expectedNorm = 1.0;
+    if (myRank == 1) {
+      expectedNorm = NaughtyValues<mag_type>::infinity ();
+    }
+    else if (myRank == 2) {
+      expectedNorm = NaughtyValues<mag_type>::quiet_NaN ();
+    }
+    gblColNorms[lclCol] = expectedNorm;
+  }
+
+  if (assumeSymmetric) {
+    out << "Skip global row-scaled column norms" << endl;
+  }
+  else {
+    out << "Compute global row-scaled column norms" << endl;
+  }
+  std::vector<mag_type> gblRowScaledColNorms
+    (assumeSymmetric ? LO (0) : lclNumCols);
+  if (! assumeSymmetric && colMap->getGlobalNumElements () != 0) {
+    for (LO lclCol = 0; lclCol < lclNumCols; ++lclCol) {
+      mag_type expectedNorm = 1.0;
+      if (myRank == 1) {
+        expectedNorm = NaughtyValues<mag_type>::quiet_NaN ();
+      }
+      else if (myRank == 2) {
+        expectedNorm = NaughtyValues<mag_type>::quiet_NaN ();
+      }
+      gblRowScaledColNorms[lclCol] = expectedNorm;
+    }
+  }
+
+  Teuchos::RCP<crs_matrix_type> A_rightScaled = [&] () {
+    Teuchos::RCP<crs_matrix_type> A_copy = deepCopyFillCompleteCrsMatrix (*A);
+    A_copy->resumeFill ();
+
+    auto A_lcl = A_copy->getLocalMatrix ();
+    auto val_h = Kokkos::create_mirror_view (A_lcl.values);
+    Kokkos::deep_copy (val_h, A_lcl.values);
+    auto ptr_h = Kokkos::create_mirror_view (A_lcl.graph.row_map);
+    Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
+    auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
+    Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+
+    for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+      using size_type = typename decltype (A_lcl.graph)::size_type;
+      for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
+        const LO lclCol = ind_h[k];
+        const mag_type colNorm = assumeSymmetric ?
+          gblColNorms[lclCol] : gblRowScaledColNorms[lclCol];
+        // const mag_type rowScalingFactor = assumeSymmetric ?
+        //   KAM::sqrt (gblRowNorms[lclRow]) : gblRowNorms[lclRow];
+        const mag_type colScalingFactor = assumeSymmetric ?
+          KAM::sqrt (colNorm) : colNorm;
+        // const mag_type scalingFactor = rowScalingFactor * colScalingFactor;
+        const mag_type scalingFactor = colScalingFactor;
+        val_h[k] = val_h[k] / scalingFactor;
+      }
+    }
+    Kokkos::deep_copy (A_lcl.values, val_h);
+    A_copy->fillComplete (A_copy->getDomainMap (), A_copy->getRangeMap ());
+    return A_copy;
+  } ();
+
+  const bool lclFoundInf = myRank == 1 ? true : false;
+  const bool lclFoundNan = myRank == 2 ? true : false;
+  const bool lclFoundZeroDiag = false;
+  const bool gblFoundInf = numProcs > 1;
+  const bool gblFoundNan = numProcs > 2;
+  const bool gblFoundZeroDiag = false;
+
+  return EquilibrationTest<SC, LO, GO, NT> {
+    A,
+    lclRowNorms,
+    lclRowDiagonalEntries,
+    lclColNorms,
+    lclColDiagonalEntries,
+    lclRowScaledColNorms,
+    gblRowNorms,
+    gblColNorms,
+    gblRowScaledColNorms,
+    A_leftScaled,
+    A_rightScaled,
+    lclFoundInf,
+    lclFoundNan,
+    lclFoundZeroDiag,
+    gblFoundInf,
+    gblFoundNan,
+    gblFoundZeroDiag
   };
 }
 
@@ -1149,49 +2014,67 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Equilibration, Test0, SC, LO, GO, NT)
   // We are now in a class method declared by the above macro.
   // The method has these input arguments:
   // (Teuchos::FancyOStream& out, bool& success)
+  using Teuchos::Comm;
+  using Teuchos::FancyOStream;
+  using Teuchos::outArg;
+  using Teuchos::RCP;
+  using Teuchos::rcpFromRef;
+  using Teuchos::REDUCE_MIN;
+  using Teuchos::reduceAll;
   using std::endl;
 
   //const bool debugMode = true;
   const bool debugMode = false;
-  Teuchos::RCP<Teuchos::FancyOStream> errStrmPtr = debugMode ?
-    Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr)) : Teuchos::null;
-  Teuchos::FancyOStream& testOut = debugMode ? *errStrmPtr : out;
+  RCP<FancyOStream> errStrmPtr = debugMode ?
+    Teuchos::getFancyOStream (rcpFromRef (std::cerr)) : Teuchos::null;
+  FancyOStream& testOut = debugMode ? *errStrmPtr : out;
 
   testOut << "Test equilibration" << endl;
   Teuchos::OSTab tab0 (testOut);
   auto comm = Tpetra::getDefaultComm ();
 
+  using test_return_type = EquilibrationTest<SC, LO, GO, NT>;
+  using test_type =
+    std::function<test_return_type (FancyOStream&,
+                                    const RCP<const Comm<int> >&,
+                                    const bool)>;
+  std::array<test_type, 4> tests {
+    makeSymmetricPositiveDefiniteTridiagonalMatrixTest<SC, LO, GO, NT>,
+    makeMatrixTestWithExplicitZeroDiag<SC, LO, GO, NT>,
+    makeMatrixTestWithExplicitInfAndNan<SC, LO, GO, NT>,
+    makeMatrixTestWithImplicitZeroDiag<SC, LO, GO, NT>
+  };
+
   for (bool assumeSymmetric : {false, true}) {
-    // The default FancyOStream 'out' only prints to Process 0 by
-    // default.  Thus, we gather up output from each process into a
-    // single string, and print it on Process 0 at the end.
-    Teuchos::RCP<std::ostringstream> osPtr (new std::ostringstream);
-    Teuchos::RCP<Teuchos::FancyOStream> curOutPtr = Teuchos::getFancyOStream (osPtr);
-    Teuchos::FancyOStream& curOut = *curOutPtr;
+    for (auto&& currentTest : tests) {
+      // The default FancyOStream 'out' only prints to Process 0 by
+      // default.  Thus, we gather up output from each process into a
+      // single string, and print it on Process 0 at the end.
+      RCP<std::ostringstream> osPtr (new std::ostringstream);
+      RCP<FancyOStream> curOutPtr = Teuchos::getFancyOStream (osPtr);
+      FancyOStream& curOut = *curOutPtr;
 
-    curOut << endl << ">>> Process " << comm->getRank () << ":" << endl << endl
-           << "assumeSymmetric=" << (assumeSymmetric ? "true" : "false")
-           << endl;
-    Teuchos::OSTab tab1 (curOut);
-    auto test0 =
-      makeSymmetricPositiveDefiniteTridiagonalMatrixTest<SC, LO, GO, NT> (curOut, comm,
-                                                                          assumeSymmetric);
-    bool curSuccess = true;
-    testEquilibration (curOut, curSuccess, test0, assumeSymmetric);
-    success = success && curSuccess;
-    Tpetra::Details::gathervPrint (testOut, osPtr->str (), *comm);
+      curOut << endl << endl
+             << ">>> Process " << comm->getRank () << ":" << endl << endl
+             << "assumeSymmetric=" << (assumeSymmetric ? "true" : "false")
+             << endl << endl;
+      Teuchos::OSTab tab1 (curOut);
+      auto test0 = currentTest (curOut, comm, assumeSymmetric);
 
-    using Teuchos::outArg;
-    using Teuchos::REDUCE_MIN;
-    using Teuchos::reduceAll;
+      bool curSuccess = true;
+      testEquilibration (curOut, curSuccess, test0, assumeSymmetric);
+      success = success && curSuccess;
 
-    int lclSuccess = success ? 1 : 0;
-    int gblSuccess = 0; // output argument
-    reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
-    TEST_EQUALITY( gblSuccess, 1 );
-    if (gblSuccess != 1) {
-      out << "Test FAILED on some process!" << endl;
-      return;
+      int lclSuccess = success ? 1 : 0;
+      int gblSuccess = 0; // output argument
+      reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+      TEST_EQUALITY( gblSuccess, 1 );
+      if (gblSuccess != 1) {
+        // Don't actually print the test output unless the test failed.
+        Tpetra::Details::gathervPrint (testOut, osPtr->str (), *comm);
+        out << "Test FAILED on some process!" << endl;
+        return;
+      }
     }
   }
 }

--- a/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
@@ -244,9 +244,11 @@ struct EquilibrationTest {
   bool lclFoundInf;
   bool lclFoundNan;
   bool lclFoundZeroDiag;
+  bool lclFoundZeroRowNorm;
   bool gblFoundInf;
   bool gblFoundNan;
   bool gblFoundZeroDiag;
+  bool gblFoundZeroRowNorm;
 };
 
 template<class SC, class LO, class GO, class NT>
@@ -292,6 +294,7 @@ testEquilibration (Teuchos::FancyOStream& out,
       TEST_EQUALITY( test.lclFoundInf, result0.foundInf );
       TEST_EQUALITY( test.lclFoundNan, result0.foundNan );
       TEST_EQUALITY( test.lclFoundZeroDiag, result0.foundZeroDiag );
+      TEST_EQUALITY( test.lclFoundZeroRowNorm, result0.foundZeroRowNorm );
     }
 
     {
@@ -454,6 +457,7 @@ testEquilibration (Teuchos::FancyOStream& out,
       TEST_EQUALITY( test.gblFoundInf, result0.foundInf );
       TEST_EQUALITY( test.gblFoundNan, result0.foundNan );
       TEST_EQUALITY( test.gblFoundZeroDiag, result0.foundZeroDiag );
+      TEST_EQUALITY( test.gblFoundZeroRowNorm, result0.foundZeroRowNorm );
     }
 
     {
@@ -633,6 +637,7 @@ testEquilibration (Teuchos::FancyOStream& out,
       TEST_EQUALITY( test.lclFoundInf, result1.foundInf );
       TEST_EQUALITY( test.lclFoundNan, result1.foundNan );
       TEST_EQUALITY( test.lclFoundZeroDiag, result1.foundZeroDiag );
+      TEST_EQUALITY( test.lclFoundZeroRowNorm, result1.foundZeroRowNorm );
     }
 
     {
@@ -759,6 +764,7 @@ testEquilibration (Teuchos::FancyOStream& out,
       TEST_EQUALITY( test.gblFoundInf, result2.foundInf );
       TEST_EQUALITY( test.gblFoundNan, result2.foundNan );
       TEST_EQUALITY( test.gblFoundZeroDiag, result2.foundZeroDiag );
+      TEST_EQUALITY( test.gblFoundZeroRowNorm, result2.foundZeroRowNorm );
     }
 
     {
@@ -1236,9 +1242,11 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
   const bool lclFoundInf = false;
   const bool lclFoundNan = false;
   const bool lclFoundZeroDiag = false;
+  const bool lclFoundZeroRowNorm = false;
   const bool gblFoundInf = false;
   const bool gblFoundNan = false;
   const bool gblFoundZeroDiag = false;
+  const bool gblFoundZeroRowNorm = false;
 
   return EquilibrationTest<SC, LO, GO, NT> {
     A,
@@ -1255,9 +1263,11 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
     lclFoundInf,
     lclFoundNan,
     lclFoundZeroDiag,
+    lclFoundZeroRowNorm,
     gblFoundInf,
     gblFoundNan,
-    gblFoundZeroDiag
+    gblFoundZeroDiag,
+    gblFoundZeroRowNorm
   };
 }
 
@@ -1469,9 +1479,11 @@ makeMatrixTestWithExplicitZeroDiag (Teuchos::FancyOStream& out,
   const bool lclFoundInf = false;
   const bool lclFoundNan = false;
   const bool lclFoundZeroDiag = myRank == 1 ? true : false;
+  const bool lclFoundZeroRowNorm = myRank == 1 ? true : false;
   const bool gblFoundInf = false;
   const bool gblFoundNan = false;
   const bool gblFoundZeroDiag = numProcs == 1 ? false : true;
+  const bool gblFoundZeroRowNorm = numProcs == 1 ? false : true;
 
   return EquilibrationTest<SC, LO, GO, NT> {
     A,
@@ -1488,9 +1500,11 @@ makeMatrixTestWithExplicitZeroDiag (Teuchos::FancyOStream& out,
     lclFoundInf,
     lclFoundNan,
     lclFoundZeroDiag,
+    lclFoundZeroRowNorm,
     gblFoundInf,
     gblFoundNan,
-    gblFoundZeroDiag
+    gblFoundZeroDiag,
+    gblFoundZeroRowNorm
   };
 }
 
@@ -1705,9 +1719,11 @@ makeMatrixTestWithImplicitZeroDiag (Teuchos::FancyOStream& out,
   const bool lclFoundInf = false;
   const bool lclFoundNan = false;
   const bool lclFoundZeroDiag = myRank == 1 ? true : false;
+  const bool lclFoundZeroRowNorm = myRank == 1 ? true : false;
   const bool gblFoundInf = false;
   const bool gblFoundNan = false;
   const bool gblFoundZeroDiag = numProcs == 1 ? false : true;
+  const bool gblFoundZeroRowNorm = numProcs == 1 ? false : true;
 
   return EquilibrationTest<SC, LO, GO, NT> {
     A,
@@ -1724,9 +1740,11 @@ makeMatrixTestWithImplicitZeroDiag (Teuchos::FancyOStream& out,
     lclFoundInf,
     lclFoundNan,
     lclFoundZeroDiag,
+    lclFoundZeroRowNorm,
     gblFoundInf,
     gblFoundNan,
-    gblFoundZeroDiag
+    gblFoundZeroDiag,
+    gblFoundZeroRowNorm
   };
 }
 
@@ -1984,9 +2002,11 @@ makeMatrixTestWithExplicitInfAndNan (Teuchos::FancyOStream& out,
   const bool lclFoundInf = myRank == 1 ? true : false;
   const bool lclFoundNan = myRank == 2 ? true : false;
   const bool lclFoundZeroDiag = false;
+  const bool lclFoundZeroRowNorm = false;
   const bool gblFoundInf = numProcs > 1;
   const bool gblFoundNan = numProcs > 2;
   const bool gblFoundZeroDiag = false;
+  const bool gblFoundZeroRowNorm = false;
 
   return EquilibrationTest<SC, LO, GO, NT> {
     A,
@@ -2003,9 +2023,11 @@ makeMatrixTestWithExplicitInfAndNan (Teuchos::FancyOStream& out,
     lclFoundInf,
     lclFoundNan,
     lclFoundZeroDiag,
+    lclFoundZeroRowNorm,
     gblFoundInf,
     gblFoundNan,
-    gblFoundZeroDiag
+    gblFoundZeroDiag,
+    gblFoundZeroRowNorm
   };
 }
 


### PR DESCRIPTION
Add Inf, NaN, zero diagonal entry, and zero row sum (I'm using the AztecOO term; this is actually a one-norm, that is, a sum of absolute values) detection to Tpetra::computeRowAndColumnNorms.  This imitates and improves upon AztecOO's zero row sum detection.

@trilinos/ifpack2 @trilinos/tpetra @vbrunini 

## Motivation and Context

Aria and Fuego want this.

## Related Issues

* Closes #2968 

## How Has This Been Tested?

Locally.  I added tests for all the different error conditions that the routine checks.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.

