### PR TITLE
Stokhos:  Get SFS specialization of MP::Vector working again.

### DIFF
--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -489,6 +489,11 @@ IF (Stokhos_ENABLE_Sacado)
       sacado/kokkos/vector/Sacado_MP_ScalarTraitsImp.hpp
       sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
       sacado/kokkos/vector/Sacado_MP_ExpressionTraits.hpp
+      sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
+      sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_op_tmpl.hpp
+      sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_func_tmpl.hpp
+      sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_op_tmpl.hpp
+      sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_func_tmpl.hpp
       sacado/kokkos/vector/Kokkos_View_MP_Vector.hpp
       sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
       sacado/kokkos/vector/Kokkos_View_MP_Vector_Interlaced.hpp

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_Sacado_Kokkos_MathFunctions.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_Sacado_Kokkos_MathFunctions.hpp
@@ -50,7 +50,27 @@
 
 #ifdef HAVE_STOKHOS_ENSEMBLE_SCALAR_TYPE
 
+#if STOKHOS_USE_MP_VECTOR_SFS_SPEC
+#define UNARYFUNC_MACRO_SFS(OP,FADOP)                                   \
+namespace Stokhos {                                                     \
+  template <typename O, typename T, int N, typename D>                  \
+  class StaticFixedStorage;                                             \
+}                                                                       \
+namespace Sacado {                                                      \
+  namespace MP {                                                        \
+    template <typename S> class Vector;                                 \
+    template <typename O, typename T, int N, typename D>                \
+    KOKKOS_INLINE_FUNCTION                                              \
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
+    OP (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >&);         \
+  }                                                                     \
+}
+#else
+#define UNARYFUNC_MACRO_SFS(OP,FADOP) /* */
+#endif
+
 #define UNARYFUNC_MACRO(OP,FADOP)                                       \
