### PR TITLE
Composite coarse level operator and direct solve

### DIFF
--- a/packages/muelu/research/luc/region_algorithms/CMakeLists.txt
+++ b/packages/muelu/research/luc/region_algorithms/CMakeLists.txt
@@ -1,22 +1,18 @@
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../../test/unit_tests)
 
+# This tets requires Tpetra, so it's only included if Tpetra is enabled
+IF (${PACKAGE_NAME}_ENABLE_Tpetra) #AND ${PACKAGE_NAME}_ENABLE_Ifpack2 AND ${PACKAGE_NAME}_ENABLE_Amesos2)
 
-# IF (${PACKAGE_NAME}_ENABLE_Galeri)
+  TRIBITS_ADD_EXECUTABLE(
+    RegionsDriver
+    SOURCES Driver.cpp
+    COMM serial mpi
+    )
 
-#   IF ((${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Ifpack2 AND ${PACKAGE_NAME}_ENABLE_Amesos2) OR
-#       (${PACKAGE_NAME}_ENABLE_Epetra AND ${PACKAGE_NAME}_ENABLE_Ifpack  AND ${PACKAGE_NAME}_ENABLE_Amesos))
+  # TRIBITS_COPY_FILES_TO_BINARY_DIR(tawiesn_cp
+  #   SOURCE_FILES driver.xml
+  #   )
 
-    TRIBITS_ADD_EXECUTABLE(
-      RegionsDriver
-      SOURCES Driver.cpp
-      COMM serial mpi
-      )
+ENDIF()
 
-    # TRIBITS_COPY_FILES_TO_BINARY_DIR(tawiesn_cp
-    #   SOURCE_FILES driver.xml
-    #   )
-
-#   ENDIF()
-
-# ENDIF() # Galeri

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -1591,7 +1591,9 @@ int main(int argc, char *argv[]) {
       regProlong[0] = fineLevelProlong;
     }
 
