### PR TITLE
MueLu: fix incorrect "unused parameter" warning

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -257,15 +257,15 @@ namespace MueLu {
 #elif defined(HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT)
     ParameterList tempList("tempList");
     tempList.set("use kokkos refactor",true);
-    MUELU_SET_VAR_2LIST(constParamList, tempList, "use kokkos refactor", bool, useKokkos);
+    MUELU_SET_VAR_2LIST(paramList, tempList, "use kokkos refactor", bool, useKokkos);
     useKokkos_ = useKokkos;
 #else
-    MUELU_SET_VAR_2LIST(constParamList, constParamList, "use kokkos refactor", bool, useKokkos);
+    MUELU_SET_VAR_2LIST(paramList, paramList, "use kokkos refactor", bool, useKokkos);
     useKokkos_ = useKokkos;
 #endif
 
     // Check for timer synchronization
-    MUELU_SET_VAR_2LIST(constParamList, constParamList, "synchronize factory timers", bool, syncTimers);
+    MUELU_SET_VAR_2LIST(paramList, paramList, "synchronize factory timers", bool, syncTimers);
     if (syncTimers)
         Factory::EnableTimerSync();
 


### PR DESCRIPTION
@trilinos/muelu 

In the ParameterListInterpreter, one should use parameterList instead of
constParameterList so that it could be updated to indicate that the
parameter has been read.