+UNARYFUNC_MACRO_SFS(OP,FADOP)                                           \
 namespace Sacado {                                                      \
                                                                         \
   namespace MP {                                                        \
@@ -90,8 +110,42 @@ UNARYFUNC_MACRO(abs, AbsOp)
 UNARYFUNC_MACRO(fabs, FAbsOp)
 
 #undef UNARYFUNC_MACRO
+#undef UNARYFUNC_MACRO_SFS
+
+#if STOKHOS_USE_MP_VECTOR_SFS_SPEC
+#define BINARYFUNC_MACRO_SFS(OP,FADOP)                                  \
+namespace Stokhos {                                                     \
+  template <typename O, typename T, int N, typename D>                  \
+  class StaticFixedStorage;                                             \
+}                                                                       \
+namespace Sacado {                                                      \
+  namespace MP {                                                        \
+    template <typename S> class Vector;                                 \
+    template <typename O, typename T, int N, typename D>                \
+    KOKKOS_INLINE_FUNCTION                                              \
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
+    OP (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >&,          \
+        const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >&);         \
+                                                                        \
+    template <typename O, typename T, int N, typename D>                \
+    KOKKOS_INLINE_FUNCTION                                              \
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
+    OP (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type&, \
+        const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >&);         \
+                                                                        \
+    template <typename O, typename T, int N, typename D>                \
+    KOKKOS_INLINE_FUNCTION                                              \
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
+    OP (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >&,          \
+        const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type&); \
+  }                                                                     \
+}
+#else
+#define BINARYFUNC_MACRO_SFS(OP,FADOP) /* */
+#endif
 
 #define BINARYFUNC_MACRO(OP,FADOP)                                      \
+BINARYFUNC_MACRO_SFS(OP,FADOP)                                          \
 namespace Sacado {                                                      \
                                                                         \
   namespace MP {                                                        \
@@ -128,6 +182,7 @@ BINARYFUNC_MACRO(max, MaxOp)
 BINARYFUNC_MACRO(min, MinOp)
 
 #undef BINARYFUNC_MACRO
+#undef BINARYFUNC_MACRO_SFS
 
 #endif
 

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
@@ -761,7 +761,7 @@ namespace Sacado {
       reference fastAccessCoeff(ordinal_type i) {
         return s[i];}
 
-       //! Returns term \c i without bounds checking
+      //! Returns term \c i without bounds checking
       KOKKOS_INLINE_FUNCTION
       const_volatile_reference operator[](ordinal_type i) const volatile {
         return s[i];}
@@ -1795,6 +1795,15 @@ namespace Sacado {
       };
 
     }; // class Vector
+  }
+}
+
+#if STOKHOS_USE_MP_VECTOR_SFS_SPEC
+#include "Sacado_MP_Vector_SFS.hpp"
+#endif
+
+namespace Sacado{
+  namespace MP {
 
     //! Type for storing nodes in expression graph
     /*!
@@ -1838,6 +1847,22 @@ namespace Sacado {
     template <typename T> struct add_volatile<volatile T> {
       typedef volatile T type;
     };
+
+    template <typename Storage>
+    std::ostream&
+    operator << (std::ostream& os, const Vector<Storage>& a)
+    {
+      typedef typename Vector<Storage>::ordinal_type ordinal_type;
+
+      os << "[ ";
+
+      for (ordinal_type i=0; i<a.size(); i++) {
+        os << a.coeff(i) << " ";
+      }
+
+      os << "]";
+      return os;
+    }
 
     template <typename Storage>
     std::ostream&
@@ -2034,8 +2059,6 @@ public:
 #endif
 
 #endif // HAVE_STOKHOS_SACADO
-
-//#include "Sacado_MP_Vector_SFS.hpp"
 
 #include "Kokkos_NumericTraits.hpp"
 

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS.hpp
@@ -74,6 +74,9 @@ namespace Sacado {
       typedef typename storage_type::const_reference const_reference;
       typedef typename storage_type::const_volatile_reference const_volatile_reference;
 
+      typedef typename execution_space::memory_space memory_space;
+      typedef typename Stokhos::MemoryTraits<memory_space> MemTraits;
+
       //! Typename of scalar's (which may be different from value_type)
       typedef typename ScalarType<value_type>::type scalar_type;
 
@@ -162,6 +165,12 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       Vector(const volatile Vector& x) : s(x.s) {}
 
+      //! Intialize from initializer_list
+      /*!
+       * No KOKKOS_INLINE_FUNCTION as it is not callable from the device
+       */
+      Vector(std::initializer_list<value_type> l) : s(l.size(), l.begin()) {}
+
       //! Destructor
       KOKKOS_INLINE_FUNCTION
       ~Vector() {}
@@ -242,10 +251,8 @@ namespace Sacado {
       void copyForWrite() volatile {  }
 
       //! Returns whether two MP objects have the same values
-      template <typename S>
       KOKKOS_INLINE_FUNCTION
-      bool isEqualTo(const Expr<S>& xx) const {
-        const typename Expr<S>::derived_type& x = xx.derived();
+      bool isEqualTo(const Vector& x) const {
         typedef IsEqual<value_type> IE;
         bool eq = true;
         for (ordinal_type i=0; i<this->size(); i++)
@@ -254,10 +261,8 @@ namespace Sacado {
       }
 
       //! Returns whether two MP objects have the same values
-      template <typename S>
       KOKKOS_INLINE_FUNCTION
-      bool isEqualTo(const Expr<S>& xx) const volatile {
-        const typename Expr<S>::derived_type& x = xx.derived();
+      bool isEqualTo(const Vector& x) const volatile {
         typedef IsEqual<value_type> IE;
         bool eq = true;
         for (ordinal_type i=0; i<this->size(); i++)
@@ -433,6 +438,94 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       reference fastAccessCoeff(ordinal_type i) {
         return s[i];}
+
+      //! Returns term \c i without bounds checking
+      KOKKOS_INLINE_FUNCTION
+      const_volatile_reference operator[](ordinal_type i) const volatile {
+        return s[i];}
+
+      //! Returns term \c i without bounds checking
+      KOKKOS_INLINE_FUNCTION
+      const_reference operator[](ordinal_type i) const {
+        return s[i];}
+
+      //! Returns term \c i without bounds checking
+      KOKKOS_INLINE_FUNCTION
+      volatile_reference operator[](ordinal_type i) volatile {
+        return s[i];}
+
+      //! Returns term \c i without bounds checking
+      KOKKOS_INLINE_FUNCTION
+      reference operator[](ordinal_type i) {
+        return s[i];}
+
+      template <int i>
+      KOKKOS_INLINE_FUNCTION
+      value_type getCoeff() const volatile {
+        return s.template getCoeff<i>(); }
+
+      template <int i>
+      KOKKOS_INLINE_FUNCTION
+      value_type getCoeff() const {
+        return s.template getCoeff<i>(); }
+
+      template <int i>
+      KOKKOS_INLINE_FUNCTION
+      volatile_reference getCoeff() volatile {
+        return s.template getCoeff<i>(); }
+
+      template <int i>
+      KOKKOS_INLINE_FUNCTION
+      reference getCoeff() {
+        return s.template getCoeff<i>(); }
+
+      //! Return iterator to first element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      pointer begin() { return s.coeff(); }
+
+      //! Return iterator to first element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_pointer begin() const { return s.coeff(); }
+
+      //! Return iterator to first element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      volatile_pointer begin() volatile { return s.coeff(); }
+
+      //! Return iterator to first element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_volatile_pointer begin() const volatile { return s.coeff(); }
+
+      //! Return iterator to first element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_pointer cbegin() const { return s.coeff(); }
+
+      //! Return iterator to first element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_volatile_pointer cbegin() const volatile { return s.coeff(); }
+
+      //! Return iterator following last element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      pointer end() { return s.coeff() + s.size(); }
+
+      //! Return iterator following last element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_pointer end() const { return s.coeff() + s.size(); }
+
+      //! Return iterator following last element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      volatile_pointer end() volatile { return s.coeff() + s.size(); }
+
+      //! Return iterator following last element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_volatile_pointer end() const volatile { return s.coeff() + s.size(); }
+
+      //! Return iterator following last element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_pointer cend() const { return s.coeff()+ s.size(); }
+
+      //! Return iterator following last element of coefficient array
+      KOKKOS_INLINE_FUNCTION
+      const_volatile_pointer cend() const volatile { return s.coeff()+ s.size(); }
 
       //@}
 

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_func_tmpl.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_func_tmpl.hpp
@@ -1,0 +1,229 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Stokhos Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Eric T. Phipps (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+namespace Sacado {
+  namespace MP {
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,
+            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<b.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a , b.fastAccessCoeff(i) );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,
+            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<b.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a , b.fastAccessCoeff(i) );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a.fastAccessCoeff(i) , b );
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          OPNAME( a.fastAccessCoeff(i) , b );
+      return c;
+    }
+  }
+}

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_op_tmpl.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_binary_op_tmpl.hpp
@@ -1,0 +1,221 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Stokhos Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Eric T. Phipps (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+namespace Sacado {
+  namespace MP {
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,
+            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<b.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a OPER b.fastAccessCoeff(i);
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,
+            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<b.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a OPER b.fastAccessCoeff(i);
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a.fastAccessCoeff(i) OPER b;
+      return c;
+    }
+
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,
+            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
+#endif
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
+#endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) =
+          a.fastAccessCoeff(i) OPER b;
+      return c;
+    }
+  }
+}

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_ops.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_ops.hpp
@@ -46,297 +46,141 @@
 #include <math_functions.h>
 #endif
 
-#define MP_UNARYOP_MACRO(OPNAME,OPER)                                   \
-namespace Sacado {                                                      \
-  namespace MP {                                                        \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) = OPER(a.fastAccessCoeff(i));              \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) = OPER(a.fastAccessCoeff(i));              \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-  }                                                                     \
-}
+#define OPNAME operator+
+#define OPER +
+#include "Sacado_MP_Vector_SFS_unary_op_tmpl.hpp"
+#undef OPNAME
+#undef OPER
 
-MP_UNARYOP_MACRO(operator+, +)
-MP_UNARYOP_MACRO(operator-, -)
-MP_UNARYOP_MACRO(exp, std::exp)
-MP_UNARYOP_MACRO(log, std::log)
-MP_UNARYOP_MACRO(log10, std::log10)
-MP_UNARYOP_MACRO(sqrt, std::sqrt)
-MP_UNARYOP_MACRO(cbrt, std::cbrt)
-MP_UNARYOP_MACRO(cos, std::cos)
-MP_UNARYOP_MACRO(sin, std::sin)
-MP_UNARYOP_MACRO(tan, std::tan)
-MP_UNARYOP_MACRO(acos, std::acos)
-MP_UNARYOP_MACRO(asin, std::asin)
-MP_UNARYOP_MACRO(atan, std::atan)
-MP_UNARYOP_MACRO(cosh, std::cosh)
-MP_UNARYOP_MACRO(sinh, std::sinh)
-MP_UNARYOP_MACRO(tanh, std::tanh)
-MP_UNARYOP_MACRO(acosh, std::acosh)
-MP_UNARYOP_MACRO(asinh, std::asinh)
-MP_UNARYOP_MACRO(atanh, std::atanh)
-MP_UNARYOP_MACRO(abs, std::abs)
-MP_UNARYOP_MACRO(fabs, std::fabs)
+#define OPNAME operator-
+#define OPER -
+#include "Sacado_MP_Vector_SFS_unary_op_tmpl.hpp"
+#undef OPNAME
+#undef OPER
 
-#undef MP_UNARYOP_MACRO
+#define OPNAME exp
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
 
-#define MP_BINARYOP_MACRO(OPNAME,OPER)                                  \
-namespace Sacado {                                                      \
-  namespace MP {                                                        \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,    \
-            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);               \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a, \
-            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);               \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,    \
-            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);               \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a, \
-            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a.fastAccessCoeff(i) OPER b.fastAccessCoeff(i);               \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,                                                 \
-            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<b.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a OPER b.fastAccessCoeff(i);                                  \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,                                                 \
-            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<b.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a OPER b.fastAccessCoeff(i);                                  \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,    \
-            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)                                                 \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a.fastAccessCoeff(i) OPER b;                                  \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a, \
-            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)                                                 \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          a.fastAccessCoeff(i) OPER b;                                  \
-      return c;                                                         \
-    }                                                                   \
-  }                                                                     \
-}
+#define OPNAME log
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
 
