### PR TITLE
Some cleanups / improvements to Newmark steppers

### DIFF
--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -170,6 +170,9 @@ public:
       Teuchos::RCP<Thyra::VectorBase<Scalar> > xdot0 = Teuchos::null,
       Teuchos::RCP<Thyra::VectorBase<Scalar> > xdotdot0 = Teuchos::null);
 
+  //! Set initial guess for Newton method
+  void setInitialGuess( Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess = Teuchos::null); 
+
   //! Return RCP to Tempus::SolutionHistory
   Teuchos::RCP<Tempus::SolutionHistory<Scalar> > 
   getSolutionHistory() const; 

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -953,6 +953,18 @@ setInitialState(Scalar t0,
 
 #ifdef ALBANY_BUILD
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+#else
+template <typename Scalar>
+void Piro::TempusSolver<Scalar>::
+#endif
+setInitialGuess(Teuchos::RCP< const Thyra::VectorBase<Scalar> > initial_guess) 
+{
+   fwdStateStepper->setInitialGuess(initial_guess); 
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 Teuchos::RCP<Tempus::SolutionHistory<Scalar> > Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #else
 template <typename Scalar>

--- a/packages/tempus/src/Tempus_Stepper.hpp
+++ b/packages/tempus/src/Tempus_Stepper.hpp
@@ -102,6 +102,10 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) = 0;
 
+    /// Pass initial guess to Newton solver (for implicit schemes) 
+    virtual void setInitialGuess(
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess = Teuchos::null) = 0; 
+
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> >
       getDefaultStepperState() = 0;
     virtual Scalar getOrder() const = 0;

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -83,6 +83,11 @@ public:
   /// Compute the first time step given the supplied startup stepper
   virtual void computeStartUp(
     const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+    
+  /// Pass initial guess to Newton solver 
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
 
   /// Provide temporary xDot memory for Stepper if SolutionState doesn't.
   virtual Teuchos::RCP<Thyra::VectorBase<Scalar> > getXDotTemp(
@@ -118,6 +123,7 @@ private:
   Scalar                                     order_;
 
   Teuchos::RCP<Thyra::VectorBase<Scalar> >   xDotTemp_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
 };
 
 /** \brief Time-derivative interface for BDF2.

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -54,6 +54,10 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
+    /// Pass initial guess to Newton solver 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
     /// Get a default (initial) StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
     virtual Scalar getOrder() const {return 1.0;}
@@ -104,6 +108,7 @@ private:
   Teuchos::RCP<StepperBackwardEulerObserver<Scalar> > stepperBEObserver_;
 
   Teuchos::RCP<Thyra::VectorBase<Scalar> >            xDotTemp_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
 };
 
 /** \brief Time-derivative interface for Backward Euler.

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -135,6 +135,10 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
+    
+  /// Pass initial guess to Newton solver 
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
 
   /// \name ParameterList methods
   //@{
@@ -176,6 +180,9 @@ protected:
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u0;
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u;
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               sc;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -109,6 +109,10 @@ public:
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+    
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
 
     /// Get a default (initial) StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
@@ -170,6 +174,9 @@ protected:
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u0;
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u;
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               sc;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -91,6 +91,10 @@ public:
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
 
+  /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
   /// Provide temporary xDot memory for Stepper if SolutionState doesn't.
   virtual Teuchos::RCP<Thyra::VectorBase<Scalar> > getXDotTemp(
     Teuchos::RCP<Thyra::VectorBase<Scalar> > x);
@@ -129,6 +133,7 @@ protected:
   Teuchos::RCP<StepperForwardEulerObserver<Scalar> > stepperFEObserver_;
 
   Teuchos::RCP<Thyra::VectorBase<Scalar> >            xDotTemp_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -62,6 +62,10 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
     /// Get a default (initial) StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
     virtual Scalar getOrder() const {
@@ -138,6 +142,9 @@ private:
   Scalar alpha_m_;
 
   Teuchos::RCP<Teuchos::FancyOStream> out_;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 
 };
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -234,7 +234,7 @@ void StepperHHTAlpha<Scalar>::takeStep(
       Thyra::copy(*d_old, d_init.ptr());
       Thyra::copy(*v_old, v_init.ptr());
       Thyra::put_scalar(0.0, a_init.ptr());
-      wrapperModel->initializeNewmark(a_init,v_init,d_init,0.0,time,beta_,gamma_);
+      wrapperModel->initializeNewmark(v_init,d_init,0.0,time,beta_,gamma_);
       const Thyra::SolveStatus<Scalar> sStatus=this->solveImplicitODE(a_init);
 
       if (sStatus.solveStatus == Thyra::SOLVE_STATUS_CONVERGED )
@@ -262,7 +262,7 @@ void StepperHHTAlpha<Scalar>::takeStep(
     predictVelocity_alpha_f(*v_pred, *v_old);
 
     //inject d_pred, v_pred, a and other relevant data into wrapperModel
-    wrapperModel->initializeNewmark(a_old,v_pred,d_pred,dt,t,beta_,gamma_);
+    wrapperModel->initializeNewmark(v_pred,d_pred,dt,t,beta_,gamma_);
 
     //Solve for new acceleration
     const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(a_new);

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -301,7 +301,12 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
+    
   //@}
+  
+  /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+     {initial_guess_ = initial_guess;}
 
   /// \name ParameterList methods
   //@{
@@ -351,6 +356,9 @@ protected:
 
   Teuchos::RCP<StepperObserver<Scalar> >            stepperObserver_;
   Teuchos::RCP<StepperIMEX_RKPartObserver<Scalar> > stepperIMEX_RKPartObserver_;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -287,6 +287,10 @@ public:
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
 
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -352,6 +356,8 @@ protected:
 
   Teuchos::RCP<StepperObserver<Scalar> >         stepperObserver_;
   Teuchos::RCP<StepperIMEX_RKObserver<Scalar> >  stepperIMEX_RKObserver_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -48,6 +48,10 @@ public:
     /// Solve problem using x in-place.
     const Thyra::SolveStatus<Scalar> solveImplicitODE(
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x);
+    
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
 
     /// Set parameter so that the initial guess is set to zero (=True) or use last timestep (=False).
     virtual void setZeroInitialGuess(bool zIG)
@@ -66,6 +70,7 @@ protected:
   Teuchos::RCP<Teuchos::ParameterList>                stepperPL_;
   Teuchos::RCP<WrapperModelEvaluator<Scalar> >        wrapperModel_;
   Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >   solver_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -103,6 +103,10 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
     /// Get a default (initial) StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
     virtual Scalar getOrder() const {return 2.0;}
@@ -157,6 +161,9 @@ protected:
 
   Teuchos::RCP<StepperObserver<Scalar> >             stepperObserver_;
   Teuchos::RCP<StepperLeapfrogObserver<Scalar> >     stepperLFObserver_;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -55,6 +55,10 @@ public:
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
+    
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
 
     /// Get a default (initial) StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
@@ -130,6 +134,9 @@ protected:
   Scalar gamma_;
 
   Teuchos::RCP<Teuchos::FancyOStream> out_;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 
 };
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -80,6 +80,10 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
+  
+  /// Pass initial guess to Newton solver  
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
 
   /// \name ParameterList methods
   //@{
@@ -133,6 +137,9 @@ private:
 
 
   Teuchos::RCP<Teuchos::FancyOStream> out_;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 
 };
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -58,6 +58,10 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
   virtual void
   takeStep(const Teuchos::RCP<SolutionHistory<Scalar>>& solutionHistory);
 
+  /// Pass initial guess to Newton solver  
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
   /// Get a default (initial) StepperState
   virtual Teuchos::RCP<Tempus::StepperState<Scalar>>
   getDefaultStepperState();
@@ -144,6 +148,8 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
 
   Scalar beta_;
   Scalar gamma_;
+
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
 
   Teuchos::RCP<Teuchos::FancyOStream> out_;
 };

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -270,12 +270,8 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
     RCP<Thyra::VectorBase<Scalar>> d_pred = Thyra::createMember(d_old->space());
     RCP<Thyra::VectorBase<Scalar>> v_pred = Thyra::createMember(v_old->space());
 
-    // create copies of d_old, so as not to modify d_old in working state
-    RCP<Thyra::VectorBase<Scalar>> d_old_copy = Thyra::createMember(d_old->space());
-    Thyra::copy(*d_old, d_old_copy.ptr());
-
     // compute displacement and velocity predictors
-    predictDisplacement(*d_pred, *d_old_copy, *v_old, *a_old, dt);
+    predictDisplacement(*d_pred, *d_old, *v_old, *a_old, dt);
     predictVelocity(*v_pred, *v_old, *a_old, dt);
 
 #ifdef DEBUG_OUTPUT
@@ -295,18 +291,26 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
 
 #endif
     // inject d_pred, v_pred, a and other relevant data into wrapperModel
-    wrapperModel->initializeNewmark(
-        d_pred, v_pred, d_pred, dt, t, beta_, gamma_);
+    wrapperModel->initializeNewmark(v_pred, d_pred, dt, t, beta_, gamma_);
+    
+    // create copies of d_pred, for use as initial guess in NOX solver
+    RCP<Thyra::VectorBase<Scalar>> initial_guess = Thyra::createMember(d_pred->space());
+    Thyra::copy(*d_pred, initial_guess.ptr());
 
+    //Set d_pred as initial guess for NOX solver, and solve nonlinear system.
     const Thyra::SolveStatus<Scalar> status =
-      this->solveImplicitODE(d_old_copy);
+      this->solveImplicitODE(initial_guess);
 
     if (status.solveStatus == Thyra::SOLVE_STATUS_CONVERGED)
       workingState->getStepperState()->stepperStatus_ = Status::PASSED;
     else
       workingState->getStepperState()->stepperStatus_ = Status::FAILED;
 
-    Thyra::copy(*d_old_copy, d_new.ptr());
+    //solveImplicitODE will return converged solution in initial_guess
+    //vector.  Copy it here to d_new, to define the new displacement.
+    Thyra::copy(*initial_guess, d_new.ptr());
+  
+    //correct acceleration, velocity
     correctAcceleration(*a_new, *d_pred, *d_new, dt);
     correctVelocity(*v_new, *v_pred, *a_new, dt);
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -296,7 +296,7 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
 #endif
     // inject d_pred, v_pred, a and other relevant data into wrapperModel
     wrapperModel->initializeNewmark(
-        a_old, v_pred, d_pred, dt, t, beta_, gamma_);
+        d_pred, v_pred, d_pred, dt, t, beta_, gamma_);
 
     const Thyra::SolveStatus<Scalar> status =
       this->solveImplicitODE(d_old_copy);

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -70,6 +70,10 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
+    /// Pass initial guess to Newton solver (only relevant for explicit schemes)  
+    virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+       {initial_guess_ = initial_guess;}
+
     /// Get a default (initial) StepperState
     virtual Teuchos::RCP<Tempus::StepperState<Scalar> > getDefaultStepperState();
     virtual Scalar getOrder()    const
@@ -158,6 +162,8 @@ protected:
   Teuchos::RCP<SolutionState<Scalar> >                tempState_;
   Teuchos::RCP<StepperObserver<Scalar> >              stepperObserver_;
   Teuchos::RCP<StepperOperatorSplitObserver<Scalar> > stepperOSObserver_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -116,7 +116,12 @@ public:
       {return stateStepper_->isOneStepMethod() and
               sensitivityStepper_->isOneStepMethod();}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
+    
   //@}
+    
+  /// Pass initial guess to Newton solver (only relevant for explicit schemes)  
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+     {initial_guess_ = initial_guess;}
 
   /// \name ParameterList methods
   //@{
@@ -156,6 +161,7 @@ private:
   Teuchos::RCP<SolutionHistory<Scalar> > sensSolutionHistory_;
   bool reuse_solver_;
   bool force_W_update_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -63,6 +63,10 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
+    
+  /// Pass initial guess to Newton solver (only relevant for explicit schemes)  
+  virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
+     {initial_guess_ = initial_guess;}
 
   /// Provide temporary xDot memory for Stepper if SolutionState doesn't.
   virtual Teuchos::RCP<Thyra::VectorBase<Scalar> > getXDotTemp(
@@ -95,6 +99,8 @@ private:
   Teuchos::RCP<StepperObserver<Scalar> >            stepperObserver_;
   Teuchos::RCP<StepperTrapezoidalObserver<Scalar> > stepperTrapObserver_;
   Teuchos::RCP<Thyra::VectorBase<Scalar> >          xDotTemp_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+
 };
 
 /** \brief Time-derivative interface for Trapezoidal method.

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
@@ -54,7 +54,7 @@ public:
     else {
        TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
        "Error: WrapperModelEvaluatorSecondOrder called with unsopported schemeName = " << schemeName
-       <<"!  Supported schemeNames are: 'Newmark Implicit a-Form' and 'HHT-Alpha'.\n");
+       <<"!  Supported schemeNames are: 'Newmark Implicit a-Form', 'HHT-Alpha' and 'Newmark Implicit d-Form'.\n");
     }
   }
 
@@ -143,15 +143,8 @@ public:
     Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int i) const
     { return appModel_->get_g_space(i); }
 
-    Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const
-    {
-#ifdef VERBOSE_DEBUG_OUTPUT
-      *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-      Thyra::ModelEvaluatorBase::InArgs<Scalar> nominalValues = appModel_->getNominalValues();
-      nominalValues.set_x(a_);
-      return nominalValues;
-    }
+    /// Set nominal values (initial guess for Newton solver) 
+    Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const; 
 
     /// Set InArgs the wrapper ModelEvalutor.
     virtual void setInArgs(Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs)

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
@@ -78,14 +78,14 @@ public:
   }
 
   /// Set values needed in evalModelImpl
-  void initializeNewmark(Teuchos::RCP<const Vector> ig, Teuchos::RCP<Vector> v_pred,
+  void initializeNewmark(Teuchos::RCP<Vector> v_pred,
                          Teuchos::RCP<Vector> d_pred, Scalar delta_t,
                          Scalar t, Scalar beta, Scalar gamma)
   {
 #ifdef VERBOSE_DEBUG_OUTPUT
     *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-    ig_ = ig; v_pred_ = v_pred; d_pred_ = d_pred;
+    v_pred_ = v_pred; d_pred_ = d_pred;
     delta_t_ = delta_t; t_ = t; beta_ = beta; gamma_ = gamma;
   }
 
@@ -148,9 +148,7 @@ public:
 #ifdef VERBOSE_DEBUG_OUTPUT
       *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-      Thyra::ModelEvaluatorBase::InArgs<Scalar> nominalValues = appModel_->getNominalValues();
-      nominalValues.set_x(ig_);
-      return nominalValues;
+      return appModel_->getNominalValues();
     }
 
     /// Set InArgs the wrapper ModelEvalutor.
@@ -201,7 +199,6 @@ private:
   Scalar gamma_;
   Scalar beta_;
   Scalar delta_t_;
-  Teuchos::RCP<const Vector> ig_; //Initial guess for Newton
   Teuchos::RCP<Vector> d_pred_;
   Teuchos::RCP<Vector> v_pred_;
   Teuchos::RCP<Teuchos::FancyOStream> out_;

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
@@ -106,9 +106,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
 
     case NEWMARK_IMPLICIT_DFORM: {
       // Setup initial condition
-      // Create and populate inArgs
-      MEB::InArgs<Scalar> appInArgs = appModel_->createInArgs();
-
+      // Populate inArgs
       RCP<Thyra::VectorBase<Scalar> const>
       d = inArgs.get_x();
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
@@ -50,29 +50,6 @@ createOutArgsImpl() const
   return outArgs;
 }
 
-template <typename Scalar>
-Thyra::ModelEvaluatorBase::InArgs<Scalar> 
-WrapperModelEvaluatorSecondOrder<Scalar>::
-getNominalValues() const
-{
-#ifdef VERBOSE_DEBUG_OUTPUT
-      *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> nominalValues = appModel_->getNominalValues();
-  switch (schemeType_) 
-  {
-    case NEWMARK_IMPLICIT_AFORM: {
-      nominalValues.set_x(a_);
-      break; 
-    }
-    case NEWMARK_IMPLICIT_DFORM: {
-      nominalValues.set_x(d_pred_);
-      break; 
-    }
-  } 
-  return nominalValues;
-}
-
 
 template <typename Scalar>
 void
@@ -177,7 +154,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
       // v_{n+1} = v_pred + \gamma dt a_{n+1}
       Thyra::V_StVpStV(
           Teuchos::ptrFromRef(*v), 1.0, *v_pred_, delta_t_ * gamma_, *a);
-     
+      
       appInArgs.set_x(d);
       appInArgs.set_x_dot(v);
       appInArgs.set_x_dot_dot(a);

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
@@ -50,6 +50,29 @@ createOutArgsImpl() const
   return outArgs;
 }
 
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar> 
+WrapperModelEvaluatorSecondOrder<Scalar>::
+getNominalValues() const
+{
+#ifdef VERBOSE_DEBUG_OUTPUT
+      *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> nominalValues = appModel_->getNominalValues();
+  switch (schemeType_) 
+  {
+    case NEWMARK_IMPLICIT_AFORM: {
+      nominalValues.set_x(a_);
+      break; 
+    }
+    case NEWMARK_IMPLICIT_DFORM: {
+      nominalValues.set_x(d_pred_);
+      break; 
+    }
+  } 
+  return nominalValues;
+}
+
 
 template <typename Scalar>
 void
@@ -154,7 +177,7 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
       // v_{n+1} = v_pred + \gamma dt a_{n+1}
       Thyra::V_StVpStV(
           Teuchos::ptrFromRef(*v), 1.0, *v_pred_, delta_t_ * gamma_, *a);
-      
+     
       appInArgs.set_x(d);
       appInArgs.set_x_dot(v);
       appInArgs.set_x_dot_dot(a);


### PR DESCRIPTION
Some cleanups and improvements to Newmark steppers.  Specifically, making the displacement predictor the initial guess for the Newmark solver instead of the displacement.  This is the more correct thing to use and cuts down the number of Newton iterations ~10% for Albany problems.  Also removing some extraneous unnecessary code that may cause confusion. 