### PR TITLE
Tpetra: Use ScopeGuard in examples

### DIFF
--- a/packages/tpetra/core/example/Additive-Schwarz-Halo/AdditiveSchwarzHalo.cpp
+++ b/packages/tpetra/core/example/Additive-Schwarz-Halo/AdditiveSchwarzHalo.cpp
@@ -44,21 +44,14 @@
 #include <sstream>
 
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_FancyOStream.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_OrdinalTraits.hpp>
-#include <Teuchos_DefaultComm.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
-#include <Tpetra_Version.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_MultiVector.hpp>
-//#include <Tpetra_TestingUtilities.hpp>
-
-
-
 
 int main (int argc, char *argv[]) 
 {
@@ -68,128 +61,113 @@ int main (int argc, char *argv[])
   using Teuchos::Array;
   using Teuchos::tuple;
 
-  // MPI / Kokkos initialization 
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv, NULL);
-  Kokkos::initialize(argc, argv);
-  RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
+  // Tpetra::ScopeGuard initializes MPI and Kokkos, if they haven't
+  // been initialized already.  Its destructor will finalize MPI and
+  // Kokkos.
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    // Put all Tpetra objects in an inner scope.  They must not be
+    // allowed to persist past the end of the Tpetra::ScopeGuard
+    // object's lifetime.
+    auto comm = Tpetra::getDefaultComm ();
 
-  int num_halo_expansions = 1;  
-  Teuchos::CommandLineProcessor clp;
+    int num_halo_expansions = 1;  
+    Teuchos::CommandLineProcessor clp;
     clp.addOutputSetupOptions(true);
-    clp.setOption(
-        "halo-expansions", &num_halo_expansions ,
-        "Number of times to expand the halo for Additive Schwarz");
-  switch (clp.parse(argc, argv)) {
+    clp.setOption("halo-expansions", &num_halo_expansions ,
+		  "Number of times to expand the halo for Additive Schwarz");
+    switch (clp.parse(argc, argv)) {
     case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
     case Teuchos::CommandLineProcessor::PARSE_ERROR:
     case Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION: return EXIT_FAILURE;
     case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:          break;
-  }
+    }
 
-
-  typedef double Scalar;
-
-  // Get LocalOrdinal & GlobalOrdinal from Map defaults.
-  typedef Tpetra::Map<>::local_ordinal_type LocalOrdinal;
-  typedef Tpetra::Map<>::global_ordinal_type GlobalOrdinal;
-  typedef Tpetra::Map<>::node_type Node;
-  typedef LocalOrdinal LO;
-  typedef GlobalOrdinal GO;
-  typedef Teuchos::ScalarTraits<Scalar> ST;
-  typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> MAT;
-  typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> MV;
-  typedef Tpetra::Import<LocalOrdinal,GlobalOrdinal,Node> IMP;
+    using Scalar = double;
+    using LO = Tpetra::Map<>::local_ordinal_type;
+    using GO = Tpetra::Map<>::global_ordinal_type;
+    using Node = Tpetra::Map<>::node_type;
+    using ST = Teuchos::ScalarTraits<Scalar>;
+    using MAT = Tpetra::CrsMatrix<Scalar>;
+    using MV = Tpetra::MultiVector<Scalar>;
+    using IMP = Tpetra::Import<>;
   
-  const GlobalOrdinal ONE = Teuchos::OrdinalTraits<GlobalOrdinal>::one();
-  const GlobalOrdinal GO_INVALID = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
-  
-  
-  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) Matrix Fill")));
+    const GO ONE = Teuchos::OrdinalTraits<GO>::one();
+    const GO GO_INVALID = Teuchos::OrdinalTraits<GO>::invalid();
 
-  const size_t numImages = comm->getSize();
-  const size_t myImageID = comm->getRank();
+    RCP<MAT> A;
+    {
+      TimeMonitor tm (*TimeMonitor::getNewTimer("1) Matrix Fill"));
 
+      const size_t numImages = comm->getSize();
+      const size_t myImageID = comm->getRank();
    
-  if (numImages < 2) return -1;
-  // create a Map
-  RCP<const Tpetra::Map<LO,GO,Node> > map =
-    Tpetra::createContigMapWithNode<LO,GO,Node>(GO_INVALID,ONE,comm);
-  // create a multivector ones(n,1)
-  MV ones(map,ONE,false), threes(map,ONE,false);
-  ones.putScalar(ST::one());
-  /* create the following matrix:
-     [2 1           ]
-     [1 1 1         ]
-     [  1 1 1       ]
-     [   . . .      ]
-     [     . . .    ]
-     [       . . .  ]
-     [         1 1 1]
-     [           1 2]
-     this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
-  */
-  MAT A(map,3);
-  if (myImageID == 0) {
-    Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*ST::one(), ST::one()));
-    Array<GO> cols(tuple<GO>(myImageID, myImageID+1));
-    A.insertGlobalValues(myImageID,cols(),vals());
-  }
-  else if (myImageID == numImages-1) {
-    Array<Scalar> vals(tuple<Scalar>(ST::one(), static_cast<Scalar>(2)*ST::one()));
-    Array<GO> cols(tuple<GO>(myImageID-1,myImageID));
-    A.insertGlobalValues(myImageID,cols(),vals());
-  }
-  else {
-    Array<Scalar> vals(3,ST::one());
-    Array<GO> cols(tuple<GO>(myImageID-1, myImageID, myImageID+1));
-    A.insertGlobalValues(myImageID,cols(),vals());
-  }
-  A.fillComplete();
+      if (numImages < 2) return -1;
+      // create a Map
+      RCP<const Tpetra::Map<> > map = 
+	Tpetra::createContigMapWithNode<LO,GO,Node>(GO_INVALID, ONE, comm);
+      /* create the following matrix:
+	 [2 1           ]
+	 [1 1 1         ]
+	 [  1 1 1       ]
+	 [   . . .      ]
+	 [     . . .    ]
+	 [       . . .  ]
+	 [         1 1 1]
+	 [           1 2]
+	 this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
+      */
+      A = rcp (new MAT(map, 3, Tpetra::StaticProfile));
+      if (myImageID == 0) {
+	Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*ST::one(), ST::one()));
+	Array<GO> cols(tuple<GO>(myImageID, myImageID+1));
+	A->insertGlobalValues(myImageID,cols(),vals());
+      }
+      else if (myImageID == numImages-1) {
+	Array<Scalar> vals(tuple<Scalar>(ST::one(), static_cast<Scalar>(2)*ST::one()));
+	Array<GO> cols(tuple<GO>(myImageID-1,myImageID));
+	A->insertGlobalValues(myImageID,cols(),vals());
+      }
+      else {
+	Array<Scalar> vals(3,ST::one());
+	Array<GO> cols(tuple<GO>(myImageID-1, myImageID, myImageID+1));
+	A->insertGlobalValues(myImageID,cols(),vals());
+      }
+      A->fillComplete();
+    }
+
+    RCP<MAT> Mold, Mnew;    
+    {
+      TimeMonitor tm (*TimeMonitor::getNewTimer("2) Halo Generation"));
+
+      Mold = A;
+      Mnew = Mold;
   
-  tm.reset();
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("2) Halo Generation")));
-
-  RCP<MAT> Mold, Mnew;
-  Mold = rcp(&A,false);
-  Mnew = Mold;
-  
-  for (int i=0; i<num_halo_expansions; i++) {
-
-    // Get the importer    
-    RCP<const IMP> rowImporter = Mold->getGraph()->getImporter();
-    
-    // ImportAndFillComplete
-    Mnew = Tpetra::importAndFillCompleteCrsMatrix<MAT>(Mold,*rowImporter);
-
-    Mold = Mnew;
-  }
-  
-
-  tm = Teuchos::null;
+      for (int i=0; i<num_halo_expansions; ++i) {
+	RCP<const IMP> rowImporter = Mold->getGraph()->getImporter();
+	Mnew = Tpetra::importAndFillCompleteCrsMatrix<MAT>(Mold,*rowImporter);
+	Mold = Mnew;
+      }
+    }
 
 #if DEBUG_OUTPUT
-
-  int rank = comm->getRank();
-  {
-    std::ofstream ofs1( std::string("orig.") + std::to_string(rank) + std::string(".dat") );
-    auto out1 = Teuchos::getFancyOStream(Teuchos::rcpFromRef(ofs1));
-    A.describe(*out1,Teuchos::VERB_EXTREME);
-  }
-  {
-    std::ofstream ofs1( std::string("new.") + std::to_string(rank) + std::string(".dat") );
-    auto out1 = Teuchos::getFancyOStream(Teuchos::rcpFromRef(ofs1));
-    Mnew->describe(*out1,Teuchos::VERB_EXTREME);
-  }
+    int rank = comm->getRank();
+    {
+      std::ofstream ofs1( std::string("orig.") + std::to_string(rank) + std::string(".dat") );
+      auto out1 = Teuchos::getFancyOStream(Teuchos::rcpFromRef(ofs1));
+      A.describe(*out1,Teuchos::VERB_EXTREME);
+    }
+    {
+      std::ofstream ofs1( std::string("new.") + std::to_string(rank) + std::string(".dat") );
+      auto out1 = Teuchos::getFancyOStream(Teuchos::rcpFromRef(ofs1));
+      Mnew->describe(*out1,Teuchos::VERB_EXTREME);
+    }
 #endif
-  
-  // Finalize Kokkos
-  Kokkos::finalize();
 
-  // This tells the Trilinos test framework that the test passed.
-  if(0 == mpiSession.getRank())
-  {
-    std::cout << "End Result: TEST PASSED" << std::endl;
+    if(comm->getRank() == 0) {
+      // Tell the Trilinos test framework that the test passed.
+      std::cout << "End Result: TEST PASSED" << std::endl;
+    }
   }
-
   return EXIT_SUCCESS;
 }  // END main()

--- a/packages/tpetra/core/example/Lesson01-Init/index.doc
+++ b/packages/tpetra/core/example/Lesson01-Init/index.doc
@@ -37,13 +37,15 @@ analogous to Epetra_Comm.)  If MPI is enabled, then this wraps an
 MPI_Comm.  Otherwise, this is a "serial communicator" with one
 process, analogous to MPI_COMM_SELF.
 
-Furthermore, Trilinos provides an MPI initialization interface,
-Teuchos::GlobalMPISession.  This calls MPI_Init and MPI_Finalize for
-you in an MPI build, and does not call them if you did not build
-Trilinos with MPI support.  The following code example shows how to
-initialize MPI (if available) and get a Teuchos::Comm corresponding
-to MPI_COMM_WORLD.  The example works whether or not Trilinos was
-build with MPI support.
+Tpetra also provides an MPI initialization interface,
+Tpetra::ScopeGuard.  If you built Trilinos with MPI enabled, but have
+not yet initialized MPI, ScopeGuard's constructor calls MPI_Init for
+you, and its destructor calls MPI_Finalize for you.  The following
+code example shows how to initialize MPI (if available) and get a
+Teuchos::Comm corresponding to MPI_COMM_WORLD.  The example works
+whether or not Trilinos was build with MPI support.  If you prefer a
+C-style initialization and finalization interface, you may use
+Tpetra::initialize and Tpetra::finalize instead.
 
 \include lesson01_mpi_only_through_Tpetra.cpp
 
@@ -59,15 +61,16 @@ such as MPI_COMM_WORLD, or by creating a new one.
 
 \section Tpetra_Lesson01_ExistingNonMpiCode Initialization for an existing non-MPI code
 
-The first code example in this lesson uses Teuchos::GlobalMPISession
-to initialize MPI.  Despite the name, in a non-MPI build of Trilinos,
-it does nothing.  Thus, if you built Trilinos with MPI disabled, you
-should feel free to invoke Teuchos::GlobalMPISession in your main()
-function.  However, if you are using a build of Trilinos that has MPI
-enabled, but you don't want to use MPI in your application, you should
-not use Teuchos::GlobalMPISession.  Instead, you should create a
-Teuchos::SerialComm directly as the "communicator."  The following
-example shows how to create a Teuchos::SerialComm.
+The first code example in this lesson uses Tpetra::ScopeGuard to
+initialize MPI.  Despite the name, in a non-MPI build of Trilinos, it
+does nothing.  Thus, if you built Trilinos with MPI disabled, you
+should feel free to use Tpetra::ScopeGuard in your main() function.
+However, if you are using a build of Trilinos that has MPI enabled,
+but you don't want to use multiple MPI processes in your application,
+you may use the three-argument version of Tpetra::ScopeGuard's
+constructor, that takes an MPI_Comm argument.  Just pass in
+MPI_COMM_SELF to force Tpetra not to use multiple processes.  The
+following example illustrates this.
 
 \include lesson01_no_mpi.cpp
 

--- a/packages/tpetra/core/example/Lesson01-Init/lesson01_mpi_on_its_own.cpp
+++ b/packages/tpetra/core/example/Lesson01-Init/lesson01_mpi_on_its_own.cpp
@@ -56,40 +56,46 @@ main (int argc, char *argv[])
   // This code takes the place of whatever you do to get an MPI_Comm.
   MPI_Comm yourComm = MPI_COMM_WORLD;
 
