### PR TITLE
3069 white cuda debug stokhos build error

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -68,6 +68,10 @@ export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NET
 module swap yamlcpp/0.3.0 yaml-cpp/20170104 
 if [ $? ]; then module load  yaml-cpp/20170104; fi
 
+module load binutils/2.27.0
+# NOTE: Above we need to use updated 'ar' from binutils 2.27 to handle big
+# object files with 'ar' that otherwise can cause "File truncated" failures (see #3069)
+
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
 export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH

--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -185,3 +185,63 @@ in the future.
 To see more documentation for each of these options, run a configure with
 ``-DTrilinos_ENABLE_Kokkos=ON`` and then look in the ``CMakeCache.txt`` file
 (as raw text or using the CMake QT GUI or ``ccmake``).
+
+
+Addressing problems with large builds of Trilinos
+-------------------------------------------------
+
+Trilinos is a large collection of complex software.  Depending on what gets
+enbaled when building Trlinos, one can experience build and installation
+problems due to this large size.
+
+When running into problems like these, the first thing that should be tried is
+to **upgrade to and use the newest supported version of CMake!** In some
+cases, newer versions of CMake may automatically fix problems with building
+and installing Trilinos.  Typically, Trilinos is kept current with new CMake
+releases as they come out.
+
+Otherwise, some problems that can arise when and solutions to those problems
+are mentioned below.
+
+**Command-line too long errors:**
+
+When turning on some options and enabling some set of package's one may
+encounter command-lines that are too long for the OS shell or the tool being
+called.  For example, on some systems, enabling CUDA and COMPLEX variable
+types (e.g. ``-D TPL_ENABLE_CUDA=ON -D Trilinos_ENABLE_COMPLEX=ON``) can
+result in "File 127" errors when trying to create libraries due to large
+numbers of ``*.o`` object files getting passed to create some libraries.
+
+Also, on some systems, the list of include directories may become so long that
+one gets "Command-line too long" errors during compilation.
+
+These and other cases can be addressed by explicitly enabling built-in CMake
+support for ``*.rsp`` resource files as described in the section `Enabling the
+usage of resource files to reduce length of build lines`_.
+
+**Large Object file errors:**
+
+Depending on settings and which packages are enabled, some of the ``*.o``
+files can become very large, so large that it overwhelms the system tools to
+create libraries.  One known case is older versions of the ``ar`` tool used to
+create static libraries (i.e. ``-D BUILD_SHARED_LIBS=OFF``) on some systems.
+Versions of ``ar`` that come with the BinUtils package **before** version 2.27
+may generate "File Truncated" failures when trying to create static libraries
+involving these large object files.
+
+The solution to that problem is to use a newer version of BinUtils 2.27+ for
+which ``ar`` can handle these large object files to create static libraries.
+Just put that newer version of ``ar`` in the default path and CMake will use
+it or configure with::
+
+  -D CMAKE_AR=<path-to-updated-binutils>/bin/ar
+
+**Long make logic times:**
+
+On some systems with slower disk operations (e.g. NFS mounted disks), the time
+that the ``make`` program with the ``Unix Makefiles`` generator to do
+dependency analysis can be excessively long (e.g. cases of more than 2 minutes
+to do dependency analysis have been reported to determine if a single target
+needs to be rebuilt).  The solution is to switch from the default ``Unix
+Makefiles`` generator to the ``Ninja`` generator (see `Enabling support for
+Ninja`_).


### PR DESCRIPTION
CC: @trilinos/stokhos 

## Description

The main contribution of the PR is that is fixes the build error for the stokhos_muelu lib in #3069.  It also contains updated build-reference documentation on the causes (see commits).

## Motivation and Context

We need the build error #3069 to be fixed and we want to provide documentation so that other people can avoid this.

## How Has This Been Tested?

I tested this locally on `white` as described below.  The full build of Stokhos passes now but there are several test failures.  (But we will create new GitHub issues for those once this posts to CDash after the merge.)

<details>
<summary>
  <b>DETAILED TEST RESULTS:</b> (click to expand)
</summary>

Testing on 'white':

