### PR TITLE
Check for Command Line Argument (Fix #3062)

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -612,7 +612,7 @@ int main(int argc, char *argv[]) {
     clp.setDocString("Driver for region multigrid\n\nUse Matlab script 'createInput.m' to create necessary input data on the hard dist.\n\nProvide filename of MueLu xml configuration via '--xml=...'.");
 
     // define command line arguments
-    clp.setOption("xml", &xmlFileName, "filename of xml-file with MueLu configuration");
+    clp.setOption("xml", &xmlFileName, "filename of xml-file with MueLu configuration", true);
 
     // force user to specify all options
     clp.recogniseAllOptions(true);
@@ -783,7 +783,7 @@ int main(int argc, char *argv[]) {
     std::stringstream fileNameSS;
     fileNameSS << "myCompositeMap_" << myRank;
     fp = fopen(fileNameSS.str().c_str(), "r");
-    if (fp != NULL)
+    if (fp == NULL)
       std::cout << std::endl << ">>> Check number of MPI ranks!" << std::endl << std::endl;
     TEUCHOS_ASSERT(fp!=NULL);
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
Check whether the user provided the mandatory command line arguement ```--xml=<path_to_xml_file>``` and throw an error if it is missing.

Minor additional fix: Correct error check for file name when reading myCompositeMap_* on each proc.

## Motivation and Context
Addressing #3062 

## Related Issues
* Follows #2805 
* Closes #3062 

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.