-  // If your code plans to use MPI on its own, as well as through
-  // Trilinos, consider giving Trilinos a copy of your MPI_Comm
-  // (created via MPI_Comm_dup) rather than your MPI_Comm directly.
-  // Trilinos may in the future duplicate the MPI_Comm automatically,
-  // but it does not currently do this.  Duplicating the MPI_Comm is
-  // not necessary, but may make it easier for you to overlap
-  // asynchronous communication operations performed by Trilinos with
-  // those performed by your code.
+  {
+    // Never create Tpetra objects at main scope.  Their destructors
+    // must be called before MPI_Finalize and Kokkos::finalize are
+    // called.
 
-  // Wrap the MPI_Comm.  If you wrap it in this way, you are telling
-  // Trilinos that you are responsible for calling MPI_Comm_free on
-  // your MPI_Comm after use, if necessary.  (It's not necessary for
-  // MPI_COMM_WORLD.)  There is a way to tell Trilinos to call
-  // MPI_Comm_free itself; we don't show it here.  (It involves
-  // passing the result of Teuchos::opaqueWrapper to MpiComm's
-  // constructor.)
+    // If your code plans to use MPI on its own, as well as through
+    // Trilinos, consider giving Trilinos a copy of your MPI_Comm
+    // (created via MPI_Comm_dup) rather than your MPI_Comm directly.
+    // Trilinos may in the future duplicate the MPI_Comm
+    // automatically, but it does not currently do this.  Duplicating
+    // the MPI_Comm is not necessary, but may make it easier for you
+    // to overlap asynchronous communication operations performed by
+    // Trilinos with those performed by your code.
 
-  RCP<const Comm<int> > comm (new MpiComm<int> (yourComm));
+    // Wrap the MPI_Comm.  If you wrap it in this way, you are telling
+    // Trilinos that you are responsible for calling MPI_Comm_free on
+    // your MPI_Comm after use, if necessary.  (It's not necessary for
+    // MPI_COMM_WORLD.)  There is a way to tell Trilinos to call
+    // MPI_Comm_free itself; we don't show it here.  (It involves
+    // passing the result of Teuchos::opaqueWrapper to MpiComm's
+    // constructor.)
 
-  // Get my process' rank, and the total number of processes.
-  // Equivalent to MPI_Comm_rank resp. MPI_Comm_size.
-  const int myRank = comm->getRank ();
-  const int numProcs = comm->getSize ();
+    RCP<const Comm<int> > comm (new MpiComm<int> (yourComm));
 
-  if (myRank == 0) {
-    cout << "Total number of processes: " << numProcs << endl;
-  }
+    // Get my process' rank, and the total number of processes.
+    // Equivalent to MPI_Comm_rank resp. MPI_Comm_size.
+    const int myRank = comm->getRank ();
+    const int numProcs = comm->getSize ();
 
-  // Do something with the new communicator.
-  exampleRoutine (comm);
+    if (myRank == 0) {
+      cout << "Total number of processes: " << numProcs << endl;
+    }
 
-  // This tells the Trilinos test framework that the test passed.
-  if (myRank == 0) {
-    cout << "End Result: TEST PASSED" << endl;
+    // Do something with the new communicator.
+    exampleRoutine (comm);
+
+    // This tells the Trilinos test framework that the test passed.
+    if (myRank == 0) {
+      cout << "End Result: TEST PASSED" << endl;
+    }
   }
 
   // If you need to call MPI_Comm_free on your MPI_Comm, now would be

--- a/packages/tpetra/core/example/Lesson01-Init/lesson01_mpi_only_through_Tpetra.cpp
+++ b/packages/tpetra/core/example/Lesson01-Init/lesson01_mpi_only_through_Tpetra.cpp
@@ -10,9 +10,8 @@
 // communicator, and printing out Tpetra version information.
 //
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 
 // Do something with the given communicator.  In this case, we just
 // print Tpetra's version to stdout on Process 0.
@@ -37,49 +36,43 @@ main (int argc, char *argv[])
 
   // Start up MPI, if using MPI.  Trilinos doesn't have to be built
   // with MPI; it's called a "serial" build if you build without MPI.
-  // GlobalMPISession hides this implementation detail.
-  //
-  // Note the third argument.  If you pass GlobalMPISession the
-  // address of an std::ostream, it will print a one-line status
-  // message with the rank on each MPI process.  This may be
-  // undesirable if running with a large number of MPI processes.
-  // You can avoid printing anything here by passing in either
-  // NULL or the address of a Teuchos::oblackholestream.
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, NULL);
+  // Tpetra::ScopeGuard hides this implementation detail.
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
-  // Get a pointer to the communicator object representing
-  // MPI_COMM_WORLD.  getDefaultPlatform.getComm() doesn't create a
-  // new object every time you call it; it just returns the same
-  // communicator each time.  Thus, you can call it anywhere and get
-  // the same communicator.  (This is handy if you don't want to pass
-  // a communicator around everywhere, though it's always better to
-  // parameterize your algorithms on the communicator.)
-  //
-  // "Tpetra::DefaultPlatform" knows whether or not we built with MPI
-  // support.  If we didn't build with MPI, we'll get a "communicator"
-  // with size 1, whose only process has rank 0.
-  Teuchos::RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  {
+    // Never let Tpetra objects persist after either MPI_Finalize or
+    // Kokkos::finalize has been called.  This is because the objects'
+    // destructors may need to call MPI or Kokkos functions.  In
+    // particular, never create Tpetra objects at main scope.
 
-  // Get my process' rank, and the total number of processes.
-  // Equivalent to MPI_Comm_rank resp. MPI_Comm_size.
-  const int myRank = comm->getRank ();
-  const int numProcs = comm->getSize ();
+    // Get a pointer to the communicator object representing
+    // MPI_COMM_WORLD.  The function knows whether or not we built with
+    // MPI support.  If we didn't build with MPI, we'll get a
+    // "communicator" with size 1, whose only process has rank 0.
+    Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
-  if (myRank == 0) {
-    cout << "Total number of processes: " << numProcs << endl;
+    // Get my process' rank, and the total number of processes.
+    // Equivalent to MPI_Comm_rank resp. MPI_Comm_size.
+    const int myRank = comm->getRank ();
+    const int numProcs = comm->getSize ();
+
+    if (myRank == 0) {
+      cout << "Total number of processes: " << numProcs << endl;
+    }
+
+    // Do something with the new communicator.
+    exampleRoutine (comm);
+
+    // This tells the Trilinos test framework that the test passed.
+    if (myRank == 0) {
+      cout << "End Result: TEST PASSED" << endl;
+    }
+    // ScopeGuard's destructor calls MPI_Finalize, if its constructor
+    // called MPI_Init.  Likewise, it calls Kokkos::finalize, if its
+    // constructor called Kokkos::initialize.
   }
 
-  // Do something with the new communicator.
-  exampleRoutine (comm);
-
-  // This tells the Trilinos test framework that the test passed.
-  if (myRank == 0) {
-    cout << "End Result: TEST PASSED" << endl;
-  }
-
-  // GlobalMPISession calls MPI_Finalize() in its destructor, if
-  // appropriate.  You don't have to do anything here!  Just return
-  // from main().  Isn't that helpful?
+  // You don't have to do anything here!  Just return from main().
+  // Isn't that helpful?
   return 0;
 }

--- a/packages/tpetra/core/example/Lesson01-Init/lesson01_no_mpi.cpp
+++ b/packages/tpetra/core/example/Lesson01-Init/lesson01_no_mpi.cpp
@@ -6,10 +6,8 @@
 */
 
 // ... Your other include files go here ...
-#include <Tpetra_DefaultPlatform.hpp>
-#include <Teuchos_DefaultSerialComm.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
-#include <Teuchos_oblackholestream.hpp>
 
 // Do something with the given communicator.  In this case, we just
 // print Tpetra's version to stdout on Process 0.
@@ -32,46 +30,53 @@ main (int argc, char *argv[])
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  // Make a "serial" (non-MPI) communicator.
-  // It doesn't actually "communicate," because it only has one process.
-  RCP<const Comm<int> > comm (new SerialComm<int> ());
+  // Tpetra's default communicator will use a 1-process comm.
+#ifdef HAVE_TPETRA_MPI
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv, MPI_COMM_SELF);
+#else
+  // Not building with MPI, so default comm won't use MPI.
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+#endif // HAVE_TPETRA_MPI  
+  {
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 
-  // With a "serial" communicator, the rank is always 0,
-  // and the number of processes is always 1.
-  const int myRank = comm->getRank ();
-  const int numProcs = comm->getSize ();
+    // With a single-process communicator, the rank is always 0, and
+    // the number of processes is always 1.
+    const int myRank = comm->getRank ();
+    const int numProcs = comm->getSize ();
 
-  if (myRank == 0) {
-    cout << "Total number of processes: " << numProcs << endl;
+    if (myRank == 0) {
+      cout << "Total number of processes: " << numProcs << endl;
+    }
+
+    // Test the two assertions in the previous comment.
+    // TEUCHOS_TEST_FOR_EXCEPTION is a macro defined in the Teuchos
+    // package that takes three arguments: a bool expression, an
+    // exception to throw if the expression evaluates to true, and a
+    // message (interpreted as if it follows a "<<" after an
+    // std::ostream) to include in the exception.  The macro includes
+    // useful line number and file information in the exception
+    // message, as well as a place where you can set a breakpoint in a
+    // debugger right before the exception is thrown.
+
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (myRank != 0, std::logic_error,
+       "This is a single-MPI-process example, but the calling process' "
+       "rank is " << myRank << " != 0.  Please report this bug.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (numProcs != 1, std::logic_error,
+       "This is a single-MPI-process example, but the number of "
+       "processes in the Teuchos::Comm is " << numProcs << " != 1.  "
+       "Please report this bug.");
+
+    // Do something with the new communicator.
+    exampleRoutine (comm);
+
+    // This tells the Trilinos test framework that the test passed.
+    if (myRank == 0) {
+      cout << "End Result: TEST PASSED" << endl;
+    }
   }
-
-  // Test the two assertions in the previous comment.
-  // TEUCHOS_TEST_FOR_EXCEPTION is a macro defined in the Teuchos
-  // package that takes three arguments: a bool expression, an
-  // exception to throw if the expression evaluates to true, and a
-  // message (interpreted as if it follows a "<<" after an
-  // std::ostream) to include in the exception.  The macro includes
-  // useful line number and file information in the exception message,
-  // as well as a place where you can set a breakpoint in a debugger
-  // right before the exception is thrown.
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    myRank != 0, std::logic_error,
-    "This is a serial (non-MPI) example, but the rank of the calling process "
-    "the Teuchos::Comm is " << myRank << " != 0.  Please report this bug.");
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    numProcs != 1, std::logic_error,
-    "This is a serial (non-MPI) example, but the number of processes in "
-    "the Teuchos::Comm is " << numProcs << " != 1.  Please report this bug.");
-
-  // Do something with the new communicator.
-  exampleRoutine (comm);
-
-  // This tells the Trilinos test framework that the test passed.
-  if (myRank == 0) {
-    cout << "End Result: TEST PASSED" << endl;
-  }
-
   return 0;
 }

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec.cpp
@@ -47,11 +47,9 @@
 \ref Tpetra_Lesson02 explains this example in detail.
 */
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Version.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
 
 void
 exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
@@ -67,8 +65,12 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   using Teuchos::REDUCE_SUM;
   using Teuchos::reduceAll;
 
+  const int myRank = comm->getRank ();
+
   // Print out the Tpetra software version information.
-  out << Tpetra::version () << endl << endl;
+  if (myRank == 0) {
+    out << Tpetra::version () << endl << endl;
+  }
 
   // Type of the Tpetra::Map specialization to use.
   typedef Tpetra::Map<> map_type;
@@ -130,15 +132,22 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   // Set all entries of x to 42.0.
   x.putScalar (42.0);
 
-  // Print the norm of x.
-  out << "Norm of x (all entries are 42.0): " << x.norm2 () << endl;
+  // norm2() is a collective, so we need to call it on all processes
+  // in the Vector's communicator.
+  auto x_norm2 = x.norm2 ();
+  if (myRank == 0) {
+    out << "Norm of x (all entries are 42.0): " << x_norm2 << endl;
+  }
 
   // Set the entries of x to (pseudo)random numbers.  Please don't
   // consider this a good parallel pseudorandom number generator.
   x.randomize ();
 
   // Print the norm of x.
-  out << "Norm of x (random numbers): " << x.norm2 () << endl;
+  x_norm2 = x.norm2 ();
+  if (myRank == 0) {
+    out << "Norm of x (random numbers): " << x_norm2 << endl;
+  }
 
   //////////////////////////////////////////////////////////////////////
   // Read the entries of the Vector
@@ -186,9 +195,11 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // Find the total number of entries less than 0.5, over all
     // processes in the Vector's communicator.  Note the trick for
     // pluralizing the word "entry" conditionally on globalCount.
-    out << "x has " << globalCount << " entr"
-        << (globalCount != 1 ? "ies" : "y")
-        << " less than 0.5." << endl;
+    if (myRank == 0) {
+      out << "x has " << globalCount << " entr"
+	  << (globalCount != 1 ? "ies" : "y")
+	  << " less than 0.5." << endl;
+    }
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -216,7 +227,10 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     }
 
     // Print the norm of x.
-    out << "Norm of x (modified random numbers): " << x.norm2 () << endl;
+    x_norm2 = x.norm2 ();
+    if (myRank == 0) {
+      out << "Norm of x (modified random numbers): " << x_norm2 << endl;
+    }
   }
 }
 
@@ -226,23 +240,14 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
 int
 main (int argc, char *argv[])
 {
-  using std::endl;
-  using Teuchos::RCP;
-
-  Teuchos::oblackholestream blackHole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-
-  const int myRank = comm->getRank ();
-  std::ostream& out = (myRank == 0) ? std::cout : blackHole;
-
-  exampleRoutine (comm, out); // This is where the action takes place.
-
-  // This tells the Trilinos test framework that the test passed.
-  if (myRank == 0) {
-    std::cout << "End Result: TEST PASSED" << std::endl;
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    exampleRoutine (comm, std::cout);
+    // This tells the Trilinos test framework that the test passed.
+    if (comm->getRank () == 0) {
+      std::cout << "End Result: TEST PASSED" << std::endl;
+    }
   }
-
   return 0;
 }

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
@@ -47,11 +47,9 @@
 \ref Tpetra_Lesson02 explains this example in detail.
 */
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Version.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
 
 void
 exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
@@ -67,8 +65,12 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   using Teuchos::REDUCE_SUM;
   using Teuchos::reduceAll;
 
+  const int myRank = comm->getRank ();
+
   // Print out the Tpetra software version information.
-  out << Tpetra::version () << endl << endl;
+  if (myRank == 0) {
+    out << Tpetra::version () << endl << endl;
+  }
 
   // Type of the Tpetra::Map specialization to use.
   typedef Tpetra::Map<> map_type;
@@ -126,15 +128,21 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   // Set all entries of x to 42.0.
   x.putScalar (42.0);
 
-  // Print the norm of x.
-  out << "Norm of x (all entries are 42.0): " << x.norm2 () << endl;
+  // norm2() is a collective, so we need to call it on all processes
+  // in the Vector's communicator.
+  auto x_norm2 = x.norm2 ();
+  if (myRank == 0) {
+    out << "Norm of x (all entries are 42.0): " << x_norm2 << endl;
+  }
 
   // Set the entries of x to (pseudo)random numbers.  Please don't
   // consider this a good parallel pseudorandom number generator.
   x.randomize ();
 
-  // Print the norm of x.
-  out << "Norm of x (random numbers): " << x.norm2 () << endl;
+  x_norm2 = x.norm2 ();
+  if (myRank == 0) {
+    out << "Norm of x (random numbers): " << x_norm2 << endl;
+  }
 
   //////////////////////////////////////////////////////////////////////
   // Read the entries of the Vector
@@ -186,9 +194,11 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // Find the total number of entries less than 0.5, over all
     // processes in the Vector's communicator.  Note the trick for
     // pluralizing the word "entry" conditionally on globalCount.
-    out << "x has " << globalCount << " entr"
-        << (globalCount != 1 ? "ies" : "y")
-        << " less than 0.5." << endl;
+    if (myRank == 0) {
+      out << "x has " << globalCount << " entr"
+	  << (globalCount != 1 ? "ies" : "y")
+	  << " less than 0.5." << endl;
+    }
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -226,7 +236,10 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   }
 
   // Print the norm of x.
-  out << "Norm of x (modified random numbers): " << x.norm2 () << endl;
+  x_norm2 = x.norm2 ();
+  if (myRank == 0) {
+    out << "Norm of x (modified random numbers): " << x_norm2 << endl;
+  }
 }
 
 //
@@ -235,23 +248,14 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
 int
 main (int argc, char *argv[])
 {
-  using std::endl;
-  using Teuchos::RCP;
-
-  Teuchos::oblackholestream blackHole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-
-  const int myRank = comm->getRank ();
-  std::ostream& out = (myRank == 0) ? std::cout : blackHole;
-
-  exampleRoutine (comm, out); // This is where the action takes place.
-
-  // This tells the Trilinos test framework that the test passed.
-  if (myRank == 0) {
-    std::cout << "End Result: TEST PASSED" << std::endl;
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    exampleRoutine (comm, std::cout);
+    // Tell the Trilinos test framework that the test passed.
+    if (comm->getRank () == 0) {
+      std::cout << "End Result: TEST PASSED" << std::endl;
+    }
   }
-
   return 0;
 }

--- a/packages/tpetra/core/example/Lesson05-Redistribution/lesson05_redistribution.cpp
+++ b/packages/tpetra/core/example/Lesson05-Redistribution/lesson05_redistribution.cpp
@@ -46,12 +46,9 @@
 \ref Tpetra_Lesson05 explains this example in detail.
 */
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
 #include <Teuchos_TimeMonitor.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
-#include <Tpetra_Version.hpp>
 #include <iostream>
 
 // Timer for use in example().