-MP_BINARYOP_MACRO(operator+, +)
-MP_BINARYOP_MACRO(operator-, -)
-MP_BINARYOP_MACRO(operator*, *)
-MP_BINARYOP_MACRO(operator/, /)
+#define OPNAME log10
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
 
-#undef MP_BINARYOP_MACRO
+#define OPNAME sqrt
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
 
-#define MP_BINARYOP_MACRO(OPNAME,OPER)                                  \
-namespace Sacado {                                                      \
-  namespace MP {                                                        \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,    \
-            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );         \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a, \
-            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );         \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,    \
-            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );         \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a, \
-            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a.fastAccessCoeff(i) ,  b.fastAccessCoeff(i) );         \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,                                                 \
-            const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b)    \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<b.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a , b.fastAccessCoeff(i) );                             \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& a,                                                 \
-            const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& b) \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<b.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a , b.fastAccessCoeff(i) );                             \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a,    \
-            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)                                                 \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a.fastAccessCoeff(i) , b );                             \
-      return c;                                                         \
-    }                                                                   \
-                                                                        \
-    template <typename O, typename T, int N, typename D>                \
-    KOKKOS_INLINE_FUNCTION                                              \
-    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >                      \
-    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a, \
-            const typename Vector< Stokhos::StaticFixedStorage<O,T,N,D> >::value_type& b)                                                 \
-    {                                                                   \
-      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;                 \
-      for (O i=0; i<a.size(); ++i)                                      \
-        c.fastAccessCoeff(i) =                                          \
-          OPER( a.fastAccessCoeff(i) , b );                             \
-      return c;                                                         \
-    }                                                                   \
-  }                                                                     \
-}
+#define OPNAME cbrt
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
 
