### PR TITLE
Anasazi: Purge use of Tpetra::DefaultPlatform from tests & examples

### DIFF
--- a/packages/anasazi/tpetra/example/CustomStatusTest/LOBPCGCustomStatusTest.cpp
+++ b/packages/anasazi/tpetra/example/CustomStatusTest/LOBPCGCustomStatusTest.cpp
@@ -47,7 +47,7 @@
 #include "AnasaziTypes.hpp"
 
 #include "Teuchos_GlobalMPISession.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 
 // These tell the compiler which namespace contains RCP, cout, etc
@@ -250,21 +250,15 @@ main (int argc, char* argv[])
   typedef Anasazi::BasicEigenproblem<Scalar,TMV,TOP> Problem;
   typedef Anasazi::MultiVecTraits<Scalar, TMV> TMVT;
   typedef Anasazi::OperatorTraits<Scalar, TMV, TOP> TOPT;
-  typedef Tpetra::Map<>::node_type Node;
   typedef Tpetra::CrsMatrix<> CrsMatrix;
   typedef Tpetra::MatrixMarket::Reader<CrsMatrix>  Reader;
 
-  //
-  // Initialize the MPI session
-  //
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackhole);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   //
   // Get the default communicator
   //
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-  RCP<Node> node = Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank();
 
   // Read the command line arguments
@@ -276,6 +270,7 @@ main (int argc, char* argv[])
   }
 
   // Get the matrix
+  Teuchos::RCP<Tpetra::Map<>::node_type> node; // for type deduction
   RCP<const CrsMatrix> A = Reader::readSparseFile (fileA, comm, node);
 
   // Create the folded operator, K = A^2

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonGeneralizedEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonGeneralizedEx.cpp
@@ -56,7 +56,7 @@
 
 // Include header for Tpetra compressed-row storage matrix
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -86,8 +86,6 @@ int main(int argc, char *argv[]) {
   // Specify types used in this example
   //
   typedef double                                       Scalar;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Tpetra::Map<>::node_type                     Node;
   typedef Tpetra::CrsMatrix<Scalar>                    CrsMatrix;
   typedef Tpetra::MultiVector<Scalar>                  MV;
   typedef Tpetra::Operator<Scalar>                     OP;
@@ -98,15 +96,12 @@ int main(int argc, char *argv[]) {
   //
   // Initialize the MPI session
   //
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv,&blackhole);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   //
-  // Get the default communicator and node
+  // Get the default communicator
   //
-  Platform& platform = Tpetra::DefaultPlatform::getDefaultPlatform ();
-  RCP<const Teuchos::Comm<int> > comm = platform.getComm ();
-  RCP<Node>                      node = platform.getNode ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
 
   //
@@ -138,6 +133,7 @@ int main(int argc, char *argv[]) {
   //
   // Read the matrices from a file
   //
+  RCP<Tpetra::Map<>::node_type> node; // can be null
   RCP<const CrsMatrix> K = Reader::readSparseFile(filenameA, comm, node);
   RCP<const CrsMatrix> M = Reader::readSparseFile(filenameB, comm, node);
 

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonSpecTransEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonSpecTransEx.cpp
@@ -56,7 +56,7 @@
 
 // Include header for Tpetra compressed-row storage matrix
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -87,8 +87,6 @@ main (int argc, char *argv[])
   // Specify types used in this example
   //
   typedef Tpetra::CrsMatrix<>::scalar_type             Scalar;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
-  typedef Tpetra::Map<>::node_type                     Node;
   typedef Tpetra::CrsMatrix<Scalar>                    CrsMatrix;
   typedef Tpetra::MultiVector<Scalar>                  MV;
   typedef Tpetra::Operator<Scalar>                     OP;
@@ -98,15 +96,12 @@ main (int argc, char *argv[])
   //
   // Initialize the MPI session
   //
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv,&blackhole);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   //
-  // Get the default communicator and node
+  // Get the default communicator
   //
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-  RCP<Node>                      node = platform.getNode();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   const int myRank = comm->getRank();
 
   //
@@ -132,6 +127,7 @@ main (int argc, char *argv[])
   //
   // Read the matrices from a file
   //
+  RCP<Tpetra::Map<>::node_type> node; // can be null
   RCP<const CrsMatrix> K = Tpetra::MatrixMarket::Reader<CrsMatrix>::readSparseFile(filenameA, comm, node);
 
   //

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonUserOpEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonUserOpEx.cpp
@@ -55,7 +55,7 @@
 #include "AnasaziOperator.hpp"
 
 // Include headers for Tpetra
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -95,7 +95,6 @@ typedef Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
 typedef TMV::local_ordinal_type                       LocalOrdinal;
 typedef TMV::global_ordinal_type                      GlobalOrdinal;
 typedef TMV::node_type                                Node;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType Platform;
 
 //
 // Define a class for our user-defined operator.
@@ -314,14 +313,12 @@ main (int argc, char *argv[])
   //
   // Initialize MPI.
   //
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackhole);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   //
-  // Get the default communicator and node
+  // Get the default communicator
   //
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
 
   //