@@ -128,8 +125,7 @@ createMatrix (const Teuchos::RCP<const typename CrsMatrixType::map_type>& map)
 
 void
 example (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-         std::ostream& out,
-         std::ostream& err)
+         std::ostream& out)
 {
   using std::endl;
   using Teuchos::ParameterList;
@@ -145,8 +141,7 @@ example (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   typedef Tpetra::Map<> map_type;
   typedef Tpetra::Map<>::global_ordinal_type global_ordinal_type;
 
-  // Print out the Tpetra software version information.
-  out << Tpetra::version () << endl << endl;
+  const int myRank = comm->getRank ();
 
   // The global number of rows in the matrix A to create.  We scale
   // this relative to the number of (MPI) processes, so that no matter
@@ -156,9 +151,11 @@ example (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
 
   // Construct a Map that is global (not locally replicated), but puts
   // all the equations on MPI Proc 0.
+  if (myRank == 0) {
+    out << "Construct Process 0 Map" << endl;
+  }
   RCP<const map_type> procZeroMap;
   {
-    const int myRank = comm->getRank ();
     const size_t numLocalIndices = (myRank == 0) ? numGlobalIndices : 0;
     procZeroMap = rcp (new map_type (numGlobalIndices, numLocalIndices,
                                      indexBase, comm));
@@ -166,11 +163,17 @@ example (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
 
   // Construct a Map that puts approximately the same number of
   // equations on each processor.
+  if (myRank == 0) {
+    out << "Construct global Map" << endl;
+  }
   RCP<const map_type> globalMap =
     rcp (new map_type (numGlobalIndices, indexBase, comm,
                        Tpetra::GloballyDistributed));
 
   // Create a sparse matrix using procZeroMap.
+  if (myRank == 0) {
+    out << "Create sparse matrix using Process 0 Map" << endl;
+  }
   RCP<const crs_matrix_type> A = createMatrix<crs_matrix_type> (procZeroMap);
 
   //
@@ -185,6 +188,9 @@ example (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   // use an Export.  We do not allow redistribution using Import or
   // Export if neither source nor target Map is one-to-one.
   RCP<crs_matrix_type> B;
+  if (myRank == 0) {
+    out << "Redistribute sparse matrix" << endl;
+  }
   {
     // We created exportTimer in main().  It's a global timer.
     // Actually starting and stopping the timer is local, but
@@ -222,37 +228,31 @@ example (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
 int
 main (int argc, char *argv[])
 {
-  using Teuchos::RCP;
-  using Teuchos::Time;
   using Teuchos::TimeMonitor;
 
-  Teuchos::oblackholestream blackHole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    const int myRank = comm->getRank ();
+    // const int numProcs = comm->getSize ();
 
-  const int myRank = comm->getRank ();
-  // const int numProcs = comm->getSize ();
-  std::ostream& out = (myRank == 0) ? std::cout : blackHole;
-  std::ostream& err = (myRank == 0) ? std::cerr : blackHole;
+    // Make global timer for sparse matrix redistribution.
+    // We will use (start and stop) this timer in example().
+    exportTimer =
+      TimeMonitor::getNewCounter ("Sparse matrix redistribution");
+    example (comm, std::cout); // Run the whole example.
 
-  // Make global timer for sparse matrix redistribution.
-  // We will use (start and stop) this timer in example().
-  exportTimer = TimeMonitor::getNewCounter ("Sparse matrix redistribution");
+    // Summarize global performance timing results, for all timers
+    // created using TimeMonitor::getNewCounter().
+    TimeMonitor::summarize (std::cout);
 
-  example (comm, out, err); // Run the whole example.
+    // Make sure that the timer goes away before main() exits.
+    exportTimer = Teuchos::null;
 
-  // Summarize global performance timing results, for all timers
-  // created using TimeMonitor::getNewCounter().
-  TimeMonitor::summarize (out);
-
-  // Make sure that the timer goes away before main() exits.
-  exportTimer = Teuchos::null;
-
-  // This tells the Trilinos test framework that the test passed.
-  if (myRank == 0) {
-    std::cout << "End Result: TEST PASSED" << std::endl;
+    // This tells the Trilinos test framework that the test passed.
+    if (myRank == 0) {
+      std::cout << "End Result: TEST PASSED" << std::endl;
+    }
   }
-
   return 0;
 }

--- a/packages/tpetra/core/example/Lesson07-Kokkos-Fill/01_init.cpp
+++ b/packages/tpetra/core/example/Lesson07-Kokkos-Fill/01_init.cpp
@@ -1,24 +1,12 @@
-#include <Teuchos_DefaultMpiComm.hpp> // or mpi.h
-// This is the only header file you need to include for the "core"
-// part of Kokkos.  That includes Kokkos::View, Kokkos::parallel_*,
-// and atomic updates.
-#include <Kokkos_Core.hpp>
+#include <Tpetra_Core.hpp>
 
 int main (int argc, char* argv[]) {
-  // Initialize MPI and Kokkos.  Both take command line arguments.
-  // Kokkos should be initialized after MPI so that processes are
-  // correctly bound to cores.
-  MPI_Init (&argc, &argv);
-  Kokkos::initialize (argc, argv);
-
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
   //
   // TODO define the problem and discretization, implement the
   // discretization, put the discretization into Tpetra data
   // structures, solve the linear system, and correct the solution for
   // the nonhomogenous Dirichlet boundary conditions.
   //
-
-  // Shut down Kokkos and MPI, in reverse order from their initialization.
-  Kokkos::finalize ();
-  MPI_Finalize ();
+  return 0;
 }

--- a/packages/tpetra/core/example/Lesson07-Kokkos-Fill/02_problem.cpp
+++ b/packages/tpetra/core/example/Lesson07-Kokkos-Fill/02_problem.cpp
@@ -1,4 +1,4 @@
-#include <Teuchos_DefaultMpiComm.hpp> // or mpi.h
+#include <Tpetra_Core.hpp>
 // This is the only header file you need to include for the "core"
 // part of Kokkos.  That includes Kokkos::View, Kokkos::parallel_*,
 // and atomic updates.
@@ -11,53 +11,47 @@ int main (int argc, char* argv[]) {
   typedef int LO;
   typedef int GO;
 
-  // Initialize MPI and Kokkos.  Both take command line arguments.
-  // Kokkos should be initialized after MPI so that processes are
-  // correctly bound to cores.
-  MPI_Init (&argc, &argv);
-  Kokkos::initialize (argc, argv);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    const int numProcs = comm->getSize ();
+    int numLclElements = 10000;
+    int numGblElements = numProcs * numLclElements;
 
-  int numProcs = 1;
-  MPI_Comm_size (MPI_COMM_WORLD, &numProcs);
-  int numLclElements = 10000;
-  int numGblElements = numProcs * numLclElements;
+    // We happened to choose a discretization with the same number of
+    // nodes and degrees of freedom as elements.  That need not always
+    // be the case.
+    int numLclNodes = numLclElements;
 
-  // We happened to choose a discretization with the same number of
-  // nodes and degrees of freedom as elements.  That need not always
-  // be the case.
-  int numLclNodes = numLclElements;
+    // Describe the physical problem (heat equation with nonhomogeneous
+    // Dirichlet boundary conditions) and its discretization.
+    Kokkos::View<double*> temperature ("temperature", numLclNodes);
+    const double diffusionCoeff = 1.0;
+    const double x_left = 0.0; // position of the left boundary
+    const double T_left = 0.0; // temperature at the left boundary
+    const double x_right = 1.0; // position of the right boundary
+    const double T_right = 1.0; // temperature at the right boundary
+    const double dx = (x_right - x_left) / numGblElements;
+    Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
 
-  // Describe the physical problem (heat equation with nonhomogeneous
-  // Dirichlet boundary conditions) and its discretization.
-  Kokkos::View<double*> temperature ("temperature", numLclNodes);
-  const double diffusionCoeff = 1.0;
-  const double x_left = 0.0; // position of the left boundary
-  const double T_left = 0.0; // temperature at the left boundary
-  const double x_right = 1.0; // position of the right boundary
-  const double T_right = 1.0; // temperature at the right boundary
-  const double dx = (x_right - x_left) / numGblElements;
-  Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
+    // Set the forcing term.  We picked it so that we can know the exact
+    // solution of the heat equation, namely
+    //
+    // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
+    Kokkos::parallel_for (numLclNodes, KOKKOS_LAMBDA (const LO node) {
+	const double x = x_left + node * dx;
 
-  // Set the forcing term.  We picked it so that we can know the exact
-  // solution of the heat equation, namely
-  //
-  // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
-  Kokkos::parallel_for (numLclNodes, KOKKOS_LAMBDA (const LO node) {
-      const double x = x_left + node * dx;
+	forcingTerm(node) = -8.0;
+	// We multiply dx*dx into the forcing term, so the matrix's
+	// entries don't need to know it.
+	forcingTerm(node) *= dx * dx;
+      });
 
-      forcingTerm(node) = -8.0;
-      // We multiply dx*dx into the forcing term, so the matrix's
-      // entries don't need to know it.
-      forcingTerm(node) *= dx * dx;
-    });
-
-  //
-  // TODO implement the discretization, put the discretization into
-  // Tpetra data structures, solve the linear system, and correct the
-  // solution for the nonhomogenous Dirichlet boundary conditions.
-  //
-
-  // Shut down Kokkos and MPI, in reverse order from their initialization.
-  Kokkos::finalize ();
-  MPI_Finalize ();
+    //
+    // TODO implement the discretization, put the discretization into
+    // Tpetra data structures, solve the linear system, and correct the
+    // solution for the nonhomogenous Dirichlet boundary conditions.
+    //
+  }
+  return 0;
 }

--- a/packages/tpetra/core/example/Lesson07-Kokkos-Fill/03_fill.cpp
+++ b/packages/tpetra/core/example/Lesson07-Kokkos-Fill/03_fill.cpp
@@ -1,4 +1,4 @@
-#include <Teuchos_DefaultMpiComm.hpp> // or mpi.h
+#include <Tpetra_Core.hpp>
 // This is the only header file you need to include for the "core"
 // part of Kokkos.  That includes Kokkos::View, Kokkos::parallel_*,
 // and atomic updates.
@@ -13,187 +13,185 @@ int main (int argc, char* argv[]) {
   typedef int LO;
   typedef int GO;
 
-  // Initialize MPI and Kokkos.  Both take command line arguments.
-  // Kokkos should be initialized after MPI so that processes are
-  // correctly bound to cores.
-  MPI_Init (&argc, &argv);
-  Kokkos::initialize (argc, argv);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    const int myRank = comm->getRank ();
+    const int numProcs = comm->getSize ();
 
-  int myRank = 0;
-  int numProcs = 1;
-  MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
-  MPI_Comm_size (MPI_COMM_WORLD, &numProcs);
+    LO numLclElements = 10000;
+    GO numGblElements = numProcs * numLclElements;
 
-  LO numLclElements = 10000;
-  GO numGblElements = numProcs * numLclElements;
+    // We happened to choose a discretization with the same number of
+    // nodes and degrees of freedom as elements.  That need not always
+    // be the case.
+    LO numLclNodes = numLclElements;
+    LO numLclRows = numLclNodes;
 
-  // We happened to choose a discretization with the same number of
-  // nodes and degrees of freedom as elements.  That need not always
-  // be the case.
-  LO numLclNodes = numLclElements;
-  LO numLclRows = numLclNodes;
+    // Describe the physical problem (heat equation with
+    // nonhomogeneous Dirichlet boundary conditions) and its
+    // discretization.
+    Kokkos::View<double*> temperature ("temperature", numLclNodes);
+    const double diffusionCoeff = 1.0;
+    const double x_left = 0.0; // position of the left boundary
+    const double T_left = 0.0; // temperature at the left boundary
+    const double x_right = 1.0; // position of the right boundary
+    const double T_right = 1.0; // temperature at the right boundary
+    const double dx = (x_right - x_left) / numGblElements;
+    Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
 
-  // Describe the physical problem (heat equation with nonhomogeneous
-  // Dirichlet boundary conditions) and its discretization.
-  Kokkos::View<double*> temperature ("temperature", numLclNodes);
-  const double diffusionCoeff = 1.0;
-  const double x_left = 0.0; // position of the left boundary
-  const double T_left = 0.0; // temperature at the left boundary
-  const double x_right = 1.0; // position of the right boundary
-  const double T_right = 1.0; // temperature at the right boundary
-  const double dx = (x_right - x_left) / numGblElements;
-  Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
+    // Set the forcing term.  We picked it so that we can know the
+    // exact solution of the heat equation, namely
+    //
+    // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
+    Kokkos::parallel_for ("Set forcing term", numLclNodes,
+      KOKKOS_LAMBDA (const LO node) {
+	//const double x = x_left + node * dx;
 
-  // Set the forcing term.  We picked it so that we can know the exact
-  // solution of the heat equation, namely
-  //
-  // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
-  Kokkos::parallel_for (numLclNodes, KOKKOS_LAMBDA (const LO node) {
-      //const double x = x_left + node * dx;
+	forcingTerm(node) = -8.0;
+	// We multiply dx*dx into the forcing term, so the matrix's
+	// entries don't need to know it.
+	forcingTerm(node) *= dx * dx;
+      });
 
-      forcingTerm(node) = -8.0;
-      // We multiply dx*dx into the forcing term, so the matrix's
-      // entries don't need to know it.
-      forcingTerm(node) *= dx * dx;
-    });
+    // Do a reduction over local elements to count the total number of
+    // (local) entries in the graph.  While doing so, count the number
+    // of (local) entries in each row, using Kokkos' atomic updates.
+    Kokkos::View<size_t*> rowCounts ("row counts", numLclRows);
+    size_t numLclEntries = 0;
+    Kokkos::parallel_reduce ("Count graph", numLclElements,
+      KOKKOS_LAMBDA (const LO elt, size_t& curNumLclEntries) {
+        const LO lclRows = elt;
 
-  // Do a reduction over local elements to count the total number of
-  // (local) entries in the graph.  While doing so, count the number
-  // of (local) entries in each row, using Kokkos' atomic updates.
-  Kokkos::View<size_t*> rowCounts ("row counts", numLclRows);
-  size_t numLclEntries = 0;
-  Kokkos::parallel_reduce (numLclElements,
-    KOKKOS_LAMBDA (const LO elt, size_t& curNumLclEntries) {
-      const LO lclRows = elt;
+	// Always add a diagonal matrix entry.
+	Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	curNumLclEntries++;
 
-      // Always add a diagonal matrix entry.
-      Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-      curNumLclEntries++;
+	// Each neighboring MPI process contributes an entry to the
+	// current row.  In a more realistic code, we might handle
+	// this either through a global assembly process (requiring
+	// MPI communication), or through ghosting a layer of elements
+	// (no MPI communication).
 
-      // Each neighboring MPI process contributes an entry to the
-      // current row.  In a more realistic code, we might handle this
-      // either through a global assembly process (requiring MPI
-      // communication), or through ghosting a layer of elements (no
-      // MPI communication).
+	// MPI process to the left sends us an entry
+	if (myRank > 0 && lclRows == 0) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  curNumLclEntries++;
+	}
+	// MPI process to the right sends us an entry
+	if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  curNumLclEntries++;
+	}
 
-      // MPI process to the left sends us an entry
-      if (myRank > 0 && lclRows == 0) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        curNumLclEntries++;
-      }
-      // MPI process to the right sends us an entry
-      if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        curNumLclEntries++;
-      }
+	// Contribute a matrix entry to the previous row.
+	if (lclRows > 0) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
+	  curNumLclEntries++;
+	}
+	// Contribute a matrix entry to the next row.
+	if (lclRows + 1 < numLclRows) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
+	  curNumLclEntries++;
+	}
+      }, numLclEntries /* reduction result */);
 
-      // Contribute a matrix entry to the previous row.
-      if (lclRows > 0) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
-        curNumLclEntries++;
-      }
-      // Contribute a matrix entry to the next row.
-      if (lclRows + 1 < numLclRows) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
-        curNumLclEntries++;
-      }
-    }, numLclEntries /* reduction result */);
+    // Use a parallel scan (prefix sum) over the array of row counts,
+    // to compute the array of row offsets for the sparse graph.
+    Kokkos::View<size_t*> rowOffsets ("row offsets", numLclRows+1);
+    Kokkos::parallel_scan ("Row offsets", numLclRows+1,
+      KOKKOS_LAMBDA (const LO lclRows, size_t& update, const bool final) {
+	if (final) {
+	  // Kokkos uses a multipass algorithm to implement scan.
+	  // Only update the array on the final pass.  Updating the
+	  // array before changing 'update' means that we do an
+	  // exclusive scan.  Update the array after for an inclusive
+	  // scan.
+	  rowOffsets[lclRows] = update;
+	}
+	if (lclRows < numLclRows) {
+	  update += rowCounts(lclRows);
+	}
+      });
 
-  // Use a parallel scan (prefix sum) over the array of row counts, to
-  // compute the array of row offsets for the sparse graph.
-  Kokkos::View<size_t*> rowOffsets ("row offsets", numLclRows+1);
-  Kokkos::parallel_scan (numLclRows+1,
-    KOKKOS_LAMBDA (const LO lclRows, size_t& update, const bool final) {
-      if (final) {
-        // Kokkos uses a multipass algorithm to implement scan.  Only
-        // update the array on the final pass.  Updating the array
-        // before changing 'update' means that we do an exclusive
-        // scan.  Update the array after for an inclusive scan.
-        rowOffsets[lclRows] = update;
-      }
-      if (lclRows < numLclRows) {
-        update += rowCounts(lclRows);
-      }
-    });
+    // Use the array of row counts to keep track of where to put each
+    // new column index, when filling the graph.  Updating the entries
+    // of rowCounts atomically lets us parallelize over elements
+    // (which may touch multiple rows at a time -- esp. in 2-D or 3-D,
+    // or with higher-order discretizations), rather than rows.
+    //
+    // We leave as an exercise to the reader how to use this array
+    // without resetting its entries.
+    Kokkos::deep_copy (rowCounts, static_cast<size_t> (0));
 
-  // Use the array of row counts to keep track of where to put each
-  // new column index, when filling the graph.  Updating the entries
-  // of rowCounts atomically lets us parallelize over elements (which
-  // may touch multiple rows at a time -- esp. in 2-D or 3-D, or with
-  // higher-order discretizations), rather than rows.
-  //
-  // We leave as an exercise to the reader how to use this array
-  // without resetting its entries.
-  Kokkos::deep_copy (rowCounts, static_cast<size_t> (0));
+    Kokkos::View<LO*> colIndices ("column indices", numLclEntries);
+    Kokkos::View<double*> matrixValues ("matrix values", numLclEntries);
 
