### PR TITLE
Reduce ctest from 16 to 8 for serial GCC builds and fix path to cmake and ninja on hansen/shiller (#2976)

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -298,28 +298,11 @@ href="#checkin-test-atdmsh">checkin-test-atdm.sh</a> script as:
 ```
 $ cd <some_build_dir>/
 $ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-sems.sh .
-$ ./checkin-test-sems.sh intel-opt-openmp \
-  --enable-all-packages=off --no-enable-fwd-packages \
-  --enable-packages=MueLu \
-  --configure --build
 $ srun ./checkin-test-sems.sh intel-opt-openmp \
   --enable-all-packages=off --no-enable-fwd-packages \
   --enable-packages=MueLu \
-  --test
+  --local-do-all
 ```
-
-When using `srun`, for some reason, one must configure and build on the login
-node but then use `srun` to run tests on the compute node.  For some reason,
-the `ninja` program in the `PATH` can't be found on the compute node when
-using `srun` with the checkin-test-atdm.sh script.
-
-WARNING: One must use `srun` and **not** `salloc` to allocate and run on a
-compute node.  The way that these machines are currently set up, running with
-`salloc` the command `squeue` will seem to show that the job is allocated and
-running on a compute node but the job is actually running on the login node!
-(Running `ps -AF | grep <script-name>` and `top` on the login node will
-clearly show that that the job is actually running on the login node and
-presumably the actual compute node is idle.)
 
 
 ### chama/serrano

--- a/cmake/std/atdm/shiller/environment.sh
+++ b/cmake/std/atdm/shiller/environment.sh
@@ -17,19 +17,6 @@ export ATDM_CONFIG_BUILD_COUNT=32
 
 module purge
 
-if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
-  export OMP_NUM_THREADS=2
-  # NOTE: With hyper-threading enabled, the 16 cores can run two threads each
-  # or 32 threads total.
-else
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
-  # NOTE: When running in serial, the second hyperthread can't see to run a
-  # sperate MPI process and if you try to run with -j32 with ctest, you get a
-  # bunch of failures that say "libgomp: Thread creation failed: Resource
-  # temporarily unavailable".  Therefore, we need to run with -j16, not -j32.
-fi
-
 if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
   export ATDM_CONFIG_KOKKOS_ARCH=HSW
   module load devpack/openmpi/2.1.1/gcc/4.9.3/cuda/8.0.61
@@ -38,6 +25,18 @@ if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
   export OMPI_FC=`which gfortran`
   export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran"
   export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran"
+  if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+    export OMP_NUM_THREADS=2
+    # NOTE: For some reason, tests run with the GNU OPenMP builds don't seem
+    # to have too much of a problem with running on all 16 cores with two
+    # threads per core (with hyperthreading turned on).
+  else
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+    # NOTE: For some reason, the tests run with the GNU serial builds seem to
+    # be running on top of each other really badly so we need to reduce the
+    # parallel level to avoid timeouts.  See #2976.
+  fi
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
   module load devpack/openmpi/2.1.1/intel/17.4.196/cuda/none
   export OMPI_CXX=`which icpc`
@@ -45,6 +44,16 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
   export OMPI_FC=`which ifort`
   export ATDM_CONFIG_LAPACK_LIB="-mkl"
   export ATDM_CONFIG_BLAS_LIB="-mkl"
+  if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+    export OMP_NUM_THREADS=2
+  else
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+  fi
+  # NOTE: For some reason the tests run with the Intel builds (serial or
+  # OpenMP) don't seem to have the problem of running on top of each other and
+  # causing the tests to take longer.  Therefore, we can use all 16 cores (and
+  # two threads per core with OpenMP and hyper threading).
 elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]]; then
   if [[ "$ATDM_CONFIG_COMPILER" == "CUDA" ]] ; then
     export ATDM_CONFIG_COMPILER=CUDA-8.0  # The default CUDA version currently
@@ -88,7 +97,7 @@ export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;-lhdf5_hl;-lhdf5;-lz;-ldl"
 export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${ATDM_CONFIG_HDF5_LIBS}"
 
 # Use manually installed cmake and ninja (see TRIL-209)
