### PR TITLE
MueLu coarse coordinates

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_Elasticity3DProblem.hpp
+++ b/packages/galeri/src-xpetra/Galeri_Elasticity3DProblem.hpp
@@ -61,7 +61,9 @@ namespace Galeri {
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     class Elasticity3DProblem : public Problem<Map,Matrix,MultiVector> {
     public:
+      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
       Elasticity3DProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map) : Problem<Map,Matrix,MultiVector>(list, map) {
+
         E  = list.get("E", Teuchos::as<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>(1e9));
         nu = list.get("nu", Teuchos::as<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>(0.25));
 
@@ -83,9 +85,9 @@ namespace Galeri {
         TEUCHOS_TEST_FOR_EXCEPTION(nx_ <= 0 || ny_ <= 0 || nz_ <= 0, std::logic_error, "nx, ny and nz must be positive");
       }
 
-      Teuchos::RCP<Matrix>      BuildMatrix();
-      Teuchos::RCP<MultiVector> BuildNullspace();
-      Teuchos::RCP<MultiVector> BuildCoords();
+      Teuchos::RCP<Matrix>                BuildMatrix();
+      Teuchos::RCP<MultiVector>           BuildNullspace();
+      Teuchos::RCP<RealValuedMultiVector> BuildCoords();
 
     private:
       typedef Scalar        SC;
@@ -331,16 +333,19 @@ namespace Galeri {
     }
 
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
-    RCP<MultiVector> Elasticity3DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildCoords() {
+    RCP<typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector>
+    Elasticity3DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildCoords() {
+      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
       // FIXME: map here is an extended map, with multiple DOF per node
       // as we cannot construct a single DOF map in Problem, we repeat the coords
-      this->Coords_ = MultiVectorTraits<Map,MultiVector>::Build(this->Map_, nDim_);
+      this->Coords_ = MultiVectorTraits<Map,RealValuedMultiVector>::Build(this->Map_, nDim_);
 
+      typedef typename RealValuedMultiVector::scalar_type real_type;
       typedef Teuchos::ScalarTraits<Scalar> TST;
 
-      Teuchos::ArrayRCP<SC> x = this->Coords_->getDataNonConst(0);
-      Teuchos::ArrayRCP<SC> y = this->Coords_->getDataNonConst(1);
-      Teuchos::ArrayRCP<SC> z = this->Coords_->getDataNonConst(2);
+      Teuchos::ArrayRCP<real_type> x = this->Coords_->getDataNonConst(0);
+      Teuchos::ArrayRCP<real_type> y = this->Coords_->getDataNonConst(1);
+      Teuchos::ArrayRCP<real_type> z = this->Coords_->getDataNonConst(2);
 
       Teuchos::ArrayView<const GO> GIDs = this->Map_->getNodeElementList();
 
@@ -365,7 +370,9 @@ namespace Galeri {
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     RCP<MultiVector> Elasticity3DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildNullspace() {
 
+      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
       typedef Teuchos::ScalarTraits<Scalar> TST;
+      typedef typename RealValuedMultiVector::scalar_type real_type;
 
       const int numVectors = 6;
       this->Nullspace_ = MultiVectorTraits<Map,MultiVector>::Build(this->Map_, numVectors);
@@ -376,9 +383,9 @@ namespace Galeri {
       Teuchos::ArrayView<const GO> GIDs = this->Map_->getNodeElementList();
 
       size_t          numDofs = this->Map_->getNodeNumElements();
-      Teuchos::ArrayRCP<SC> x = this->Coords_->getDataNonConst(0);
-      Teuchos::ArrayRCP<SC> y = this->Coords_->getDataNonConst(1);
-      Teuchos::ArrayRCP<SC> z = this->Coords_->getDataNonConst(2);
+      Teuchos::ArrayRCP<real_type> x = this->Coords_->getDataNonConst(0);
+      Teuchos::ArrayRCP<real_type> y = this->Coords_->getDataNonConst(1);
+      Teuchos::ArrayRCP<real_type> z = this->Coords_->getDataNonConst(2);
 
       SC one = TST::one();
 
@@ -394,9 +401,9 @@ namespace Galeri {
       }
 
       // Calculate center
-      SC cx = this->Coords_->getVector(0)->meanValue();
-      SC cy = this->Coords_->getVector(1)->meanValue();
-      SC cz = this->Coords_->getVector(2)->meanValue();
+      real_type cx = this->Coords_->getVector(0)->meanValue();
+      real_type cy = this->Coords_->getVector(1)->meanValue();
+      real_type cz = this->Coords_->getVector(2)->meanValue();
 
       // Rotations
       Teuchos::ArrayRCP<SC> R0 = this->Nullspace_->getDataNonConst(3), R1 = this->Nullspace_->getDataNonConst(4), R2 = this->Nullspace_->getDataNonConst(5);

--- a/packages/galeri/src-xpetra/Galeri_MultiVectorTraits.hpp
+++ b/packages/galeri/src-xpetra/Galeri_MultiVectorTraits.hpp
@@ -98,6 +98,7 @@ namespace Galeri {
     class MultiVectorTraits<Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>,Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > {
     public:
       typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> type;
+      typedef Tpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node> type_real;
 
       static Teuchos::RCP<Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > Build(const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& map, size_t num) {
         return Teuchos::rcp(new Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>(map, num));
@@ -111,6 +112,7 @@ namespace Galeri {
     class MultiVectorTraits<Map,::Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > {
     public:
       typedef ::Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> type;
+      typedef ::Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node> type_real;
 
       static Teuchos::RCP< ::Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > Build(const Teuchos::RCP<const Map>& map, size_t num) {
         return ::Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(map, num);

--- a/packages/galeri/src-xpetra/Galeri_Problem.hpp
+++ b/packages/galeri/src-xpetra/Galeri_Problem.hpp
@@ -50,6 +50,7 @@
 #include <Teuchos_RCP.hpp>
 
 #include "Galeri_ConfigDefs.h"
+#include "Galeri_MultiVectorTraits.hpp"
 
 namespace Galeri {
 
@@ -69,6 +70,8 @@ namespace Galeri {
     template<typename Map, typename Matrix, typename MultiVector>
     class Problem : public Teuchos::Describable {
     public:
+      using RealValuedMultiVector = typename MultiVectorTraits<Map,MultiVector>::type_real;
+
       Problem(Teuchos::ParameterList& list) : list_(list) {
         SetBoundary();
       };
@@ -78,29 +81,29 @@ namespace Galeri {
       };
       virtual ~Problem() { }
 
-      virtual Teuchos::RCP<Matrix>      BuildMatrix() = 0;
-      virtual Teuchos::RCP<MultiVector> BuildCoords() {
+      virtual Teuchos::RCP<Matrix>                BuildMatrix() = 0;
+      virtual Teuchos::RCP<RealValuedMultiVector> BuildCoords() {
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "Coordinates construction is not implemented for this problem");
       }
-      virtual Teuchos::RCP<MultiVector> BuildNullspace() {
+      virtual Teuchos::RCP<MultiVector>           BuildNullspace() {
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "Nullspace construction is not implemented for this problem");
       }
 
       // Get methods
-      Teuchos::RCP<const Map>           getMap()                                   const { return Map_; }
-      Teuchos::RCP<const Matrix>        getMatrix()                                const { return A_; }
-      Teuchos::RCP<const MultiVector>   getNullspace()                             const { return Nullspace_; }
-      Teuchos::RCP<const MultiVector>   getCoords()                                const { return Coords_; }
+      Teuchos::RCP<const Map>                     getMap()                                   const { return Map_; }
+      Teuchos::RCP<const Matrix>                  getMatrix()                                const { return A_; }
+      Teuchos::RCP<const MultiVector>             getNullspace()                             const { return Nullspace_; }
+      Teuchos::RCP<const RealValuedMultiVector>   getCoords()                                const { return Coords_; }
 
       // Set methods
       void                              setMap(const Teuchos::RCP<const Map>& map)       { Map_ = map; }
 
     protected:
-      Teuchos::ParameterList&           list_;
-      Teuchos::RCP<const Map>           Map_;
-      Teuchos::RCP<Matrix>              A_;
-      Teuchos::RCP<MultiVector>         Nullspace_;
-      Teuchos::RCP<MultiVector>         Coords_;
+      Teuchos::ParameterList&             list_;
+      Teuchos::RCP<const Map>             Map_;
+      Teuchos::RCP<Matrix>                A_;
+      Teuchos::RCP<MultiVector>           Nullspace_;
+      Teuchos::RCP<RealValuedMultiVector> Coords_;
 
       DirBC                             DirichletBC_;
 

--- a/packages/galeri/src-xpetra/Galeri_StencilProblems.hpp
+++ b/packages/galeri/src-xpetra/Galeri_StencilProblems.hpp
@@ -51,6 +51,7 @@
 
 #include "Galeri_Problem.hpp"
 #include "Galeri_XpetraMatrixTypes.hpp"
+#include "Galeri_XpetraUtils.hpp"
 
 namespace Galeri {
 
@@ -60,8 +61,11 @@ namespace Galeri {
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     class Laplace1DProblem : public Problem<Map,Matrix,MultiVector> {
     public:
+      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
+
       Laplace1DProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map) : Problem<Map,Matrix,MultiVector>(list, map) { }
       Teuchos::RCP<Matrix> BuildMatrix();
+      Teuchos::RCP<RealValuedMultiVector> BuildCoords();
     };
 
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
@@ -74,6 +78,22 @@ namespace Galeri {
       this->A_ = TriDiag<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix>(this->Map_, nx, 2.0, -1.0, -1.0);
       this->A_->setObjectLabel(this->getObjectLabel());
       return this->A_;
+    }
+
+    template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+    Teuchos::RCP<typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector> Laplace1DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildCoords() {
+      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
+
+      GlobalOrdinal nx = this->list_.get("nx", (GlobalOrdinal) -1);
+
+      if (nx == -1) {
+        nx = this->Map_->getGlobalNumElements();
+      }
+
+      Utils::CreateCartesianCoordinates<typename RealValuedMultiVector::scalar_type, LocalOrdinal, GlobalOrdinal, Map, RealValuedMultiVector>("1D", this->Map_, this->list_);
+
+      return this->Coords_;
+
     }
 
     // =============================================  Laplace2D  =============================================

--- a/packages/galeri/src-xpetra/Galeri_XpetraUtils.hpp
+++ b/packages/galeri/src-xpetra/Galeri_XpetraUtils.hpp
@@ -74,19 +74,20 @@ namespace Galeri {
 
     public:
 
-    template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename MultiVector>
-    static Teuchos::RCP<MultiVector>
+    template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename RealValuedMultiVector>
+    static Teuchos::RCP<RealValuedMultiVector>
     CreateCartesianCoordinates(std::string const &coordType, RCP<const Map> const & map, Teuchos::ParameterList& list) {
       using Galeri::Xpetra::VectorTraits;
+      typedef typename RealValuedMultiVector::scalar_type real_type;
 
-      Teuchos::RCP<MultiVector> coordinates;
+      Teuchos::RCP<RealValuedMultiVector> coordinates;
 
       GlobalOrdinal ix, iy, iz;
-      Scalar delta_x, delta_y, delta_z;
+      real_type delta_x, delta_y, delta_z;
 
-      Scalar lx = Teuchos::as<Scalar>(list.get<double>("lx", 1) * list.get<double>("stretchx", 1));
-      Scalar ly = Teuchos::as<Scalar>(list.get<double>("ly", 1) * list.get<double>("stretchy", 1));
-      Scalar lz = Teuchos::as<Scalar>(list.get<double>("lz", 1) * list.get<double>("stretchz", 1));
+      real_type lx = Teuchos::as<real_type>(list.get<double>("lx", 1) * list.get<double>("stretchx", 1));
+      real_type ly = Teuchos::as<real_type>(list.get<double>("ly", 1) * list.get<double>("stretchy", 1));
+      real_type lz = Teuchos::as<real_type>(list.get<double>("lz", 1) * list.get<double>("stretchz", 1));
 
       GlobalOrdinal nx = list.get<GlobalOrdinal>("nx", -1);
       GlobalOrdinal ny = list.get<GlobalOrdinal>("ny", -1);
@@ -97,44 +98,44 @@ namespace Galeri {
       Teuchos::ArrayView<const GlobalOrdinal> MyGlobalElements = map->getNodeElementList();
 
       if (coordType == "1D") {
-        coordinates = VectorTraits<Map,MultiVector>::Build(map, 1, false);
-        Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar> > Coord(1);
+        coordinates = VectorTraits<Map,RealValuedMultiVector>::Build(map, 1, false);
+        Teuchos::ArrayRCP<Teuchos::ArrayRCP<real_type> > Coord(1);
         Coord[0] = coordinates->getDataNonConst(0);
 
-        delta_x = lx / Teuchos::as<Scalar>(nx - 1);
+        delta_x = lx / Teuchos::as<real_type>(nx - 1);
 
         for (size_t i = 0; i < NumMyElements; ++i) {
           ix = MyGlobalElements[i];
-          Coord[0][i] = delta_x * Teuchos::as<Scalar>(ix);
+          Coord[0][i] = delta_x * Teuchos::as<real_type>(ix);
         }
 
       } else if (coordType == "2D") {
-        coordinates = VectorTraits<Map,MultiVector>::Build(map, 2, false);
-        Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar> > Coord(2);
+        coordinates = VectorTraits<Map,RealValuedMultiVector>::Build(map, 2, false);
+        Teuchos::ArrayRCP<Teuchos::ArrayRCP<real_type> > Coord(2);
         Coord[0] = coordinates->getDataNonConst(0);
         Coord[1] = coordinates->getDataNonConst(1);
 
-        delta_x = lx / Teuchos::as<Scalar>(nx - 1);
-        delta_y = ly / Teuchos::as<Scalar>(ny - 1);
+        delta_x = lx / Teuchos::as<real_type>(nx - 1);
+        delta_y = ly / Teuchos::as<real_type>(ny - 1);
 
         for (size_t i = 0; i < NumMyElements; ++i) {
           ix = MyGlobalElements[i] % nx;
           iy = (MyGlobalElements[i] - ix) / nx;
 
-          Coord[0][i] = delta_x * Teuchos::as<Scalar>(ix);
-          Coord[1][i] = delta_y * Teuchos::as<Scalar>(iy);
+          Coord[0][i] = delta_x * Teuchos::as<real_type>(ix);
+          Coord[1][i] = delta_y * Teuchos::as<real_type>(iy);
         }
 
       } else if (coordType == "3D") {
-        coordinates = VectorTraits<Map,MultiVector>::Build(map, 3, false);
-        Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar> > Coord(3);
+        coordinates = VectorTraits<Map,RealValuedMultiVector>::Build(map, 3, false);
+        Teuchos::ArrayRCP<Teuchos::ArrayRCP<real_type> > Coord(3);
         Coord[0] = coordinates->getDataNonConst(0);
         Coord[1] = coordinates->getDataNonConst(1);
         Coord[2] = coordinates->getDataNonConst(2);
 
-        delta_x = lx / Teuchos::as<Scalar>(nx - 1);
-        delta_y = ly / Teuchos::as<Scalar>(ny - 1);
-        delta_z = lz / Teuchos::as<Scalar>(nz - 1);
+        delta_x = lx / Teuchos::as<real_type>(nx - 1);
+        delta_y = ly / Teuchos::as<real_type>(ny - 1);
+        delta_z = lz / Teuchos::as<real_type>(nz - 1);
 
         for (size_t i = 0; i < NumMyElements; i++) {
           GlobalOrdinal ixy = MyGlobalElements[i] % (nx * ny);
@@ -143,9 +144,9 @@ namespace Galeri {
           ix = ixy % nx;
           iy = (ixy - ix) / nx;
 
-          Coord[0][i] = delta_x * Teuchos::as<Scalar>(ix);
-          Coord[1][i] = delta_y * Teuchos::as<Scalar>(iy);
-          Coord[2][i] = delta_z * Teuchos::as<Scalar>(iz);
+          Coord[0][i] = delta_x * Teuchos::as<real_type>(ix);
+          Coord[1][i] = delta_y * Teuchos::as<real_type>(iy);
+          Coord[2][i] = delta_z * Teuchos::as<real_type>(iz);
         }
 
       } else {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -647,7 +647,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SparseDirectSolver, SC
     Galeri::Xpetra::CreateMap<LO, GO, Node> (xpetraParameters.GetLib (),
                                              "Cartesian2D", comm, GaleriList);
   RCP<Galeri::Xpetra::Problem<XMapType,XCrsType,XMVectorType> > Pr =
-    Galeri::Xpetra::BuildProblem<SC,LO,GO,XMapType,XCrsType,XMVectorType> (std::string ("Laplace2D"),
+    Galeri::Xpetra::BuildProblem<SC,LO,GO,XMapType,XCrsType,XMVectorType> (std::string("Laplace2D"),
                                                                            xmap, GaleriList);
 
   RCP<XCrsType> XA = Pr->BuildMatrix ();

--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuTpetraQ2Q1PreconditionerFactory_def.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuTpetraQ2Q1PreconditionerFactory_def.hpp
@@ -633,6 +633,8 @@ namespace Thyra {
     // difference is that pressure has to go first, so that velocity can use
     // some of pressure data
     RCP<FactoryManager> M11 = rcp(new FactoryManager()), M22 = rcp(new FactoryManager());
+    M11->SetKokkosRefactor(paramList.get<bool>("use kokkos refactor"));
+    M22->SetKokkosRefactor(paramList.get<bool>("use kokkos refactor"));
     SetBlockDependencyTree(*M11, 0, 0, "velocity", paramList);
     SetBlockDependencyTree(*M22, 1, 1, "pressure", paramList);
 

--- a/packages/muelu/adapters/tpetra/MueLu_ShiftedLaplacian_decl.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_ShiftedLaplacian_decl.hpp
@@ -60,6 +60,7 @@
 
 #include <MueLu_BaseClass.hpp>
 #include <MueLu_CoalesceDropFactory_fwd.hpp>
+#include <MueLu_CoarseMapFactory_fwd.hpp>
 #include <MueLu_CoupledAggregationFactory_fwd.hpp>
 #include <MueLu_CoupledRBMFactory_fwd.hpp>
 #include <MueLu_DirectSolver_fwd.hpp>
@@ -285,6 +286,7 @@ namespace MueLu {
     RCP<CoalesceDropFactory>          Dropfact_;
     RCP<CoupledAggregationFactory>    Aggfact_;
     RCP<UncoupledAggregationFactory>  UCaggfact_;
+    RCP<CoarseMapFactory>             CoarseMapfact_;
     RCP<SmootherPrototype>            smooProto_, coarsestSmooProto_;
     RCP<SmootherFactory>              smooFact_,  coarsestSmooFact_;
     Teuchos::ParameterList            coarsestSmooList_;

--- a/packages/muelu/adapters/tpetra/MueLu_ShiftedLaplacian_def.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_ShiftedLaplacian_def.hpp
@@ -51,6 +51,7 @@
 #if defined(HAVE_MUELU_IFPACK2) and defined(HAVE_MUELU_TPETRA)
 
 #include <MueLu_CoalesceDropFactory.hpp>
+#include <MueLu_CoarseMapFactory.hpp>
 #include <MueLu_CoupledAggregationFactory.hpp>
 #include <MueLu_CoupledRBMFactory.hpp>
 #include <MueLu_DirectSolver.hpp>
@@ -221,17 +222,18 @@ void ShiftedLaplacian<Scalar,LocalOrdinal,GlobalOrdinal,Node>::setLevelShifts(st
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ShiftedLaplacian<Scalar,LocalOrdinal,GlobalOrdinal,Node>::initialize() {
 
-  TentPfact_ = rcp( new TentativePFactory           );
-  Pfact_     = rcp( new SaPFactory                  );
-  PgPfact_   = rcp( new PgPFactory                  );
-  TransPfact_= rcp( new TransPFactory               );
-  Rfact_     = rcp( new GenericRFactory             );
-  Acfact_    = rcp( new RAPFactory                  );
-  Acshift_   = rcp( new RAPShiftFactory             );
-  Dropfact_  = rcp( new CoalesceDropFactory         );
-  Aggfact_   = rcp( new CoupledAggregationFactory   );
-  UCaggfact_ = rcp( new UncoupledAggregationFactory );
-  Manager_   = rcp( new FactoryManager              );
+  TentPfact_     = rcp( new TentativePFactory           );
+  Pfact_         = rcp( new SaPFactory                  );
+  PgPfact_       = rcp( new PgPFactory                  );
+  TransPfact_    = rcp( new TransPFactory               );
+  Rfact_         = rcp( new GenericRFactory             );
+  Acfact_        = rcp( new RAPFactory                  );
+  Acshift_       = rcp( new RAPShiftFactory             );
+  Dropfact_      = rcp( new CoalesceDropFactory         );
+  Aggfact_       = rcp( new CoupledAggregationFactory   );
+  UCaggfact_     = rcp( new UncoupledAggregationFactory );
+  CoarseMapfact_ = rcp( new CoarseMapFactory            );
+  Manager_       = rcp( new FactoryManager              );
   if(isSymmetric_==true) {
     Manager_   -> SetFactory("P", Pfact_);
     Manager_   -> SetFactory("R", TransPfact_);
@@ -253,6 +255,7 @@ void ShiftedLaplacian<Scalar,LocalOrdinal,GlobalOrdinal,Node>::initialize() {
   else {
     Manager_   -> SetFactory("Aggregates", UCaggfact_ );
   }
+  Manager_     -> SetFactory("CoarseMap", CoarseMapfact_);
 
   // choose smoother
   if(Smoother_=="jacobi") {

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -902,6 +902,15 @@
       <visible>false</visible>
     </parameter>
 
+    <parameter>
+      <name>tentative: build coarse coordinates</name>
+      <type>bool</type>
+      <default>true</default>
+      <description>If false, skip the calculation of coarse coordinates.</description>
+      <visible>false</visible>
+      <comment-ML>not supported by ML</comment-ML>
+    </parameter>
+
   </multigrid>
 
   <rebalancing>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -184,6 +184,8 @@
         
 \cbb{tentative: calculate qr}{bool}{true}{If false, skip local QR decomposition phase of smoothed aggregation.}
         
+\cbb{tentative: build coarse coordinates}{bool}{true}{If false, skip the calculation of coarse coordinates.}
+        
 \cbb{repartition: enable}{bool}{false}{Rebalancing on/off switch.}
         
 \cbb{repartition: partitioner}{string}{"zoltan2"}{Partitioning package to use. Possible values: "zoltan" (\zoltan{} library), "zoltan2" (\zoltantwo{} library).}

--- a/packages/muelu/example/advanced/blockcrs/BlockCrs.cpp
+++ b/packages/muelu/example/advanced/blockcrs/BlockCrs.cpp
@@ -202,6 +202,7 @@ namespace MueLuExamples {
 
     typedef typename Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
     typedef typename Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> multivector_type;
+    typedef typename Xpetra::MultiVector<double,LocalOrdinal,GlobalOrdinal,Node> realvaluedmultivector_type;
     typedef typename Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node> matrixwrap_type;
     RCP<const map_type >   map;
     RCP<multivector_type > coordinates;
@@ -228,7 +229,7 @@ namespace MueLuExamples {
         << "========================================================" << std::endl;
 
     RCP<Galeri::Xpetra::Problem<map_type,matrixwrap_type,multivector_type> > Pr =
-        Galeri::Xpetra::BuildProblem<Scalar,LocalOrdinal,GlobalOrdinal,map_type,matrixwrap_type,multivector_type>(matrixType, map, galeriList);
+      Galeri::Xpetra::BuildProblem<Scalar,LocalOrdinal,GlobalOrdinal,map_type,matrixwrap_type,multivector_type>(matrixType, map, galeriList);
 
     A = Pr->BuildMatrix();
 

--- a/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
+++ b/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
@@ -199,7 +199,7 @@ namespace MueLuExamples {
         << "========================================================" << std::endl;
 
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriList);
+      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriList);
 
     A = Pr->BuildMatrix();
 

--- a/packages/muelu/example/advanced/multiplesolve/StandardReuse.cpp
+++ b/packages/muelu/example/advanced/multiplesolve/StandardReuse.cpp
@@ -138,7 +138,7 @@ void ConstructData(const std::string& matrixType, Teuchos::ParameterList& galeri
   }
 
   RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriList);
+    Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriList);
   A = Pr->BuildMatrix();
 
   if (matrixType == "Elasticity2D" ||

--- a/packages/muelu/example/basic/Simple.cpp
+++ b/packages/muelu/example/basic/Simple.cpp
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
     case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
     case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
   }
-  
+
   if (xpetraParameters.GetLib() == Xpetra::UseEpetra) {
     throw std::invalid_argument("This example only supports Tpetra.");
   }

--- a/packages/muelu/research/q2q1/Q2Q1.cpp
+++ b/packages/muelu/research/q2q1/Q2Q1.cpp
@@ -324,11 +324,11 @@ int main(int argc, char *argv[]) {
     std::cout << "Input parameters: " << *stratimikosList << std::endl;
 
     // Stratimikos vodou
-    typedef Thyra::PreconditionerFactoryBase<SC>         Base;
+    typedef Thyra::PreconditionerFactoryBase<SC>             Base;
     typedef Thyra::Ifpack2PreconditionerFactory<tCrsMatrix > Impl;
-    typedef Thyra::LinearOpWithSolveFactoryBase<SC>      LOWSFB;
-    typedef Thyra::LinearOpWithSolveBase<SC>             LOWSB;
-    typedef Thyra::MultiVectorBase<SC>                   TH_Mvb;
+    typedef Thyra::LinearOpWithSolveFactoryBase<SC>          LOWSFB;
+    typedef Thyra::LinearOpWithSolveBase<SC>                 LOWSB;
+    typedef Thyra::MultiVectorBase<SC>                       TH_Mvb;
 
     Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
 
@@ -373,8 +373,8 @@ int main(int argc, char *argv[]) {
     // Set the initial guess Dirichlet points to the proper value.
     // This step is pretty important as the preconditioner may return zero at Dirichlet points
     ArrayRCP<const bool> dirBCs = Utilities::DetectDirichletRows(*MueLu::TpetraCrs_To_XpetraMatrix(rcp_dynamic_cast<tCrsMatrix>(A)));
-    ArrayRCP<SC>        tXdata = tX->getDataNonConst(0);
-    ArrayRCP<const SC>  tBdata = tB->getData(0);
+    ArrayRCP<SC>         tXdata = tX->getDataNonConst(0);
+    ArrayRCP<const SC>   tBdata = tB->getData(0);
     for (LO i = 0; i < tXdata.size(); i++)
       if (dirBCs[i])
         tXdata[i] = tBdata[i];

--- a/packages/muelu/research/q2q1/driver.xml
+++ b/packages/muelu/research/q2q1/driver.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter name="max levels"                  type="int"      value="3"/>
   <Parameter name="coarse: max size"            type="int"      value="1"/>
+  <Parameter name="use kokkos refactor"         type="bool"     value="false"/>
 
   <Parameter name="multigrid algorithm"         type="string"   value="emin"/>
   <Parameter name="emin: num iterations"        type="int"      value="1"/>

--- a/packages/muelu/research/semicoarsening/driver.cpp
+++ b/packages/muelu/research/semicoarsening/driver.cpp
@@ -249,7 +249,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     // Construct the matrix based on the problem name and provided
     // parameters.
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
+      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
     A = Pr->BuildMatrix();
 
   } else {

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -170,10 +170,10 @@ namespace MueLu {
 
     if (paramList.isSublist("Hierarchy")) {
       SetFactoryParameterList(paramList);
+
     } else if (paramList.isParameter("MueLu preconditioner") == true) {
       this->GetOStream(Runtime0) << "Use facade class: " << paramList.get<std::string>("MueLu preconditioner")  << std::endl;
       Teuchos::RCP<ParameterList> pp = facadeFact_->SetParameterList(paramList);
-
       SetFactoryParameterList(*pp);
 
     }  else {
@@ -973,6 +973,7 @@ namespace MueLu {
     if (defaultList.isSublist("matrixmatrix: kernel params"))
       ptentParams.sublist("matrixmatrix: kernel params", false) = defaultList.sublist("matrixmatrix: kernel params");
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: calculate qr", bool, ptentParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: build coarse coordinates", bool, ptentParams);
     Ptent->SetParameterList(ptentParams);
     Ptent->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
     Ptent->SetFactory("CoarseMap",  manager.GetFactory("CoarseMap"));

--- a/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_kokkos_def.hpp
@@ -167,19 +167,19 @@ namespace MueLu {
       typename AppendTrait<decltype(fineCoordsView), Kokkos::RandomAccess>::type fineCoordsRandomView = fineCoordsView;
       for (size_t j = 0; j < dim; j++) {
         Kokkos::parallel_for("MueLu:CoordinatesTransferF:Build:coord", Kokkos::RangePolicy<local_ordinal_type, execution_space>(0, numAggs),
-          KOKKOS_LAMBDA(const LO i) {
-            // A row in this graph represents all node ids in the aggregate
-            // Therefore, averaging is very easy
+                             KOKKOS_LAMBDA(const LO i) {
+                               // A row in this graph represents all node ids in the aggregate
+                               // Therefore, averaging is very easy
 
-            auto aggregate = aggGraph.rowConst(i);
+                               auto aggregate = aggGraph.rowConst(i);
 
-            double sum = 0.0; // do not use Scalar here (Stokhos)
-            for (size_t colID = 0; colID < static_cast<size_t>(aggregate.length); colID++)
-              sum += fineCoordsRandomView(aggregate(colID),j);
+                               double sum = 0.0; // do not use Scalar here (Stokhos)
+                               for (size_t colID = 0; colID < static_cast<size_t>(aggregate.length); colID++)
+                                 sum += fineCoordsRandomView(aggregate(colID),j);
 
-            coarseCoordsView(i,j) = sum / aggregate.length;
-          });
-        }
+                               coarseCoordsView(i,j) = sum / aggregate.length;
+                             });
+      }
     }
 
     Set<RCP<doubleMultiVector> >(coarseLevel, "Coordinates", coarseCoords);

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_def.hpp
@@ -46,8 +46,6 @@
 #ifndef MUELU_FACTORYMANAGER_DEF_HPP
 #define MUELU_FACTORYMANAGER_DEF_HPP
 
-#include "MueLu_FactoryManager_decl.hpp"
-
 #include <Teuchos_ParameterList.hpp>
 
 // Headers for factories used by default:
@@ -55,6 +53,7 @@
 #include "MueLu_CoalesceDropFactory.hpp"
 #include "MueLu_CoarseMapFactory.hpp"
 #include "MueLu_ConstraintFactory.hpp"
+#include "MueLu_CoordinatesTransferFactory.hpp"
 #include "MueLu_DirectSolver.hpp"
 #include "MueLu_LineDetectionFactory.hpp"
 // #include "MueLu_MultiVectorTransferFactory.hpp"
@@ -76,11 +75,14 @@
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
 #include "MueLu_CoalesceDropFactory_kokkos.hpp"
 #include "MueLu_CoarseMapFactory_kokkos.hpp"
+#include "MueLu_CoordinatesTransferFactory_kokkos.hpp"
 #include "MueLu_NullspaceFactory_kokkos.hpp"
 #include "MueLu_SaPFactory_kokkos.hpp"
 #include "MueLu_TentativePFactory_kokkos.hpp"
 #include "MueLu_UncoupledAggregationFactory_kokkos.hpp"
 #endif
+
+#include "MueLu_FactoryManager_decl.hpp"
 
 
 namespace MueLu {
@@ -157,6 +159,7 @@ namespace MueLu {
         factory->SetFactory("Nullspace", GetFactory("Ptent"));
         return SetAndReturnDefaultFactory(varName, factory);
       }
+      if (varName == "Coordinates")                     return GetFactory("Ptent");
 
       if (varName == "R")                               return SetAndReturnDefaultFactory(varName, rcp(new TransPFactory()));
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)

--- a/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
@@ -113,7 +113,7 @@ namespace MueLu {
           else if(name == "Coordinates") //Scalar of Coordinates MV is always double
           {
             level->AddKeepFlag(name,NoFactory::get(),MueLu::UserData);
-            level->Set(name, Teuchos::getValue<RCP<Xpetra::MultiVector<double, LocalOrdinal, GlobalOrdinal, Node> > >(it2->second), NoFactory::get());
+            level->Set(name, Teuchos::getValue<RCP<RealValuedMultiVector> >(it2->second), NoFactory::get());
             //M->SetFactory(name, NoFactory::getRCP()); // TAW: generally it is a bad idea to overwrite the factory manager data here
           }
 #ifdef HAVE_MUELU_INTREPID2

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -234,6 +234,7 @@ namespace MueLu {
   "<Parameter name=\"emin: pattern\" type=\"string\" value=\"AkPtent\"/>"
   "<Parameter name=\"emin: pattern order\" type=\"int\" value=\"1\"/>"
   "<Parameter name=\"tentative: calculate qr\" type=\"bool\" value=\"true\"/>"
+  "<Parameter name=\"tentative: build coarse coordinates\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"repartition: enable\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"repartition: partitioner\" type=\"string\" value=\"zoltan2\"/>"
   "<ParameterList name=\"repartition: params\"/>"
@@ -608,6 +609,8 @@ namespace MueLu {
          ("emin: pattern order","emin: pattern order")
       
          ("tentative: calculate qr","tentative: calculate qr")
+      
+         ("tentative: build coarse coordinates","tentative: build coarse coordinates")
       
          ("repartition: enable","repartition: enable")
       

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_decl.hpp
@@ -159,6 +159,8 @@ namespace MueLu {
                          RCP<const Map> coarseMap, RCP<Matrix>& Ptentative, RCP<MultiVector>& coarseNullspace) const;
     bool isGoodMap(const Map& rowMap, const Map& colMap) const;
 
+    mutable bool bTransferCoordinates_ = false;
+
   }; //class TentativePFactory
 
 } //namespace MueLu

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -79,6 +79,7 @@ namespace MueLu {
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))
     SET_VALID_ENTRY("tentative: calculate qr");
+    SET_VALID_ENTRY("tentative: build coarse coordinates");
 #undef  SET_VALID_ENTRY
 
     validParamList->set< RCP<const FactoryBase> >("A",                  Teuchos::null, "Generating factory of the matrix A");
@@ -86,6 +87,7 @@ namespace MueLu {
     validParamList->set< RCP<const FactoryBase> >("Nullspace",          Teuchos::null, "Generating factory of the nullspace");
     validParamList->set< RCP<const FactoryBase> >("UnAmalgamationInfo", Teuchos::null, "Generating factory of UnAmalgamationInfo");
     validParamList->set< RCP<const FactoryBase> >("CoarseMap",          Teuchos::null, "Generating factory of the coarse map");
+    validParamList->set< RCP<const FactoryBase> >("Coordinates",        Teuchos::null, "Generating factory of the coordinates");
 
     // Make sure we don't recursively validate options for the matrixmatrix kernels
     ParameterList norecurse;
@@ -97,11 +99,22 @@ namespace MueLu {
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
   void TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+
+    const ParameterList& pL = GetParameterList();
+
     Input(fineLevel, "A");
     Input(fineLevel, "Aggregates");
     Input(fineLevel, "Nullspace");
     Input(fineLevel, "UnAmalgamationInfo");
     Input(fineLevel, "CoarseMap");
+    if( fineLevel.GetLevelID() == 0 &&
+        fineLevel.IsAvailable("Coordinates", NoFactory::get()) &&     // we have coordinates (provided by user app)
+        pL.get<bool>("tentative: build coarse coordinates") ) {       // and we want coordinates on other levels
+      bTransferCoordinates_ = true;                                   // then set the transfer coordinates flag to true
+      Input(fineLevel, "Coordinates");
+    } else if (bTransferCoordinates_) {
+      Input(fineLevel, "Coordinates");
+    }
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -112,18 +125,86 @@ namespace MueLu {
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
   void TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLevel, Level& coarseLevel) const {
     FactoryMonitor m(*this, "Build", coarseLevel);
+    typedef typename RealValuedMultiVector::scalar_type coord_type;
 
-    RCP<Matrix>           A             = Get< RCP<Matrix> >          (fineLevel, "A");
-    RCP<Aggregates>       aggregates    = Get< RCP<Aggregates> >      (fineLevel, "Aggregates");
-    RCP<AmalgamationInfo> amalgInfo     = Get< RCP<AmalgamationInfo> >(fineLevel, "UnAmalgamationInfo");
-    RCP<MultiVector>      fineNullspace = Get< RCP<MultiVector> >     (fineLevel, "Nullspace");
-    RCP<const Map>        coarseMap     = Get< RCP<const Map> >       (fineLevel, "CoarseMap");
+    RCP<Matrix>                A             = Get< RCP<Matrix> >               (fineLevel, "A");
+    RCP<Aggregates>            aggregates    = Get< RCP<Aggregates> >           (fineLevel, "Aggregates");
+    RCP<AmalgamationInfo>      amalgInfo     = Get< RCP<AmalgamationInfo> >     (fineLevel, "UnAmalgamationInfo");
+    RCP<MultiVector>           fineNullspace = Get< RCP<MultiVector> >          (fineLevel, "Nullspace");
+    RCP<const Map>             coarseMap     = Get< RCP<const Map> >            (fineLevel, "CoarseMap");
+    RCP<RealValuedMultiVector> fineCoords;
+    if(bTransferCoordinates_) {
+      fineCoords = Get< RCP<RealValuedMultiVector> >(fineLevel, "Coordinates");
+    }
 
     TEUCHOS_TEST_FOR_EXCEPTION(A->getRowMap()->getNodeNumElements() != fineNullspace->getMap()->getNodeNumElements(),
 			       Exceptions::RuntimeError,"MueLu::TentativePFactory::MakeTentative: Size mismatch between A and Nullspace");
 
-    RCP<Matrix>           Ptentative;
-    RCP<MultiVector>      coarseNullspace;
+    RCP<Matrix>                Ptentative;
+    RCP<MultiVector>           coarseNullspace;
+    RCP<RealValuedMultiVector> coarseCoords;
+
+    if(bTransferCoordinates_) {
+      //*** Create the coarse coordinates ***
+      // First create the coarse map and coarse multivector
+      ArrayView<const GO> elementAList = coarseMap->getNodeElementList();
+      LO                  blkSize      = 1;
+      if (rcp_dynamic_cast<const StridedMap>(coarseMap) != Teuchos::null)
+        blkSize = rcp_dynamic_cast<const StridedMap>(coarseMap)->getFixedBlockSize();
+      GO                  indexBase     = coarseMap->getIndexBase();
+      size_t              numNodes      = elementAList.size() / blkSize;
+      Array<GO>           nodeList(numNodes);
+      const int           numDimensions = fineCoords->getNumVectors();
+
+      for (LO i = 0; i < Teuchos::as<LO>(numNodes); i++) {
+        nodeList[i] = (elementAList[i*blkSize]-indexBase)/blkSize + indexBase;
+      }
+      RCP<const Map> coarseCoordsMap = MapFactory::Build(fineCoords->getMap()->lib(),
+                                                         Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
+                                                         nodeList,
+                                                         indexBase,
+                                                         fineCoords->getMap()->getComm());
+      coarseCoords = RealValuedMultiVectorFactory::Build(coarseCoordsMap, numDimensions);
+
+      // Create overlapped fine coordinates to reduce global communication
+      RCP<RealValuedMultiVector> ghostedCoords;
+      if (aggregates->AggregatesCrossProcessors()) {
+        RCP<const Map>    aggMap = aggregates->GetMap();
+        RCP<const Import> importer     = ImportFactory::Build(fineCoords->getMap(), aggMap);
+
+        ghostedCoords = RealValuedMultiVectorFactory::Build(aggMap, numDimensions);
+        ghostedCoords->doImport(*fineCoords, *importer, Xpetra::INSERT);
+      } else {
+        ghostedCoords = fineCoords;
+      }
+
+      // Get some info about aggregates
+      int                         myPID        = coarseCoordsMap->getComm()->getRank();
+      LO                          numAggs      = aggregates->GetNumAggregates();
+      ArrayRCP<LO>                aggSizes     = aggregates->ComputeAggregateSizes();
+      const ArrayRCP<const LO>    vertex2AggID = aggregates->GetVertex2AggId()->getData(0);
+      const ArrayRCP<const LO>    procWinner   = aggregates->GetProcWinner()->getData(0);
+
+      // Fill in coarse coordinates
+      for (int dim = 0; dim < numDimensions; ++dim) {
+        ArrayRCP<const coord_type> fineCoordsData = ghostedCoords->getData(dim);
+        ArrayRCP<coord_type>     coarseCoordsData = coarseCoords->getDataNonConst(dim);
+
+        for (LO lnode = 0; lnode < numNodes; lnode++) {
+          if (procWinner[lnode] == myPID &&
+              lnode < vertex2AggID.size() &&
+              lnode < fineCoordsData.size() &&
+              vertex2AggID[lnode] < coarseCoordsData.size() &&
+              Teuchos::ScalarTraits<double>::isnaninf(fineCoordsData[lnode]) == false) {
+            coarseCoordsData[vertex2AggID[lnode]] += fineCoordsData[lnode];
+          }
+        }
+        for (LO agg = 0; agg < numAggs; agg++) {
+          coarseCoordsData[agg] /= aggSizes[agg];
+        }
+      }
+    }
+
     if (!aggregates->AggregatesCrossProcessors())
       BuildPuncoupled(A, aggregates, amalgInfo, fineNullspace, coarseMap, Ptentative, coarseNullspace,coarseLevel.GetLevelID());
     else
@@ -145,8 +226,11 @@ namespace MueLu {
     else
       Ptentative->CreateView("stridedMaps", Ptentative->getRangeMap(),   coarseMap);
 
-    Set(coarseLevel, "Nullspace", coarseNullspace);
-    Set(coarseLevel, "P",         Ptentative);
+    if(bTransferCoordinates_) {
+      Set(coarseLevel, "Coordinates", coarseCoords);
+    }
+    Set(coarseLevel, "Nullspace",   coarseNullspace);
+    Set(coarseLevel, "P",           Ptentative);
 
     if (IsPrint(Statistics2)) {
       RCP<ParameterList> params = rcp(new ParameterList());

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
@@ -164,6 +164,8 @@ namespace MueLu {
     void BuildPcoupled  (RCP<Matrix> A, RCP<Aggregates_kokkos> aggregates, RCP<AmalgamationInfo> amalgInfo, RCP<MultiVector> fineNullspace,
                          RCP<const Map> coarseMap, RCP<Matrix>& Ptentative, RCP<MultiVector>& coarseNullspace) const;
 
+    mutable bool bTransferCoordinates_ = false;
+
   };
 
 } //namespace MueLu

--- a/packages/muelu/test/convergence/Convergence.cpp
+++ b/packages/muelu/test/convergence/Convergence.cpp
@@ -226,7 +226,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
 #endif
 
       RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-          Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriParameters);
+        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriParameters);
       A = Pr->BuildMatrix();
 
       if (matrixType == "Elasticity2D" ||

--- a/packages/muelu/test/helmholtz/Helmholtz1D.cpp
+++ b/packages/muelu/test/helmholtz/Helmholtz1D.cpp
@@ -120,7 +120,7 @@ int main(int argc, char *argv[]) {
     RCP<TimeMonitor> tm = rcp (new TimeMonitor(*TimeMonitor::getNewTimer("ScalingTest: 1 - Matrix Build")));
 
     Teuchos::ParameterList pl = matrixParameters.GetParameterList();
-    RCP<MultiVector> coordinates;
+    RCP<RealValuedMultiVector> coordinates;
     Teuchos::ParameterList galeriList;
     galeriList.set("nx", pl.get("nx", nx));
     galeriList.set("ny", pl.get("ny", ny));
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
     RCP<const Map> map;
 
     map = MapFactory::Build(xpetraParameters.GetLib(), matrixParameters.GetNumGlobalElements(), 0, comm);
-    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, MultiVector>("1D", map, matrixParameters.GetParameterList());
+    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, RealValuedMultiVector>("1D", map, matrixParameters.GetParameterList());
 
     RCP<const Tpetra::Map<LO, GO, NO> > tmap = Xpetra::toTpetra(map);
 

--- a/packages/muelu/test/helmholtz/Helmholtz2D.cpp
+++ b/packages/muelu/test/helmholtz/Helmholtz2D.cpp
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
     //****************************************//
 
     Teuchos::ParameterList pl = matrixParameters_aux.GetParameterList();
-    RCP<MultiVector> coordinates;
+    RCP<RealValuedMultiVector> coordinates;
     Teuchos::ParameterList galeriList;
     galeriList.set("nx", pl.get("nx", nx));
     galeriList.set("ny", pl.get("ny", ny));
@@ -140,7 +140,7 @@ int main(int argc, char *argv[]) {
     RCP<const Map> map;
 
     map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian2D", comm, galeriList);
-    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, MultiVector>("2D", map, matrixParameters_aux.GetParameterList());
+    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, RealValuedMultiVector>("2D", map, matrixParameters_aux.GetParameterList());
 
     RCP<const Tpetra::Map<LO, GO, NO> > tmap = Xpetra::toTpetra(map);
 
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
       RCP<Galeri::Xpetra::Problem_Helmholtz<Map,CrsMatrixWrap,MultiVector> > Pr_helmholtz =
         Galeri::Xpetra::BuildProblem_Helmholtz<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixParameters_helmholtz.GetMatrixType(), map, matrixParams_helmholtz);
       RCP<Matrix> Amat = Pr_helmholtz->BuildMatrix();
-      
+
       RCP<Galeri::Xpetra::Problem_Helmholtz<Map,CrsMatrixWrap,MultiVector> > Pr_shifted =
         Galeri::Xpetra::BuildProblem_Helmholtz<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixParameters_shifted.GetMatrixType(), map, matrixParams_shifted);
       RCP<Matrix> Pmat = Pr_shifted->BuildMatrix();

--- a/packages/muelu/test/helmholtz/Helmholtz3D.cpp
+++ b/packages/muelu/test/helmholtz/Helmholtz3D.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
     RCP<TimeMonitor> tm = rcp (new TimeMonitor(*TimeMonitor::getNewTimer("ScalingTest: 1 - Matrix Build")));
 
     Teuchos::ParameterList pl = matrixParameters_helmholtz.GetParameterList();
-    RCP<MultiVector> coordinates;
+    RCP<RealValuedMultiVector> coordinates;
     Teuchos::ParameterList galeriList;
     galeriList.set("nx", pl.get("nx", nx));
     galeriList.set("ny", pl.get("ny", ny));
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
     RCP<const Map> map;
 
     map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
-    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, MultiVector>("3D", map, matrixParameters_helmholtz.GetParameterList());
+    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, RealValuedMultiVector>("3D", map, matrixParameters_helmholtz.GetParameterList());
 
     RCP<const Tpetra::Map<LO, GO, NO> > tmap = Xpetra::toTpetra(map);
 

--- a/packages/muelu/test/helmholtz/HelmholtzFEM2D.cpp
+++ b/packages/muelu/test/helmholtz/HelmholtzFEM2D.cpp
@@ -139,15 +139,15 @@ int main(int argc, char *argv[]) {
     RCP<TimeMonitor> tm = rcp (new TimeMonitor(*TimeMonitor::getNewTimer("ScalingTest: 1 - Matrix Build")));
 
     Teuchos::ParameterList pl = matrixParameters_helmholtz.GetParameterList();
-    RCP<MultiVector> coordinates;
+    RCP<RealValuedMultiVector> coordinates;
     Teuchos::ParameterList galeriList;
     galeriList.set("nx", pl.get("nx", nx));
     galeriList.set("ny", pl.get("ny", ny));
     galeriList.set("nz", pl.get("nz", nz));
     RCP<const Map> map;
-    
+
     map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian2D", comm, galeriList);
-    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, MultiVector>("2D", map, matrixParameters_helmholtz.GetParameterList());
+    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, RealValuedMultiVector>("2D", map, matrixParameters_helmholtz.GetParameterList());
 
     RCP<const Tpetra::Map<LO, GO, NO> > tmap = Xpetra::toTpetra(map);
 

--- a/packages/muelu/test/helmholtz/HelmholtzFEM3D.cpp
+++ b/packages/muelu/test/helmholtz/HelmholtzFEM3D.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
     RCP<TimeMonitor> tm = rcp (new TimeMonitor(*TimeMonitor::getNewTimer("ScalingTest: 1 - Matrix Build")));
 
     Teuchos::ParameterList pl = matrixParameters_helmholtz.GetParameterList();
-    RCP<MultiVector> coordinates;
+    RCP<RealValuedMultiVector> coordinates;
     Teuchos::ParameterList galeriList;
     galeriList.set("nx", pl.get("nx", nx));
     galeriList.set("ny", pl.get("ny", ny));
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
     RCP<const Map> map;
 
     map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
-    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, MultiVector>("3D", map, matrixParameters_helmholtz.GetParameterList());
+    coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC, LO, GO, Map, RealValuedMultiVector>("3D", map, matrixParameters_helmholtz.GetParameterList());
 
     RCP<const Tpetra::Map<LO, GO, NO> > tmap = Xpetra::toTpetra(map);
 

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -172,7 +172,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         found = baseFile.find("_np");
         jumpOut = true;
       }
-      
+
       if (numProc == 1 && found != std::string::npos) {
 #ifdef HAVE_MPI
         baseFile = baseFile.substr(0, found);
@@ -182,7 +182,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 #endif
       }
       std::cout << "Testing: "<< xmlFile << std::endl;
-      
+
       baseFile = baseFile + (lib == Xpetra::UseEpetra ? "_epetra" : "_tpetra");
       std::string goldFile = baseFile + ".gold";
       std::ifstream f(goldFile.c_str());

--- a/packages/muelu/test/interface/complex/Output/MLcoarse1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse1b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -329,6 +333,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -379,6 +383,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse2b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -352,6 +356,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse3b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse4b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse5_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse5_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse5_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLempty_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLempty_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLemptyb_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLpgamg1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLpgamg1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -118,6 +119,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -191,6 +193,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -264,6 +267,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLpgamg1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -138,6 +139,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -221,6 +223,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -304,6 +307,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLpgamg1b_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -191,6 +193,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -263,6 +266,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLpgamg2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLpgamg2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLpgamg2b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -214,6 +216,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -295,6 +298,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother1b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother2b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother3b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother4b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/MLunsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLunsmoothed1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -108,6 +109,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -172,6 +174,7 @@ Level 3
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -236,6 +239,7 @@ Level 4
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/complex/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLunsmoothed1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -128,6 +129,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -202,6 +204,7 @@ Level 3
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -276,6 +279,7 @@ Level 4
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/complex/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLunsmoothed1b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation2_epetra.gold
@@ -37,6 +37,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -97,6 +98,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation2_tpetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -117,6 +118,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation3_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation3_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -155,6 +156,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation5_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation5_epetra.gold
@@ -39,6 +39,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation5_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation5_np4_epetra.gold
@@ -39,6 +39,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation5_np4_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -129,6 +130,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation5_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -129,6 +130,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse2_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -352,6 +356,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse2_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -317,6 +320,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -402,6 +406,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse3_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse3_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_e3d_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_mhd_np4_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -117,6 +118,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_mhd_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -117,6 +118,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/complex/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_p2d_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_p3d_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_pg_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_pg_np4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_pg_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_pg_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_epetra.gold
@@ -54,6 +54,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -169,6 +170,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -284,6 +286,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_epetra.gold
@@ -54,6 +54,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -317,6 +319,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_epetra.gold
@@ -54,6 +54,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -169,6 +170,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -284,6 +286,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_epetra.gold
@@ -54,6 +54,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -317,6 +319,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +146,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +146,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin3_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin3_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +146,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/empty_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/empty_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_1_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_1_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_1_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_1_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/pg1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/pg1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/pg2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/pg2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -316,6 +318,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -432,6 +435,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -309,6 +311,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -425,6 +428,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -339,6 +341,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -465,6 +468,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -346,6 +348,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -472,6 +475,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -316,6 +318,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -432,6 +435,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -309,6 +311,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -425,6 +428,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -339,6 +341,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -465,6 +468,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -346,6 +348,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -472,6 +475,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -387,6 +389,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -380,6 +382,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -420,6 +422,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -427,6 +429,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_epetra.gold
@@ -49,6 +49,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -153,6 +154,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -338,6 +340,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_epetra.gold
@@ -49,6 +49,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -153,6 +154,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -331,6 +333,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -59,6 +59,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -173,6 +174,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -371,6 +373,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
@@ -59,6 +59,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -173,6 +174,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -378,6 +380,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/complex/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother10_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother10_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother11_epetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother11_tpetra.gold
@@ -81,6 +81,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -185,6 +186,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother12_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -196,6 +198,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -269,6 +272,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -342,6 +346,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother12_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -317,6 +320,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -402,6 +406,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother13_epetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother13_tpetra.gold
@@ -69,6 +69,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -161,6 +162,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother2_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother2_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother3_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother3_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother4_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother4_tpetra.gold
@@ -43,6 +43,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother5_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother5_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother6_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother6_tpetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother9_epetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother9_tpetra.gold
@@ -69,6 +69,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -161,6 +162,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/sync1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/sync1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -143,6 +144,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/complex/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/complex/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/complex/Output/unsmoothed1_epetra.gold
@@ -46,6 +46,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -109,6 +110,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/unsmoothed1_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -129,6 +130,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLcoarse1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -329,6 +333,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -379,6 +383,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -352,6 +356,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse5_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse5_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse5_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLempty_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLempty_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLemptyb_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLpgamg1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -118,6 +119,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -191,6 +193,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -264,6 +267,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -138,6 +139,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -221,6 +223,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -304,6 +307,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1b_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -191,6 +193,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -263,6 +266,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLpgamg2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg2b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -214,6 +216,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -295,6 +298,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -155,6 +156,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -262,6 +264,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -369,6 +372,7 @@ Level 4
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -476,6 +480,7 @@ Level 5
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -175,6 +176,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -292,6 +294,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -409,6 +412,7 @@ Level 4
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -526,6 +530,7 @@ Level 5
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -155,6 +156,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -262,6 +264,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -369,6 +372,7 @@ Level 4
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -175,6 +176,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -292,6 +294,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -409,6 +412,7 @@ Level 4
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -155,6 +156,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -262,6 +264,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -369,6 +372,7 @@ Level 4
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -175,6 +176,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -292,6 +294,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -409,6 +412,7 @@ Level 4
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/MLsmoother1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -116,6 +117,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -187,6 +189,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -258,6 +261,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -136,6 +137,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -217,6 +219,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -298,6 +301,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -114,6 +115,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -184,6 +186,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -254,6 +257,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -274,6 +277,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
@@ -51,6 +51,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -273,6 +276,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -108,6 +109,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -172,6 +174,7 @@ Level 3
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -236,6 +239,7 @@ Level 4
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -128,6 +129,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -202,6 +204,7 @@ Level 3
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -276,6 +279,7 @@ Level 4
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1b_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation2_epetra.gold
@@ -37,6 +37,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -97,6 +98,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation2_tpetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -117,6 +118,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation3_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -155,6 +156,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation5_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_epetra.gold
@@ -39,6 +39,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation5_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_np4_epetra.gold
@@ -39,6 +39,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -129,6 +130,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -129,6 +130,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse2_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -277,6 +280,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -352,6 +356,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse2_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -317,6 +320,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -402,6 +406,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse3_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse3_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -117,6 +118,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
@@ -52,6 +52,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -117,6 +118,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_np4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
@@ -57,6 +57,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -175,6 +176,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -293,6 +295,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
@@ -57,6 +57,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -60,6 +60,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -60,6 +60,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -181,6 +182,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -302,6 +304,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
@@ -57,6 +57,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -175,6 +176,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -293,6 +295,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
@@ -57,6 +57,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -60,6 +60,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -60,6 +60,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -181,6 +182,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -302,6 +304,7 @@ Level 3
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +146,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +146,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -125,6 +126,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +146,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/empty_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/empty_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -202,6 +204,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -232,6 +234,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -124,6 +125,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -199,6 +201,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -144,6 +145,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -229,6 +231,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg1_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg2_epetra.gold
@@ -47,6 +47,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +140,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -316,6 +318,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -432,6 +435,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -309,6 +311,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -425,6 +428,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -339,6 +341,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -465,6 +468,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -346,6 +348,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -472,6 +475,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -316,6 +318,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -432,6 +435,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -309,6 +311,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -425,6 +428,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -339,6 +341,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -465,6 +468,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -346,6 +348,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -472,6 +475,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -387,6 +389,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +172,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -380,6 +382,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -420,6 +422,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -191,6 +192,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -427,6 +429,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
@@ -49,6 +49,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -153,6 +154,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -338,6 +340,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
@@ -49,6 +49,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -153,6 +154,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -331,6 +333,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -59,6 +59,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -173,6 +174,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -371,6 +373,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -59,6 +59,7 @@ Level 1
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -173,6 +174,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -378,6 +380,7 @@ Level 2
      Domain GID offsets = {0}   [default]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/default/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother10_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother11_epetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
@@ -81,6 +81,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -185,6 +186,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -196,6 +198,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -269,6 +272,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -342,6 +346,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -214,6 +216,7 @@ Level 3
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -293,6 +296,7 @@ Level 4
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -372,6 +376,7 @@ Level 5
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_epetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
@@ -63,6 +63,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,6 +150,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother2_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother3_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother4_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
@@ -43,6 +43,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother6_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
@@ -50,6 +50,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_epetra.gold
@@ -57,6 +57,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
@@ -63,6 +63,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,6 +150,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/sync1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +128,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -147,6 +148,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose1_epetra.gold
@@ -52,6 +52,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
@@ -62,6 +62,7 @@ Level 1
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -143,6 +144,7 @@ Level 2
    Domain GID offsets = {0}   [default]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
@@ -55,6 +55,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +160,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -65,6 +65,7 @@ Level 1
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -179,6 +180,7 @@ Level 2
       Domain GID offsets = {0}   [default]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_epetra.gold
@@ -46,6 +46,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -109,6 +110,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -129,6 +130,7 @@ Level 2
   Domain GID offsets = {0}   [default]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -291,16 +287,19 @@ Level 4
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -308,27 +307,23 @@ Level 5
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -341,16 +337,19 @@ Level 4
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -358,27 +357,23 @@ Level 5
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -312,6 +320,8 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse4b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLempty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLempty_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLemptyb_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_epetra.gold
@@ -11,15 +11,18 @@ Level 0
  
 Level 1
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -81,15 +80,18 @@ Level 1
  
 Level 2
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -97,27 +99,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -154,15 +152,18 @@ Level 2
  
 Level 3
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -170,27 +171,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -227,15 +224,18 @@ Level 3
  
 Level 4
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -243,27 +243,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
@@ -21,15 +21,18 @@ Level 0
  
 Level 1
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -101,15 +100,18 @@ Level 1
  
 Level 2
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -117,27 +119,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -184,15 +182,18 @@ Level 2
  
 Level 3
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -200,27 +201,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -267,15 +264,18 @@ Level 3
  
 Level 4
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -283,27 +283,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +115,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -182,6 +186,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -251,6 +257,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg2_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg2b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -117,6 +119,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -190,6 +194,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -263,6 +269,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_epetra.gold
@@ -10,15 +10,18 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -26,24 +29,20 @@ Level 1
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -71,15 +70,18 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -87,27 +89,23 @@ Level 2
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -135,15 +133,18 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -151,27 +152,23 @@ Level 3
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -199,15 +196,18 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -215,27 +215,23 @@ Level 4
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
@@ -20,15 +20,18 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -36,24 +39,20 @@ Level 1
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -91,15 +90,18 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -107,27 +109,23 @@ Level 2
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -165,15 +163,18 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -181,27 +182,23 @@ Level 3
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -239,15 +236,18 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -255,27 +255,23 @@ Level 4
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1b_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +117,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +137,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +212,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse2_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +251,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -312,6 +320,8 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse2_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +212,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -285,6 +291,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -362,6 +370,8 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse3_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse3_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_e3d_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
@@ -49,6 +49,8 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -111,6 +113,8 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
@@ -49,6 +49,8 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -111,6 +113,8 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_p2d_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_p3d_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_epetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +111,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_epetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +111,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +135,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +135,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_epetra.gold
@@ -46,6 +46,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -149,6 +151,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -252,6 +256,8 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_epetra.gold
@@ -46,6 +46,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -285,6 +289,8 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_epetra.gold
@@ -46,6 +46,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -149,6 +151,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -252,6 +256,8 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_epetra.gold
@@ -46,6 +46,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -285,6 +289,8 @@ Level 3
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +121,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +141,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin2_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +121,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin2_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +141,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin3_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +121,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin3_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -139,6 +141,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/empty_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/empty_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +212,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +182,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +212,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +110,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +179,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +130,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +209,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +110,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +179,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +130,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +209,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +110,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +179,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +130,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +209,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -108,6 +110,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +179,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -128,6 +130,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -205,6 +209,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +115,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +135,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg2_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +115,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg2_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +135,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -284,6 +288,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -388,6 +394,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -277,6 +281,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -381,6 +387,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -307,6 +311,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -421,6 +427,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -314,6 +318,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -428,6 +434,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -284,6 +288,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -388,6 +394,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -277,6 +281,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -381,6 +387,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -307,6 +311,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -421,6 +427,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -314,6 +318,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -428,6 +434,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -349,6 +353,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -151,6 +153,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -342,6 +346,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -382,6 +386,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -171,6 +173,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -389,6 +393,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_epetra.gold
@@ -46,6 +46,8 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -143,6 +145,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -317,6 +321,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_epetra.gold
@@ -46,6 +46,8 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -143,6 +145,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -310,6 +314,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -56,6 +56,8 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -163,6 +165,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -350,6 +354,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
@@ -56,6 +56,8 @@ Level 1
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -163,6 +165,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -357,6 +361,8 @@ Level 2
      Build (MueLu::CoarseMapFactory_kokkos)
      [empty list]
      
+    tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother10_epetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +109,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother10_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother11_epetra.gold
@@ -49,6 +49,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +123,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother11_tpetra.gold
@@ -73,6 +73,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -169,6 +171,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother12_epetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +109,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -172,6 +176,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -237,6 +243,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -302,6 +310,8 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother12_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +212,8 @@ Level 3
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -285,6 +291,8 @@ Level 4
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -362,6 +370,8 @@ Level 5
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother13_epetra.gold
@@ -49,6 +49,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +123,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother13_tpetra.gold
@@ -61,6 +61,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +147,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother2_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother2_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother3_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother3_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother4_epetra.gold
@@ -35,6 +35,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -93,6 +95,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother4_tpetra.gold
@@ -35,6 +35,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -93,6 +95,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother5_epetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +109,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother5_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother6_epetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +109,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother6_tpetra.gold
@@ -42,6 +42,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +109,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother9_epetra.gold
@@ -49,6 +49,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +123,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother9_tpetra.gold
@@ -61,6 +61,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -145,6 +147,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/sync1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +113,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/sync1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -131,6 +133,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose1_epetra.gold
@@ -44,6 +44,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -107,6 +109,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose1_tpetra.gold
@@ -54,6 +54,8 @@ Level 1
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -127,6 +129,8 @@ Level 2
    Build (MueLu::CoarseMapFactory_kokkos)
    [empty list]
    
+  tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_epetra.gold
@@ -47,6 +47,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -139,6 +141,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
@@ -57,6 +57,8 @@ Level 1
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -159,6 +161,8 @@ Level 2
       Build (MueLu::CoarseMapFactory_kokkos)
       [empty list]
       
+     tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_epetra.gold
@@ -43,6 +43,8 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -103,6 +105,8 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
@@ -53,6 +53,8 @@ Level 1
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -123,6 +125,8 @@ Level 2
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
   
+ tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
@@ -13,16 +13,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0.01
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = distance laplacian
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -30,24 +33,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -23,16 +23,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0.01
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = distance laplacian
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -40,24 +43,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -291,16 +287,19 @@ Level 4
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -308,27 +307,23 @@ Level 5
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -341,16 +337,19 @@ Level 4
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -358,27 +357,23 @@ Level 5
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -317,6 +321,7 @@ Level 5
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLempty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLempty_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLemptyb_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_epetra.gold
@@ -11,15 +11,18 @@ Level 0
  
 Level 1
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -81,15 +80,18 @@ Level 1
  
 Level 2
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -97,27 +99,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -154,15 +152,18 @@ Level 2
  
 Level 3
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -170,27 +171,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -227,15 +224,18 @@ Level 3
  
 Level 4
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -243,27 +243,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
@@ -21,15 +21,18 @@ Level 0
  
 Level 1
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -101,15 +100,18 @@ Level 1
  
 Level 2
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -117,27 +119,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -184,15 +182,18 @@ Level 2
  
 Level 3
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -200,27 +201,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -267,15 +264,18 @@ Level 3
  
 Level 4
  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -283,27 +283,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -185,6 +187,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -255,6 +258,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg2_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg2b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -119,6 +120,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -193,6 +195,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -267,6 +270,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
@@ -13,16 +13,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -30,24 +33,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -120,16 +119,19 @@ Level 2
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -137,24 +139,20 @@ Level 2
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -227,16 +225,19 @@ Level 3
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -244,24 +245,20 @@ Level 3
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -334,16 +331,19 @@ Level 4
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -351,24 +351,20 @@ Level 4
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -441,16 +437,19 @@ Level 5
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -458,24 +457,20 @@ Level 5
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -23,16 +23,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -40,24 +43,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -140,16 +139,19 @@ Level 2
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -157,24 +159,20 @@ Level 2
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -257,16 +255,19 @@ Level 3
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -274,24 +275,20 @@ Level 3
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -374,16 +371,19 @@ Level 4
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -391,24 +391,20 @@ Level 4
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -491,16 +487,19 @@ Level 5
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -508,24 +507,20 @@ Level 5
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
@@ -13,16 +13,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -30,24 +33,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -120,16 +119,19 @@ Level 2
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -137,24 +139,20 @@ Level 2
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -227,16 +225,19 @@ Level 3
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -244,24 +245,20 @@ Level 3
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -334,16 +331,19 @@ Level 4
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -351,24 +351,20 @@ Level 4
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -23,16 +23,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -40,24 +43,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -140,16 +139,19 @@ Level 2
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -157,24 +159,20 @@ Level 2
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -257,16 +255,19 @@ Level 3
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -274,24 +275,20 @@ Level 3
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -374,16 +371,19 @@ Level 4
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -391,24 +391,20 @@ Level 4
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
@@ -13,16 +13,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -30,24 +33,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -120,16 +119,19 @@ Level 2
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -137,24 +139,20 @@ Level 2
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -227,16 +225,19 @@ Level 3
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -244,24 +245,20 @@ Level 3
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -334,16 +331,19 @@ Level 4
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -351,24 +351,20 @@ Level 4
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -23,16 +23,19 @@ Level 1
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -40,24 +43,20 @@ Level 1
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -140,16 +139,19 @@ Level 2
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -157,24 +159,20 @@ Level 2
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -257,16 +255,19 @@ Level 3
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -274,24 +275,20 @@ Level 3
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -374,16 +371,19 @@ Level 4
  Build (MueLu::RebalanceTransferFactory)
   Build (MueLu::RepartitionFactory)
    Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
+    Prolongator smoothing (MueLu::SaPFactory_kokkos)
+     Build (MueLu::TentativePFactory_kokkos)
+      Build (MueLu::UncoupledAggregationFactory_kokkos)
+       Build (MueLu::CoalesceDropFactory_kokkos)
         Build (MueLu::AmalgamationFactory)
         [empty list]
         
        aggregation: drop tol = 0   [default]
        aggregation: Dirichlet threshold = 0   [default]
        aggregation: drop scheme = classical   [default]
+       filtered matrix: use lumping = 1   [default]
+       filtered matrix: reuse graph = 1   [default]
+       filtered matrix: reuse eigenvalue = 1   [default]
        lightweight wrap = 1   [default]
        
       aggregation: max agg size = -1   [default]
@@ -391,24 +391,20 @@ Level 4
       aggregation: max selected neighbors = 0   [unused]
       aggregation: ordering = natural   [unused]
       aggregation: enable phase 1 = 1   [default]
+      aggregation: phase 1 algorithm = Serial   [default]
       aggregation: enable phase 2a = 1   [default]
       aggregation: enable phase 2b = 1   [default]
       aggregation: enable phase 3 = 1   [default]
       aggregation: preserve Dirichlet points = 0   [unused]
       aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
       OnePt aggregate map name =    [default]
       OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
       
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
+      Build (MueLu::CoarseMapFactory_kokkos)
+      [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_epetra.gold
@@ -10,16 +10,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -27,24 +30,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -78,16 +77,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -95,27 +97,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -149,16 +147,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -166,27 +167,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -220,16 +217,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -237,27 +237,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
@@ -20,16 +20,19 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -37,24 +40,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -98,16 +97,19 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -115,27 +117,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -179,16 +177,19 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -196,27 +197,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -260,16 +257,19 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -277,27 +277,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_epetra.gold
@@ -9,16 +9,19 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -26,24 +29,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -76,16 +75,19 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -93,27 +95,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -146,16 +144,19 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -163,27 +164,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -216,16 +213,19 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -233,27 +233,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -14,16 +14,19 @@ Level 0
   chebyshev: assume matrix does not change = 0   [default]
  
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -31,24 +34,20 @@ Level 1
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -86,16 +85,19 @@ Level 1
   chebyshev: assume matrix does not change = 0   [default]
  
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -103,27 +105,23 @@ Level 2
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -161,16 +159,19 @@ Level 2
   chebyshev: assume matrix does not change = 0   [default]
  
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -178,27 +179,23 @@ Level 3
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -236,16 +233,19 @@ Level 3
   chebyshev: assume matrix does not change = 0   [default]
  
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
+ Prolongator smoothing (MueLu::SaPFactory_kokkos)
+  Build (MueLu::TentativePFactory_kokkos)
+   Build (MueLu::UncoupledAggregationFactory_kokkos)
+    Build (MueLu::CoalesceDropFactory_kokkos)
      Build (MueLu::AmalgamationFactory)
      [empty list]
      
     aggregation: drop tol = 0   [default]
     aggregation: Dirichlet threshold = 0   [default]
     aggregation: drop scheme = classical   [default]
+    filtered matrix: use lumping = 1   [default]
+    filtered matrix: reuse graph = 1   [default]
+    filtered matrix: reuse eigenvalue = 1   [default]
     lightweight wrap = 1   [default]
     
    aggregation: max agg size = -1   [default]
@@ -253,27 +253,23 @@ Level 4
    aggregation: max selected neighbors = 0   [unused]
    aggregation: ordering = natural   [unused]
    aggregation: enable phase 1 = 1   [default]
+   aggregation: phase 1 algorithm = Serial   [default]
    aggregation: enable phase 2a = 1   [default]
    aggregation: enable phase 2b = 1   [default]
    aggregation: enable phase 3 = 1   [default]
    aggregation: preserve Dirichlet points = 0   [unused]
    aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
    OnePt aggregate map name =    [default]
    OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
    
    Nullspace factory (MueLu::NullspaceFactory)
    Fine level nullspace = Nullspace
    
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
+   Build (MueLu::CoarseMapFactory_kokkos)
+   [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4b_epetra.gold
@@ -44,6 +44,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -245,6 +248,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_epetra.gold
@@ -10,15 +10,18 @@ Level 0
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -26,24 +29,20 @@ Level 1
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -71,15 +70,18 @@ Level 1
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -87,27 +89,23 @@ Level 2
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -135,15 +133,18 @@ Level 2
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -151,27 +152,23 @@ Level 3
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -199,15 +196,18 @@ Level 3
   A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
  
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -215,27 +215,23 @@ Level 4
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
@@ -20,15 +20,18 @@ Level 0
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -36,24 +39,20 @@ Level 1
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -91,15 +90,18 @@ Level 1
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -107,27 +109,23 @@ Level 2
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -165,15 +163,18 @@ Level 2
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -181,27 +182,23 @@ Level 3
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -239,15 +236,18 @@ Level 3
   relaxation: ifpack2 dump matrix = 0   [default]
  
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
+ Build (MueLu::TentativePFactory_kokkos)
+  Build (MueLu::UncoupledAggregationFactory_kokkos)
+   Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
     
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
+   filtered matrix: use lumping = 1   [default]
+   filtered matrix: reuse graph = 1   [default]
+   filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1   [default]
    
   aggregation: max agg size = -1   [default]
@@ -255,27 +255,23 @@ Level 4
   aggregation: max selected neighbors = 0   [unused]
   aggregation: ordering = natural   [unused]
   aggregation: enable phase 1 = 1   [default]
+  aggregation: phase 1 algorithm = Serial   [default]
   aggregation: enable phase 2a = 1   [default]
   aggregation: enable phase 2b = 1   [default]
   aggregation: enable phase 3 = 1   [default]
   aggregation: preserve Dirichlet points = 0   [unused]
   aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
   
   Nullspace factory (MueLu::NullspaceFactory)
   Fine level nullspace = Nullspace
   
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
+  Build (MueLu::CoarseMapFactory_kokkos)
+  [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1b_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -117,6 +118,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -137,6 +138,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -211,6 +213,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -249,6 +252,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -317,6 +321,7 @@ Level 5
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -211,6 +213,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -289,6 +292,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -367,6 +371,7 @@ Level 5
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -50,6 +50,7 @@ Level 1
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -113,6 +114,7 @@ Level 2
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
@@ -50,6 +50,7 @@ Level 1
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -113,6 +114,7 @@ Level 2
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -111,6 +112,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -50,6 +50,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -157,6 +158,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -264,6 +266,7 @@ Level 3
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
@@ -50,6 +50,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -53,6 +53,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -53,6 +53,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -163,6 +164,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -273,6 +275,7 @@ Level 3
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -50,6 +50,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -157,6 +158,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -264,6 +266,7 @@ Level 3
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
@@ -50,6 +50,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -53,6 +53,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -53,6 +53,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -163,6 +164,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -273,6 +275,7 @@ Level 3
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -141,6 +142,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -141,6 +142,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -141,6 +142,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -211,6 +213,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -181,6 +183,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -211,6 +213,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -110,6 +111,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -130,6 +131,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -110,6 +111,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -130,6 +131,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -110,6 +111,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -130,6 +131,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -110,6 +111,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -178,6 +180,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -130,6 +131,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -208,6 +210,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -115,6 +116,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -287,6 +289,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -392,6 +395,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -280,6 +282,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -385,6 +388,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -310,6 +312,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -425,6 +428,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -317,6 +319,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -432,6 +435,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -287,6 +289,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -392,6 +395,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -280,6 +282,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -385,6 +388,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -310,6 +312,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -425,6 +428,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -317,6 +319,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -432,6 +435,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -352,6 +354,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -153,6 +154,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -345,6 +347,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -385,6 +387,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -173,6 +174,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -392,6 +394,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -47,6 +47,7 @@ Level 1
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -145,6 +146,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -320,6 +322,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
@@ -47,6 +47,7 @@ Level 1
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -145,6 +146,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -313,6 +315,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -165,6 +166,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -353,6 +355,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -57,6 +57,7 @@ Level 1
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -165,6 +166,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     
@@ -360,6 +362,7 @@ Level 2
      [empty list]
      
     tentative: calculate qr = 1   [default]
+    tentative: build coarse coordinates = 1   [default]
     matrixmatrix: kernel params -> 
      [empty list]
     

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -74,6 +74,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -171,6 +172,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -175,6 +177,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -241,6 +244,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -307,6 +311,7 @@ Level 5
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -193,6 +195,7 @@ Level 3
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -265,6 +268,7 @@ Level 4
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -337,6 +341,7 @@ Level 5
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_epetra.gold
@@ -36,6 +36,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -95,6 +96,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -36,6 +36,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -95,6 +96,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -49,6 +49,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -121,6 +122,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_epetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -43,6 +43,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_epetra.gold
@@ -50,6 +50,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -123,6 +124,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -56,6 +56,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -135,6 +136,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -113,6 +114,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -133,6 +134,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_epetra.gold
@@ -45,6 +45,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -109,6 +110,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -55,6 +55,7 @@ Level 1
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   
@@ -129,6 +130,7 @@ Level 2
    [empty list]
    
   tentative: calculate qr = 1   [default]
+  tentative: build coarse coordinates = 1   [default]
   matrixmatrix: kernel params -> 
    [empty list]
   

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
@@ -48,6 +48,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -141,6 +142,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -58,6 +58,7 @@ Level 1
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      
@@ -161,6 +162,7 @@ Level 2
       [empty list]
       
      tentative: calculate qr = 1   [default]
+     tentative: build coarse coordinates = 1   [default]
      matrixmatrix: kernel params -> 
       [empty list]
      

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_epetra.gold
@@ -44,6 +44,7 @@ Level 1
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -105,6 +106,7 @@ Level 2
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -54,6 +54,7 @@ Level 1
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  
@@ -125,6 +126,7 @@ Level 2
   [empty list]
   
  tentative: calculate qr = 1   [default]
+ tentative: build coarse coordinates = 1   [default]
  matrixmatrix: kernel params -> 
   [empty list]
  

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_epetra.gold
@@ -3,18 +3,18 @@ Level 0
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother ->
+ smoother -> 
   relaxation: type = symmetric Gauss-Seidel   [unused]
   relaxation: sweeps = 1   [unused]
   relaxation: damping factor = 1   [unused]
-
+ 
 Level 1
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-
+    
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -22,7 +22,7 @@ Level 1
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-
+   
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -36,46 +36,47 @@ Level 1
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-
+  
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-
+  
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-
+  
  tentative: calculate qr = 0
- matrixmatrix: kernel params ->
+ tentative: build coarse coordinates = 1   [default]
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Computing Ac (MueLu::RAPFactory)
  transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother ->
+ smoother -> 
   relaxation: type = symmetric Gauss-Seidel   [unused]
   relaxation: sweeps = 1   [unused]
   relaxation: damping factor = 1   [unused]
-
+ 
 Level 2
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-
+    
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -83,7 +84,7 @@ Level 2
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-
+   
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -97,37 +98,38 @@ Level 2
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-
+  
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-
+  
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-
+  
  tentative: calculate qr = 0
- matrixmatrix: kernel params ->
+ tentative: build coarse coordinates = 1   [default]
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Computing Ac (MueLu::RAPFactory)
  transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother ->
+ presmoother -> 
   [empty list]
-
+ 
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -3,7 +3,7 @@ Level 0
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother ->
+ smoother -> 
   relaxation: type = Symmetric Gauss-Seidel
   relaxation: sweeps = 1
   relaxation: damping factor = 1
@@ -17,14 +17,14 @@ Level 0
   relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
   relaxation: symmetric matrix structure = 0   [default]
   relaxation: ifpack2 dump matrix = 0   [default]
-
+ 
 Level 1
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-
+    
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -32,7 +32,7 @@ Level 1
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-
+   
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -46,35 +46,36 @@ Level 1
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-
+  
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-
+  
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-
+  
  tentative: calculate qr = 0
- matrixmatrix: kernel params ->
+ tentative: build coarse coordinates = 1   [default]
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Computing Ac (MueLu::RAPFactory)
  transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother ->
+ smoother -> 
   relaxation: type = Symmetric Gauss-Seidel
   relaxation: sweeps = 1
   relaxation: damping factor = 1
@@ -88,14 +89,14 @@ Level 1
   relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
   relaxation: symmetric matrix structure = 0   [default]
   relaxation: ifpack2 dump matrix = 0   [default]
-
+ 
 Level 2
  Build (MueLu::TentativePFactory_kokkos)
   Build (MueLu::UncoupledAggregationFactory_kokkos)
    Build (MueLu::CoalesceDropFactory_kokkos)
     Build (MueLu::AmalgamationFactory)
     [empty list]
-
+    
    aggregation: drop tol = 0   [default]
    aggregation: Dirichlet threshold = 0   [default]
    aggregation: drop scheme = classical   [default]
@@ -103,7 +104,7 @@ Level 2
    filtered matrix: reuse graph = 1   [default]
    filtered matrix: reuse eigenvalue = 1   [default]
    lightweight wrap = 1
-
+   
   aggregation: max agg size = -1   [default]
   aggregation: min agg size = 2   [default]
   aggregation: max selected neighbors = 0   [default]
@@ -117,37 +118,38 @@ Level 2
   aggregation: allow user-specified singletons = 0   [default]
   OnePt aggregate map name =    [default]
   OnePt aggregate map factory =    [default]
-
+  
   Nullspace factory (MueLu::NullspaceFactory_kokkos)
   Fine level nullspace = Nullspace
-
+  
   Build (MueLu::CoarseMapFactory_kokkos)
   [empty list]
-
+  
  tentative: calculate qr = 0
- matrixmatrix: kernel params ->
+ tentative: build coarse coordinates = 1   [default]
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Computing Ac (MueLu::RAPFactory)
  transpose: use implicit = 0   [default]
  rap: triple product = 0   [default]
  rap: fix zero diagonals = 0   [default]
  CheckMainDiagonal = 0   [default]
  RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params ->
+ matrixmatrix: kernel params -> 
   [empty list]
-
+ 
  Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
  keep smoother data = 0   [default]
  PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
  PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother ->
+ presmoother -> 
   [empty list]
-
+ 
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---

--- a/packages/muelu/test/navierstokes/Navier2DBlocked_BraessSarazin.cpp
+++ b/packages/muelu/test/navierstokes/Navier2DBlocked_BraessSarazin.cpp
@@ -339,6 +339,7 @@ int main(int argc, char *argv[]) {
   M11->SetFactory("Nullspace", nspFact11);
   // M11->SetFactory("Ptent", P11Fact);
   M11->SetFactory("CoarseMap", coarseMapFact11);
+  M11->SetFactory("Graph", dropFact11);
 #endif
   M11->SetIgnoreUserData(true);               // always use data from factories defined in factory manager
 

--- a/packages/muelu/test/navierstokes/Navier2DBlocked_Epetra.cpp
+++ b/packages/muelu/test/navierstokes/Navier2DBlocked_Epetra.cpp
@@ -359,6 +359,7 @@ int main(int argc, char *argv[]) {
     M11->SetFactory("A", A11Fact);
     M11->SetFactory("P", P11Fact);
     M11->SetFactory("R", R11Fact);
+    M11->SetFactory("Graph", dropFact11);
     M11->SetFactory("Aggregates", CoupledAggFact11);
     M11->SetFactory("UnAmalgamationInfo", amalgFact11);
     M11->SetFactory("Nullspace", nspFact11);

--- a/packages/muelu/test/navierstokes/Navier2DBlocked_Simple.cpp
+++ b/packages/muelu/test/navierstokes/Navier2DBlocked_Simple.cpp
@@ -340,6 +340,7 @@ int main(int argc, char *argv[]) {
     M11->SetFactory("Nullspace", nspFact11);
     // M11->SetFactory("Ptent", P11Fact);
     M11->SetFactory("CoarseMap", coarseMapFact11);
+    M11->SetFactory("Graph", dropFact11);
 #endif
     M11->SetIgnoreUserData(true);               // always use data from factories defined in factory manager
 

--- a/packages/muelu/test/navierstokes/Navier2D_Epetra.cpp
+++ b/packages/muelu/test/navierstokes/Navier2D_Epetra.cpp
@@ -316,6 +316,7 @@ int main(int argc, char *argv[]) {
     RCP<SmootherFactory> coarsestSmooFact = rcp(new SmootherFactory(coarsestSmooProto, Teuchos::null));
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("Graph", dropFact);
     //M.SetFactory("UnAmalgamationInfo", amalgFact);
     M.SetFactory("Aggregates", CoupledAggFact);

--- a/packages/muelu/test/navierstokes/myBGS1.xml
+++ b/packages/muelu/test/navierstokes/myBGS1.xml
@@ -19,8 +19,15 @@
       <Parameter name="block col"                 type="int"     value="0"/>
     </ParameterList>
 
+    <ParameterList name="myCoalesceDropFact1">
+      <Parameter name="factory" type="string" value="CoalesceDropFactory"/>
+      <Parameter name="lightweight wrap"                    type="bool"   value="true"/>
+      <Parameter name="aggregation: drop tol"               type="double" value="0.00"/>
+    </ParameterList>
+
     <ParameterList name="myAggFact1">
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
+      <Parameter name="Graph"           type="string" value="myCoalesceDropFact1"/>
       <Parameter name="aggregation: min agg size" type="int" value="5"/>
       <Parameter name="aggregation: max selected neighbors" type="int" value="1"/>
     </ParameterList>
@@ -79,6 +86,7 @@
       <Parameter name="Aggregates" type="string" value="myAggFact1"/>
       <Parameter name="Nullspace" type="string" value="myNspFact1"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
+      <Parameter name="Graph" type="string" value="myCoalesceDropFact1"/>
     </ParameterList>
 
     <ParameterList name="mySecondGroup">
@@ -170,6 +178,7 @@
     </ParameterList>
 
   </ParameterList>
+
 
   <!-- Definition of the multigrid preconditioner -->
   <ParameterList name="Hierarchy">

--- a/packages/muelu/test/navierstokes/myBS2.xml
+++ b/packages/muelu/test/navierstokes/myBS2.xml
@@ -19,8 +19,15 @@
       <Parameter name="block col"                 type="int"     value="0"/>
     </ParameterList>
 
+    <ParameterList name="myDropFact1">
+      <Parameter name="factory" type="string" value="CoalesceDropFactory"/>
+      <!-- <Parameter name="lightweight wrap"                    type="bool"   value="true"/> -->
+      <!-- <Parameter name="aggregation: drop tol"               type="double" value="0.00"/> -->
+    </ParameterList>
+
     <ParameterList name="myAggFact1">
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
+      <Parameter name="Graph" type="string" value="myDropFact1"/>
       <Parameter name="aggregation: min agg size" type="int" value="5"/>
       <Parameter name="aggregation: max selected neighbors" type="int" value="1"/>
     </ParameterList>
@@ -79,6 +86,7 @@
       <Parameter name="Aggregates" type="string" value="myAggFact1"/>
       <Parameter name="Nullspace" type="string" value="myNspFact1"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
+      <Parameter name="Graph" type="string" value="myDropFact1"/>
     </ParameterList>
 
     <ParameterList name="mySecondGroup">

--- a/packages/muelu/test/navierstokes/myIndefDiag1.xml
+++ b/packages/muelu/test/navierstokes/myIndefDiag1.xml
@@ -19,6 +19,10 @@
       <Parameter name="block col"                 type="int"     value="0"/>
     </ParameterList>
 
+    <ParameterList name="myDropFact1">
+      <Parameter name="factory" type="string" value="CoalesceDropFactory"/>
+    </ParameterList>
+
     <ParameterList name="myAggFact1">
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
       <Parameter name="aggregation: min agg size" type="int" value="5"/>
@@ -79,6 +83,7 @@
       <Parameter name="Aggregates" type="string" value="myAggFact1"/>
       <Parameter name="Nullspace" type="string" value="myNspFact1"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
+      <Parameter name="Graph" type="string" value="myDropFact1"/>
     </ParameterList>
 
     <ParameterList name="mySecondGroup">

--- a/packages/muelu/test/navierstokes/mySIM1.xml
+++ b/packages/muelu/test/navierstokes/mySIM1.xml
@@ -19,6 +19,10 @@
       <Parameter name="block col"                 type="int"     value="0"/>
     </ParameterList>
 
+    <ParameterList name="myDropFact1">
+      <Parameter name="factory" type="string" value="CoalesceDropFactory"/>
+    </ParameterList>
+
     <ParameterList name="myAggFact1">
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
       <Parameter name="aggregation: min agg size" type="int" value="5"/>
@@ -79,6 +83,7 @@
       <Parameter name="Aggregates" type="string" value="myAggFact1"/>
       <Parameter name="Nullspace" type="string" value="myNspFact1"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
+      <Parameter name="Graph" type="string" value="myDropFact1"/>
     </ParameterList>
 
     <ParameterList name="mySecondGroup">

--- a/packages/muelu/test/navierstokes/mySIM2.xml
+++ b/packages/muelu/test/navierstokes/mySIM2.xml
@@ -19,6 +19,10 @@
       <Parameter name="block col"                 type="int"     value="0"/>
     </ParameterList>
 
+    <ParameterList name="myDropFact1">
+      <Parameter name="factory" type="string" value="CoalesceDropFactory"/>
+    </ParameterList>
+
     <ParameterList name="myAggFact1">
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
       <Parameter name="aggregation: min agg size" type="int" value="5"/>
@@ -79,6 +83,7 @@
       <Parameter name="Aggregates" type="string" value="myAggFact1"/>
       <Parameter name="Nullspace" type="string" value="myNspFact1"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
+      <Parameter name="Graph" type="string" value="myDropFact1"/>
     </ParameterList>
 
     <ParameterList name="mySecondGroup">

--- a/packages/muelu/test/navierstokes/myUzawa1.xml
+++ b/packages/muelu/test/navierstokes/myUzawa1.xml
@@ -19,6 +19,10 @@
       <Parameter name="block col"                 type="int"     value="0"/>
     </ParameterList>
 
+    <ParameterList name="myDropFact1">
+      <Parameter name="factory" type="string" value="CoalesceDropFactory"/>
+    </ParameterList>
+
     <ParameterList name="myAggFact1">
       <Parameter name="factory" type="string" value="UncoupledAggregationFactory"/>
       <Parameter name="aggregation: min agg size" type="int" value="5"/>
@@ -79,6 +83,7 @@
       <Parameter name="Aggregates" type="string" value="myAggFact1"/>
       <Parameter name="Nullspace" type="string" value="myNspFact1"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMap1"/>
+      <Parameter name="Graph" type="string" value="myDropFact1"/>
     </ParameterList>
 
     <ParameterList name="mySecondGroup">

--- a/packages/muelu/test/perf_tests_kokkos/Redirection.cpp
+++ b/packages/muelu/test/perf_tests_kokkos/Redirection.cpp
@@ -120,8 +120,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D")
     map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
 
-  RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, galeriList);
+  RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector,RealValuedMultiVector> > Pr =
+    Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector,RealValuedMultiVector>(matrixType, map, galeriList);
   RCP<Matrix> A = Pr->BuildMatrix();
 
   LO numRows = A->getNodeNumRows();

--- a/packages/muelu/test/scaling/ImportPerformance.cpp
+++ b/packages/muelu/test/scaling/ImportPerformance.cpp
@@ -568,7 +568,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
     }
 
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
+      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
     A = Pr->BuildMatrix();
 
     if (matrixType == "Elasticity2D" ||

--- a/packages/muelu/test/scaling/MatrixLoad.hpp
+++ b/packages/muelu/test/scaling/MatrixLoad.hpp
@@ -146,7 +146,7 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> > &comm,  Xpetra::Underlyi
     }
 
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
+      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
     A = Pr->BuildMatrix();
 
     if (matrixType == "Elasticity2D" ||

--- a/packages/muelu/test/scaling/TAFCPerformance.cpp
+++ b/packages/muelu/test/scaling/TAFCPerformance.cpp
@@ -339,7 +339,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     }
 
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-        Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
+      Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
     A = Pr->BuildMatrix();
 
 

--- a/packages/muelu/test/scaling/simple.xml
+++ b/packages/muelu/test/scaling/simple.xml
@@ -1,3 +1,4 @@
 <ParameterList name="MueLu">
+  <Parameter name="tentative: build coarse coordinates" type="bool" value="false"/>
   <Parameter name="max levels" type="int" value="2"/>
 </ParameterList>

--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -128,12 +128,14 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,dMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 
       RCP<tpetra_crsmatrix_type> tpA = MueLu::Utilities<SC,LO,GO,NO>::Op2NonConstTpetraCrs(Op);
 
+      out << "========== Create Preconditioner from xmlFile ==========" << std::endl;
+      out << "xmlFileName: " << xmlFileName << std::endl;
       RCP<MueLu::TpetraOperator<SC,LO,GO,NO> > tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName);
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
@@ -150,6 +152,7 @@ namespace MueLuTests {
       RCP<dtpetra_multivector_type> tpcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
       RCP<tpetra_multivector_type>  tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
 
+      out << "========== Create Preconditioner from xmlFile and coordinates ==========" << std::endl;
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates);
       X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
@@ -163,6 +166,7 @@ namespace MueLuTests {
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
+      out << "========== Create Preconditioner from xmlFile, coordinates and nullspace ==========" << std::endl;
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates, tpnullspace);
       X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
@@ -177,6 +181,7 @@ namespace MueLuTests {
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
       //Test interface with no ParameterList or XML filename provided.
+      out << "========== Create Preconditioner from coordinates and nullspace ==========" << std::endl;
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), tpcoordinates, tpnullspace);
       X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
@@ -197,7 +202,6 @@ namespace MueLuTests {
 
     } else if (lib == Xpetra::UseEpetra) {
 #ifdef HAVE_MUELU_EPETRA
-      typedef Xpetra::MultiVector<double,LO,GO,NO> dMultiVector;
 
       // Matrix
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
@@ -218,7 +222,7 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,dMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 
@@ -304,7 +308,7 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,dMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 

--- a/packages/muelu/test/unit_tests/Adapters/test.xml
+++ b/packages/muelu/test/unit_tests/Adapters/test.xml
@@ -30,6 +30,7 @@
     <Parameter name="coarse: max size"                      type="int"      value="500"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
     <Parameter name="use kokkos refactor"                   type="bool"     value="false"/>
+    <Parameter name="tentative: build coarse coordinates"   type="bool"     value="false"/>
 
     <ParameterList name="All">
       <Parameter name="startLevel"                          type="int"      value="0"/>

--- a/packages/muelu/test/unit_tests/Aggregates.cpp
+++ b/packages/muelu/test/unit_tests/Aggregates.cpp
@@ -728,8 +728,7 @@ class AggregateGenerator {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
 
@@ -781,8 +780,7 @@ class AggregateGenerator {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
 
@@ -837,8 +835,7 @@ class AggregateGenerator {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
 

--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -796,6 +796,7 @@ namespace MueLuTests {
   RCP<TentativePFactory> P11Fact = rcp(new TentativePFactory());
   P11Fact->SetFactory("Aggregates",AggFact11);
   P11Fact->SetFactory("UnAmalgamationInfo",Amalg11);
+  P11Fact->SetParameter("tentative: build coarse coordinates", Teuchos::ParameterEntry(false));
   RCP<TransPFactory> R11Fact = rcp(new TransPFactory());
   RCP<Factory> Nullspace11 = rcp(new NullspaceFactory());
   Nullspace11->SetParameter("Fine level nullspace", Teuchos::ParameterEntry(std::string("Nullspace1")));
@@ -831,6 +832,7 @@ namespace MueLuTests {
   RCP<TentativePFactory>P22Fact = rcp(new TentativePFactory());
   P22Fact->SetFactory("Aggregates",AggFact22);
   P22Fact->SetFactory("UnAmalgamationInfo",Amalg22);
+  P22Fact->SetParameter("tentative: build coarse coordinates", Teuchos::ParameterEntry(false));
   RCP<TransPFactory> R22Fact = rcp(new TransPFactory());
   RCP<Factory> Nullspace22 = rcp(new NullspaceFactory());
   Nullspace22->SetParameter("Fine level nullspace", Teuchos::ParameterEntry(std::string("Nullspace2")));
@@ -852,7 +854,7 @@ namespace MueLuTests {
   M22->SetFactory("P", P22Fact);
   M22->SetFactory("R", R22Fact);
   M22->SetFactory("Ptent", P22Fact); //for Nullspace
-  M22->SetFactory("Coordinates", Coord22);
+  M22->SetFactory("Coordinates", P22Fact);
   M22->SetFactory("Smoother", Smoo22Fact);
   M22->SetFactory("CoarseMap",Cmap22);
   M22->SetFactory("Nullspace",Nullspace22);

--- a/packages/muelu/test/unit_tests/GeneralGeometricPFactory.cpp
+++ b/packages/muelu/test/unit_tests/GeneralGeometricPFactory.cpp
@@ -409,7 +409,8 @@ namespace MueLuTests {
     // problemParamList.set("keepBCs", true);
 
     // create Poisson problem and matrix
-    Galeri::Xpetra::Laplace3DProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector> PoissonOnCube(problemParamList, map);
+    Galeri::Xpetra::Laplace3DProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector> PoissonOnCube(problemParamList,
+                                                                                           map);
     RCP<Matrix> Op = PoissonOnCube.BuildMatrix();
 
     // build nullspace
@@ -615,7 +616,8 @@ namespace MueLuTests {
     // problemParamList.set("keepBCs", true);
 
     // create Poisson problem and matrix
-    Galeri::Xpetra::Laplace3DProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector> PoissonOnCube(problemParamList, map);
+    Galeri::Xpetra::Laplace3DProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector> PoissonOnCube(problemParamList,
+                                                                                           map);
     RCP<Matrix> Op = PoissonOnCube.BuildMatrix();
 
     // build nullspace
@@ -1166,7 +1168,8 @@ namespace MueLuTests {
     // problemParamList.set("keepBCs", true);
 
     // create Poisson problem and matrix
-    Galeri::Xpetra::Laplace3DProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector> PoissonOnCube(problemParamList, map);
+    Galeri::Xpetra::Laplace3DProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector> PoissonOnCube(problemParamList,
+                                                                                           map);
     RCP<Matrix> Op = PoissonOnCube.BuildMatrix();
 
     // build nullspace

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
@@ -198,7 +198,7 @@ namespace MueLuTests {
 
         RCP<const Map> map = MapFactory::Build(lib, numGlobalElements, 0, comm);
         RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-            Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, matrixList);
+          Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, matrixList);
         RCP<Matrix> Op = Pr->BuildMatrix();
 
         return Op;
@@ -343,10 +343,11 @@ namespace MueLuTests {
         return A;
       } // Build2DPoisson()
 
-      static RCP<Xpetra::MultiVector<double,LO,GO,NO> >
+      static RCP<RealValuedMultiVector>
       BuildGeoCoordinates(const int numDimensions, const Array<GO> gNodesPerDir,
                           Array<LO>& lNodesPerDir, Array<GO>& meshData,
                           const std::string meshLayout = "Global Lexicographic") {
+        typedef typename RealValuedMultiVector::scalar_type real_type;
 
         // Get MPI infos
         Xpetra::UnderlyingLib lib = TestHelpers::Parameters::getLib();
@@ -388,7 +389,7 @@ namespace MueLuTests {
           }
 
           if(numDimensions == 1) {
-            LO numNodesPerRank = std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / numRanks);
+            LO numNodesPerRank = std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / numRanks);
             if(myRank == numRanks - 1) {
               lNodesPerDir[0] = gNodesPerDir[0] - myRank*numNodesPerRank;
             } else {
@@ -407,14 +408,14 @@ namespace MueLuTests {
             }
           } else {
             if(myRank == 0 || myRank == 2) {
-              lNodesPerDir[0] = std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / 2);
+              lNodesPerDir[0] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / 2);
             } else {
-              lNodesPerDir[0] = std::floor(Teuchos::as<double>(gNodesPerDir[0]) / 2);
+              lNodesPerDir[0] = std::floor(Teuchos::as<real_type>(gNodesPerDir[0]) / 2);
             }
             if(myRank == 0 || myRank == 1) {
-              lNodesPerDir[1] = std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2);
+              lNodesPerDir[1] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2);
             } else {
-              lNodesPerDir[1] = std::floor(Teuchos::as<double>(gNodesPerDir[1]) / 2);
+              lNodesPerDir[1] = std::floor(Teuchos::as<real_type>(gNodesPerDir[1]) / 2);
             }
             if(meshLayout == "Local Lexicographic") {
               for(int j = 0; j < 2; ++j) {
@@ -422,16 +423,16 @@ namespace MueLuTests {
                   int rank = 2*j + i;
                   if(i == 0) {
                     meshData[10*rank + 3] = 0;
-                    meshData[10*rank + 4] = std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / 2) - 1;
+                    meshData[10*rank + 4] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / 2) - 1;
                   } else if(i == 1) {
-                    meshData[10*rank + 3] = std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / 2);
+                    meshData[10*rank + 3] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / 2);
                     meshData[10*rank + 4] = gNodesPerDir[0] - 1;
                   }
                   if(j == 0) {
                     meshData[10*rank + 5] = 0;
-                    meshData[10*rank + 6] = std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2) - 1;
+                    meshData[10*rank + 6] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2) - 1;
                   } else if(j == 1) {
-                    meshData[10*rank + 5] = std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2);
+                    meshData[10*rank + 5] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2);
                     meshData[10*rank + 6] = gNodesPerDir[1] - 1;
                   }
                 }
@@ -464,31 +465,31 @@ namespace MueLuTests {
         GO myGIDOffset = 0;
         Array<GO> myLowestTuple(3);
         if(numDimensions == 1) {
-          myGIDOffset = myRank*std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / numRanks);
+          myGIDOffset = myRank*std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / numRanks);
           myLowestTuple[0] = myGIDOffset;
         } else {
           if(myRank == 1) {
-            myLowestTuple[0] = std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / 2);
+            myLowestTuple[0] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / 2);
             if(meshLayout == "Global Lexicographic") {
               myGIDOffset = myLowestTuple[0];
             } else if(meshLayout == "Local Lexicographic") {
-              myGIDOffset = myLowestTuple[0]*std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2)
+              myGIDOffset = myLowestTuple[0]*std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2)
                 *gNodesPerDir[2];
             }
           } else if(myRank == 2) {
-            myLowestTuple[1] = std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2);
+            myLowestTuple[1] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2);
             if(meshLayout == "Global Lexicographic") {
-              myGIDOffset = std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2)*gNodesPerDir[0];
+              myGIDOffset = std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2)*gNodesPerDir[0];
             } else if(meshLayout == "Local Lexicographic") {
               myGIDOffset = gNodesPerDir[0]*myLowestTuple[1]*gNodesPerDir[2];
             }
           } else if(myRank == 3) {
-            myLowestTuple[0] = std::ceil(Teuchos::as<double>(gNodesPerDir[0]) / 2);
-            myLowestTuple[1] = std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2);
+            myLowestTuple[0] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[0]) / 2);
+            myLowestTuple[1] = std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2);
             if(meshLayout == "Global Lexicographic") {
               myGIDOffset = myLowestTuple[1]*gNodesPerDir[0] + myLowestTuple[0];
             } else if(meshLayout == "Local Lexicographic") {
-              myGIDOffset = (myLowestTuple[0]*std::ceil(Teuchos::as<double>(gNodesPerDir[1]) / 2)
+              myGIDOffset = (myLowestTuple[0]*std::ceil(Teuchos::as<real_type>(gNodesPerDir[1]) / 2)
                              + myLowestTuple[1]*gNodesPerDir[0])*gNodesPerDir[2];
             }
           }
@@ -523,9 +524,9 @@ namespace MueLuTests {
         //    Step 3: Compute coordinates    //
         //                                   //
         ///////////////////////////////////////
-        RCP<Xpetra::MultiVector<double,LO,GO,NO> > Coordinates
-          = Xpetra::MultiVectorFactory<double,LO,GO,NO>::Build(coordMap, numDimensions);
-        Array<ArrayRCP<double> > myCoords(numDimensions);
+        RCP<RealValuedMultiVector> Coordinates = RealValuedMultiVectorFactory::Build(coordMap,
+                                                                                     numDimensions);
+        Array<ArrayRCP<real_type> > myCoords(numDimensions);
         for(int dim = 0; dim < numDimensions; ++dim) {
           myCoords[dim] = Coordinates->getDataNonConst(dim);
         }
@@ -541,7 +542,7 @@ namespace MueLuTests {
                   myCoords[dim][nodeIdx] = 0.0;
                 } else {
                   myCoords[dim][nodeIdx] =
-                    Teuchos::as<double>(myLowestTuple[dim] + ijk[dim]) / (gNodesPerDir[dim] - 1);
+                    Teuchos::as<real_type>(myLowestTuple[dim] + ijk[dim]) / (gNodesPerDir[dim] - 1);
                 }
               }
             }

--- a/packages/muelu/test/unit_tests/MultiVectorTransferFactory.cpp
+++ b/packages/muelu/test/unit_tests/MultiVectorTransferFactory.cpp
@@ -104,9 +104,14 @@ namespace MueLuTests {
     RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx);
     fineLevel.Set("A",A);
 
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
+
     RCP<MultiVector> fineOnes = MultiVectorFactory::Build(A->getRowMap(),1);
     fineOnes->putScalar(1.0);
     fineLevel.Set("onesVector",fineOnes);
+    fineLevel.Set("Coordinates", coordinates);
 
     RCP<TentativePFactory>    TentativePFact = rcp(new TentativePFactory());
     RCP<TransPFactory>        RFact = rcp(new TransPFactory());
@@ -154,6 +159,10 @@ namespace MueLuTests {
     GO nx = 199;
     RCP<Matrix> A = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx);
 
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
+
 
     // Set up three level hierarchy.
     RCP<Hierarchy> H = rcp( new Hierarchy() );
@@ -164,7 +173,8 @@ namespace MueLuTests {
     fineLevel->Set("A",A);                       // set fine level matrix
     RCP<MultiVector> nullSpace = MultiVectorFactory::Build(A->getRowMap(),1);
     nullSpace->putScalar( (SC) 1.0);
-    fineLevel->Set("Nullspace",nullSpace);       // set null space information for finest level
+    fineLevel->Set("Nullspace", nullSpace);       // set null space information for finest level
+    fineLevel->Set("Coordinates", coordinates);   // set coordinates on finest level
 
     RCP<CoupledAggregationFactory> CoupledAggFact = rcp(new CoupledAggregationFactory());
     CoupledAggFact->SetMinNodesPerAggregate(3);

--- a/packages/muelu/test/unit_tests/PgPFactory.cpp
+++ b/packages/muelu/test/unit_tests/PgPFactory.cpp
@@ -637,7 +637,7 @@ namespace MueLuTests {
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(PgPFactory, ReUseOmegas, Scalar, LocalOrdinal, GlobalOrdinal, Node)
   {
-#   include <MueLu_UseShortNames.hpp>
+#include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
 #   if !defined(HAVE_MUELU_IFPACK2)
@@ -664,6 +664,11 @@ namespace MueLuTests {
     // create nonsymmetric tridiagonal matrix
     RCP<Matrix> Op = Galeri::Xpetra::TriDiag<SC,LocalOrdinal,GlobalOrdinal,Map,CrsMatrixWrap>(map, nEle, 2.0, -1.0, -1.0);
 
+    GO nx = nEle;
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<Scalar,LocalOrdinal,GlobalOrdinal,Map,RealValuedMultiVector>("1D", map, galeriList);
+
     // build nullspace
     RCP<MultiVector> nullSpace = MultiVectorFactory::Build(map,1);
     nullSpace->putScalar( (SC) 1.0);
@@ -680,6 +685,7 @@ namespace MueLuTests {
     Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
     Finest->Set("A",         Op);              // set fine level matrix
     Finest->Set("Nullspace", nullSpace);       // set null space information for finest level
+    Finest->Set("Coordinates", coordinates);   // set coordinates for finest level
 
     // define transfer operators
     RCP<CoupledAggregationFactory> CoupledAggFact = rcp(new CoupledAggregationFactory());
@@ -840,6 +846,11 @@ namespace MueLuTests {
     // create nonsymmetric tridiagonal matrix
     RCP<Matrix> Op = Galeri::Xpetra::TriDiag<SC,LocalOrdinal,GlobalOrdinal,Map,CrsMatrixWrap>(map, nEle, 2.0, -1.0, -1.0);
 
+    GO nx = nEle;
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<Scalar,LocalOrdinal,GlobalOrdinal,Map,RealValuedMultiVector>("1D", map, galeriList);
+
     // build nullspace
     RCP<MultiVector> nullSpace = MultiVectorFactory::Build(map,1);
     nullSpace->putScalar( (SC) 1.0);
@@ -854,8 +865,9 @@ namespace MueLuTests {
 
     RCP<Level> Finest = H->GetLevel();
     Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
-    Finest->Set("A",Op);                      // set fine level matrix
-    Finest->Set("Nullspace",nullSpace);       // set null space information for finest level
+    Finest->Set("A", Op);                      // set fine level matrix
+    Finest->Set("Nullspace", nullSpace);       // set null space information for finest level
+    Finest->Set("Coordinates", coordinates);   // set coordinates for finest level
 
     // define transfer operators
     RCP<CoupledAggregationFactory> CoupledAggFact = rcp(new CoupledAggregationFactory());
@@ -1027,6 +1039,7 @@ namespace MueLuTests {
         RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
           Galeri::Xpetra::BuildProblem<SC, LocalOrdinal, GlobalOrdinal, Map, CrsMatrixWrap, MultiVector>("Laplace1D", map, matrixParameters);
         RCP<Matrix> Op = Pr->BuildMatrix();
+        RCP<RealValuedMultiVector> coordinates = Pr->BuildCoords();
 
         // build nullspace
         RCP<MultiVector> nullSpace = MultiVectorFactory::Build(map,1);
@@ -1044,6 +1057,7 @@ namespace MueLuTests {
         Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
         Finest->Set("A",Op);                      // set fine level matrix
         Finest->Set("Nullspace",nullSpace);       // set null space information for finest level
+        // Finest->Set("Coordinates", coordinates);  // set coordinates for finest level
 
         // define transfer operators
         RCP<CoupledAggregationFactory> CoupledAggFact = rcp(new CoupledAggregationFactory());

--- a/packages/muelu/test/unit_tests/RAPFactory.cpp
+++ b/packages/muelu/test/unit_tests/RAPFactory.cpp
@@ -92,8 +92,14 @@ namespace MueLuTests {
 
     Level fineLevel, coarseLevel; TestHelpers::TestFactory<Scalar, LO, GO, NO>::createTwoLevelHierarchy(fineLevel, coarseLevel);
 
-    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(27*comm->getSize());
+    GO nx = 27*comm->getSize();
+    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(nx);
     fineLevel.Set("A",Op);
+
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+    fineLevel.Set("Coordinates", coordinates);
 
     TentativePFactory tentpFactory;
     SaPFactory sapFactory;
@@ -181,8 +187,14 @@ namespace MueLuTests {
     fineLevel.SetFactoryManager(defManager);
     coarseLevel.SetFactoryManager(defManager);
 
-    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(19*comm->getSize());
+    GO nx = 19*comm->getSize();
+    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(nx);
     fineLevel.Set("A",Op);
+
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+    fineLevel.Set("Coordinates", coordinates);
 
     TentativePFactory tentpFactory;
     SaPFactory sapFactory;

--- a/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
+++ b/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
@@ -93,12 +93,18 @@ namespace MueLuTests {
 
     Level fineLevel, coarseLevel; TestHelpers::TestFactory<Scalar, LO, GO, NO>::createTwoLevelHierarchy(fineLevel, coarseLevel);
 
-    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(27*comm->getSize());
+    GO nx = 27*comm->getSize();
+    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(nx);
     fineLevel.Set("A",Op);
 
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+    fineLevel.Set("Coordinates", coordinates);
+
     // Set "K" and "M" to be copies of A
-    fineLevel.Set("K",Op); 
-    fineLevel.Set("M",Op); 
+    fineLevel.Set("K",Op);
+    fineLevel.Set("M",Op);
 
     TentativePFactory tentpFactory;
     SaPFactory sapFactory;
@@ -190,10 +196,16 @@ namespace MueLuTests {
     fineLevel.SetFactoryManager(defManager);
     coarseLevel.SetFactoryManager(defManager);
 
-    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(19*comm->getSize());
+    GO nx = 19*comm->getSize();
+    RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(nx);
     fineLevel.Set("A",Op);
     fineLevel.Set("K",Op);
     fineLevel.Set("M",Op);
+
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+    fineLevel.Set("Coordinates", coordinates);
 
     TentativePFactory tentpFactory;
     SaPFactory sapFactory;
@@ -273,10 +285,15 @@ namespace MueLuTests {
 
     typedef typename Teuchos::ScalarTraits<Scalar> TST;
     RCP<const Teuchos::Comm<int> > comm = Parameters::getDefaultComm();
-    RCP<Matrix> A = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(1999*comm->getSize());
+    GO nx = 1999*comm->getSize();
+    RCP<Matrix> A = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(nx);
+
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
     // The ugly way of managing input decks
-    std::string myInputString = 
+    std::string myInputString =
 "<ParameterList name=\"MueLu\">"
 "  <ParameterList name=\"Factories\">"
 "   <ParameterList name=\"myFilteredAFact\">"
@@ -321,8 +338,7 @@ namespace MueLuTests {
     pLevel0.set("M",A);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
-    
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params, coordinates, Teuchos::null);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -353,7 +369,7 @@ namespace MueLuTests {
     result1->norm2(normResult1);
     result2->norm2(normResult2);
     TEST_FLOATING_EQUALITY(normResult1[0], normResult2[0], 1e-12);
-    
+
   }
 
 
@@ -375,8 +391,13 @@ namespace MueLuTests {
 
     typedef typename Teuchos::ScalarTraits<Scalar> TST;
     RCP<const Teuchos::Comm<int> > comm = Parameters::getDefaultComm();
-    RCP<Matrix> A = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(1999*comm->getSize());
-    
+    GO nx = 1999*comm->getSize();
+    RCP<Matrix> A = TestHelpers::TestFactory<Scalar, LO, GO, NO>::Build1DPoisson(nx);
+
+    Teuchos::ParameterList galeriList;
+    galeriList.set("nx", nx);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
+
     // The pretty way of managing input decks
     RCP<Teuchos::ParameterList> Params = rcp(new Teuchos::ParameterList);
     Params->set("rap: algorithm","shift");
@@ -390,8 +411,7 @@ namespace MueLuTests {
     pLevel0.set("M",A);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
-    
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params,coordinates,Teuchos::null);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -422,7 +442,7 @@ namespace MueLuTests {
     result1->norm2(normResult1);
     result2->norm2(normResult2);
     TEST_FLOATING_EQUALITY(normResult1[0], normResult2[0], 1e-12);
-    
+
   }
 
 

--- a/packages/muelu/test/unit_tests/StructuredAggregationFactory.cpp
+++ b/packages/muelu/test/unit_tests/StructuredAggregationFactory.cpp
@@ -87,7 +87,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  "Global Lexicographic");
@@ -126,7 +126,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  "Local Lexicographic");
@@ -173,7 +173,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -182,8 +182,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -273,7 +272,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -282,8 +281,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace2D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace2D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -373,7 +371,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -382,8 +380,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -474,7 +471,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -483,8 +480,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -576,7 +572,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -585,8 +581,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace2D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace2D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -678,7 +673,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -687,8 +682,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -782,7 +776,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -796,8 +790,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace1D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -892,7 +885,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -906,8 +899,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace2D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace2D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -1002,7 +994,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<const Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -1016,8 +1008,7 @@ namespace MueLuTests {
     matrixList.set("nx", gNodesPerDir[0]);
     matrixList.set("matrixType","Laplace1D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
     fineLevel.Request("A");
@@ -1108,7 +1099,7 @@ namespace MueLuTests {
       }
     }
 
-    RCP<Xpetra::MultiVector<double,LO,GO,NO> > Coordinates =
+    RCP<RealValuedMultiVector> Coordinates =
       TestHelpers::TestFactory<SC,LO,GO,NO>::BuildGeoCoordinates(numDimensions, gNodesPerDir,
                                                                  lNodesPerDir, meshData,
                                                                  meshLayout);
@@ -1124,8 +1115,7 @@ namespace MueLuTests {
     matrixList.set("nz", gNodesPerDir[2]);
     matrixList.set("matrixType","Laplace3D");
     RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr = Galeri::Xpetra::
-      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D",
-                                                           Coordinates->getMap(),
+      BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>("Laplace3D", Coordinates->getMap(),
                                                            matrixList);
     RCP<Matrix> A = Pr->BuildMatrix();
 
@@ -1145,10 +1135,10 @@ namespace MueLuTests {
     // create the factory manager and the factories
     FactoryManager M;
 
-    RCP<Factory>      amalgFact     = rcp(new AmalgamationFactory());
+    RCP<Factory>      AmalgFact     = rcp( new AmalgamationFactory() );
     RCP<Factory>      CDropfact     = rcp( new CoalesceDropFactory() );
     RCP<Factory>      Aggfact       = rcp( new StructuredAggregationFactory() );
-    RCP<Factory>      coarseMapFact = rcp(new CoarseMapFactory());
+    RCP<Factory>      coarseMapFact = rcp( new CoarseMapFactory() );
     RCP<Factory>      Pfact         = rcp( new TentativePFactory() );
     RCP<Factory>      Rfact         = rcp( new TransPFactory() );
     RCP<Factory>      Tfact         = rcp( new CoordinatesTransferFactory() );
@@ -1164,7 +1154,7 @@ namespace MueLuTests {
     Tfact->SetParameter("structured aggregation", Teuchos::ParameterEntry(true));
 
     // Set interfactory dependencies
-    CDropfact->SetFactory("UnAmalgamationInfo", amalgFact);
+    CDropfact->SetFactory("UnAmalgamationInfo", AmalgFact);
     Aggfact->SetFactory("Graph", CDropfact);
     coarseMapFact->SetFactory("Aggregates", Aggfact);
     Pfact->SetFactory("Aggregates", Aggfact);
@@ -1174,14 +1164,12 @@ namespace MueLuTests {
     Acfact->AddTransferFactory(Tfact);
 
     // Set default factories in the manager
-    M.SetFactory("P",           Pfact);
-    M.SetFactory("R",           Rfact);
-    M.SetFactory("A",           Acfact);
-    M.SetFactory("Nullspace",   NSfact);
-    M.SetFactory("Graph",       CDropfact);
-    M.SetFactory("gNodesPerDim", Tfact);
-    M.SetFactory("lNodesPerDim", Tfact);
-    M.SetFactory("gCoarseNodesPerDim", Aggfact);
+    M.SetFactory("P",                  Pfact);
+    M.SetFactory("R",                  Rfact);
+    M.SetFactory("A",                  Acfact);
+    M.SetFactory("Nullspace",          NSfact);
+    M.SetFactory("Graph",              CDropfact);
+    M.SetFactory("lNodesPerDim",       Tfact);
     M.SetFactory("lCoarseNodesPerDim", Aggfact);
 
     // setup smoothers
@@ -1204,11 +1192,8 @@ namespace MueLuTests {
     Finest->setDefaultVerbLevel(Teuchos::VERB_HIGH);
     Finest->Set("A", A);                        // set fine level matrix
     Finest->Set("Nullspace", nullSpace);        // set null space information for finest level
-    Finest->Set("Coordinates", Coordinates);    // set fine level coordinates
-    Finest->Set("gNodesPerDim", gNodesPerDir);  // set GeneralGeometricPFactory specific info
+    // Finest->Set("Coordinates", Coordinates);    // set fine level coordinates
     Finest->Set("lNodesPerDim", lNodesPerDir);  // set GeneralGeometricPFactory specific info
-    // Finest->Set("meshData", meshData);          // set GeneralGeometricPFactory specific info
-    Finest->SetFactoryManager(Teuchos::rcpFromRef(M));
 
     // Setup the hierarchy
     LO maxLevels = 5;

--- a/packages/muelu/test/unit_tests/VariableDofLaplacianFactory.cpp
+++ b/packages/muelu/test/unit_tests/VariableDofLaplacianFactory.cpp
@@ -80,7 +80,7 @@ namespace MueLuTests {
     RCP<Matrix> A = Pr->BuildMatrix();
 
     // TODO coords should use SC = double
-    RCP<MultiVector> coords = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,MultiVector>("2D", A->getRowMap(), matrixParameters);
+    RCP<RealValuedMultiVector> coords = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("2D", A->getRowMap(), matrixParameters);
 
     // build hierarchy
     RCP<Level> l = rcp(new Level());
@@ -137,7 +137,7 @@ namespace MueLuTests {
     RCP<const Map> nodeMap = Galeri::Xpetra::CreateMap<LocalOrdinal, GlobalOrdinal, Node>(lib, "Cartesian2D", comm, galeriList);
 
     //build coordinates before expanding map (nodal coordinates, not dof-based)
-    RCP<mv_type_double> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LocalOrdinal,GlobalOrdinal,Map,mv_type_double>("2D", nodeMap, galeriList);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LocalOrdinal,GlobalOrdinal,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
     RCP<const Map> dofMap = MapFactory::Build(nodeMap, 2); //expand map for 2 DOFs per node
 
     galeriList.set("right boundary" , "Neumann");
@@ -235,7 +235,7 @@ namespace MueLuTests {
     RCP<const Map> nodeMap = Galeri::Xpetra::CreateMap<LocalOrdinal, GlobalOrdinal, Node>(lib, "Cartesian2D", comm, galeriList);
 
     //build coordinates before expanding map (nodal coordinates, not dof-based)
-    RCP<mv_type_double> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LocalOrdinal,GlobalOrdinal,Map,mv_type_double>("2D", nodeMap, galeriList);
+    RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LocalOrdinal,GlobalOrdinal,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
     RCP<const Map> dofMap = MapFactory::Build(nodeMap, 2); //expand map for 2 DOFs per node
 
     galeriList.set("right boundary" , "Neumann");
@@ -278,6 +278,7 @@ namespace MueLuTests {
     Level fineLevel, coarseLevel;
     test_factory::createTwoLevelHierarchy(fineLevel, coarseLevel);
 
+    fineLevel.Set("Coordinates", coordinates);
     fineLevel.Set("A", lapA);
 
     TentativePFactory PFact;

--- a/packages/muelu/test/unit_tests_kokkos/MueLu_TestHelpers_kokkos.hpp
+++ b/packages/muelu/test/unit_tests_kokkos/MueLu_TestHelpers_kokkos.hpp
@@ -182,7 +182,7 @@ namespace MueLuTests {
 
         RCP<const Map> map = MapFactory::Build(lib, numGlobalElements, 0, comm);
         RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-            Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, matrixList);
+          Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(matrixType, map, matrixList);
         RCP<Matrix> Op = Pr->BuildMatrix();
 
         return Op;


### PR DESCRIPTION
@trilinos/muelu 

## Description
Modifying the creation of coarse coordinates from CoordinateTransferFactory to prolongators.

## Motivation and Context
This avoids having multiple intricate algorithm in the transfer factory when the prolongators already implement most of the work.

## Related Issues

* Blocks #2577 
* Follows #2362 
* Part of #2230  #2687 

## How Has This Been Tested?
All unit-test requiring coordinates to be injected in MueLu are still passing

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.