-  Kokkos::View<LO*> colIndices ("column indices", numLclEntries);
-  Kokkos::View<double*> matrixValues ("matrix values", numLclEntries);
+    // Iterate over elements in parallel to fill the graph, matrix,
+    // and right-hand side (forcing term).  The latter gets the
+    // boundary conditions (a trick for nonzero Dirichlet boundary
+    // conditions).
+    Kokkos::parallel_for ("Assemble", numLclElements,
+      KOKKOS_LAMBDA (const LO elt) {
+	// We multiply dx*dx into the forcing term, so the matrix's
+	// entries don't need to know it.
+	const double offCoeff = -diffusionCoeff / 2.0;
+	const double midCoeff =  diffusionCoeff;
+	// In this discretization, every element corresponds to a
+	// degree of freedom, and to a row of the matrix.  (Boundary
+	// conditions are Dirichlet, so they don't count as degrees of
+	// freedom.)
+	const int lclRows = elt;
 
-  // Iterate over elements in parallel to fill the graph, matrix, and
-  // right-hand side (forcing term).  The latter gets the boundary
-  // conditions (a trick for nonzero Dirichlet boundary conditions).
-  Kokkos::parallel_for (numLclElements, KOKKOS_LAMBDA (const LO elt) {
-      // We multiply dx*dx into the forcing term, so the matrix's
-      // entries don't need to know it.
-      const double offCoeff = -diffusionCoeff / 2.0;
-      const double midCoeff =  diffusionCoeff;
-      // In this discretization, every element corresponds to a degree
-      // of freedom, and to a row of the matrix.  (Boundary conditions
-      // are Dirichlet, so they don't count as degrees of freedom.)
-      const int lclRows = elt;
+	// Always add a diagonal matrix entry.
+	{
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  colIndices(rowOffsets(lclRows) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), midCoeff);
+	}
 
-      // Always add a diagonal matrix entry.
-      {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        colIndices(rowOffsets(lclRows) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), midCoeff);
-      }
+	// Each neighboring MPI process contributes an entry to the
+	// current row.  In a more realistic code, we might handle
+	// this either through a global assembly process (requiring
+	// MPI communication), or through ghosting a layer of elements
+	// (no MPI communication).
 
-      // Each neighboring MPI process contributes an entry to the
-      // current row.  In a more realistic code, we might handle this
-      // either through a global assembly process (requiring MPI
-      // communication), or through ghosting a layer of elements (no
-      // MPI communication).
+	// MPI process to the left sends us an entry
+	if (myRank > 0 && lclRows == 0) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  colIndices(rowOffsets(lclRows) + count) = numLclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
+	}
+	// MPI process to the right sends us an entry
+	if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
 
-      // MPI process to the left sends us an entry
-      if (myRank > 0 && lclRows == 0) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        colIndices(rowOffsets(lclRows) + count) = numLclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
-      }
-      // MPI process to the right sends us an entry
-      if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  // Give this entry the right local column index, depending
+	  // on whether the MPI process to the left has already sent
+	  // us an entry.
+	  const int colInd = (myRank > 0) ? numLclRows + 1 : numLclRows;
+	  colIndices(rowOffsets(lclRows) + count) = colInd;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
+	}
 
-        // Give this entry the right local column index, depending on
-        // whether the MPI process to the left has already sent us an
-        // entry.
-        const int colInd = (myRank > 0) ? numLclRows + 1 : numLclRows;
-        colIndices(rowOffsets(lclRows) + count) = colInd;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
-      }
+	// Contribute a matrix entry to the previous row.
+	if (lclRows > 0) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
+	  colIndices(rowOffsets(lclRows-1) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows-1) + count), offCoeff);
+	}
+	// Contribute a matrix entry to the next row.
+	if (lclRows + 1 < numLclRows) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
+	  colIndices(rowOffsets(lclRows+1) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows+1) + count), offCoeff);
+	}
+      });
 
-      // Contribute a matrix entry to the previous row.
-      if (lclRows > 0) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
-        colIndices(rowOffsets(lclRows-1) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows-1) + count), offCoeff);
-      }
-      // Contribute a matrix entry to the next row.
-      if (lclRows + 1 < numLclRows) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
-        colIndices(rowOffsets(lclRows+1) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows+1) + count), offCoeff);
-      }
-    });
-
-  //
-  // TODO put the discretization into Tpetra data structures, solve
-  // the linear system, and correct the solution for the nonhomogenous
-  // Dirichlet boundary conditions.
-  //
-
-  // Shut down Kokkos and MPI, in reverse order from their initialization.
-  Kokkos::finalize ();
-  MPI_Finalize ();
+    //
+    // TODO put the discretization into Tpetra data structures, solve
+    // the linear system, and correct the solution for the
+    // nonhomogenous Dirichlet boundary conditions.
+    //
+  }
 }

--- a/packages/tpetra/core/example/Lesson07-Kokkos-Fill/04_tpetra.cpp
+++ b/packages/tpetra/core/example/Lesson07-Kokkos-Fill/04_tpetra.cpp
@@ -1,4 +1,4 @@
-#include <Teuchos_DefaultMpiComm.hpp>
+#include <Tpetra_Core.hpp>
 // This is the only header file you need to include for the "core"
 // part of Kokkos.  That includes Kokkos::View, Kokkos::parallel_*,
 // and atomic updates.
@@ -11,252 +11,246 @@ int main (int argc, char* argv[]) {
   using std::endl;
   // We're filling into Tpetra data structures now, so we have to
   // respect Tpetra's choices of local and global indices.
-  typedef Tpetra::Map<>::local_ordinal_type LO;
-  typedef Tpetra::Map<>::global_ordinal_type GO;
+  using LO = Tpetra::Map<>::local_ordinal_type;
+  using GO = Tpetra::Map<>::global_ordinal_type;
 
-  // Initialize MPI and Kokkos.  Both take command line arguments.
-  // Kokkos should be initialized after MPI so that processes are
-  // correctly bound to cores.
-  MPI_Init (&argc, &argv);
-  Kokkos::initialize (argc, argv);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    const int myRank = comm->getRank ();
+    const int numProcs = comm->getSize ();
 
-  int myRank = 0;
-  int numProcs = 1;
-  MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
-  MPI_Comm_size (MPI_COMM_WORLD, &numProcs);
+    LO numLclElements = 10000;
+    int numGblElements = numProcs * numLclElements;
 
-  LO numLclElements = 10000;
-  int numGblElements = numProcs * numLclElements;
+    // We happened to choose a discretization with the same number of
+    // nodes and degrees of freedom as elements.  That need not always
+    // be the case.
+    LO numLclNodes = numLclElements;
+    LO numLclRows = numLclNodes;
 
-  // We happened to choose a discretization with the same number of
-  // nodes and degrees of freedom as elements.  That need not always
-  // be the case.
-  LO numLclNodes = numLclElements;
-  LO numLclRows = numLclNodes;
+    // Describe the physical problem (heat equation with
+    // nonhomogeneous Dirichlet boundary conditions) and its
+    // discretization.
+    Kokkos::View<double*> temperature ("temperature", numLclNodes);
+    const double diffusionCoeff = 1.0;
+    const double x_left = 0.0; // position of the left boundary
+    const double T_left = 0.0; // temperature at the left boundary
+    const double x_right = 1.0; // position of the right boundary
+    const double T_right = 1.0; // temperature at the right boundary
+    const double dx = (x_right - x_left) / numGblElements;
+    Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
 
-  // Describe the physical problem (heat equation with nonhomogeneous
-  // Dirichlet boundary conditions) and its discretization.
-  Kokkos::View<double*> temperature ("temperature", numLclNodes);
-  const double diffusionCoeff = 1.0;
-  const double x_left = 0.0; // position of the left boundary
-  const double T_left = 0.0; // temperature at the left boundary
-  const double x_right = 1.0; // position of the right boundary
-  const double T_right = 1.0; // temperature at the right boundary
-  const double dx = (x_right - x_left) / numGblElements;
-  Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
+    // Set the forcing term.  We picked it so that we can know the
+    // exact solution of the heat equation, namely
+    //
+    // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
+    Kokkos::parallel_for ("Set forcing term", numLclNodes,
+      KOKKOS_LAMBDA (const LO node) {
+	//const double x = x_left + node * dx;
 
-  // Set the forcing term.  We picked it so that we can know the exact
-  // solution of the heat equation, namely
-  //
-  // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
-  Kokkos::parallel_for (numLclNodes, KOKKOS_LAMBDA (const LO node) {
-      //const double x = x_left + node * dx;
+	forcingTerm(node) = -8.0;
+	// We multiply dx*dx into the forcing term, so the matrix's
+	// entries don't need to know it.
+	forcingTerm(node) *= dx * dx;
+      });
 
-      forcingTerm(node) = -8.0;
-      // We multiply dx*dx into the forcing term, so the matrix's
-      // entries don't need to know it.
-      forcingTerm(node) *= dx * dx;
-    });
+    // Do a reduction over local elements to count the total number of
+    // (local) entries in the graph.  While doing so, count the number
+    // of (local) entries in each row, using Kokkos' atomic updates.
+    Kokkos::View<size_t*> rowCounts ("row counts", numLclRows);
+    size_t numLclEntries = 0;
+    Kokkos::parallel_reduce ("Count graph", numLclElements,
+      KOKKOS_LAMBDA (const LO elt, size_t& curNumLclEntries) {
+        const LO lclRows = elt;
 
-  // Do a reduction over local elements to count the total number of
-  // (local) entries in the graph.  While doing so, count the number
-  // of (local) entries in each row, using Kokkos' atomic updates.
-  Kokkos::View<size_t*> rowCounts ("row counts", numLclRows);
-  size_t numLclEntries = 0;
-  Kokkos::parallel_reduce (numLclElements,
-    KOKKOS_LAMBDA (const LO elt, size_t& curNumLclEntries) {
-      const LO lclRows = elt;
+	// Always add a diagonal matrix entry.
+	Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	curNumLclEntries++;
 
-      // Always add a diagonal matrix entry.
-      Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-      curNumLclEntries++;
+	// Each neighboring MPI process contributes an entry to the
+	// current row.  In a more realistic code, we might handle
+	// this either through a global assembly process (requiring
+	// MPI communication), or through ghosting a layer of elements
+	// (no MPI communication).
 
-      // Each neighboring MPI process contributes an entry to the
-      // current row.  In a more realistic code, we might handle this
-      // either through a global assembly process (requiring MPI
-      // communication), or through ghosting a layer of elements (no
-      // MPI communication).
+	// MPI process to the left sends us an entry
+	if (myRank > 0 && lclRows == 0) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  curNumLclEntries++;
+	}
+	// MPI process to the right sends us an entry
+	if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  curNumLclEntries++;
+	}
 
-      // MPI process to the left sends us an entry
-      if (myRank > 0 && lclRows == 0) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        curNumLclEntries++;
-      }
-      // MPI process to the right sends us an entry
-      if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        curNumLclEntries++;
-      }
+	// Contribute a matrix entry to the previous row.
+	if (lclRows > 0) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
+	  curNumLclEntries++;
+	}
+	// Contribute a matrix entry to the next row.
+	if (lclRows + 1 < numLclRows) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
+	  curNumLclEntries++;
+	}
+      }, numLclEntries /* reduction result */);
 
-      // Contribute a matrix entry to the previous row.
-      if (lclRows > 0) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
-        curNumLclEntries++;
-      }
+    // Use a parallel scan (prefix sum) over the array of row counts,
+    // to compute the array of row offsets for the sparse graph.
+    Kokkos::View<size_t*> rowOffsets ("row offsets", numLclRows+1);
+    Kokkos::parallel_scan ("Row offsets", numLclRows+1,
+      KOKKOS_LAMBDA (const LO lclRows, size_t& update, const bool final) {
+        if (final) {
+	  // Kokkos uses a multipass algorithm to implement scan.  Only
+	  // update the array on the final pass.  Updating the array
+	  // before changing 'update' means that we do an exclusive
+	  // scan.  Update the array after for an inclusive scan.
+	  rowOffsets[lclRows] = update;
+	}
+	if (lclRows < numLclRows) {
+	  update += rowCounts(lclRows);
+	}
+      });
+
+    // Use the array of row counts to keep track of where to put each
+    // new column index, when filling the graph.  Updating the entries
+    // of rowCounts atomically lets us parallelize over elements
+    // (which may touch multiple rows at a time -- esp. in 2-D or 3-D,
+    // or with higher-order discretizations), rather than rows.
+    //
+    // We leave as an exercise to the reader how to use this array
+    // without resetting its entries.
+    Kokkos::deep_copy (rowCounts, static_cast<size_t> (0));
+
+    Kokkos::View<LO*> colIndices ("column indices", numLclEntries);
+    Kokkos::View<double*> matrixValues ("matrix values", numLclEntries);
+
+    // Iterate over elements in parallel to fill the graph, matrix,
+    // and right-hand side (forcing term).  The latter gets the
+    // boundary conditions (a trick for nonzero Dirichlet boundary
+    // conditions).
+    Kokkos::parallel_for ("Assemble", numLclElements,
+      KOKKOS_LAMBDA (const LO elt) {
+        // Push dx*dx into the forcing term.
+        const double offCoeff = -diffusionCoeff / 2.0;
+        const double midCoeff =  diffusionCoeff;
+	// In this discretization, every element corresponds to a
+	// degree of freedom, and to a row of the matrix.  (Boundary
+	// conditions are Dirichlet, so they don't count as degrees of
+	// freedom.)
+	const int lclRows = elt;
+
+	// Always add a diagonal matrix entry.
+	{
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  colIndices(rowOffsets(lclRows) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), midCoeff);
+	}
+
+	// Each neighboring MPI process contributes an entry to the
+	// current row.  In a more realistic code, we might handle
+	// this either through a global assembly process (requiring
+	// MPI communication), or through ghosting a layer of elements
+	// (no MPI communication).
+
+	// MPI process to the left sends us an entry
+	if (myRank > 0 && lclRows == 0) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+	  colIndices(rowOffsets(lclRows) + count) = numLclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
+	}
+	// MPI process to the right sends us an entry
+	if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
+
+	  // Give this entry the right local column index, depending
+	  // on whether the MPI process to the left has already sent
+	  // us an entry.
+	  const int colInd = (myRank > 0) ? numLclRows + 1 : numLclRows;
+	  colIndices(rowOffsets(lclRows) + count) = colInd;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
+	}
+
+	// Contribute a matrix entry to the previous row.
+	if (lclRows > 0) {
+	  const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
+	  colIndices(rowOffsets(lclRows-1) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows-1) + count), offCoeff);
+	}
       // Contribute a matrix entry to the next row.
       if (lclRows + 1 < numLclRows) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
