### PR TITLE
MueLu,Galeri: Purge use of Tpetra::DefaultPlatform

### DIFF
--- a/packages/galeri/test/bug_5851.cpp
+++ b/packages/galeri/test/bug_5851.cpp
@@ -1,5 +1,5 @@
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Xpetra_Vector.hpp>
 #include <Xpetra_CrsMatrix.hpp>
@@ -57,11 +57,11 @@ int buildCrsMatrix(int xdim, int ydim, int zdim, std::string problemType,
                                      Tpetra::CrsMatrix<scalar_t, lno_t, gno_t>,
                                      Tpetra::MultiVector<scalar_t, lno_t, gno_t> >
                         (params.GetMatrixType(), map, params.GetParameterList());
-    if (comm->getRank() == 0) 
+    if (comm->getRank() == 0)
       cout << "AFTER GALERI BuildProblem M_=" << M_ << endl;
 
     M_ = Pr->BuildMatrix();
-    if (comm->getRank() == 0) 
+    if (comm->getRank() == 0)
       cout << "AFTER GALERI BuildMatrix  M_=" << M_ << endl;
   }
   catch (std::exception &e) {    // Probably not enough memory
@@ -70,7 +70,7 @@ int buildCrsMatrix(int xdim, int ydim, int zdim, std::string problemType,
   }
   if (M_.is_null())
     return 1;
-  else 
+  else
     return 0;
 }
 
