### PR TITLE
Disable MueLu_UnitTestsTpetra_MPI_4 for standard CI GCC 4.8.4 OpenMP build (#3035)

### DIFF
--- a/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake
+++ b/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP.cmake
@@ -31,6 +31,9 @@ TRIL_SET_BOOL_CACHE_VAR(ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_
 TRIL_SET_BOOL_CACHE_VAR(ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE TRUE)
 TRIL_SET_BOOL_CACHE_VAR(ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE TRUE)
 
+# Disable this MueLu test until it can be fixed for OpenMP (#3035)
+TRIL_SET_BOOL_CACHE_VAR(MueLu_UnitTestsTpetra_MPI_4_DISABLE TRUE)
+
 # NOTE: The order of these includes matters!
 
 include("${CMAKE_CURRENT_LIST_DIR}/MpiReleaseDebugSharedPtSettings.cmake")


### PR DESCRIPTION
## Description

This test has already been disabled for the Trilinos GCC 4.8.4 OpenMP PR
build, but since that build duplicated all of these options instead of sharing
the files, it did not get updated for this build.

This should allow us to finally add "Disabled Tests" label to #3035.

## Motivation and Context

The CI build was failing because of this since 6/20/2018.  I did not see that because a name change in that CI build for adding OPENMP to the name broke my email filter.

## How Has This Been Tested?

I tested this with the `checkin-test-sems.sh` script locally and saw in the configure output:

```
...
-- Setting MueLu_UnitTestsTpetra_MPI_4_DISABLE='TRUE' by default
...
-- MueLu_UnitTestsTpetra_MPI_4: NOT added test because MueLu_UnitTestsTpetra_MPI_4_DISABLE='TRUE'!
...
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