-        curNumLclEntries++;
-      }
-    }, numLclEntries /* reduction result */);
-
-  // Use a parallel scan (prefix sum) over the array of row counts, to
-  // compute the array of row offsets for the sparse graph.
-  Kokkos::View<size_t*> rowOffsets ("row offsets", numLclRows+1);
-  Kokkos::parallel_scan (numLclRows+1,
-    KOKKOS_LAMBDA (const LO lclRows, size_t& update, const bool final) {
-      if (final) {
-        // Kokkos uses a multipass algorithm to implement scan.  Only
-        // update the array on the final pass.  Updating the array
-        // before changing 'update' means that we do an exclusive
-        // scan.  Update the array after for an inclusive scan.
-        rowOffsets[lclRows] = update;
-      }
-      if (lclRows < numLclRows) {
-        update += rowCounts(lclRows);
-      }
-    });
-
-  // Use the array of row counts to keep track of where to put each
-  // new column index, when filling the graph.  Updating the entries
-  // of rowCounts atomically lets us parallelize over elements (which
-  // may touch multiple rows at a time -- esp. in 2-D or 3-D, or with
-  // higher-order discretizations), rather than rows.
-  //
-  // We leave as an exercise to the reader how to use this array
-  // without resetting its entries.
-  Kokkos::deep_copy (rowCounts, static_cast<size_t> (0));
-
-  Kokkos::View<LO*> colIndices ("column indices", numLclEntries);
-  Kokkos::View<double*> matrixValues ("matrix values", numLclEntries);
-
-  // Iterate over elements in parallel to fill the graph, matrix, and
-  // right-hand side (forcing term).  The latter gets the boundary
-  // conditions (a trick for nonzero Dirichlet boundary conditions).
-  Kokkos::parallel_for (numLclElements, KOKKOS_LAMBDA (const LO elt) {
-      // Push dx*dx into the forcing term.
-      const double offCoeff = -diffusionCoeff / 2.0;
-      const double midCoeff =  diffusionCoeff;
-      // In this discretization, every element corresponds to a degree
-      // of freedom, and to a row of the matrix.  (Boundary conditions
-      // are Dirichlet, so they don't count as degrees of freedom.)
-      const int lclRows = elt;
-
-      // Always add a diagonal matrix entry.
-      {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        colIndices(rowOffsets(lclRows) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), midCoeff);
-      }
-
-      // Each neighboring MPI process contributes an entry to the
-      // current row.  In a more realistic code, we might handle this
-      // either through a global assembly process (requiring MPI
-      // communication), or through ghosting a layer of elements (no
-      // MPI communication).
-
-      // MPI process to the left sends us an entry
-      if (myRank > 0 && lclRows == 0) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-        colIndices(rowOffsets(lclRows) + count) = numLclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
-      }
-      // MPI process to the right sends us an entry
-      if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), size_t(1));
-
-        // Give this entry the right local column index, depending on
-        // whether the MPI process to the left has already sent us an
-        // entry.
-        const int colInd = (myRank > 0) ? numLclRows + 1 : numLclRows;
-        colIndices(rowOffsets(lclRows) + count) = colInd;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
-      }
-
-      // Contribute a matrix entry to the previous row.
-      if (lclRows > 0) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), size_t(1));
-        colIndices(rowOffsets(lclRows-1) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows-1) + count), offCoeff);
-      }
-      // Contribute a matrix entry to the next row.
-      if (lclRows + 1 < numLclRows) {
-        const size_t count = Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
+        const size_t count =
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), size_t(1));
         colIndices(rowOffsets(lclRows+1) + count) = lclRows;
         Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows+1) + count), offCoeff);
       }
     });
 
-  //
-  // Construct Tpetra objects
-  //
-  using Teuchos::RCP;
-  using Teuchos::rcp;
+    //
+    // Construct Tpetra objects
+    //
+    using Teuchos::RCP;
+    using Teuchos::rcp;
 
-  // Wrap the "raw" MPI communicator for use in Tpetra.
-  RCP<const Teuchos::Comm<int> > comm =
-    rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+    const GO indexBase = 0;
+    RCP<const Tpetra::Map<> > rowMap =
+      rcp (new Tpetra::Map<> (numGblElements, numLclElements, indexBase, comm));
 
-  const GO indexBase = 0;
-  RCP<const Tpetra::Map<> > rowMap =
-    rcp (new Tpetra::Map<> (numGblElements, numLclElements, indexBase, comm));
+    LO num_col_inds = numLclElements;
+    if (myRank > 0) {
+      num_col_inds++;
+    }
+    if (myRank + 1 < numProcs) {
+      num_col_inds++;
+    }
 
-  LO num_col_inds = numLclElements;
-  if (myRank > 0) {
-    num_col_inds++;
+    // Soon, it will be acceptable to use a device View here.  The
+    // issues are that Teuchos::RCP isn't thread safe, and the Kokkos
+    // version of Tpetra::Map isn't quite ready yet.  We will change
+    // the latter soon.
+    Kokkos::View<GO*>::HostMirror colInds ("Column Map", num_col_inds);
+    for (LO k = 0; k < numLclElements; ++k) {
+      colInds(k) = rowMap->getGlobalElement (k);
+    }
+    LO k = numLclElements;
+    if (myRank > 0) {
+      // Contribution from left process.
+      colInds(k++) = rowMap->getGlobalElement (0) - 1;
+    }
+    if (myRank + 1 < numProcs) {
+      // Contribution from right process.
+      colInds(k++) = rowMap->getGlobalElement (numLclElements - 1) + 1;
+    }
+
+    // Flag to tell Tpetra::Map to compute the global number of
+    // indices in the Map.
+    const Tpetra::global_size_t INV =
+      Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid ();
+    // Soon, it will be acceptable to pass in a Kokkos::View here,
+    // instead of a Teuchos::ArrayView.
+    RCP<const Tpetra::Map<> > colMap =
+      rcp (new Tpetra::Map<> (INV, Kokkos::Compat::getConstArrayView (colInds), indexBase, comm));
+
+    Tpetra::CrsMatrix<> A (rowMap, colMap, rowOffsets, colIndices, matrixValues);
+    A.fillComplete ();
+
+    // Hack to deal with the fact that Tpetra::Vector needs a
+    // DualView<double**> for now, rather than a View<double*>.
+    Kokkos::DualView<double**, Kokkos::LayoutLeft> b_lcl ("b", numLclRows, 1);
+    b_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
+    Kokkos::deep_copy (Kokkos::subview (b_lcl.d_view, Kokkos::ALL (), 0), forcingTerm);
+    Tpetra::Vector<> b (A.getRangeMap (), b_lcl);
+
+    Kokkos::DualView<double**, Kokkos::LayoutLeft> x_lcl ("b", numLclRows, 1);
+    x_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
+    Kokkos::deep_copy (Kokkos::subview (x_lcl.d_view, Kokkos::ALL (), 0), temperature);
+    Tpetra::Vector<> x (A.getDomainMap (), x_lcl);
+
+    //
+    // TODO solve the linear system, and correct the solution for the
+    // nonhomogenous Dirichlet boundary conditions.
+    //
   }
-  if (myRank + 1 < numProcs) {
-    num_col_inds++;
-  }
-
-  // Soon, it will be acceptable to use a device View here.  The
-  // issues are that Teuchos::RCP isn't thread safe, and the Kokkos
-  // version of Tpetra::Map isn't quite ready yet.  We will change the
-  // latter soon.
-  Kokkos::View<GO*>::HostMirror colInds ("Column Map", num_col_inds);
-  for (LO k = 0; k < numLclElements; ++k) {
-    colInds(k) = rowMap->getGlobalElement (k);
-  }
-  LO k = numLclElements;
-  if (myRank > 0) {
-    // Contribution from left process.
-    colInds(k++) = rowMap->getGlobalElement (0) - 1;
-  }
-  if (myRank + 1 < numProcs) {
-    // Contribution from right process.
-    colInds(k++) = rowMap->getGlobalElement (numLclElements - 1) + 1;
-  }
-
-  // Flag to tell Tpetra::Map to compute the global number of indices
-  // in the Map.
-  const Tpetra::global_size_t INV =
-    Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid ();
-  // Soon, it will be acceptable to pass in a Kokkos::View here,
-  // instead of a Teuchos::ArrayView.
-  RCP<const Tpetra::Map<> > colMap =
-    rcp (new Tpetra::Map<> (INV, Kokkos::Compat::getConstArrayView (colInds), indexBase, comm));
-
-  Tpetra::CrsMatrix<> A (rowMap, colMap, rowOffsets, colIndices, matrixValues);
-  A.fillComplete ();
-
-  // Hack to deal with the fact that Tpetra::Vector needs a
-  // DualView<double**> for now, rather than a View<double*>.
-  Kokkos::DualView<double**, Kokkos::LayoutLeft> b_lcl ("b", numLclRows, 1);
-  b_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
-  Kokkos::deep_copy (Kokkos::subview (b_lcl.d_view, Kokkos::ALL (), 0), forcingTerm);
-  Tpetra::Vector<> b (A.getRangeMap (), b_lcl);
-
-  Kokkos::DualView<double**, Kokkos::LayoutLeft> x_lcl ("b", numLclRows, 1);
-  x_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
-  Kokkos::deep_copy (Kokkos::subview (x_lcl.d_view, Kokkos::ALL (), 0), temperature);
-  Tpetra::Vector<> x (A.getDomainMap (), x_lcl);
-
-  //
-  // TODO solve the linear system, and correct the solution for the
-  // nonhomogenous Dirichlet boundary conditions.
-  //
-
-  // Shut down Kokkos and MPI, in reverse order from their initialization.
-  Kokkos::finalize ();
-  MPI_Finalize ();
 }

--- a/packages/tpetra/core/example/Lesson07-Kokkos-Fill/05_solve.cpp
+++ b/packages/tpetra/core/example/Lesson07-Kokkos-Fill/05_solve.cpp
@@ -45,19 +45,16 @@
 \ref Tpetra_Lesson07 explains this example in detail.
 */
 
+#include <Tpetra_Core.hpp>
 // This is the only header file you need to include for the "core"
 // part of Kokkos.  That includes Kokkos::View, Kokkos::parallel_*,
 // and atomic updates.
 #include <Kokkos_Core.hpp>
-
-#include <iostream>
-#include <mpi.h>
-
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
-
-#include <Teuchos_DefaultMpiComm.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Vector.hpp>
+#include <iostream>
+
+#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 
 // Exact solution of the partial differential equation that main()
 // discretizes.  We include it here to check the error.
@@ -144,337 +141,332 @@ int main (int argc, char* argv[]) {
   using std::endl;
   // We're filling into Tpetra data structures now, so we have to
   // respect Tpetra's choices of local and global indices.
-  typedef Tpetra::Map<>::local_ordinal_type LO;
-  typedef Tpetra::Map<>::global_ordinal_type GO;
+  using LO = Tpetra::Map<>::local_ordinal_type;
+  using GO = Tpetra::Map<>::global_ordinal_type;
 
-  // Initialize MPI and Kokkos.  Both take command line arguments.
-  // Kokkos should be initialized after MPI so that processes are
-  // correctly bound to cores.
-  MPI_Init (&argc, &argv);
-  Kokkos::initialize (argc, argv);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    auto comm = Tpetra::getDefaultComm ();
+    const int myRank = comm->getRank ();
+    const int numProcs = comm->getSize ();
 
-  int myRank = 0;
-  int numProcs = 1;
-  MPI_Comm_rank (MPI_COMM_WORLD, &myRank);
-  MPI_Comm_size (MPI_COMM_WORLD, &numProcs);
+    LO numLclElements = 10000;
+    int numGblElements = numProcs * numLclElements;
 
-  LO numLclElements = 10000;
-  int numGblElements = numProcs * numLclElements;
+    // We happened to choose a discretization with the same number of
+    // nodes and degrees of freedom as elements.  That need not always
+    // be the case.
+    LO numLclNodes = numLclElements;
+    LO numLclRows = numLclNodes;
 
-  // We happened to choose a discretization with the same number of
-  // nodes and degrees of freedom as elements.  That need not always
-  // be the case.
-  LO numLclNodes = numLclElements;
-  LO numLclRows = numLclNodes;
+    // Describe the physical problem (heat equation with
+    // nonhomogeneous Dirichlet boundary conditions) and its
+    // discretization.
+    Kokkos::View<double*> temperature ("temperature", numLclNodes);
+    const double diffusionCoeff = 1.0;
+    const double x_left = 0.0; // position of the left boundary
+    const double T_left = 0.0; // temperature at the left boundary
+    const double x_right = 1.0; // position of the right boundary
+    const double T_right = 1.0; // temperature at the right boundary
+    const double dx = (x_right - x_left) / numGblElements;
+    Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
 
-  // Describe the physical problem (heat equation with nonhomogeneous
-  // Dirichlet boundary conditions) and its discretization.
-  Kokkos::View<double*> temperature ("temperature", numLclNodes);
-  const double diffusionCoeff = 1.0;
-  const double x_left = 0.0; // position of the left boundary
-  const double T_left = 0.0; // temperature at the left boundary
-  const double x_right = 1.0; // position of the right boundary
-  const double T_right = 1.0; // temperature at the right boundary
-  const double dx = (x_right - x_left) / numGblElements;
-  Kokkos::View<double*> forcingTerm ("forcing term", numLclNodes);
+    // Set the forcing term.  We picked it so that we can know the exact
+    // solution of the heat equation, namely
+    //
+    // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
+    Kokkos::parallel_for ("Set forcing term", numLclNodes,
+      KOKKOS_LAMBDA (const LO node) {
+        //const double x = x_left + node * dx;
 
-  // Set the forcing term.  We picked it so that we can know the exact
-  // solution of the heat equation, namely
-  //
-  // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
-  Kokkos::parallel_for (numLclNodes, KOKKOS_LAMBDA (const LO node) {
-      //const double x = x_left + node * dx;
+        forcingTerm(node) = -8.0;
+        // We multiply dx*dx into the forcing term, so the matrix's
+        // entries don't need to know it.
+        forcingTerm(node) *= dx * dx;
+      });
 
-      forcingTerm(node) = -8.0;
-      // We multiply dx*dx into the forcing term, so the matrix's
-      // entries don't need to know it.
-      forcingTerm(node) *= dx * dx;
-    });
+    // Do a reduction over local elements to count the total number of
+    // (local) entries in the graph.  While doing so, count the number
+    // of (local) entries in each row, using Kokkos' atomic updates.
+    // We may use LO for the number of entries in each row, since it
+    // may not exceed the number of columns in the local matrix.
+    Kokkos::View<LO*> rowCounts ("row counts", numLclRows);
+    size_t numLclEntries = 0;
+    Kokkos::parallel_reduce ("Count graph", numLclElements,
+      KOKKOS_LAMBDA (const LO elt, size_t& curNumLclEntries) {
+        const LO lclRows = elt;
 
-  // Do a reduction over local elements to count the total number of
-  // (local) entries in the graph.  While doing so, count the number
-  // of (local) entries in each row, using Kokkos' atomic updates.  We
-  // may use LO for the number of entries in each row, since it may
-  // not exceed the number of columns in the local matrix.
-  Kokkos::View<LO*> rowCounts ("row counts", numLclRows);
-  size_t numLclEntries = 0;
-  Kokkos::parallel_reduce (numLclElements,
-    KOKKOS_LAMBDA (const LO elt, size_t& curNumLclEntries) {
-      const LO lclRows = elt;
+        // Always add a diagonal matrix entry.
+	Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
+	curNumLclEntries++;
 
-      // Always add a diagonal matrix entry.
-      Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
-      curNumLclEntries++;
+	// Each neighboring MPI process contributes an entry to the
+	// current row.  In a more realistic code, we might handle
+	// this either through a global assembly process (requiring
+	// MPI communication), or through ghosting a layer of elements
+	// (no MPI communication).
 
-      // Each neighboring MPI process contributes an entry to the
-      // current row.  In a more realistic code, we might handle this
-      // either through a global assembly process (requiring MPI
-      // communication), or through ghosting a layer of elements (no
-      // MPI communication).
+	// MPI process to the left sends us an entry
+	if (myRank > 0 && lclRows == 0) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
+	  curNumLclEntries++;
+	}
+	// MPI process to the right sends us an entry
+	if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
+	  curNumLclEntries++;
+	}
 
-      // MPI process to the left sends us an entry
-      if (myRank > 0 && lclRows == 0) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
-        curNumLclEntries++;
-      }
-      // MPI process to the right sends us an entry
-      if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
-        curNumLclEntries++;
-      }
+	// Contribute a matrix entry to the previous row.
+	if (lclRows > 0) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), LO(1));
+	  curNumLclEntries++;
+	}
+	// Contribute a matrix entry to the next row.
+	if (lclRows + 1 < numLclRows) {
+	  Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), LO(1));
+	  curNumLclEntries++;
+	}
+      }, numLclEntries /* reduction result */);
 
-      // Contribute a matrix entry to the previous row.
-      if (lclRows > 0) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), LO(1));
-        curNumLclEntries++;
-      }
-      // Contribute a matrix entry to the next row.
-      if (lclRows + 1 < numLclRows) {
-        Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), LO(1));
-        curNumLclEntries++;
-      }
-    }, numLclEntries /* reduction result */);
+    // mfh 20 Aug 2017: We can't just use a Kokkos::View<size_t*> for
+    // the row offsets, because Tpetra::CrsMatrix reserves the right
+    // to use a different row offset type for different execution /
+    // memory spaces.  Instead, we first deduce the row offset type,
+    // then construct a View of it.  (Note that a row offset needs to
+    // have a type that can contain the sum of the row counts.)
+    using row_offset_type =
+      Tpetra::CrsMatrix<>::local_matrix_type::row_map_type::non_const_value_type;
 
