### PR TITLE
Belos: Purge use of Tpetra::DefaultPlatform; fix build warnings

### DIFF
--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_complex_hb.cpp
@@ -56,7 +56,7 @@
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using namespace Teuchos;
@@ -85,12 +85,10 @@ int main(int argc, char *argv[]) {
 
   int MyPID = 0;
 
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType           Platform;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
-  Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-  RCP<const Comm<int> > comm = platform.getComm();
-  RCP<Node>             node = platform.getNode();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  RCP<Node>             node; // only for type deduction; null ok
 
   //
   // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
@@ -58,7 +58,7 @@
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using namespace Teuchos;
@@ -89,12 +89,10 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType           Platform;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+    typedef Tpetra::Map<>::node_type Node;
 
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node = platform.getNode();
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    RCP<Node>             node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
@@ -55,9 +55,8 @@
 #include <Trilinos_Util_iohb.h>
 
 #include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_ScalarTraits.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_DiagPrecond.hpp>
 #include <Teuchos_TypeNameTraits.hpp>
@@ -71,8 +70,6 @@
 
 using namespace Teuchos;
 using namespace Belos;
-using Tpetra::DefaultPlatform;
-using Tpetra::Platform;
 using Tpetra::Operator;
 using Tpetra::CrsMatrix;
 using Tpetra::DiagPrecond;
@@ -238,9 +235,8 @@ bool runTest(double ltol, double times[], int &numIters, RCP<MultiVector<Scalar,
 ///////////////////////////////////////////////////////////////////////////
 int main(int argc, char *argv[]) 
 {
-  GlobalMPISession mpisess(&argc,&argv,&cout);
-  RCP<const Platform<int> > platform = DefaultPlatform<int>::getPlatform();
-  RCP<const Comm<int> > comm = platform->getComm();
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
   //
   // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
@@ -58,7 +58,7 @@
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 int main (int argc, char *argv[])
@@ -89,12 +89,9 @@ int main (int argc, char *argv[])
 
     int MyPID = 0;
 
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType           Platform;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node;
+    typedef Tpetra::Map<>::node_type Node;
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    RCP<Node>             node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
@@ -56,9 +56,8 @@
 
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 int
@@ -83,16 +82,13 @@ main (int argc, char *argv[])
 
   typedef Teuchos::CommandLineProcessor   CLP;
 
-
-
-  Teuchos::GlobalMPISession mpisess (&argc, &argv, &cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   bool success = false;
   bool verbose = false;
   try {
-    RCP<const Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<node_type> node;
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
+    RCP<node_type> node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
@@ -56,9 +56,8 @@
 
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using namespace Teuchos;
@@ -80,7 +79,7 @@ int main(int argc, char *argv[]) {
   typedef Belos::OperatorTraits<ST,MV,OP> OPT;
   typedef Belos::MultiVecTraits<ST,MV>    MVT;
 
-  GlobalMPISession mpisess(&argc,&argv,&cout);
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
 
   bool success = false;
   bool verbose = false;
@@ -89,12 +88,9 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType           Platform;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node> node;
+    typedef Tpetra::Map<>::node_type Node;
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    RCP<Node> node; // only for type deduction; null ok
     //
     // Get test parameters from command-line processor
     //

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
@@ -55,15 +55,13 @@
 #include <Trilinos_Util_iohb.h>
 
 #include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_ScalarTraits.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Teuchos_TypeNameTraits.hpp>
 
 using namespace Teuchos;
 using namespace Belos;
-using Tpetra::DefaultPlatform;
 using Tpetra::Operator;
 using Tpetra::CrsMatrix;
 using Tpetra::MultiVector;
@@ -210,9 +208,9 @@ bool runTest(double ltol, double times[], int &numIters, const RCP<Map<> >& vmap
 ///////////////////////////////////////////////////////////////////////////
 int main(int argc, char *argv[]) 
 {
-  GlobalMPISession mpisess(&argc,&argv,&cout);
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
 
-  RCP<const Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
   //
   // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/FixedPoint/test_fp_hb.cpp
+++ b/packages/belos/tpetra/test/FixedPoint/test_fp_hb.cpp
@@ -58,7 +58,7 @@
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 using namespace Teuchos;
@@ -90,12 +90,9 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType           Platform;
-    typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
-
-    Platform &platform = Tpetra::DefaultPlatform::getDefaultPlatform();
-    RCP<const Comm<int> > comm = platform.getComm();
-    RCP<Node>             node;
+    typedef Tpetra::Map<>::node_type Node;
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    RCP<Node>             node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/LinearSolverFactory/CustomSolverFactory.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/CustomSolverFactory.cpp
@@ -76,41 +76,41 @@ public:
   }
 
   virtual const Belos::LinearProblem<SC, MV, OP>&
-  getProblem () const {
+  getProblem () const override {
     return linearProblem_;
   }
 
   virtual Teuchos::RCP<const Teuchos::ParameterList>
-  getValidParameters () const {
+  getValidParameters () const override {
     return Teuchos::null;
   }
 
   virtual Teuchos::RCP<const Teuchos::ParameterList>
-  getCurrentParameters () const {
+  getCurrentParameters () const override {
     return Teuchos::null;
   }
 
-  virtual int getNumIters () const {
+  virtual int getNumIters () const override {
     return 0;
   }
 
-  virtual bool isLOADetected () const {
+  virtual bool isLOADetected () const override {
     return false;
   }
 
   virtual void
-  setProblem (const Teuchos::RCP<Belos::LinearProblem<SC, MV, OP> >& /* problem */)
+  setProblem (const Teuchos::RCP<Belos::LinearProblem<SC, MV, OP> >& /* problem */) override
   {}
 
   virtual void
-  setParameters (const Teuchos::RCP<Teuchos::ParameterList>& /* params */)
+  setParameters (const Teuchos::RCP<Teuchos::ParameterList>& /* params */) override
   {}
 
   virtual void
-  reset (const Belos::ResetType /* type */)
+  reset (const Belos::ResetType /* type */) override
   {}
 
-  virtual Belos::ReturnType solve () {
+  virtual Belos::ReturnType solve () override {
     return Belos::Unconverged;
   }
 

--- a/packages/belos/tpetra/test/LinearSolverFactory/LinearSolverFactory.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/LinearSolverFactory.cpp
@@ -41,7 +41,7 @@
 
 #include "Teuchos_UnitTestHarness.hpp"
 #include "BelosTpetraAdapter.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 #include "BelosSolverFactory.hpp"
 #include "Trilinos_Details_LinearSolver.hpp"
@@ -236,8 +236,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( LinearSolverFactory, Solve, SC, LO, GO, NT )
   return;
 #endif // NOT TRILINOS_HAVE_LINEAR_SOLVER_FACTORY_REGISTRATION
 
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   const Tpetra::global_size_t gblNumRows = comm->getSize () * 10;
   const size_t numVecs = 3;
 

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactory.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactory.cpp
@@ -43,7 +43,7 @@
 #include "BelosSolverFactory.hpp"
 #include "BelosTpetraAdapter.hpp"
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "TpetraCore_ETIHelperMacros.h"
 
@@ -203,8 +203,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( SolverFactory, CreateAndSolve, SC, LO, GO, NT
   typedef Tpetra::MultiVector<SC,LO,GO,NT> MV;
   typedef Tpetra::Operator<SC,LO,GO,NT> OP;
 
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   const Tpetra::global_size_t gblNumRows = comm->getSize () * 10;
   const size_t numVecs = 3;
 

--- a/packages/belos/tpetra/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/belos/tpetra/test/MVOPTester/cxx_main_complex.cpp
@@ -42,7 +42,7 @@
 */
 
 #include <Teuchos_UnitTestHarness.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 #include "BelosConfigDefs.hpp"
@@ -57,7 +57,6 @@ namespace {
   using Teuchos::ArrayRCP;
   using Teuchos::rcp;
   using Tpetra::Map;
-  using Tpetra::DefaultPlatform;
   using std::vector;
   using std::sort;
   using Teuchos::arrayViewFromVector;
@@ -77,7 +76,7 @@ namespace {
   using Belos::Warnings;
   using Teuchos::tuple;
 
-  typedef DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   bool testMpi = true;
   double errorTolSlack = 1e+1;
@@ -98,7 +97,7 @@ namespace {
   RCP<const Comm<int> > getDefaultComm()
   {
     if (testMpi) {
-      DefaultPlatform::getDefaultPlatform().getComm();
+      return Tpetra::getDefaultComm();
     }
     return rcp(new Teuchos::SerialComm<int>());
   }

--- a/packages/belos/tpetra/test/MultipleSolves/MultipleSolves.cpp
+++ b/packages/belos/tpetra/test/MultipleSolves/MultipleSolves.cpp
@@ -42,7 +42,7 @@
 #include "BelosSolverFactory.hpp"
 #include "BelosTpetraAdapter.hpp"
 #include "MatrixMarket_Tpetra.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Teuchos_UnitTestHarness.hpp"
 
@@ -279,8 +279,7 @@ TEUCHOS_UNIT_TEST( MultipleSolves, GMRES )
   Teuchos::OSTab tab1 (out);
 
   // Get the default communicator for tests.
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> reader_type;
   std::istringstream matrixFile (symPosDefMatrixString);
@@ -371,8 +370,7 @@ TEUCHOS_UNIT_TEST( MultipleSolves, CG )
   Teuchos::OSTab tab1 (out);
 
   // Get the default communicator for tests.
-  RCP<const Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 
   typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> reader_type;
   std::istringstream matrixFile (symPosDefMatrixString);

--- a/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra.cpp
+++ b/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra.cpp
@@ -47,9 +47,8 @@
 /// and Tpetra::Operator as the operator implementation.
 ///
 #include "belos_orthomanager_tpetra_util.hpp"
-#include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Tpetra_Core.hpp"
 
 using std::endl;
 
@@ -394,10 +393,9 @@ main (int argc, char *argv[])
   using Teuchos::rcp;
   bool success = false;
 
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
   try {
-    RCP<const Teuchos::Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
     // Get values of command-line arguments.
     getCmdLineArgs (*comm, argc, argv);

--- a/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_benchmark.cpp
+++ b/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_benchmark.cpp
@@ -47,9 +47,9 @@
 /// Tpetra::Operator as the operator implementation.
 ///
 #include "belos_orthomanager_tpetra_util.hpp"
-#include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
+#include "Tpetra_Core.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_oblackholestream.hpp"
 #include <algorithm>
 
 using std::endl;
@@ -88,13 +88,12 @@ main (int argc, char *argv[])
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &std::cout);
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
   bool success = false;
   bool verbose = false; // Verbosity of output
   try {
-    RCP<const Teuchos::Comm<int> > pComm =
-      Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int> > pComm = Tpetra::getDefaultComm();
     // This factory object knows how to make a (Mat)OrthoManager
     // subclass, given a name for the subclass.  The name is not the
     // same as the class' syntactic name: e.g., "TSQR" is the name of

--- a/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_util.hpp
+++ b/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_util.hpp
@@ -45,7 +45,7 @@
 #include <BelosOrthoManagerFactory.hpp>
 #include <BelosOrthoManagerTest.hpp>
 #include <BelosTpetraAdapter.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files


### PR DESCRIPTION
@trilinos/belos @trilinos/tpetra 

## Description

Purge use of `Tpetra::DefaultPlatform` from Belos' tests and examples.  Fix build warnings in Belos' Tpetra tests.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.