### PR TITLE
Ifpack2: Purge use of Tpetra::DefaultPlatform from tests & examples

### DIFF
--- a/packages/ifpack2/example/ex1.cpp
+++ b/packages/ifpack2/example/ex1.cpp
@@ -3,9 +3,8 @@
 #include <BelosSolverFactory.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_ParameterXMLFileReader.hpp>
 #include <Teuchos_TimeMonitor.hpp>
 
@@ -61,7 +60,7 @@ main (int argc, char* argv[])
   typedef Belos::SolverManager<scalar_type, MV, OP> solver_type;
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> reader_type;
 
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, NULL);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   RCP<Time> totalTime = Teuchos::TimeMonitor::getNewTimer ("Total");
   RCP<Time> precSetupTime =
@@ -71,8 +70,7 @@ main (int argc, char* argv[])
   RCP<Time> solveTime = Teuchos::TimeMonitor::getNewTimer ("Solve");
 
   Teuchos::TimeMonitor totalTimeMon (*totalTime);
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 
   // Get command-line arguments.
   CmdLineArgs args;

--- a/packages/ifpack2/src/Ifpack2_Factory_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Factory_decl.hpp
@@ -91,11 +91,8 @@ The following fragment of code shows the basic usage of this class.
 using Teuchos::ParameterList;
 using Teuchos::RCP;
 typedef double Scalar;
-typedef int    LocalOrdinal;
-typedef int    GlobalOrdinal;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-typedef Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> crs_matrix_type;
-typedef Ifpack2::Preconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node> prec_type;
+typedef Tpetra::CrsMatrix<Scalar> crs_matrix_type;
+typedef Ifpack2::Preconditioner<Scalar> prec_type;
 // ...
 
 Ifpack2::Factory factory;

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -44,7 +44,7 @@
 #define IFPACK2_LOCALSPARSETRIANGULARSOLVER_DEF_HPP
 
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Teuchos_StandardParameterEntryValidators.hpp"
 #include "Tpetra_Details_determineLocalTriangularStructure.hpp"
 
