### PR TITLE
Belos: Fix MueLu Xpetra DII for Tpetra_INST_INT_INT off

### DIFF
--- a/packages/belos/xpetra/src/Belos_Details_Xpetra_registerSolverFactory.cpp
+++ b/packages/belos/xpetra/src/Belos_Details_Xpetra_registerSolverFactory.cpp
@@ -91,12 +91,12 @@ void registerSolverFactory() {
 
 // Epetra = on, Tpetra = on
 #if defined(HAVE_BELOS_EPETRA) && defined(HAVE_BELOS_TPETRA)
-  #define BELOS_XPETRA_CALL(INSTMACRO) TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR(INSTMACRO)
 #if ((defined(EPETRA_HAVE_OMP) && (!defined(HAVE_TPETRA_INST_OPENMP) || !defined(HAVE_TPETRA_INST_INT_INT))) || \
     (!defined(EPETRA_HAVE_OMP) && (!defined(HAVE_TPETRA_INST_SERIAL) || !defined(HAVE_TPETRA_INST_INT_INT))))
-  #define BELOS_XPETRA_CALL(INSTMACRO) INSTMACRO(double, int, int, EpetraNode)
-# endif
-
+  #define BELOS_XPETRA_CALL(INSTMACRO) INSTMACRO(double, int, int, EpetraNode) TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR(INSTMACRO)
+# else
+  #define BELOS_XPETRA_CALL(INSTMACRO) TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR(INSTMACRO)
+#endif
 #endif
 
 // Epetra = off, Tpetra = on


### PR DESCRIPTION
Resolve failing Maxwell3D tests when Tpetra_INST_INT_INT was off.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Description
<!--- Please describe your changes in detail. -->
This fixes faulty logic in the Belos Xpetra DII macros for auto registration of the solvers.

If Tpetra_INST_INT_INT was off and Epetra was on,
then DII would not register the Tpetra cases.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Resolves failing Maxwell3D tests for some builds.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
Resolves at least 3 of the builds mentioned in #3015. Not sure about the clang build yet which had other build errors.
## Related Issues
#3015
* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Local testing and a sems check up to package MueLu passes.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
Note on a basic SEMS test I'm seeing MueLu_UnitTestsEpetra_MPI_4 fail for develop already. That appears to be a separate issue.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
