### PR TITLE
Retrive the number of openMP threads and change the expected

### DIFF
--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -364,7 +364,18 @@ namespace MueLuTests {
       out << "Skip detailed tests. Matrix was not rebalanced" << std::endl;
       return;
     }
-    TEST_EQUALITY(nNumProcsReb, 2);
+    int expectedPartitions=2;
+#if defined(HAVE_MUELU_KOKKOSCORE) && defined(KOKKOS_HAVE_OPENMP)
+    using execution_space = typename Node::device_type::execution_space;
+    if (std::is_same<execution_space, Kokkos::OpenMP>::value)
+    {
+       int thread_per_mpi_rank = execution_space::concurrency();
+       if (thread_per_mpi_rank > 1)
+          expectedPartitions=1;
+    }
+#endif
+    
+    TEST_EQUALITY(nNumProcsReb, expectedPartitions);
 
     //////////////////////////////////////////////////
     // extract partitions


### PR DESCRIPTION
## Description
This just looks at the number of threads requested and changes the expected number of partitions accordingly.

## Motivation and Context
This test is failing on all openMP builds.

## Related Issues

* Closes #3014 
* Blocks #3003 

## How Has This Been Tested?
I used OMP_NUM_THREADS=1, 2, and 4

## Checklist

- [ x ] My commit messages mention the appropriate GitHub issue numbers.
- [ x ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

