### PR TITLE
Tpetra multivector sync cleanup

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2288,18 +2288,7 @@ namespace Tpetra {
     //! \name Implementation of various useful kernel utilities
     //@{
 
- /// \brief Update: <tt>this = beta*this + alpha*A</tt>.
-    ///
-    /// Update this MultiVector with scaled values of A.  If beta is
-    /// zero, overwrite \c *this unconditionally, even if it contains
-    /// NaN entries.  It is legal for the input A to alias this
-    /// MultiVector.
-    template <class cur_memory_space>
-    void
-    updateImpl (const Scalar& alpha,
-                const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
-                const Scalar& beta);
-
+ 
     //@}
     //! @name Misc. implementation details
     //@{

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2285,6 +2285,37 @@ namespace Tpetra {
               const EWhichNorm whichNorm) const;
 
     //@}
+    //! \name Implementation of various useful kernel utilities
+    //@{
+
+ /// \brief Update: <tt>this = beta*this + alpha*A</tt>.
+    ///
+    /// Update this MultiVector with scaled values of A.  If beta is
+    /// zero, overwrite \c *this unconditionally, even if it contains
+    /// NaN entries.  It is legal for the input A to alias this
+    /// MultiVector.
+    template <class cur_memory_space>
+    void
+    updateImpl (const Scalar& alpha,
+                const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
+                const Scalar& beta);
+
+    /// \brief Update: <tt>this = gamma*this + alpha*A + beta*B</tt>.
+    ///
+    /// Update this MultiVector with scaled values of A and B.  If
+    /// gamma is zero, overwrite \c *this unconditionally, even if it
+    /// contains NaN entries.  It is legal for the inputs A or B to
+    /// alias this MultiVector.
+    template <class cur_memory_space>
+    void 
+    updateImpl (const Scalar& alpha,
+            const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
+            const Scalar& beta,
+            const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& B,
+            const Scalar& gamma);
+
+
+    //@}
     //! @name Misc. implementation details
     //@{
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2300,21 +2300,6 @@ namespace Tpetra {
                 const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
                 const Scalar& beta);
 
-    /// \brief Update: <tt>this = gamma*this + alpha*A + beta*B</tt>.
-    ///
-    /// Update this MultiVector with scaled values of A and B.  If
-    /// gamma is zero, overwrite \c *this unconditionally, even if it
-    /// contains NaN entries.  It is legal for the inputs A or B to
-    /// alias this MultiVector.
-    template <class cur_memory_space>
-    void 
-    updateImpl (const Scalar& alpha,
-            const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
-            const Scalar& beta,
-            const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& B,
-            const Scalar& gamma);
-
-
     //@}
     //! @name Misc. implementation details
     //@{

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3223,10 +3223,12 @@ namespace Tpetra {
     }
     else if(thisIsHost == AIsHost && AIsHost) {
       typedef typename host_view_type::memory_space cur_memory_space;
+      this->template modify<cur_memory_space> ();
       this->updateImpl<cur_memory_space>(alpha,A,beta);
     }
     else { //thisIsHost == AIsHost && !AIsHost)
       typedef typename dev_view_type::memory_space cur_memory_space;
+      this->template modify<cur_memory_space> ();
       this->updateImpl<cur_memory_space>(alpha,A,beta);
     }
   }

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -872,11 +872,11 @@ namespace Tpetra {
     }
 
     if (copyOnHost) {
-      this->template sync<HMS> ();
+      if(this->template need_sync<HMS> ()) this->template sync<HMS> ();
       this->template modify<HMS> ();
     }
     else {
-      this->template sync<DMS> ();
+      if(this->template need_sync<DMS> ()) this->template sync<DMS> ();
       this->template modify<DMS> ();
     }
 