-    // Get coarse level matrices and prolongators from MueLu hierarchy (Note: fine level has been dealt with previously)
+    /* Get coarse level matrices and prolongators from MueLu hierarchy
+     * Note: fine level has been dealt with previously, so we start at level 1 here.
+     */
     for (int l = 1; l < numLevels; ++l) { // Note: we start at level 1 (which is the first coarse level)
       for (int j = 0; j < maxRegPerProc; ++j) {
         RCP<MueLu::Level> level = regGrpHierarchy[j]->GetLevel(l);
@@ -2031,7 +2033,7 @@ int main(int argc, char *argv[]) {
           TEUCHOS_ASSERT(err == 0);
 
 //          sleep(1);
-//          std::cout << myRank << " | Printing the tranpose ..." << std::endl;
+//          std::cout << myRank << " | Printing the transpose ..." << std::endl;
 //          Comm.Barrier();
 //          transDuplicateMapping->Print(std::cout);
         }

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -2172,7 +2172,7 @@ int main(int argc, char *argv[]) {
   {
     std::cout << myRank << " | Computing interface scaling factors ..." << std::endl;
 
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!numLevels>0, "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(!(numLevels>0), "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
 
     for (int l = 0; l < numLevels; l++)
     {
@@ -2202,7 +2202,7 @@ int main(int argc, char *argv[]) {
   {
     std::cout << myRank << " | Running V-cycle ..." << std::endl;
 
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!numLevels>0, "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(!(numLevels>0), "We require numLevel > 0. Probaly, numLevel has not been set, yet.");
 
     /* We first use the non-level container variables to setup the fine grid problem.
      * This is ok since the initial setup just mimics the application and the outer

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -50,6 +50,9 @@
 #include <iostream>
 #include <numeric>
 
+#include "Amesos.h"
+#include "Amesos_BaseSolver.h"
+
 #define RegionsSpanProcs  1
 #define MultipleRegionsPerProc  2
 #include "ml_config.h"
@@ -330,11 +333,13 @@ void regionalToComposite(const std::vector<Teuchos::RCP<Epetra_CrsMatrix> >& reg
         TEUCHOS_ASSERT(err == 0);
       }
 
+//      int err = compMat->FillComplete(compMat->RowMap(), compMat->RowMap());
       int err = compMat->FillComplete();
       TEUCHOS_ASSERT(err == 0);
     }
   }
   else {
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(false, "Not implemented, yet.");
 //    /* Let's fake an ADD combine mode that also adds local values by
 //     * 1. exporting quasiRegional vectors to auxiliary composite vectors (1 per group)
 //     * 2. add all auxiliary vectors together
@@ -369,7 +374,7 @@ void regionalToComposite(const std::vector<Teuchos::RCP<Epetra_CrsMatrix> >& reg
 /*! \brief Sum region interface values
  *
  *  Sum values of interface GIDs using the underlying Export() routines. Technically, we perform the
- *  exchange/summation of interace data by exporting a regional vector to the composite layout and
+ *  exchange/summation of interface data by exporting a regional vector to the composite layout and
  *  then immediately importing it back to the regional layout. The Export() involved when going to the
  *  composite layout takes care of the summation of interface values.
  */
@@ -410,7 +415,7 @@ void createRegionalVector(std::vector<Teuchos::RCP<Epetra_Vector> >& regVecs, //
  *
  *  The residual is computed based on matrices and vectors in a regional layout.
  *  1. Compute y = A*x in regional layout.
- *  2. Sum interface valus of y to account for duplication of interface DOFs.
+ *  2. Sum interface values of y to account for duplication of interface DOFs.
  *  3. Compute r = b - y
  */
 std::vector<Teuchos::RCP<Epetra_Vector> > computeResidual(
@@ -592,6 +597,49 @@ std::vector<int> findCommonRegions(const int nodeA, ///< GID of first node
   return finalCommonRegions;
 }
 
+/*! \brief Create coarse level maps with continuous GIDs
+ *
+ *  The direct solver requires maps with continuous GIDs. Starting from the
+ *  coarse level composite maps with discontinuous GIDs, we create a new row map
+ *  and a matching column map.
+ *
+ *  Range and Domain map happen to correspond to the Row map, so we don't have
+ *  to deal with them in particular.
+ */
+void createContinuousCoarseLevelMaps(const Epetra_Map& rowMap, ///< row map
+    const Epetra_Map& colMap, ///< column map
+    Teuchos::RCP<Epetra_Map>& contRowMap, ///< row map with continuous GIDs
+    Teuchos::RCP<Epetra_Map>& contColMap ///< column map with continuous GIDs
+    )
+{
+  // Create row map with continuous GIDs
+  contRowMap = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),
+      rowMap.NumMyElements(), 0, rowMap.Comm()));
+
+  /* Create column map based on row map with continuous GIDs
+   *
+   * We use an Importer to create an auxiliary vector in colMap format containing
+   * the GIDs of the contRowMap as its entries. By looping over its LIDs, we can
+   * then form the contColMap.
+   */
+  Teuchos::RCP<Epetra_Import> rowColImport = Teuchos::rcp(new Epetra_Import(colMap, rowMap));
+  Teuchos::RCP<Epetra_Vector> colGIDVec = Teuchos::rcp(new Epetra_Vector(rowMap, true));
+  for (int i = 0; i < colGIDVec->MyLength(); ++i)
+    (*colGIDVec)[i] = contRowMap->GID(i);
+  Teuchos::RCP<Epetra_Vector> contColGIDVec = Teuchos::rcp(new Epetra_Vector(colMap, true));
+  int err = contColGIDVec->Import(*colGIDVec, *rowColImport, Insert);
+  TEUCHOS_ASSERT(err == 0);
+
+  std::vector<int> contColGIDs;
+  for (int i = 0; i < contColGIDVec->MyLength(); ++i) {
+    contColGIDs.push_back((*contColGIDVec)[i]);
+  }
+  contColMap = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),
+      contColGIDs.size(), contColGIDs.data(), 0, rowMap.Comm()));
+
+  return;
+}
+
 //! Recursive V-cycle in region fashion
 void vCycle(const int l, ///< ID of current level
     const int numLevels, ///< Total number of levels
@@ -603,11 +651,12 @@ void vCycle(const int l, ///< ID of current level
     std::vector<Teuchos::RCP<Epetra_Vector> > fineRegB, ///< right hand side
     Teuchos::Array<std::vector<Teuchos::RCP<Epetra_CrsMatrix> > > regMatrices, ///< Matrices in region layout
     Teuchos::Array<std::vector<Teuchos::RCP<Epetra_CrsMatrix> > > regProlong, ///< Prolongators in region layout
-    Teuchos::Array<Teuchos::RCP<Epetra_Map> > compMaps, ///< composite maps
+    Teuchos::Array<Teuchos::RCP<Epetra_Map> > compRowMaps, ///< composite maps
     Teuchos::Array<std::vector<Teuchos::RCP<Epetra_Map> > > quasiRegRowMaps, ///< quasiRegional row maps
     Teuchos::Array<std::vector<Teuchos::RCP<Epetra_Map> > > regRowMaps, ///< regional row maps
     Teuchos::Array<std::vector<Teuchos::RCP<Epetra_Import> > > regRowImporters, ///< regional row importers
-    Teuchos::Array<std::vector<Teuchos::RCP<Epetra_Vector> > > regInterfaceScalings ///< regional interface scaling factors
+    Teuchos::Array<std::vector<Teuchos::RCP<Epetra_Vector> > > regInterfaceScalings, ///< regional interface scaling factors
+    Teuchos::RCP<Epetra_CrsMatrix> coarseCompMat ///< Coarsest level composite operator
     )
 {
   using Teuchos::RCP;
@@ -617,12 +666,12 @@ void vCycle(const int l, ///< ID of current level
 
     // pre-smoothing
     jacobiIterate(maxFineIter, omega, fineRegX, fineRegB, regMatrices[l],
-        regInterfaceScalings[l], maxRegPerProc, compMaps[l],
+        regInterfaceScalings[l], maxRegPerProc, compRowMaps[l],
         quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
 
     std::vector<Teuchos::RCP<Epetra_Vector> > regRes(maxRegPerProc);
     createRegionalVector(regRes, maxRegPerProc, regRowMaps[l]);
-    computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], compMaps[l],
+    computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], compRowMaps[l],
         quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
 
     // Transfer to coarse level
@@ -640,13 +689,13 @@ void vCycle(const int l, ///< ID of current level
       TEUCHOS_ASSERT(regProlong[l+1][j]->RangeMap().PointSameAs(regRes[j]->Map()));
       TEUCHOS_ASSERT(regProlong[l+1][j]->DomainMap().PointSameAs(coarseRegB[j]->Map()));
     }
-    sumInterfaceValues(coarseRegB, compMaps[l+1], maxRegPerProc,
+    sumInterfaceValues(coarseRegB, compRowMaps[l+1], maxRegPerProc,
         quasiRegRowMaps[l+1], regRowMaps[l+1], regRowImporters[l+1]);
 
     // Call V-cycle recursively
     vCycle(l+1, numLevels, maxFineIter, maxCoarseIter, omega, maxRegPerProc,
-        coarseRegX, coarseRegB, regMatrices, regProlong, compMaps,
-        quasiRegRowMaps, regRowMaps, regRowImporters, regInterfaceScalings);
+        coarseRegX, coarseRegB, regMatrices, regProlong, compRowMaps,
+        quasiRegRowMaps, regRowMaps, regRowImporters, regInterfaceScalings, coarseCompMat);
 
     // Transfer coarse level correction to fine level
     std::vector<Teuchos::RCP<Epetra_Vector> > regCorrection(maxRegPerProc);
@@ -666,17 +715,141 @@ void vCycle(const int l, ///< ID of current level
 
     // post-smoothing
     jacobiIterate(maxFineIter, omega, fineRegX, fineRegB, regMatrices[l],
-        regInterfaceScalings[l], maxRegPerProc, compMaps[l], quasiRegRowMaps[l],
+        regInterfaceScalings[l], maxRegPerProc, compRowMaps[l], quasiRegRowMaps[l],
         regRowMaps[l], regRowImporters[l]);
   }
   else { // coarse level
 
-    // coarse level solve
-    /* For now, we do Jacobi. We need to figure out how to deal with free-floating
-     * regions or recombine to a composite matrix on the coarse level
-     */
-    jacobiIterate(maxCoarseIter, omega, fineRegX, fineRegB, regMatrices[l],
-        regInterfaceScalings[l], maxRegPerProc, compMaps[l],
+    // Create composite error vector (zero initial guess)
+    Teuchos::RCP<Epetra_Vector> compX = Teuchos::rcp(new Epetra_Vector(coarseCompMat->RowMap(), true));
+
+    // Create composite right-hand side vector
+    Teuchos::RCP<Epetra_Vector> compRhs = Teuchos::rcp(new Epetra_Vector(coarseCompMat->RowMap(), true));
+    {
+      for (int j = 0; j < maxRegPerProc; j++) {
+        for (int i = 0; i < fineRegB[j]->MyLength(); ++i)
+          (*fineRegB[j])[i] /= (*((regInterfaceScalings[l])[j]))[i];
+      }
+
+      regionalToComposite(fineRegB, compRhs, maxRegPerProc, quasiRegRowMaps[l],
+          regRowImporters[l], Add, true);
+    }
+
+//    std::cout << "compRhs before direct solve:" << std::endl;
+//    compRhs->Print(std::cout);
+
+//    coarseCompMat->RowMap().Print(std::cout);
+//    coarseCompMat->ColMap().Print(std::cout);
+
+    const int myRank = coarseCompMat->Comm().MyPID();
+    std::cout << myRank << " | " << __LINE__ << __FILE__ << std::endl;
+
+    // create row and column maps with continuous GIDs
+    Teuchos::RCP<Epetra_Map> contRowMap = Teuchos::rcp(new Epetra_Map(coarseCompMat->RowMap()));
+    Teuchos::RCP<Epetra_Map> contColMap = Teuchos::rcp(new Epetra_Map(coarseCompMat->ColMap()));
+    createContinuousCoarseLevelMaps(coarseCompMat->RowMap(),
+        coarseCompMat->ColMap(), contRowMap, contColMap);
+
+    std::cout << myRank << " | " << __LINE__ << __FILE__ << std::endl;
+
+    // transform coarse level problem to use maps with continuous GIDs
+    Teuchos::RCP<Epetra_CrsMatrix> contCompMat = Teuchos::null;
+    Teuchos::RCP<Epetra_Vector> contCompX = Teuchos::null;
+    Teuchos::RCP<Epetra_Vector> contCompRhs = Teuchos::null;
+    Teuchos::RCP<Epetra_Import> contRowImporter = Teuchos::null;
+    Teuchos::RCP<Epetra_Import> contColImporter = Teuchos::null; // remove?
+    {
+      // Create Importer
+      contRowImporter = Teuchos::rcp(new Epetra_Import(*contRowMap, coarseCompMat->RowMap()));
+      contColImporter = Teuchos::rcp(new Epetra_Import(*contColMap, coarseCompMat->ColMap()));
+
+      std::cout << myRank << " | " << __LINE__ << __FILE__ << std::endl;
+
+      int err = 0;
+
+      // Transform vectors
+      {
+        contCompX = Teuchos::rcp(new Epetra_Vector(*contRowMap, true));
+        contCompRhs = Teuchos::rcp(new Epetra_Vector(*contRowMap, true));
+
+        err = contCompX->Import(*compX, *contRowImporter, Insert);
+        TEUCHOS_ASSERT(err == 0);
+        err = contCompRhs->Import(*compRhs, *contRowImporter, Insert);
+        TEUCHOS_ASSERT(err == 0);
+
+        contCompRhs->Print(std::cout);
+      }
+
+      std::cout << myRank << " | " << __LINE__ << __FILE__ << std::endl;
+
+//      // Transform matrix
+//      contCompMat = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *contRowMap, *contColMap, 3, false));
+//      err = contCompMat->Import(*coarseCompMat, *contRowImporter, Add);
+//      TEUCHOS_ASSERT(err == 0);
+////      err = contCompMat->FillComplete(*contRowMap, *contRowMap);
+//      err = contCompMat->FillComplete();
+//      TEUCHOS_ASSERT(err == 0);
+
+      contCompMat = Teuchos::rcp(new Epetra_CrsMatrix(*coarseCompMat,
+          *contRowImporter, &(*contColImporter), contRowMap.get(), contRowMap.get(), false));
+//      contCompMat = Teuchos::rcp(new Epetra_CrsMatrix(*coarseCompMat,
+//          *contRowImporter, contRowMap.get(), contRowMap.get(), false));
+
+      std::cout << myRank << " | " << __LINE__ << __FILE__ << std::endl;
+
+      sleep(1);
+      coarseCompMat->Print(std::cout);
+
+//      sleep(1);
+//      std::cout << "After FillComplete()" << std::endl;
+      sleep(1);
+
+      contCompMat->Print(std::cout);
+//      sleep(1);
+//      contCompMat->RowMap().Print(std::cout);
+//      sleep(1);
+//      contCompMat->ColMap().Print(std::cout);
+//      sleep(1);
+//      contCompMat->RangeMap().Print(std::cout);
+//      sleep(1);
+//      contCompMat->DomainMap().Print(std::cout);
+//
+//      std::cout << myRank << " | " << __LINE__ << __FILE__ << std::endl;
+//
+//      exit(0);
+
+    }
+
+    // create a linear problem object
+    Epetra_LinearProblem problem(contCompMat.get(), &(*contCompX), &(*contCompRhs));
+
+    // Use Amesos for direct solver
+    {
+      Teuchos::ParameterList pList;
+      pList.set("PrintTiming",true);
+      pList.set("PrintStatus",true);
+      pList.set("MaxProcs", contCompMat->Comm().NumProc());
+
+      Amesos Factory;
+      Amesos_BaseSolver* solver = Factory.Create("Amesos_Umfpack", problem);
+      TEUCHOS_ASSERT(solver!=NULL);
+
+      solver->SetParameters(pList);
+      solver->SetUseTranspose(false);
+
+      solver->SymbolicFactorization();
+      solver->NumericFactorization();
+      solver->Solve();
+    }
+
+    std::cout << "compX after direct solve:" << std::endl;
+    compX->Print(std::cout);
+    exit(0);
+
+
+    // transform solution back to regional vector
+    std::vector<Teuchos::RCP<Epetra_Vector> > quasiRegVec(maxRegPerProc);
+    compositeToRegional(compX, quasiRegVec, fineRegX, maxRegPerProc,
         quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
   }
 
@@ -888,16 +1061,21 @@ int main(int argc, char *argv[]) {
    * We use Teuchos::Array<T> to store each quantity on each level.
    */
   int numLevels = 0;
-  Array<RCP<Epetra_Map> > compMaps;
-  Array<std::vector<RCP<Epetra_Map> > > regRowMaps;
-  Array<std::vector<RCP<Epetra_Map> > > quasiRegRowMaps;
-  Array<std::vector<RCP<Epetra_CrsMatrix> > > regMatrices;
-  Array<std::vector<RCP<Epetra_CrsMatrix> > > regProlong;
-  Array<std::vector<RCP<Epetra_Import> > > regRowImporters;
-  Array<std::vector<RCP<Epetra_Vector> > > regInterfaceScalings;
+  Array<RCP<Epetra_Map> > compRowMaps; ///< composite row maps on each level
+  Array<RCP<Epetra_Map> > compColMaps; ///< composite columns maps on each level
+  Array<std::vector<RCP<Epetra_Map> > > regRowMaps; ///< regional row maps on each level
+  Array<std::vector<RCP<Epetra_Map> > > quasiRegRowMaps; ///< quasiRegional row maps on each level
+  Array<std::vector<RCP<Epetra_Map> > > regColMaps; ///< regional column maps on each level
+  Array<std::vector<RCP<Epetra_Map> > > quasiRegColMaps; ///< quasiRegional column maps on each level
+  Array<std::vector<RCP<Epetra_CrsMatrix> > > regMatrices; ///< regional matrices on each level
+  Array<std::vector<RCP<Epetra_CrsMatrix> > > regProlong; ///< regional prolongators on each level
+  Array<std::vector<RCP<Epetra_Import> > > regRowImporters; ///< regional row importers on each level
+  Array<std::vector<RCP<Epetra_Vector> > > regInterfaceScalings; ///< regional interface scaling factors on each level
 
   Array<std::vector<std::vector<int> > > interfaceLIDs; // local IDs of interface nodes on each level in each group
   Array<std::vector<std::vector<std::vector<int> > > > interfaceGIDPairs; // pairs of GIDs of interface nodes on each level in each group
+
+  Teuchos::RCP<Epetra_CrsMatrix> coarseCompOp = Teuchos::null;
 
   /* The actual computations start here. It's a sequence of operations to
    * - read region data from files
@@ -1008,10 +1186,12 @@ int main(int argc, char *argv[]) {
     fp = fopen(fileNameSS.str().c_str(), "r");
     TEUCHOS_ASSERT(fp!=NULL);
 
+    int retval; // dummy return value for fscanf()
+
     if (doing1D) {
       int minGID, maxGID;
       for (int i = 0; i < (int) myRegions.size(); i++) {
-        fscanf(fp,"%d%d",&minGID,&maxGID);
+        retval = fscanf(fp,"%d%d",&minGID,&maxGID);
         minGIDComp[i] = minGID;
         maxGIDComp[i] = maxGID;
       }
@@ -1019,9 +1199,9 @@ int main(int argc, char *argv[]) {
       appData.lDim = (int *) malloc(sizeof(int)*3*myRegions.size());
       appData.lowInd= (int *) malloc(sizeof(int)*3*myRegions.size());
       for (int i = 0; i < (int) myRegions.size(); i++) {
-        fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
-        fscanf(fp,"%d%d%d",&(appData.lDim[3*i]),&(appData.lDim[3*i+1]),&(appData.lDim[3*i+2]));
-        fscanf(fp,"%d%d%d",&(appData.lowInd[3*i]),&(appData.lowInd[3*i+1]),&(appData.lowInd[3*i+2]));
+        retval = fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
+        retval = fscanf(fp,"%d%d%d",&(appData.lDim[3*i]),&(appData.lDim[3*i+1]),&(appData.lDim[3*i+2]));
+        retval = fscanf(fp,"%d%d%d",&(appData.lowInd[3*i]),&(appData.lowInd[3*i+1]),&(appData.lowInd[3*i+2]));
       }
       appData.minGIDComp = minGIDComp.data();
       appData.maxGIDComp = maxGIDComp.data();
@@ -1037,10 +1217,10 @@ int main(int argc, char *argv[]) {
       appData.relcornery= (int *) malloc(sizeof(int)*myRegions.size());
       int garbage;
       for (int i = 0; i < (int) myRegions.size(); i++) {
-        fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
-        fscanf(fp,"%d%d%d",&(appData.lDimx[i]),&(appData.lDimy[i]),&garbage);
-        fscanf(fp,"%d%d%d",&(appData.relcornerx[i]),&(appData.relcornery[i]),&garbage);
-        fscanf(fp,"%d%d%d",&(appData.trueCornerx[i]),&(appData.trueCornery[i]),&garbage);
+        retval = fscanf(fp,"%d%d%d",&(appData.gDim[3*i]),&(appData.gDim[3*i+1]),&(appData.gDim[3*i+2]));
+        retval = fscanf(fp,"%d%d%d",&(appData.lDimx[i]),&(appData.lDimy[i]),&garbage);
+        retval = fscanf(fp,"%d%d%d",&(appData.relcornerx[i]),&(appData.relcornery[i]),&garbage);
+        retval = fscanf(fp,"%d%d%d",&(appData.trueCornerx[i]),&(appData.trueCornery[i]),&garbage);
       }
     }
 
@@ -1435,15 +1615,34 @@ int main(int argc, char *argv[]) {
 
   Comm.Barrier();
 
-  /* Form a composite operator (needed for coarse level) */
-  {
-    Teuchos::RCP<Epetra_CrsMatrix> compOp = Teuchos::rcp(new Epetra_CrsMatrix(Copy, AComp->RowMap(), AComp->ColMap(), 3));
-    regionalToComposite(regionGrpMats, compOp, maxRegPerProc, rowMapPerGrp, colMapPerGrp, rowImportPerGrp, Add, false);
-  }
+//  /* Form composite operator on fine level for debug purposes */
+//  {
+//    Teuchos::RCP<Epetra_CrsMatrix> compOp = Teuchos::rcp(new Epetra_CrsMatrix(Copy, AComp->RowMap(), AComp->ColMap(), 3));
+//    regionalToComposite(regionGrpMats, compOp, maxRegPerProc, rowMapPerGrp, colMapPerGrp, rowImportPerGrp, Add, false);
+//
+//    sleep(1);
+//    std::cout << myRank << " | Printing compOp ..." << std::endl;
+//    Comm.Barrier();
+//    compOp->Print(std::cout);
+//
+//    Teuchos::RCP<Epetra_CrsMatrix> diffOp = Teuchos::rcp(new Epetra_CrsMatrix(Copy, AComp->Graph()));
+//    Epetra_CrsMatrix* diffOp_ptr = diffOp.get();
+//    EpetraExt::MatrixMatrix::Add(*AComp, false, 1.0, *compOp, false, -1.0, diffOp_ptr);
+//
+//    sleep(1);
+//    std::cout << myRank << " | Printing diffOp ..." << std::endl;
+//    Comm.Barrier();
+//    diffOp->Print(std::cout);
+//
+//    Comm.Barrier();
+//    std::cout << myRank << " | Calling exit(0) ..." << std::endl;
+//    Comm.Barrier();
+//    exit(0);
+//  }
 
   Comm.Barrier();
 
-  // Make MueLu transfer operators
+  // Create multigrid hierarchy
   {
     std::cout << myRank << " | Setting up MueLu hierarchies ..." << std::endl;
 
@@ -1554,9 +1753,12 @@ int main(int argc, char *argv[]) {
     {
       // resize level containers
       numLevels = regGrpHierarchy[0]->GetNumLevels();
-      compMaps.resize(numLevels);
+      compRowMaps.resize(numLevels);
+      compColMaps.resize(numLevels);
       regRowMaps.resize(numLevels);
+      regColMaps.resize(numLevels);
       quasiRegRowMaps.resize(numLevels);
+      quasiRegColMaps.resize(numLevels);
       regMatrices.resize(numLevels);
       regProlong.resize(numLevels);
       regRowImporters.resize(numLevels);
@@ -1565,7 +1767,9 @@ int main(int argc, char *argv[]) {
       // resize group containers on each level
       for (int l = 0; l < numLevels; ++l) {
         regRowMaps[l].resize(maxRegPerProc);
+        regColMaps[l].resize(maxRegPerProc);
         quasiRegRowMaps[l].resize(maxRegPerProc);
+        quasiRegColMaps[l].resize(maxRegPerProc);
         regMatrices[l].resize(maxRegPerProc);
         regProlong[l].resize(maxRegPerProc);
         regRowImporters[l].resize(maxRegPerProc);
@@ -1575,9 +1779,11 @@ int main(int argc, char *argv[]) {
 
     // Fill fine level with our data
     {
-      compMaps[0] = mapComp;
+      compRowMaps[0] = mapComp;
       quasiRegRowMaps[0] = rowMapPerGrp;
+      quasiRegColMaps[0] = colMapPerGrp;
       regRowMaps[0] = revisedRowMapPerGrp;
+      regColMaps[0] = revisedColMapPerGrp;
       regRowImporters[0] = rowImportPerGrp;
       regMatrices[0] = regionGrpMats;
 
@@ -1605,6 +1811,7 @@ int main(int argc, char *argv[]) {
         regMatrices[l][j] = Utilities::Op2NonConstEpetraCrs(regRAPXpetra);
 
         regRowMaps[l][j] = Teuchos::rcp(new Epetra_Map(regMatrices[l][j]->RowMap())); // ToDo (mayr.mt) Do not copy!
+        regColMaps[l][j] = Teuchos::rcp(new Epetra_Map(regMatrices[l][j]->ColMap())); // ToDo (mayr.mt) Do not copy!
       }
     }
 
@@ -1619,10 +1826,10 @@ int main(int argc, char *argv[]) {
       /* General strategy to create coarse level maps:
        * =============================================
        *
-       * We need three maps on the next coarser level:
-       * - regional map: just extract the RowMap() from the prolongator
-       * - quasiRegional map: needs to be formed manually
-       * - composite map: needs to be formed manually
+       * We need three row maps on the next coarser level:
+       * - regional row map: just extract the RowMap() from the prolongator
+       * - quasiRegional row map: needs to be formed manually
+       * - composite row map: needs to be formed manually
        *
        * After extracting the RowMap() from the prolongator to be used as the
        * coarse level's regional map, we need to identify pairs/sets of GIDs
@@ -1649,6 +1856,17 @@ int main(int argc, char *argv[]) {
        * To form the composite map, we loop over the quasiRegional map and
        * - every proc accepts every GID that it owns.
        * - every proc ignores every GID that it doesn't own.
+       *
+       * To form a composite operator on the coarsest level, we also need the
+       * column map on the coarsest level. Hence, we have to recursively
+       * re-construct all column maps on each level, namely
+       * - regional col map: just extract the ColMap() from the prolongator
+       * - quasiRegional col map: needs to be formed manually
+       * - composite col map: needs to be formed manually
+       *
+       * To form column maps, lots of information that we used to generate row
+       * maps can be reused. The central piece of information is the mapping
+       * of duplicated interface GIDs.
        */
 
       int err = 0;
@@ -1730,7 +1948,7 @@ int main(int argc, char *argv[]) {
             (*regDupGIDVec[j])[interfaceLIDs[l][j][i]] = 1.0;
         }
 
-        RCP<Epetra_Vector> compDupGIDVec = rcp(new Epetra_Vector(*compMaps[l]), true);
+        RCP<Epetra_Vector> compDupGIDVec = rcp(new Epetra_Vector(*compRowMaps[l]), true);
         regionalToComposite(regDupGIDVec, compDupGIDVec, maxRegPerProc,
             quasiRegRowMaps[l], regRowImporters[l], Add, true);
 
@@ -2078,7 +2296,7 @@ int main(int argc, char *argv[]) {
 //          regRowMaps[l+1][0]->Print(std::cout);
 //          sleep(2);
 
-          // create quasiRegional map
+          // create quasiRegional row map
           {
             std::vector<int> myQuasiRegGIDs;
 
@@ -2131,10 +2349,9 @@ int main(int argc, char *argv[]) {
 //            std::cout << myRank << " | Printing quasiRegRowMaps[" << l+1 << "][0] ..." << std::endl;
 //            Comm.Barrier();
 //            quasiRegRowMaps[l+1][0]->Print(std::cout);
-
           }
 
-          // create composite map
+          // create composite row map
           {
             std::vector<int> myCompGIDs;
             for (int j = 0; j < maxRegPerProc; j++) {
@@ -2146,23 +2363,100 @@ int main(int argc, char *argv[]) {
               }
             }
 
-            compMaps[l+1] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myCompGIDs.size(), myCompGIDs.data(), 0, Comm));
-            TEUCHOS_ASSERT(!compMaps[l+1].is_null());
+            compRowMaps[l+1] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myCompGIDs.size(), myCompGIDs.data(), 0, Comm));
+            TEUCHOS_ASSERT(!compRowMaps[l+1].is_null());
 
 //            sleep(1);
-//            std::cout << myRank << " | Printing compMaps["<< l+1 << "] ..." << std::endl;
+//            std::cout << myRank << " | Printing compRowMaps["<< l+1 << "] ..." << std::endl;
 //            Comm.Barrier();
-//            compMaps[l+1]->Print(std::cout);
+//            compRowMaps[l+1]->Print(std::cout);
           }
 
           // create regRowImporter
           for (int j = 0; j < maxRegPerProc; ++j) {
             regRowImporters[l+1][j] =
-                rcp(new Epetra_Import(*quasiRegRowMaps[l+1][j], *compMaps[l+1]));
+                rcp(new Epetra_Import(*quasiRegRowMaps[l+1][j], *compRowMaps[l+1]));
             TEUCHOS_ASSERT(!regRowImporters[l+1][j].is_null());
+          }
+
+          // Create quasiRegional column map
+          {
+            std::vector<int> myQuasiRegGIDs;
+
+            for (int i = 0; i < regColMaps[l+1][0]->NumMyElements(); ++i) {
+              // grab current regional GID to be processed
+              int currGID = regColMaps[l+1][0]->GID(i);
+              int quasiGID = currGID; // assign dummy value
+
+              /* Find quasiRegional counterpart
+               *
+               * We should be able to use the same procedure as for the
+               * quasiRegRowMap since duplicated GIDs only live on the interface.
+               * Hence, even if the column map reaches across an interface,
+               * GIDs from 'the other side of the interface' do not have to be
+               * modified as they have not been duplicated (only those on the
+               * interface).
+               */
+              {
+                // Is this an interface GID?
+                bool isInterface = false;
+                for (std::size_t k = 0; k < myCoarseInterfaceDuplicates.size(); ++k) {
+                  for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk) {
+                    if (currGID == myCoarseInterfaceDuplicates[k][kk])
+                      isInterface = true;
+                  }
+                }
+
+                if (isInterface) {
+                  for (std::size_t k = 0; k < myCoarseInterfaceDuplicates.size(); ++k) {
+                    bool found = false;
+                    for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk) {
+                      if (currGID == myCoarseInterfaceDuplicates[k][kk])
+                        found = true;
+                    }
+
+                    if (found) {
+                      for (std::size_t kk = 0; kk < myCoarseInterfaceDuplicates[k].size(); ++kk)
+                        quasiGID = std::min(quasiGID, Teuchos::as<int>(myCoarseInterfaceDuplicates[k][kk]));
+
+//                      std::cout << myRank << " | Interface GID " << currGID << " is replaced by quasiGID " << quasiGID << std::endl;
+                      break;
+                    }
+                  }
+                }
+                else { // interior node --> take GID from regional map
+                  quasiGID = currGID;
+                }
+              }
+
+              TEUCHOS_ASSERT(quasiGID>=0);
+              myQuasiRegGIDs.push_back(quasiGID);
+            }
+
+            quasiRegColMaps[l+1][0] = rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), myQuasiRegGIDs.size(), myQuasiRegGIDs.data(), 0, Comm));
+            TEUCHOS_ASSERT(!quasiRegColMaps[l+1][0].is_null());
+
+//            sleep(1);
+//            std::cout << myRank << " | Printing quasiRegColMaps[" << l+1 << "][0] ..." << std::endl;
+//            Comm.Barrier();
+//            quasiRegColMaps[l+1][0]->Print(std::cout);
           }
         }
       }
+    }
+
+    // Form the composite coarse level operator
+    {
+      const int maxLevel = numLevels - 1;
+      coarseCompOp = Teuchos::rcp(new Epetra_CrsMatrix(Copy, *compRowMaps[maxLevel], 3));
+      regionalToComposite(regMatrices[maxLevel], coarseCompOp, maxRegPerProc,
+          quasiRegRowMaps[maxLevel], quasiRegColMaps[maxLevel],
+          regRowImporters[maxLevel], Add, false);
+
+//      sleep(1);
+//      std::cout << myRank << " | Printing coarseCompOp ..." << std::endl;
+//      Comm.Barrier();
+//      coarseCompOp->Print(std::cout);
     }
   }
 
@@ -2183,7 +2477,7 @@ int main(int argc, char *argv[]) {
       }
 
       // transform to composite layout while adding interface values via the Export() combine mode
-      RCP<Epetra_Vector> compInterfaceScalingSum = rcp(new Epetra_Vector(*compMaps[l], true));
+      RCP<Epetra_Vector> compInterfaceScalingSum = rcp(new Epetra_Vector(*compRowMaps[l], true));
       regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, maxRegPerProc, quasiRegRowMaps[l], regRowImporters[l], Add, true);
 
       /* transform composite layout back to regional layout. Now, GIDs associated
@@ -2306,8 +2600,8 @@ int main(int argc, char *argv[]) {
     for (int cycle = 0; cycle < maxVCycle; ++cycle) {
 
       vCycle(0, numLevels, maxFineIter, maxCoarseIter, omega, maxRegPerProc, regX, regB, regMatrices,
-          regProlong, compMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
-          regInterfaceScalings);
+          regProlong, compRowMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
+          regInterfaceScalings, coarseCompOp);
 
       ////////////////////////////////////////////////////////////////////////
       // SWITCH BACK TO NON-LEVEL VARIABLES

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -924,7 +924,7 @@ int main(int argc, char *argv[]) {
     while (fscanf(fp, "%d", &i) != EOF)
       fileData.push_back(i);
 
-    mapComp = Teuchos::rcp(new Epetra_Map(-1, (int) fileData.size(), fileData.data(), 0, Comm));
+    mapComp = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), (int) fileData.size(), fileData.data(), 0, Comm));
 //    mapComp->Print(std::cout);
   }
 
@@ -1075,12 +1075,12 @@ int main(int argc, char *argv[]) {
         if (tempRegIDs[idx[i]] != -1)
           rowGIDsReg.push_back(colGIDsComp[idx[i]]);
       }
-      rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1, (int) rowGIDsReg.size(),
+      rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), (int) rowGIDsReg.size(),
           rowGIDsReg.data(), 0, Comm));
     }
 
     for (int k=(int) myRegions.size(); k < maxRegPerProc; k++) {
-      rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+      rowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),0,NULL,0,Comm));
     }
   }
 
@@ -1094,11 +1094,11 @@ int main(int argc, char *argv[]) {
       // clone rowMap
       for (int j=0; j < maxRegPerProc; j++) {
         if (j < (int) myRegions.size()) {
-          colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1,
+          colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),
               rowMapPerGrp[j]->NumMyElements(),
               rowMapPerGrp[j]->MyGlobalElements(), 0, Comm));
         }
-        else colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+        else colMapPerGrp[j] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),0,NULL,0,Comm));
       }
     }
     else if (whichCase == RegionsSpanProcs) {//so maxRegPerProc = 1
@@ -1128,10 +1128,10 @@ int main(int argc, char *argv[]) {
         }
       }
       if ((int) myRegions.size() > 0) {
-       colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(-1, (int) colIDsReg.size(),
+       colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), (int) colIDsReg.size(),
            colIDsReg.data(), 0, Comm));
       }
-      else colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+      else colMapPerGrp[0] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),0,NULL,0,Comm));
     }
     else { fprintf(stderr,"whichCase not set properly\n"); exit(1); }
   }
@@ -1225,7 +1225,7 @@ int main(int argc, char *argv[]) {
         }
       }
 
-      revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,(int) revisedGIDs.size(),
+      revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),(int) revisedGIDs.size(),
                                           revisedGIDs.data(),0,Comm));
       // now append more stuff to handle ghosts ... needed for
       // revised version of column map
@@ -1248,12 +1248,12 @@ int main(int argc, char *argv[]) {
           }
         }
       }
-      revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1, (int) revisedGIDs.size(),
+      revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(), (int) revisedGIDs.size(),
           revisedGIDs.data(), 0, Comm));
     }
     for (int k = (int) myRegions.size(); k < maxRegPerProc; k++) {
-      revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
-      revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(-1,0,NULL,0,Comm));
+      revisedRowMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),0,NULL,0,Comm));
+      revisedColMapPerGrp[k] = Teuchos::rcp(new Epetra_Map(Teuchos::OrdinalTraits<int>::invalid(),0,NULL,0,Comm));
     }
 
     // Setup importers

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mk2DRegionFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mk2DRegionFile.m
@@ -211,7 +211,7 @@ elseif(strcmp(filename, 'caseSeventeen') == true)  % caseSeventeen
   pxProcChange         = [31];
   pyProcChange         = [31];
   
-elseif(strcmp(filename, 'caseEightteen') == true)  % caseEightteen
+elseif(strcmp(filename, 'caseEighteen') == true)  % caseEightteen
 
 %px:0   0   0   0   1   1   1
 %px:            1                
@@ -270,7 +270,9 @@ elseif(strcmp(filename, 'caseTwenty') == true)  % caseTwenty
   ryInterfaceLocations = [9 18];   
   pxProcChange         = [10];
   pyProcChange         = [10];
-
+  
+else
+  error('Unknown case %s', filename);
 end
 
 nrx = length(rxInterfaceLocations);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/muelu_structured.xml
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/muelu_structured.xml
@@ -1,5 +1,5 @@
 <ParameterList name="MueLu">
-  
+
   <!-- Configuration of the Xpetra operator (fine level) -->
   <ParameterList name="Matrix">
     <Parameter name="PDE equations"                   type="int" value="1"/> <!-- Number of PDE equations at each grid node.-->

--- a/packages/muelu/research/mmayr/composite_to_regions/src/shadow_caseFifteen.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/shadow_caseFifteen.m
@@ -1,0 +1,86 @@
+% Do a 2-level V-cycle in composite form for caseFifteen
+%
+% Perform all operations in composite form to allow for comparison to the region
+% algorithm. For simplicity, we skip postsmooting.
+%
+% Note: 
+% - Initial guess and forcing vector need to be hard-coded in main.cpp.
+% - Disable QR in tentative P
+%
+fineA = twoDimensionalLaplace(49);
+finex = [0 1 4 9 16 25 36 49 64 81 100 121 144 169 196 225 0 1 4 9 16 25 36 49 64 81 100 121 0 1 4 9 16 25 36 49 64 81 100 121 0 1 4 9 16 25 36 49 64]';
+fineb = zeros(size(finex));
+fineb(end) = 1e-3;
+findd = diag(fineA);
+omega = .67;
+
+Phat = [1 0 0 0 0   0 0 0 0; % 0
+        1 0 0 0 0   0 0 0 0; % 1
+        0 1 0 0 0   0 0 0 0; % 2
+        0 1 0 0 0   0 0 0 0; % 3
+        0 1 0 0 0   0 0 0 0; % 4
+        0 0 1 0 0   0 0 0 0; % 5
+        0 0 1 0 0   0 0 0 0; % 6
+        1 0 0 0 0   0 0 0 0; % 7
+        1 0 0 0 0   0 0 0 0; % 8
+        0 1 0 0 0   0 0 0 0; % 9
+        0 1 0 0 0   0 0 0 0; % 10
+        0 1 0 0 0   0 0 0 0; % 11
+        0 0 1 0 0   0 0 0 0; % 12
+        0 0 1 0 0   0 0 0 0; % 13
+        0 0 0 1 0   0 0 0 0; % 14
+        0 0 0 1 0   0 0 0 0; % 15
+        0 0 0 0 1   0 0 0 0; % 16
+        0 0 0 0 1   0 0 0 0; % 17
+        0 0 0 0 1   0 0 0 0; % 18
+        0 0 0 0 0   1 0 0 0; % 19
+        0 0 0 0 0   1 0 0 0; % 20
+        0 0 0 1 0   0 0 0 0; % 21
+        0 0 0 1 0   0 0 0 0; % 22
+        0 0 0 0 1   0 0 0 0; % 23
+        0 0 0 0 1   0 0 0 0; % 24
+        0 0 0 0 1   0 0 0 0; % 25
+        0 0 0 0 0   1 0 0 0; % 26
+        0 0 0 0 0   1 0 0 0; % 27
+        0 0 0 1 0   0 0 0 0; % 28
+        0 0 0 1 0   0 0 0 0; % 29
+        0 0 0 0 1   0 0 0 0; % 30
+        0 0 0 0 1   0 0 0 0; % 31
+        0 0 0 0 1   0 0 0 0; % 32
+        0 0 0 0 0   1 0 0 0; % 33
+        0 0 0 0 0   1 0 0 0; % 34
+        0 0 0 0 0   0 1 0 0; % 35
+        0 0 0 0 0   0 1 0 0; % 36
+        0 0 0 0 0   0 0 1 0; % 37
+        0 0 0 0 0   0 0 1 0; % 38
+        0 0 0 0 0   0 0 1 0; % 39
+        0 0 0 0 0   0 0 0 1; % 40
+        0 0 0 0 0   0 0 0 1; % 41
+        0 0 0 0 0   0 1 0 0; % 42
+        0 0 0 0 0   0 1 0 0; % 43
+        0 0 0 0 0   0 0 1 0; % 44
+        0 0 0 0 0   0 0 1 0; % 45
+        0 0 0 0 0   0 0 1 0; % 46
+        0 0 0 0 0   0 0 0 1; % 47
+        0 0 0 0 0   0 0 0 1;]; % 48
+    
+Rhat = Phat';
+AH = Rhat*fineA*Phat;
+coarsed = diag(AH);
+
+
+for i=1:1
+   finex =  finex + omega*(fineb - fineA*finex)./findd;
+   finer = fineb - fineA*finex;
+   fprintf('r is %20.13e\n',norm(finer));
+   coarseb = Rhat*finer;
+   coarsex = zeros(size(coarseb,1),1);
+   for k=1:1
+      coarsex =  coarsex + omega*(coarseb - AH*coarsex)./coarsed;
+   end
+   finex   = finex + Phat*coarsex;
+end
+Phat*coarsex,
+
+
+

--- a/packages/muelu/research/mmayr/composite_to_regions/src/shadow_caseTen.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/shadow_caseTen.m
@@ -42,17 +42,28 @@ Rhat = Phat';
 AH = Rhat*fineA*Phat;
 coarsed = diag(AH);
 
+onlyJacobi = false;
 
-for i=1:1
-   finex =  finex + omega*(fineb - fineA*finex)./findd;
-   finer = fineb - fineA*finex;
-   fprintf('r is %20.13e\n',norm(finer));
-   coarseb = Rhat*finer;
-   coarsex = zeros(size(coarseb,1),1);
-   for k=1:1
+if (onlyJacobi == true)
+  for i=1:1
+    finex =  finex + omega*(fineb - fineA*finex)./findd;
+    finer = fineb - fineA*finex;
+    fprintf('r is %20.13e\n',norm(finer));
+    coarseb = Rhat*finer;
+    coarsex = zeros(size(coarseb,1),1);
+    for k=1:1
       coarsex =  coarsex + omega*(coarseb - AH*coarsex)./coarsed;
-   end
-   finex   = finex + Phat*coarsex;
+    end
+    finex   = finex + Phat*coarsex;
+  end
+else
+  for i=1:1
+    finex =  finex + omega*(fineb - fineA*finex)./findd;
+    finer = fineb - fineA*finex;
+    fprintf('r is %20.13e\n',norm(finer));
+    coarseb = Rhat*finer;
+    coarsex = AH \ coarseb;
+  end
 end
 Phat*coarsex,
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
Enable regional multigrid code to 
- form a composite operator on the coarsest level
- perform a direct solve on the coarsest level (based on this composite operator)

## Motivation and Context
We usually want to use the regional framework for the fine and intermediate levels in order to exploit data locality and structuredness of the regions. However, on the coarsest level, a direct solve is required which in turn requires a composite operator. Furthermore, a coarse level operator can be used as a starting point for building an (unstructured) algebraic MG hierarchy on top of a region hierarchy. This allows to do true HHG-type problems.

## Related Issues

* Closes #2798 

## How Has This Been Tested?
Runs locally for small problems.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.