--- a/packages/anasazi/tpetra/test/BlockDavidson/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/BlockDavidson/cxx_main_complex.cpp
@@ -61,8 +61,7 @@
 #include "AnasaziBlockDavidsonSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files
@@ -91,14 +90,13 @@ int main(int argc, char *argv[])
   typedef Anasazi::MultiVecTraits<ST,MV>      MVT;
   typedef Anasazi::OperatorTraits<ST,MV,OP>   OPT;
 
-  Teuchos::GlobalMPISession mpisess (&argc, &argv, &std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   const ST ONE  = SCT::one();
   int info = 0;
   int MyPID = 0;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   MyPID = rank(*comm);
 

--- a/packages/anasazi/tpetra/test/BlockDavidson/cxx_main_lap.cpp
+++ b/packages/anasazi/tpetra/test/BlockDavidson/cxx_main_lap.cpp
@@ -51,8 +51,7 @@
 #include "AnasaziBlockDavidsonSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using Tpetra::CrsMatrix;
@@ -76,10 +75,8 @@ int main(int argc, char *argv[])
   typedef Anasazi::OperatorTraits<ST,MV,OP>  OPT;
   const ST ONE  = SCT::one();
 
-  Teuchos::GlobalMPISession mpisess (&argc,&argv,&std::cout);
-
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  Tpetra::ScopeGuard tpetraScope (&argc,&argv);
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   const int MyPID = comm->getRank ();
   const int NumImages = comm->getSize ();

--- a/packages/anasazi/tpetra/test/BlockKrylovSchur/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/BlockKrylovSchur/cxx_main_complex.cpp
@@ -58,8 +58,7 @@
 #include "AnasaziBlockKrylovSchurSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files
@@ -89,7 +88,7 @@ int main(int argc, char *argv[])
   typedef Anasazi::MultiVecTraits<ST,MV>     MVT;
   typedef Anasazi::OperatorTraits<ST,MV,OP>  OPT;
 
-  Teuchos::GlobalMPISession mpisess (&argc, &argv, &std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   bool success = false;
 
@@ -97,8 +96,7 @@ int main(int argc, char *argv[])
 
   int info = 0;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   const int MyPID = comm->getRank ();
 

--- a/packages/anasazi/tpetra/test/BlockKrylovSchur/cxx_main_lap.cpp
+++ b/packages/anasazi/tpetra/test/BlockKrylovSchur/cxx_main_lap.cpp
@@ -51,8 +51,7 @@
 #include "AnasaziBlockKrylovSchurSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using Tpetra::CrsMatrix;
@@ -76,10 +75,8 @@ int main(int argc, char *argv[])
   typedef Anasazi::OperatorTraits<ST,MV,OP>  OPT;
   const ST ONE  = SCT::one();
 
-  Teuchos::GlobalMPISession mpisess (&argc,&argv,&std::cout);
-
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   const int MyPID = comm->getRank ();
   const int NumImages = comm->getSize ();

--- a/packages/anasazi/tpetra/test/IRTR/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/IRTR/cxx_main_complex.cpp
@@ -58,8 +58,7 @@
 #include "AnasaziRTRSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files
@@ -85,7 +84,7 @@ int main(int argc, char *argv[])
   typedef Operator<ST>                        OP;
   typedef Anasazi::MultiVecTraits<ST,MV>     MVT;
   typedef Anasazi::OperatorTraits<ST,MV,OP>  OPT;
-  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   bool success = false;
   ST ONE  = SCT::one();
@@ -93,8 +92,7 @@ int main(int argc, char *argv[])
   int info = 0;
   int MyPID = 0;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   MyPID = rank(*comm);
 

--- a/packages/anasazi/tpetra/test/IRTR/cxx_main_lap.cpp
+++ b/packages/anasazi/tpetra/test/IRTR/cxx_main_lap.cpp
@@ -51,8 +51,7 @@
 #include "AnasaziRTRSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using namespace Teuchos;
@@ -76,13 +75,12 @@ int main(int argc, char *argv[])
   typedef Anasazi::OperatorTraits<ST,MV,OP>  OPT;
   const ST ONE  = SCT::one();
 
-  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   int MyPID = 0;
   int NumImages = 1;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   MyPID = rank(*comm);
   NumImages = size(*comm);

--- a/packages/anasazi/tpetra/test/LOBPCG/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/LOBPCG/cxx_main_complex.cpp
@@ -58,8 +58,7 @@
 #include "AnasaziLOBPCGSolMgr.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files
@@ -87,13 +86,12 @@ int main(int argc, char *argv[])
   typedef Anasazi::OperatorTraits<ST,MV,OP>  OPT;
   const ST ONE  = SCT::one();
 
-  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   int info = 0;
   int MyPID = 0;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   MyPID = rank(*comm);
 

--- a/packages/anasazi/tpetra/test/LOBPCG/cxx_main_doublefloat.cpp
+++ b/packages/anasazi/tpetra/test/LOBPCG/cxx_main_doublefloat.cpp
@@ -55,17 +55,14 @@
 #include <Trilinos_Util_iohb.h>
 
 #include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_ScalarTraits.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_DiagPrecond.hpp>
 
 
 using namespace Teuchos;
 using namespace Anasazi;
-using Tpetra::DefaultPlatform;
-using Tpetra::Platform;
 using Tpetra::Operator;
 using Tpetra::CrsMatrix;
 using Tpetra::MultiVector;
@@ -236,9 +233,8 @@ bool runTest(double ltol, double times[], int &numIters)
 ///////////////////////////////////////////////////////////////////////////
 int main(int argc, char *argv[])
 {
-  GlobalMPISession mpisess(&argc,&argv,&cout);
-  RCP<const Platform<int> > platform = DefaultPlatform<int>::getPlatform();
-  RCP<const Comm<int> > comm = platform->getComm();
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
   //
   // Get test parameters from command-line processor

--- a/packages/anasazi/tpetra/test/MVOPTester/MultiVecTraitsTest2.cpp
+++ b/packages/anasazi/tpetra/test/MVOPTester/MultiVecTraitsTest2.cpp
@@ -39,7 +39,7 @@
 // ***********************************************************************
 // @HEADER
 #include <Teuchos_UnitTestHarness.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Vector.hpp>
 
@@ -90,8 +90,7 @@ namespace {
     out << "Test SetBlock with index vector: Y(:, [1,2]) := X(:, [0,1])"
         << endl;
 
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     RCP<const Map<> > map (new Map<> (INV, numLclRows, indexBase, comm));
     const GST numGblRows = map->getGlobalNumElements ();
 
@@ -213,8 +212,7 @@ namespace {
     out << "Test SetBlock with Range1D: Y(:, [1,2]) := X(:, [0,1])"
         << endl;
 
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     RCP<const Map<> > map (new Map<> (INV, numLclRows, indexBase, comm));
     const GST numGblRows = map->getGlobalNumElements ();
 
@@ -352,8 +350,7 @@ namespace {
     const size_t numCols = 3;
     const GO indexBase = 1; // just for a change
 
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     RCP<const Map<> > map (new Map<> (INV, numLclRows, indexBase, comm));
     const GST numGblRows = map->getGlobalNumElements ();
 
@@ -443,8 +440,7 @@ namespace {
 
     out << "Test SetBlock by imitating AnasaziMVOPTester.hpp" << endl;
 
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     RCP<const Map<> > map (new Map<> (INV, numLclRows, indexBase, comm));
     const GST numGblRows = map->getGlobalNumElements ();
 

--- a/packages/anasazi/tpetra/test/MVOPTester/cxx_main.cpp
+++ b/packages/anasazi/tpetra/test/MVOPTester/cxx_main.cpp
@@ -39,7 +39,7 @@
 // ***********************************************************************
 // @HEADER
 #include <Teuchos_UnitTestHarness.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 #include "AnasaziConfigDefs.hpp"
@@ -54,7 +54,6 @@ namespace { // (anonymous)
   using Teuchos::ArrayRCP;
   using Teuchos::rcp;
   using Tpetra::Map;
-  using Tpetra::DefaultPlatform;
   using std::vector;
   using std::sort;
   using Teuchos::arrayViewFromVector;
@@ -74,8 +73,7 @@ namespace { // (anonymous)
   using Anasazi::BasicOutputManager;
   using Anasazi::Warnings;
   using Teuchos::tuple;
-
-  typedef DefaultPlatform::DefaultPlatformType::NodeType Node;
+  using Node = Tpetra::Map<>::node_type;
 
   bool testMpi = true;
   double errorTolSlack = 1e+1;
@@ -96,7 +94,7 @@ namespace { // (anonymous)
   RCP<const Comm<int> > getDefaultComm()
   {
     if (testMpi) {
-      DefaultPlatform::getDefaultPlatform().getComm();
+      return Tpetra::getDefaultComm();
     }
     return rcp(new Teuchos::SerialComm<int>());
   }

--- a/packages/anasazi/tpetra/test/OrthoManager/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/OrthoManager/cxx_main_complex.cpp
@@ -59,8 +59,7 @@
 #include "AnasaziTpetraAdapter.hpp"
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files
@@ -106,13 +105,12 @@ int main(int argc, char *argv[])
 {
   const ST ONE = SCT::one();
   const MT ZERO = SCT::magnitude(SCT::zero());
-  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   int info = 0;
   int MyPID = 0;
 
-  RCP< const Teuchos::Comm<int> > comm = 
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP< const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   MyPID = rank(*comm);
 

--- a/packages/anasazi/tpetra/test/OrthoManager/cxx_main_tsqr.cpp
+++ b/packages/anasazi/tpetra/test/OrthoManager/cxx_main_tsqr.cpp
@@ -57,9 +57,9 @@
 
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_Map.hpp>
 
 // I/O for Harwell-Boeing files
 #include <Trilinos_Util_iohb.h>
@@ -67,8 +67,6 @@
 
 #include <complex>
 #include <stdexcept>
-
-#include "Kokkos_DefaultNode.hpp"
 
 using namespace Anasazi;
 using namespace Teuchos;
@@ -81,7 +79,6 @@ typedef double                                scalar_type;
 typedef double                                mag_type;
 typedef ScalarTraits<scalar_type>             STraits;
 typedef Tpetra::MultiVector<scalar_type>      MultiVec;
-typedef MultiVec::node_type                   node_type;
 typedef Tpetra::Operator<scalar_type>         OP;
 typedef MultiVecTraits<scalar_type, MultiVec> MVTraits;
 typedef SerialDenseMatrix<int, scalar_type>   serial_matrix_type;
@@ -199,13 +196,12 @@ main (int argc, char *argv[])
 {
   const scalar_type ONE = STraits::one();
   const mag_type ZERO = STraits::magnitude(STraits::zero());
-  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
 
   int info = 0;
   int MyPID = 0;
 
-  RCP< const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP< const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   MyPID = rank(*comm);
 

--- a/packages/anasazi/tpetra/test/TraceMin/cxx_main_standard_noprec.cpp
+++ b/packages/anasazi/tpetra/test/TraceMin/cxx_main_standard_noprec.cpp
@@ -57,7 +57,7 @@
 #include "AnasaziOperator.hpp"
 
 // Include headers for Tpetra
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -286,14 +286,12 @@ int main(int argc, char *argv[]) {
   //
   // Initialize the MPI session
   //
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackhole);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   //
   // Get the default communicator
   //
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
 
   //

--- a/packages/anasazi/tpetra/test/TraceMinDavidson/cxx_main_standard_noprec.cpp
+++ b/packages/anasazi/tpetra/test/TraceMinDavidson/cxx_main_standard_noprec.cpp
@@ -55,7 +55,7 @@
 #include "AnasaziOperator.hpp"
 
 // Include headers for Tpetra
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -80,21 +80,17 @@
 
   //
   // Specify types used in this example
-  // Instead of constantly typing Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>,
-  // we can type TMV.
   //
-  typedef double                                                       Scalar;
-  typedef Teuchos::ScalarTraits<Scalar>                                TSCT;
-  typedef Tpetra::Map<>::local_ordinal_type                            LocalOrdinal;
-  typedef Tpetra::Map<>::global_ordinal_type                           GlobalOrdinal;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType                 Platform;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType       Node;
-  typedef Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>               Map;
-  typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>  TMV;
-  typedef Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node>     TOP;
-  typedef Anasazi::MultiVecTraits<Scalar, TMV>                         TMVT;
-  typedef Anasazi::OperatorTraits<Scalar, TMV, TOP>                    TOPT;
-  typedef Tpetra::Import<LocalOrdinal,GlobalOrdinal,Node>              Import;
+  typedef double                                    Scalar;
+  typedef Teuchos::ScalarTraits<Scalar>             TSCT;
+  typedef Tpetra::Map<>::local_ordinal_type         LocalOrdinal;
+  typedef Tpetra::Map<>::global_ordinal_type        GlobalOrdinal;
+  typedef Tpetra::Map<>                             Map;
+  typedef Tpetra::MultiVector<Scalar>               TMV;
+  typedef Tpetra::Operator<Scalar>                  TOP;
+  typedef Anasazi::MultiVecTraits<Scalar, TMV>      TMVT;
+  typedef Anasazi::OperatorTraits<Scalar, TMV, TOP> TOPT;
+  typedef Tpetra::Import<>                          Import;
 
 
 
@@ -288,15 +284,12 @@ int main(int argc, char *argv[]) {
   //
   // Initialize the MPI session
   //
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv,&blackhole);
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
 
   //
-  // Get the default communicator and node
+  // Get the default communicator
   //
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  RCP<const Teuchos::Comm<int> > comm = platform.getComm();
-  RCP<Node>                      node = platform.getNode();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   const int myRank = comm->getRank();
 
   //


### PR DESCRIPTION
@trilinos/anasazi @trilinos/tpetra

## Description

Purge use of Tpetra::DefaultPlatform from Anasazi's Tpetra tests and examples.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