-export PATH=/ascldap/users/rabartl/install/hansen-shiller/cmake-3.11.2/bin:/ascldap/users/rabartl/install/hansen-shiller/ninja-1.8.2/bin:$PATH
+export PATH=/home/rabartl/install/hansen-shiller/cmake-3.11.2/bin:/home/rabartl/install/hansen-shiller/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
 export MPICC=`which mpicc`


### PR DESCRIPTION
CC: @fryeguy52 

## Description

This setup has a problem of having tests run on top of each other using the
same cores with the GCC 4.9.3 serial executables.  I tried passing different
sets of arguments into 'mpiexec' but that just resulted in "There are not
enough slots available in the system" errors for a bunch of tests.  See #2976
for more details.

The only successful solution to ths problem will likely be an extension to
ctest to control process and thread affinity and a close collaboration with
MPI as described in #2422 and:

* https://gitlab.kitware.com/snl/project-1/issues/17#note_422034

I also fixed the path for cmake and ninja in my home directory to point to
/home/rabartl/.  On the login this can be /ascldap/users/rabartl/ but on the
compute nodes, that directory does not exist.  This fixes being able to
configure and build on the compute nodes on hansen/shiller with just using
'srun'.

I also removed the warning about using 'srun' over 'salloc'.  I misunderstood
how 'salloc' and 'srun' work.

## Motivation and Context

