### PR TITLE
Amesos2: Purge use of Tpetra::DefaultPlatform

### DIFF
--- a/packages/amesos2/example/ComplexSolve_WithTranspose.cpp
+++ b/packages/amesos2/example/ComplexSolve_WithTranspose.cpp
@@ -49,7 +49,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <MatrixMarket_Tpetra.hpp> // for loading matrices from file
 
 #include "Amesos2.hpp"
@@ -78,10 +78,8 @@ using Tpetra::CrsMatrix;
 using Tpetra::MultiVector;
 using Tpetra::Map;
 
-typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-
 int main(int argc, char *argv[]){
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
   typedef float SCALAR;
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
@@ -96,8 +94,7 @@ int main(int argc, char *argv[]){
   std::ostream &out = std::cout;
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(out));
 
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  RCP<const Comm<int> > comm = platform.getComm();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
   RCP<MAT> A =
     Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../test/matrices/amesos2_test_mat3.mtx",comm);

--- a/packages/amesos2/example/MultipleSolves_File.cpp
+++ b/packages/amesos2/example/MultipleSolves_File.cpp
@@ -48,7 +48,7 @@
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Vector.hpp>
@@ -62,14 +62,13 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
   typedef double Scalar;
   typedef Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
 
   typedef double Scalar;
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
 
   typedef Tpetra::CrsMatrix<Scalar,LO,GO> MAT;
   typedef Tpetra::MultiVector<Scalar,LO,GO> MV;
@@ -84,8 +83,7 @@ int main(int argc, char *argv[]) {
   //
   // Get the default communicator
   //
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   int myRank  = comm->getRank();
 
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));

--- a/packages/amesos2/example/NewAdapter/Amesos2_NewMatrixAdapter_decl.hpp
+++ b/packages/amesos2/example/NewAdapter/Amesos2_NewMatrixAdapter_decl.hpp
@@ -77,12 +77,12 @@ public:
 
   /* TODO: Redefine the following types as needed */
   // public type definitions
-  typedef double                                                scalar_type;
-  typedef int                                            local_ordinal_type;
-  typedef int                                           global_ordinal_type;
-  typedef size_t                                           global_size_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  node_type;
-  typedef NewMatrix                                             matrix_type;
+  typedef double                   scalar_type;
+  typedef int                      local_ordinal_type;
+  typedef int                      global_ordinal_type;
+  typedef size_t                   global_size_type;
+  typedef Tpetra::Map<>::node_type node_type;
+  typedef NewMatrix                matrix_type;
 
   /// The name of this adapter class.
   static const char* name;

--- a/packages/amesos2/example/NewAdapter/Amesos2_NewMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/example/NewAdapter/Amesos2_NewMultiVecAdapter_decl.hpp
@@ -76,7 +76,7 @@ public:
   typedef int                                            local_ordinal_type;
   typedef int                                           global_ordinal_type;
   typedef size_t                                           global_size_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  node_type;
+  typedef Tpetra::Map<>::node_type node_type;
   typedef NewMultiVector                                      multivec_type;
 
   static const char* name;

--- a/packages/amesos2/example/SimpleSolve.cpp
+++ b/packages/amesos2/example/SimpleSolve.cpp
@@ -54,12 +54,11 @@
 
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_oblackholestream.hpp>
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_VerboseObject.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -69,7 +68,7 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   typedef double Scalar;
   typedef Tpetra::Map<>::local_ordinal_type LO;
@@ -90,8 +89,8 @@ int main(int argc, char *argv[]) {
                                 // failure, which it isn't really
   }
 
-  Teuchos::RCP<const Teuchos::Comm<int> > comm
-    = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm =
+    Tpetra::getDefaultComm();
 
   size_t myRank = comm->getRank();
 

--- a/packages/amesos2/example/SimpleSolveNonContigMap.cpp
+++ b/packages/amesos2/example/SimpleSolveNonContigMap.cpp
@@ -57,15 +57,13 @@
 
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_oblackholestream.hpp>
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_VerboseObject.hpp>
 
 #include <Teuchos_CommandLineProcessor.hpp>
 
-
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -75,7 +73,7 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   std::string solver_name = "Basker";
   Teuchos::CommandLineProcessor cmdp(false,true);
