### PR TITLE
Tpetra:  Issue3129 makeOptimizedColMapAndImport

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
@@ -462,7 +462,7 @@ namespace Details {
                                 bool& lclErr,
                                 const MapType& domMap,
                                 const MapType& colMap,
-                                const typename OptColMap<MapType>::import_type* oldImport)
+                                const typename OptColMap<MapType>::import_type* oldImport = nullptr)
   {
     using local_ordinal_type = typename MapType::local_ordinal_type;
     using global_ordinal_type = typename MapType::global_ordinal_type;

--- a/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
@@ -317,14 +317,10 @@ namespace Details {
     ///   Import: an Import from \c domMap to \c colMap.  This is not
     ///   required, but if you supply this, this function may use it
     ///   to avoid some communication and/or work when setting up the
-    ///   new Import object.  This function will <i>only</i> look at
-    ///   this pointer if \c makeImport is true.
-    /// \param makeImport [in] Whether to make and return an Import from
-    ///   the input domain Map to the new column Map.
+    ///   new Import object. 
     ///
     /// \return The possibly reordered column Map \c newColMap, and the
-    ///   corresponding Import from \c domMap to \c newColMap.  The
-    ///   latter is nonnull if and only if \c makeImport is true.
+    ///   corresponding Import from \c domMap to \c newColMap. 
     ///
     /// \pre \c domMap and \c colMap must have the same or congruent
     ///   communicators.
@@ -370,6 +366,11 @@ namespace Details {
   /// \param domMap [in] Domain Map of a CrsGraph or CrsMatrix.
   /// \param colMap [in] <i>Original</i> column Map of the same
   ///   CrsGraph or CrsMatrix as \c domMap.
+  /// \param oldImport [in] Optional pointer to the "original
+  ///   Import: an Import from \c domMap to \c colMap.  This is not
+  ///   required, but if you supply this, this function may use it
+  ///   to avoid some communication and/or work when setting up the
+  ///   new Import object. 
   ///
   /// \return The possibly reordered column Map \c newColMap.
   ///
@@ -422,12 +423,14 @@ namespace Details {
   /// \param domMap [in] Domain Map of a CrsGraph or CrsMatrix.
   /// \param colMap [in] <i>Original</i> column Map of the same
   ///   CrsGraph or CrsMatrix as \c domMap.
-  /// \param makeImport [in] Whether to make and return an Import from
-  ///   the input domain Map to the new column Map.
+  /// \param oldImport [in] Optional pointer to the "original
+  ///   Import: an Import from \c domMap to \c colMap.  This is not
+  ///   required, but if you supply this, this function may use it
+  ///   to avoid some communication and/or work when setting up the
+  ///   new Import object. 
   ///
   /// \return The possibly reordered column Map \c newColMap, and the
-  ///   corresponding Import from \c domMap to \c newColMap.  The
-  ///   latter is nonnull if and only if \c makeImport is true.
+  ///   corresponding Import from \c domMap to \c newColMap. 
   ///
   /// \pre \c domMap and \c colMap must have the same or congruent
   ///   communicators.
@@ -459,8 +462,7 @@ namespace Details {
                                 bool& lclErr,
                                 const MapType& domMap,
                                 const MapType& colMap,
-                                const typename OptColMap<MapType>::import_type* oldImport,
-                                const bool makeImport)
+                                const typename OptColMap<MapType>::import_type* oldImport)
   {
     using local_ordinal_type = typename MapType::local_ordinal_type;
     using global_ordinal_type = typename MapType::global_ordinal_type;
@@ -468,14 +470,8 @@ namespace Details {
     using map_type = ::Tpetra::Map<local_ordinal_type, global_ordinal_type, node_type>;
     using impl_type = OptColMap<map_type>;
 
-    if (! makeImport) {
-      auto mapPtr = impl_type::makeOptColMap (errStream, lclErr, domMap, colMap, oldImport);
-      return std::make_pair (mapPtr, Teuchos::null);
-    }
-    else {
-      auto mapAndImp = impl_type::makeOptColMapAndImport (errStream, lclErr, domMap, colMap, oldImport);
-      return std::make_pair (mapAndImp.first, mapAndImp.second);
-    }
+    auto mapAndImp = impl_type::makeOptColMapAndImport (errStream, lclErr, domMap, colMap, oldImport);
+    return std::make_pair (mapAndImp.first, mapAndImp.second);
   }
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
@@ -378,7 +378,7 @@ namespace Details {
   /// It does everything that that function does, except that it does
   /// not compute a new Import.
   template<class MapType>
-  MapType
+  Teuchos::RCP<const MapType>
   makeOptimizedColMap (std::ostream& errStream,
                        bool& lclErr,
                        const MapType& domMap,
@@ -395,7 +395,7 @@ namespace Details {
     using impl_type = OptColMap<map_type>;
     auto mapPtr = impl_type::makeOptColMap (errStream, lclErr,
                                             domMap, colMap, oldImport);
-    return *mapPtr;
+    return mapPtr;
   }
 
   /// \brief Return an optimized reordering of the given column Map.
@@ -453,7 +453,8 @@ namespace Details {
   /// domain Map) permits the use of contiguous send and receive
   /// buffers in Distributor, which is used in an Import operation.
   template<class MapType>
-  std::pair<MapType, Teuchos::RCP<typename OptColMap<MapType>::import_type> >
+  std::pair<Teuchos::RCP<const MapType>,
+            Teuchos::RCP<typename OptColMap<MapType>::import_type> >
   makeOptimizedColMapAndImport (std::ostream& errStream,
                                 bool& lclErr,
                                 const MapType& domMap,
@@ -469,11 +470,11 @@ namespace Details {
 
     if (! makeImport) {
       auto mapPtr = impl_type::makeOptColMap (errStream, lclErr, domMap, colMap, oldImport);
-      return std::make_pair (*mapPtr, Teuchos::null);
+      return std::make_pair (mapPtr, Teuchos::null);
     }
     else {
       auto mapAndImp = impl_type::makeOptColMapAndImport (errStream, lclErr, domMap, colMap, oldImport);
-      return std::make_pair (* (mapAndImp.first), mapAndImp.second);
+      return std::make_pair (mapAndImp.first, mapAndImp.second);
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
@@ -88,8 +88,7 @@ namespace Details {
     makeOptColMap (std::ostream& errStream,
                    bool& lclErr,
                    const map_type& domMap,
-                   const map_type& colMap,
-                   const import_type* /* oldImport */)
+                   const map_type& colMap)
     {
       using ::Tpetra::Details::Behavior;
       using Teuchos::Array;
@@ -313,18 +312,9 @@ namespace Details {
     /// \param domMap [in] Domain Map of a CrsGraph or CrsMatrix.
     /// \param colMap [in] <i>Original</i> column Map of the same
     ///   CrsGraph or CrsMatrix as \c domMap.
-    /// \param oldImport [in] Optional pointer to the "original
-    ///   Import: an Import from \c domMap to \c colMap.  This is not
-    ///   required, but if you supply this, this function may use it
-    ///   to avoid some communication and/or work when setting up the
-    ///   new Import object.  This function will <i>only</i> look at
-    ///   this pointer if \c makeImport is true.
-    /// \param makeImport [in] Whether to make and return an Import from
-    ///   the input domain Map to the new column Map.
     ///
     /// \return The possibly reordered column Map \c newColMap, and the
-    ///   corresponding Import from \c domMap to \c newColMap.  The
-    ///   latter is nonnull if and only if \c makeImport is true.
+    ///   corresponding Import from \c domMap to \c newColMap.  
     ///
     /// \pre \c domMap and \c colMap must have the same or congruent
     ///   communicators.
@@ -335,8 +325,7 @@ namespace Details {
     makeOptColMapAndImport (std::ostream& errStream,
                             bool& lclErr,
                             const map_type& domMap,
-                            const map_type& colMap,
-                            const import_type* oldImport)
+                            const map_type& colMap)
     {
       using Teuchos::RCP;
       using Teuchos::rcp;
@@ -345,7 +334,7 @@ namespace Details {
       // the conventional two-Map (source and target) Import
       // constructor.
       RCP<const map_type> newColMap =
-        makeOptColMap (errStream, lclErr, domMap, colMap, oldImport);
+        makeOptColMap (errStream, lclErr, domMap, colMap);
       RCP<import_type> imp (new import_type (rcp (new map_type (domMap)), newColMap));
 
       // FIXME (mfh 06 Jul 2014) This constructor throws a runtime
@@ -382,19 +371,14 @@ namespace Details {
   makeOptimizedColMap (std::ostream& errStream,
                        bool& lclErr,
                        const MapType& domMap,
-                       const MapType& colMap,
-                       const Tpetra::Import<
-                         typename MapType::local_ordinal_type,
-                         typename MapType::global_ordinal_type,
-                         typename MapType::node_type>* oldImport = nullptr)
+                       const MapType& colMap)
   {
     using map_type = ::Tpetra::Map<
       typename MapType::local_ordinal_type,
       typename MapType::global_ordinal_type,
       typename MapType::node_type>;
     using impl_type = OptColMap<map_type>;
-    auto mapPtr = impl_type::makeOptColMap (errStream, lclErr,
-                                            domMap, colMap, oldImport);
+    auto mapPtr = impl_type::makeOptColMap (errStream, lclErr, domMap, colMap);
     return mapPtr;
   }
 
@@ -407,7 +391,7 @@ namespace Details {
   /// distributed graph (Tpetra::CrsGraph) or matrix (e.g.,
   /// Tpetra::CrsMatrix).  It then creates a new column Map, which
   /// optimizes the performance of an Import operation from the domain
-  /// Map to the new column Map.  This function also optionally
+  /// Map to the new column Map.  This function also 
   /// creates that Import.  Creating the new column Map and its Import
   /// at the same time saves some communication, since making the
   /// Import requires some of the same information that optimizing the
@@ -422,12 +406,9 @@ namespace Details {
   /// \param domMap [in] Domain Map of a CrsGraph or CrsMatrix.
   /// \param colMap [in] <i>Original</i> column Map of the same
   ///   CrsGraph or CrsMatrix as \c domMap.
-  /// \param makeImport [in] Whether to make and return an Import from
-  ///   the input domain Map to the new column Map.
   ///
   /// \return The possibly reordered column Map \c newColMap, and the
-  ///   corresponding Import from \c domMap to \c newColMap.  The
-  ///   latter is nonnull if and only if \c makeImport is true.
+  ///   corresponding Import from \c domMap to \c newColMap. 
   ///
   /// \pre \c domMap and \c colMap must have the same or congruent
   ///   communicators.
@@ -458,9 +439,7 @@ namespace Details {
   makeOptimizedColMapAndImport (std::ostream& errStream,
                                 bool& lclErr,
                                 const MapType& domMap,
-                                const MapType& colMap,
-                                const typename OptColMap<MapType>::import_type* oldImport,
-                                const bool makeImport)
+                                const MapType& colMap)
   {
     using local_ordinal_type = typename MapType::local_ordinal_type;
     using global_ordinal_type = typename MapType::global_ordinal_type;
@@ -468,14 +447,8 @@ namespace Details {
     using map_type = ::Tpetra::Map<local_ordinal_type, global_ordinal_type, node_type>;
     using impl_type = OptColMap<map_type>;
 
-    if (! makeImport) {
-      auto mapPtr = impl_type::makeOptColMap (errStream, lclErr, domMap, colMap, oldImport);
-      return std::make_pair (mapPtr, Teuchos::null);
-    }
-    else {
-      auto mapAndImp = impl_type::makeOptColMapAndImport (errStream, lclErr, domMap, colMap, oldImport);
-      return std::make_pair (mapAndImp.first, mapAndImp.second);
-    }
+    auto mapAndImp = impl_type::makeOptColMapAndImport (errStream, lclErr, domMap, colMap);
+    return std::make_pair (mapAndImp.first, mapAndImp.second);
   }
 
 } // namespace Details

--- a/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
+++ b/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
@@ -615,7 +615,7 @@ runTest (Teuchos::FancyOStream& out,
     Teuchos::RCP<const map_type> actualTgtMap =
       Tpetra::Details::makeOptimizedColMap (out, lclErr, *sourceMap,
                                             *expUnoptTgtMap,
-                                            expUnoptImport.getRawPtr ());;
+                                            expUnoptImport.getRawPtr ());
     const bool gblMadeItThrough = trueEverywhere (! lclErr, *comm);
     TEST_ASSERT( gblMadeItThrough );
     if (! gblMadeItThrough) {

--- a/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
+++ b/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
@@ -614,8 +614,7 @@ runTest (Teuchos::FancyOStream& out,
     bool lclErr = false;
     Teuchos::RCP<const map_type> actualTgtMap =
       Tpetra::Details::makeOptimizedColMap (out, lclErr, *sourceMap,
-                                            *expUnoptTgtMap,
-                                            expUnoptImport.getRawPtr ());;
+                                            *expUnoptTgtMap);
     const bool gblMadeItThrough = trueEverywhere (! lclErr, *comm);
     TEST_ASSERT( gblMadeItThrough );
     if (! gblMadeItThrough) {

--- a/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
+++ b/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
@@ -612,7 +612,7 @@ runTest (Teuchos::FancyOStream& out,
 
     std::ostringstream errStrm;
     bool lclErr = false;
-    const map_type actualTgtMap =
+    Teuchos::RCP<const map_type> actualTgtMap =
       Tpetra::Details::makeOptimizedColMap (out, lclErr, *sourceMap,
                                             *expUnoptTgtMap,
                                             expUnoptImport.getRawPtr ());;
@@ -624,9 +624,9 @@ runTest (Teuchos::FancyOStream& out,
     }
 
     out << "Actual target Map:" << endl;
-    printMapCompactly (out, actualTgtMap);
+    printMapCompactly (out, *actualTgtMap);
 
-    const import_type actualImport (sourceMap, rcp (new map_type (actualTgtMap)));
+    const import_type actualImport (sourceMap, actualTgtMap);
     const bool gblImportsSame =
       importsGloballySame (out, *expOptImport, "expOptImport",
                            actualImport, "actualImport");

--- a/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
+++ b/packages/tpetra/core/test/ImportExport/Issue_2198.cpp
@@ -614,7 +614,8 @@ runTest (Teuchos::FancyOStream& out,
     bool lclErr = false;
     Teuchos::RCP<const map_type> actualTgtMap =
       Tpetra::Details::makeOptimizedColMap (out, lclErr, *sourceMap,
-                                            *expUnoptTgtMap);
+                                            *expUnoptTgtMap,
+                                            expUnoptImport.getRawPtr ());;
     const bool gblMadeItThrough = trueEverywhere (! lclErr, *comm);
     TEST_ASSERT( gblMadeItThrough );
     if (! gblMadeItThrough) {

--- a/packages/tpetra/core/test/ImportExport/MakeOptColMap.cpp
+++ b/packages/tpetra/core/test/ImportExport/MakeOptColMap.cpp
@@ -308,53 +308,19 @@ namespace {
       TEST_ASSERT( colMapsCompat );
     }
 
-    // Call makeOptimizedColMapAndImport with makeImport = false.
-    // This should have the same result as makeOptimizedColMap.
-    out << "Calling makeOptimizedColMapAndImport with makeImport = false" << endl;
-    std::ostringstream errStrm2;
-    bool lclErr2 = false;
-    std::pair<RCP<const map_type>, RCP<import_type> > result2 =
-      makeOptimizedColMapAndImport<map_type> (errStrm2, lclErr2, domMap,
-                                              oldColMap, NULL, false);
-    // We asked it not to make an Import, so it shouldn't have made an Import.
-    TEST_ASSERT( result2.second.is_null () );
-    // Make sure that all processes succeeded.
-    lclSuccess = lclErr2 ? 0 : 1;
-    gblSuccess = 1;
-    reduceAll<int, int> (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
-    TEST_EQUALITY( gblSuccess, 1 );
-    if (gblSuccess != 1) {
-      reportErrors (comm, errStrm2, lclErr2);
-    }
-    // Check that calling makeOptimizedColMapAndImport with makeImport
-    // = false produces the same column Map as makeOptimizedColMap.
-    //
-    // NOTE (mfh 05 Jul 2014) It's bad form to put any kind of
-    // "serious" function call in a macro, even if that function
-    // promises to have no side effects.  This is because the macro
-    // might be defined _not_ to call the function.  For example, the
-    // function might have collective semantics.  In that case,
-    // putting the function call in the macro would make that line of
-    // code no longer a collective, thus possibly changing the
-    // behavior of code that follows.
-    {
-      const bool sameMaps = result2.first->isSameAs (*newColMap);
-      TEST_ASSERT( sameMaps );
-    }
-
-    // Call makeOptimizedColMapAndImport with makeImport = true.  This
+    // Call makeOptimizedColMapAndImport.  This
     // will make both the optimized column Map, and its corresponding
     // Import (from the domain Map 'domMap' to the new column Map).
     // Note that the function only promises to make an Import if
     // necessary, that is, if the domain Map and the new column Map
     // are not the same.
-    out << "Calling makeOptimizedColMapAndImport with makeImport = true"
+    out << "Calling makeOptimizedColMapAndImport"
         << endl;
     std::ostringstream errStrm3;
     bool lclErr3 = false;
     std::pair<RCP<const map_type>, RCP<import_type> > result3 =
       makeOptimizedColMapAndImport<map_type> (errStrm3, lclErr3, domMap,
-                                              oldColMap, NULL, true);
+                                              oldColMap, NULL);
     // Make sure that all processes succeeded.
     lclSuccess = lclErr3 ? 0 : 1;
     gblSuccess = 1;
@@ -363,8 +329,8 @@ namespace {
     if (gblSuccess != 1) {
       reportErrors (comm, errStrm3, lclErr3);
     }
-    // Check that calling makeOptimizedColMapAndImport with makeImport
-    // = true produces the same column Map as makeOptimizedColMap.
+    // Check that calling makeOptimizedColMapAndImport 
+    // produces the same column Map as makeOptimizedColMap.
     {
       const bool sameMaps = result3.first->isSameAs (*newColMap);
       TEST_ASSERT( sameMaps );

--- a/packages/tpetra/core/test/ImportExport/MakeOptColMap.cpp
+++ b/packages/tpetra/core/test/ImportExport/MakeOptColMap.cpp
@@ -308,16 +308,14 @@ namespace {
       TEST_ASSERT( colMapsCompat );
     }
 
-    // Call makeOptimizedColMapAndImport with makeImport = false.
+    // Call makeOptimizedColMapAndImport 
     // This should have the same result as makeOptimizedColMap.
     out << "Calling makeOptimizedColMapAndImport with makeImport = false" << endl;
     std::ostringstream errStrm2;
     bool lclErr2 = false;
     std::pair<RCP<const map_type>, RCP<import_type> > result2 =
       makeOptimizedColMapAndImport<map_type> (errStrm2, lclErr2, domMap,
-                                              oldColMap, NULL, false);
-    // We asked it not to make an Import, so it shouldn't have made an Import.
-    TEST_ASSERT( result2.second.is_null () );
+                                              oldColMap);
     // Make sure that all processes succeeded.
     lclSuccess = lclErr2 ? 0 : 1;
     gblSuccess = 1;
@@ -326,8 +324,8 @@ namespace {
     if (gblSuccess != 1) {
       reportErrors (comm, errStrm2, lclErr2);
     }
-    // Check that calling makeOptimizedColMapAndImport with makeImport
-    // = false produces the same column Map as makeOptimizedColMap.
+    // Check that calling makeOptimizedColMapAndImport 
+    // produces the same column Map as makeOptimizedColMap.
     //
     // NOTE (mfh 05 Jul 2014) It's bad form to put any kind of
     // "serious" function call in a macro, even if that function
@@ -342,45 +340,17 @@ namespace {
       TEST_ASSERT( sameMaps );
     }
 
-    // Call makeOptimizedColMapAndImport with makeImport = true.  This
-    // will make both the optimized column Map, and its corresponding
-    // Import (from the domain Map 'domMap' to the new column Map).
-    // Note that the function only promises to make an Import if
-    // necessary, that is, if the domain Map and the new column Map
-    // are not the same.
-    out << "Calling makeOptimizedColMapAndImport with makeImport = true"
-        << endl;
-    std::ostringstream errStrm3;
-    bool lclErr3 = false;
-    std::pair<RCP<const map_type>, RCP<import_type> > result3 =
-      makeOptimizedColMapAndImport<map_type> (errStrm3, lclErr3, domMap,
-                                              oldColMap, NULL, true);
-    // Make sure that all processes succeeded.
-    lclSuccess = lclErr3 ? 0 : 1;
-    gblSuccess = 1;
-    reduceAll<int, int> (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
-    TEST_EQUALITY( gblSuccess, 1 );
-    if (gblSuccess != 1) {
-      reportErrors (comm, errStrm3, lclErr3);
-    }
-    // Check that calling makeOptimizedColMapAndImport with makeImport
-    // = true produces the same column Map as makeOptimizedColMap.
-    {
-      const bool sameMaps = result3.first->isSameAs (*newColMap);
-      TEST_ASSERT( sameMaps );
-    }
-
     out << "Check that either the domain and new column Maps are the same, "
       "or that the returned Import is nontrivial (nonnull)." << endl;
     // Make sure that on all processes, either the domain and new
     // column Maps are the same, or the returned Import is nontrivial
     // (nonnull).
-    lclSuccess = (result3.first->isSameAs (domMap) || ! result3.second.is_null ());
+    lclSuccess = (result2.first->isSameAs (domMap) || ! result2.second.is_null ());
     gblSuccess = 1;
     reduceAll<int, int> (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
     TEST_EQUALITY( gblSuccess, 1 );
 
-    if (gblSuccess && ! result3.second.is_null ()) {
+    if (gblSuccess && ! result2.second.is_null ()) {
       // The tests below only make sense if the returned Import is
       // nontrivial (nonnull).  Checking gblSuccess as well as the
       // Import ensures that the above condition is true on all
@@ -393,8 +363,8 @@ namespace {
       // below are collective.
       out << "The returned Import is nontrivial.  "
         "Check that its source and target Maps are nonnull." << endl;
-      lclSuccess = ! result3.second->getSourceMap ().is_null () &&
-        ! result3.second->getTargetMap ().is_null ();
+      lclSuccess = ! result2.second->getSourceMap ().is_null () &&
+        ! result2.second->getTargetMap ().is_null ();
       gblSuccess = 1;
       reduceAll<int, int> (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
       TEST_EQUALITY( gblSuccess, 1 );
@@ -411,8 +381,8 @@ namespace {
 
         // These are collectives.  We may safely call them without
         // risk of deadlock, because of the global checks above.
-        TEST_ASSERT( result3.second->getSourceMap ()->isSameAs (domMap) );
-        TEST_ASSERT( result3.second->getTargetMap ()->isSameAs (*newColMap) );
+        TEST_ASSERT( result2.second->getSourceMap ()->isSameAs (domMap) );
+        TEST_ASSERT( result2.second->getTargetMap ()->isSameAs (*newColMap) );
       }
 
       // Create an Import from domMap to newColMap in the usual way.
@@ -421,7 +391,7 @@ namespace {
       out << "Compare the returned Import against an Import created in the "
         "conventional way." << endl;
       import_type newImport (Teuchos::rcp (new map_type (domMap)),
-                             result3.first);
+                             result2.first);
       // It should always be the case that an Import's source and target
       // Maps are nonnull, especially if the Import was created in the
       // usual way.  It's worth checking, though.
@@ -438,25 +408,25 @@ namespace {
         // global checks above.
 
         // Check that both Imports' source Maps are the same.
-        const map_type& srcMap = * (result3.second->getSourceMap ());
+        const map_type& srcMap = * (result2.second->getSourceMap ());
         const bool srcMapsSame = srcMap.isSameAs (* (newImport.getSourceMap ()));
         TEST_ASSERT( srcMapsSame );
 
         // Check that both Imports' target Maps are the same.
-        const map_type& tgtMap = * (result3.second->getTargetMap ());
+        const map_type& tgtMap = * (result2.second->getTargetMap ());
         const bool tgtMapsSame = tgtMap.isSameAs (* (newImport.getTargetMap ()));
         TEST_ASSERT( tgtMapsSame );
 
         // Check that both Imports are the same.
         const bool impSame =
-          importsGloballySame<import_type> (* (result3.second), newImport);
+          importsGloballySame<import_type> (* (result2.second), newImport);
         TEST_ASSERT( impSame );
       }
     }
 
     // The calling test may want to check the returned Map and Import
     // in other ways, so we return them.
-    return result3;
+    return result2;
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( MakeOptColMap, Test1, LO, GO )


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Description
minor changes to address #3129 
consistent return arguments in std::pair
removed unused and/or unneeded arguments

## Motivation and Context
simplify interface

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
make test on mac, clang compiler
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ x] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ x] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