-MP_BINARYOP_MACRO(atan2, std::atan2)
-MP_BINARYOP_MACRO(pow, std::pow)
-#ifdef __CUDACC__
-MP_BINARYOP_MACRO(max, ::max)
-MP_BINARYOP_MACRO(min, ::min)
-#else
-MP_BINARYOP_MACRO(max, std::max)
-MP_BINARYOP_MACRO(min, std::min)
-#endif
+#define OPNAME cos
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
 
-#undef MP_BINARYOP_MACRO
+#define OPNAME sin
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME tan
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME acos
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME asin
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME atan
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME cosh
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME sinh
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME tanh
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME acosh
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME asinh
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME atanh
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME abs
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME fabs
+#include "Sacado_MP_Vector_SFS_unary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME operator+
+#define OPER +
+#include "Sacado_MP_Vector_SFS_binary_op_tmpl.hpp"
+#undef OPNAME
+#undef OPER
+
+#define OPNAME operator-
+#define OPER -
+#include "Sacado_MP_Vector_SFS_binary_op_tmpl.hpp"
+#undef OPNAME
+#undef OPER
+
+#define OPNAME operator*
+#define OPER *
+#include "Sacado_MP_Vector_SFS_binary_op_tmpl.hpp"
+#undef OPNAME
+#undef OPER
+
+#define OPNAME operator/
+#define OPER /
+#include "Sacado_MP_Vector_SFS_binary_op_tmpl.hpp"
+#undef OPNAME
+#undef OPER
+
+#define OPNAME atan2
+#include "Sacado_MP_Vector_SFS_binary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME pow
+#include "Sacado_MP_Vector_SFS_binary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME max
+#include "Sacado_MP_Vector_SFS_binary_func_tmpl.hpp"
+#undef OPNAME
+
+#define OPNAME min
+#include "Sacado_MP_Vector_SFS_binary_func_tmpl.hpp"
+#undef OPNAME
+
+//#ifdef __CUDACC__
+//MP_BINARYOP_MACRO(max, ::max)
+//MP_BINARYOP_MACRO(min, ::min)
+//#else
+//MP_BINARYOP_MACRO(max, std::max)
+//MP_BINARYOP_MACRO(min, std::min)
+//#endif
 
 //-------------------------- Relational Operators -----------------------
 

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_func_tmpl.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_func_tmpl.hpp
@@ -39,53 +39,50 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef STOKHOS_CONFIGDEFS_H
-#define STOKHOS_CONFIGDEFS_H
+namespace Sacado {
+  namespace MP {
 
-#ifndef __cplusplus
-#define __cplusplus
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
 #endif
-
-/*
- * The macros PACKAGE, PACKAGE_NAME, etc, get defined for each package and
- * need to be undef'd here to avoid warnings when this file is included from
- * another package.
- * KL 11/25/02
- */
-#ifdef PACKAGE
-#undef PACKAGE
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
 #endif
-
-#ifdef PACKAGE_NAME
-#undef PACKAGE_NAME
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
 #endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) = OPNAME(a.fastAccessCoeff(i));
+      return c;
+    }
 
-#ifdef PACKAGE_BUGREPORT
-#undef PACKAGE_BUGREPORT
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a)
+    {
+      using std::OPNAME;
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
 #endif
-
-#ifdef PACKAGE_STRING
-#undef PACKAGE_STRING
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
 #endif
-
-#ifdef PACKAGE_TARNAME
-#undef PACKAGE_TARNAME
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
 #endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) = ONAME(a.fastAccessCoeff(i));
+      return c;
+    }
 
