### PR TITLE
Sacado fixes for issue #3017

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -879,16 +879,23 @@ private:
 
   typedef ViewArrayAnalysis< typename Traits::data_type > array_analysis ;
 
+  // Offset without Fad dimension
+  typedef ViewOffset< typename Traits::dimension
+                    , typename Traits::array_layout
+                    , void
+                    >  offset_type ;
+
   // Append the fad dimension for the internal offset mapping.
   typedef ViewOffset
     < typename array_analysis::dimension::
         template append<( unsigned(FadStaticDimension) > 0 ? unsigned(FadStaticDimension) + 1 : 0 )>::type
     , typename Traits::array_layout
     , void
-    >  offset_type ;
+    >  array_offset_type ;
 
   handle_type  m_handle ;
   offset_type  m_offset ;
+  array_offset_type  m_array_offset ;
   sacado_size_type m_fad_size ;
   sacado_stride_type m_fad_stride ;
 
@@ -902,58 +909,49 @@ public:
   // Using the internal offset mapping so limit to public rank:
   template< typename iType >
   KOKKOS_INLINE_FUNCTION constexpr size_t extent( const iType & r ) const
-    { return unsigned(r) < unsigned(Rank) ? m_offset.m_dim.extent(r) : 1 ; }
+    { return m_offset.m_dim.extent(r) ; }
 
   KOKKOS_INLINE_FUNCTION constexpr
   typename Traits::array_layout layout() const