@@ -1548,11 +1548,11 @@ namespace Tpetra {
     // because copyAndPermute may have modified *this in the other
     // memory space.
     if (unpackOnHost) {
-      this->template sync<HMS> ();
+      if(this->template need_sync<HMS> ()) this->template sync<HMS> ();
       this->template modify<HMS> ();
     }
     else { // unpack on device
-      this->template sync<DMS> ();
+      if(this->template need_sync<DMS> ()) this->template sync<DMS> ();
       this->template modify<DMS> ();
     }
     auto X_d = this->template getLocalView<DMS> ();

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3150,6 +3150,7 @@ namespace Tpetra {
     using Kokkos::subview;
     using Kokkos::ALL;
     typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
+    typedef typename dual_view_type::t_dev::memory_space dev_memory_space;
     
     ::Tpetra::Details::ProfilingRegion region ("Tpetra::MV::update(alpha,A,beta)");
 
@@ -3164,11 +3165,8 @@ namespace Tpetra {
       numVecs != A.getNumVectors (), std::invalid_argument,
       "this->getNumVectors() = " << numVecs << " != A.getNumVectors() = "
       << A.getNumVectors () << ".");
-
-    typedef typename dual_view_type::t_dev dev_view_type;
  
     // Are this or A in the "host" state?  If so, sync to device
-    typedef typename dev_view_type::memory_space dev_memory_space;
     if (this->template need_sync<device_type> ()) this->template sync<dev_memory_space> ();
     if (A.template need_sync<device_type> ())     const_cast<MV*>(&A)->template sync<dev_memory_space> ();
 
@@ -3241,6 +3239,7 @@ namespace Tpetra {
     const impl_scalar_type theBeta = static_cast<impl_scalar_type> (beta);
     const impl_scalar_type theGamma = static_cast<impl_scalar_type> (gamma);
 
+    // Sync everything to the device only if we need to
     // We're lucky if *this, A, and B are all sync'd to the same
     // memory space.  If not, we have to sync _something_.  Unlike
     // three-argument update() or (say) dot(), we may have to sync one

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3014,13 +3014,11 @@ namespace Tpetra {
     else {
       using Kokkos::ALL;
       using Kokkos::subview;
-      typedef Kokkos::View<impl_scalar_type*, device_type> view_type;
-      
       for (size_t k = 0; k < numVecs; ++k) {
         const size_t this_col = isConstantStride () ? k : whichVectors_[k];
-        view_type vector_k = subview (this_view_dev, ALL (), this_col);
+        auto vector_k = subview (this_view_dev, ALL (), this_col);
         const size_t A_col = isConstantStride () ? k : A.whichVectors_[k];
-        view_type vector_Ak = subview (A_view_dev, ALL (), A_col);
+        auto vector_Ak = subview (A_view_dev, ALL (), A_col);
         KokkosBlas::reciprocal (vector_k, vector_Ak);
       }
     }
@@ -3032,6 +3030,8 @@ namespace Tpetra {
   abs (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A)
   {
     typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
+    typedef typename MV::dual_view_type::t_dev::memory_space dev_memory_space;  
+
     const char tfecfFuncName[] = "abs";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
        getLocalLength () != A.getLocalLength (), std::runtime_error,
@@ -3043,22 +3043,15 @@ namespace Tpetra {
       ": MultiVectors do not have the same number of columns (vectors).  "
        "this->getNumVectors() = " << getNumVectors ()
        << " != A.getNumVectors() = " << A.getNumVectors () << ".");
-
-    // FIXME (mfh 07 Jan 2015) See note on two-argument scale() above.
-
     const size_t numVecs = getNumVectors ();
 
-    this->template sync<device_type> ();
-    this->template modify<device_type> ();
-    // FIXME (mfh 23 Jul 2014) I'm not sure if it should be our
-    // responsibility to sync A.
-    //
-    // FIXME (mfh 18 May 2016) It's rude to sync the input
-    // argument, since it is marked const.
-    const_cast<MV&> (A).template sync<device_type> ();
+    // All non-unary kernels are executed on the device as per Tpetra policy.  Sync to device if needed.
+    if (this->template need_sync<dev_memory_space> ()) this->template sync<dev_memory_space> ();
+    if (A.template need_sync<dev_memory_space> ())     const_cast<MV&>(A).template sync<dev_memory_space> ();
+    this->template modify<dev_memory_space> ();
 
-    auto this_view_dev = this->template getLocalView<device_type> ();
-    auto A_view_dev = A.template getLocalView<device_type> ();
+    auto this_view_dev = this->template getLocalView<dev_memory_space> ();
+    auto A_view_dev = A.template getLocalView<dev_memory_space> ();
 
     if (isConstantStride () && A.isConstantStride ()) {
       KokkosBlas::abs (this_view_dev, A_view_dev);
@@ -3066,13 +3059,12 @@ namespace Tpetra {
     else {
       using Kokkos::ALL;
       using Kokkos::subview;
-      typedef Kokkos::View<impl_scalar_type*, device_type> view_type;
 
       for (size_t k=0; k < numVecs; ++k) {
         const size_t this_col = isConstantStride () ? k : whichVectors_[k];
-        view_type vector_k = subview (this_view_dev, ALL (), this_col);
+        auto vector_k = subview (this_view_dev, ALL (), this_col);
         const size_t A_col = isConstantStride () ? k : A.whichVectors_[k];
-        view_type vector_Ak = subview (A_view_dev, ALL (), A_col);
+        auto vector_Ak = subview (A_view_dev, ALL (), A_col);
         KokkosBlas::abs (vector_k, vector_Ak);
       }
     }

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3166,9 +3166,9 @@ namespace Tpetra {
       "this->getNumVectors() = " << numVecs << " != A.getNumVectors() = "
       << A.getNumVectors () << ".");
  
-    // Are this or A in the "host" state?  If so, sync to device
-    if (this->template need_sync<device_type> ()) this->template sync<dev_memory_space> ();
-    if (A.template need_sync<device_type> ())     const_cast<MV*>(&A)->template sync<dev_memory_space> ();
+    // All kernels are executed on the device by rule.  So we sync there if needed
+    if (this->template need_sync<dev_memory_space> ()) this->template sync<dev_memory_space> ();
+    if (A.template need_sync<dev_memory_space> ())     const_cast<MV*>(&A)->template sync<dev_memory_space> ();
 
     const impl_scalar_type theAlpha = static_cast<impl_scalar_type> (alpha);
     const impl_scalar_type theBeta = static_cast<impl_scalar_type> (beta);
@@ -3210,6 +3210,8 @@ namespace Tpetra {
     using Kokkos::ALL;
     using Kokkos::subview;
     typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
+    typedef typename dual_view_type::t_dev::memory_space dev_memory_space;
+ 
     const char tfecfFuncName[] = "update(alpha,A,beta,B,gamma): ";
 
     ::Tpetra::Details::ProfilingRegion region ("Tpetra::MV::update(alpha,A,beta,B,gamma)");
@@ -3244,7 +3246,7 @@ namespace Tpetra {
     // memory space.  If not, we have to sync _something_.  Unlike
     // three-argument update() or (say) dot(), we may have to sync one
     // of the inputs.  For now, we just sync _everything_ to device.
-    this->template sync<device_type> ();
+    this->template sync<dev_memory_space> ();
     const_cast<MV&> (A).template sync<device_type> ();
     const_cast<MV&> (B).template sync<device_type> ();
 

--- a/packages/tpetra/core/test/MultiVector/MultiVector_MicroBenchmark.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_MicroBenchmark.cpp
@@ -99,26 +99,29 @@ namespace { // (anonymous)
       ::Tpetra::Details::ProfilingRegion region ("Tpetra Update Loop");
       for(size_t i=0; i<num_repeats; i++) {
         X.update(ONE,Y,ONE);
+        Kokkos::fence();
       }
     }
 
     X.putScalar(ZERO);
     auto X_lcl = X.template getLocalView<cur_memory_space> ();
     auto Y_lcl = Y.template getLocalView<cur_memory_space> ();
-    Kokkos::fence();
+
 
     // Run KokkosBlas Update Loop
     {
       ::Tpetra::Details::ProfilingRegion region ("KokkosBlas Update Loop");
       for(size_t i=0; i<num_repeats; i++) {
         KokkosBlas::axpby(ONE, X_lcl, ONE, Y_lcl);
+        Kokkos::fence();
       }
     }
 
     X.putScalar(ZERO);
     Kokkos::fence();
-    Kokkos::RangePolicy<cur_exec_space> policy (0, vector_size);
+
     // Run raw lambda loop
+    Kokkos::RangePolicy<cur_exec_space> policy (0, vector_size);
     {
       ::Tpetra::Details::ProfilingRegion region ("Raw Lambda Update Loop");
       for(size_t i=0; i<num_repeats; i++) {
@@ -128,10 +131,9 @@ namespace { // (anonymous)
             // This is the special case code that actually executes inside KokkosKernels for alpha=1
             X_lcl(i,0) += ONE * Y_lcl(i,0);
           });
+        Kokkos::fence();
       }
     }
-    Kokkos::fence();
-  
   }
 
 //


### PR DESCRIPTION
Merge of the Tpetra::MultiVector sync cleanup into develop.  This should have *no* effect except on CUDA.  Both ATDM apps cleared the merge as OK.