-#ifdef PACKAGE_VERSION
-#undef PACKAGE_VERSION
-#endif
-
-#ifdef VERSION
-#undef VERSION
-#endif
-
-#ifndef TRILINOS_NO_CONFIG_H
-#include <Stokhos_config.h>
-#endif
-
-// Whether to use the Static-Fixed-Storage specialization of Sacado::MP::Vector,
-// which does not use expression templates (default is to not)
-#define STOKHOS_USE_MP_VECTOR_SFS_SPEC 0
-
-#endif /* STOKHOS_CONFIGDEFS_H */
+  }
+}

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_op_tmpl.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_SFS_unary_op_tmpl.hpp
@@ -39,53 +39,48 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef STOKHOS_CONFIGDEFS_H
-#define STOKHOS_CONFIGDEFS_H
+namespace Sacado {
+  namespace MP {
 
-#ifndef __cplusplus
-#define __cplusplus
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
 #endif
-
-/*
- * The macros PACKAGE, PACKAGE_NAME, etc, get defined for each package and
- * need to be undef'd here to avoid warnings when this file is included from
- * another package.
- * KL 11/25/02
- */
-#ifdef PACKAGE
-#undef PACKAGE
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
 #endif
-
-#ifdef PACKAGE_NAME
-#undef PACKAGE_NAME
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
 #endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) = OPER(a.fastAccessCoeff(i));
+      return c;
+    }
 
-#ifdef PACKAGE_BUGREPORT
-#undef PACKAGE_BUGREPORT
+    template <typename O, typename T, int N, typename D>
+    KOKKOS_INLINE_FUNCTION
+    Vector< Stokhos::StaticFixedStorage<O,T,N,D> >
+    OPNAME (const volatile Vector< Stokhos::StaticFixedStorage<O,T,N,D> >& a)
+    {
+      Vector< Stokhos::StaticFixedStorage<O,T,N,D> > c;
+#ifdef STOKHOS_HAVE_PRAGMA_IVDEP
+#pragma ivdep
 #endif
-
-#ifdef PACKAGE_STRING
-#undef PACKAGE_STRING
+#ifdef STOKHOS_HAVE_PRAGMA_VECTOR_ALIGNED
+#pragma vector aligned
 #endif
-
-#ifdef PACKAGE_TARNAME
-#undef PACKAGE_TARNAME
+#ifdef STOKHOS_HAVE_PRAGMA_UNROLL
+#pragma unroll
 #endif
+      for (O i=0; i<a.size(); ++i)
+        c.fastAccessCoeff(i) = OPER(a.fastAccessCoeff(i));
+      return c;
+    }
 
-#ifdef PACKAGE_VERSION
-#undef PACKAGE_VERSION
-#endif
-
-#ifdef VERSION
-#undef VERSION
-#endif
-
-#ifndef TRILINOS_NO_CONFIG_H
-#include <Stokhos_config.h>
-#endif
-
-// Whether to use the Static-Fixed-Storage specialization of Sacado::MP::Vector,
-// which does not use expression templates (default is to not)
-#define STOKHOS_USE_MP_VECTOR_SFS_SPEC 0
-
-#endif /* STOKHOS_CONFIGDEFS_H */
+  }
+}


### PR DESCRIPTION
The SFS specialization is a specialization of Sacado::MP::Vector for the StaticFixedStorage storage type and doesn't use expression templates.  The hope is the compiler can do a better job autovectorizing the overloaded operators since it doesn't have to optimize through the expression-template hierarchy.  

This was implemented a while ago, but has been disabled and so quit working.  This pull request gets it working again.  Mostly this is copying various things I have added to the main
MP::Vector implementation to the SFS specialization.  There is now a
define in Stokhos_ConfigDefs.h that determines whether it is used
(default is off).  I also redid how the overloaded operators are defined
so that the relevant pragmas can be used.  If you turn it on, everything
in my build appears to work.  To turn it on, change

#define STOKHOS_USE_MP_VECTOR_SFS_SPEC 1

in Stokhos_ConfigDefs.h