-  // mfh 20 Aug 2017: We can't just use a Kokkos::View<size_t*> for
-  // the row offsets, because Tpetra::CrsMatrix reserves the right to
-  // use a different row offset type for different execution / memory
-  // spaces.  Instead, we first deduce the row offset type, then
-  // construct a View of it.  (Note that a row offset needs to have a
-  // type that can contain the sum of the row counts.)
-  typedef Tpetra::CrsMatrix<>::local_matrix_type::row_map_type::non_const_value_type row_offset_type;
+    // Use a parallel scan (prefix sum) over the array of row counts, to
+    // compute the array of row offsets for the sparse graph.
+    Kokkos::View<row_offset_type*> rowOffsets ("row offsets", numLclRows+1);
+    Kokkos::parallel_scan ("Row offsets", numLclRows+1,
+      KOKKOS_LAMBDA (const LO lclRows,
+                     row_offset_type& update,
+                     const bool final) {
+        if (final) {
+          // Kokkos uses a multipass algorithm to implement scan.  Only
+	  // update the array on the final pass.  Updating the array
+	  // before changing 'update' means that we do an exclusive
+	  // scan.  Update the array after for an inclusive scan.
+	  rowOffsets[lclRows] = update;
+	}
+	if (lclRows < numLclRows) {
+	  update += rowCounts(lclRows);
+	}
+      });
 
-  // Use a parallel scan (prefix sum) over the array of row counts, to
-  // compute the array of row offsets for the sparse graph.
-  Kokkos::View<row_offset_type*> rowOffsets ("row offsets", numLclRows+1);
-  Kokkos::parallel_scan (numLclRows+1,
-    KOKKOS_LAMBDA (const LO lclRows,
-                   row_offset_type& update,
-                   const bool final) {
-      if (final) {
-        // Kokkos uses a multipass algorithm to implement scan.  Only
-        // update the array on the final pass.  Updating the array
-        // before changing 'update' means that we do an exclusive
-        // scan.  Update the array after for an inclusive scan.
-        rowOffsets[lclRows] = update;
-      }
-      if (lclRows < numLclRows) {
-        update += rowCounts(lclRows);
-      }
-    });
+    // Use the array of row counts to keep track of where to put each
+    // new column index, when filling the graph.  Updating the entries
+    // of rowCounts atomically lets us parallelize over elements
+    // (which may touch multiple rows at a time -- esp. in 2-D or 3-D,
+    // or with higher-order discretizations), rather than rows.
+    //
+    // We leave as an exercise to the reader how to use this array
+    // without resetting its entries.
+    Kokkos::deep_copy (rowCounts, 0);
 
-  // Use the array of row counts to keep track of where to put each
-  // new column index, when filling the graph.  Updating the entries
-  // of rowCounts atomically lets us parallelize over elements (which
-  // may touch multiple rows at a time -- esp. in 2-D or 3-D, or with
-  // higher-order discretizations), rather than rows.
-  //
-  // We leave as an exercise to the reader how to use this array
-  // without resetting its entries.
-  Kokkos::deep_copy (rowCounts, 0);
+    Kokkos::View<LO*> colIndices ("column indices", numLclEntries);
+    Kokkos::View<double*> matrixValues ("matrix values", numLclEntries);
 
-  Kokkos::View<LO*> colIndices ("column indices", numLclEntries);
-  Kokkos::View<double*> matrixValues ("matrix values", numLclEntries);
+    // Iterate over elements in parallel to fill the graph, matrix,
+    // and right-hand side (forcing term).  The latter gets the
+    // boundary conditions (a trick for nonzero Dirichlet boundary
+    // conditions).
+    Kokkos::parallel_for ("Assemble", numLclElements,
+      KOKKOS_LAMBDA (const LO elt) {
+        // Push dx*dx into the forcing term.
+        const double offCoeff = -diffusionCoeff / 2.0;
+        const double midCoeff =  diffusionCoeff;
+        // In this discretization, every element corresponds to a
+        // degree of freedom, and to a row of the matrix.  (Boundary
+        // conditions are Dirichlet, so they don't count as degrees of
+        // freedom.)
+        const int lclRows = elt;
 
-  // Iterate over elements in parallel to fill the graph, matrix, and
-  // right-hand side (forcing term).  The latter gets the boundary
-  // conditions (a trick for nonzero Dirichlet boundary conditions).
-  Kokkos::parallel_for (numLclElements, KOKKOS_LAMBDA (const LO elt) {
-      // Push dx*dx into the forcing term.
-      const double offCoeff = -diffusionCoeff / 2.0;
-      const double midCoeff =  diffusionCoeff;
-      // In this discretization, every element corresponds to a degree
-      // of freedom, and to a row of the matrix.  (Boundary conditions
-      // are Dirichlet, so they don't count as degrees of freedom.)
-      const int lclRows = elt;
+	// Always add a diagonal matrix entry.
+	{
+	  const LO count =
+	    Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
+	  colIndices(rowOffsets(lclRows) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), midCoeff);
+	}
 
-      // Always add a diagonal matrix entry.
-      {
-        const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
-        colIndices(rowOffsets(lclRows) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), midCoeff);
-      }
+	// Each neighboring MPI process contributes an entry to the
+	// current row.  In a more realistic code, we might handle
+	// this either through a global assembly process (requiring
+	// MPI communication), or through ghosting a layer of elements
+	// (no MPI communication).
 
-      // Each neighboring MPI process contributes an entry to the
-      // current row.  In a more realistic code, we might handle this
-      // either through a global assembly process (requiring MPI
-      // communication), or through ghosting a layer of elements (no
-      // MPI communication).
+	// MPI process to the left sends us an entry
+	if (myRank > 0 && lclRows == 0) {
+	  const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
+	  colIndices(rowOffsets(lclRows) + count) = numLclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
+	}
+	// MPI process to the right sends us an entry
+	if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
+	  const LO count =
+	    Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
 
-      // MPI process to the left sends us an entry
-      if (myRank > 0 && lclRows == 0) {
-        const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
-        colIndices(rowOffsets(lclRows) + count) = numLclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
-      }
-      // MPI process to the right sends us an entry
-      if (myRank + 1 < numProcs && lclRows + 1 == numLclRows) {
-        const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows), LO(1));
+	  // Give this entry the right local column index, depending
+	  // on whether the MPI process to the left has already sent
+	  // us an entry.
+	  const int colInd = (myRank > 0) ? numLclRows + 1 : numLclRows;
+	  colIndices(rowOffsets(lclRows) + count) = colInd;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
+	}
 
-        // Give this entry the right local column index, depending on
-        // whether the MPI process to the left has already sent us an
-        // entry.
-        const int colInd = (myRank > 0) ? numLclRows + 1 : numLclRows;
-        colIndices(rowOffsets(lclRows) + count) = colInd;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows) + count), offCoeff);
-      }
+        // Contribute a matrix entry to the previous row.
+        if (lclRows > 0) {
+	  const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), LO(1));
+	  colIndices(rowOffsets(lclRows-1) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows-1) + count), offCoeff);
+	}
+	// Contribute a matrix entry to the next row.
+	if (lclRows + 1 < numLclRows) {
+	  const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), LO(1));
+	  colIndices(rowOffsets(lclRows+1) + count) = lclRows;
+	  Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows+1) + count), offCoeff);
+	}
+      });
 
-      // Contribute a matrix entry to the previous row.
-      if (lclRows > 0) {
-        const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows-1), LO(1));
-        colIndices(rowOffsets(lclRows-1) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows-1) + count), offCoeff);
-      }
-      // Contribute a matrix entry to the next row.
-      if (lclRows + 1 < numLclRows) {
-        const LO count = Kokkos::atomic_fetch_add (&rowCounts(lclRows+1), LO(1));
-        colIndices(rowOffsets(lclRows+1) + count) = lclRows;
-        Kokkos::atomic_fetch_add (&matrixValues(rowOffsets(lclRows+1) + count), offCoeff);
-      }
-    });
+    //
+    // Construct Tpetra objects
+    //
+    using Teuchos::RCP;
+    using Teuchos::rcp;
 
-  //
-  // Construct Tpetra objects
-  //
-  using Teuchos::RCP;
-  using Teuchos::rcp;
+    const GO indexBase = 0;
+    RCP<const Tpetra::Map<> > rowMap =
+      rcp (new Tpetra::Map<> (numGblElements, numLclElements, indexBase, comm));
 
-  // Wrap the "raw" MPI communicator for use in Tpetra.
-  RCP<const Teuchos::Comm<int> > comm =
-    rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+    LO num_col_inds = numLclElements;
+    if (myRank > 0) {
+      num_col_inds++;
+    }
+    if (myRank + 1 < numProcs) {
+      num_col_inds++;
+    }
 
-  const GO indexBase = 0;
-  RCP<const Tpetra::Map<> > rowMap =
-    rcp (new Tpetra::Map<> (numGblElements, numLclElements, indexBase, comm));
+    // Soon, it will be acceptable to use a device View here.  The
+    // issues are that Teuchos::RCP isn't thread safe, and the Kokkos
+    // version of Tpetra::Map isn't quite ready yet.  We will change
+    // the latter soon.
+    Kokkos::View<GO*>::HostMirror colInds ("Column Map", num_col_inds);
+    for (LO k = 0; k < numLclElements; ++k) {
+      colInds(k) = rowMap->getGlobalElement (k);
+    }
+    LO k = numLclElements;
+    if (myRank > 0) {
+      // Contribution from left process.
+      colInds(k++) = rowMap->getGlobalElement (0) - 1;
+    }
+    if (myRank + 1 < numProcs) {
+      // Contribution from right process.
+      colInds(k++) = rowMap->getGlobalElement (numLclElements - 1) + 1;
+    }
 
-  LO num_col_inds = numLclElements;
-  if (myRank > 0) {
-    num_col_inds++;
-  }
-  if (myRank + 1 < numProcs) {
-    num_col_inds++;
-  }
+    // Flag to tell Tpetra::Map to compute the global number of
+    // indices in the Map.
+    const Tpetra::global_size_t INV =
+      Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid ();
+    RCP<const Tpetra::Map<> > colMap =
+      rcp (new Tpetra::Map<> (INV, colInds.data (), colInds.extent (0), indexBase, comm));
 
-  // Soon, it will be acceptable to use a device View here.  The
-  // issues are that Teuchos::RCP isn't thread safe, and the Kokkos
-  // version of Tpetra::Map isn't quite ready yet.  We will change the
-  // latter soon.
-  Kokkos::View<GO*>::HostMirror colInds ("Column Map", num_col_inds);
-  for (LO k = 0; k < numLclElements; ++k) {
-    colInds(k) = rowMap->getGlobalElement (k);
-  }
-  LO k = numLclElements;
-  if (myRank > 0) {
-    // Contribution from left process.
-    colInds(k++) = rowMap->getGlobalElement (0) - 1;
-  }
-  if (myRank + 1 < numProcs) {
-    // Contribution from right process.
-    colInds(k++) = rowMap->getGlobalElement (numLclElements - 1) + 1;
-  }
+    Tpetra::CrsMatrix<> A (rowMap, colMap, rowOffsets,
+			   colIndices, matrixValues);
+    A.fillComplete ();
 
-  // Flag to tell Tpetra::Map to compute the global number of indices
-  // in the Map.
-  const Tpetra::global_size_t INV =
-    Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid ();
-  RCP<const Tpetra::Map<> > colMap =
-    rcp (new Tpetra::Map<> (INV, colInds.data (), colInds.extent (0), indexBase, comm));
+    // Hack to deal with the fact that Tpetra::Vector needs a
+    // DualView<double**> for now, rather than a View<double*>.
+    Kokkos::DualView<double**, Kokkos::LayoutLeft> b_lcl ("b", numLclRows, 1);
+    b_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
+    Kokkos::deep_copy (Kokkos::subview (b_lcl.d_view, Kokkos::ALL (), 0), forcingTerm);
+    Tpetra::Vector<> b (A.getRangeMap (), b_lcl);
 
-  Tpetra::CrsMatrix<> A (rowMap, colMap, rowOffsets, colIndices, matrixValues);
-  A.fillComplete ();
+    Kokkos::DualView<double**, Kokkos::LayoutLeft> x_lcl ("b", numLclRows, 1);
+    x_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
+    Kokkos::deep_copy (Kokkos::subview (x_lcl.d_view, Kokkos::ALL (), 0), temperature);
+    Tpetra::Vector<> x (A.getDomainMap (), x_lcl);
 
-  // Hack to deal with the fact that Tpetra::Vector needs a
-  // DualView<double**> for now, rather than a View<double*>.
-  Kokkos::DualView<double**, Kokkos::LayoutLeft> b_lcl ("b", numLclRows, 1);
-  b_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
-  Kokkos::deep_copy (Kokkos::subview (b_lcl.d_view, Kokkos::ALL (), 0), forcingTerm);
-  Tpetra::Vector<> b (A.getRangeMap (), b_lcl);
+    const int numIters = solve (x, A, b, dx); // solve the linear system
+    if (myRank == 0) {
+      cout << "Linear system Ax=b took " << numIters << " iteration(s) to solve" << endl;
+    }
 
-  Kokkos::DualView<double**, Kokkos::LayoutLeft> x_lcl ("b", numLclRows, 1);
-  x_lcl.modify<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
-  Kokkos::deep_copy (Kokkos::subview (x_lcl.d_view, Kokkos::ALL (), 0), temperature);
-  Tpetra::Vector<> x (A.getDomainMap (), x_lcl);
+    // Hack to deal with the fact that Tpetra::Vector needs a
+    // DualView<double**> for now, rather than a View<double*>.  This
+    // means that we have to make a deep copy back into the
+    // 'temperature' output array.
+    x_lcl.sync<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
+    Kokkos::deep_copy (temperature, Kokkos::subview (b_lcl.d_view, Kokkos::ALL (), 0));
 
-  const int numIters = solve (x, A, b, dx); // solve the linear system
-  if (myRank == 0) {
-    cout << "Linear system Ax=b took " << numIters << " iteration(s) to solve" << endl;
-  }
+    // Correct the solution for the nonhomogenous Dirichlet boundary
+    // conditions.
+    Kokkos::parallel_for ("Boundary conditions", numLclNodes,
+      KOKKOS_LAMBDA (const LO node) {
+	const double x_cur = x_left + node * dx;
+	temperature(node) += (T_left - T_right) * x_cur;
+      });
 
-  // Hack to deal with the fact that Tpetra::Vector needs a
-  // DualView<double**> for now, rather than a View<double*>.  This
-  // means that we have to make a deep copy back into the
-  // 'temperature' output array.
-  x_lcl.sync<Kokkos::DualView<double**, Kokkos::LayoutLeft>::t_dev::execution_space> ();
-  Kokkos::deep_copy (temperature, Kokkos::subview (b_lcl.d_view, Kokkos::ALL (), 0));
+    // Compare the computed solution against the known exact solution:
+    //
+    // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
+    Tpetra::Vector<> x_exact (x, Teuchos::Copy);
+    typedef Tpetra::Vector<>::dual_view_type dual_view_type;
+    typedef dual_view_type::t_dev::execution_space execution_space;
+    typedef dual_view_type::t_dev::memory_space memory_space;
+    typedef Kokkos::RangePolicy<execution_space, LO> policy_type;
 
-  // Correct the solution for the nonhomogenous Dirichlet boundary
-  // conditions.
-  Kokkos::parallel_for (numLclNodes, KOKKOS_LAMBDA (const LO node) {
-      const double x_cur = x_left + node * dx;
-      temperature(node) += (T_left - T_right) * x_cur;
-    });
+    x_exact.sync<memory_space> ();
+    x_exact.modify<memory_space> ();
 
-  // Compare the computed solution against the known exact solution:
-  //
-  // u(x) = -4.0 * (x - 0.5) * (x - 0.5) + 1.0 + (T_left - T_right)x.
-  Tpetra::Vector<> x_exact (x, Teuchos::Copy);
-  typedef Tpetra::Vector<>::dual_view_type dual_view_type;
-  typedef dual_view_type::t_dev::execution_space execution_space;
-  typedef dual_view_type::t_dev::memory_space memory_space;
-  typedef Kokkos::RangePolicy<execution_space, LO> policy_type;
-
-  x_exact.sync<memory_space> ();
-  x_exact.modify<memory_space> ();
-
-  // Slight breakage with respect to GCC < 4.8.
-  // mfh 20 Aug 2017: See also GitHub issue #1629.
+    // Slight breakage with respect to GCC < 4.8.
+    // mfh 20 Aug 2017: See also GitHub issue #1629.
 #if defined(__GNUC__)
 #  if __GNUC__ == 4 && __GNUC_MINOR__ <= 7
-  auto x_exact_lcl = x_exact.getLocalView<memory_space> ();
+    auto x_exact_lcl = x_exact.getLocalView<memory_space> ();
 #  elif __GNUC__ == 4 && __GNUC_MINOR__ > 7 // GCC >= 4.8
-  auto x_exact_lcl = x_exact.template getLocalView<memory_space> ();
+    auto x_exact_lcl = x_exact.template getLocalView<memory_space> ();
 #  else // GCC >= 5
