### PR TITLE
Use all-at-one config, build, test, submit for rhel6 machines (TRIL-199)

### DIFF
--- a/cmake/ctest/drivers/atdm/rhel6/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/rhel6/local-driver.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -l
 
+if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
+  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+fi
+
 set -x
 
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh


### PR DESCRIPTION
This env is using CMake 3.11.1 and we are submitting to
testing-vm.sandia.gov/cdash/ which can handle the all-at-once data so there is
no reason not to switch to the all-at-once appraoch.