@@ -844,7 +844,7 @@ describe (Teuchos::FancyOStream& out,
     // somewhere, so we ask Tpetra for its default communicator.  If
     // MPI is enabled, this wraps MPI_COMM_WORLD or a clone thereof.
     auto comm = A_.is_null () ?
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm () :
+      Tpetra::getDefaultComm () :
       A_->getComm ();
 
     // Users aren't supposed to do anything with the matrix on

--- a/packages/ifpack2/test/belos/AdditiveSchwarzRILUK/Test.cpp
+++ b/packages/ifpack2/test/belos/AdditiveSchwarzRILUK/Test.cpp
@@ -1,6 +1,4 @@
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
 
 #include "Solve.hpp"
@@ -29,10 +27,8 @@ main (int argc, char **argv)
   using std::cout;
   using std::endl;
 
-  Teuchos::oblackholestream blackHole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 

--- a/packages/ifpack2/test/belos/belos_extprec_solve.cpp
+++ b/packages/ifpack2/test/belos/belos_extprec_solve.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_IFPACK2_QD
 
-#include "Teuchos_GlobalMPISession.hpp"
+#include "Tpetra_Core.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_ParameterXMLFileReader.hpp"
@@ -53,8 +53,6 @@
 #include "Teuchos_Comm.hpp"
 
 #include "Ifpack2_Parameters.hpp"
-
-#include "Tpetra_DefaultPlatform.hpp"
 
 #include <qd/dd_real.h>
 // Set a flag that we are using QD so that the solver builder only instantiates supported solvers
@@ -73,17 +71,15 @@ int main(int argc, char*argv[])
   Teuchos::Time timer("total");
   timer.start();
 
-  Teuchos::GlobalMPISession mpisess(&argc,&argv,&std::cout);
-
-  Tpetra::DefaultPlatform::DefaultPlatformType& platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   typedef dd_real Scalar;
   typedef int LO; //LocalOrdinal
   typedef int GO; //GlobalOrdinal
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-  typedef Tpetra::MultiVector<Scalar,LO,GO,Node> TMV;
-  typedef Tpetra::Operator<Scalar,LO,GO,Node>    TOP;
+  typedef Tpetra::Map<LO, GO>::node_type Node;
+  typedef Tpetra::MultiVector<Scalar,LO,GO> TMV;
+  typedef Tpetra::Operator<Scalar,LO,GO>    TOP;
   typedef Belos::LinearProblem<Scalar,TMV,TOP>   BLinProb;
   typedef Belos::SolverManager<Scalar,TMV,TOP>   BSolverMgr;
 

--- a/packages/ifpack2/test/belos/belos_solve.cpp
+++ b/packages/ifpack2/test/belos/belos_solve.cpp
@@ -40,7 +40,6 @@
 //@HEADER
 */
 
-#include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_StandardCatchMacros.hpp"
 #include "Teuchos_VerboseObject.hpp"
@@ -51,7 +50,7 @@
 
 #include "Ifpack2_Parameters.hpp"
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 
 #include "build_problem.hpp"
@@ -66,7 +65,7 @@ process_command_line (bool& printedHelp,
 
 int main (int argc, char* argv[])
 {
-  Teuchos::GlobalMPISession mpisess(&argc, &argv);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   bool success = true;
 
@@ -78,17 +77,17 @@ int main (int argc, char* argv[])
     Teuchos::Time timer("total");
     timer.start();
 
-    Tpetra::DefaultPlatform::DefaultPlatformType& platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+    Teuchos::RCP<const Teuchos::Comm<int> > comm =
+      Tpetra::getDefaultComm();
 
     typedef double Scalar;
-    typedef Tpetra::Map<>::local_ordinal_type LO;
-    typedef Tpetra::Map<>::global_ordinal_type GO;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-    typedef Tpetra::MultiVector<Scalar,LO,GO,Node> TMV;
-    typedef Tpetra::Operator<Scalar,LO,GO,Node>    TOP;
-    typedef Belos::LinearProblem<Scalar,TMV,TOP>   BLinProb;
-    typedef Belos::SolverManager<Scalar,TMV,TOP>   BSolverMgr;
+    typedef Tpetra::Map<>::local_ordinal_type    LO;
+    typedef Tpetra::Map<>::global_ordinal_type   GO;
+    typedef Tpetra::Map<>::node_type             Node;
+    typedef Tpetra::MultiVector<Scalar,LO,GO>    TMV;
+    typedef Tpetra::Operator<Scalar,LO,GO>       TOP;
+    typedef Belos::LinearProblem<Scalar,TMV,TOP> BLinProb;
+    typedef Belos::SolverManager<Scalar,TMV,TOP> BSolverMgr;
 
     //Just get one parameter from the command-line: the name of an xml file
     //to get parameters from.

--- a/packages/ifpack2/test/unit_tests/Ifpack2_SolverFactory.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_SolverFactory.cpp
@@ -1,5 +1,5 @@
 #include "Teuchos_UnitTestHarness.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Ifpack2_Factory.hpp"
@@ -196,8 +196,7 @@ namespace {
     return;
 #endif // NOT TRILINOS_HAVE_LINEAR_SOLVER_FACTORY_REGISTRATION
 
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     const Tpetra::global_size_t gblNumRows = comm->getSize () * 10;
     const size_t numVecs = 3;
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTest234.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTest234.cpp
@@ -62,7 +62,7 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Ifpack2_Chebyshev.hpp"
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include <type_traits>
 
@@ -98,8 +98,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(Chebyshev, Issue234, SC)
 
   out << "Create test matrix A" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   // Create a nonzero diagonal matrix with a single row per process.
   // We won't actually do anything with it; we just need to give the

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -635,8 +635,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SparseDirectSolver, SC
 
   // Generate the matrix using Galeri.  Galeri wraps it in an Xpetra
   // matrix, so after it finishes, ask it for the Tpetra matrix.
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   Teuchos::CommandLineProcessor clp;
   GO nx = 10, ny=10, nz=10;
   Galeri::Xpetra::Parameters<GO> GaleriParameters (clp, nx, ny, nz, "Laplace2D");
@@ -984,8 +983,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, ILU_Overlap, Scalar, L
   typedef Teuchos::ScalarTraits<Scalar>          STS;
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> Reader;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   //this test can only be run on 4 procs
   if(comm->getSize() != 4)
@@ -1052,8 +1050,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, ILU_NonOverlap, Scalar
   typedef Teuchos::ScalarTraits<Scalar>          STS;
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> Reader;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   //this test can only be run on 4 procs
   if(comm->getSize() != 4)
@@ -1124,8 +1121,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SGS_NonOverlap, Scalar
   typedef Teuchos::ScalarTraits<Scalar>          STS;
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> Reader;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   //this test can only be run on 4 procs
   if(comm->getSize() != 4)
@@ -1194,8 +1190,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, SGS_Overlap, Scalar, L
   typedef Teuchos::ScalarTraits<Scalar>          STS;
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> Reader;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   //this test can only be run on 4 procs
   if(comm->getSize() != 4)

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarzBug5963.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarzBug5963.cpp
@@ -53,7 +53,7 @@
 #include <Ifpack2_AdditiveSchwarz.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_RowMatrix.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 
 
 namespace {
@@ -76,7 +76,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(AdditiveSchwarz, AddCombineMode, ScalarType, L
   typedef ScalarType scalar_type;
   typedef LocalOrdinalType local_ordinal_type;
   typedef GlobalOrdinalType global_ordinal_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_type;
+  typedef Tpetra::Map<>::node_type node_type;
 
   typedef Tpetra::global_size_t GST;
   typedef Teuchos::ScalarTraits<scalar_type> STS;
@@ -98,8 +98,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(AdditiveSchwarz, AddCombineMode, ScalarType, L
                       node_type> map_type;
   typedef Ifpack2::AdditiveSchwarz<row_matrix_type> global_solver_type;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -241,7 +240,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(AdditiveSchwarz, ZeroCombineMode, ScalarType, 
   typedef ScalarType scalar_type;
   typedef LocalOrdinalType local_ordinal_type;
   typedef GlobalOrdinalType global_ordinal_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_type;
+  typedef Tpetra::Map<>::node_type node_type;
 
   typedef Tpetra::global_size_t GST;
   typedef Teuchos::ScalarTraits<scalar_type> STS;
@@ -263,8 +262,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(AdditiveSchwarz, ZeroCombineMode, ScalarType, 
                       node_type> map_type;
   typedef Ifpack2::AdditiveSchwarz<row_matrix_type> global_solver_type;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -468,7 +468,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, OverlappingPartition, 
   out << "#local blocks = " << numLocalBlocks << std::endl;
 
   //out.setOutputToRootOnly(-1);
-  //Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
   //const int myRank = comm->getRank ();
   for (int i=0,j=0; i<numLocalBlocks; ++i) {
     ArrayRCP<LocalOrdinal> block(3);
@@ -631,8 +630,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestDiagonalBlockCrsMa
 
   out << "Ifpack2::BlockRelaxation diagonal block matrix test" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -738,8 +736,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestLowerTriangularBlo
 
   out << "Ifpack2::BlockRelaxation lower triangular BlockCrsMatrix test" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -859,7 +856,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestUpperTriangularBlo
   const int num_rows_per_proc = 3;
   const int blockSize = 5;
 
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  auto comm = Tpetra::getDefaultComm();
   Teuchos::RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph =
     tif_utest::create_dense_local_graph<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
   Teuchos::RCP<block_crs_matrix_type> bcrsmatrix =

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxationPerf.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxationPerf.cpp
@@ -17,7 +17,7 @@
 #include "ml_include.h"
 #include "ml_MultiLevelPreconditioner.h"
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_MultiVector_def.hpp>
 #include <Tpetra_Vector_def.hpp>
@@ -48,7 +48,7 @@ using std::string;
 using Teuchos::RCP;
 using Teuchos::rcp;
 typedef unsigned long long u64;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType NO;
+typedef Tpetra::Map<>::node_type NO;
 typedef Tpetra::CrsMatrix<double,int,int,NO> TMat;
 typedef Tpetra::Map<int,int,NO> TMap;
 
@@ -108,7 +108,7 @@ TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
 {
   using Teuchos::ArrayRCP;
   //use the same types as epetra for fair comparison
-  auto tcomm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  auto tcomm = Tpetra::getDefaultComm();
   if(tcomm->getSize() == 1)
   {
     //Configure ranges of testing

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestContainerFactory.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestContainerFactory.cpp
@@ -56,7 +56,7 @@
 #include "Ifpack2_TriDiContainer.hpp"
 #include "Ifpack2_Details_DenseSolver.hpp"
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include <type_traits>
 
@@ -72,7 +72,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(ContainerFactory, TestTypesAndInput, SC, LO, G
   using Teuchos::rcp;
   using Teuchos::tuple;
   using std::endl;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType NT;
+  typedef Tpetra::Map<>::node_type NT;
   typedef Tpetra::global_size_t GST;
   typedef Tpetra::CrsMatrix<SC, LO, GO, NT> crs_matrix_type;
   typedef Tpetra::RowMatrix<SC, LO, GO, NT> row_matrix_type;
@@ -85,8 +85,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(ContainerFactory, TestTypesAndInput, SC, LO, G
 
   out << "Create test matrix A" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   // Create a nonzero diagonal matrix with a single row per process.
   // We won't actually do anything with it; we just need to give the

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp
@@ -52,7 +52,7 @@
 #include <Ifpack2_UnitTestHelpers.hpp>
 #include <Ifpack2_Details_DenseSolver.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Teuchos_LAPACK.hpp>
 
 
@@ -73,7 +73,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(DenseSolver, LapackComparison, ScalarType, Loc
   typedef ScalarType scalar_type;
   typedef LocalOrdinalType local_ordinal_type;
   typedef GlobalOrdinalType global_ordinal_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_type;
+  typedef Tpetra::Map<>::node_type node_type;
 
   typedef Tpetra::global_size_t GST;
   typedef Teuchos::ScalarTraits<scalar_type> STS;
@@ -95,8 +95,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(DenseSolver, LapackComparison, ScalarType, Loc
                       node_type> map_type;
   typedef Ifpack2::Details::DenseSolver<row_matrix_type> solver_type;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   // We are now in a class method declared by the above macro.
   // The method has these input arguments:

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestFactory.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestFactory.cpp
@@ -171,8 +171,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Factory, BlockCrs, Scalar, LocalOrdinal
   const int num_rows_per_proc = 5;
   const int blockSize = 3;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph =
     tif_utest::create_diagonal_graph<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
@@ -44,9 +44,10 @@
 #ifndef IFPACK2_UNITTESTHELPERS_HPP
 #define IFPACK2_UNITTESTHELPERS_HPP
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_Map.hpp"
 #include "Ifpack2_Details_RowMatrix.hpp"
 #include "Teuchos_Comm.hpp"
 #include "Teuchos_OrdinalTraits.hpp"
@@ -55,12 +56,12 @@
 namespace tif_utest {
 using Tpetra::global_size_t;
 
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+typedef Tpetra::Map<>::node_type Node;
 
 inline
 Teuchos::RCP<const Teuchos::Comm<int> > getDefaultComm()
 {
-  return Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  return Tpetra::getDefaultComm();
 }
 
 template<class LocalOrdinal,class GlobalOrdinal,class Node>

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
@@ -128,8 +128,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, Test0, Scalar, LO
   int gblSuccess = 1;
   std::ostringstream errStrm; // for error collection
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -263,7 +262,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
   typedef Scalar scalar_type;
   typedef LO local_ordinal_type;
   typedef GO global_ordinal_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_type;
+  typedef Tpetra::Map<>::node_type node_type;
 
   typedef Tpetra::CrsMatrix<scalar_type,
                             local_ordinal_type,
@@ -288,7 +287,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
 
   // This test assumes indexBase == 0.
 
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   // Short circuit --- this test should only be run in parallel.
   if (comm->getSize() == 1) {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
@@ -57,7 +57,7 @@
 #include "MatrixMarket_Tpetra.hpp"
 #include "TpetraExt_MatrixMatrix.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Experimental_BlockCrsMatrix.hpp"
 #include "Tpetra_Experimental_BlockMultiVector.hpp"
 #include "Tpetra_MatrixIO.hpp"
@@ -113,8 +113,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, LowerTriangularBlockCrsMatrix, Scalar,
 
   out << "Ifpack2::Experimental::RBILUK lower triangular BlockCrsMatrix test" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -228,7 +227,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, UpperTriangularBlockCrsMatrix, Scalar,
   const int num_rows_per_proc = 3;
   const int blockSize = 5;
 
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   RCP<crs_graph_type> crsgraph =
     tif_utest::create_dense_local_graph<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
   RCP<block_crs_matrix_type> bcrsmatrix =
@@ -282,7 +281,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, FullLocalBlockCrsMatrix, Scalar, Local
   const int num_rows_per_proc = 3;
   const int blockSize = 5;
 
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   RCP<crs_graph_type> crsgraph =
     tif_utest::create_dense_local_graph<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
   RCP<block_crs_matrix_type> bcrsmatrix =
@@ -341,7 +340,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, BandedBlockCrsMatrixWithDropping, Scal
 
   const int lof = 0;
   const size_t rbandwidth = lof+2+2;
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph =
     tif_utest::create_banded_graph<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc, rbandwidth);
   RCP<block_crs_matrix_type> bcrsmatrix =
@@ -586,8 +585,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, DiagonalBlockCrsMatrix, Scalar, LocalO
   int lclSuccess = 1;
   int gblSuccess = 1;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   const bool useOut = false;
   RCP<Teuchos::oblackholestream> blackHole (new Teuchos::oblackholestream ());

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRILUK.cpp
@@ -53,7 +53,7 @@
 #include <Ifpack2_Version.hpp>
 #include <iostream>
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_MatrixIO.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 #include "TpetraExt_MatrixMatrix.hpp"
@@ -83,8 +83,7 @@ static Teuchos::RCP<Ifpack2::RILUK<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalO
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  Tpetra::DefaultPlatform::DefaultPlatformType& platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   int nx = 2;
   size_t numElementsPerProc = nx*nx;

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
@@ -217,7 +217,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, Test3, Scalar, LocalOrdinal
   out << "Ifpack2::Version(): " << Ifpack2::Version() << std::endl;
 
   GST num_rows_per_proc = 0;
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  auto comm = Tpetra::getDefaultComm();
   if(!comm->getRank()) num_rows_per_proc=5;
 
   RCP<const map_type> rowmap = tif_utest::create_tpetra_map<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
@@ -291,7 +291,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, SymGaussSeidelZeroRows, Sca
 
   out << "Ifpack2::Version(): " << Ifpack2::Version () << endl;
 
-  RCP<const Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   if (comm->getSize () == 1) {
     out << "The unit test's (MPI) communicator only contains one process."
         << endl << "This test only makes sense if the communicator contains "
@@ -369,7 +369,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, LocalSymGaussSeidelZeroRows
   std::string version = Ifpack2::Version();
   out << "Ifpack2::Version(): " << version << endl;
 
-  RCP<const Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   if (comm->getSize () == 1) {
     out << "The unit test's (MPI) communicator only contains one process."
         << endl << "This test only makes sense if the communicator contains "
@@ -457,8 +457,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, SGS_mult_sweeps, Scalar, Lo
       << endl;
   Teuchos::OSTab tab0 (out);
 
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -701,8 +700,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, NotCrsMatrix, Scalar, LO, G
 
   out << "Ifpack2 \"NonCrsMatrix\" test" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -813,8 +811,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestDiagonalBlockCrsMatrix,
 
   out << "Ifpack2::Relaxation diagonal block matrix test" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -913,8 +910,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestLowerTriangularBlockCrs
 
   out << "Ifpack2::Relaxation lower triangular BlockCrsMatrix test" << endl;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 
@@ -1024,7 +1020,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestUpperTriangularBlockCrs
   const int num_rows_per_proc = 3;
   const int blockSize = 5;
 
-  RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph =
     tif_utest::create_dense_local_graph<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
   RCP<block_crs_matrix_type> bcrsmatrix =

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestSGSMT.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestSGSMT.cpp
@@ -73,8 +73,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(SGS_MT, JacobiComparison, Scalar, LO, GO)
   out << "Test multiple threaded SGS sweeps compared w.r.t. Jacobi" << endl;
   Teuchos::OSTab tab1 (out);
 
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 
   Tpetra::MatrixMarket::Reader<crs_matrix_type> crs_reader;
   std::string file_name = "sherman1.mtx";

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestSingleProcessRILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestSingleProcessRILUK.cpp
@@ -53,7 +53,7 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include <iostream>
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_MatrixIO.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 #include "TpetraExt_MatrixMatrix.hpp"
@@ -297,8 +297,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2RILUKSingleProcess, FillLevel, Scalar, 
 
   out << "Ifpack2::RILUK: FillLevel" << endl;
 
-  Tpetra::DefaultPlatform::DefaultPlatformType& platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   if (comm->getSize() > 1) {
     out << endl << "This test is only meaningful in serial." << endl;
@@ -399,9 +398,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2RILUKSingleProcess, IgnoreRowMapGIDs, S
 
   out << "Ifpack2::RILUK: IgnoreRowMapGIDs" << endl;
 
-  Tpetra::DefaultPlatform::DefaultPlatformType& platform =
-    Tpetra::DefaultPlatform::getDefaultPlatform ();
-  RCP<const Teuchos::Comm<int> > comm = platform.getComm();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   if (comm->getSize() > 1) {
     out << endl << "This test is only meaningful in serial." << endl;
@@ -552,8 +549,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2RILUKSingleProcess, TestGIDConsistency,
   out << "Ifpack2::RILUK: TestGIDConsistency" << endl;
 
   const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   if (comm->getSize () > 1) {
     out << endl << "This test only runs in serial." << endl;

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp
@@ -53,7 +53,7 @@
 #include <Ifpack2_Details_TriDiSolver.hpp>
 #include <Ifpack2_Details_DenseSolver.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Teuchos_LAPACK.hpp>
 #include <Teuchos_SerialTriDiMatrix.hpp>
 
@@ -74,7 +74,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(TriDiSolver, LapackComparison, ScalarType, Loc
   typedef ScalarType scalar_type;
   typedef LocalOrdinalType local_ordinal_type;
   typedef GlobalOrdinalType global_ordinal_type;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType node_type;
+  typedef Tpetra::Map<>::node_type node_type;
 
   typedef Tpetra::global_size_t GST;
   typedef Teuchos::ScalarTraits<scalar_type> STS;
@@ -99,8 +99,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(TriDiSolver, LapackComparison, ScalarType, Loc
   typedef Ifpack2::Details::TriDiSolver<row_matrix_type> solver_type;
     //  typedef Ifpack2::Details::DenseSolver<row_matrix_type> solver_type;
 
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
   // We are now in a class method declared by the above macro.
   // The method has these input arguments:

--- a/packages/ifpack2/test/vanka/TomVankaTest.cpp
+++ b/packages/ifpack2/test/vanka/TomVankaTest.cpp
@@ -100,13 +100,11 @@
 #include "Teuchos_ConfigDefs.hpp"
 #include "Ifpack2_ConfigDefs.hpp"
 
-// Teuchos
 #include "Teuchos_Array.hpp"
 #include "Teuchos_ArrayRCP.hpp"
 #include "Teuchos_ArrayView.hpp"
 #include "Teuchos_DefaultComm.hpp"
 #include "Teuchos_FancyOStream.hpp"
-#include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_TestingHelpers.hpp"
 #ifdef HAVE_MPI
@@ -115,13 +113,11 @@
 #include "Teuchos_DefaultSerialComm.hpp"
 #endif
 
-// Tpetra
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_CrsGraph.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 
-// Ifpack2
 #include "Ifpack2_AdditiveSchwarz.hpp"
 #include "Ifpack2_BlockRelaxation_decl.hpp"
 #include "Ifpack2_BlockRelaxation_def.hpp"
@@ -136,22 +132,17 @@
 int
 main (int argc, char *argv[])
 {
-  Teuchos::GlobalMPISession mpisess (&argc, &argv);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
-  //Define communicator:
-  Tpetra::DefaultPlatform::DefaultPlatformType& platform =
-    Tpetra::DefaultPlatform::getDefaultPlatform ();
-  Teuchos::RCP<const Teuchos::Comm<int> > comm = platform.getComm ();
-
-  Teuchos::RCP<Teuchos::FancyOStream> fos =
-    Teuchos::fancyOStream (Teuchos::rcpFromRef (std::cout));
+  auto comm = Tpetra::getDefaultComm ();
+  auto fos = Teuchos::fancyOStream (Teuchos::rcpFromRef (std::cout));
   //out->setOutputToRootOnly (0);
 
   // General stuff
   typedef Tpetra::Vector<>::scalar_type ST;
   typedef Tpetra::Map<>::local_ordinal_type LO;
-  typedef Tpetra::Map<LO>::global_ordinal_type GO;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::global_ordinal_type GO;
+  typedef Tpetra::Map<>::node_type Node;
 
   // Matrix stuff
   typedef Tpetra::Map<LO,GO,Node> map_type;


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/tpetra

## Description

Purge use of Tpetra::DefaultPlatform from tests & examples.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.