@@ -78,9 +78,8 @@ int main(int narg, char **arg)
 {
   int ierr, jerr;
 
-  Teuchos::GlobalMPISession mpiSession(&narg, &arg, NULL);
-  RCP<const Teuchos::Comm<int> > comm =
-    Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  Tpetra::ScopeGuard mpiSession(&narg, &arg);
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   if (comm->getRank() == 0) cout << "TESTING WITH scalar_t == DOUBLE" << endl;
   ierr = buildCrsMatrix<int, long, double>(10, 10, 10, std::string("Laplace3D"), comm);

--- a/packages/muelu/example/advanced/memory/Tpetra1DLaplace.cpp
+++ b/packages/muelu/example/advanced/memory/Tpetra1DLaplace.cpp
@@ -43,13 +43,11 @@
 // ***********************************************************************
 //
 // @HEADER
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_Array.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -59,8 +57,7 @@
 #include "MueLu_MemoryProfiler.hpp"
 
 int main(int argc, char *argv[]) {
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv,&blackhole);
+  Tpetra::ScopeGuard mpiSession(&argc,&argv);
 
   bool success = false;
   bool verbose = true;
@@ -81,8 +78,7 @@ int main(int argc, char *argv[]) {
     using Teuchos::rcp;
     using Teuchos::tuple;
 
-    RCP<const Teuchos::Comm<int> > comm =
-      Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
     //const int myRank = comm->getRank();
 
     //int numGlobalElements = 10000000;

--- a/packages/muelu/matlab/bin/muemex.cpp
+++ b/packages/muelu/matlab/bin/muemex.cpp
@@ -55,7 +55,7 @@
 #error "MueMex requires Epetra, Tpetra and MATLAB."
 #endif
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include "MueLu_MatlabUtils.hpp"
 #include "MueLu_TwoLevelMatlabFactory.hpp"
 #include "MueLu_SingleLevelMatlabFactory.hpp"
@@ -256,7 +256,7 @@ mxArray* TpetraSystem<Scalar>::solve(RCP<ParameterList> params, RCP<Tpetra::CrsM
     typedef Tpetra::Vector<Scalar, mm_LocalOrd, mm_GlobalOrd, mm_node_t> Tpetra_Vector;
     typedef Tpetra::MultiVector<Scalar, mm_LocalOrd, mm_GlobalOrd, mm_node_t> Tpetra_MultiVector;
     typedef Tpetra::Operator<Scalar, mm_LocalOrd, mm_GlobalOrd, mm_node_t> Tpetra_Operator;
-    RCP<const Teuchos::Comm<int>> comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
     //numGlobalIndices for map constructor is the number of rows in matrix/vectors, right?
     RCP<const muemex_map_type> map = rcp(new muemex_map_type(matSize, (mm_GlobalOrd) 0, comm));
     RCP<Tpetra_MultiVector> rhs = loadDataFromMatlab<RCP<Tpetra::MultiVector<Scalar, mm_LocalOrd, mm_GlobalOrd, mm_node_t>>>(b);
@@ -1170,10 +1170,10 @@ void parse_list_item(RCP<ParameterList> List, char *option_name, const mxArray *
         List->set(option_name, *opt_int);
 #ifdef HAVE_MUELU_INTREPID2
       else if (strcmp(option_name, "pcoarsen: element to node map") == 0)
-	List->set(option_name, loadDataFromMatlab<RCP<FieldContainer_ordinal>>(prhs));
+        List->set(option_name, loadDataFromMatlab<RCP<FieldContainer_ordinal>>(prhs));
 #endif
-      else 
-	List->set(option_name, loadDataFromMatlab<RCP<Xpetra_ordinal_vector>>(prhs));
+      else
+        List->set(option_name, loadDataFromMatlab<RCP<Xpetra_ordinal_vector>>(prhs));
       break;
       // NTS: 64-bit ints will break on a 32-bit machine.        We
       // should probably detect machine type, or somthing, but that would

--- a/packages/muelu/matlab/src/MueLu_MatlabUtils_decl.hpp
+++ b/packages/muelu/matlab/src/MueLu_MatlabUtils_decl.hpp
@@ -73,7 +73,7 @@
 #include "Xpetra_MapFactory.hpp"
 #include "Xpetra_CrsGraph.hpp"
 #include "Xpetra_VectorFactory.hpp"
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 
 #include "Kokkos_DynRankView.hpp"
 

--- a/packages/muelu/matlab/src/MueLu_MatlabUtils_def.hpp
+++ b/packages/muelu/matlab/src/MueLu_MatlabUtils_def.hpp
@@ -269,7 +269,7 @@ RCP<Tpetra_MultiVector_double> loadDataFromMatlab<RCP<Tpetra_MultiVector_double>
     int nr = mxGetM(mxa);
     int nc = mxGetN(mxa);
     double* pr = mxGetPr(mxa);
-    RCP<const Teuchos::Comm<int>> comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
     //numGlobalIndices for map constructor is the number of rows in matrix/vectors, right?
     RCP<const muemex_map_type> map = rcp(new muemex_map_type(nr, (mm_GlobalOrd) 0, comm));
     //Allocate a new array of complex values to use with the multivector
@@ -294,7 +294,7 @@ RCP<Tpetra_MultiVector_complex> loadDataFromMatlab<RCP<Tpetra_MultiVector_comple
     int nc = mxGetN(mxa);
     double* pr = mxGetPr(mxa);
     double* pi = mxGetPi(mxa);
-    RCP<const Teuchos::Comm<int>> comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
     //numGlobalIndices for map constructor is the number of rows in matrix/vectors, right?
     RCP<const muemex_map_type> map = rcp(new muemex_map_type(nr, (mm_GlobalOrd) 0, comm));
     //Allocate a new array of complex values to use with the multivector
@@ -391,7 +391,7 @@ RCP<Tpetra_CrsMatrix_complex> loadDataFromMatlab<RCP<Tpetra_CrsMatrix_complex>>(
   //Create a map in order to create the matrix (taken from muelu basic example - complex)
   try
   {
-    RCP<const Teuchos::Comm<int>> comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+    RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
     const Tpetra::global_size_t numGlobalIndices = mxGetM(mxa);
     const mm_GlobalOrd indexBase = 0;
     RCP<const muemex_map_type> rowMap = rcp(new muemex_map_type(numGlobalIndices, indexBase, comm));
@@ -1311,11 +1311,11 @@ mxArray* saveDataToMatlab(RCP<FieldContainer_ordinal>& data)
 
   int nr = data->dimension(0);
   int nc = data->dimension(1);
-  
+
   mwSize dims[]={(mwSize)nr,(mwSize)nc};
   mxArray* mxa = mxCreateNumericArray(2,dims, mxINT32_CLASS, mxREAL);
   int *array = (int*) mxGetData(mxa);
-  
+
   for(int col = 0; col < nc; col++)
   {
     for(int row = 0; row < nr; row++)

--- a/packages/muelu/research/q2q1/Q2Q1.cpp
+++ b/packages/muelu/research/q2q1/Q2Q1.cpp
@@ -55,7 +55,7 @@
 
 #ifdef HAVE_MUELU_TPETRA
 #include <Tpetra_CrsMatrix.hpp>
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #endif
 
@@ -225,7 +225,6 @@ int main(int argc, char *argv[]) {
     typedef Tpetra::MultiVector<SC,LO,GO,NO>      tMultiVector;
     typedef Tpetra::Map<LO,GO,NO>                 tMap;
     typedef Thyra::TpetraVectorSpace<SC,LO,GO,NO> THTP_Vs;
-    RCP<NO> node = Tpetra::DefaultPlatform::getDefaultPlatform().getNode();
 
     // Read data from files
     RCP<tOperator> A11, A119Pt, A21, A12;
@@ -236,11 +235,11 @@ int main(int argc, char *argv[]) {
     try {
       if (!binary) {
         filename = prefix + "A.mm";
-        A11     = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm, node);
+        A11     = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm);
         A119Pt  = A11;
         if (use9ptPatA) {
           filename = prefix + "AForPat.mm";
-          A119Pt = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm, node);
+          A119Pt = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm);
         }
       } else {
         filename = prefix + "A.dat";
@@ -252,15 +251,15 @@ int main(int argc, char *argv[]) {
         }
       }
       filename = prefix + "B.mm";
-      A21 = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm, node);
+      A21 = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm);
       filename = prefix + "Bt.mm";
-      A12 = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm, node);
+      A12 = Reader<tCrsMatrix>::readSparseFile(filename.c_str(), comm);
 
       RCP<const tMap> cmap1 = A11->getDomainMap(), cmap2 = A12->getDomainMap();
       filename = prefix + "VelCoords.mm";
-      Vcoords = Reader<tCrsMatrix>::readDenseFile(filename.c_str(),  comm, node, cmap1);
+      Vcoords = Reader<tCrsMatrix>::readDenseFile(filename.c_str(),  comm, cmap1);
       filename = prefix + "PresCoords.mm";
-      Pcoords = Reader<tCrsMatrix>::readDenseFile(filename.c_str(), comm, node, cmap2);
+      Pcoords = Reader<tCrsMatrix>::readDenseFile(filename.c_str(), comm, cmap2);
 
       // For now, we assume that p2v maps local pressure DOF to a local x-velocity DOF
       filename = prefix + "p2vMap.mm";
@@ -365,7 +364,7 @@ int main(int argc, char *argv[]) {
       A->apply(*tX, *tB);
     } else {
       typedef Tpetra::MatrixMarket::Reader<tCrsMatrix> reader_type;
-      tB = reader_type::readDenseFile(rhs.c_str(), fullMap->getComm(), fullMap->getNode(), fullMap);
+      tB = reader_type::readDenseFile(rhs.c_str(), fullMap->getComm(), fullMap);
     }
 
     tX->putScalar(0.0);

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
@@ -178,8 +178,7 @@ namespace MueLu {
     We use Teko and the Teko::LinearOp which is declared as
     Teuchos::RCP<const Thyra::LinearOpBase<ST> > with ST=double. See e.g. Teko_ConfigDefs.hpp.
 
-    In Teko SC=double and LO=int are hard-coded. The node is
-    Tpetra::DefaultPlatform::DefaultPlatformType::NodeType
+    In Teko SC=double and LO=int are hard-coded. The node is Tpetra::Map<>::node_type.
     The global ordinal GO is chosen as a conservative choice from what Tpetra supports
     (see Teko_ConfigDefs.hpp for more details)
 

--- a/packages/muelu/test/simple1D/amesos2StandAlone.cpp
+++ b/packages/muelu/test/simple1D/amesos2StandAlone.cpp
@@ -104,7 +104,7 @@
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_VerboseObject.hpp>
 
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -114,7 +114,7 @@
 
 
 int main(int argc, char *argv[]) {
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Tpetra::ScopeGuard mpiSession(&argc,&argv);
 
   typedef Tpetra::MultiVector<> MV;
   typedef MV::scalar_type Scalar;
@@ -131,9 +131,7 @@ int main(int argc, char *argv[]) {
   std::ostream &out = std::cout;
   RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(rcpFromRef(out));
 
-  RCP<const Teuchos::Comm<int> > comm
-    = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
-
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
   size_t myRank = comm->getRank();
 
   out << "Amesos2 stand-alone test" << endl << endl;


### PR DESCRIPTION
@trilinos/muelu @trilinos/galeri @trilinos/tpetra

## Description

Purge use of `Tpetra::DefaultPlatform` from MueLu and Galeri.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Linux, GCC, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] No new compiler warnings were introduced.