-  auto x_exact_lcl = x_exact.getLocalView<memory_space> ();
+    auto x_exact_lcl = x_exact.getLocalView<memory_space> ();
 #  endif // __GNUC__ == 4 && __GNUC_MINOR__ <= 7
 #else // ! defined(__GNUC__)
-  auto x_exact_lcl = x_exact.template getLocalView<memory_space> ();
+    auto x_exact_lcl = x_exact.template getLocalView<memory_space> ();
 #endif // defined(__GNUC__)
 
-  Kokkos::parallel_for (policy_type (0, numLclNodes),
-                        KOKKOS_LAMBDA (const LO& node) {
-      const double x_cur = x_left + node * dx;
-      x_exact_lcl(node,0) -= exactSolution (x_cur, T_left, T_right);
-    });
-  const double absErrNorm = x_exact.norm2 ();
-  const double relErrNorm = b.norm2 () / absErrNorm;
-  if (myRank == 0) {
-    cout << "Relative error norm: " << relErrNorm << endl;
+    Kokkos::parallel_for ("Compare solutions",
+      policy_type (0, numLclNodes),
+      KOKKOS_LAMBDA (const LO& node) {
+        const double x_cur = x_left + node * dx;
+        x_exact_lcl(node,0) -= exactSolution (x_cur, T_left, T_right);
+      });
+    const double absErrNorm = x_exact.norm2 ();
+    const double relErrNorm = b.norm2 () / absErrNorm;
+    if (myRank == 0) {
+      cout << "Relative error norm: " << relErrNorm << endl;
+    }
+
+    if (myRank == 0) {
+      cout << "End Result: TEST PASSED" << endl;
+    }
   }
-
-  if (myRank == 0) {
-    cout << "End Result: TEST PASSED" << endl;
-  }
-
-  // Shut down Kokkos and MPI, in reverse order from their initialization.
-  Kokkos::finalize ();
-  MPI_Finalize ();
-
   return EXIT_SUCCESS;
 }
 
 #else
 
 int main (int argc, char* argv[]) {
-  MPI_Init (&argc, &argv);
-  int rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  if (rank == 0) {
-    std::cout <<
-      "This lesson was not compiled because Kokkos\n" <<
-      "was not configured with lambda support for all backends.\n" <<
-      "Tricking CTest into perceiving success anyways:\n" <<
-      "End Result: TEST PASSED\n";
-  }
-  MPI_Finalize();
+  using std::cout;
+  using std::endl;
+  
+  cout << "This lesson was not compiled because Kokkos" << endl
+    "was not configured with lambda support for all backends." << endl
+    "Tricking CTest into perceiving success anyways:" << endl
+    "End Result: TEST PASSED" << endl;
+  return 0;
 }
 
 #endif

--- a/packages/tpetra/core/example/advanced/Benchmarks/import.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/import.cpp
@@ -53,6 +53,7 @@
 #  endif // EPETRA_MPI
 #endif // HAVE_TPETRACORE_EPETRA
 
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Import.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
@@ -69,10 +70,9 @@ using Teuchos::rcp;
 using Teuchos::Time;
 using Teuchos::TimeMonitor;
 
-typedef Tpetra::Vector<>::scalar_type ST;
-typedef Tpetra::Vector<>::local_ordinal_type LO;
-typedef int GO; // So that Epetra and Tpetra can use the same GID lists
-typedef Tpetra::Vector<>::node_type NT;
+using ST = Tpetra::Vector<>::scalar_type;
+using LO = Tpetra::Vector<>::local_ordinal_type;
+using GO = int; // So Epetra and Tpetra can use the same GID lists
 
 // Create a new timer with the given name if it hasn't already been
 // created, else get the previously created timer with that name.
@@ -90,16 +90,16 @@ benchmarkTpetraImport (ArrayView<const GO> srcGlobalElts,
                        ArrayView<const GO> destGlobalElts,
                        const GO indexBase,
                        RCP<const Comm<int> > comm,
-                       RCP<NT> node,
                        const int numMapCreateTrials,
                        const int numImportCreateTrials,
                        const int numVectorCreateTrials,
                        const int numImportExecTrials)
 {
-  typedef Tpetra::Import<LO, GO, NT> import_type;
-  typedef Tpetra::Map<LO, GO, NT> map_type;
-  typedef Tpetra::Vector<ST, LO, GO, NT> vector_type;
-  const global_size_t INVALID = Teuchos::OrdinalTraits<global_size_t>::invalid ();
+  using import_type = Tpetra::Import<LO, GO>;
+  using map_type = Tpetra::Map<LO, GO>;
+  using vector_type = Tpetra::Vector<ST, LO, GO>;
+  const global_size_t INVALID =
+    Teuchos::OrdinalTraits<global_size_t>::invalid ();
 
   TEUCHOS_TEST_FOR_EXCEPTION(
     numMapCreateTrials < 1 && numImportCreateTrials > 0, std::invalid_argument,
@@ -123,8 +123,8 @@ benchmarkTpetraImport (ArrayView<const GO> srcGlobalElts,
   {
     TimeMonitor timeMon (*mapCreateTimer);
     for (int k = 0; k < numMapCreateTrials; ++k) {
-      srcMap = rcp (new map_type (INVALID, srcGlobalElts, indexBase, comm, node));
-      destMap = rcp (new map_type (INVALID, destGlobalElts, indexBase, comm, node));
+      srcMap = rcp (new map_type (INVALID, srcGlobalElts, indexBase, comm));
+      destMap = rcp (new map_type (INVALID, destGlobalElts, indexBase, comm));
     }
   }
   RCP<import_type> import;
@@ -283,99 +283,106 @@ createGidLists (Array<GO>& srcGlobalElts,
 int main (int argc, char* argv[]) {
   using std::cout;
   using std::endl;
-  Teuchos::oblackholestream blackHole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
 
-  RCP<const Teuchos::Comm<int> > tpetraComm;
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    RCP<const Teuchos::Comm<int> > tpetraComm;
 #ifdef HAVE_TPETRACORE_EPETRA
-  #ifdef EPETRA_MPI
-  Epetra_MpiComm epetraComm (MPI_COMM_WORLD);
-  tpetraComm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+#ifdef EPETRA_MPI
+    Epetra_MpiComm epetraComm (MPI_COMM_WORLD);
+    tpetraComm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
 #  else
-  Epetra_SerialComm epetraComm;
-  tpetraComm = rcp (new Teuchos::SerialComm<int>);
+    Epetra_SerialComm epetraComm;
+    tpetraComm = rcp (new Teuchos::SerialComm<int>);
 #  endif // EPETRA_MPI
 #endif // HAVE_TPETRACORE_EPETRA
-  RCP<NT> node = KokkosClassic::Details::getNode<NT> ();
 
-  const int numProcs = tpetraComm->getSize ();
-  const int myRank = tpetraComm->getRank ();
-  const int indexBase = 1; // of interest to Sierra
+    const int numProcs = tpetraComm->getSize ();
+    const int myRank = tpetraComm->getRank ();
+    const int indexBase = 1; // of interest to Sierra
 
-  // Benchmark parameters
-  int numEltsPerProc = 100000;
-  int numTrials = 100;
+    // Benchmark parameters
+    int numEltsPerProc = 100000;
+    int numTrials = 100;
 #ifdef HAVE_TPETRACORE_EPETRA
-  bool runEpetra = true;
+    bool runEpetra = true;
 #else
-  bool runEpetra = false;
+    bool runEpetra = false;
 #endif // HAVE_TPETRACORE_EPETRA
-  bool runTpetra = true;
+    bool runTpetra = true;
 
-  CommandLineProcessor cmdp;
-  cmdp.setOption ("numEltsPerProc", &numEltsPerProc, "Number of global indices "
-                  "owned by each process");
-  cmdp.setOption ("numTrials", &numTrials, "Number of times to repeat each "
-                  "operation in a timing loop");
-  cmdp.setOption ("runEpetra", "noEpetra", &runEpetra,
-                  "Whether to run the Epetra benchmark");
-  cmdp.setOption ("runTpetra", "noTpetra", &runTpetra,
-                  "Whether to run the Tpetra benchmark");
-  const CommandLineProcessor::EParseCommandLineReturn parseResult =
-    cmdp.parse (argc, argv);
-  if (parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
-    // The user specified --help at the command line to print help
-    // with command-line arguments.  We printed help already, so quit
-    // with a happy return code.
-    return EXIT_SUCCESS;
-  } else {
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
-      std::invalid_argument, "Failed to parse command-line arguments.");
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      numTrials < 0, std::invalid_argument, "numTrials must be nonnegative.");
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      numEltsPerProc < 0, std::invalid_argument,
-      "numEltsPerProc must be nonnegative.");
+    CommandLineProcessor cmdp;
+    cmdp.setOption ("numEltsPerProc", &numEltsPerProc,
+		    "Number of global indices "
+		    "owned by each process");
+    cmdp.setOption ("numTrials", &numTrials,
+		    "Number of times to repeat each "
+		    "operation in a timing loop");
+    cmdp.setOption ("runEpetra", "noEpetra", &runEpetra,
+		    "Whether to run the Epetra benchmark");
+    cmdp.setOption ("runTpetra", "noTpetra", &runTpetra,
+		    "Whether to run the Tpetra benchmark");
+    const CommandLineProcessor::EParseCommandLineReturn parseResult =
+      cmdp.parse (argc, argv);
+    if (parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
+      // The user specified --help at the command line to print help
+      // with command-line arguments.  We printed help already, so
+      // quit with a happy return code.
+      return EXIT_SUCCESS;
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
+	 std::invalid_argument,
+	 "Failed to parse command-line arguments.");
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(numTrials < 0, std::invalid_argument,
+	 "numTrials must be nonnegative.");
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(numEltsPerProc < 0, std::invalid_argument,
+	 "numEltsPerProc must be nonnegative.");
 #ifndef HAVE_TPETRACORE_EPETRA
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      runEpetra, std::invalid_argument, "Tpetra was not built with Epetra "
-      "enabled, so you cannot run the Epetra benchmark." );
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(runEpetra, std::invalid_argument, "Tpetra was not built with "
+	 "Epetra enable, so you cannot run the Epetra benchmark." );
 #endif // HAVE_TPETRACORE_EPETRA
-  }
+    }
 
-  // Derived benchmark parameters
-  const int numMapCreateTrials = numTrials;
-  const int numImportCreateTrials = numTrials;
-  const int numVectorCreateTrials = numTrials;
-  const int numImportExecTrials = numTrials;
+    // Derived benchmark parameters
+    const int numMapCreateTrials = numTrials;
+    const int numImportCreateTrials = numTrials;
+    const int numVectorCreateTrials = numTrials;
+    const int numImportExecTrials = numTrials;
 
-  if (myRank == 0) {
-    cout << endl << "---" << endl
-         << "Command-line options:" << endl
-         << "  numEltsPerProc: " << numEltsPerProc << endl
-         << "  numTrials: " << numTrials << endl
-         << "  runEpetra: " << (runEpetra ? "true" : "false") << endl
-         << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
-         << endl;
-  }
+    if (myRank == 0) {
+      cout << endl << "---" << endl
+	   << "Command-line options:" << endl
+	   << "  numEltsPerProc: " << numEltsPerProc << endl
+	   << "  numTrials: " << numTrials << endl
+	   << "  runEpetra: " << (runEpetra ? "true" : "false") << endl
+	   << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
+	   << endl;
+    }
 
-  // Run the benchmark
-  Array<GO> srcGlobalElts, destGlobalElts;
-  createGidLists (srcGlobalElts, destGlobalElts, numProcs, myRank,
-                  numEltsPerProc, indexBase);
+    // Run the benchmark
+    Array<GO> srcGlobalElts, destGlobalElts;
+    createGidLists (srcGlobalElts, destGlobalElts, numProcs, myRank,
+		    numEltsPerProc, indexBase);
 #ifdef HAVE_TPETRACORE_EPETRA
-  if (runEpetra) {
-    benchmarkEpetraImport (srcGlobalElts, destGlobalElts, indexBase, epetraComm,
-                           numMapCreateTrials, numImportCreateTrials,
-                           numVectorCreateTrials, numImportExecTrials);
-  }
+    if (runEpetra) {
+      benchmarkEpetraImport (srcGlobalElts, destGlobalElts, indexBase,
+			     epetraComm,
+			     numMapCreateTrials, numImportCreateTrials,
+			     numVectorCreateTrials, numImportExecTrials);
+    }
 #endif // HAVE_TPETRACORE_EPETRA
-  if (runTpetra) {
-    benchmarkTpetraImport (srcGlobalElts, destGlobalElts, indexBase, tpetraComm,
-                           node, numMapCreateTrials, numImportCreateTrials,
-                           numVectorCreateTrials, numImportExecTrials);
+    if (runTpetra) {
+      benchmarkTpetraImport (srcGlobalElts, destGlobalElts, indexBase,
+			     tpetraComm,
+			     numMapCreateTrials, numImportCreateTrials,
+			     numVectorCreateTrials, numImportExecTrials);
+    }
+    TimeMonitor::report (tpetraComm.ptr (), std::cout);
   }
-  TimeMonitor::report (tpetraComm.ptr (), std::cout);
   return EXIT_SUCCESS;
 }

--- a/packages/tpetra/core/example/advanced/Benchmarks/vector.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/vector.cpp
@@ -60,10 +60,12 @@
 #  endif // EPETRA_MPI
 #endif // HAVE_TPETRACORE_EPETRA
 
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_oblackholestream.hpp>
 
 typedef Tpetra::global_size_t GST;
 using Teuchos::Array;
@@ -307,103 +309,105 @@ main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
-  Teuchos::oblackholestream blackHole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
 
-  RCP<const Teuchos::Comm<int> > tpetraComm;
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  {
+    RCP<const Teuchos::Comm<int> > tpetraComm;
 #ifdef HAVE_TPETRACORE_EPETRA
-  #ifdef EPETRA_MPI
-  Epetra_MpiComm epetraComm (MPI_COMM_WORLD);
-  tpetraComm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+#  ifdef EPETRA_MPI
+    Epetra_MpiComm epetraComm (MPI_COMM_WORLD);
+    tpetraComm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
 #  else
-  Epetra_SerialComm epetraComm;
-  tpetraComm = rcp (new Teuchos::SerialComm<int>);
+    Epetra_SerialComm epetraComm;
+    tpetraComm = rcp (new Teuchos::SerialComm<int>);
 #  endif // EPETRA_MPI
 #endif // HAVE_TPETRACORE_EPETRA
 
-  //const int numProcs = tpetraComm->getSize (); // unused
-  const int myRank = tpetraComm->getRank ();
-  const int indexBase = 0;
+    //const int numProcs = tpetraComm->getSize (); // unused
+    const int myRank = tpetraComm->getRank ();
+    const int indexBase = 0;
 
-  // Benchmark parameters
-  int numIndsPerProc = 100000;
-  int numTrials = 1000;
+    // Benchmark parameters
+    int numIndsPerProc = 100000;
+    int numTrials = 1000;
 
 #ifdef HAVE_TPETRACORE_EPETRA
-  bool runEpetra = true;
+    bool runEpetra = true;
 #else
-  bool runEpetra = false;
+    bool runEpetra = false;
 #endif // HAVE_TPETRACORE_EPETRA
-  bool runTpetra = true;
+    bool runTpetra = true;
 
-  CommandLineProcessor cmdp;
-  cmdp.setOption ("numIndsPerProc", &numIndsPerProc, "Number of global indices "
-                  "owned by each process");
-  cmdp.setOption ("numTrials", &numTrials, "Number of timing loop iterations for each event to time");
-  cmdp.setOption ("runEpetra", "noEpetra", &runEpetra,
-                  "Whether to run the Epetra benchmark");
-  cmdp.setOption ("runTpetra", "noTpetra", &runTpetra,
-                  "Whether to run the Tpetra benchmark");
-  const CommandLineProcessor::EParseCommandLineReturn parseResult =
-    cmdp.parse (argc, argv);
-  if (parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
-    // The user specified --help at the command line to print help
-    // with command-line arguments.  We printed help already, so quit
-    // with a happy return code.
-    return EXIT_SUCCESS;
-  } else {
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
-      std::invalid_argument, "Failed to parse command-line arguments.");
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      numIndsPerProc < 0, std::invalid_argument,
-      "numIndsPerProc must be nonnegative.");
+    CommandLineProcessor cmdp;
+    cmdp.setOption ("numIndsPerProc", &numIndsPerProc, "Number of global indices "
+		    "owned by each process");
+    cmdp.setOption ("numTrials", &numTrials, "Number of timing loop iterations for each event to time");
+    cmdp.setOption ("runEpetra", "noEpetra", &runEpetra,
+		    "Whether to run the Epetra benchmark");
+    cmdp.setOption ("runTpetra", "noTpetra", &runTpetra,
+		    "Whether to run the Tpetra benchmark");
+    const CommandLineProcessor::EParseCommandLineReturn parseResult =
+      cmdp.parse (argc, argv);
+    if (parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
+      // The user specified --help at the command line to print help
+      // with command-line arguments.  We printed help already, so quit
+      // with a happy return code.
+      return EXIT_SUCCESS;
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
+	 std::invalid_argument, "Failed to parse command-line arguments.");
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(numIndsPerProc < 0, std::invalid_argument,
+	 "numIndsPerProc must be nonnegative.");
 #ifndef HAVE_TPETRACORE_EPETRA
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      runEpetra, std::invalid_argument, "Tpetra was not built with Epetra "
-      "enabled, so you cannot run the Epetra benchmark." );
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(runEpetra, std::invalid_argument, "Tpetra was not built with Epetra "
+	 "enabled, so you cannot run the Epetra benchmark." );
 #endif // HAVE_TPETRACORE_EPETRA
