### PR TITLE
Teuchos: fix GCC 8.0 warning

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
@@ -273,7 +273,7 @@ namespace Teuchos {
         if (nonnull(stackedTimer_))
           stackedTimer_->stop(counter().name());
       }
-      catch (std::runtime_error) {
+      catch (std::runtime_error&) {
         std::ostringstream warning;
         warning <<
           "\n*********************************************************************\n"


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

## Description
<!--- Please describe your changes in detail. -->
Changed an exception type in `catch` to be a reference.
GCC 8.0 warns about not catching polymorphic exception classes by reference, even if they go unused.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Allows the Teuchos sub-packages I use to build without warnings under GCC 8.0 (with no non-default warning flags specified).

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

