### PR TITLE
MueLu: Attempt at handling output when proc 0 drops out

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -233,9 +233,7 @@ namespace MueLu {
       // FIXME: Should allow specification of NumVectors on parameterlist
       H.AllocateLevelMultiVectors(1);
       
-      RCP<Teuchos::FancyOStream> fos = this->getOStream();
-      fos->setOutputToRootOnly(0);
-      H.describe(*fos, verbosity_);
+      H.describe(H.GetOStream(Statistics0), verbosity_);
 
       // When we reuse hierarchy, it is necessary that we don't
       // change the number of levels. We also cannot make requests

--- a/packages/muelu/src/MueCentral/MueLu_VerboseObject.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerboseObject.cpp
@@ -77,17 +77,7 @@ namespace MueLu {
       MPI_Comm_size(MPI_COMM_WORLD, &numProcs_);
     }
 #endif
-
-    // When Teuchos::VerboseObject is constructed, its default OStream is set to output only to processor 0.
-    // We have another machinery in place to decide when to output, so by default we want to always print.
-    static RCP<Teuchos::FancyOStream> defaultOStream;
-    if (defaultOStream.get() == NULL) {
-      defaultOStream = Teuchos::fancyOStream(rcpFromRef(std::cout));
-      defaultOStream->setOutputToRootOnly(-1);
-
-      setDefaultOStream(defaultOStream);
     }
-  }
 
   VerboseObject::~VerboseObject() { }
 
@@ -119,7 +109,7 @@ namespace MueLu {
     if (!IsPrint(type, thisProcRankOnly))
       return *blackHole_;
 
-    Teuchos::FancyOStream& os = *getOStream();
+    Teuchos::FancyOStream& os = *GetMueLuOStream();
     if (!(type & ((Extreme | Test) ^ Warnings)))
       os << "\n******* WARNING *******" << std::endl;
 
@@ -140,13 +130,18 @@ namespace MueLu {
     return globalVerbLevel_;
   }
 
-  void VerboseObject::SetDefaultOStream(const Teuchos::RCP<Teuchos::FancyOStream>& defaultOStream) {
-    defaultOStream->setOutputToRootOnly(-1);
-    setDefaultOStream(defaultOStream);
+  void VerboseObject::SetMueLuOStream(const Teuchos::RCP<Teuchos::FancyOStream>& mueluOStream) {
+    mueluOStream->setOutputToRootOnly(-1);
+    GetMueLuOStream() = mueluOStream;
   }
 
-  Teuchos::RCP<Teuchos::FancyOStream> VerboseObject::GetDefaultOStream() {
-    return getDefaultOStream();
+  Teuchos::RCP<Teuchos::FancyOStream> VerboseObject::GetMueLuOStream() {
+    static Teuchos::RCP<Teuchos::FancyOStream> mueluOutputStream;
+    if (mueluOutputStream.get()==NULL) {
+      mueluOutputStream = fancyOStream(rcpFromRef(std::cout));
+      mueluOutputStream->setOutputToRootOnly(-1);
+    }
+    return mueluOutputStream;
   }
 
   VerbLevel VerboseObject::globalVerbLevel_ = High; // Default global verbose level.

--- a/packages/muelu/src/MueCentral/MueLu_VerboseObject.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerboseObject.hpp
@@ -113,9 +113,9 @@ namespace MueLu {
 
     Teuchos::FancyOStream & GetBlackHole() const;
 
-    static void SetDefaultOStream(const Teuchos::RCP<Teuchos::FancyOStream> &defaultOStream);
+    static void SetMueLuOStream(const Teuchos::RCP<Teuchos::FancyOStream> &mueluOStream);
 
-    static Teuchos::RCP<Teuchos::FancyOStream> GetDefaultOStream();
+    static Teuchos::RCP<Teuchos::FancyOStream> GetMueLuOStream();
 
     //! @name Public static member functions
     //@{

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers_Common.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers_Common.hpp
@@ -109,7 +109,7 @@
 // Macro to set MueLu's internal oh-so FancyOStream to be the same as the one used by Teuchos' unit testing framework.
 // This prevents MueLu's output from intermingling with with the unit test pass/fail summary lines.
 #define MUELU_TESTING_SET_OSTREAM \
-   MueLu::VerboseObject::SetDefaultOStream(Teuchos::fancyOStream(out.getOStream()));
+   MueLu::VerboseObject::SetMueLuOStream(Teuchos::fancyOStream(out.getOStream()));
 
 #define MUELU_TESTING_DO_NOT_TEST(lib,packagesNotEnabled) \
   if (TestHelpers::Parameters::getLib() == lib) { \


### PR DESCRIPTION
## Description
Currently, we set rank 0 to be responsible of all MueLu output. This is problematic when this rank drops out in repartitioning. (See #1471 and #1489.) With this PR, we introduce a global variable `defaultMueLuOutputRank` which is reset every time we repartition to an MPI rank that is still active. Whenever a new MueLu_VerboseObject is created, the current value of `defaultMueLuOutputRank` is copied to a member variable in that object and used for output. 

I believe that this addresses the above issues, but would appreciate a thorough review. I could not find any small examples where proc 0 dropped out..