### PR TITLE
Only add test Piro_AnalysisDriverTpetra_MPI_4 if ROL is enabled (#3115)

### DIFF
--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -94,13 +94,15 @@ IF (Piro_ENABLE_NOX)
   
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
     AnalysisDriverTpetra
+    EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_ROL
     SOURCES
-    Main_AnalysisDriver_Tpetra.cpp
-    MockModelEval_A_Tpetra.cpp
-    MockModelEval_A_Tpetra.hpp
+      Main_AnalysisDriver_Tpetra.cpp
+      MockModelEval_A_Tpetra.cpp
+      MockModelEval_A_Tpetra.hpp
     NUM_MPI_PROCS 1-4
     ARGS -v
     PASS_REGULAR_EXPRESSION "TEST PASSED"
+    ADDED_TESTS_NAMES_OUT AnalysisDriverTpetra_NAME 
   )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -141,6 +143,12 @@ IF (Piro_ENABLE_NOX)
     STANDARD_PASS_OUTPUT
   )
 
+  IF (AnalysisDriverTpetra_NAME)
+   SET(AnalysisDriverTpetra_EXENAME AnalysisDriverTpetra)
+  ELSE()
+   SET(AnalysisDriverTpetra_EXENAME)
+  ENDIF()
+
   TRIBITS_COPY_FILES_TO_BINARY_DIR(copyTestInputFiles
     DEST_FILES   input_Solve_NOX_1.xml
                  input_Solve_NOX_2.xml
@@ -167,8 +175,7 @@ IF (Piro_ENABLE_NOX)
 	  input_SGAnalysis.xml dakota_sg.in dakota_sg_target.txt
     SOURCE_DIR   ${PACKAGE_SOURCE_DIR}/test
     SOURCE_PREFIX "_"
-    #EXEDEPS EpetraSolver ThyraSolver AnalysisDriver UnitTests NOXSolver_UnitTests
-    EXEDEPS ThyraSolver AnalysisDriver AnalysisDriverTpetra UnitTests NOXSolver_UnitTests
+    EXEDEPS ThyraSolver AnalysisDriver ${AnalysisDriverTpetra_EXENAME} UnitTests NOXSolver_UnitTests
   )
 
 ENDIF()


### PR DESCRIPTION
CC: @trilinos/piro, @mperego, @rppawlo, @fryeguy52 

## Description

This commit changes behavior to only add the test `Piro_AnalysisDriverTpetra_MPI_4` is ROL is enabled.

## Motivation and Context

The Piro test suite should run and pass no matter what subset of optional upstream packages are enabled or disabled.

## How Has This Been Tested?

I just did a local configure using the instructions provided at in #3115 and (after adding `-DTrilinos_TRACE_ADD_TEST=ON`) the configure output showed:

```
-- Piro_AnalysisDriverTpetra: NOT added test because EXCLUDE_IF_NOT_TRUE Piro_ENABLE_ROL='OFF'!
```

When the PR testing runs, we will verify that this test is enabled and passes in the standard PR builds.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
