### PR TITLE
Switch ATDM SEMS 7.2.0 build to use CMake 3.11.1 and all-at-once approach

### DIFF
--- a/cmake/ctest/drivers/atdm/sems_gcc-7.2.0/drive_linux_mpi_sems_atdm_7.2.0.sh
+++ b/cmake/ctest/drivers/atdm/sems_gcc-7.2.0/drive_linux_mpi_sems_atdm_7.2.0.sh
@@ -35,5 +35,9 @@ cd $TEST_DIR/
 
 export Trilinos_REPOSITORY_LOCATION=https://github.com/trilinos/Trilinos.git
 
+if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
+  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+fi
+
 env CTEST_DASHBOARD_ROOT=$PWD \
   ctest -V -S $DRIVER_SCRIPT_DIR/ctest_linux_mpi_sems_atdm_7.2.0.cmake

--- a/cmake/std/sems/atdm/load_atdm_7.2_dev_env.sh
+++ b/cmake/std/sems/atdm/load_atdm_7.2_dev_env.sh
@@ -3,7 +3,7 @@ module purge
 module load sems-env
 module load atdm-env
 module load sems-python/2.7.9
-module load atdm-cmake/3.10.1
+module load atdm-cmake/3.11.1
 module load sems-git/2.10.1
 module load atdm-gcc/7.2.0
 module load atdm-openmpi/1.6.5/atdm


### PR DESCRIPTION
CC: @fryeguy52 

## Description

This small PR switches the ATDM SEMS-based GCC 7.2.0 build to use CMake 3.11.1 and use the all-at-once approach with ctest/cdash.  This should be the last ATDM Trilinos build to be swtiched over to the all-at-once approach.

## Motivation and Context

CMake 3.11.1 is faster at running tests than CMake 3.10.1 and most of the other ATDM Trilinos builds are using CMake 3.11.1.

The all-at-once approach is faster at configure, build, and running tests and displays results better on CDash.

## How Has This Been Tested?

I ran this locally on crf450 using:

```
time env \
>  CTEST_DASHBOARD_ROOT=$PWD \
>  Trilinos_PACKAGES=Kokkos,Teuchos \
>  CTEST_TEST_TYPE=Experimental \
>  CTEST_DO_SUBMIT=OFF \
>  CTEST_DO_UPDATES=OFF \
>  CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
> ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/sems_gcc-7.2.0/drive_linux_mpi_sems_atdm_7.2.0.sh \
> &> console.out

real    4m25.828s
user    29m23.354s
sys     1m57.741s
```

That `console.out` log file showed:

```
...


***
*** Configure, build, test and submit results all-at-once for all enabled packages ...
***
...

100% tests passed, 0 tests failed out of 158

Subproject Time Summary:
Kokkos     =  42.01 sec*proc (23 tests)
Teuchos    = 120.18 sec*proc (135 tests)

Total Test time (real) =  21.99 sec
File '' does NOT exist so all tests passed!
```

and I verified that CMake 3.11.1 was being used in the configure output file under Testing/Temporary/.

