### PR TITLE
Tpetra: Fix #2459 (add ScopeGuard)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Core.cpp
+++ b/packages/tpetra/core/src/Tpetra_Core.cpp
@@ -55,7 +55,7 @@ namespace Tpetra {
     class HideOutputExceptOnProcess0 {
     public:
       HideOutputExceptOnProcess0 (std::ostream& stream,
-				  const int myRank) :
+                                  const int myRank) :
         stream_ (stream),
         originalBuffer_ (stream.rdbuf ())
       {
@@ -81,36 +81,36 @@ namespace Tpetra {
       // Not sure if MPI_Initialized or MPI_Finalized meet the strong
       // exception guarantee.
       try {
-	(void) MPI_Initialized (&isInitialized);
+        (void) MPI_Initialized (&isInitialized);
       }
       catch (...) {
-	isInitialized = 0;
+        isInitialized = 0;
       }
       try {
-	(void) MPI_Finalized (&isFinalized);
+        (void) MPI_Finalized (&isFinalized);
       }
       catch (...) {
-	isFinalized = 0;
+        isFinalized = 0;
       }
       return isInitialized != 0 && isFinalized == 0;
     }
 
     int getRankHarmlessly (MPI_Comm comm)
     {
-      int myRank = 0;      
+      int myRank = 0;
       if (mpiIsInitializedAndNotFinalized ()) {
-	try {
-	  (void) MPI_Comm_rank (comm, &myRank);
-	}
-	catch (...) {
-	  // Not sure if MPI_Comm_rank meets strong exception guarantee
-	  myRank = 0;
-	}
+        try {
+          (void) MPI_Comm_rank (comm, &myRank);
+        }
+        catch (...) {
+          // Not sure if MPI_Comm_rank meets strong exception guarantee
+          myRank = 0;
+        }
       }
       return myRank;
     }
 #endif // defined(HAVE_TPETRACORE_MPI)
-    
+
 
     // Whether one of the Tpetra::initialize() functions has been called before.
     bool tpetraIsInitialized_ = false;
@@ -155,8 +155,8 @@ namespace Tpetra {
         Kokkos::is_initialized ();
       TEUCHOS_TEST_FOR_EXCEPTION
         (! kokkosIsInitialized, std::logic_error, "At the end of "
-	 "initKokkosIfNeeded, Kokkos is not initialized.  "
-	 "Please report this bug to the Tpetra developers.");
+         "initKokkosIfNeeded, Kokkos is not initialized.  "
+         "Please report this bug to the Tpetra developers.");
     }
 
 #ifdef HAVE_TPETRACORE_MPI
@@ -174,19 +174,19 @@ namespace Tpetra {
 
       const bool mpiReady = mpiIsInitializedAndNotFinalized ();
       if (! mpiReady) {
-	// Tpetra doesn't currently need to call MPI_Init_thread,
-	// since with Tpetra, only one thread ever calls MPI
-	// functions.  If we ever want to explore
-	// MPI_THREAD_MULTIPLE, here would be the place to call
-	// MPI_Init_thread.
-	const int err = MPI_Init (argc, argv);
+        // Tpetra doesn't currently need to call MPI_Init_thread,
+        // since with Tpetra, only one thread ever calls MPI
+        // functions.  If we ever want to explore
+        // MPI_THREAD_MULTIPLE, here would be the place to call
+        // MPI_Init_thread.
+        const int err = MPI_Init (argc, argv);
         TEUCHOS_TEST_FOR_EXCEPTION
           (err != MPI_SUCCESS, std::runtime_error, "MPI_Init failed with "
            "error code " << err << " != MPI_SUCCESS.  If MPI was set up "
            "correctly, then this should not happen, since we have already "
-	   "checked that MPI_Init (or MPI_Init_thread) has not yet been "
-	   "called.  This may indicate that your MPI library is corrupted "
-	   "or that it is incorrectly linked to your program.");
+           "checked that MPI_Init (or MPI_Init_thread) has not yet been "
+           "called.  This may indicate that your MPI library is corrupted "
+           "or that it is incorrectly linked to your program.");
         tpetraInitializedMpi_ = true;
       }
     }
@@ -214,10 +214,10 @@ namespace Tpetra {
       // initialized and not finalized.
       const bool mpiReady = mpiIsInitializedAndNotFinalized ();
       if (mpiReady) {
-	comm = Teuchos::rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+        comm = Teuchos::rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
       }
       else {
-	comm = Teuchos::rcp (new Teuchos::SerialComm<int> ());
+        comm = Teuchos::rcp (new Teuchos::SerialComm<int> ());
       }
 #else
       comm = Teuchos::rcp (new Teuchos::SerialComm<int> ());
@@ -226,11 +226,11 @@ namespace Tpetra {
     }
     return wrappedDefaultComm_;
   }
