### PR TITLE
Add support for Kokkos::atomic_add() with Sacado Fad types

### DIFF
--- a/packages/phalanx/src/Phalanx_MDField_Utilities_Def.hpp
+++ b/packages/phalanx/src/Phalanx_MDField_Utilities_Def.hpp
@@ -45,6 +45,8 @@
 #ifndef PHX_MDFIELD_UTILITIES_DEF_HPP
 #define PHX_MDFIELD_UTILITIES_DEF_HPP
 
+#include <memory>
+
 namespace PHX {
 
   template<typename T>
@@ -56,7 +58,8 @@ namespace PHX {
     // operator-> requires a raw pointer to end its recursive invocation. val_
     // holds an object in memory so that the pointer remains valid for the
     // duration of it->'s use of it.
-    const reference_type* operator-> () const { return &val_; }
+    // Note:  don't use & since it may be overloaded
+    const reference_type* operator-> () const { return std::addressof(val_); }
   };
 
   template<typename T> inline MDFieldIterator<T>::

--- a/packages/sacado/src/Sacado_CacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_CacheFad_Ops.hpp
@@ -2661,5 +2661,4 @@ namespace Sacado {
 
 } // namespace Sacado
 
-
 #endif // SACADO_CACHEFAD_OPS_HPP

--- a/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
@@ -3716,5 +3716,4 @@ namespace Sacado {
 
 } // namespace Sacado
 
-
 #endif // SACADO_CACHEFAD_OPS_HPP

--- a/packages/sacado/src/Sacado_ELRFad_GeneralFad.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_GeneralFad.hpp
@@ -215,6 +215,10 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       bool updateValue() const { return true; }
 
+      //! Cache values
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
       //! Returns whether two Fad objects have the same values
       template <typename S>
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/Sacado_ELRFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_Ops.hpp
@@ -93,6 +93,9 @@ namespace Sacado {                                                      \
       bool updateValue() const { return expr.updateValue(); }           \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
         return VALUE;                                                   \
       }                                                                 \
@@ -403,6 +406,9 @@ namespace Sacado {                                                      \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
         return VALUE;                                                   \
       }                                                                 \
@@ -528,6 +534,9 @@ namespace Sacado {                                                      \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
         return VALUE;                                                   \
       }                                                                 \
@@ -639,6 +648,9 @@ namespace Sacado {                                                      \
       bool updateValue() const {                                        \
         return expr2.updateValue();                                     \
       }                                                                 \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
@@ -1067,6 +1079,5 @@ namespace Sacado {
   } // namespace Fad
 
 } // namespace Sacado
-
 
 #endif // SACADO_FAD_OPS_HPP

--- a/packages/sacado/src/Sacado_ELRFad_SFad.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_SFad.hpp
@@ -243,6 +243,10 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       bool updateValue() const { return true; }
 
+      //! Cache values
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
       //! Returns whether two Fad objects have the same values
       template <typename S>
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/Sacado_Fad_DFad_tmpl.hpp
+++ b/packages/sacado/src/Sacado_Fad_DFad_tmpl.hpp
@@ -27,6 +27,11 @@
 // ***********************************************************************
 // @HEADER
 
+#if defined(HAVE_SACADO_KOKKOSCORE)
+#include "Kokkos_Atomic.hpp"
+#include "impl/Kokkos_Error.hpp"
+#endif
+
 namespace Sacado {
 
   namespace FAD_NS {
@@ -302,3 +307,45 @@ namespace Sacado {
   };
 
 } // namespace Sacado
+
+#if defined(HAVE_SACADO_KOKKOSCORE)
+
+//-------------------------- Atomic Operators -----------------------
+
+namespace Sacado {
+
+  namespace FAD_NS {
+
+    // Overload of Kokkos::atomic_add for Fad types.
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(DFad<T>* dst, const DFad<T>& x) {
+      using Kokkos::atomic_add;
+
+      const int xsz = x.size();
+      const int sz = dst->size();
+
+      // We currently cannot handle resizing since that would need to be
+      // done atomically.
+      if (xsz > sz)
+        Kokkos::abort(
+          "Sacado error: Fad resize within atomic_add() not supported!");
+
+      if (xsz != sz && sz > 0 && xsz > 0)
+        Kokkos::abort(
+          "Sacado error: Fad assignment of incompatiable sizes!");
+
+
+      if (sz > 0 && xsz > 0) {
+        SACADO_FAD_DERIV_LOOP(i,sz)
+          atomic_add(&(dst->fastAccessDx(i)), x.fastAccessDx(i));
+      }
+      SACADO_FAD_THREAD_SINGLE
+        atomic_add(&(dst->val()), x.val());
+    }
+
+  } // namespace Fad
+
+} // namespace Sacado
+
+#endif // HAVE_SACADO_KOKKOSCORE

--- a/packages/sacado/src/Sacado_Fad_GeneralFad.hpp
+++ b/packages/sacado/src/Sacado_Fad_GeneralFad.hpp
@@ -59,10 +59,20 @@ namespace Sacado {
   //! Namespace for forward-mode AD classes
   namespace Fad {
 
+#ifndef SACADO_FAD_DERIV_LOOP
 #if defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDA_ARCH__)
 #define SACADO_FAD_DERIV_LOOP(I,SZ) for (int I=threadIdx.x; I<SZ; I+=blockDim.x)
 #else
 #define SACADO_FAD_DERIV_LOOP(I,SZ) for (int I=0; I<SZ; ++I)
+#endif
+#endif
+
+#ifndef SACADO_FAD_THREAD_SINGLE
+#if (defined(SACADO_VIEW_CUDA_HIERARCHICAL) || defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDA_ARCH__)
+#define SACADO_FAD_THREAD_SINGLE if (threadIdx.x == 0)
+#else
+#define SACADO_FAD_THREAD_SINGLE /* */
+#endif
 #endif
 
     //! Forward-mode AD class templated on the storage for the derivative array
@@ -176,6 +186,10 @@ namespace Sacado {
       //! Return whether this Fad object has an updated value
       KOKKOS_INLINE_FUNCTION
       bool updateValue() const { return true; }
+
+      //! Cache values
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
 
       //! Returns whether two Fad objects have the same values
       template <typename S>

--- a/packages/sacado/src/Sacado_Fad_Ops.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops.hpp
@@ -92,6 +92,9 @@ namespace Sacado {                                                      \
       bool updateValue() const { return expr.updateValue(); }           \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
       value_type val() const {                                          \
         USING                                                           \
         return VALUE;                                                   \
@@ -325,6 +328,9 @@ namespace Sacado {                                                      \
       }                                                                 \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
       const value_type val() const {                                    \
         USING                                                           \
         return VALUE;                                                   \
@@ -399,6 +405,9 @@ namespace Sacado {                                                      \
       bool updateValue() const { return expr1.updateValue(); }          \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
       const value_type val() const {                                    \
         USING                                                           \
         return VAL_CONST_DX_2;                                          \
@@ -471,6 +480,9 @@ namespace Sacado {                                                      \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       bool updateValue() const { return expr2.updateValue(); }          \
+                                                                        \
+      KOKKOS_INLINE_FUNCTION                                            \
+      void cache() const {}                                             \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       const value_type val() const {                                    \
@@ -737,6 +749,9 @@ namespace Sacado {
       }
 
       KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
       const value_type val() const {
         return expr1.val()*expr2.val();
       }
@@ -814,6 +829,9 @@ namespace Sacado {
       bool updateValue() const { return expr1.updateValue(); }
 
       KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
       const value_type val() const {
         return expr1.val()*c.val();
       }
@@ -882,6 +900,9 @@ namespace Sacado {
 
       KOKKOS_INLINE_FUNCTION
       bool updateValue() const { return expr2.updateValue(); }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
 
       KOKKOS_INLINE_FUNCTION
       const value_type val() const {
@@ -1037,6 +1058,9 @@ namespace Sacado {
       }
 
       KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
       const value_type val() const {
         using Sacado::if_then_else;
         return if_then_else( cond, expr1.val(), expr2.val() );
@@ -1112,6 +1136,9 @@ namespace Sacado {
       bool updateValue() const { return expr1.updateValue(); }
 
       KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
       const value_type val() const {
         using Sacado::if_then_else;
         return if_then_else( cond, expr1.val(), c.val() );
@@ -1184,6 +1211,9 @@ namespace Sacado {
 
       KOKKOS_INLINE_FUNCTION
       bool updateValue() const { return expr2.updateValue(); }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
 
       KOKKOS_INLINE_FUNCTION
       const value_type val() const {
@@ -1483,6 +1513,5 @@ namespace Sacado {
   } // namespace Fad
 
 } // namespace Sacado
-
 
 #endif // SACADO_FAD_OPS_HPP

--- a/packages/sacado/src/Sacado_Fad_SFad.hpp
+++ b/packages/sacado/src/Sacado_Fad_SFad.hpp
@@ -76,6 +76,22 @@ namespace Sacado {
   //! Namespace for forward-mode AD classes
   namespace Fad {
 
+#ifndef SACADO_FAD_DERIV_LOOP
+#if defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDA_ARCH__)
+#define SACADO_FAD_DERIV_LOOP(I,SZ) for (int I=threadIdx.x; I<SZ; I+=blockDim.x)
+#else
+#define SACADO_FAD_DERIV_LOOP(I,SZ) for (int I=0; I<SZ; ++I)
+#endif
+#endif
+
+#ifndef SACADO_FAD_THREAD_SINGLE
+#if (defined(SACADO_VIEW_CUDA_HIERARCHICAL) || defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDA_ARCH__)
+#define SACADO_FAD_THREAD_SINGLE if (threadIdx.x == 0)
+#else
+#define SACADO_FAD_THREAD_SINGLE /* */
+#endif
+#endif
+
     //! A tag for specializing Expr for SFad expressions
     template <typename T, int Num>
     struct SFadExprTag {};

--- a/packages/sacado/src/Sacado_Fad_SFad.hpp
+++ b/packages/sacado/src/Sacado_Fad_SFad.hpp
@@ -253,6 +253,10 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       bool updateValue() const { return true; }
 
+      //! Cache values
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
       //! Returns whether two Fad objects have the same values
       template <typename S>
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/Sacado_Fad_SFad_tmpl.hpp
+++ b/packages/sacado/src/Sacado_Fad_SFad_tmpl.hpp
@@ -27,6 +27,11 @@
 // ***********************************************************************
 // @HEADER
 
+#if defined(HAVE_SACADO_KOKKOSCORE)
+#include "Kokkos_Atomic.hpp"
+#include "impl/Kokkos_Error.hpp"
+#endif
+
 namespace Sacado {
 
   namespace FAD_NS {
@@ -305,3 +310,45 @@ namespace Sacado {
   };
 
 } // namespace Sacado
+
+#if defined(HAVE_SACADO_KOKKOSCORE)
+
+//-------------------------- Atomic Operators -----------------------
+
+namespace Sacado {
+
+  namespace FAD_NS {
+
+    // Overload of Kokkos::atomic_add for Fad types.
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SFad<T,N>* dst, const SFad<T,N>& x) {
+      using Kokkos::atomic_add;
+
+      const int xsz = x.size();
+      const int sz = dst->size();
+
+      // We currently cannot handle resizing since that would need to be
+      // done atomically.
+      if (xsz > sz)
+        Kokkos::abort(
+          "Sacado error: Fad resize within atomic_add() not supported!");
+
+      if (xsz != sz && sz > 0 && xsz > 0)
+        Kokkos::abort(
+          "Sacado error: Fad assignment of incompatiable sizes!");
+
+
+      if (sz > 0 && xsz > 0) {
+        SACADO_FAD_DERIV_LOOP(i,sz)
+          atomic_add(&(dst->fastAccessDx(i)), x.fastAccessDx(i));
+      }
+      SACADO_FAD_THREAD_SINGLE
+        atomic_add(&(dst->val()), x.val());
+    }
+
+  } // namespace Fad
+
+} // namespace Sacado
+
+#endif // HAVE_SACADO_KOKKOSCORE

--- a/packages/sacado/src/Sacado_MathFunctions.hpp
+++ b/packages/sacado/src/Sacado_MathFunctions.hpp
@@ -429,6 +429,100 @@ BINARYFUNC_MACRO(min, MinOp)
 
 #undef BINARYFUNC_MACRO
 
+#if defined(HAVE_SACADO_KOKKOSCORE)
+
+namespace Sacado {
+#ifndef SACADO_NEW_FAD_DESIGN_IS_DEFAULT
+  namespace Fad {
+    template <typename ValT, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr;
+    template <typename T> class DFad;
+    template <typename T, int N> class SFad;
+    template <typename T, int N> class SLFad;
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(DFad<T>* dst, const DFad<T>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SFad<T,N>* dst, const SFad<T,N>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SLFad<T,N>* dst, const SLFad<T,N>& x);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+  }
+#endif
+  namespace ELRFad {
+    template <typename ValT, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr;
+    template <typename T> class DFad;
+    template <typename T, int N> class SFad;
+    template <typename T, int N> class SLFad;
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(DFad<T>* dst, const DFad<T>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SFad<T,N>* dst, const SFad<T,N>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SLFad<T,N>* dst, const SLFad<T,N>& x);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+  }
+  namespace CacheFad {
+    template <typename ValT, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr;
+    template <typename T> class DFad;
+    template <typename T, int N> class SFad;
+    template <typename T, int N> class SLFad;
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(DFad<T>* dst, const DFad<T>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SFad<T,N>* dst, const SFad<T,N>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SLFad<T,N>* dst, const SLFad<T,N>& x);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+  }
+  namespace ELRCacheFad {
+    template <typename ValT, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr;
+    template <typename T> class DFad;
+    template <typename T, int N> class SFad;
+    template <typename T, int N> class SLFad;
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(DFad<T>* dst, const DFad<T>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SFad<T,N>* dst, const SFad<T,N>& x);
+    template <typename T, int N>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(SLFad<T,N>* dst, const SLFad<T,N>& x);
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+  }
+}
+
+namespace Kokkos {
+#ifndef SACADO_NEW_FAD_DESIGN_IS_DEFAULT
+  using Sacado::Fad::atomic_add;
+#endif
+  using Sacado::ELRFad::atomic_add;
+  using Sacado::CacheFad::atomic_add;
+  using Sacado::ELRCacheFad::atomic_add;
+}
+
+#endif
+
 #ifdef SACADO_ENABLE_NEW_DESIGN
 #include "Sacado_Fad_Exp_MathFunctions.hpp"
 #endif

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ExprAssign.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ExprAssign.hpp
@@ -35,10 +35,20 @@ namespace Sacado {
   namespace Fad {
   namespace Exp {
 
+#ifndef SACADO_FAD_DERIV_LOOP
 #if defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDA_ARCH__)
 #define SACADO_FAD_DERIV_LOOP(I,SZ) for (int I=threadIdx.x; I<SZ; I+=blockDim.x)
 #else
 #define SACADO_FAD_DERIV_LOOP(I,SZ) for (int I=0; I<SZ; ++I)
+#endif
+#endif
+
+#ifndef SACADO_FAD_THREAD_SINGLE
+#if (defined(SACADO_VIEW_CUDA_HIERARCHICAL) || defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDA_ARCH__)
+#define SACADO_FAD_THREAD_SINGLE if (threadIdx.x == 0)
+#else
+#define SACADO_FAD_THREAD_SINGLE /* */
+#endif
 #endif
 
     //! Class that implements various forms of expression assignments

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_MathFunctions.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_MathFunctions.hpp
@@ -128,4 +128,30 @@ BINARYFUNC_MACRO(min, MinOp)
 
 #undef BINARYFUNC_MACRO
 
+#if defined(HAVE_SACADO_KOKKOSCORE)
+
+namespace Sacado {
+  namespace Fad {
+  namespace Exp {
+    template <typename S> class GeneralFad;
+    template <typename ValT, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr;
+
+    template <typename S>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(GeneralFad<S>* dst, const GeneralFad<S>& x);
+
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& x);
+  }
+  }
+}
+
+namespace Kokkos {
+  using Sacado::Fad::Exp::atomic_add;
+}
+
+#endif
+
 #endif // SACADO_FAD_EXP_MATHFUNCTIONS_HPP

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewFad.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewFad.hpp
@@ -33,6 +33,11 @@
 #include "Sacado_Fad_Exp_GeneralFad.hpp"
 #include "Sacado_Fad_Exp_ViewStorage.hpp"
 
+#if defined(HAVE_SACADO_KOKKOSCORE)
+#include "Kokkos_Atomic.hpp"
+#include "impl/Kokkos_Error.hpp"
+#endif
+
 namespace Sacado {
 
   namespace Fad {
@@ -40,6 +45,58 @@ namespace Sacado {
 
     template <typename T, unsigned static_length, unsigned static_stride, typename U>
     using  ViewFad = GeneralFad< ViewStorage<T,static_length,static_stride,U> >;
+
+    // Class representing a pointer to ViewFad so that &ViewFad is supported
+    template <typename T, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr : public ViewFad<T,sl,ss,U> {
+    public:
+
+      // Storage type base class
+      typedef ViewFad<T,sl,ss,U> view_fad_type;
+
+      // Bring in constructors
+      using view_fad_type::view_fad_type;
+
+      // Add overload of dereference operator
+      KOKKOS_INLINE_FUNCTION
+      view_fad_type* operator->() { return this; }
+
+      // Add overload of dereference operator
+      KOKKOS_INLINE_FUNCTION
+      view_fad_type& operator*() { *this; }
+    };
+
+#if defined(HAVE_SACADO_KOKKOSCORE)
+    // Overload of Kokkos::atomic_add for ViewFad types.
+    template <typename ValT, unsigned sl, unsigned ss, typename U, typename T>
+    KOKKOS_INLINE_FUNCTION
+    void atomic_add(ViewFadPtr<ValT,sl,ss,U> dst, const Expr<T>& xx) {
+      using Kokkos::atomic_add;
+
+      const typename Expr<T>::derived_type& x = xx.derived();
+
+      const int xsz = x.size();
+      const int sz = dst->size();
+
+      // We currently cannot handle resizing since that would need to be
+      // done atomically.
+      if (xsz > sz)
+        Kokkos::abort(
+          "Sacado error: Fad resize within atomic_add() not supported!");
+
+      if (xsz != sz && sz > 0 && xsz > 0)
+        Kokkos::abort(
+          "Sacado error: Fad assignment of incompatiable sizes!");
+
+
+      if (sz > 0 && xsz > 0) {
+        SACADO_FAD_DERIV_LOOP(i,sz)
+          atomic_add(&(dst->fastAccessDx(i)), x.fastAccessDx(i));
+      }
+      SACADO_FAD_THREAD_SINGLE
+        atomic_add(&(dst->val()), x.val());
+    }
+#endif
 
   } // namespace Exp
   } // namespace Fad

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -31,6 +31,7 @@
 #define SACADO_FAD_EXP_VIEWSTORAGE_HPP
 
 #include <type_traits>
+#include <memory>
 
 #include "Sacado_DynamicArrayTraits.hpp"
 #include "Sacado_mpl_integral_nonzero_constant.hpp"
@@ -39,6 +40,10 @@ namespace Sacado {
 
   namespace Fad {
   namespace Exp {
+
+    // Class representing a pointer to ViewFad so that &ViewFad is supported
+    template <typename T, unsigned sl, unsigned ss, typename U>
+    class ViewFadPtr;
 
     /*!
      * \brief Derivative array storage class that is a view into a contiguous
@@ -110,7 +115,7 @@ namespace Sacado {
       //! Assignment
       KOKKOS_INLINE_FUNCTION
       ViewStorage& operator=(const ViewStorage& x) {
-        if (this != &x) {
+        if (this != std::addressof(x)) {
           *val_ = *x.val_;
           if (stride_one)
             for (int i=0; i<sz_.value; ++i)
@@ -188,6 +193,13 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       const T& fastAccessDx(int i) const {
         return dx_[ stride_one ? i : i * stride_.value ];
+      }
+
+      //! Overload of addressof operator
+      KOKKOS_INLINE_FUNCTION
+      ViewFadPtr<T,static_length,static_stride,U> operator&() const {
+        return ViewFadPtr<T,static_length,static_stride,U>(
+          this->dx_, this->val_, this->sz_.value, this->stride_.value);
       }
 
     protected:

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -61,7 +61,7 @@ bool checkFads(const FadType1& x, const FadType2& x2,
   TEUCHOS_TEST_EQUALITY(x.size(), x2.size(), out, success);
 
   // Check values match
-  TEUCHOS_TEST_EQUALITY(x.val(), x2.val(), out, success);
+  TEUCHOS_TEST_FLOATING_EQUALITY(x.val(), x2.val(), tol, out, success);
 
   // Check derivatives match
   for (int i=0; i<x.size(); ++i)
@@ -373,6 +373,69 @@ struct AssignRank2Rank1Kernel {
     else {
       range_policy_type policy( 0, nrow );
       Kokkos::parallel_for( policy, AssignRank2Rank1Kernel(v1,v2,col) );
+    }
+  }
+};
+
+// Kernel to test atomic_add
+template <typename ViewType, typename ScalarViewType>
+struct AtomicAddKernel {
+  typedef typename ViewType::execution_space execution_space;
+  typedef typename ViewType::size_type size_type;
+  typedef Kokkos::TeamPolicy< execution_space> team_policy_type;
+  typedef Kokkos::RangePolicy< execution_space> range_policy_type;
+  typedef typename team_policy_type::member_type team_handle;
+  typedef typename Kokkos::ThreadLocalScalarType<ViewType>::type local_scalar_type;
+  static const size_type stride = Kokkos::ViewScalarStride<ViewType>::stride;
+
+  const ViewType m_v;
+  const ScalarViewType m_s;
+
+  AtomicAddKernel(const ViewType& v, const ScalarViewType& s) :
+    m_v(v), m_s(s) {};
+
+  // Multiply entries for row 'i' with a value
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const size_type i) const {
+    Kokkos::atomic_add(&(m_s()), m_v(i));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()( const team_handle& team ) const
+  {
+    const size_type i = team.league_rank()*team.team_size() + team.team_rank();
+    if (i < m_v.extent(0))
+      (*this)(i);
+  }
+
+  // Kernel launch
+  static void apply(const ViewType& v, const ScalarViewType& s) {
+    const size_type nrow = v.extent(0);
+
+#if defined (KOKKOS_ENABLE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL)
+    const bool use_team =
+      std::is_same<execution_space, Kokkos::Cuda>::value &&
+      ( Kokkos::is_view_fad_contiguous<ViewType>::value ||
+        Kokkos::is_dynrankview_fad_contiguous<ViewType>::value ) &&
+      ( stride > 1 );
+#elif defined (KOKKOS_ENABLE_CUDA) && defined (SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)
+    const bool use_team =
+      std::is_same<execution_space, Kokkos::Cuda>::value &&
+      ( Kokkos::is_view_fad_contiguous<ViewType>::value ||
+        Kokkos::is_dynrankview_fad_contiguous<ViewType>::value ) &&
+      is_dfad<typename ViewType::non_const_value_type>::value;
+#else
+    const bool use_team = false;
+#endif
+
+    if (use_team) {
+      const size_type team_size = 256 / stride;
+      team_policy_type policy( (nrow+team_size-1)/team_size, team_size, stride );
+      Kokkos::parallel_for( policy, AtomicAddKernel(v,s) );
+    }
+    else {
+      range_policy_type policy( 0, nrow );
+      Kokkos::parallel_for( policy, AtomicAddKernel(v,s) );
     }
   }
 };
@@ -881,6 +944,50 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   // Check
   FadType f3 = f0 * f1;
   success = checkFads(f3, f2, out);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AtomicAdd, FadType, Layout, Device )
+{
+  typedef Kokkos::View<FadType*,Layout,Device> ViewType;
+  typedef Kokkos::View<FadType,Layout,Device> ScalarViewType;
+  typedef typename ViewType::size_type size_type;
+  typedef typename ScalarViewType::HostMirror host_scalar_view_type;
+
+  const size_type num_rows = global_num_rows;
+  const size_type fad_size = global_fad_size;
+
+  // Create and fill view
+  ViewType v;
+#if defined (SACADO_DISABLE_FAD_VIEW_SPEC)
+  v = ViewType ("view", num_rows);
+#else
+  v = ViewType ("view", num_rows, fad_size+1);
+#endif
+  FadType a(fad_size, 2.3456);
+  for (size_type i=0; i<fad_size; ++i)
+    a.fastAccessDx(i) = 7.89+i;
+  Kokkos::deep_copy( v, a );
+
+  // Create scalar view
+  ScalarViewType s;
+#if defined (SACADO_DISABLE_FAD_VIEW_SPEC)
+  s = ScalarViewType ("scalar view");
+#else
+  s = ScalarViewType ("scalar view", fad_size+1);
+#endif
+  Kokkos::deep_copy( s, FadType(fad_size,0.0) );
+
+  // Call atomic_add kernel, which adds up entries in v
+  AtomicAddKernel<ViewType,ScalarViewType>::apply( v, s );
+
+  // Copy to host
+  host_scalar_view_type hs = Kokkos::create_mirror_view(s);
+  Kokkos::deep_copy(hs, s);
+
+  // Check
+  FadType b = num_rows*a;
+  success = checkFads(b, hs(), out);
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
@@ -1925,6 +2032,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, MultiplyUpdate, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, MultiplyConst, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, MultiplyMixed, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AtomicAdd, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, Rank8, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, Roger, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AssignDifferentStrides, F, L, D ) \

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -397,7 +397,8 @@ struct AtomicAddKernel {
   // Multiply entries for row 'i' with a value
   KOKKOS_INLINE_FUNCTION
   void operator() (const size_type i) const {
-    Kokkos::atomic_add(&(m_s()), m_v(i));
+    local_scalar_type x = m_v(i);
+    Kokkos::atomic_add(&(m_s()), x);
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Requested by @CamelliaDPG.  This provides overloads of Kokkos::atomic_add() for all Fad types.  It also implements operator&() for ViewFad, allowing you to do things like 
```
Kokkos::atomic_add(&v(i,j,k),x);
```
Note that because of this overload, ViewFad::operator&() does not return ViewFad*, which required a small change in Phalanx.  Since you could only safely take the address of a ViewFad in limited situations, I am hoping this kind of change is not needed in many places.