### PR TITLE
Avoid error when MPI's atexit is redefined via a macro

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp
+++ b/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp
@@ -237,7 +237,7 @@ namespace Teuchos
         // out of memory for storing callbacks).  We could throw an
         // exception here in that case, but I think it's better just
         // to let the minor memory leak happen.
-        atexit(freeTableFormat);
+        static_cast<void>( atexit(freeTableFormat) );
       }
       TEUCHOS_TEST_FOR_EXCEPTION(
         format_ == NULL, std::logic_error, "Teuchos::PerformanceMonitorBase::"
@@ -320,7 +320,7 @@ namespace Teuchos
         // out of memory for storing callbacks).  We could throw an
         // exception here in that case, but I think it's better just
         // to let the minor memory leak happen.
-        atexit(freeCounters);
+        static_cast<void>( atexit(freeCounters) );
       }
       TEUCHOS_TEST_FOR_EXCEPTION(
         counters_ == NULL, std::logic_error, "Teuchos::PerformanceMonitorBase::"

--- a/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp
+++ b/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp
@@ -237,7 +237,7 @@ namespace Teuchos
         // out of memory for storing callbacks).  We could throw an
         // exception here in that case, but I think it's better just
         // to let the minor memory leak happen.
-        (void) atexit (freeTableFormat);
+        atexit(freeTableFormat);
       }
       TEUCHOS_TEST_FOR_EXCEPTION(
         format_ == NULL, std::logic_error, "Teuchos::PerformanceMonitorBase::"
@@ -320,7 +320,7 @@ namespace Teuchos
         // out of memory for storing callbacks).  We could throw an
         // exception here in that case, but I think it's better just
         // to let the minor memory leak happen.
-        (void) atexit (freeCounters);
+        atexit(freeCounters);
       }
       TEUCHOS_TEST_FOR_EXCEPTION(
         counters_ == NULL, std::logic_error, "Teuchos::PerformanceMonitorBase::"


### PR DESCRIPTION
When compiled using Charm++'s Adaptive MPI, MPI's `atexit` is redfined via a macro, in AMPI's mpi.h at

https://github.com/UIUC-PPL/charm/blob/charm/src/libs/ck-libs/ampi/ampi.h#L46.

This commit prevents the following error:
```
<trilinos>/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp: In static membe
r function ‘static Teuchos::TableFormat& Teuchos::PerformanceMonitorBase<T>::format()’:
<ampi>/charm/bin/../include/mpi.h:34:21: error: expected primary-expression before ‘do’
 #define atexit(...) do {atexit(__VA_ARGS__); atexit((void (*)())ampiMarkAtexit);} while(0)
                     ^
<trilinos>/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp:225:16: note: in
 expansion of macro ‘atexit’
         (void) atexit(freeTableFormat);
                ^~~~~~
<trilinos>/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp: In static membe
r function ‘static std::map<std::__cxx11::basic_string<char>, Teuchos::RCP<T1> >& Teuchos::PerformanceMonitorBase<T>::co
unters()’:
<ampi>/charm/bin/../include/mpi.h:34:21: error: expected primary-expression before ‘do’
 #define atexit(...) do {atexit(__VA_ARGS__); atexit((void (*)())ampiMarkAtexit);} while(0)
                     ^
<trilinos>/packages/teuchos/comm/src/Teuchos_PerformanceMonitorBase.hpp:308:16: note: in
 expansion of macro ‘atexit’
         (void) atexit(freeCounters);
                ^~~~~~
Fatal Error by charmc in directory <ampi-build>/trilinos-build/packages/tpetra/core/src
```
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/3121)
<!-- Reviewable:end -->