-  
+
   void initialize (int* argc, char*** argv)
   {
     if (! tpetraIsInitialized_) {
-#if defined(HAVE_TPETRACORE_MPI)      
+#if defined(HAVE_TPETRACORE_MPI)
       initMpiIfNeeded (argc, argv);
       // It's technically legal to initialize Tpetra after
       // MPI_Finalize has been called.  This means that we can't call
@@ -238,7 +238,7 @@ namespace Tpetra {
       const int myRank = getRankHarmlessly (MPI_COMM_WORLD);
 #else
       const int myRank = 0;
-#endif // defined(HAVE_TPETRACORE_MPI)      
+#endif // defined(HAVE_TPETRACORE_MPI)
       initKokkosIfNeeded (argc, argv, myRank);
     }
     tpetraIsInitialized_ = true;
@@ -248,19 +248,19 @@ namespace Tpetra {
   void initialize (int* argc, char*** argv, MPI_Comm comm)
   {
     if (! tpetraIsInitialized_) {
-#if defined(HAVE_TPETRACORE_MPI)      
+#if defined(HAVE_TPETRACORE_MPI)
       initMpiIfNeeded (argc, argv);
       // It's technically legal to initialize Tpetra after
       // MPI_Finalize has been called.  This means that we can't call
       // MPI_Comm_rank without first checking MPI_Finalized.
-      const int myRank = getRankHarmlessly (comm); 
+      const int myRank = getRankHarmlessly (comm);
 #else
       const int myRank = 0;
-#endif // defined(HAVE_TPETRACORE_MPI)      
+#endif // defined(HAVE_TPETRACORE_MPI)
       initKokkosIfNeeded (argc, argv, myRank);
     }
     tpetraIsInitialized_ = true;
-    
+
     // Set the default communicator.  We set it here, after the above
     // initialize() call, just in case users have not yet initialized
     // MPI.  (This is legal if users pass in a predefined
@@ -292,7 +292,7 @@ namespace Tpetra {
               const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
   {
     if (! tpetraIsInitialized_) {
-#if defined(HAVE_TPETRACORE_MPI)   
+#if defined(HAVE_TPETRACORE_MPI)
       initMpiIfNeeded (argc, argv);
 #endif // defined(HAVE_TPETRACORE_MPI)
       // It's technically legal to initialize Tpetra after
@@ -330,12 +330,12 @@ namespace Tpetra {
       // throw an exception on error.  MPI implementations do have
       // the option to throw on error, so let's catch that here.
       try {
-	if (Details::mpiIsInitialized ()) {
-	  // This must be called by the same thread that called
-	  // MPI_Init or MPI_Init_thread (possibly, but not
-	  // necessarily, in Tpetra::initialize()).
-	  (void) MPI_Finalize ();
-	}
+        if (Details::mpiIsInitialized ()) {
+          // This must be called by the same thread that called
+          // MPI_Init or MPI_Init_thread (possibly, but not
+          // necessarily, in Tpetra::initialize()).
+          (void) MPI_Finalize ();
+        }
       }
       catch (...) {}
     }
@@ -343,4 +343,22 @@ namespace Tpetra {
 
     tpetraIsInitialized_ = false; // it's not anymore.
   }
+
+  ScopeGuard::ScopeGuard (int* argc, char*** argv)
+  {
+    ::Tpetra::initialize (argc, argv);
+  }
+
+#ifdef HAVE_TPETRA_MPI
+  ScopeGuard::ScopeGuard (int* argc, char*** argv, MPI_Comm comm)
+  {
+    ::Tpetra::initialize (argc, argv, comm);
+  }
+#endif // HAVE_TPETRA_MPI
+
+  ScopeGuard::~ScopeGuard ()
+  {
+    ::Tpetra::finalize ();
+  }
+
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Core.hpp
+++ b/packages/tpetra/core/src/Tpetra_Core.hpp
@@ -39,6 +39,9 @@
 // ************************************************************************
 // @HEADER
 
+#ifndef TPETRA_CORE_HPP
+#define TPETRA_CORE_HPP
+
 /// \file Tpetra_Core.hpp
 /// \brief Functions for initializing and finalizing Tpetra.
 ///
@@ -173,4 +176,85 @@ namespace Tpetra {
   /// responsible for finalizing Kokkos resp. MPI.
   void finalize ();
 
+  /// \brief Scope guard whose destructor automatically calls
+  ///   Tpetra::finalize for you.
+  ///
+  /// This class' constructor does the same thing as
+  /// Tpetra::initialize (see above).  Its destructor automatically
+  /// calls Tpetra::finalize.  This ensures correct Tpetra
+  /// finalization even if intervening code throws an exception.
+  ///
+  /// Compare to Kokkos::ScopeGuard and Teuchos::GlobalMPISession.
+  ///
+  /// Always give the ScopeGuard instance a name.  Otherwise, you'll
+  /// create a temporary object whose destructor will be called right
+  /// away.  That's not what you want.
+  ///
+  /// Here is an example of how to use this class:
+  /// \code
+  /// #include "Tpetra_Core.hpp"
+  /// #include "Tpetra_Map.hpp"
+  ///
+  /// int main (int argc, char* argv[]) {
+  ///   Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  ///
+  ///   // Never create Tpetra or Kokkos objects (other than
+  ///   // the ScopeGuard object itself) at main scope.
+  ///   // Otherwise, their destructors will be called after
+  ///   // MPI_Finalize and Kokkos::finalize are called, which
+  ///   // is forbidden.
+  ///   {
+  ///     auto comm = Tpetra::getDefaultComm ();
+  ///     using GO = Tpetra::Map<>::global_ordinal_type;
+  ///     const GO gblNumInds = 1000;
+  ///     const GO indexBase = 0;
+  ///     Tpetra::Map<> map (gblNumInds, indexBase, comm,
+  ///                        Tpetra::GloballyDistributed);
+  ///     // ... code that uses map ...
+  ///   }
+  ///   return EXIT_SUCCESS;
+  /// }
+  /// \endcode
+  class ScopeGuard {
+  public:
+    /// \brief Initialize Tpetra.
+    ///
+    /// If MPI_Init has not yet been called, then call it.  If
+    /// Kokkos::initialize has not yet been called, then call it.
+    ///
+    /// \param argc [in/out] Address of the first argument to main().
+    /// \param argv [in/out] Address of the second argument to main().
+    ScopeGuard (int* argc, char*** argv);
+
+#ifdef HAVE_TPETRA_MPI
+    /// \brief Initialize Tpetra, and set Tpetra's default MPI communicator.
+    ///
+    /// Assume that MPI_Init has been called.  If Kokkos::initialize
+    /// has not yet been called, then call it.  Make the input MPI
+    /// communicator Tpetra's default MPI communicator.
+    ///
+    /// \param argc [in/out] Address of the first argument to main().
+    /// \param argv [in/out] Address of the second argument to main().
+    /// \param comm [in] Default MPI communicator for Tpetra.  The
+    ///   caller is responsible for calling MPI_Comm_free on this
+    ///   after use, if necessary.
+    ScopeGuard (int* argc, char*** argv, MPI_Comm comm);
+#endif // HAVE_TPETRA_MPI
+
+    /// \brief Default constructor (FORBIDDEN)
+    ///
+    /// You must give ScopeGuard's constructor argc and argv.
+    /// Use the constructor above this one.
+    ScopeGuard () = delete;
+
+    /// \brief Finalize Tpetra.
+    ///
+    /// If the constructor called Kokkos::initialize, then call
+    /// Kokkos::finalize.  If the constructor called MPI_Init, then
+    /// call MPI_Finalize.
+    ~ScopeGuard ();
+  };
+
 } // namespace Tpetra
+
+#endif // TPETRA_CORE_HPP

--- a/packages/tpetra/core/test/Core/CMakeLists.txt
+++ b/packages/tpetra/core/test/Core/CMakeLists.txt
@@ -7,9 +7,25 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_tpetra_initializes_mpi
+  SOURCES
+    ScopeGuard_tpetra_inits_mpi
+  COMM mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Core_initialize_where_user_initializes_mpi
   SOURCES
     initialize_user_inits_mpi
+  COMM mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_user_initializes_mpi
+  SOURCES
+    ScopeGuard_user_inits_mpi
   COMM mpi
   STANDARD_PASS_OUTPUT
   )
@@ -25,10 +41,30 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
+# This test does an MPI_Comm_split,
+# so it needs at least 2 processes.
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_user_initializes_mpi_and_provides_comm
+  SOURCES
+    ScopeGuard_user_inits_mpi_and_provides_comm
+  COMM mpi
+  NUM_MPI_PROCS 2-4
+  STANDARD_PASS_OUTPUT
+  )
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Core_initialize_where_tpetra_initializes_kokkos
   SOURCES
     initialize_tpetra_inits_kokkos
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_tpetra_initializes_kokkos
+  SOURCES
+    ScopeGuard_tpetra_inits_kokkos
   COMM serial mpi
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT
@@ -44,6 +80,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_user_initializes_kokkos
+  SOURCES
+    ScopeGuard_user_inits_kokkos
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Core_initialize_where_tpetra_initializes_mpi_and_user_initializes_kokkos
   SOURCES
     initialize_tpetra_inits_mpi_user_inits_kokkos
@@ -53,9 +98,27 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_tpetra_initializes_mpi_and_user_initializes_kokkos
+  SOURCES
+    ScopeGuard_tpetra_inits_mpi_user_inits_kokkos
+  COMM mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Core_initialize_where_user_initializes_mpi_and_tpetra_initializes_kokkos
   SOURCES
     initialize_user_inits_mpi_tpetra_inits_kokkos
+  COMM mpi
+  NUM_MPI_PROCS 2  
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Core_ScopeGuard_where_user_initializes_mpi_and_tpetra_initializes_kokkos
+  SOURCES
+    ScopeGuard_user_inits_mpi_tpetra_inits_kokkos
   COMM mpi
   NUM_MPI_PROCS 2  
   STANDARD_PASS_OUTPUT

--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_kokkos.cpp
@@ -1,0 +1,111 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+namespace { // (anonymous)
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  // In this example, Tpetra::ScopeGuard is responsible for calling
+  // Kokkos::initialize and Kokkos::finalize.
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "before Tpetra::ScopeGuard was created." << endl;
+    return;
+  }
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+
+    if (! Kokkos::is_initialized ()) {
+      success = false;
+      cout << "Kokkos::is_initialized() is false, "
+        "after Tpetra::ScopeGuard was created." << endl;
+    }
+    if (! Tpetra::isInitialized ()) {
+      success = false;
+      cout << "Tpetra::isInitialized() is false, "
+        "even after Tpetra::ScopeGuard was created." << endl;
+    }
+
+    auto comm = Tpetra::getDefaultComm ();
+    if (comm.is_null ()) {
+      success = false;
+      cout << "Tpetra::getDefaultComm() is null." << endl;
+    }
+
+    cout << "About to leave Tpetra scope." << endl;
+  }
+  cout << "Left Tpetra scope." << endl;
+
+  // Kokkos is like Tpetra; Kokkos::is_initialized() means "was
+  // initialized and was not finalized."  That differs from MPI, where
+  // MPI_Initialized only refers to MPI_Init and MPI_Finalized only
+  // refers to MPI_Finalize.
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard did not call Kokkos::finalize." << endl;
+    return;
+  }
+
+  // MPI is no longer initialized, so we can't all-reduce on this.
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Tpetra::isInitialized() is true, "
+      "even after Tpetra::ScopeGuard::~ScopeGuard has been called" << endl;
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi.cpp
@@ -1,0 +1,226 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+bool isMpiFinalized ()
+{
+  int mpiFinalizedInt = 0;
+  (void) MPI_Finalized (&mpiFinalizedInt);
+  return mpiFinalizedInt != 0;
+}
+
+int getRankInCommWorld ()
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
+  return myRank;
+}
+
+bool allTrueInCommWorld (const bool lclTruth)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1, MPI_INT,
+                 MPI_MIN, MPI_COMM_WORLD);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (MPI_COMM_WORLD, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup on the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  // In this example, Tpetra::ScopeGuard is responsible for calling
+  // MPI_Init and MPI_Finalize.  Ditto for Kokkos::initialize and
+  // Kokkos::finalize.
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI was initialized, "
+      "before Tpetra::initialize was called." << endl;
+    return;
+  }
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "before Tpetra::initialize was called." << endl;
+    return;
+  }
+
+  int myRank = 0; // to be set below
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+
+    if (! isMpiInitialized ()) {
+      success = false;
+      cout << "MPI_Initialized claims MPI is not initialized, "
+        "even after MPI_Init and Tpetra::ScopeGuard::ScopeGuard "
+        "were called." << endl;
+      return;
+    }
+    if (! Kokkos::is_initialized ()) {
+      success = false;
+      cout << "Kokkos::is_initialized returned false, "
+        "after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      return;
+    }
+    myRank = getRankInCommWorld ();
+
+    // MPI is initialized, so we can check whether all processes
+    // report Tpetra as initialized.
+    const bool tpetraIsNowInitialized =
+      allTrueInCommWorld (Tpetra::isInitialized ());
+    if (! tpetraIsNowInitialized) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::isInitialized() is false on at least one process, "
+          "even after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      }
+      return;
+    }
+
+    auto comm = Tpetra::getDefaultComm ();
+    const bool tpetraCommGloballyValid =
+      allTrueInCommWorld (tpetraCommIsLocallyLegit (comm.get ()));
+    if (! tpetraCommGloballyValid) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::getDefaultComm() returns an invalid comm "
+          "on at least one process." << endl;
+      }
+    }
+
+    const int myTpetraRank = comm->getRank ();
+    const bool ranksSame = allTrueInCommWorld (myRank == myTpetraRank);
+    if (! ranksSame) {
+      success = false;
+      if (myRank == 0) {
+        cout << "MPI rank does not match Tpetra rank "
+          "on at least one process" << endl;
+      }
+    }
+
+    if (myRank == 0) {
+      cout << "About to leave Tpetra scope" << endl;
+    }
+  }
+
+  if (myRank == 0) {
+    cout << "Left Tpetra scope" << endl;
+  }
+  // Since Tpetra is responsible for calling MPI_Finalize,
+  // Tpetra::finalize MUST have called MPI_Finalize.
+  if (! isMpiFinalized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard did not call MPI_Finalize."
+         << endl;
+  }
+  // Kokkos is like Tpetra; Kokkos::is_initialized() means "was
+  // initialized and was not finalized."  That differs from MPI, where
+  // MPI_Initialized only refers to MPI_Init and MPI_Finalized only
+  // refers to MPI_Finalize.
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard did not call Kokkos::finalize."
+         << endl;
+    return;
+  }
+
+  // MPI is no longer initialized, so we can't all-reduce on this.
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() returns true, "
+        "even after Tpetra::ScopeGuard::~ScopeGuard was called" << endl;
+    }
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi_user_inits_kokkos.cpp
@@ -1,0 +1,246 @@
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+bool isMpiFinalized ()
+{
+  int mpiFinalizedInt = 0;
+  (void) MPI_Finalized (&mpiFinalizedInt);
+  return mpiFinalizedInt != 0;
+}
+
+int getRankInCommWorld ()
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
+  return myRank;
+}
+
+bool allTrueInCommWorld (const bool lclTruth)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1, MPI_INT,
+                 MPI_MIN, MPI_COMM_WORLD);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (MPI_COMM_WORLD, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup on the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  // In this example, Tpetra::ScopeGuard's constructor is responsible
+  // for calling MPI_Init and MPI_Finalize, but the "user" is
+  // responsible for calling Kokkos::initialize and Kokkos::finalize.
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI was initialized, "
+      "before Tpetra::initialize was called." << endl;
+    return;
+  }
+
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "before Kokkos::initialize was called." << endl;
+    return;
+  }
+  Kokkos::initialize (argc, argv);
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "after Kokkos::initialize was called." << endl;
+    return;
+  }
+
+  int myRank = 0; // to be set below
+
+  cout << "Entering Tpetra scope" << endl;
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+
+    if (! isMpiInitialized ()) {
+      success = false;
+      cout << "MPI_Initialized claims MPI is not initialized, even after "
+        "MPI_Init and Tpetra::ScopeGuard::ScopeGuard were called." << endl;
+      Kokkos::finalize (); // for completeness
+      return;
+    }
+    // MPI claims to have been initialized, so after this point and
+    // before Tpetra::ScopeGuard's destructor is called, it should be
+    // safe to use MPI functions.
+
+    myRank = getRankInCommWorld ();
+
+    // Do all processes report Tpetra as initialized?
+    const bool tpetraInitialized = allTrueInCommWorld (Tpetra::isInitialized ());
+    if (! tpetraInitialized) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::isInitialized() is false on at least one process, "
+          "even after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      }
+    }
+
+    if (! Kokkos::is_initialized ()) {
+      success = false;
+      cout << "Kokkos::is_initialized() is false, even after "
+        "Kokkos::initialize and Tpetra::ScopeGuard::ScopeGuard were called."
+        << endl;
+    }
+
+    auto comm = Tpetra::getDefaultComm ();
+    const bool tpetraCommGloballyValid =
+      allTrueInCommWorld (tpetraCommIsLocallyLegit (comm.get ()));
+    if (! tpetraCommGloballyValid) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::getDefaultComm() returns an invalid comm "
+          "on at least one process." << endl;
+      }
+    }
+
+    // Means we should run on at least two MPI processes.
+    const int myTpetraRank = comm.is_null () ? 0 : comm->getRank ();
+    const bool ranksSame = allTrueInCommWorld (myRank == myTpetraRank);
+    if (! ranksSame) {
+      success = false;
+      if (myRank == 0) {
+        cout << "MPI rank does not match Tpetra rank "
+          "on at least one process" << endl;
+      }
+    }
+
+    if (myRank == 0) {
+      cout << "About to leave Tpetra scope" << endl;
+    }
+  }
+  if (myRank == 0) {
+    cout << "Left Tpetra scope" << endl;
+  }
+  // Since Tpetra::ScopeGuard's destructor was responsible for calling
+  // MPI_Finalize, the destructor MUST have called MPI_Finalize.
+  if (! isMpiFinalized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard did not call MPI_Finalize."
+         << endl;
+  }
+  // Kokkos is like Tpetra; Kokkos::is_initialized() means "was
+  // initialized and was not finalized."  That differs from MPI, where
+  // MPI_Initialized only refers to MPI_Init and MPI_Finalized only
+  // refers to MPI_Finalize.
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard was not supposed to call "
+      "Kokkos::finalize, but apparently did." << endl;
+    return;
+  }
+
+  // MPI is no longer initialized, so we can't all-reduce on this.
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() returns true, "
+        "even after Tpetra::ScopeGuard::~ScopeGuard has been called." << endl;
+    }
+  }
+
+  Kokkos::finalize ();
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false "
+      "even after calling Kokkos::finalize." << endl;
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_kokkos.cpp
@@ -1,0 +1,120 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+namespace { // (anonymous)
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "even before Kokkos::initialize was called." << endl;
+    return;
+  }
+  Kokkos::initialize (argc, argv);
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "even after Kokkos::initialize was called." << endl;
+    return;
+  }
+
+  // In this example, the "user" has called Kokkos::initialize before
+  // Tpetra::ScopeGuard's constructor is called.  ScopeGuard's
+  // constructor must not try to call it again.
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+    if (! Tpetra::isInitialized ()) {
+      success = false;
+      cout << "Tpetra::isInitialized() is false, "
+        "even after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      return;
+    }
+    if (! Kokkos::is_initialized ()) {
+      success = false;
+      cout << "Kokkos::is_initialized() is false, even after "
+        "Kokkos::initialize and Tpetra::ScopeGuard::ScopeGuard "
+        "were called." << endl;
+      // Let the program keep going, so MPI (if applicable) gets finalized.
+    }
+
+    cout << "About to leave Tpetra scope" << endl;
+  }
+  cout << "Left Tpetra scope" << endl;
+  if (Tpetra::isInitialized ()) {
+    success = false;
+    cout << "Tpetra::isInitialized() is true, "
+      "even after Tpetra::ScopeGuard::~ScopeGuard was called." << endl;
+    // Let the program keep going, so Kokkos gets finalized.
+  }
+
+  // Since the "user" is responsible for calling Kokkos::finalize,
+  // Tpetra::ScopeGuard's destructor should NOT have called
+  // Kokkos::finalize.
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "after Tpetra::ScopeGuard::~ScopeGuard was called." << endl;
+  }
+  Kokkos::finalize ();
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "even after Kokkos::initialize was called." << endl;
+  }
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi.cpp
@@ -1,0 +1,232 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+int getRankInCommWorld ()
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
+  return myRank;
+}
+
+bool allTrueInCommWorld (const bool lclTruth)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1, MPI_INT,
+                 MPI_MIN, MPI_COMM_WORLD);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (MPI_COMM_WORLD, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup on the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is initialized, "
+      "before MPI_Init was called" << endl;
+    return;
+  }
+  (void) MPI_Init (&argc, &argv);
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is not initialized, "
+      "even after MPI_Init was called" << endl;
+    return;
+  }
+  const int myRank = getRankInCommWorld ();
+
+  Kokkos::initialize (argc, argv);
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized claims Kokkos was not initialized, "
+      "even after Kokkos::initialize was called." << endl;
+    return;
+  }
+
+  // In this example, the "user" has called MPI_Init before
+  // Tpetra::ScopeGuard::ScopeGuard is called.  ScopeGuard's
+  // constructor must not try to call it again.
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+    if (! isMpiInitialized ()) {
+      success = false;
+      cout << "MPI_Initialized claims MPI was not initialized, "
+        "even after MPI_Init and Tpetra::ScopeGuard::ScopeGuard were called"
+        << endl;
+      return;
+    }
+    if (! Kokkos::is_initialized ()) {
+      success = false;
+      cout << "Kokkos::is_initialized() is false, "
+        "even after Kokkos::initialize and Tpetra::ScopeGuard::ScopeGuard "
+        " were called." << endl;
+      return;
+    }
+
+    // MPI is initialized, so we can check whether all processes
+    // report Tpetra as initialized.
+    const bool tpetraIsNowInitialized =
+      allTrueInCommWorld (Tpetra::isInitialized ());
+    if (! tpetraIsNowInitialized) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::isInitialized() is false on at least one process"
+          ", even after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      }
+      return;
+    }
+
+    auto comm = Tpetra::getDefaultComm ();
+    const bool tpetraCommGloballyValid =
+      allTrueInCommWorld (tpetraCommIsLocallyLegit (comm.get ()));
+    if (! tpetraCommGloballyValid) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::getDefaultComm() returns an invalid comm "
+          "on at least one process." << endl;
+      }
+    }
+
+    const int myTpetraRank = comm.is_null () ? 0 : comm->getRank ();
+    const bool ranksSame = allTrueInCommWorld (myRank == myTpetraRank);
+    if (! ranksSame) {
+      success = false;
+      if (myRank == 0) {
+        cout << "MPI rank does not match Tpetra rank "
+          "on at least one process" << endl;
+      }
+    }
+
+    if (myRank == 0) {
+      cout << "About to leave Tpetra scope" << endl;
+    }
+  }
+  if (myRank == 0) {
+    cout << "Left Tpetra scope" << endl;
+  }
+  // Since the "user" is responsible for calling Kokkos::finalize,
+  // Tpetra::ScopeGuard's destructor should NOT have called
+  // Kokkos::finalize.
+  if (! Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is false, "
+      "after Tpetra::ScopeGuard::~ScopeGuard was called." << endl;
+  }
+  // Since the "user" is responsible for calling MPI_Finalize,
+  // Tpetra::ScopeGuard's destructor should NOT have called
+  // MPI_Finalize.
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard seems to have called "
+      "MPI_Finalize, even though the user was responsible for "
+      "initializing and finalizing MPI." << endl;
+    return;
+  }
+
+  // MPI is still initialized, so we can check whether processes are
+  // consistent.
+  const bool tpetraGloballyFinalized =
+    allTrueInCommWorld (! Tpetra::isInitialized ());
+  if (! tpetraGloballyFinalized) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() returns true on some process, "
+        "even after Tpetra::ScopeGuard::~ScopeGuard was called" << endl;
+    }
+  }
+
+  (void) MPI_Finalize ();
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_and_provides_comm.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_and_provides_comm.cpp
@@ -1,0 +1,244 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+int getRankInComm (MPI_Comm comm)
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (comm, &myRank);
+  return myRank;
+}
+
+bool allTrueInComm (const bool lclTruth, MPI_Comm comm)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  (void) MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1,
+                        MPI_INT, MPI_MIN, comm);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm,
+                          MPI_Comm expectedMpiComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (expectedMpiComm, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "TEST FAILED: MPI_Initialized claims MPI is "
+      "initialized, before MPI_Init was called." << endl;
+    return;
+  }
+  (void) MPI_Init (&argc, &argv);
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "TEST FAILED: MPI_Initialized claims MPI is not "
+      "initialized, even after MPI_Init was called." << endl;
+    return;
+  }
+
+  // Split off Process 0 into a comm by itself.  Only create a
+  // Tpetra::ScopeGuard instance on the remaining processes.  The
+  // point is to test that there are no hidden dependencies on
+  // MPI_COMM_WORLD, since those often manifest as asking Process 0 in
+  // MPI_COMM_WORLD to do something.
+  const int color = (getRankInComm (MPI_COMM_WORLD) == 0) ? 0 : 1;
+  MPI_Comm splitComm = MPI_COMM_NULL;
+  {
+    const int key = 0;
+    const int errCode =
+      MPI_Comm_split (MPI_COMM_WORLD, color, key, &splitComm);
+    if (errCode != MPI_SUCCESS) {
+      success = false;
+      cout << "TEST FAILED: MPI_Comm_split failed!" << endl;
+      (void) MPI_Abort (MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+  }
+
+  if (color == 0) { // this subcomm doesn't participate
+    MPI_Comm_free (&splitComm);
+    MPI_Finalize ();
+    return;
+  }
+  // Invariant: color == 1, and we're on the corresponding splitComm.
+  const int mySplitRank = getRankInComm (splitComm);
+
+  // Special case of Tpetra::ScopeGuard, for when users want Tpetra to
+  // use a custom MPI_Comm as Tpetra's default communicator.
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv, splitComm);
+    if (! isMpiInitialized ()) {
+      success = false;
+      cout << "TEST FAILED: MPI_Initialized claims MPI was not initialized, "
+        "even after MPI_Init and Tpetra::ScopeGuard::ScopeGuard were called."
+        << endl;
+      return;
+    }
+
+    // MPI is initialized, so we can check whether all processes
+    // report Tpetra as initialized.
+    const bool tpetraIsNowInitialized =
+      allTrueInComm (Tpetra::isInitialized (), splitComm);
+    if (! tpetraIsNowInitialized) {
+      success = false;
+      if (mySplitRank == 0) {
+        cout << "TEST FAILED: Tpetra::isInitialized() is false on at least "
+          "one process, even after Tpetra::ScopeGuard::ScopeGuard was called."
+          << endl;
+      }
+      (void) MPI_Abort (MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    auto comm = Tpetra::getDefaultComm ();
+    const bool tpetraCommLocallyValid =
+      tpetraCommIsLocallyLegit (comm.get (), splitComm);
+    const bool tpetraCommGloballyValid =
+      allTrueInComm (tpetraCommLocallyValid, splitComm);
+    if (! tpetraCommGloballyValid) {
+      success = false;
+      if (mySplitRank == 0) {
+        cout << "TEST FAILED: Tpetra::getDefaultComm() returns "
+          "an invalid comm on at least one process." << endl;
+      }
+    }
+
+    {
+      // The above check already tests whether comm is null, so we
+      // just need to make sure that error case won't dereference
+      // nullptr.
+      const int myTpetraRank = comm.is_null () ? 0 : comm->getRank ();
+      const bool ranksSame =
+        allTrueInComm (mySplitRank == myTpetraRank, splitComm);
+      if (! ranksSame) {
+        success = false;
+        if (mySplitRank == 0) {
+          cout << "TEST FAILED: MPI rank does not match Tpetra rank "
+            "on at least one process." << endl;
+        }
+      }
+    }
+
+    if (mySplitRank == 0) {
+      cout << "About to leave Tpetra scope" << endl;
+    }
+  }
+  if (mySplitRank == 0) {
+    cout << "Left Tpetra scope" << endl;
+  }
+  // Since the "user" is responsible for calling MPI_Finalize,
+  // Tpetra::ScopeGuard's destructor should NOT have called
+  // MPI_Finalize.
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "TEST FAILED: Tpetra::ScopeGuard::~ScopeGuard seems to have "
+      "called MPI_Finalize, even though the user was supposed to be "
+      "responsible for initializing and finalizing MPI." << endl;
+    return;
+  }
+
+  // MPI is still initialized, so we can check whether processes are
+  // consistent.
+  const bool tpetraGloballyFinalized =
+    allTrueInComm (! Tpetra::isInitialized (), splitComm);
+  if (! tpetraGloballyFinalized) {
+    success = false;
+    if (mySplitRank == 0) {
+      cout << "TEST FAILED: Tpetra::isInitialized() returns true on some "
+        "process, even after Tpetra::ScopeGuard::~ScopeGuard has been called."
+        << endl;
+    }
+  }
+
+  (void) MPI_Comm_free (&splitComm);
+  (void) MPI_Finalize ();
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_tpetra_inits_kokkos.cpp
@@ -1,0 +1,233 @@
+#include <cstdlib>
+#include <iostream>
+#include "Tpetra_Core.hpp"
+#include "Kokkos_Core.hpp"
+
+#if ! defined(HAVE_TPETRACORE_MPI)
+#  error "Building and testing this example requires MPI."
+#endif // ! defined(HAVE_TPETRACORE_MPI)
+#include "mpi.h"
+#include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
+
+namespace { // (anonymous)
+
+bool isMpiInitialized ()
+{
+  int mpiInitializedInt = 0;
+  (void) MPI_Initialized (&mpiInitializedInt);
+  return mpiInitializedInt != 0;
+}
+
+int getRankInCommWorld ()
+{
+  int myRank = 0;
+  (void) MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
+  return myRank;
+}
+
+bool allTrueInCommWorld (const bool lclTruth)
+{
+  int lclTruthInt = lclTruth ? 1 : 0;
+  int gblTruthInt = 0;
+  MPI_Allreduce (&lclTruthInt, &gblTruthInt, 1, MPI_INT,
+                 MPI_MIN, MPI_COMM_WORLD);
+  return gblTruthInt != 0;
+}
+
+bool
+tpetraCommIsLocallyLegit (const Teuchos::Comm<int>* wrappedTpetraComm)
+{
+  if (wrappedTpetraComm == nullptr) {
+    return false;
+  }
+  MPI_Comm tpetraComm;
+  try {
+    using Tpetra::Details::extractMpiCommFromTeuchos;
+    tpetraComm = extractMpiCommFromTeuchos (*wrappedTpetraComm);
+  }
+  catch (...) {
+    return false;
+  }
+  if (tpetraComm == MPI_COMM_NULL) {
+    return false;
+  }
+  int result = MPI_UNEQUAL;
+  (void) MPI_Comm_compare (MPI_COMM_WORLD, tpetraComm, &result);
+  // Tpetra reserves the right to MPI_Comm_dup on the input comm.
+  return result == MPI_IDENT || result == MPI_CONGRUENT;
+}
+
+
+// NOTE TO TEST AUTHORS: The code that calls this function captures
+// std::cerr, so don't write to std::cerr on purpose in this function.
+void testMain (bool& success, int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  if (isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is initialized, "
+      "before MPI_Init was called" << endl;
+    return;
+  }
+  (void) MPI_Init (&argc, &argv);
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "MPI_Initialized claims MPI is not initialized, "
+      "even after MPI_Init was called" << endl;
+    return;
+  }
+  const int myRank = getRankInCommWorld ();
+
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "even though Kokkos::initialize was not yet called." << endl;
+    return;
+  }
+
+  // This test exercises the case where the "user" has called MPI_Init
+  // before calling Tpetra::ScopeGuard's constructor, but has not yet
+  // called Kokkos::initialize.
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+    if (! isMpiInitialized ()) {
+      success = false;
+      cout << "MPI_Initialized claims MPI was not initialized, "
+        "even after MPI_Init and Tpetra::ScopeGuard::ScopeGuard were called."
+        << endl;
+      return;
+    }
+    if (! Kokkos::is_initialized ()) {
+      success = false;
+      cout << "Kokkos::is_initialized() is false, "
+        "even after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      return;
+    }
+
+    // MPI is initialized, so we can check whether all processes
+    // report Tpetra as initialized.
+    const bool tpetraIsNowInitialized =
+      allTrueInCommWorld (Tpetra::isInitialized ());
+    if (! tpetraIsNowInitialized) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::isInitialized() is false on at least one process"
+          ", even after Tpetra::ScopeGuard::ScopeGuard was called." << endl;
+      }
+      if (Kokkos::is_initialized ()) {
+        Kokkos::finalize ();
+      }
+      (void) MPI_Finalize (); // just for completeness
+      return;
+    }
+
+    auto comm = Tpetra::getDefaultComm ();
+    const bool tpetraCommGloballyValid =
+      allTrueInCommWorld (tpetraCommIsLocallyLegit (comm.get ()));
+    if (! tpetraCommGloballyValid) {
+      success = false;
+      if (myRank == 0) {
+        cout << "Tpetra::getDefaultComm() returns an invalid comm "
+          "on at least one process." << endl;
+      }
+    }
+
+    const int myTpetraRank = comm.is_null () ? 0 : comm->getRank ();
+    const bool ranksSame = allTrueInCommWorld (myRank == myTpetraRank);
+    if (! ranksSame) {
+      success = false;
+      if (myRank == 0) {
+        cout << "MPI rank does not match Tpetra rank "
+          "on at least one process" << endl;
+      }
+    }
+
+    if (myRank == 0) {
+      cout << "About to leave Tpetra scope" << endl;
+    }
+  }
+  if (myRank == 0) {
+    cout << "Left Tpetra scope" << endl;
+  }
+  // Tpetra::ScopeGuard's destructor was responsible for calling
+  // Kokkos::finalize.
+  if (Kokkos::is_initialized ()) {
+    success = false;
+    cout << "Kokkos::is_initialized() is true, "
+      "after Tpetra::ScopeGuard::~ScopeGuard was called." << endl;
+  }
+  // Since the "user" is responsible for calling MPI_Finalize,
+  // Tpetra::ScopeGuard's destructor should NOT have called
+  // MPI_Finalize.
+  if (! isMpiInitialized ()) {
+    success = false;
+    cout << "Tpetra::ScopeGuard::~ScopeGuard seems to have called "
+      "MPI_Finalize, even though the user was responsible for initializing "
+      "and finalizing MPI." << endl;
+    return;
+  }
+
+  // MPI is still initialized, so we can check whether processes are
+  // consistent.
+  const bool tpetraGloballyFinalized =
+    allTrueInCommWorld (! Tpetra::isInitialized ());
+  if (! tpetraGloballyFinalized) {
+    success = false;
+    if (myRank == 0) {
+      cout << "Tpetra::isInitialized() returns true on some process, "
+        "even after Tpetra::ScopeGuard::~ScopeGuard has been called." << endl;
+    }
+  }
+
+  (void) MPI_Finalize ();
+}
+
+class CaptureOstream {
+public:
+  CaptureOstream (std::ostream& stream) :
+    originalStream_ (stream),
+    originalBuffer_ (stream.rdbuf ())
+  {
+    originalStream_.rdbuf (tempStream_.rdbuf ());
+  }
+
+  std::string getCapturedOutput () const {
+    return tempStream_.str ();
+  }
+
+  ~CaptureOstream () {
+    originalStream_.rdbuf (originalBuffer_);
+  }
+private:
+  std::ostream& originalStream_;
+  std::ostringstream tempStream_;
+  using buf_ptr_type = decltype (originalStream_.rdbuf ());
+  buf_ptr_type originalBuffer_;
+};
+
+} // namespace (anonymous)
+
+int main (int argc, char* argv[])
+{
+  using std::cout;
+  using std::endl;
+
+  bool success = true;
+  {
+    // Capture std::cerr output, so we can tell if Tpetra::initialize
+    // printed a warning message.
+    CaptureOstream captureCerr (std::cerr);
+    testMain (success, argc, argv);
+    const std::string capturedOutput = captureCerr.getCapturedOutput ();
+    cout << "Captured output: " << capturedOutput << endl;
+    if (capturedOutput.size () != 0) {
+      success = false; // should NOT have printed in this case
+      cout << "Captured output is empty!" << endl;
+    }
+  }
+
+  cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
@trilinos/tpetra

## Description

Tpetra now has a ScopeGuard class, analogous to `Kokkos::ScopeGuard` and `Teuchos::GlobalMPISession`.  This fixes #2459.  I also added tests for all possible cases of MPI and/or Kokkos initialization.

## Motivation and Context

Scope guards ensure safe finalization even if an exception is thrown.

## Related Issues

* Closes #2459 

## How Has This Been Tested?

Locally, with MPI enabled.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.