```
$ cd ~/Trilinos.base/BUILD/WHITE/CUDA/CUDA-DEBUG/

$ . load-env.sh
Hostname 'white11' matches known ATDM host 'white' and system 'ride'
ATDM_CONFIG_TRILNOS_DIR = /home/rabartl/Trilinos.base/Trilinos
Setting default compiler and build options for JOB_NAME='cuda-debug'
Using white/ride compiler stack CUDA to build DEBUG code with Kokkos node type CUDA

$ rm -r CMake*

$ rm -r packages/

$ time cmake -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake \
  -DTrilinos_ENABLE_TESTS=ON -DTrilinos_ENABLE_Stokhos=ON \
  ~/Trilinos.base/Trilinos \
  &> configure.out

real    1m37.779s
user    0m59.169s
sys     0m17.638s

$ time make NP=32 &> make.out

real    51m55.785s
user    1320m38.264s
sys     233m46.608s

$ time bsub -x -Is -q rhel7F -n 16 ctest -j8 --timeout 600 &> ctest.out

real    10m44.521s
user    0m0.013s
sys     0m0.040s
```

The returned the result:

```
20% tests passed, 67 tests failed out of 84

Subproject Time Summary:
Stokhos    = 2648.79 sec*proc (84 tests)

Total Test time (real) = 643.47 sec

The following tests FAILED:
	  1 - Stokhos_LegendreBasisUnitTest_MPI_1 (Failed)
	  2 - Stokhos_NormalizedLegendreBasisUnitTest_MPI_1 (Failed)
	  3 - Stokhos_HermiteBasisUnitTest_MPI_1 (Failed)
	  4 - Stokhos_NormalizedHermiteBasisUnitTest_MPI_1 (Failed)
	  5 - Stokhos_JacobiBasisUnitTest_MPI_1 (Failed)
	  6 - Stokhos_QuadExpansionUnitTest_MPI_1 (Failed)
	  7 - Stokhos_QuadraturePseudoSpectralExpansionUnitTest_MPI_1 (Failed)
	  8 - Stokhos_TensorProductPseudoSpectralExpansionUnitTest_MPI_1 (Failed)
	  9 - Stokhos_SmolyakPseudoSpectralExpansionUnitTest_MPI_1 (Failed)
	 10 - Stokhos_AlgebraicExpansionUnitTest_MPI_1 (Failed)
	 12 - Stokhos_DivisionOperatorUnitTest_MPI_1 (Failed)
	 13 - Stokhos_StieltjesUnitTest_MPI_1 (Failed)
	 14 - Stokhos_LanczosUnitTest_MPI_1 (Failed)
	 15 - Stokhos_GramSchmidtUnitTest_MPI_1 (Failed)
	 16 - Stokhos_Sparse3TensorUnitTest_MPI_1 (Failed)
	 17 - Stokhos_ExponentialRandomFieldUnitTest_MPI_1 (Failed)
	 18 - Stokhos_LogNormalUnitTest_MPI_1 (Failed)
	 20 - Stokhos_ProductBasisUtilsUnitTest_MPI_1 (Failed)
	 21 - Stokhos_TensorProductBasisUnitTest_MPI_1 (Failed)
	 22 - Stokhos_TotalOrderBasisUnitTest_MPI_1 (Failed)
	 23 - Stokhos_SmolyakBasisUnitTest_MPI_1 (Failed)
	 24 - Stokhos_TensorProductPseudoSpectralOperatorUnitTest_MPI_1 (Failed)
	 25 - Stokhos_LexicographicTreeBasisUnitTest_MPI_1 (Failed)
	 26 - Stokhos_SparseGridQuadratureUnitTest_MPI_1 (Failed)
	 27 - Stokhos_MatrixFreeOperatorUnitTest_MPI_1 (Failed)
	 28 - Stokhos_InterlacedOpUnitTest_MPI_2 (Failed)
	 29 - Stokhos_BasisInteractionGraphUnitTest_MPI_1 (Failed)
	 30 - Stokhos_AdaptivityToolsUnitTest_MPI_1 (Failed)
	 32 - Stokhos_InterlacedMapUnitTest_MPI_2 (Failed)
	 35 - Stokhos_SacadoPCEUnitTest_MPI_1 (Failed)
	 36 - Stokhos_SacadoETPCEUnitTest_MPI_1 (Failed)
	 37 - Stokhos_SacadoPCESerializationTests_MPI_1 (Failed)
	 38 - Stokhos_SacadoPCECommTests_MPI_1 (Failed)
	 39 - Stokhos_SacadoUQPCEUnitTest_MPI_1 (Failed)
	 40 - Stokhos_SacadoUQPCESerializationTests_MPI_1 (Failed)
	 41 - Stokhos_SacadoUQPCECommTests_MPI_1 (Failed)
	 42 - Stokhos_KokkosViewUQPCEUnitTest_Serial_MPI_1 (Failed)
	 43 - Stokhos_KokkosViewUQPCEUnitTest_Cuda_MPI_1 (Failed)
	 44 - Stokhos_KokkosCrsMatrixUQPCEUnitTest_Serial_MPI_1 (Failed)
	 45 - Stokhos_KokkosCrsMatrixUQPCEUnitTest_Cuda_MPI_1 (Failed)
	 46 - Stokhos_TpetraCrsMatrixUQPCEUnitTest_Serial_MPI_4 (Failed)
	 47 - Stokhos_TpetraCrsMatrixUQPCEUnitTest_Cuda_MPI_4 (Failed)
	 59 - Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda_MPI_4 (Timeout)
	 60 - Stokhos_KokkosArrayKernelsUnitTest_Serial_MPI_1 (Failed)
	 61 - Stokhos_KokkosArrayKernelsUnitTest_Cuda_MPI_1 (Failed)
	 63 - Stokhos_hermite_example_MPI_1 (Failed)
	 64 - Stokhos_Linear2D_Diffusion_PCE_Example_MPI_2 (Failed)
	 65 - Stokhos_Linear2D_Diffusion_PCE_Interlaced_Example_MPI_2 (Failed)
	 66 - Stokhos_nox_example_MPI_1 (Failed)
	 67 - Stokhos_Linear2D_Diffusion_PCE_NOX_Example_MPI_2 (Failed)
	 68 - Stokhos_Linear2D_Diffusion_GMRES_Mean_Based_MPI_2 (Failed)
	 69 - Stokhos_Linear2D_Diffusion_GMRES_AGS_MPI_2 (Failed)
	 70 - Stokhos_Linear2D_Diffusion_CG_AGS_MPI_2 (Failed)
	 71 - Stokhos_Linear2D_Diffusion_GMRES_GS_MPI_2 (Failed)
	 72 - Stokhos_Linear2D_Diffusion_GMRES_AJ_MPI_2 (Failed)
	 73 - Stokhos_Linear2D_Diffusion_GMRES_KP_MPI_2 (Failed)
	 74 - Stokhos_Linear2D_Diffusion_GS_MPI_2 (Failed)
	 75 - Stokhos_Linear2D_Diffusion_JA_MPI_2 (Failed)
	 76 - Stokhos_Linear2D_Diffusion_LN_MPI_2 (Failed)
	 77 - Stokhos_Linear2D_Diffusion_GSLN_MPI_2 (Failed)
	 78 - Stokhos_Linear2D_Diffusion_GMRES_FA_MPI_2 (Failed)
	 79 - Stokhos_Linear2D_Diffusion_GMRES_KL_MPI_2 (Failed)
	 80 - Stokhos_Linear2D_Diffusion_GMRES_KLR_MPI_2 (Failed)
	 81 - Stokhos_uq_handbook_nonlinear_sg_example_MPI_1 (Failed)
	 82 - Stokhos_sacado_example_MPI_1 (Failed)
	 83 - Stokhos_division_example_MPI_1 (Failed)
	 84 - Stokhos_sacado_ensemble_example_MPI_1 (Failed)
Errors while running CTest
```

So that passed the build, but there are a bunch of failing Stokhos tests.  We will deal with that in a new issue.

</details>

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] I have updated the documentation accordingly.