-  }
+    }
 
-  if (myRank == 0) {
-    cout << endl << "---" << endl
-         << "Command-line options:" << endl
-         << "  numIndsPerProc: " << numIndsPerProc << endl
-         << "  numTrials: " << numTrials << endl;
+    if (myRank == 0) {
+      cout << endl << "---" << endl
+	   << "Command-line options:" << endl
+	   << "  numIndsPerProc: " << numIndsPerProc << endl
+	   << "  numTrials: " << numTrials << endl;
 #ifdef HAVE_TPETRACORE_EPETRA
-    cout << "  runEpetra: " << (runEpetra ? "true" : "false") << endl;
+      cout << "  runEpetra: " << (runEpetra ? "true" : "false") << endl;
 #else
-    cout << "  runEpetra: " << (runEpetra ? "true" : "false") << endl;
+      cout << "  runEpetra: " << (runEpetra ? "true" : "false") << endl;
 #endif // HAVE_TPETRACORE_EPETRA
-    cout << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
-         << endl;
-  }
+      cout << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
+	   << endl;
+    }
 
-  const int numMapCreateTrials = numTrials;
-  const int numVecCreateTrials = numTrials;
-  const int numVecRandTrials = numTrials;
-  const int numVecNormTrials = numTrials;
-  const int numVecDotTrials = numTrials;
+    const int numMapCreateTrials = numTrials;
+    const int numVecCreateTrials = numTrials;
+    const int numVecRandTrials = numTrials;
+    const int numVecNormTrials = numTrials;
+    const int numVecDotTrials = numTrials;
 
-  // Run the benchmark
+    // Run the benchmark
 #ifdef HAVE_TPETRACORE_EPETRA
-  if (runEpetra) {
-    benchmarkEpetra (epetraComm, numIndsPerProc, indexBase,
-                     numMapCreateTrials,
-                     numVecCreateTrials,
-                     numVecRandTrials,
-                     numVecNormTrials,
-                     numVecDotTrials);
-  }
+    if (runEpetra) {
+      benchmarkEpetra (epetraComm, numIndsPerProc, indexBase,
+		       numMapCreateTrials,
+		       numVecCreateTrials,
+		       numVecRandTrials,
+		       numVecNormTrials,
+		       numVecDotTrials);
+    }
 #endif // HAVE_TPETRACORE_EPETRA
-  if (runTpetra) {
-    benchmarkTpetra (tpetraComm, numIndsPerProc, indexBase,
-                     numMapCreateTrials,
-                     numVecCreateTrials,
-                     numVecRandTrials,
-                     numVecNormTrials,
-                     numVecDotTrials);
+    if (runTpetra) {
+      benchmarkTpetra (tpetraComm, numIndsPerProc, indexBase,
+		       numMapCreateTrials,
+		       numVecCreateTrials,
+		       numVecRandTrials,
+		       numVecNormTrials,
+		       numVecDotTrials);
+    }
+    TimeMonitor::report (tpetraComm.ptr (), std::cout);
   }
-  TimeMonitor::report (tpetraComm.ptr (), std::cout);
   return EXIT_SUCCESS;
 }

--- a/packages/tpetra/core/example/utilities/compareMaps.cpp
+++ b/packages/tpetra/core/example/utilities/compareMaps.cpp
@@ -41,11 +41,10 @@
 
 #include "MatrixMarket_Tpetra.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_CommHelpers.hpp"
-#include "Teuchos_GlobalMPISession.hpp"
 #include <cstdlib> // EXIT_SUCCESS, EXIT_FAILURE
 #include <fstream>
 #include <sstream>
@@ -68,148 +67,151 @@ main (int argc, char* argv[])
   // Reader must be templated on a CrsMatrix specialization
   typedef Tpetra::MatrixMarket::Reader<Tpetra::CrsMatrix<> > reader_type;
 
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv);
-  const int myRank = mpiSession.getRank ();
-  const int rootRank = 0;
-  auto comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-
-  std::string mapFile1, mapFile2;
-  bool tolerant = false;
-  bool debug = false;
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
   {
-    const bool throwExceptions = false;
-    const bool recognizeAllOptions = true; // let Kokkos options through
-    Teuchos::CommandLineProcessor cmdLineProc (throwExceptions, recognizeAllOptions);
-    cmdLineProc.setOption ("mapFile1", &mapFile1, "Filename of first Map file, to read on Process 0");
-    cmdLineProc.setOption ("mapFile2", &mapFile2, "Filename of second Map file, to read on Process 0");
-    cmdLineProc.setOption ("tolerant", "strict", &tolerant, "Read Maps in tolerant mode");
-    cmdLineProc.setOption ("debug", "release", &debug, "Enable debug output");
+    auto comm = Tpetra::getDefaultComm ();
+    const int myRank = comm->getRank ();
+    const int rootRank = 0;
 
-    auto result = cmdLineProc.parse (argc, argv);
-    if (result != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
-      if (result == Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED) {
-        return EXIT_SUCCESS; // printed help; now we're done
+    std::string mapFile1, mapFile2;
+    bool tolerant = false;
+    bool debug = false;
+    {
+      const bool throwExceptions = false;
+      const bool recognizeAllOptions = true; // let Kokkos options through
+      Teuchos::CommandLineProcessor cmdLineProc (throwExceptions, recognizeAllOptions);
+
+      cmdLineProc.setOption ("mapFile1", &mapFile1, "Filename of first Map file, to read on Process 0");
+      cmdLineProc.setOption ("mapFile2", &mapFile2, "Filename of second Map file, to read on Process 0");
+      cmdLineProc.setOption ("tolerant", "strict", &tolerant, "Read Maps in tolerant mode");
+      cmdLineProc.setOption ("debug", "release", &debug, "Enable debug output");
+
+      auto result = cmdLineProc.parse (argc, argv);
+      if (result != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+	if (result == Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED) {
+	  return EXIT_SUCCESS; // printed help; now we're done
+	}
+	else if (result != Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION) {
+	  return EXIT_FAILURE; // some error that's not just an unrecognized option
+	}
       }
-      else if (result != Teuchos::CommandLineProcessor::PARSE_UNRECOGNIZED_OPTION) {
-        return EXIT_FAILURE; // some error that's not just an unrecognized option
+    }
+
+    // On Process 0, test whether the files exist.
+    int lclFileExists = 0;
+    int gblFileExists = 0;
+    if (myRank == rootRank) {
+      std::ifstream f1 (mapFile1);
+      lclFileExists = f1.good () ? 1 : 0;
+      gblFileExists = lclFileExists;
+      f1.close ();
+    }
+    broadcast<int, int> (*comm, rootRank, outArg (gblFileExists));
+    if (gblFileExists != 1) {
+      if (myRank == rootRank) {
+	cerr << "Cannot read the first Map file \"" << mapFile1 << "\"!" << endl;
       }
+      return EXIT_FAILURE;
     }
-  }
 
-  // On Process 0, test whether the files exist.
-  int lclFileExists = 0;
-  int gblFileExists = 0;
-  if (myRank == rootRank) {
-    std::ifstream f1 (mapFile1);
-    lclFileExists = f1.good () ? 1 : 0;
-    gblFileExists = lclFileExists;
-    f1.close ();
-  }
-  broadcast<int, int> (*comm, rootRank, outArg (gblFileExists));
-  if (gblFileExists != 1) {
     if (myRank == rootRank) {
-      cerr << "Cannot read the first Map file \"" << mapFile1 << "\"!" << endl;
+      std::ifstream f2 (mapFile2);
+      lclFileExists = f2.good ();
+      gblFileExists = lclFileExists;
+      f2.close ();
     }
-    return EXIT_FAILURE;
-  }
+    broadcast<int, int> (*comm, rootRank, outArg (gblFileExists));
+    if (gblFileExists != 1) {
+      if (myRank == rootRank) {
+	cerr << "Cannot read the second Map file \"" << mapFile2 << "\"!" << endl;
+      }
+      return EXIT_FAILURE;
+    }
 
-  if (myRank == rootRank) {
-    std::ifstream f2 (mapFile2);
-    lclFileExists = f2.good ();
-    gblFileExists = lclFileExists;
-    f2.close ();
-  }
-  broadcast<int, int> (*comm, rootRank, outArg (gblFileExists));
-  if (gblFileExists != 1) {
+    if (debug && myRank == rootRank) {
+      cerr << "Both Map files are readable" << endl;
+    }
+
+    RCP<const map_type> map1;
+    RCP<const map_type> map2;
+
+    int lclSuccess = 0;
+    int gblSuccess = 0;
+    std::ostringstream errStrm;
+    try {
+      map1 = reader_type::readMapFile (mapFile1, comm, tolerant, debug);
+      lclSuccess = 1;
+    }
+    catch (std::exception& e) {
+      errStrm << "Process " << myRank << ": Caught exception while reading "
+	"first Map file: " << e.what () << endl;
+    }
+    catch (...) {
+      errStrm << "Process " << myRank << ": Caught exception not a subclass of "
+	"std::exception, while reading first Map file" << endl;
+    }
+    if (map1.is_null ()) {
+      errStrm << "Process " << myRank << ": Attempt to read first Map file "
+	"returned null" << endl;
+      lclSuccess = 0;
+    }
+
+    reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    if (gblSuccess != 1) {
+      Tpetra::Details::gathervPrint (std::cerr, errStrm.str (), *comm);
+      return EXIT_FAILURE;
+    }
+
+    if (debug && myRank == rootRank) {
+      cerr << "Read first Map file" << endl;
+    }
+
+    try {
+      map2 = reader_type::readMapFile (mapFile2, comm, tolerant, debug);
+      lclSuccess = 1;
+    }
+    catch (std::exception& e) {
+      errStrm << "Process " << myRank << ": Caught exception while reading "
+	"second Map file: " << e.what () << endl;
+    }
+    catch (...) {
+      errStrm << "Process " << myRank << ": Caught exception not a subclass of "
+	"std::exception, while reading second Map file" << endl;
+    }
+    if (map2.is_null ()) {
+      errStrm << "Process " << myRank << ": Attempt to read second Map file "
+	"returned null" << endl;
+      lclSuccess = 0;
+    }
+
+    reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    if (gblSuccess != 1) {
+      Tpetra::Details::gathervPrint (std::cerr, errStrm.str (), *comm);
+      return EXIT_FAILURE;
+    }
+
+    if (debug && myRank == rootRank) {
+      cerr << "Read second Map file" << endl;
+    }
+
+    // At this point, we have two valid Maps.  Let's print stuff about them.
+    const bool compat = map1->isCompatible (*map2);
+    const bool same = map1->isSameAs (*map2);
+    // This is a local (per MPI process) property.  Thus, we have to
+    // all-reduce to find out whether it's true on all processes
+    // (which is actually what we want to know).
+    const bool locallyFitted = map1->isLocallyFitted (*map2);
+    const int locallyFittedInt = locallyFitted ? 1 : 0;
+    int globallyFittedInt = 0; // output argument
+    reduceAll<int, int> (*comm, REDUCE_MIN, locallyFittedInt,
+			 outArg (globallyFittedInt));
+    const bool globallyFitted = (globallyFittedInt == 1);
+
     if (myRank == rootRank) {
-      cerr << "Cannot read the second Map file \"" << mapFile2 << "\"!" << endl;
+      cout << "Maps compatible? " << (compat ? "YES" : "NO") << endl
+	   << "Maps same?       " << (same ? "YES" : "NO") << endl
+	   << "Maps fitted?     " << (globallyFitted ? "YES" : "NO") << endl;
     }
-    return EXIT_FAILURE;
-  }
-
-  if (debug && myRank == rootRank) {
-    cerr << "Both Map files are readable" << endl;
-  }
-
-  RCP<const map_type> map1;
-  RCP<const map_type> map2;
-
-  int lclSuccess = 0;
-  int gblSuccess = 0;
-  std::ostringstream errStrm;
-  try {
-    map1 = reader_type::readMapFile (mapFile1, comm, tolerant, debug);
-    lclSuccess = 1;
-  }
-  catch (std::exception& e) {
-    errStrm << "Process " << myRank << ": Caught exception while reading "
-      "first Map file: " << e.what () << endl;
-  }
-  catch (...) {
-    errStrm << "Process " << myRank << ": Caught exception not a subclass of "
-      "std::exception, while reading first Map file" << endl;
-  }
-  if (map1.is_null ()) {
-    errStrm << "Process " << myRank << ": Attempt to read first Map file "
-      "returned null" << endl;
-    lclSuccess = 0;
-  }
-
-  reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
-  if (gblSuccess != 1) {
-    Tpetra::Details::gathervPrint (std::cerr, errStrm.str (), *comm);
-    return EXIT_FAILURE;
-  }
-
-  if (debug && myRank == rootRank) {
-    cerr << "Read first Map file" << endl;
-  }
-
-  try {
-    map2 = reader_type::readMapFile (mapFile2, comm, tolerant, debug);
-    lclSuccess = 1;
-  }
-  catch (std::exception& e) {
-    errStrm << "Process " << myRank << ": Caught exception while reading "
-      "second Map file: " << e.what () << endl;
-  }
-  catch (...) {
-    errStrm << "Process " << myRank << ": Caught exception not a subclass of "
-      "std::exception, while reading second Map file" << endl;
-  }
-  if (map2.is_null ()) {
-    errStrm << "Process " << myRank << ": Attempt to read second Map file "
-      "returned null" << endl;
-    lclSuccess = 0;
-  }
-
-  reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
-  if (gblSuccess != 1) {
-    Tpetra::Details::gathervPrint (std::cerr, errStrm.str (), *comm);
-    return EXIT_FAILURE;
-  }
-
-  if (debug && myRank == rootRank) {
-    cerr << "Read second Map file" << endl;
-  }
-
-  // At this point, we have two valid Maps.  Let's print stuff about them.
-  const bool compat = map1->isCompatible (*map2);
-  const bool same = map1->isSameAs (*map2);
-  // This is a local (per MPI process) property.  Thus, we have to
-  // all-reduce to find out whether it's true on all processes (which
-  // is actually what we want to know).
-  const bool locallyFitted = map1->isLocallyFitted (*map2);
-  const int locallyFittedInt = locallyFitted ? 1 : 0;
-  int globallyFittedInt = 0; // output argument
-  reduceAll<int, int> (*comm, REDUCE_MIN, locallyFittedInt,
-                       outArg (globallyFittedInt));
-  const bool globallyFitted = (globallyFittedInt == 1);
-
-  if (myRank == rootRank) {
-    cout << "Maps compatible? " << (compat ? "YES" : "NO") << endl
-         << "Maps same?       " << (same ? "YES" : "NO") << endl
-         << "Maps fitted?     " << (globallyFitted ? "YES" : "NO") << endl;
   }
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
@trilinos/tpetra 

## Description

Use the new `Tpetra::ScopeGuard` initialization and finalization class (see #2459, fixed in PR #3067) in Tpetra's examples and tutorial.  Update the text in Tpetra's tutorial to refer to ScopeGuard.

## Motivation and Context

`Tpetra::ScopeGuard` is easier to use.  It also ensures that `Kokkos::initialize` sees all the command-line arguments, without needing complicated capture machinery (as `Teuchos::GlobalMPISession` does for the unit tests).

## Related Issues

* Follows #2459 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.  Changes only affect TpetraCore examples.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.
