### PR TITLE
Stokhos: Purge use of Tpetra::DefaultPlatform from tests & examples

### DIFF
--- a/packages/stokhos/example/experimental/linear2d_diffusion.cpp
+++ b/packages/stokhos/example/experimental/linear2d_diffusion.cpp
@@ -55,6 +55,7 @@
 #include "BelosTpetraAdapter.hpp"
 #include "BelosPseudoBlockCGSolMgr.hpp"
 #include "BelosPseudoBlockGmresSolMgr.hpp"
+#include "Tpetra_Core.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 
 // Stokhos Stochastic Galerkin
@@ -69,7 +70,7 @@ int main(int argc, char *argv[]) {
   typedef double BasisScalar;
   typedef int LocalOrdinal;
   typedef int GlobalOrdinal;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
 
   using Teuchos::RCP;
   using Teuchos::rcp;

--- a/packages/stokhos/example/experimental/linear2d_diffusion_pce.cpp
+++ b/packages/stokhos/example/experimental/linear2d_diffusion_pce.cpp
@@ -220,7 +220,7 @@ void PrintMatrix(Teuchos::FancyOStream &fos, Teuchos::RCP<Xpetra_Matrix> const &
 int main(int argc, char *argv[]) {
   typedef double MeshScalar;
   typedef double BasisScalar;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
   typedef Teuchos::ScalarTraits<Scalar>::magnitudeType magnitudeType;
 
   using Teuchos::RCP;

--- a/packages/stokhos/example/experimental/linear2d_diffusion_pce_ifpack2.cpp
+++ b/packages/stokhos/example/experimental/linear2d_diffusion_pce_ifpack2.cpp
@@ -126,7 +126,7 @@ const char *prec_option_names[] = { "full", "linear"};
 int main(int argc, char *argv[]) {
   typedef double MeshScalar;
   typedef double BasisScalar;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType Node;
+  typedef Tpetra::Map<>::node_type Node;
   typedef Teuchos::ScalarTraits<Scalar>::magnitudeType magnitudeType;
 
   using Teuchos::RCP;

--- a/packages/stokhos/example/experimental/twoD_diffusion_problem_tpetra.hpp
+++ b/packages/stokhos/example/experimental/twoD_diffusion_problem_tpetra.hpp
@@ -46,7 +46,6 @@
 #include "Teuchos_Array.hpp"
 #include "Teuchos_Comm.hpp"
 
-#include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_Import.hpp"

--- a/packages/stokhos/src/belos/BelosPCETpetraAdapter.hpp
+++ b/packages/stokhos/src/belos/BelosPCETpetraAdapter.hpp
@@ -287,7 +287,7 @@ namespace Belos {
 #endif
       // create local map
       Teuchos::SerialComm<int> scomm;
-      Tpetra::Map<LO,GO,Node> LocalMap(B.numRows(), 0, Teuchos::rcpFromRef< const Teuchos::Comm<int> >(scomm), Tpetra::LocallyReplicated, A.getMap()->getNode());
+      Tpetra::Map<LO,GO,Node> LocalMap(B.numRows(), 0, Teuchos::rcpFromRef< const Teuchos::Comm<int> >(scomm), Tpetra::LocallyReplicated);
       // encapsulate Teuchos::SerialDenseMatrix data in ArrayView
       Teuchos::ArrayView<const Scalar> Bvalues(B.values(),B.stride()*B.numCols());
       // create locally replicated MultiVector with a copy of this data
@@ -336,7 +336,7 @@ namespace Belos {
                 strideC  = C.stride();
       Teuchos::SerialComm<int> scomm;
       // create local map with serial comm
-      Tpetra::Map<LO,GO,Node> LocalMap(numRowsC, 0, Teuchos::rcpFromRef< const Teuchos::Comm<int> >(scomm), Tpetra::LocallyReplicated, A.getMap()->getNode());
+      Tpetra::Map<LO,GO,Node> LocalMap(numRowsC, 0, Teuchos::rcpFromRef< const Teuchos::Comm<int> >(scomm), Tpetra::LocallyReplicated);
       // create local multivector to hold the result
       const bool INIT_TO_ZERO = true;
       Tpetra::MultiVector<Scalar,LO,GO,Node> C_mv(Teuchos::rcpFromRef(LocalMap),numColsC, INIT_TO_ZERO);

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -48,8 +48,7 @@
 // Tpetra
 #include "Stokhos_Tpetra_MP_Vector.hpp"
 #include "Stokhos_Tpetra_Utilities_MP_Vector.hpp"
-#include "Tpetra_ConfigDefs.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Vector.hpp"
@@ -147,8 +146,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -227,8 +225,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -329,8 +326,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -418,8 +414,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -534,8 +529,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -661,8 +655,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -783,8 +776,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -921,8 +913,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1043,8 +1034,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 50;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1189,8 +1179,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 50;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1345,8 +1334,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1498,8 +1486,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1661,8 +1648,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 50;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1849,8 +1835,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 50;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest.hpp
@@ -49,8 +49,7 @@
 #include "Stokhos_Tpetra_UQ_PCE.hpp"
 #include "Stokhos_Tpetra_Utilities.hpp"
 #include "Stokhos_Tpetra_Utilities_UQ_PCE.hpp"
-#include "Tpetra_ConfigDefs.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Vector.hpp"
@@ -210,8 +209,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   LocalOrdinal pce_size = cijk.dimension();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -299,8 +297,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   LocalOrdinal pce_size = cijk.dimension();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -388,8 +385,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   LocalOrdinal pce_size = cijk.dimension();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -486,8 +482,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   LocalOrdinal pce_size = cijk.dimension();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -587,8 +582,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   LocalOrdinal pce_size = cijk.dimension();
 
   // Comm
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
 
   // Map
   GlobalOrdinal nrow = 10;
@@ -698,8 +692,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 13;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -845,8 +838,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1003,8 +995,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1159,8 +1150,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 10;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1334,8 +1324,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 10;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1534,8 +1523,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1708,8 +1696,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -1893,8 +1880,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 10;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -2116,8 +2102,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // 1-D Laplacian matrix
   GlobalOrdinal nrow = 10;
   BaseScalar h = 1.0 / static_cast<BaseScalar>(nrow-1);
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);

--- a/packages/stokhos/test/UnitTest/tpetra_mat_vec.cpp
+++ b/packages/stokhos/test/UnitTest/tpetra_mat_vec.cpp
@@ -5,7 +5,7 @@
 #include "Teuchos_GlobalMPISession.hpp"
 
 // Tpetra
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_CrsGraph.hpp"
@@ -36,8 +36,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);
@@ -131,8 +130,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Build banded matrix
   GlobalOrdinal nrow = 10;
-  RCP<const Tpetra_Comm> comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
       nrow, comm);


### PR DESCRIPTION
@trilinos/stokhos @trilinos/tpetra

## Description

Purge use of `Tpetra::DefaultPlatform` from Stokhos' tests and examples.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0.