-    { return typename Traits::array_layout(
-        0 < unsigned(Rank) ? m_offset.dimension_0() : 0,
-        1 < unsigned(Rank) ? m_offset.dimension_1() : 0,
-        2 < unsigned(Rank) ? m_offset.dimension_2() : 0,
-        3 < unsigned(Rank) ? m_offset.dimension_3() : 0,
-        4 < unsigned(Rank) ? m_offset.dimension_4() : 0,
-        5 < unsigned(Rank) ? m_offset.dimension_5() : 0,
-        6 < unsigned(Rank) ? m_offset.dimension_6() : 0,
-        7 < unsigned(Rank) ? m_offset.dimension_7() : 0
-        );
-    }
+    { return m_offset.layout(); }
 
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_0() const
-    { return 0 < unsigned(Rank) ? m_offset.dimension_0() : 1 ; }
-
+    { return m_offset.dimension_0(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_1() const
-    { return 1 < unsigned(Rank) ? m_offset.dimension_1() : 1 ; }
-
+    { return m_offset.dimension_1(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_2() const
-    { return 2 < unsigned(Rank) ? m_offset.dimension_2() : 1 ; }
-
+    { return m_offset.dimension_2(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_3() const
-    { return 3 < unsigned(Rank) ? m_offset.dimension_3() : 1 ; }
-
+    { return m_offset.dimension_3(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_4() const
-    { return 4 < unsigned(Rank) ? m_offset.dimension_4() : 1 ; }
-
+    { return m_offset.dimension_4(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_5() const
-    { return 5 < unsigned(Rank) ? m_offset.dimension_5() : 1 ; }
-
+    { return m_offset.dimension_5(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_6() const
-    { return 6 < unsigned(Rank) ? m_offset.dimension_6() : 1 ; }
-
+    { return m_offset.dimension_6(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_7() const
-    { return 7 < unsigned(Rank) ? m_offset.dimension_7() : 1 ; }
+    { return m_offset.dimension_7(); }
 
   // Can only be regular layout with uniform striding
   // when LayoutRight with contiguous values so not guaranteed true.
   using is_regular = std::false_type ;
 
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_0() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_1() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_2() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_3() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_4() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_5() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_6() const { return 0 ; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_7() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_0() const
+    { return m_offset.stride_0(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_1() const
+    { return m_offset.stride_1(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_2() const
+    { return m_offset.stride_2(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_3() const
+    { return m_offset.stride_3(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_4() const
+    { return m_offset.stride_4(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_5() const
+    { return m_offset.stride_5(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_6() const
+    { return m_offset.stride_6(); }
+  KOKKOS_INLINE_FUNCTION constexpr size_t stride_7() const
+    { return m_offset.stride_7(); }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION void stride( iType * const s ) const
@@ -975,7 +973,7 @@ public:
 
   /** \brief  Span of the mapped range : [ data() .. data() + span() ) */
   KOKKOS_INLINE_FUNCTION constexpr size_t span() const
-    { return m_offset.span(); }
+    { return m_array_offset.span(); }
 
   /** \brief  The mapped range span cannot be guaranteed contiguous */
   KOKKOS_INLINE_FUNCTION constexpr bool span_is_contiguous() const
@@ -997,14 +995,14 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type
   reference( const I0 & i0 ) const
-    { return reference_type( m_handle + m_offset(i0,0)
+    { return reference_type( m_handle + m_array_offset(i0,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
   template< typename I0 , typename I1 >
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type reference( const I0 & i0 , const I1 & i1 ) const
-    { return reference_type( m_handle + m_offset(i0,i1,0)
+    { return reference_type( m_handle + m_array_offset(i0,i1,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
@@ -1012,14 +1010,14 @@ public:
   template< typename I0 , typename I1 , typename I2 >
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type reference( const I0 & i0 , const I1 & i1 , const I2 & i2 ) const
-    { return reference_type( m_handle + m_offset(i0,i1,i2,0)
+    { return reference_type( m_handle + m_array_offset(i0,i1,i2,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
   template< typename I0 , typename I1 , typename I2 , typename I3 >
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type reference( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 ) const
-    { return reference_type( m_handle + m_offset(i0,i1,i2,i3,0)
+    { return reference_type( m_handle + m_array_offset(i0,i1,i2,i3,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
@@ -1028,7 +1026,7 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type reference( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3
                           , const I4 & i4 ) const
-    { return reference_type( m_handle + m_offset(i0,i1,i2,i3,i4,0)
+    { return reference_type( m_handle + m_array_offset(i0,i1,i2,i3,i4,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
@@ -1037,7 +1035,7 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type reference( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3
                           , const I4 & i4 , const I5 & i5 ) const
-    { return reference_type( m_handle + m_offset(i0,i1,i2,i3,i4,i5,0)
+    { return reference_type( m_handle + m_array_offset(i0,i1,i2,i3,i4,i5,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
@@ -1047,7 +1045,7 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION
   reference_type reference( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3
                           , const I4 & i4 , const I5 & i5 , const I6 & i6 ) const
-    { return reference_type( m_handle + m_offset(i0,i1,i2,i3,i4,i5,i6,0)
+    { return reference_type( m_handle + m_array_offset(i0,i1,i2,i3,i4,i5,i6,0)
                            , m_fad_size.value
                            , m_fad_stride.value ); }
 
@@ -1055,17 +1053,27 @@ public:
 
   /** \brief  Span, in bytes, of the required memory */
   KOKKOS_INLINE_FUNCTION
-  static constexpr size_t memory_span( typename Traits::array_layout const & layout )
+  static size_t memory_span( typename Traits::array_layout const & layout )
     {
+      size_t dims[8];
+      for (int i=0; i<8; ++i)
+        dims[i] = layout.dimension[i];
+      if (unsigned(FadStaticDimension) > 0)
+        dims[unsigned(Rank)] = FadStaticDimension+1;
+
+      typename Traits::array_layout alayout(
+        dims[0], dims[1], dims[2], dims[3],
+        dims[4], dims[5], dims[6], dims[7] );
+
       // Do not introduce padding...
       typedef std::integral_constant< unsigned , 0 >  padding ;
-      return offset_type( padding() , layout ).span() * sizeof(fad_value_type);
+      return array_offset_type( padding() , alayout ).span() * sizeof(fad_value_type);
     }
 
   //----------------------------------------
 
   KOKKOS_INLINE_FUNCTION ~ViewMapping() = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping() : m_handle(0) , m_offset() , m_fad_size(0) , m_fad_stride(0) {}
+  KOKKOS_INLINE_FUNCTION ViewMapping() : m_handle(0) , m_offset() , m_array_offset() , m_fad_size(0) , m_fad_stride(0) {}
 
   KOKKOS_INLINE_FUNCTION ViewMapping( const ViewMapping & ) = default ;
   KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
@@ -1082,36 +1090,38 @@ public:
     : m_handle( ( (ViewCtorProp<void,pointer_type> const &) prop ).value )
     , m_offset( std::integral_constant< unsigned , 0 >()
               , local_layout )
-    // Query m_offset, not input, in case of static dimension
+    , m_array_offset( std::integral_constant< unsigned , 0 >()
+                    , local_layout )
+    // Query m_array_offset, not input, in case of static dimension
     , m_fad_size(
-       ( Rank == 0 ? m_offset.dimension_0() :
-       ( Rank == 1 ? m_offset.dimension_1() :
-       ( Rank == 2 ? m_offset.dimension_2() :
-       ( Rank == 3 ? m_offset.dimension_3() :
-       ( Rank == 4 ? m_offset.dimension_4() :
-       ( Rank == 5 ? m_offset.dimension_5() :
-       ( Rank == 6 ? m_offset.dimension_6() :
-                     m_offset.dimension_7() ))))))) - 1 )
+       ( Rank == 0 ? m_array_offset.dimension_0() :
+       ( Rank == 1 ? m_array_offset.dimension_1() :
+       ( Rank == 2 ? m_array_offset.dimension_2() :
+       ( Rank == 3 ? m_array_offset.dimension_3() :
+       ( Rank == 4 ? m_array_offset.dimension_4() :
+       ( Rank == 5 ? m_array_offset.dimension_5() :
+       ( Rank == 6 ? m_array_offset.dimension_6() :
+                     m_array_offset.dimension_7() ))))))) - 1 )
     , m_fad_stride(
-       ( Rank == 0 ? m_offset.stride_0() :
-       ( Rank == 1 ? m_offset.stride_1() :
-       ( Rank == 2 ? m_offset.stride_2() :
-       ( Rank == 3 ? m_offset.stride_3() :
-       ( Rank == 4 ? m_offset.stride_4() :
-       ( Rank == 5 ? m_offset.stride_5() :
-       ( Rank == 6 ? m_offset.stride_6() :
-                     m_offset.stride_7() ))))))))
+       ( Rank == 0 ? m_array_offset.stride_0() :
+       ( Rank == 1 ? m_array_offset.stride_1() :
+       ( Rank == 2 ? m_array_offset.stride_2() :
+       ( Rank == 3 ? m_array_offset.stride_3() :
+       ( Rank == 4 ? m_array_offset.stride_4() :
+       ( Rank == 5 ? m_array_offset.stride_5() :
+       ( Rank == 6 ? m_array_offset.stride_6() :
+                     m_array_offset.stride_7() ))))))))
 
     {
       const unsigned fad_dim =
-       ( Rank == 0 ? m_offset.dimension_0() :
-       ( Rank == 1 ? m_offset.dimension_1() :
-       ( Rank == 2 ? m_offset.dimension_2() :
-       ( Rank == 3 ? m_offset.dimension_3() :
-       ( Rank == 4 ? m_offset.dimension_4() :
-       ( Rank == 5 ? m_offset.dimension_5() :
-       ( Rank == 6 ? m_offset.dimension_6() :
-         m_offset.dimension_7() )))))));
+       ( Rank == 0 ? m_array_offset.dimension_0() :
+       ( Rank == 1 ? m_array_offset.dimension_1() :
+       ( Rank == 2 ? m_array_offset.dimension_2() :
+       ( Rank == 3 ? m_array_offset.dimension_3() :
+       ( Rank == 4 ? m_array_offset.dimension_4() :
+       ( Rank == 5 ? m_array_offset.dimension_5() :
+       ( Rank == 6 ? m_array_offset.dimension_6() :
+         m_array_offset.dimension_7() )))))));
       if (unsigned(FadStaticDimension) == 0 && fad_dim == 0)
         Kokkos::abort("invalid fad dimension (0) supplied!");
     }
@@ -1138,38 +1148,40 @@ public:
 
     // Check if ViewCtorProp has CommonViewAllocProp - if so, retrieve the fad_size and append to layout
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
-    using CVTR = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFad 
+    using CVTR = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFad
                                                            , typename Traits::value_type >;
-    m_offset = offset_type( padding(), 
+    m_offset = offset_type( padding(), local_layout );
+
+    m_array_offset = array_offset_type( padding(),
                             ( test_traits_check == true
-                             && ((Kokkos::Impl::ViewCtorProp<void, CVTR> const &)prop).value.is_view_type) 
-                            ? Kokkos::Impl::appendFadToLayoutViewAllocHelper< Traits, ctor_prop >::returnNewLayoutPlusFad(prop, local_layout) 
+                             && ((Kokkos::Impl::ViewCtorProp<void, CVTR> const &)prop).value.is_view_type)
+                            ? Kokkos::Impl::appendFadToLayoutViewAllocHelper< Traits, ctor_prop >::returnNewLayoutPlusFad(prop, local_layout)
                             : local_layout );
 
     const unsigned fad_dim =
-      ( Rank == 0 ? m_offset.dimension_0() :
-      ( Rank == 1 ? m_offset.dimension_1() :
-      ( Rank == 2 ? m_offset.dimension_2() :
-      ( Rank == 3 ? m_offset.dimension_3() :
-      ( Rank == 4 ? m_offset.dimension_4() :
-      ( Rank == 5 ? m_offset.dimension_5() :
-      ( Rank == 6 ? m_offset.dimension_6() :
-        m_offset.dimension_7() )))))));
+      ( Rank == 0 ? m_array_offset.dimension_0() :
+      ( Rank == 1 ? m_array_offset.dimension_1() :
+      ( Rank == 2 ? m_array_offset.dimension_2() :
+      ( Rank == 3 ? m_array_offset.dimension_3() :
+      ( Rank == 4 ? m_array_offset.dimension_4() :
+      ( Rank == 5 ? m_array_offset.dimension_5() :
+      ( Rank == 6 ? m_array_offset.dimension_6() :
+        m_array_offset.dimension_7() )))))));
     if (unsigned(FadStaticDimension) == 0 && fad_dim == 0)
       Kokkos::abort("invalid fad dimension (0) supplied!");
     m_fad_size = fad_dim - 1 ;
 
     m_fad_stride =
-       ( Rank == 0 ? m_offset.stride_0() :
-       ( Rank == 1 ? m_offset.stride_1() :
-       ( Rank == 2 ? m_offset.stride_2() :
-       ( Rank == 3 ? m_offset.stride_3() :
-       ( Rank == 4 ? m_offset.stride_4() :
-       ( Rank == 5 ? m_offset.stride_5() :
-       ( Rank == 6 ? m_offset.stride_6() :
-                     m_offset.stride_7() )))))));
+       ( Rank == 0 ? m_array_offset.stride_0() :
+       ( Rank == 1 ? m_array_offset.stride_1() :
+       ( Rank == 2 ? m_array_offset.stride_2() :
+       ( Rank == 3 ? m_array_offset.stride_3() :
+       ( Rank == 4 ? m_array_offset.stride_4() :
+       ( Rank == 5 ? m_array_offset.stride_5() :
+       ( Rank == 6 ? m_array_offset.stride_6() :
+                     m_array_offset.stride_7() )))))));
 
-    const size_t alloc_size = m_offset.span() * sizeof(fad_value_type);
+    const size_t alloc_size = m_array_offset.span() * sizeof(fad_value_type);
 
     // Create shared memory tracking record with allocate memory from the memory space
     record_type * const record =
@@ -1188,7 +1200,7 @@ public:
         // The ViewValueFunctor has both value construction and destruction operators.
         record->m_destroy = functor_type( ( (ViewCtorProp<void,execution_space> const &) prop).value
                                         , (fad_value_type *) m_handle
-                                        , m_offset.span()
+                                        , m_array_offset.span()
                                         );
 
         // Construct values
@@ -1209,10 +1221,100 @@ public:
 namespace Kokkos {
 namespace Impl {
 
-// Integer argument is the actual rank => ranks 0 to Rank-1 will be assigned
 /**\brief  Assign compatible Sacado FAD view mappings.
  *
  *  View<FAD>      = View<FAD>
+ */
+template< class DstTraits , class SrcTraits >
+class ViewMapping< DstTraits , SrcTraits ,
+  typename std::enable_if<(
+    Kokkos::Impl::MemorySpaceAccess
+     < typename DstTraits::memory_space
+     , typename SrcTraits::memory_space >::assignable
+    &&
+    // Destination view has FAD
+    std::is_same< typename DstTraits::specialize
+                , ViewSpecializeSacadoFad >::value
+    &&
+    // Source view has FAD
+    std::is_same< typename SrcTraits::specialize
+                , ViewSpecializeSacadoFad >::value
+  )>::type >
+{
+public:
+
+  enum { is_assignable = true };
+
+  typedef Kokkos::Impl::SharedAllocationTracker  TrackType ;
+  typedef ViewMapping< DstTraits , void >  DstType ;
+  typedef ViewMapping< SrcTraits , void >  SrcFadType ;
+
+  template< class DstType >
+  KOKKOS_INLINE_FUNCTION static
+  void assign( DstType & dst
+             , const SrcFadType & src
+             , const TrackType & )
+    {
+      static_assert(
+        (
+          std::is_same< typename DstTraits::array_layout
+                      , Kokkos::LayoutLeft >::value ||
+          std::is_same< typename DstTraits::array_layout
+                      , Kokkos::LayoutRight >::value ||
+          std::is_same< typename DstTraits::array_layout
+                      , Kokkos::LayoutStride >::value
+        )
+        &&
+        (
+          std::is_same< typename SrcTraits::array_layout
+                      , Kokkos::LayoutLeft >::value ||
+          std::is_same< typename SrcTraits::array_layout
+                      , Kokkos::LayoutRight >::value ||
+          std::is_same< typename SrcTraits::array_layout
+                      , Kokkos::LayoutStride >::value
+        )
+        , "View of FAD requires LayoutLeft, LayoutRight, or LayoutStride" );
+
+      static_assert(
+        std::is_same< typename DstTraits::array_layout
+                    , typename SrcTraits::array_layout >::value ||
+        std::is_same< typename DstTraits::array_layout
+                    , Kokkos::LayoutStride >::value ,
+        "View assignment must have compatible layout" );
+
+      static_assert(
+        std::is_same< typename DstTraits::scalar_array_type
+                    , typename SrcTraits::scalar_array_type >::value ||
+        std::is_same< typename DstTraits::scalar_array_type
+                    , typename SrcTraits::const_scalar_array_type >::value ,
+        "View assignment must have same value type or const = non-const" );
+
+      static_assert(
+        ViewDimensionAssignable
+          < typename DstType::offset_type::dimension_type
+          , typename SrcFadType::offset_type::dimension_type >::value ,
+        "View assignment must have compatible dimensions" );
+
+       static_assert(
+        ViewDimensionAssignable
+          < typename DstType::array_offset_type::dimension_type
+          , typename SrcFadType::array_offset_type::dimension_type >::value ,
+        "View assignment must have compatible dimensions" );
+
+      typedef typename DstType::offset_type  dst_offset_type ;
+      typedef typename DstType::array_offset_type  dst_array_offset_type ;
+
+      dst.m_handle  = src.m_handle ;
+      dst.m_offset  = dst_offset_type( src.m_offset );
+      dst.m_array_offset = dst_array_offset_type( src.m_array_offset );
+      dst.m_fad_size = src.m_fad_size.value ;
+      dst.m_fad_stride = src.m_fad_stride.value ;
+    }
+};
+
+// Integer argument is the actual rank => ranks 0 to Rank-1 will be assigned
+/**\brief  Assign compatible Sacado FAD view mappings.
+ *
  *  View<ordinary> = View<FAD>
  *  (TBD)  View<FAD> = View<ordinary>
  */
@@ -1223,12 +1325,8 @@ class ViewMapping< DstTraits , SrcTraits ,
      < typename DstTraits::memory_space
      , typename SrcTraits::memory_space >::assignable
     &&
-    // Destination view has FAD or ordinary
-    ( std::is_same< typename DstTraits::specialize
-                , ViewSpecializeSacadoFad >::value
-      ||
-      std::is_same< typename DstTraits::specialize , void >::value
-    )
+    // Destination view has ordinary
+    std::is_same< typename DstTraits::specialize , void >::value
     &&
     // Source view has FAD only
     std::is_same< typename SrcTraits::specialize
@@ -1244,45 +1342,28 @@ public:
   typedef ViewMapping< DstTraits , void >  DstType ;
   typedef ViewMapping< SrcTraits , void >  SrcFadType ;
 
-  template< class S , class D >
-  KOKKOS_INLINE_FUNCTION static
-  typename std::enable_if<( 
-    std::is_same< S , ViewSpecializeSacadoFad >::value
-    )>::type
-  assign_fad_size( D & dst , const SrcFadType & src )
-    { dst.m_fad_size = src.m_fad_size.value ;
-      dst.m_fad_stride = src.m_fad_stride.value ;
-    }
-
-  template< class S , class D >
-  KOKKOS_INLINE_FUNCTION static
-  typename std::enable_if<(
-    ! std::is_same< S , ViewSpecializeSacadoFad >::value 
-    )>::type
-  assign_fad_size( D & , const SrcFadType & ) {}
-
 
   // Helpers to assign, and generate if necessary, ViewOffset to the dst map
   // These are necessary to use Kokkos' deep_copy with nested fads
-  template < class DstType, class SrcFadType, class Truth = void > 
+  template < class DstType, class SrcFadType, class Truth = void >
     struct AssignOffset;
 
-  template < class DstType, class SrcFadType > 
-    struct AssignOffset< DstType, SrcFadType, typename std::enable_if< ((int)DstType::offset_type::dimension_type::rank != (int)SrcFadType::offset_type::dimension_type::rank) >::type >
+  template < class DstType, class SrcFadType >
+    struct AssignOffset< DstType, SrcFadType, typename std::enable_if< ((int)DstType::offset_type::dimension_type::rank != (int)SrcFadType::array_offset_type::dimension_type::rank) >::type >
     {
       // ViewOffset's Dimensions Ranks do not match
       KOKKOS_INLINE_FUNCTION
-      static void assign( DstType & dst, const SrcFadType & src ) 
+      static void assign( DstType & dst, const SrcFadType & src )
       {
         typedef typename SrcTraits::value_type TraitsValueType;
 
-        if ( Sacado::IsFad<TraitsValueType>::value 
-            && Sacado::IsStaticallySized< typename Sacado::ValueType< TraitsValueType >::type >::value 
-           ) 
+        if ( Sacado::IsFad<TraitsValueType>::value
+            && Sacado::IsStaticallySized< typename Sacado::ValueType< TraitsValueType >::type >::value
+           )
         {
           typedef typename DstType::offset_type::array_layout DstLayoutType;
           //typedef typename ViewArrayLayoutSelector<typename DstType::offset_type::array_layout>::type DstLayoutType;
-          typedef typename SrcFadType::offset_type::dimension_type SrcViewDimension;
+          typedef typename SrcFadType::array_offset_type::dimension_type SrcViewDimension;
 
           // This is the static dimension of the inner fad, missing from ViewDimension
           const size_t InnerStaticDim = Sacado::StaticSize< typename Sacado::ValueType< TraitsValueType >::type >::value;
@@ -1290,7 +1371,7 @@ public:
           static constexpr bool is_layout_left =
             std::is_same< DstLayoutType, Kokkos::LayoutLeft>::value;
 
-          typedef typename std::conditional< is_layout_left, 
+          typedef typename std::conditional< is_layout_left,
                                              typename SrcViewDimension:: template prepend< InnerStaticDim+1 >::type,
                                              typename SrcViewDimension:: template append < InnerStaticDim+1 >::type
                     >::type SrcViewDimensionAppended;
@@ -1299,7 +1380,7 @@ public:
 
           typedef ViewOffset< SrcViewDimensionAppended, DstLayoutType > TmpOffsetType;
 
-          auto src_layout = src.m_offset.layout();
+          auto src_layout = src.m_array_offset.layout();
 
           if ( is_layout_left ) {
             auto prepend_layout = Kokkos::Impl::prependFadToLayout< DstLayoutType >::returnNewLayoutPlusFad(src_layout, InnerStaticDim+1);
@@ -1317,17 +1398,15 @@ public:
       }
     };
 
-  template < class DstType, class SrcFadType > 
-    struct AssignOffset< DstType, SrcFadType, typename std::enable_if< ((int)DstType::offset_type::dimension_type::rank == (int)SrcFadType::offset_type::dimension_type::rank) >::type >
+  template < class DstType, class SrcFadType >
+    struct AssignOffset< DstType, SrcFadType, typename std::enable_if< ((int)DstType::offset_type::dimension_type::rank == (int)SrcFadType::array_offset_type::dimension_type::rank) >::type >
     {
       KOKKOS_INLINE_FUNCTION
-      static void assign( DstType & dst, const SrcFadType & src ) 
+      static void assign( DstType & dst, const SrcFadType & src )
       {
 
-        //typedef typename DstType::offset_type  dst_offset_type ;
-        //dst.m_offset  = dst_offset_type( src.m_offset );
-        dst.m_offset = src.m_offset;
-        ViewMapping::template assign_fad_size< typename DstTraits::specialize >( dst , src );
+        typedef typename DstType::offset_type  dst_offset_type ;
+        dst.m_offset  = dst_offset_type( src.m_array_offset );
       }
     };
 
@@ -1335,8 +1414,8 @@ public:
 // If the dst and src mappings are not equal in Rank, the src should come from a View of nested fads
 // In the case of two nested fads, the innermost must be an SFad (static Fad)
 // The offset_type's are not compatible in the case of nested fads because the ViewDimension's ranks will not agree
-// In this case, rather than trying to construct an offset_type from src (which will fail at compile time) 
-// and assign to dst.m_offset, manually assign the ViewDimension arguments to dst; 
+// In this case, rather than trying to construct an offset_type from src (which will fail at compile time)
+// and assign to dst.m_offset, manually assign the ViewDimension arguments to dst;
 // requires appending the missing inner SFad dim + 1 to the Rank-1 ViewDimension
   // DstType and SrcFadType are MAPS...
   template < class DstType >
@@ -1344,7 +1423,7 @@ public:
   void
   assign( DstType & dst
         , const SrcFadType & src
-        , const TrackType & 
+        , const TrackType &
         )
   {
 
@@ -1504,22 +1583,26 @@ public:
     {
       typedef ViewMapping< traits_type , void > DstType ;
       typedef typename DstType::offset_type  dst_offset_type ;
+      typedef typename DstType::array_offset_type  dst_array_offset_type ;
       typedef typename DstType::handle_type  dst_handle_type ;
 
+      const SubviewExtents< SrcTraits::rank , rank >
+        extents( src.m_offset.m_dim , args... );
       const SubviewExtents< SrcTraits::rank + 1 , rank + 1 >
-        extents( src.m_offset.m_dim , args... , Kokkos::ALL() );
+        array_extents( src.m_array_offset.m_dim , args... , Kokkos::ALL() );
 
       dst.m_offset = dst_offset_type( src.m_offset , extents );
-      dst.m_handle = dst_handle_type( src.m_handle +
-                                      src.m_offset( extents.domain_offset(0)
-                                                  , extents.domain_offset(1)
-                                                  , extents.domain_offset(2)
-                                                  , extents.domain_offset(3)
-                                                  , extents.domain_offset(4)
-                                                  , extents.domain_offset(5)
-                                                  , extents.domain_offset(6)
-                                                  , extents.domain_offset(7)
-                                                  ) );
+      dst.m_array_offset = dst_array_offset_type( src.m_array_offset , array_extents );
+      dst.m_handle =
+        dst_handle_type( src.m_handle +
+                         src.m_array_offset( array_extents.domain_offset(0)
+                                           , array_extents.domain_offset(1)
+                                           , array_extents.domain_offset(2)
+                                           , array_extents.domain_offset(3)
+                                           , array_extents.domain_offset(4)
+                                           , array_extents.domain_offset(5)
+                                           , array_extents.domain_offset(6)
+                                           , array_extents.domain_offset(7) ) );
       dst.m_fad_size = src.m_fad_size;
       dst.m_fad_stride = src.m_fad_stride.value;
     }

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -1259,11 +1259,12 @@ public:
         DstTraits::dimension::rank == SrcTraits::dimension::rank,
         "View assignment must have same rank" );
 
-      typedef typename DstType::offset_type  dst_offset_type ;
+      typedef typename DstType::array_offset_type  dst_offset_type ;
 
       dst.m_handle  = src.m_handle ;
       dst.m_fad_size = src.m_fad_size.value ;
       dst.m_fad_stride = src.m_fad_stride ;
+      dst.m_offset = src.m_offset;
 
       size_t N[8], S[8];
       N[0] = src.m_array_offset.dimension_0();
@@ -1305,7 +1306,7 @@ public:
                                N[5], S[5],
                                N[6], S[6],
                                N[7], S[7] );
-      dst.m_offset  = dst_offset_type(std::integral_constant<unsigned,0>(), ls);
+      dst.m_array_offset  = dst_offset_type(std::integral_constant<unsigned,0>(), ls);
     }
 };
 
@@ -1338,21 +1339,21 @@ public:
 
   // Helpers to assign, and generate if necessary, ViewOffset to the dst map
   // These are necessary to use Kokkos' deep_copy with nested fads
-  template < class DstType, class SrcFadType, class Enable = void > 
+  template < class DstType, class SrcFadType, class Enable = void >
     struct AssignOffset;
 
-  template < class DstType, class SrcFadType > 
+  template < class DstType, class SrcFadType >
     struct AssignOffset< DstType, SrcFadType, typename std::enable_if< ((int)DstType::offset_type::dimension_type::rank != (int)SrcFadType::array_offset_type::dimension_type::rank) >::type >
     {
       // ViewOffset's Dimensions Ranks do not match
       KOKKOS_INLINE_FUNCTION
-      static void assign( DstType & dst, const SrcFadType & src ) 
+      static void assign( DstType & dst, const SrcFadType & src )
       {
         typedef typename SrcTraits::value_type TraitsValueType;
 
-        if ( Sacado::IsFad<TraitsValueType>::value 
-            && Sacado::IsStaticallySized< typename Sacado::ValueType< TraitsValueType >::type >::value 
-           ) 
+        if ( Sacado::IsFad<TraitsValueType>::value
+            && Sacado::IsStaticallySized< typename Sacado::ValueType< TraitsValueType >::type >::value
+           )
         {
 
           typedef typename DstType::offset_type::array_layout DstLayoutType;
@@ -1365,7 +1366,7 @@ public:
           static constexpr bool is_layout_left =
             std::is_same< DstLayoutType, Kokkos::LayoutLeft>::value;
 
-          typedef typename std::conditional< is_layout_left, 
+          typedef typename std::conditional< is_layout_left,
                                              typename SrcViewDimension:: template prepend< InnerStaticDim+1 >::type,
                                              typename SrcViewDimension:: template append < InnerStaticDim+1 >::type
                     >::type SrcViewDimensionAppended;
@@ -1391,11 +1392,11 @@ public:
       }
     };
 
-  template < class DstType, class SrcFadType > 
+  template < class DstType, class SrcFadType >
     struct AssignOffset< DstType, SrcFadType, typename std::enable_if< ((int)DstType::offset_type::dimension_type::rank == (int)SrcFadType::array_offset_type::dimension_type::rank) >::type >
     {
       KOKKOS_INLINE_FUNCTION
-      static void assign( DstType & dst, const SrcFadType & src ) 
+      static void assign( DstType & dst, const SrcFadType & src )
       {
         typedef typename DstType::offset_type  dst_offset_type ;
         dst.m_offset  = dst_offset_type( src.m_array_offset );
@@ -1406,7 +1407,7 @@ public:
   KOKKOS_INLINE_FUNCTION static
   void assign( DstType & dst
              , const SrcFadType & src
-             , const TrackType & 
+             , const TrackType &
              )
     {
       static_assert(

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -1116,8 +1116,9 @@ namespace Impl {
 template< class DstTraits , class SrcTraits >
 class ViewMapping< DstTraits , SrcTraits ,
   typename std::enable_if<(
-    std::is_same< typename DstTraits::memory_space
-                , typename SrcTraits::memory_space >::value
+    Kokkos::Impl::MemorySpaceAccess
+     < typename DstTraits::memory_space
+     , typename SrcTraits::memory_space >::assignable
     &&
     // Destination view has FAD
     std::is_same< typename DstTraits::specialize

--- a/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
@@ -681,8 +681,9 @@ public:
 template< class DstTraits , class SrcTraits >
 class ViewMapping< DstTraits , SrcTraits ,
   typename std::enable_if<(
-    std::is_same< typename DstTraits::memory_space
-                , typename SrcTraits::memory_space >::value
+    Kokkos::Impl::MemorySpaceAccess
+     < typename DstTraits::memory_space
+     , typename SrcTraits::memory_space >::assignable
     &&
     // Destination view has FAD only
     std::is_same< typename DstTraits::specialize
@@ -769,8 +770,9 @@ public:
 template< class DstTraits , class SrcTraits >
 class ViewMapping< DstTraits , SrcTraits ,
   typename std::enable_if<(
-    std::is_same< typename DstTraits::memory_space
-                , typename SrcTraits::memory_space >::value
+    Kokkos::Impl::MemorySpaceAccess
+     < typename DstTraits::memory_space
+     , typename SrcTraits::memory_space >::assignable
     &&
     // Destination view has ordinary
     std::is_same< typename DstTraits::specialize , void >::value

--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -30,8 +30,7 @@
 #ifndef KOKKOS_LAYOUT_CONTIGUOUS_HPP
 #define KOKKOS_LAYOUT_CONTIGUOUS_HPP
 
-#include "Kokkos_Core.hpp"
-#include "Kokkos_Macros.hpp"
+#include "Kokkos_Core_fwd.hpp"
 #include "Kokkos_Layout.hpp"
 
 namespace Kokkos {

--- a/packages/sacado/src/Kokkos_LayoutNatural.hpp
+++ b/packages/sacado/src/Kokkos_LayoutNatural.hpp
@@ -30,8 +30,7 @@
 #ifndef KOKKOS_LAYOUT_NATURAL_HPP
 #define KOKKOS_LAYOUT_NATURAL_HPP
 
-#include "Kokkos_Core.hpp"
-#include "Kokkos_Macros.hpp"
+#include "Kokkos_Core_fwd.hpp"
 #include "Kokkos_Layout.hpp"
 #include "Kokkos_LayoutContiguous.hpp" // for inner_layout<>
 

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -1622,12 +1622,12 @@ public:
       static_assert(
         ViewDimensionAssignable
           < typename DstType::offset_type::dimension_type
-          , typename SrcFadType::offset_type::dimension_type >::value ,
+          , typename SrcFadType::array_offset_type::dimension_type >::value ,
         "View assignment must have compatible dimensions" );
 
       typedef typename DstType::offset_type  dst_offset_type ;
 
-      dst.m_offset  = dst_offset_type( src.m_offset );
+      dst.m_offset  = dst_offset_type( src.m_array_offset );
       dst.m_handle.assign(src.m_handle) ;
       dst.m_stride  = 1;
 


### PR DESCRIPTION
Changes to Kokkos::View specialization for Fad scalar types to allow Kokkos::resize() to work, including a reproducing unit test.  See issue #3017 for description of the problem and commits logs for changes to fix it.