This change was to resolve the test `Tempus_DIRK_Combined_FSA_MPI_1` timeout (#2976) but it will help other tests as well.

## How Has This Been Tested?

I tested this by running the `checkin-test-atdm.sh` script for all of the `gnu` and `intel` builds on 'shiller' for the Tempus and Panzer test suites together.  This avoided all timeouts and the longest running tests was as Panzer test under 500s (see details) below.

<details>
<summary>
  <b>DETAILED TESTING:</b> (click to expand)
</summary>


To test this I ran:

```
$ srun ./checkin-test-atdm.sh gnu-debug-serial gnu-opt-serial \
  gnu-debug-openmp gnu-opt-openmp intel-debug-serial \
  intel-opt-serial intel-debug-openmp intel-opt-openmp \
  --enable-packages=Tempus,Panzer --local-do-all
```

which returned:

```
PASSED (NOT READY TO PUSH): Trilinos: shiller02

Wed Jun 20 06:58:34 MDT 2018

Enabled Packages: Tempus, Panzer

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT_OPENMP => Test case MPI_RELEASE_DEBUG_SHARED_PT_OPENMP was not run! => Does not affect push readiness! (-1.00 min)
1) gnu-debug-serial => passed: passed=191,notpassed=0 (39.86 min)
2) gnu-opt-serial => passed: passed=191,notpassed=0 (28.14 min)
3) gnu-debug-openmp => passed: passed=191,notpassed=0 (27.26 min)
4) gnu-opt-openmp => passed: passed=191,notpassed=0 (18.07 min)
5) intel-debug-serial => passed: passed=190,notpassed=0 (46.27 min)
6) intel-opt-serial => passed: passed=191,notpassed=0 (39.63 min)
7) intel-debug-openmp => passed: passed=191,notpassed=0 (51.48 min)
8) intel-opt-openmp => passed: passed=191,notpassed=0 (42.71 min)
```

The most expensive tests for these builds were:

```
$ for build_dir in gnu-debug-serial gnu-opt-serial gnu-debug-openmp gnu-opt-openmp intel-debug-serial intel-opt-serial intel-debug-openmp intel-opt-openmp ; do ./print_expensive_tests.sh $build_dir/ctest.out ; done
 
***
*** gnu-debug-serial/ctest.out: 10 most expensive tests
***

191/191 Test #169: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 .......   Passed  487.86 sec
162/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed  365.03 sec
160/191 Test  #28: Tempus_IMEX_RK_Combined_FSA_MPI_1 ................................   Passed  283.76 sec
129/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed  266.60 sec
142/191 Test  #23: Tempus_DIRK_ASA_MPI_1 ............................................   Passed  252.24 sec
158/191 Test  #31: Tempus_IMEX_RK_Partitioned_Combined_FSA_MPI_1 ....................   Passed  241.93 sec
175/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed  231.65 sec
176/191 Test #168: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-2 .......   Passed  178.27 sec
 16/191 Test   #4: Tempus_BackwardEuler_Combined_FSA_MPI_1 ..........................   Passed  120.78 sec
 17/191 Test   #9: Tempus_BDF2_Combined_FSA_MPI_1 ...................................   Passed  114.67 sec

***
*** gnu-opt-serial/ctest.out: 10 most expensive tests
***

162/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed  313.27 sec
160/191 Test  #28: Tempus_IMEX_RK_Combined_FSA_MPI_1 ................................   Passed  293.16 sec
129/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed  266.48 sec
131/191 Test  #23: Tempus_DIRK_ASA_MPI_1 ............................................   Passed  266.43 sec
142/191 Test  #31: Tempus_IMEX_RK_Partitioned_Combined_FSA_MPI_1 ....................   Passed  248.29 sec
191/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed  218.58 sec
 28/191 Test   #4: Tempus_BackwardEuler_Combined_FSA_MPI_1 ..........................   Passed  140.25 sec
 27/191 Test   #9: Tempus_BDF2_Combined_FSA_MPI_1 ...................................   Passed  131.86 sec
171/191 Test #160: PanzerAdaptersSTK_PoissonExample-ConvTest-Tri-Order-4 ............   Passed   87.50 sec
172/191 Test #164: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3 .....   Passed   86.35 sec

***
*** gnu-debug-openmp/ctest.out: 10 most expensive tests
***

191/191 Test #169: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 .......   Passed  376.21 sec
190/191 Test #168: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-2 .......   Passed   95.15 sec
151/191 Test  #15: Tempus_ExplicitRK_Staggered_FSA_MPI_1 ............................   Passed   79.01 sec
177/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed   63.11 sec
 94/191 Test  #14: Tempus_ExplicitRK_Combined_FSA_MPI_1 .............................   Passed   60.12 sec
 90/191 Test   #3: Tempus_BackwardEuler_MPI_1 .......................................   Passed   58.20 sec
107/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed   53.13 sec
148/191 Test  #32: Tempus_IMEX_RK_Partitioned_Staggered_FSA_MPI_1 ...................   Passed   50.30 sec
 86/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed   46.50 sec
 34/191 Test   #8: Tempus_BDF2_MPI_1 ................................................   Passed   45.16 sec

***
*** gnu-opt-openmp/ctest.out: 10 most expensive tests
***

191/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed   59.29 sec
190/191 Test #169: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 .......   Passed   33.59 sec
108/191 Test  #15: Tempus_ExplicitRK_Staggered_FSA_MPI_1 ............................   Passed   29.95 sec
 64/191 Test   #3: Tempus_BackwardEuler_MPI_1 .......................................   Passed   25.23 sec
 56/191 Test  #14: Tempus_ExplicitRK_Combined_FSA_MPI_1 .............................   Passed   24.64 sec
 40/191 Test   #8: Tempus_BDF2_MPI_1 ................................................   Passed   22.73 sec
 57/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed   15.85 sec
 63/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed   15.52 sec
172/191 Test #160: PanzerAdaptersSTK_PoissonExample-ConvTest-Tri-Order-4 ............   Passed   15.22 sec
105/191 Test  #32: Tempus_IMEX_RK_Partitioned_Staggered_FSA_MPI_1 ...................   Passed   14.88 sec

***
*** intel-debug-serial/ctest.out: 10 most expensive tests
***

190/190 Test #168: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-2 .......   Passed  162.56 sec
154/190 Test  #15: Tempus_ExplicitRK_Staggered_FSA_MPI_1 ............................   Passed   86.03 sec
187/190 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed   86.02 sec
103/190 Test  #14: Tempus_ExplicitRK_Combined_FSA_MPI_1 .............................   Passed   64.28 sec
 98/190 Test   #3: Tempus_BackwardEuler_MPI_1 .......................................   Passed   62.80 sec
150/190 Test  #32: Tempus_IMEX_RK_Partitioned_Staggered_FSA_MPI_1 ...................   Passed   60.35 sec
 95/190 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed   58.11 sec
 90/190 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed   55.28 sec
107/190 Test  #24: Tempus_HHTAlpha_MPI_1 ............................................   Passed   51.83 sec
173/190 Test #160: PanzerAdaptersSTK_PoissonExample-ConvTest-Tri-Order-4 ............   Passed   49.14 sec

***
*** intel-opt-serial/ctest.out: 10 most expensive tests
***

191/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed   77.14 sec
190/191 Test #169: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 .......   Passed   59.31 sec
125/191 Test  #15: Tempus_ExplicitRK_Staggered_FSA_MPI_1 ............................   Passed   26.64 sec
172/191 Test #160: PanzerAdaptersSTK_PoissonExample-ConvTest-Tri-Order-4 ............   Passed   21.24 sec
 70/191 Test  #14: Tempus_ExplicitRK_Combined_FSA_MPI_1 .............................   Passed   19.30 sec
 54/191 Test   #3: Tempus_BackwardEuler_MPI_1 .......................................   Passed   17.86 sec
173/191 Test #164: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3 .....   Passed   16.70 sec
 69/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed   16.14 sec
109/191 Test  #32: Tempus_IMEX_RK_Partitioned_Staggered_FSA_MPI_1 ...................   Passed   16.01 sec
 55/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed   14.68 sec


***
*** intel-debug-openmp/ctest.out: 10 most expensive tests
***

191/191 Test #169: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 .......   Passed  464.57 sec
190/191 Test #168: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-2 .......   Passed  126.60 sec
155/191 Test  #15: Tempus_ExplicitRK_Staggered_FSA_MPI_1 ............................   Passed   87.61 sec
107/191 Test   #3: Tempus_BackwardEuler_MPI_1 .......................................   Passed   66.78 sec
176/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed   66.29 sec
111/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed   65.51 sec
152/191 Test  #32: Tempus_IMEX_RK_Partitioned_Staggered_FSA_MPI_1 ...................   Passed   64.48 sec
 97/191 Test  #14: Tempus_ExplicitRK_Combined_FSA_MPI_1 .............................   Passed   63.29 sec
 85/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed   53.22 sec
 72/191 Test   #8: Tempus_BDF2_MPI_1 ................................................   Passed   53.19 sec

***
*** intel-opt-openmp/ctest.out: 10 most expensive tests
***

191/191 Test #165: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 .....   Passed   58.28 sec
190/191 Test #169: PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 .......   Passed   35.93 sec
114/191 Test  #15: Tempus_ExplicitRK_Staggered_FSA_MPI_1 ............................   Passed   24.27 sec
 63/191 Test  #14: Tempus_ExplicitRK_Combined_FSA_MPI_1 .............................   Passed   18.35 sec
 62/191 Test   #3: Tempus_BackwardEuler_MPI_1 .......................................   Passed   18.29 sec
 73/191 Test  #20: Tempus_DIRK_Combined_FSA_MPI_1 ...................................   Passed   16.48 sec
 72/191 Test  #21: Tempus_DIRK_Staggered_FSA_MPI_1 ..................................   Passed   16.07 sec
113/191 Test  #32: Tempus_IMEX_RK_Partitioned_Staggered_FSA_MPI_1 ...................   Passed   15.96 sec
 38/191 Test   #8: Tempus_BDF2_MPI_1 ................................................   Passed   15.84 sec
 92/191 Test  #31: Tempus_IMEX_RK_Partitioned_Combined_FSA_MPI_1 ....................   Passed   13.38 sec
```

All tests were under 500 sec so hopefully that will take care of these timeouts on 'hansen' once and for all.

</details>

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