@@ -105,7 +103,7 @@ int main(int argc, char *argv[]) {
   using Teuchos::rcp;
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm
-    = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    = Tpetra::getDefaultComm();
 
   size_t myRank = comm->getRank();
 

--- a/packages/amesos2/example/SimpleSolve_File.cpp
+++ b/packages/amesos2/example/SimpleSolve_File.cpp
@@ -43,12 +43,11 @@
 
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_oblackholestream.hpp>
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -62,13 +61,11 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
-  typedef double Scalar;
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   typedef double Scalar;
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
 
   typedef Tpetra::CrsMatrix<Scalar,LO,GO> MAT;
   typedef Tpetra::MultiVector<Scalar,LO,GO> MV;
@@ -83,8 +80,7 @@ int main(int argc, char *argv[]) {
   //
   // Get the default communicator
   //
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   int myRank = comm->getRank();
 
   Teuchos::oblackholestream blackhole;

--- a/packages/amesos2/example/SimpleSolve_WithParameters.cpp
+++ b/packages/amesos2/example/SimpleSolve_WithParameters.cpp
@@ -52,12 +52,11 @@
 
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_ParameterList.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -67,7 +66,7 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
   typedef double Scalar;
   typedef Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
 
@@ -83,7 +82,7 @@ int main(int argc, char *argv[]) {
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
 
 

--- a/packages/amesos2/example/TwoPartSolve.cpp
+++ b/packages/amesos2/example/TwoPartSolve.cpp
@@ -53,12 +53,11 @@
 #include <Teuchos_Array.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Vector.hpp>
@@ -72,14 +71,13 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
   typedef double Scalar;
   typedef Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
 
   typedef double Scalar;
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
 
   typedef Tpetra::CrsMatrix<Scalar,LO,GO> MAT;
   typedef Tpetra::MultiVector<Scalar,LO,GO> MV;
@@ -96,8 +94,7 @@ int main(int argc, char *argv[]) {
   //
   // Get the default communicator
   //
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   int myRank  = comm->getRank();
 
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));

--- a/packages/amesos2/example/quick_solve.cpp
+++ b/packages/amesos2/example/quick_solve.cpp
@@ -54,11 +54,10 @@
 
 #include <Teuchos_ScalarTraits.hpp>
 #include <Teuchos_RCP.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -69,13 +68,12 @@
 #include "Amesos2_Version.hpp"
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   typedef double Scalar;
   typedef Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
 
   typedef Tpetra::CrsMatrix<Scalar,LO,GO> MAT;
   typedef Tpetra::MultiVector<Scalar,LO,GO> MV;
@@ -85,8 +83,7 @@ int main(int argc, char *argv[]) {
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   size_t myRank = comm->getRank();
 
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));

--- a/packages/amesos2/example/quick_solve_epetra.cpp
+++ b/packages/amesos2/example/quick_solve_epetra.cpp
@@ -58,10 +58,7 @@
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
 #include <Tpetra_Map.hpp>
-#include <Tpetra_MultiVector.hpp>
-#include <Tpetra_CrsMatrix.hpp>
 
 #include <Epetra_Map.h>
 #include <Epetra_CrsMatrix.h>

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
@@ -57,7 +57,6 @@
 #include <Teuchos_Array.hpp>
 #include <Teuchos_as.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Map.hpp>
 
@@ -82,7 +81,7 @@ namespace Amesos2 {
     typedef int                                            local_ordinal_t;
     typedef int                                           global_ordinal_t;
     typedef size_t                                           global_size_t;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  node_t;
+    typedef Tpetra::Map<>::node_type  node_t;
     typedef Epetra_MultiVector                                  multivec_t;
 
     friend Teuchos::RCP<MultiVecAdapter<multivec_t> > createMultiVecAdapter<>(Teuchos::RCP<multivec_t>);

--- a/packages/amesos2/src/Amesos2_MatrixTraits.hpp
+++ b/packages/amesos2/src/Amesos2_MatrixTraits.hpp
@@ -52,7 +52,6 @@
 
 #ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
-#  include <Tpetra_DefaultPlatform.hpp>
 #  include <Epetra_RowMatrix.h>
 #  include <Epetra_CrsMatrix.h>
 // #  include <Epetra_MsrMatrix.h>
@@ -128,7 +127,7 @@ namespace Amesos2 {
     typedef double scalar_t;
     typedef int local_ordinal_t;
     typedef int global_ordinal_t;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_t;
+    typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_RowMatrix matrix_type;
     typedef matrix_type local_matrix_t;
@@ -144,7 +143,7 @@ namespace Amesos2 {
     typedef double scalar_t;
     typedef int local_ordinal_t;
     typedef int global_ordinal_t;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_t;
+    typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_CrsMatrix matrix_type;
     typedef matrix_type local_matrix_t;
@@ -160,7 +159,7 @@ namespace Amesos2 {
   //   typedef double scalar_t;
   //   typedef int local_ordinal_t;
   //   typedef int global_ordinal_t;
-  //   typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_t;
+  //   typedef Tpetra::Map<>::node_type node_t;
 
   //   typedef row_access major_access;
   // };
@@ -170,7 +169,7 @@ namespace Amesos2 {
     typedef double scalar_t;
     typedef int local_ordinal_t;
     typedef int global_ordinal_t;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_t;
+    typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_VbrMatrix matrix_type;
     typedef matrix_type local_matrix_t;

--- a/packages/amesos2/src/Amesos2_VectorTraits.hpp
+++ b/packages/amesos2/src/Amesos2_VectorTraits.hpp
@@ -52,7 +52,6 @@
 
 #ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
-#  include <Tpetra_DefaultPlatform.hpp>
 #  include <Epetra_MultiVector.h>
 // and perhaps some others later...
 #endif
@@ -94,7 +93,7 @@ namespace Amesos2 {
     typedef double scalar_t;
     typedef int local_ordinal_t;
     typedef int global_ordinal_t;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_t;
+    typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_MultiVector multivector_type;
     typedef double ptr_scalar_type; // TODO Make this a pointer

--- a/packages/amesos2/test/adapters/CrsMatrix_Adapter_Consistency_Tests.cpp
+++ b/packages/amesos2/test/adapters/CrsMatrix_Adapter_Consistency_Tests.cpp
@@ -66,7 +66,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
@@ -111,8 +111,6 @@ namespace {
   using Amesos2::ROOTED;
   using Amesos2::GLOBALLY_REPLICATED;
   using Amesos2::SORTED_INDICES;
-
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
 
   // Where to look for input files
   string filedir = "../matrices/";
@@ -187,11 +185,10 @@ namespace {
 
     RCP<const Epetra_Comm> ecomm = getDefaultEComm();
     RCP<const Comm<int> > tcomm = getDefaultTComm();
-    Teuchos::RCP<Node> node = Tpetra::DefaultPlatform::getDefaultPlatform().getNode();
 
     // Read in test matrix file
     std::string mat_pathname = filedir + test_mat_file;
-    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm,node);
+    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm);
     EMAT* EA;
     EpetraExt::MatrixMarketFileToCrsMatrix(mat_pathname.c_str(), *ecomm, EA, false, false);
 
@@ -222,11 +219,10 @@ namespace {
 
     RCP<const Epetra_Comm> ecomm = getDefaultEComm();
     RCP<const Comm<int> > tcomm = getDefaultTComm();
-    Teuchos::RCP<Node> node = Tpetra::DefaultPlatform::getDefaultPlatform().getNode();
 
     // Read in test matrix file
     std::string mat_pathname = filedir + test_mat_file;
-    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm,node);
+    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm);
     EMAT* EA;
     EpetraExt::MatrixMarketFileToCrsMatrix(mat_pathname.c_str(), *ecomm, EA, false, false);
 
@@ -271,11 +267,10 @@ namespace {
 
     RCP<const Epetra_Comm> ecomm = getDefaultEComm();
     RCP<const Comm<int> > tcomm = getDefaultTComm();
-    Teuchos::RCP<Node> node = Tpetra::DefaultPlatform::getDefaultPlatform().getNode();
 
     // Read in test matrix file
     std::string mat_pathname = filedir + test_mat_file;
-    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm,node);
+    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm);
     EMAT* EA;
     EpetraExt::MatrixMarketFileToCrsMatrix(mat_pathname.c_str(), *ecomm, EA, false, false);
 
@@ -319,13 +314,12 @@ namespace {
 
     RCP<const Epetra_Comm> ecomm = getDefaultEComm();
     RCP<const Comm<int> > tcomm = getDefaultTComm();
-    Teuchos::RCP<Node> node = Tpetra::DefaultPlatform::getDefaultPlatform().getNode();
     const int numprocs = tcomm->getSize();
     const int rank = tcomm->getRank();
 
     // Read in test matrix file
     std::string mat_pathname = filedir + test_mat_file;
-    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm,node);
+    RCP<TMAT> TA = Tpetra::MatrixMarket::Reader<TMAT>::readSparseFile(mat_pathname,tcomm);
     EMAT* EA;
     EpetraExt::MatrixMarketFileToCrsMatrix(mat_pathname.c_str(), *ecomm, EA, false, false);
 

--- a/packages/amesos2/test/adapters/Epetra_MultiVector_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Epetra_MultiVector_Adapter_UnitTests.cpp
@@ -47,7 +47,7 @@
 #include <Teuchos_Array.hpp>
 #include <Teuchos_as.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 
 #include <Epetra_MultiVector.h>
@@ -96,7 +96,7 @@ namespace {
   using Amesos2::Util::get_1d_copy_helper;
   using Amesos2::Util::put_1d_data_helper;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   TEUCHOS_STATIC_SETUP()
   {

--- a/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
@@ -52,7 +52,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 
 #include <Epetra_CrsMatrix.h>
@@ -93,7 +93,7 @@ namespace {
 
   using Amesos2::Util::to_teuchos_comm;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = false;
 

--- a/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
@@ -52,7 +52,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <MatrixMarket_Tpetra.hpp>
@@ -111,8 +111,7 @@ namespace {
   using Amesos2::GLOBALLY_REPLICATED;
 
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Platform::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = true;
 
@@ -135,7 +134,7 @@ namespace {
   {
     RCP<const Comm<int> > ret;
     if( testMpi ){
-      ret = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+      ret = Tpetra::getDefaultComm();
     } else {
       ret = rcp(new Teuchos::SerialComm<int>());
     }
@@ -252,9 +251,7 @@ namespace {
     typedef CrsMatrix<Scalar,LO,GO,Node> MAT;
     typedef MatrixAdapter<MAT> ADAPT;
     typedef std::pair<Scalar,GO> my_pair_t;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     const size_t rank          = comm->getRank();
 
     /* We will be using the following matrix for this test (amesos2_test_mat0[_complex].mtx:
@@ -268,7 +265,7 @@ namespace {
      */
     RCP<MAT> mat =
       Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(TestTraitsNS::test_traits<Scalar>::test_mat,
-                                                        comm, node, true, true);
+                                                        comm, true, true);
     RCP<const Map<LO,GO,Node> > map = mat->getRowMap();
 
     RCP<ADAPT> adapter = Amesos2::createMatrixAdapter<MAT>(mat);
@@ -335,9 +332,7 @@ namespace {
     typedef CrsMatrix<Scalar,LO,GO,Node> MAT;
     typedef MatrixAdapter<MAT> ADAPT;
     typedef std::pair<Scalar,GO> my_pair_t;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     // create a Map for our matrix
     global_size_t nrows = 6;
     RCP<const Map<LO,GO,Node> > map = createUniformContigMap<LO,GO>(nrows,comm);
@@ -353,7 +348,7 @@ namespace {
      */
     RCP<MAT> mat =
       Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(TestTraitsNS::test_traits<Scalar>::test_mat,
-                                                        comm, node, true, true);
+                                                        comm, true, true);
 
     RCP<ADAPT> adapter = Amesos2::createMatrixAdapter<MAT>(mat);
 
@@ -416,9 +411,7 @@ namespace {
      */
     typedef CrsMatrix<Scalar,LO,GO,Node> MAT;
     typedef MatrixAdapter<MAT> ADAPT;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     const size_t numprocs = comm->getSize();
     const size_t rank     = comm->getRank();
     // create a Map for our matrix
@@ -436,7 +429,7 @@ namespace {
      */
     RCP<MAT> mat =
       Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(TestTraitsNS::test_traits<Scalar>::test_mat,
-                                                        comm, node, true, true);
+                                                        comm, true, true);
 
     RCP<ADAPT> adapter = Amesos2::createMatrixAdapter<MAT>(mat);
 
@@ -497,9 +490,7 @@ namespace {
     typedef CrsMatrix<Scalar,LO,GO,Node> MAT;
     typedef MatrixAdapter<MAT> ADAPT;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     const size_t rank          = comm->getRank();
 
     /* We will be using the following matrix for this test:
@@ -513,7 +504,7 @@ namespace {
      */
     RCP<MAT> mat =
       Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(TestTraitsNS::test_traits<Scalar>::test_mat,
-                                                        comm, node, true, true);
+                                                        comm, true, true);
 
     RCP<ADAPT> adapter = Amesos2::createMatrixAdapter<MAT>(mat);
 

--- a/packages/amesos2/test/adapters/Tpetra_MultiVector_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_MultiVector_Adapter_UnitTests.cpp
@@ -47,7 +47,7 @@
 #include <Teuchos_Array.hpp>
 #include <Teuchos_as.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 
 #include "Amesos2_MultiVecAdapter.hpp"
 #include "Amesos2_Util.hpp"
@@ -76,7 +76,6 @@ namespace {
 
   using Tpetra::global_size_t;
   using Tpetra::MultiVector;
-  using Tpetra::DefaultPlatform;
   using Tpetra::Map;
 
   using Amesos2::MultiVecAdapter;
@@ -91,7 +90,7 @@ namespace {
   using Amesos2::GLOBALLY_REPLICATED;
 
 
-  typedef DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = false;
 
@@ -108,7 +107,7 @@ namespace {
   {
     RCP<const Comm<int> > ret;
     if( testMpi ){
-      ret = DefaultPlatform::getDefaultPlatform().getComm();
+      ret = Tpetra::getDefaultComm();
     } else {
       ret = rcp(new Teuchos::SerialComm<int>());
     }

--- a/packages/amesos2/test/solvers/Basker_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/Basker_UnitTests.cpp
@@ -58,7 +58,7 @@
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_ParameterXMLFileReader.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -115,8 +115,7 @@ namespace {
   using Amesos2::Basker;
   using Amesos2::Meta::is_same;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Platform::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = true;
 
@@ -137,7 +136,7 @@ namespace {
   {
     RCP<const Comm<int> > ret;
     if( testMpi ){
-      ret = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+      ret = Tpetra::getDefaultComm();
     } else {
       ret = rcp(new Teuchos::SerialComm<int>());
     }
@@ -293,9 +292,7 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 1;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
 #ifdef SHYLU_NODEBASKER 
     // NDE: Beginning changes towards passing parameter list to shylu basker
@@ -334,7 +331,7 @@ namespace {
 #endif
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
@@ -388,12 +385,10 @@ namespace {
     typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -451,9 +446,7 @@ namespace {
     using Teuchos::rcp;
     using Scalar = SCALAR;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     size_t myRank = comm->getRank();
     const global_size_t numProcs = comm->getSize();
@@ -610,12 +603,10 @@ namespace {
     typedef MultiVector<cmplx,LO,GO,Node> MV;
     typedef typename ST::magnitudeType Mag;
     //typedef ScalarTraits<Mag> MT;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -682,12 +673,10 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -730,12 +719,10 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();

--- a/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
@@ -53,7 +53,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -103,8 +103,7 @@ namespace {
 
   using Amesos2::Meta::is_same;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Platform::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = true;
 
@@ -125,7 +124,7 @@ namespace {
   {
     RCP<const Comm<int> > ret;
     if( testMpi ){
-      ret = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+      ret = Tpetra::getDefaultComm();
     } else {
       ret = rcp(new Teuchos::SerialComm<int>());
     }
@@ -281,13 +280,11 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 1;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
@@ -336,12 +333,10 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -393,9 +388,7 @@ namespace {
     using Teuchos::rcp;
     using Scalar = SCALAR;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     size_t myRank = comm->getRank();
     const global_size_t numProcs = comm->getSize();
@@ -555,12 +548,10 @@ namespace {
     typedef MultiVector<cmplx,LO,GO,Node> MV;
     typedef typename ST::magnitudeType Mag;
     //typedef ScalarTraits<Mag> MT;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -627,12 +618,10 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -675,12 +664,10 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();

--- a/packages/amesos2/test/solvers/MUMPS_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/MUMPS_UnitTests.cpp
@@ -53,7 +53,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -99,8 +99,7 @@ namespace {
   using Amesos2::MUMPS;
   using Amesos2::Meta::is_same;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Platform::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = true;
 
@@ -121,7 +120,7 @@ namespace {
   {
     RCP<const Comm<int> > ret;
     if( testMpi ){
-      ret = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+      ret = Tpetra::getDefaultComm();
     } else {
       ret = rcp(new Teuchos::SerialComm<int>());
     }
@@ -273,14 +272,12 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 1;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
 
     printf("Consider Matrix 1 \n");
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
@@ -334,12 +331,10 @@ namespace {
     typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -391,13 +386,11 @@ namespace {
     typedef MultiVector<cmplx,LO,GO,Node> MV;
     typedef typename ST::magnitudeType Mag;
     //typedef ScalarTraits<Mag> MT;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     printf("Consider Matrix 4 \n");
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -464,13 +457,11 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     printf("Consider Matrix 2 \n");
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -513,13 +504,11 @@ namespace {
     //typedef ScalarTraits<Mag> MT;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     printf("Consider Matrix 3\n");
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();

--- a/packages/amesos2/test/solvers/SolverFactory.cpp
+++ b/packages/amesos2/test/solvers/SolverFactory.cpp
@@ -42,7 +42,7 @@
 // @HEADER
 
 #include "Teuchos_UnitTestHarness.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Amesos2_Factory.hpp"
@@ -310,8 +310,7 @@ namespace {
     return;
 #endif // NOT TRILINOS_HAVE_LINEAR_SOLVER_FACTORY_REGISTRATION
 
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     const Tpetra::global_size_t gblNumRows = comm->getSize () * 10;
     const size_t numVecs = 3;
 

--- a/packages/amesos2/test/solvers/Solver_Test_Basker.cpp
+++ b/packages/amesos2/test/solvers/Solver_Test_Basker.cpp
@@ -8,7 +8,7 @@
 #include "Teuchos_Comm.hpp"
 #include "Teuchos_Array.hpp"
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -24,7 +24,7 @@ void process_command_line(int argc, char*argv[], std::string& xml_file);
 int main(int argc, char *argv[])
 {
 
-  Teuchos::GlobalMPISession mpisess(&argc, &argv);
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
   bool success = true;
 
   Teuchos::RCP<Teuchos::FancyOStream>
@@ -35,13 +35,10 @@ int main(int argc, char *argv[])
       Teuchos::Time timer("total");
       timer.start();
 
-      Tpetra::DefaultPlatform::DefaultPlatformType& platform = 
-	Tpetra::DefaultPlatform::getDefaultPlatform();
-      
       typedef double Scalar;
       typedef Tpetra::Map<>::local_ordinal_type LO;
       typedef Tpetra::Map<>::global_ordinal_type GO;
-      typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+      typedef Tpetra::Map<>::node_type Node;
       typedef Tpetra::MultiVector<Scalar,LO,GO,Node> TMV;
       typedef Tpetra::Operator<Scalar,LO,GO,Node>    TOP;
 
@@ -50,8 +47,7 @@ int main(int argc, char *argv[])
       
 
 
-      Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-      Teuchos::RCP<Node>                      node = platform.getNode();
+      Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
       std::string xml_file("shylubasker_test1_mm.xml");
       process_command_line(argc, argv, xml_file);
@@ -79,8 +75,7 @@ int main(int argc, char *argv[])
      
       Teuchos::RCP<crs_matrix_type> A = 
 	Tpetra::MatrixMarket::Reader<crs_matrix_type>::readSparseFile(mm_file,
-								     comm,
-								     node);
+								      comm);
 
       *out << "Done reading matrix market file" << std::endl;
       

--- a/packages/amesos2/test/solvers/Superlu_Solve_Tests.cpp
+++ b/packages/amesos2/test/solvers/Superlu_Solve_Tests.cpp
@@ -61,7 +61,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -90,9 +90,6 @@ namespace {
   using Tpetra::CrsMatrix;
   using Tpetra::MultiVector;
   using Tpetra::Map;
-
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Platform::NodeType Node;
 
   bool testMpi = false;
 
@@ -123,24 +120,22 @@ namespace {
   // with a reasonably small tolerance.  While this could also produce
   // a false-positive, it is less likely.
 #define TEST_WITH_MATRIX(MATNAME, transpose)                            \
-  typedef CrsMatrix<SCALAR,LO,GO,Node> MAT;                             \
-  typedef MultiVector<SCALAR,LO,GO,Node> MV;                            \
+  typedef CrsMatrix<SCALAR,LO,GO> MAT;                                  \
+  typedef MultiVector<SCALAR,LO,GO> MV;                                 \
   typedef ScalarTraits<SCALAR> ST;                                      \
   typedef typename ST::magnitudeType Mag;                               \
   typedef ScalarTraits<Mag> MT;                                         \
   const size_t numVecs = 5;                                             \
   ETransp trans = ((transpose) ? CONJ_TRANS : NO_TRANS);                \
                                                                         \
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();   \
-  RCP<const Comm<int> > comm = platform.getComm();                      \
-  RCP<Node>             node = platform.getNode();                      \
+  RCP<const Comm<int> > comm = Tpetra.getDefaultComm();                 \
                                                                         \
   string path = string("../matrices/") + (MATNAME);                     \
   RCP<MAT> AMat =                                                       \
-    Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(path,comm,node);  \
+    Tpetra::MatrixMarket::Reader<MAT>::readSparseFile(path,comm);       \
                                                                         \
-  RCP<const Map<LO,GO,Node> > dmnmap = AMat->getDomainMap();            \
-  RCP<const Map<LO,GO,Node> > rngmap = AMat->getRangeMap();             \
+  RCP<const Map<LO,GO> > dmnmap = AMat->getDomainMap();                 \
+  RCP<const Map<LO,GO> > rngmap = AMat->getRangeMap();                  \
                                                                         \
   RCP<MV> X, B, Xhat;                                                   \
   if( transpose ){                                                      \

--- a/packages/amesos2/test/solvers/Superlu_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/Superlu_UnitTests.cpp
@@ -53,7 +53,7 @@
 #include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_ScalarTraits.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -103,8 +103,7 @@ namespace {
 
   using Amesos2::Meta::is_same;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Platform::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = true;
 
@@ -125,7 +124,7 @@ namespace {
   {
     RCP<const Comm<int> > ret;
     if( testMpi ){
-      ret = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+      ret = Tpetra::getDefaultComm();
     } else {
       ret = rcp(new Teuchos::SerialComm<int>());
     }
@@ -276,14 +275,12 @@ namespace {
     typedef typename ST::magnitudeType Mag;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     out << "Reading file" << std::endl;
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
     out << "Done reading file" << std::endl;
 
@@ -334,12 +331,10 @@ namespace {
     typedef typename ST::magnitudeType Mag;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat1.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -389,9 +384,7 @@ namespace {
     using Teuchos::rcp;
     using Scalar = SCALAR;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     size_t myRank = comm->getRank();
     const global_size_t numProcs = comm->getSize();
@@ -551,12 +544,10 @@ namespace {
     typedef ScalarTraits<cmplx> ST;
     typedef MultiVector<cmplx,LO,GO,Node> MV;
     typedef typename ST::magnitudeType Mag;
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat4.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -622,12 +613,10 @@ namespace {
     typedef typename ST::magnitudeType Mag;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat2.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();
@@ -669,12 +658,10 @@ namespace {
     typedef typename ST::magnitudeType Mag;
     const size_t numVecs = 7;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
     RCP<MAT> A =
-      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm,node);
+      Tpetra::MatrixMarket::Reader<MAT>::readSparseFile("../matrices/amesos2_test_mat3.mtx",comm);
 
     RCP<const Map<LO,GO,Node> > dmnmap = A->getDomainMap();
     RCP<const Map<LO,GO,Node> > rngmap = A->getRangeMap();

--- a/packages/amesos2/test/tklu_simple/tklu_simple.cpp
+++ b/packages/amesos2/test/tklu_simple/tklu_simple.cpp
@@ -50,7 +50,7 @@
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_oblackholestream.hpp>
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
   typedef int Ordinal;
   using Tpetra::global_size_t;
 
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   size_t myRank = comm->getRank();
   size_t numProc = comm->getSize();


### PR DESCRIPTION
@trilinos/amesos2 @trilinos/tpetra

## Description

Purge all use of `Tpetra::DefaultPlatform` from Amesos2 source, tests, and examples.  Use `Tpetra::ScopeGuard` where appropriate.

## Motivation and Context

This relates to #57 and will help ensure more consistent Tpetra initialization and choice of defaults.

## Related Issues

* Related to #57 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
