### PR TITLE
MueLu repartitioning: Allow use of graph partitioners

### DIFF
--- a/packages/muelu/src/Misc/MueLu_StructuredLineDetectionFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_StructuredLineDetectionFactory_def.hpp
@@ -87,8 +87,6 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void StructuredLineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& currentLevel) const {
 
-    using xdMV = Xpetra::MultiVector<double, LO, GO, NO>;
-
     // The following three variables are needed by the line smoothers in Ifpack/Ifpack2
     LO                        NumZDir        = 0;
     Teuchos::ArrayRCP<LO>     VertLineId     = Teuchos::arcp<LO>(0);

--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_decl.hpp
@@ -74,7 +74,7 @@ namespace MueLu {
     @ingroup Rebalancing
 
     This interface provides access to partitioning methods in Zoltan2.
-    Currently, it supports the RCB algorithm only.
+    Currently, it supports RCB and multijagged as well as all graph partitioning algorithms from Zoltan2.
 
     ## Input/output of Zoltan2Interface ##
 
@@ -82,7 +82,7 @@ namespace MueLu {
     Parameter | type | default | master.xml | validated | requested | description
     ----------|------|---------|:----------:|:---------:|:---------:|------------
     | A                                      | Factory | null  |   | * | * | Generating factory of the matrix A used during the prolongator smoothing process |
-    | Coordinates                            | Factory | null  |   | * | * | Factory generating coordinates vector used for rebalancing (RCB algorithm)
+    | Coordinates                            | Factory | null  |   | * | (*) | Factory generating coordinates vector used for rebalancing. The coordinates are only needed when the chosen algorithm is 'multijagged' or 'rcb'.
     | ParameterList                          | ParamterList | null |  | * |  | Zoltan2 parameters
     | number of partitions                   | GO      | - |  |  |  | Short-cut parameter set by RepartitionFactory. Avoid repartitioning algorithms if only one partition is necessary (see details below)
 
@@ -189,17 +189,25 @@ namespace MueLu {
     void DeclareInput(Level& currentLevel) const {
       Input(currentLevel, "A");
       Input(currentLevel, "number of partitions");
-      Input(currentLevel, "Coordinates");
+      const ParameterList& pL = GetParameterList();
+      // We do this dance, because we don't want "ParameterList" to be marked as used.
+      // Is there a better way?
+      Teuchos::ParameterEntry entry = pL.getEntry("ParameterList");
+      RCP<const Teuchos::ParameterList> providedList = Teuchos::any_cast<RCP<const Teuchos::ParameterList> >(entry.getAny(false));
+      if (providedList != Teuchos::null && providedList->isType<std::string>("algorithm")) {
+        const std::string algo = providedList->get<std::string>("algorithm");
+        if (algo == "multijagged" || algo == "rcb")
+          Input(currentLevel, "Coordinates");
+      } else
+        Input(currentLevel, "Coordinates");
     };
     void Build(Level& currentLevel) const {
       this->GetOStream(Warnings0) << "Tpetra does not support <double,int,int,EpetraNode> instantiation, "
           "switching Zoltan2Interface to ZoltanInterface" << std::endl;
 
-      typedef Xpetra::MultiVector<double, LocalOrdinal, GlobalOrdinal, Node> dMultiVector;
-
       // Put the data into a fake level
       level_->Set("A",                    Get<RCP<Matrix> >      (currentLevel, "A"));
-      level_->Set("Coordinates",          Get<RCP<dMultiVector> >(currentLevel, "Coordinates"));
+      level_->Set("Coordinates",          Get<RCP<RealValuedMultiVector> >(currentLevel, "Coordinates"));
       level_->Set("number of partitions", currentLevel.Get<GO>("number of partitions"));
 
       level_->Request("Partition", zoltanInterface_.get());


### PR DESCRIPTION
@trilinos/muelu 

## Description
Repartitioning using Zoltan2 only allowed the use of coordinate based repartitioning. This PR adds the option to use other, graph-based partitioners such as Scotch or ParMetis through Zoltan2. The default behavior is not changed.

## Motivation and Context
This allows repartitioning without having coordinates. I have not done any timing runs, but graph partitioning might be more expensive, so the setup cost might go up. On the other hand, graph partitioning minimizes the number of edge cuts, so we could potentially see faster solves.