### PR TITLE
Tpetra:  clean up warnings reported by clang

### DIFF
--- a/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
+++ b/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
@@ -287,7 +287,7 @@ public:
 
     int numPacketsForCount = 0; // output argument of countPackTriplesCount
     {
-      const int errCode =
+      errCode =
         countPackTriplesCount (comm, numPacketsForCount, errStrm);
       if (errCode != 0) {
         if (errStrm != NULL) {
@@ -307,7 +307,7 @@ public:
 
     int numPacketsForTriples = 0; // output argument of countPackTriples
     {
-      const int errCode = countPackTriples<SC, GO> (numEnt, comm, numPacketsForTriples);
+      errCode = countPackTriples<SC, GO> (numEnt, comm, numPacketsForTriples);
       TEUCHOS_TEST_FOR_EXCEPTION
         (errCode != 0, std::runtime_error, prefix << "countPackTriples "
          "returned errCode = " << errCode << " != 0.");

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_decl.hpp
@@ -62,7 +62,7 @@ class RowMatrix;
 
 namespace Details {
 template<class ValueType, class DeviceType>
-class EquilibrationInfo;
+struct EquilibrationInfo;
 } // namespace Details
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests0.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests0.cpp
@@ -1081,7 +1081,7 @@ namespace {
                 TEST_COMPARE_ARRAYS( inds (0, numinds), grows (0, numunique) );
 
                 out << "On Proc 0:" << endl;
-                Teuchos::OSTab tab2 (out);
+                Teuchos::OSTab tab5 (out);
                 out << "numinds: " << numinds << endl
                     << "inds(0,numinds): " << inds (0, numinds) << endl
                     << "numunique: " << numunique << endl

--- a/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
@@ -1121,7 +1121,6 @@ makeSymmetricPositiveDefiniteTridiagonalMatrixTest (Teuchos::FancyOStream& out,
     for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
       const GO gblRow = rowMap->getGlobalElement (lclRow);
       const GO gblCol = gblRow;
-      mag_type lclRowScaledColNorm {0.0};
 
       if (gblRow == rowMap->getMinAllGlobalIndex ()) {
         const LO diagLclColInd = colMap->getLocalElement (gblCol);
@@ -1414,9 +1413,7 @@ makeMatrixTestWithExplicitZeroDiag (Teuchos::FancyOStream& out,
       const GO gblRow = rowMap->getGlobalElement (lclRow);
       const GO gblCol = gblRow;
       const LO lclCol = colMap->getLocalElement (gblCol);
-      mag_type lclRowScaledColNorm {0.0};
 
-      const mag_type matrixAbsVal = myRank == 1 ? 0.0 : 1.0;
       lclRowScaledColNorms[lclCol] = myRank == 1 ?
         NaughtyValues<mag_type>::quiet_NaN () : 1.0;
     }
@@ -1652,9 +1649,7 @@ makeMatrixTestWithImplicitZeroDiag (Teuchos::FancyOStream& out,
       const GO gblCol = gblRow;
       const LO lclCol = colMap->getLocalElement (gblCol);
       if (lclCol != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
-        mag_type lclRowScaledColNorm {0.0};
 
-        const mag_type matrixAbsVal = myRank == 1 ? 0.0 : 1.0;
         lclRowScaledColNorms[lclCol] = myRank == 1 ?
           NaughtyValues<mag_type>::quiet_NaN () : 1.0;
       }
@@ -1919,7 +1914,6 @@ makeMatrixTestWithExplicitInfAndNan (Teuchos::FancyOStream& out,
       const GO gblRow = rowMap->getGlobalElement (lclRow);
       const GO gblCol = gblRow;
       const LO lclCol = colMap->getLocalElement (gblCol);
-      mag_type lclRowScaledColNorm {0.0};
 
       mag_type matrixAbsVal = 1.0;
       if (myRank == 1) {
@@ -2060,12 +2054,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Equilibration, Test0, SC, LO, GO, NT)
     std::function<test_return_type (FancyOStream&,
                                     const RCP<const Comm<int> >&,
                                     const bool)>;
-  std::array<test_type, 4> tests {
+  std::array<test_type, 4> tests {{
     makeSymmetricPositiveDefiniteTridiagonalMatrixTest<SC, LO, GO, NT>,
     makeMatrixTestWithExplicitZeroDiag<SC, LO, GO, NT>,
     makeMatrixTestWithExplicitInfAndNan<SC, LO, GO, NT>,
     makeMatrixTestWithImplicitZeroDiag<SC, LO, GO, NT>
-  };
+  }};
 
   for (bool assumeSymmetric : {false, true}) {
     for (auto&& currentTest : tests) {

--- a/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
@@ -1037,8 +1037,8 @@ namespace { // (anonymous)
       testEntriesOfNonoverlappingCrsMatrix (out, success,
                                             *A_nonoverlapping,
                                             *colMap_expected);
-      const int lclSuccess = success ? 1 : 0;
-      int gblSuccess = 0; // output argument
+      lclSuccess = success ? 1 : 0;
+      gblSuccess = 0; // output argument
       reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
       TEST_EQUALITY_CONST( gblSuccess, 1 );
       if (gblSuccess != 1) {
@@ -1102,8 +1102,8 @@ namespace { // (anonymous)
       testEntriesOfNonoverlappingCrsMatrix (out, success,
                                             *A_nonoverlapping,
                                             *colMap_expected);
-      const int lclSuccess = success ? 1 : 0;
-      int gblSuccess = 0; // output argument
+      lclSuccess = success ? 1 : 0;
+      gblSuccess = 0; // output argument
       reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
       TEST_EQUALITY_CONST( gblSuccess, 1 );
       if (gblSuccess != 1) {

--- a/packages/tpetra/core/test/ImportExport/ImportExport_ImportConstructExpert.cpp
+++ b/packages/tpetra/core/test/ImportExport/ImportExport_ImportConstructExpert.cpp
@@ -60,7 +60,7 @@ namespace {
   using Teuchos::outArg;
   using std::endl;
 
-  bool testMpi = true;
+  // bool testMpi = true;
 
   TEUCHOS_STATIC_SETUP()
   {

--- a/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
@@ -91,7 +91,7 @@ namespace {
   using Tpetra::createContigMap;
   using Tpetra::createContigMapWithNode;
 
-  bool testMpi = true;
+  // bool testMpi = true;
   double errorTolSlack = 1e+1;
 
   TEUCHOS_STATIC_SETUP()

--- a/packages/tpetra/core/test/Map/Map_UnitTests.cpp
+++ b/packages/tpetra/core/test/Map/Map_UnitTests.cpp
@@ -127,7 +127,7 @@ namespace {
       TEST_EQUALITY( m->getMinAllGlobalIndex(),
 		     static_cast<GO> (0) );
       TEST_EQUALITY( m->getMaxAllGlobalIndex(),
-		     static_cast<size_t> (numImages-1) );
+		     static_cast<GO> (numImages-1) );
     }
 
     // Make sure that the test passed on all MPI processes.

--- a/packages/tpetra/core/test/Map/NegativeBaseIndexTest.cpp
+++ b/packages/tpetra/core/test/Map/NegativeBaseIndexTest.cpp
@@ -66,7 +66,6 @@ namespace {
   {
     using std::endl;
     using map_type = Tpetra::Map<>;
-    using LO = Tpetra::Map<>::local_ordinal_type;
     using GO = Tpetra::Map<>::global_ordinal_type;
     using size_type = Teuchos::Array<GO>::size_type;
     

--- a/packages/tpetra/core/test/inout/CooMatrixImpl.cpp
+++ b/packages/tpetra/core/test/inout/CooMatrixImpl.cpp
@@ -98,11 +98,11 @@ testCooMatrixImpl (bool& success, Teuchos::FancyOStream& out)
   }
 
   const size_t origNumEnt = 6;
-  const GO gblRowInds[] = {418, 31, 31, 31, 666, 93};
-  const GO gblColInds[] = {7, 5, 6, 5, 4, 3};
-  const SC vals[] = {7.0, 1.0, 2.0, 3.0, 10.0, 11.0};
+  const GO origGblRowInds[] = {418, 31, 31, 31, 666, 93};
+  const GO origGblColInds[] = {7, 5, 6, 5, 4, 3};
+  const SC origVals[] = {7.0, 1.0, 2.0, 3.0, 10.0, 11.0};
 
-  A.sumIntoGlobalValues (gblRowInds, gblColInds, vals, origNumEnt);
+  A.sumIntoGlobalValues (origGblRowInds, origGblColInds, origVals, origNumEnt);
 
   const size_t expectedNumEnt = 5;
   TEST_ASSERT( A.getLclNumEntries () == expectedNumEnt );


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Description
These changes remove compiler warnings in Tpetra code and tests that were reported in builds using clang on a mac.  Most warnings related to unused variables or shadow declarations.

## Motivation and Context
Trying to keep the compilation clean.

<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
Extensive build of Tpetra through MueLu, Ifpack2, Xpetra, etc., on mac and linux.
All tests passed except         
230 - MueLu_Maxwell3D-Tpetra-Stratimikos_MPI_4 (Failed)
This test also failed in equivalent develop branch testing.


<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
