### PR TITLE
Tpetra: Fix #3078 (add default constructor for Vector)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
@@ -135,6 +135,9 @@ public:
   //! \name Constructors and destructor
   //@{
 
+  //! Default constructor: makes a Vector with no rows or columns.
+  Vector ();
+
   /// \brief Basic constructor.
   ///
   /// \param map [in] The Vector's Map.  The Map describes the

--- a/packages/tpetra/core/src/Tpetra_Vector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_def.hpp
@@ -59,6 +59,12 @@ namespace Tpetra {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  Vector ()
+    : base_type ()
+  {}
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   Vector (const Teuchos::RCP<const map_type>& map,
           const bool zeroOut)
     : base_type (map, 1, zeroOut)

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -216,8 +216,9 @@ namespace {
   ////
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, basic, LO, GO, Scalar , Node )
   {
-    typedef Tpetra::Map<LO, GO, Node> map_type;
-    typedef Tpetra::MultiVector<Scalar,LO,GO,Node> MV;
+    using map_type = Tpetra::Map<LO, GO, Node>;
+    using MV = Tpetra::MultiVector<Scalar, LO, GO, Node>;
+    using vec_type = Tpetra::Vector<Scalar, LO, GO, Node>;
     typedef typename ScalarTraits<Scalar>::magnitudeType Magnitude;
 
     const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid ();
@@ -230,6 +231,24 @@ namespace {
     const GO indexBase = 0;
     RCP<const map_type> map =
       rcp (new map_type (INVALID, numLocal, indexBase, comm));
+
+    // Test the default constructors of MultiVector and Vector.
+    {
+      MV defaultConstructedMultiVector;
+      auto dcmv_map = defaultConstructedMultiVector.getMap ();
+      TEST_ASSERT( dcmv_map.get () != nullptr );
+      if (dcmv_map.get () != nullptr) {
+	TEST_EQUALITY( dcmv_map->getGlobalNumElements (),
+		       Tpetra::global_size_t (0) );
+      }
+      vec_type defaultConstructedVector;
+      auto dcv_map = defaultConstructedVector.getMap ();
+      TEST_ASSERT( dcv_map.get () != nullptr );
+      if (dcv_map.get () != nullptr) {
+	TEST_EQUALITY( dcv_map->getGlobalNumElements (),
+		       Tpetra::global_size_t (0) );
+      }
+    }
 
     RCP<MV> mvec;
     TEST_NOTHROW( mvec = rcp (new MV (map, numVecs, true)) );


### PR DESCRIPTION
@trilinos/tpetra

## Description

Add a default constructor to Vector.  Make Tpetra's tests exercise the default constructors of both MultiVector and Vector.

## Related Issues

* Closes #3078 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.