### PR TITLE
ShyLU: Purge use of Tpetra::DefaultPlatform

### DIFF
--- a/packages/shylu/shylu_dd/bddc/src/shylu_CoarseSpaceBDDC.h
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_CoarseSpaceBDDC.h
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -64,15 +64,15 @@ using Teuchos::rcp;
 
 // Author: Clark R. Dohrmann
 namespace bddc {
-  
-template <class SX, class SM, class LO, class GO> 
+
+template <class SX, class SM, class LO, class GO>
   class CoarseSpaceBDDC
 {
 public:
   //
   // Convenience typedefs
   //
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+  typedef Tpetra::Map<>::node_type  Node;
   typedef Tpetra::Map<LO,GO,Node>                                 Map;
   typedef Tpetra::CrsGraph<LO,GO,Node>                            CrsGraph;
   typedef Tpetra::CrsMatrix<SX,LO,GO,Node>                        CrsMatrix;
@@ -128,8 +128,8 @@ public:
     return m_AcRoot->getGlobalNumRows();
   }
 
-  void applyCoarseCorrection(RCP<Vector> & rB, 
-			     RCP<Vector> & solB)
+  void applyCoarseCorrection(RCP<Vector> & rB,
+                             RCP<Vector> & solB)
   {
     m_Phi->apply(*rB, *m_vecCoarse1to1, Teuchos::CONJ_TRANS);
     m_rootVec->doImport(*m_vecCoarse1to1, *m_importerInterlevel, Tpetra::INSERT);
@@ -137,7 +137,7 @@ public:
       Teuchos::ArrayRCP<SX> values = m_rootVec->getDataNonConst();
       for (size_t i=0; i<m_rhsCoarse.size(); i++) m_rhsCoarse[i] = values[i];
       if (m_coarseSolver != 0) {
-	m_coarseSolver->Solve(1, &m_rhsCoarse[0], &m_solCoarse[0]);
+        m_coarseSolver->Solve(1, &m_rhsCoarse[0], &m_solCoarse[0]);
       }
       for (size_t i=0; i<m_rhsCoarse.size(); i++) values[i] = m_solCoarse[i];
     }
@@ -167,8 +167,8 @@ public:
       SM tol(1e-10);
       values = m_vecBoundary1to1->getDataNonConst();
       for (LO i=0; i<numRowsFine; i++) {
-	SM error = std::abs(values[i] -1);
-	if (error > maxError) maxError = error;
+        SM error = std::abs(values[i] -1);
+        if (error > maxError) maxError = error;
       }
     }
     else if (m_problemType == ELASTICITY) {
@@ -178,21 +178,21 @@ public:
       assert (numNodeFine*m_spatialDim == numRowsFine);
       Teuchos::ArrayRCP<SX> coarseValues = m_vecCoarse1to1->getDataNonConst();
       for (LO j=0; j<m_spatialDim; j++) {
-	for (LO i=0; i<numRowsCoarse; i++) coarseValues[i] = 0;
-	for (LO i=0; i<numNodeCoarse; i++) coarseValues[j+m_spatialDim*i] = 1;
-	m_Phi->apply(*m_vecCoarse1to1, *m_vecBoundary1to1, Teuchos::NO_TRANS);
-	SM tol(1e-10);
-	Teuchos::ArrayRCP<SX> fineValues = m_vecBoundary1to1->getDataNonConst();
-	for (LO i=0; i<numNodeFine; i++) {
-	  LO row = j+m_spatialDim*i;
-	  SM error = std::abs(fineValues[row] - 1);
-	  if (error > maxError) maxError = error;
-	}
+        for (LO i=0; i<numRowsCoarse; i++) coarseValues[i] = 0;
+        for (LO i=0; i<numNodeCoarse; i++) coarseValues[j+m_spatialDim*i] = 1;
+        m_Phi->apply(*m_vecCoarse1to1, *m_vecBoundary1to1, Teuchos::NO_TRANS);
+        SM tol(1e-10);
+        Teuchos::ArrayRCP<SX> fineValues = m_vecBoundary1to1->getDataNonConst();
+        for (LO i=0; i<numNodeFine; i++) {
+          LO row = j+m_spatialDim*i;
+          SM error = std::abs(fineValues[row] - 1);
+          if (error > maxError) maxError = error;
+        }
       }
     }
     SM maxErrorAll;
     Teuchos::reduceAll<int, SM>(*m_Comm, Teuchos::REDUCE_MAX, 1,
-				&maxError, &maxErrorAll);
+                                &maxError, &maxErrorAll);
     return maxErrorAll;
   }
 
@@ -205,8 +205,8 @@ public:
     LO numElem = elemConn.size();
     for (LO i=0; i<numElem; i++) {
       for (size_t j=0; j<elemConn[i].size(); j++) {
-	LO node = elemConn[i][j];
-	nodeElements[node].push_back(i);
+        LO node = elemConn[i][j];
+        nodeElements[node].push_back(i);
       }
     }
     nodalConn.resize(numNode);
@@ -215,23 +215,23 @@ public:
     for (LO i=0; i<numNode; i++) {
       LO nanode = 0;
       for (size_t j=0; j<nodeElements[i].size(); j++) {
-	LO elem = nodeElements[i][j];
-	for (size_t k=0; k<elemConn[elem].size(); k++) {
-	  LO node = elemConn[elem][k];
-	  if (nodeFlag[node] == false) {
-	    nodalConn[i].push_back(node);
-	    anode[nanode] = node;
-	    nodeFlag[node] = true;
-	    nanode++;
-	  }
-	}
+        LO elem = nodeElements[i][j];
+        for (size_t k=0; k<elemConn[elem].size(); k++) {
+          LO node = elemConn[elem][k];
+          if (nodeFlag[node] == false) {
+            nodalConn[i].push_back(node);
+            anode[nanode] = node;
+            nodeFlag[node] = true;
+            nanode++;
+          }
+        }
       }
       for (LO j=0; j<nanode; j++) {
-	nodeFlag[anode[j]] = false;
+        nodeFlag[anode[j]] = false;
       }
     }
   }
-  
+
 private:
   std::vector< SubdomainBDDC<SX,SM,LO,GO>* > & m_Subdomain;
   RCP< PartitionOfUnity<SX,SM,LO,GO> > & m_Partition;
@@ -254,23 +254,23 @@ private:
   RCP<Vector> m_vecBoundary1to1, m_vecCoarse1to1, m_rootVec;
   SolverBase<SX>* m_coarseSolver;
 
-  void determineReorder(LO sub, 
-			std::vector<LO> & reorder)
+  void determineReorder(LO sub,
+                        std::vector<LO> & reorder)
   {
-    const std::vector<LO> & coarseDofEquiv = 
+    const std::vector<LO> & coarseDofEquiv =
       m_Subdomain[sub]->getCoarseDofEquiv();
     LO numEquiv = m_Subdomain[sub]->getNumEquiv();
     LO numDofs = coarseDofEquiv.size();
     for (LO i=0; i<numEquiv; i++) {
       for (LO j=0; j<numDofs; j++) {
-	if (coarseDofEquiv[j] == i) reorder.push_back(j);
+        if (coarseDofEquiv[j] == i) reorder.push_back(j);
       }
     }
     assert (LO(reorder.size()) == numDofs);
   }
 
   void determineCoarseStiffnessMatrix
-    (const std::vector< std::vector<LO> > & subEquivs, 
+    (const std::vector< std::vector<LO> > & subEquivs,
      const std::vector< std::vector<LO> > & equivConn,
      std::vector< std::vector<SX> > & subAc)
   {
@@ -281,12 +281,12 @@ private:
     std::vector< std::vector<LO> > columnsA(numDof);
     for (LO i=0; i<numNode; i++) {
       for (LO j=nodeBegin[i]; j<nodeBegin[i+1]; j++) {
-	for (size_t k=0; k<equivConn[i].size(); k++) {
-	  LO node2 = equivConn[i][k];
-	  for (LO m=nodeBegin[node2]; m<nodeBegin[node2+1]; m++) {
-	    columnsA[j].push_back(m);
-	  }
-	}
+        for (size_t k=0; k<equivConn[i].size(); k++) {
+          LO node2 = equivConn[i][k];
+          for (LO m=nodeBegin[node2]; m<nodeBegin[node2+1]; m++) {
+            columnsA[j].push_back(m);
+          }
+        }
       }
     }
     // coarse element assembly
@@ -303,28 +303,28 @@ private:
       determineReorder(i, reorder);
       determineSubDofs(subEquivs[i], nodeBegin, subDofs);
       for (size_t j=0; j<subDofs.size(); j++) {
-	LO dof = subDofs[j];
-	for (size_t k=0; k<columnsA[dof].size(); k++) {
-	  colMap[columnsA[dof][k]] = k;
-	}
-	getSubdomainMatrixRow(Ac, j, reorder, rowValues);
-	for (size_t k=0; k<subDofs.size(); k++) {
-	  LO col = colMap[subDofs[k]];
-	  assert (col != -1);
-	  valuesA[dof][col] += rowValues[k];
-	}
-	for (size_t k=0; k<columnsA[dof].size(); k++) {
-	  colMap[columnsA[dof][k]] = -1;
-	}
+        LO dof = subDofs[j];
+        for (size_t k=0; k<columnsA[dof].size(); k++) {
+          colMap[columnsA[dof][k]] = k;
+        }
+        getSubdomainMatrixRow(Ac, j, reorder, rowValues);
+        for (size_t k=0; k<subDofs.size(); k++) {
+          LO col = colMap[subDofs[k]];
+          assert (col != -1);
+          valuesA[dof][col] += rowValues[k];
+        }
+        for (size_t k=0; k<columnsA[dof].size(); k++) {
+          colMap[columnsA[dof][k]] = -1;
+        }
       }
     }
     Teuchos::ArrayRCP<size_t> count(numDof);
     for (LO i=0; i<numDof; i++) count[i] = columnsA[i].size();
-    CrsMatrix ALocal(m_dofMapCoarse, m_dofMapCoarse, count, 
-		     Tpetra::StaticProfile);
+    CrsMatrix ALocal(m_dofMapCoarse, m_dofMapCoarse, count,
+                     Tpetra::StaticProfile);
     for (LO i=0; i<numDof; i++) {
       ALocal.insertLocalValues(i, Teuchos::ArrayView<LO>(columnsA[i]),
-			       Teuchos::ArrayView<SX>(valuesA[i]));
+                               Teuchos::ArrayView<SX>(valuesA[i]));
     }
     ALocal.fillComplete(m_dofMapCoarse1to1, m_dofMapCoarse1to1);
     m_Ac = rcp( new CrsMatrix(m_dofMapCoarse1to1, 0) );
@@ -333,10 +333,10 @@ private:
   }
 
   void getPhiRow(std::vector<SX> & Phi,
-		 LO row,
-		 LO numRows,
-		 std::vector<LO> & reorder,
-		 std::vector<SX> & rowValues) const
+                 LO row,
+                 LO numRows,
+                 std::vector<LO> & reorder,
+                 std::vector<SX> & rowValues) const
   {
     LO numCols = reorder.size();
     rowValues.resize(numCols);
@@ -347,8 +347,8 @@ private:
   }
 
   void determineSubDofs(const std::vector<LO> & subEquivs,
-			const std::vector<LO> & nodeBegin,
-			std::vector<LO> & subDofs) const
+                        const std::vector<LO> & nodeBegin,
+                        std::vector<LO> & subDofs) const
   {
     LO numSubDofs = 0;
     for (size_t i=0; i<subEquivs.size(); i++) {
@@ -360,13 +360,13 @@ private:
     for (size_t i=0; i<subEquivs.size(); i++) {
       LO equiv = subEquivs[i];
       for (LO j=nodeBegin[equiv]; j<nodeBegin[equiv+1]; j++) {
-	subDofs[numSubDofs++] = j;
+        subDofs[numSubDofs++] = j;
       }
     }
   }
 
-  void scalePhi(LO sub, 
-		std::vector<SX> & Phi) const
+  void scalePhi(LO sub,
+                std::vector<SX> & Phi) const
   {
     LO numRows = m_Subdomain[sub]->getNumBoundaryDofs();
     LO numCols = m_Subdomain[sub]->getCoarseSpaceDimension();
@@ -381,7 +381,7 @@ private:
 
   void determineInterpolationMatrix
     (const std::vector< std::vector<LO> > & subEquivs,
-     const std::vector< std::vector<LO> > & equivConn, 
+     const std::vector< std::vector<LO> > & equivConn,
      std::vector< std::vector<SX> > & subPhi)
   {
     LO numEquiv = m_equivBoundaryDofs.size();
@@ -392,14 +392,14 @@ private:
       LO numAdjEquiv = equivConn[i].size();
       LO numEquivDof = m_equivBoundaryDofs[i].size();
       for (LO j=0; j<numAdjEquiv; j++) {
-	LO equiv = equivConn[i][j];
-	for (LO k=nodeBegin[equiv]; k<nodeBegin[equiv+1]; k++) {
-	  LO dofCoarse = k;
-	  for (LO m=0; m<numEquivDof; m++) {
-	    LO dofB = m_equivBoundaryDofs[i][m];
-	    columnsPhi[dofB].push_back(dofCoarse);
-	  }
-	}
+        LO equiv = equivConn[i][j];
+        for (LO k=nodeBegin[equiv]; k<nodeBegin[equiv+1]; k++) {
+          LO dofCoarse = k;
+          for (LO m=0; m<numEquivDof; m++) {
+            LO dofB = m_equivBoundaryDofs[i][m];
+            columnsPhi[dofB].push_back(dofCoarse);
+          }
+        }
       }
     }
     std::vector< std::vector<SX> > valuesPhi(numDofB);
@@ -418,19 +418,19 @@ private:
       determineSubDofs(subEquivs[i], nodeBegin, subDofs);
       LO numBoundaryDofs = m_Subdomain[i]->getNumBoundaryDofs();
       for (size_t j=0; j<m_subBoundaryDofs[i].size(); j++) {
-	LO dofB = m_subBoundaryDofs[i][j];
-	for (size_t k=0; k<columnsPhi[dofB].size(); k++) {
-	  colMap[columnsPhi[dofB][k]] = k;
-	}
-	getPhiRow(Phi, j, numBoundaryDofs, reorder, rowValues);
-	for (size_t k=0; k<subDofs.size(); k++) {
-	  LO col = colMap[subDofs[k]];
-	  assert (col != -1);
-	  valuesPhi[dofB][col] += rowValues[k];
-	}
-	for (size_t k=0; k<columnsPhi[dofB].size(); k++) {
-	  colMap[columnsPhi[dofB][k]] = -1;
-	}
+        LO dofB = m_subBoundaryDofs[i][j];
+        for (size_t k=0; k<columnsPhi[dofB].size(); k++) {
+          colMap[columnsPhi[dofB][k]] = k;
+        }
+        getPhiRow(Phi, j, numBoundaryDofs, reorder, rowValues);
+        for (size_t k=0; k<subDofs.size(); k++) {
+          LO col = colMap[subDofs[k]];
+          assert (col != -1);
+          valuesPhi[dofB][col] += rowValues[k];
+        }
+        for (size_t k=0; k<columnsPhi[dofB].size(); k++) {
+          colMap[columnsPhi[dofB][k]] = -1;
+        }
       }
     }
     Teuchos::ArrayRCP<size_t> count(numDofB);
@@ -438,7 +438,7 @@ private:
     CrsMatrix PhiLocal(m_dofMapB, m_dofMapCoarse, count, Tpetra::StaticProfile);
     for (LO i=0; i<numDofB; i++) {
       PhiLocal.insertLocalValues(i, Teuchos::ArrayView<LO>(columnsPhi[i]),
-				 Teuchos::ArrayView<SX>(valuesPhi[i]));
+                                 Teuchos::ArrayView<SX>(valuesPhi[i]));
     }
     PhiLocal.fillComplete(m_dofMapCoarse1to1, m_dofMapB1to1);
     m_Phi = rcp( new CrsMatrix(m_dofMapB1to1, 0) );
@@ -453,9 +453,9 @@ private:
     bool restrictPhiToBoundary = true;
     for (LO i=0; i<numSub; i++) {
       m_Subdomain[i]->calculateCoarseMatrices(subPhi[i], subAc[i],
-					      restrictPhiToBoundary);
+                                              restrictPhiToBoundary);
     }
-    const std::vector< std::vector<LO> > & subEquivs = 
+    const std::vector< std::vector<LO> > & subEquivs =
       m_Partition->getSubdomainEquivClasses();
     std::vector< std::vector<LO> > equivConn;
     determineNodalConnectivity(subEquivs, m_numCoarseNodes, equivConn);
@@ -464,13 +464,13 @@ private:
   }
 
   void getMinMemoryProcs(int numCoarseProcs,
-			 std::vector<int> & minMemoryProcs)
+                         std::vector<int> & minMemoryProcs)
   {
     long procLoad = getProcessorLoad();
     int numProc = m_Comm->getSize();
     std::vector<long> procLoadAll(numProc);
-    Teuchos::gatherAll<int, long> (*m_Comm, 1, &procLoad, numProc, 
-				   &procLoadAll[0]);
+    Teuchos::gatherAll<int, long> (*m_Comm, 1, &procLoad, numProc,
+                                   &procLoadAll[0]);
     std::vector< std::pair<long, int> > procSize(numProc);
     for (int i=0; i<numProc; i++) {
       procSize[i] = std::make_pair(procLoadAll[i], i);
@@ -483,7 +483,7 @@ private:
       minMemoryProcs[i] = iter->second;
     }
   }
-    
+
   void coarsen()
   {
     int numCoarseProcs = 1; // two level method for now
@@ -491,12 +491,12 @@ private:
     getMinMemoryProcs(numCoarseProcs, minMemoryProcs);
     assert (numCoarseProcs == 1);
     m_rootProc = minMemoryProcs[0];
-    DofManager<LO,GO>::generateRootMap(m_dofMapCoarse1to1, m_rootProc, 
-				       m_dofMapCoarseRoot);
+    DofManager<LO,GO>::generateRootMap(m_dofMapCoarse1to1, m_rootProc,
+                                       m_dofMapCoarseRoot);
     m_importerInterlevel = rcp(new Import(m_dofMapCoarse1to1,
-					  m_dofMapCoarseRoot) );
+                                          m_dofMapCoarseRoot) );
     m_exporterInterlevel = rcp(new Export(m_dofMapCoarseRoot,
-					  m_dofMapCoarse1to1) );
+                                          m_dofMapCoarse1to1) );
     m_rootVec = rcp( new Vector(m_dofMapCoarseRoot) );
     m_AcRoot = rcp( new CrsMatrix(m_dofMapCoarseRoot, 0) );
     m_AcRoot->doImport(*m_Ac, *m_importerInterlevel, Tpetra::INSERT);
@@ -518,25 +518,25 @@ private:
       Teuchos::ArrayView<const SX> Values;
       numTerms = 0;
       for (LO i=0; i<numRows; i++) {
-	m_AcRoot->getLocalRowView(i, Indices, Values);
-	for (LO j=0; j<Indices.size(); j++) {
-	  columns[numTerms] = Indices[j];
-	  values[numTerms] = Values[j];
-	  numTerms++;
-	}
-	rowBegin[i+1] = numTerms;
+        m_AcRoot->getLocalRowView(i, Indices, Values);
+        for (LO j=0; j<Indices.size(); j++) {
+          columns[numTerms] = Indices[j];
+          values[numTerms] = Values[j];
+          numTerms++;
+        }
+        rowBegin[i+1] = numTerms;
       }
       bool printCoarseMatrix = m_Parameters->get("Print Coarse Matrix", false);
       if (printCoarseMatrix) {
-	UtilBDDC<SX,SM>::printSparseMatrix
-	  (numRows, &rowBegin[0], &columns[0], &values[0], "Ac.dat");
+        UtilBDDC<SX,SM>::printSparseMatrix
+          (numRows, &rowBegin[0], &columns[0], &values[0], "Ac.dat");
       }
       SolverFactory<SX> Factory;
       m_coarseSolver = Factory.Generate(numRows,
-					&rowBegin[0],
-					&columns[0],
-					&values[0],
-					*m_Parameters);
+                                        &rowBegin[0],
+                                        &columns[0],
+                                        &values[0],
+                                        *m_Parameters);
       m_coarseSolver->Initialize();
     }
   }
@@ -554,8 +554,8 @@ private:
     return 0;
   }
 
-  void extractDenseMatrix(const CrsMatrix & A, 
-			  std::vector<SX> & AFull) const
+  void extractDenseMatrix(const CrsMatrix & A,
+                          std::vector<SX> & AFull) const
   {
     Teuchos::ArrayView<const LO> Indices;
     Teuchos::ArrayView<const SX> Values;
@@ -566,15 +566,15 @@ private:
     for (LO i=0; i<numRows; i++) {
       A.getLocalRowView(i, Indices, Values);
       for (LO j=0; j<Indices.size(); j++) {
-	LO col = Indices[j];
-	AFull[i+col*numRows] = Values[j];
+        LO col = Indices[j];
+        AFull[i+col*numRows] = Values[j];
       }
     }
   }
 
   void getNumZeroEigenValuesCoarseStiffnessMatrix(CrsMatrix & Ac)
   {
-    // getNumZeroEigenValuesCoarseStiffnessMatrix is a diagnostic tool 
+    // getNumZeroEigenValuesCoarseStiffnessMatrix is a diagnostic tool
     // intended for smaller examples with no essential boundary conditions.
     bool checkMatrices = m_Parameters->get("Check Coarse Matrices", false);
     if (checkMatrices == false) return;
@@ -589,34 +589,34 @@ private:
       int LWORK = std::max(1, 3*N);
       int INFO(0);
       std::vector<SX> WORK(LWORK);
-      LAPACK.HEEV(JOBZ, UPLO, N, &AcFull[0], N, &W[0], &WORK[0], LWORK, 
-		  &RWORK[0], &INFO);
+      LAPACK.HEEV(JOBZ, UPLO, N, &AcFull[0], N, &W[0], &WORK[0], LWORK,
+                  &RWORK[0], &INFO);
       assert (INFO == 0);
       SM tol(1e-10);
       SM compareValue = tol*W[N-1];
       if (m_problemType == SCALARPDE) {
-	if (N == 1) compareValue = tol;
+        if (N == 1) compareValue = tol;
       }
       else if (m_problemType == ELASTICITY) {
-	if (m_spatialDim == 2) {
-	  if (N < 4) compareValue = tol;
-	}
-	else if (m_spatialDim == 3) {
-	  if (N < 7) compareValue = tol;
-	}
+        if (m_spatialDim == 2) {
+          if (N < 4) compareValue = tol;
+        }
+        else if (m_spatialDim == 3) {
+          if (N < 7) compareValue = tol;
+        }
       }
       m_numZeroEigenValues = 0;
       for (LO i=0; i<N; i++) {
-	if (std::abs(W[i]) < compareValue) m_numZeroEigenValues++;
+        if (std::abs(W[i]) < compareValue) m_numZeroEigenValues++;
       }
     }
     Teuchos::broadcast<int, LO> (*m_Comm, m_rootProc, 1, &m_numZeroEigenValues);
   }
 
   void getSubdomainMatrixRow(std::vector<SX> & Ac,
-			     LO row,
-			     std::vector<LO> & reorder,
-			     std::vector<SX> & rowValues)
+                             LO row,
+                             std::vector<LO> & reorder,
+                             std::vector<SX> & rowValues)
   {
     LO numElemDofs = reorder.size();
     rowValues.resize(numElemDofs);
@@ -629,21 +629,21 @@ private:
 
   void determineGlobalIDs()
   {
-    const std::vector< std::vector<LO> > & subdomainEquivClasses = 
+    const std::vector< std::vector<LO> > & subdomainEquivClasses =
       m_Partition->getSubdomainEquivClasses();
     LO numCoarseNodes = m_Partition->getNumEquivClasses();
     std::vector<LO> numDofsCoarseNode(numCoarseNodes);
     for (LO i=0; i<m_numSub; i++) {
       LO numEquiv = m_Subdomain[i]->getNumEquiv();
       for (LO j=0; j<numEquiv; j++) {
-	LO equiv = subdomainEquivClasses[i][j];
-	numDofsCoarseNode[equiv] = 0;
+        LO equiv = subdomainEquivClasses[i][j];
+        numDofsCoarseNode[equiv] = 0;
       }
-      const std::vector<LO> & coarseDofEquiv = 
-	m_Subdomain[i]->getCoarseDofEquiv();
+      const std::vector<LO> & coarseDofEquiv =
+        m_Subdomain[i]->getCoarseDofEquiv();
       for (size_t j=0; j<coarseDofEquiv.size(); j++) {
-	LO equiv = subdomainEquivClasses[i][coarseDofEquiv[j]];
-	numDofsCoarseNode[equiv]++;
+        LO equiv = subdomainEquivClasses[i][coarseDofEquiv[j]];
+        numDofsCoarseNode[equiv]++;
       }
     }
     m_nodeBeginCoarse.resize(numCoarseNodes+1, 0);
@@ -653,14 +653,14 @@ private:
     numCoarseDofs = 0;
     for (LO i=0; i<numCoarseNodes; i++) {
       for (LO j=0; j<numDofsCoarseNode[i]; j++) {
-	m_localDofsCoarse[numCoarseDofs] = j;
-	numCoarseDofs++;
+        m_localDofsCoarse[numCoarseDofs] = j;
+        numCoarseDofs++;
       }
       m_nodeBeginCoarse[i+1] = numCoarseDofs;
     }
     const std::vector<GO> & coarseNodeGIDs = m_Partition->getGlobalIDs();
     DofManager<LO,GO>::determineGlobalIDs
-      (numCoarseNodes, &coarseNodeGIDs[0], &m_nodeBeginCoarse[0], 
+      (numCoarseNodes, &coarseNodeGIDs[0], &m_nodeBeginCoarse[0],
        &m_localDofsCoarse[0], m_Comm, m_dofMapCoarse, m_dofMapCoarse1to1);
     m_numCoarseNodes = numCoarseNodes;
     m_exporterCoarse = rcp( new Export(m_dofMapCoarse, m_dofMapCoarse1to1) );
@@ -673,4 +673,4 @@ private:
 } // namespace bddc
 
 #endif // COARSESPACEBDDC_H
-  
+

--- a/packages/shylu/shylu_dd/bddc/src/shylu_ConstraintsBDDC.h
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_ConstraintsBDDC.h
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -61,15 +61,15 @@ using Teuchos::rcp;
 
 // Author: Clark R. Dohrmann
 namespace bddc {
-  
-template <class SX, class SM, class LO, class GO> 
+
+template <class SX, class SM, class LO, class GO>
   class ConstraintsBDDC
 {
 public:
   //
   // Convenience typedefs
   //
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+  typedef Tpetra::Map<>::node_type  Node;
   typedef Tpetra::Map<LO,GO,Node>                                 Map;
   typedef Tpetra::CrsGraph<LO,GO,Node>                            CrsGraph;
   typedef Tpetra::CrsMatrix<SX,LO,GO,Node>                        CrsMatrix;
@@ -125,9 +125,9 @@ public:
 
   void determineBaseConstraints()
   {
-    const std::vector< std::vector<LO> > & subdomainEquivClasses = 
+    const std::vector< std::vector<LO> > & subdomainEquivClasses =
       m_Partition->getSubdomainEquivClasses();
-    const std::vector< std::vector<LO> > & equivClasses = 
+    const std::vector< std::vector<LO> > & equivClasses =
       m_Partition->getEquivClasses();
     const std::vector<LO> & equivCard = m_Partition->getEquivCardinality();
     std::vector<LO> dofMap(m_numDofs, -1), dofMapEquiv(m_numDofs, -1);
@@ -135,25 +135,25 @@ public:
       LO numEquiv = subdomainEquivClasses[i].size();
       setDofMap(m_subNodes[i], dofMap);
       std::vector< std::vector<LO> > equivClassDofs(numEquiv),
-	equivConstraintsLocalDofs(numEquiv);
+        equivConstraintsLocalDofs(numEquiv);
       std::vector< std::vector<SX> > equivConstraints(numEquiv);
       std::vector<LO> numEquivConstraints(numEquiv);
       LO numCorners(0), numEdges(0), numFaces(0);
       getNumCornersEdgesFaces(subdomainEquivClasses[i], equivClasses,
-			      equivCard, numCorners, numEdges, numFaces);
+                              equivCard, numCorners, numEdges, numFaces);
       for (LO j=0; j<numEquiv; j++) {
-	LO equiv = subdomainEquivClasses[i][j];
-	const std::vector<LO> & equivNodes = equivClasses[equiv];
-	getDofsEquiv(equivNodes, dofMap, equivClassDofs[j]);
-	setDofMap(equivNodes, dofMapEquiv);
-	determineEquivConstraints
-	  (i, equivNodes, equiv, dofMapEquiv, numCorners, numEdges, numFaces,
-	   equivConstraintsLocalDofs[j], equivConstraints[j]);
-	resetDofMap(equivNodes, dofMapEquiv);
+        LO equiv = subdomainEquivClasses[i][j];
+        const std::vector<LO> & equivNodes = equivClasses[equiv];
+        getDofsEquiv(equivNodes, dofMap, equivClassDofs[j]);
+        setDofMap(equivNodes, dofMapEquiv);
+        determineEquivConstraints
+          (i, equivNodes, equiv, dofMapEquiv, numCorners, numEdges, numFaces,
+           equivConstraintsLocalDofs[j], equivConstraints[j]);
+        resetDofMap(equivNodes, dofMapEquiv);
       }
       m_Subdomain[i]->setEquivalenceClasses(equivClassDofs);
       m_Subdomain[i]->setInitialConstraints(equivConstraintsLocalDofs,
-					    equivConstraints);
+                                            equivConstraints);
       resetDofMap(m_subNodes[i], dofMap);
     }
   }
@@ -176,35 +176,35 @@ private:
   Tpetra::global_size_t m_IGO;
   bool m_useCorners, m_useEdges, m_useFaces;
 
-  void setDofMap(const std::vector<LO> & nodes, 
-		 std::vector<LO> & dofMap)
+  void setDofMap(const std::vector<LO> & nodes,
+                 std::vector<LO> & dofMap)
   {
     LO numDof = 0;
     for (size_t i=0; i<nodes.size(); i++) {
       LO node = nodes[i];
       for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
-	dofMap[j] = numDof++;
+        dofMap[j] = numDof++;
       }
     }
   }
 
-  void resetDofMap(const std::vector<LO> & nodes, 
-		   std::vector<LO> & dofMap)
+  void resetDofMap(const std::vector<LO> & nodes,
+                   std::vector<LO> & dofMap)
   {
     for (size_t i=0; i<nodes.size(); i++) {
       LO node = nodes[i];
       for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
-	dofMap[j] = -1;
+        dofMap[j] = -1;
       }
     }
   }
 
   void getNumCornersEdgesFaces
-    (const std::vector<LO> & subEquivClasses, 
+    (const std::vector<LO> & subEquivClasses,
      const std::vector< std::vector<LO> > & equivClasses,
-     const std::vector<LO> & equivCard, 
-     LO & numCorners, 
-     LO & numEdges, 
+     const std::vector<LO> & equivCard,
+     LO & numCorners,
+     LO & numEdges,
      LO & numFaces)
   {
     numCorners = numEdges = numFaces = 0;
@@ -219,25 +219,25 @@ private:
   }
 
   void getDofsEquiv(const std::vector<LO> & equivClass,
-		    std::vector<LO> & dofMap,
-		    std::vector<LO> & equivDofs)
+                    std::vector<LO> & dofMap,
+                    std::vector<LO> & equivDofs)
   {
     LO numNodes = equivClass.size();
     for (LO i=0; i<numNodes; i++) {
       LO node = equivClass[i];
       for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
-	LO dof = dofMap[j];
-	assert (dof != -1);
-	equivDofs.push_back(dof);
+        LO dof = dofMap[j];
+        assert (dof != -1);
+        equivDofs.push_back(dof);
       }
     }
   }
 
-  void getLocalDofsAndCoordinates(const std::vector<LO> & equivNodes, 
-				  std::vector<LO> & equivLocalDofs, 
-				  std::vector<SM> & xCoords,
-				  std::vector<SM> & yCoords,
-				  std::vector<SM> & zCoords)
+  void getLocalDofsAndCoordinates(const std::vector<LO> & equivNodes,
+                                  std::vector<LO> & equivLocalDofs,
+                                  std::vector<SM> & xCoords,
+                                  std::vector<SM> & yCoords,
+                                  std::vector<SM> & zCoords)
   {
     LO numRows(0);
     for (size_t i=0; i<equivNodes.size(); i++) {
@@ -246,19 +246,19 @@ private:
     }
     equivLocalDofs.resize(numRows);
     xCoords.resize(numRows);
-    yCoords.resize(numRows); 
+    yCoords.resize(numRows);
     zCoords.resize(numRows);
     numRows = 0;
     SM xSum(0), ySum(0), zSum(0);
     for (size_t i=0; i<equivNodes.size(); i++) {
       LO node = equivNodes[i];
       for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
-	int localDof = m_localDofs[j];
-	equivLocalDofs[numRows] = localDof;
-	xCoords[numRows] = m_xCoord[node]; xSum += m_xCoord[node];
-	yCoords[numRows] = m_yCoord[node]; ySum += m_yCoord[node];
-	zCoords[numRows] = m_zCoord[node]; zSum += m_zCoord[node];
-	numRows++;
+        int localDof = m_localDofs[j];
+        equivLocalDofs[numRows] = localDof;
+        xCoords[numRows] = m_xCoord[node]; xSum += m_xCoord[node];
+        yCoords[numRows] = m_yCoord[node]; ySum += m_yCoord[node];
+        zCoords[numRows] = m_zCoord[node]; zSum += m_zCoord[node];
+        numRows++;
       }
     }
     SM xCent = xSum/numRows;
@@ -284,11 +284,11 @@ private:
     return numNeededAncestors;
   }
 
-  void getNullSpace(const std::vector<LO> & localDofs, 
-		    const std::vector<SM> & xCoords, 
-		    const std::vector<SM> & yCoords, 
-		    const std::vector<SM> & zCoords, 
-		    std::vector<SX> & nullSpace)
+  void getNullSpace(const std::vector<LO> & localDofs,
+                    const std::vector<SM> & xCoords,
+                    const std::vector<SM> & yCoords,
+                    const std::vector<SM> & zCoords,
+                    std::vector<SX> & nullSpace)
   {
     const LO numRows = localDofs.size();
     if (m_problemType == SCALARPDE) {
@@ -296,39 +296,39 @@ private:
     }
     else if (m_problemType == ELASTICITY) {
       if (m_spatialDim == 2) {
-	int numRBM = 3;
-	LO numTerms = numRBM*numRows;
-	nullSpace.resize(numTerms, 0);
-	numTerms = 0;
-	for (int j=0; j<numRBM; j++) {
-	  for (LO i=0; i<numRows; i++) {
-	    nullSpace[numTerms++] = 
-	      getElasticityRBM2D(j, localDofs[i],
-				 xCoords[i], yCoords[i], zCoords[i]);
-	  }
-	}
+        int numRBM = 3;
+        LO numTerms = numRBM*numRows;
+        nullSpace.resize(numTerms, 0);
+        numTerms = 0;
+        for (int j=0; j<numRBM; j++) {
+          for (LO i=0; i<numRows; i++) {
+            nullSpace[numTerms++] =
+              getElasticityRBM2D(j, localDofs[i],
+                                 xCoords[i], yCoords[i], zCoords[i]);
+          }
+        }
       }
       else if (m_spatialDim == 3) {
-	int numRBM = 6;
-	LO numTerms = numRBM*numRows;
-	nullSpace.resize(numTerms, 0);
-	numTerms = 0;
-	for (int j=0; j<numRBM; j++) {
-	  for (LO i=0; i<numRows; i++) {
-	    nullSpace[numTerms++] = 
-	      getElasticityRBM3D(j, localDofs[i],
-				 xCoords[i], yCoords[i], zCoords[i]);
-	  }
-	}
+        int numRBM = 6;
+        LO numTerms = numRBM*numRows;
+        nullSpace.resize(numTerms, 0);
+        numTerms = 0;
+        for (int j=0; j<numRBM; j++) {
+          for (LO i=0; i<numRows; i++) {
+            nullSpace[numTerms++] =
+              getElasticityRBM3D(j, localDofs[i],
+                                 xCoords[i], yCoords[i], zCoords[i]);
+          }
+        }
       }
     }
   }
 
-  SM getElasticityRBM2D(int rbm, 
-			int localDof,
-			const SM xCoord, 
-			const SM yCoord, 
-			const SM zCoord)
+  SM getElasticityRBM2D(int rbm,
+                        int localDof,
+                        const SM xCoord,
+                        const SM yCoord,
+                        const SM zCoord)
   {
     SM value = 0.0;
     if (localDof == rbm) value = 1.0;
@@ -339,11 +339,11 @@ private:
     return value;
   }
 
-  SM getElasticityRBM3D(int rbm, 
-			int localDof,
-			const SM xCoord, 
-			const SM yCoord, 
-			const SM zCoord)
+  SM getElasticityRBM3D(int rbm,
+                        int localDof,
+                        const SM xCoord,
+                        const SM yCoord,
+                        const SM zCoord)
   {
     SM value = 0.0;
     if (localDof == rbm) value = 1.0;
@@ -366,11 +366,11 @@ private:
     return value;
   }
 
-  void determineIndependentColumns(const LO numRows, 
-				   const std::vector<SX> & nullSpace, 
-				   const int numMissing,
-				   const enum EquivType equivType,
-				   std::vector<int> & independentCols)
+  void determineIndependentColumns(const LO numRows,
+                                   const std::vector<SX> & nullSpace,
+                                   const int numMissing,
+                                   const enum EquivType equivType,
+                                   std::vector<int> & independentCols)
   {
     if (numRows == 0) return;
     int numColsMax = nullSpace.size()/numRows;
@@ -389,32 +389,32 @@ private:
       SX* col = &A[numRows*i];
       SM norm = BLAS.NRM2(numRows, col, INCX);
       if (norm > tol) {
-	independentCols.push_back(i);
-	for (LO j=0; j<numRows; j++) col[j] /= norm;
-	for (int j=i+1; j<numColsMax; j++) {
-	  SX* col2 = &A[numRows*j];
-	  SX dotProd = 0;
-	  for (LO k=0; k<numRows; k++) dotProd += col[k]*col2[k];
-	  for (LO k=0; k<numRows; k++) col2[k] -= dotProd*col[k];
-	}
+        independentCols.push_back(i);
+        for (LO j=0; j<numRows; j++) col[j] /= norm;
+        for (int j=i+1; j<numColsMax; j++) {
+          SX* col2 = &A[numRows*j];
+          SX dotProd = 0;
+          for (LO k=0; k<numRows; k++) dotProd += col[k]*col2[k];
+          for (LO k=0; k<numRows; k++) col2[k] -= dotProd*col[k];
+        }
       }
     }
   }
 
-  void determineEquivConstraints(const LO numRows, 
-				 const std::vector<SX> & nullSpace, 
-				 const std::vector<int> & independentCols, 
-				 std::vector<SX> & equivConstraints)
+  void determineEquivConstraints(const LO numRows,
+                                 const std::vector<SX> & nullSpace,
+                                 const std::vector<int> & independentCols,
+                                 std::vector<SX> & equivConstraints)
   {
     const int numCols = independentCols.size();
     std::vector<SX> A(numRows*numCols);
     for (int j=0; j<numCols; j++) {
       const int col = independentCols[j];
       for (int i=0; i<numRows; i++) {
-	A[j*numRows+i] = nullSpace[col*numRows+i];
+        A[j*numRows+i] = nullSpace[col*numRows+i];
       }
     }
-    // The the pseudo-inverse of A (transpose), obtained using the singular 
+    // The the pseudo-inverse of A (transpose), obtained using the singular
     // value decomposition, is used for the equivalence class constraints
     int M = numRows;
     int N = numCols;
@@ -425,13 +425,13 @@ private:
     SX U[1], dumWORK[1];
     int LDU(1), INFO, LDVT(N), LWORK(-1);
     Teuchos::LAPACK<int, SX> LAPACK;
-    LAPACK.GESVD(JOBU, JOBVT, M, N, A.data(), M, S.data(), U, LDU, 
-		 VT.data(), LDVT, dumWORK, LWORK, RWORK.data(), &INFO);
+    LAPACK.GESVD(JOBU, JOBVT, M, N, A.data(), M, S.data(), U, LDU,
+                 VT.data(), LDVT, dumWORK, LWORK, RWORK.data(), &INFO);
     assert (INFO == 0);
     LWORK = dumWORK[0];
     std::vector<SX> WORK(LWORK);
-    LAPACK.GESVD(JOBU, JOBVT, M, N, A.data(), M, S.data(), U, LDU, 
-		 VT.data(), LDVT, WORK.data(), LWORK, RWORK.data(), &INFO);
+    LAPACK.GESVD(JOBU, JOBVT, M, N, A.data(), M, S.data(), U, LDU,
+                 VT.data(), LDVT, WORK.data(), LWORK, RWORK.data(), &INFO);
     // Note: for A = U * S * V^T, the matrix V^T is stored one column at
     //       a time in VT (regular Fortran column ordering for transpose of V)
     assert (INFO == 0);
@@ -439,25 +439,25 @@ private:
     for (int j=0; j<N; j++) {
       SX* colU = &A[M*j];
       for (LO i=0; i<numRows; i++) {
-	colU[i] /= S[j];
+        colU[i] /= S[j];
       }
     }
     equivConstraints.resize(M*N);
     Teuchos::BLAS<int, SX>  BLAS;
     SX ALPHA(1), BETA(0);
-    BLAS.GEMM(Teuchos::NO_TRANS, Teuchos::NO_TRANS, M, N, N, ALPHA, A.data(), 
-	      M, VT.data(), N, BETA, equivConstraints.data(), M);
+    BLAS.GEMM(Teuchos::NO_TRANS, Teuchos::NO_TRANS, M, N, N, ALPHA, A.data(),
+              M, VT.data(), N, BETA, equivConstraints.data(), M);
   }
 
   void determineEquivConstraints(LO sub,
-				 const std::vector<LO> & equivNodes,
-				 LO equiv,
-				 std::vector<LO> & dofMapEquiv,
-				 LO numCorners, 
-				 LO numEdges, 
-				 LO numFaces,
-				 std::vector<LO> & equivConstraintsLocalDofs, 
-				 std::vector<SX> & equivConstraints)
+                                 const std::vector<LO> & equivNodes,
+                                 LO equiv,
+                                 std::vector<LO> & dofMapEquiv,
+                                 LO numCorners,
+                                 LO numEdges,
+                                 LO numFaces,
+                                 std::vector<LO> & equivConstraintsLocalDofs,
+                                 std::vector<SX> & equivConstraints)
   {
     enum EquivType equivType = m_Partition->getEquivType(equiv);
     int numAncestors = m_Partition->getNumActiveAncestors(equiv);
@@ -482,17 +482,17 @@ private:
     if (isActive == true) {
       std::vector<LO> equivLocalDofs;
       std::vector<SM> xCoords, yCoords, zCoords;
-      getLocalDofsAndCoordinates(equivNodes, equivLocalDofs, 
-				 xCoords, yCoords, zCoords);
+      getLocalDofsAndCoordinates(equivNodes, equivLocalDofs,
+                                 xCoords, yCoords, zCoords);
       const LO numRows = equivLocalDofs.size();
       std::vector<SX> nullSpace;
-      getNullSpace(equivLocalDofs, xCoords, yCoords, zCoords, nullSpace); 
+      getNullSpace(equivLocalDofs, xCoords, yCoords, zCoords, nullSpace);
       std::vector<int> independentCols;
       determineIndependentColumns(numRows, nullSpace, numMissing, equivType,
-				  independentCols);
-      determineEquivConstraints(numRows, nullSpace, independentCols, 
-				equivConstraints);
-      equivConstraintsLocalDofs = independentCols;      
+                                  independentCols);
+      determineEquivConstraints(numRows, nullSpace, independentCols,
+                                equivConstraints);
+      equivConstraintsLocalDofs = independentCols;
       /*
       clark;
       int numDofLocal = localDofsAll.size();
@@ -500,11 +500,11 @@ private:
       equivConstraints.resize(numDofLocal*numDofEquiv);
       numEquivConstraints = numDofLocal;
       for (LO i=0; i<numDofLocal; i++) {
-	for (LO j=0; j<numDofEquiv; j++) {
-	  if (localDofsEquiv[j] == localDofsAll[i]) {
-	    equivConstraints[j+i*numDofEquiv] = 1.0/numDofEquiv;
-	  }
-	}
+        for (LO j=0; j<numDofEquiv; j++) {
+          if (localDofsEquiv[j] == localDofsAll[i]) {
+            equivConstraints[j+i*numDofEquiv] = 1.0/numDofEquiv;
+          }
+        }
       }
       */
     }
@@ -519,15 +519,15 @@ private:
   }
 
   void processFluxConstraints(const std::vector<LO> & equivNodes,
-			      std::vector<SX> & equivConstraints)
+                              std::vector<SX> & equivConstraints)
   {
     LO numNode = equivNodes.size();
     LO numFlux(0), numDof(0);
     for (LO i=0; i<numNode; i++) {
       LO node = equivNodes[i];
       for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
-	if (m_localDofs[j] == 7) numFlux++;
-	numDof++;
+        if (m_localDofs[j] == 7) numFlux++;
+        numDof++;
       }
     }
     if (numFlux > 0) {
@@ -535,11 +535,11 @@ private:
       equivConstraints.resize(numDof);
       numDof = 0;
       for (LO i=0; i<numNode; i++) {
-	LO node = equivNodes[i];
-	for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
-	  if (m_localDofs[j] == 7) equivConstraints[numDof] = 1;
-	  numDof++;
-	}
+        LO node = equivNodes[i];
+        for (LO j=m_nodeBegin[node]; j<m_nodeBegin[node+1]; j++) {
+          if (m_localDofs[j] == 7) equivConstraints[numDof] = 1;
+          numDof++;
+        }
       }
     }
   }
@@ -549,4 +549,4 @@ private:
 } // namespace bddc
 
 #endif // CONSTRAINTSBDDC_H
-  
+

--- a/packages/shylu/shylu_dd/bddc/src/shylu_DofManager.h
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_DofManager.h
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -52,22 +52,20 @@
 using Teuchos::RCP;
 using Teuchos::rcp;
 
-#include "Tpetra_ConfigDefs.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 
 // Author: Clark R. Dohrmann
 namespace bddc {
-  
-template <class LO, class GO> 
+
+template <class LO, class GO>
   class DofManager
 {
 public:
   //
   // Convenience typedefs
   //
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+  typedef Tpetra::Map<>::node_type  Node;
   typedef Tpetra::Map<LO,GO,Node>                                 Map;
   typedef Tpetra::CrsGraph<LO,GO,Node>                            CrsGraph;
   typedef Tpetra::CrsMatrix<GO,LO,GO,Node>                        CrsMatrixGO;
@@ -77,7 +75,7 @@ public:
   DofManager()
   {
   }
-   
+
   ~DofManager()
   {
   }
@@ -94,25 +92,25 @@ public:
   {
     Tpetra::global_size_t IGO =
       Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
-    RCP<const Map> nodeMap = 
-      rcp( new Map(IGO, 
-		   Teuchos::ArrayView<const GO>(nodeGlobalIDs, numNodes), 
-		   0, Comm));
+    RCP<const Map> nodeMap =
+      rcp( new Map(IGO,
+                   Teuchos::ArrayView<const GO>(nodeGlobalIDs, numNodes),
+                   0, Comm));
     RCP<const Map> nodeMap1to1;
     if (nodeGlobalIDs1to1 == nullptr) {
       nodeMap1to1 = Tpetra::createOneToOne<LO,GO,Node>(nodeMap);
     }
     else {
-      nodeMap1to1 = 
-	rcp( new Map(IGO, Teuchos::ArrayView<const GO>(*nodeGlobalIDs1to1), 
-		     0, Comm) );
+      nodeMap1to1 =
+        rcp( new Map(IGO, Teuchos::ArrayView<const GO>(*nodeGlobalIDs1to1),
+                     0, Comm) );
     }
-    // The rows and columns of the graph nodeGraphSubdomain are node global IDs 
+    // The rows and columns of the graph nodeGraphSubdomain are node global IDs
     // and local degrees of freedom (dofs), respectively, prior to assembly.
     RCP<CrsGraph> nodeGraphSubdomain;
-    determineNodalDofGraph(numNodes, nodeBegin, localDofs, Comm, nodeMap, 
-			   nodeMap1to1, nodeGraphSubdomain);
-    // The graph nodeGraph1to1 is the counterpart of graph nodeGraphSubdomain, 
+    determineNodalDofGraph(numNodes, nodeBegin, localDofs, Comm, nodeMap,
+                           nodeMap1to1, nodeGraphSubdomain);
+    // The graph nodeGraph1to1 is the counterpart of graph nodeGraphSubdomain,
     // but with uniquely owned rows. Note: it is assumed that the local dofs
     // for each node are identical across all processors
     RCP<CrsGraph> nodeGraph1to1 = rcp( new CrsGraph(nodeMap1to1, 0) );
@@ -134,7 +132,7 @@ public:
       Values.resize(Indices.size());
       for (LO j=0; j<Indices.size(); j++) Values[j] = baseGID++;
       nodeMatrix1to1.replaceLocalValues
-	(i, Indices, Teuchos::ArrayView<GO>(Values));
+        (i, Indices, Teuchos::ArrayView<GO>(Values));
     }
     nodeMatrix1to1.fillComplete(domainMap, nodeMap1to1);
     CrsMatrixGO nodeMatrix(nodeMap, 0);
@@ -146,26 +144,26 @@ public:
   }
 
   static void determineNodeMatrices(LO numNodes,
-				    const GO* nodeGlobalIDs,
-				    const LO* nodeBegin,
-				    const LO* localDofs,
-				    RCP<const Teuchos::Comm<int> > & Comm,
-				    RCP<CrsMatrixGO> & nodeMatrix,
-				    RCP<CrsMatrixGO> & nodeMatrix1to1)
+                                    const GO* nodeGlobalIDs,
+                                    const LO* nodeBegin,
+                                    const LO* localDofs,
+                                    RCP<const Teuchos::Comm<int> > & Comm,
+                                    RCP<CrsMatrixGO> & nodeMatrix,
+                                    RCP<CrsMatrixGO> & nodeMatrix1to1)
   {
     Tpetra::global_size_t IGO =
       Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
-    RCP<const Map> nodeMap = 
-      rcp( new Map(IGO, 
-		   Teuchos::ArrayView<const GO>(nodeGlobalIDs, numNodes), 
-		   0, Comm));
+    RCP<const Map> nodeMap =
+      rcp( new Map(IGO,
+                   Teuchos::ArrayView<const GO>(nodeGlobalIDs, numNodes),
+                   0, Comm));
     RCP<const Map> nodeMap1to1 = Tpetra::createOneToOne<LO,GO,Node>(nodeMap);
-    // The rows and columns of the graph nodeGraphSubdomain are node global IDs 
+    // The rows and columns of the graph nodeGraphSubdomain are node global IDs
     // and local degrees of freedom (dofs), respectively, prior to assembly.
     RCP<CrsGraph> nodeGraphSubdomain;
-    determineNodalDofGraph(numNodes, nodeBegin, localDofs, Comm, nodeMap, 
-			   nodeMap1to1, nodeGraphSubdomain);
-    // The graph nodeGraph1to1 is the counterpart of graph nodeGraphSubdomain, 
+    determineNodalDofGraph(numNodes, nodeBegin, localDofs, Comm, nodeMap,
+                           nodeMap1to1, nodeGraphSubdomain);
+    // The graph nodeGraph1to1 is the counterpart of graph nodeGraphSubdomain,
     // but with uniquely owned rows. Note: it is assumed that the local dofs
     // for each node are identical across all processors
     RCP<CrsGraph> nodeGraph1to1 = rcp( new CrsGraph(nodeMap1to1, 0) );
@@ -187,7 +185,7 @@ public:
       Values.resize(Indices.size());
       for (LO j=0; j<Indices.size(); j++) Values[j] = baseGID++;
       nodeMatrix1to1->replaceLocalValues
-	(i, Indices, Teuchos::ArrayView<GO>(Values));
+        (i, Indices, Teuchos::ArrayView<GO>(Values));
     }
     nodeMatrix1to1->fillComplete(domainMap, nodeMap1to1);
     nodeMatrix = rcp( new CrsMatrixGO(nodeMap, 0) );
@@ -197,7 +195,7 @@ public:
   }
 
   static void determineNodalDofGraph
-    (const LO numNode, 
+    (const LO numNode,
      const LO* nodeBegin,
      const LO* localDofs,
      RCP<const Teuchos::Comm<int> > & Comm,
@@ -213,7 +211,7 @@ public:
     std::vector<GO> uniqueIndicesGO(numDof);
     for (LO i=0; i<numDof; i++) uniqueIndicesGO[i] = localDofs[i];
     determineUniqueIndices(uniqueIndicesGO);
-    RCP<const Map> ColMap = 
+    RCP<const Map> ColMap =
       rcp( new Map(IGO, Teuchos::ArrayView<GO>(uniqueIndicesGO), 0, Comm) );
     A = rcp( new CrsGraph(NodeMap, ColMap, count) );
     std::vector<LO> localDofsIndex(numDof);
@@ -222,8 +220,8 @@ public:
     }
     for (LO i=0; i<numNode; i++) {
       if (count[i] > 0) {
-	A->insertLocalIndices
-	  (i, Teuchos::ArrayView<LO>(&localDofsIndex[nodeBegin[i]], count[i]));
+        A->insertLocalIndices
+          (i, Teuchos::ArrayView<LO>(&localDofsIndex[nodeBegin[i]], count[i]));
       }
     }
     RCP<const Map> ColMap1to1 = Tpetra::createOneToOne<LO,GO,Node>(ColMap);
@@ -231,7 +229,7 @@ public:
   }
 
   static void extractDofMap(CrsMatrixGO & A,
-			    RCP<const Map> & dofMap)
+                            RCP<const Map> & dofMap)
   {
     Tpetra::global_size_t IGO =
       Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
@@ -244,15 +242,15 @@ public:
     for (size_t i=0; i<A.getNodeNumRows(); i++) {
       A.getLocalRowView(i, Indices, Values);
       for (LO j=0; j<Indices.size(); j++) {
-	globalIDs[numDof++] = Values[j];
+        globalIDs[numDof++] = Values[j];
       }
     }
-    dofMap = 
+    dofMap =
       rcp( new Map(IGO, Teuchos::ArrayView<GO>(globalIDs), 0, Comm) );
   }
 
-  static void determineUniqueIndices(const std::vector<GO> & indices, 
-				     std::vector<GO> & uniqueIndices)
+  static void determineUniqueIndices(const std::vector<GO> & indices,
+                                     std::vector<GO> & uniqueIndices)
   {
     uniqueIndices = indices;
     std::sort(uniqueIndices.begin(), uniqueIndices.end());
@@ -267,9 +265,9 @@ public:
     indices.erase(iter, indices.end());
   }
 
-  static void generateRootMap(RCP<const Map> & inputMap, 
-			      int root,
-			      RCP<const Map> & rootMap)
+  static void generateRootMap(RCP<const Map> & inputMap,
+                              int root,
+                              RCP<const Map> & rootMap)
   {
     // we assume InputMap has uniquely owned rows
     RCP<const Teuchos::Comm<int> > Comm = inputMap->getComm();
@@ -277,22 +275,22 @@ public:
     LO sendCount = inputMap->getNodeNumElements();
     std::vector<LO> recvCounts(numProc), displs(numProc);
     Teuchos::gather<int, LO> (&sendCount, 1, &recvCounts[0], 1,
-			      root, *Comm);
+                              root, *Comm);
     int numGIDs(0);
     std::vector<GO> myNewGIDs;
     if (Comm->getRank() == root) {
       for (int i=0; i<numProc; i++) {
-	numGIDs += recvCounts[i];
-	if (i < numProc-1) displs[i+1] = displs[i] + recvCounts[i];
+        numGIDs += recvCounts[i];
+        if (i < numProc-1) displs[i+1] = displs[i] + recvCounts[i];
       }
       assert (numGIDs == LO(inputMap->getGlobalNumElements()));
       myNewGIDs.resize(numGIDs);
     }
     const GO* globalIDs = (inputMap->getNodeElementList()).getRawPtr();
-    Teuchos::gatherv<int, LO> (globalIDs, sendCount, myNewGIDs.data(), 
-			       recvCounts.data(), displs.data(), root, *Comm);
-    rootMap = rcp( new Map(-1, Teuchos::ArrayView<GO>(myNewGIDs), 0, 
-			   Comm) );
+    Teuchos::gatherv<int, LO> (globalIDs, sendCount, myNewGIDs.data(),
+                               recvCounts.data(), displs.data(), root, *Comm);
+    rootMap = rcp( new Map(-1, Teuchos::ArrayView<GO>(myNewGIDs), 0,
+                           Comm) );
   }
 
 };
@@ -300,4 +298,4 @@ public:
 } // namespace bddc
 
 #endif // DOFMANAGERBDDC_H
-  
+

--- a/packages/shylu/shylu_dd/bddc/src/shylu_PartitionOfUnityBDDC.h
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_PartitionOfUnityBDDC.h
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -51,10 +51,8 @@
 #include "shylu_enumsBDDC.h"
 
 #include "Teuchos_RCP.hpp"
-#include "Teuchos_ParameterList.hpp"  
+#include "Teuchos_ParameterList.hpp"
 
-#include "Tpetra_ConfigDefs.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsGraph.hpp"
@@ -68,15 +66,15 @@ using Teuchos::rcp;
 namespace bddc {
 
 template <class SX,
-	  class SM,
-	  class LO,
-	  class GO> class PartitionOfUnity
+          class SM,
+          class LO,
+          class GO> class PartitionOfUnity
 {
  public:
   //
   // Convenience typedefs
   //
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+  typedef Tpetra::Map<>::node_type                                Node;
   typedef Tpetra::Map<LO,GO,Node>                                 Map;
   typedef Tpetra::CrsGraph<LO,GO,Node>                            CrsGraph;
   typedef Tpetra::Export<LO,GO,Node>                              Export;
@@ -87,16 +85,16 @@ template <class SX,
   }
 
   PartitionOfUnity(LO numNodes,
-		   const GO* nodeGlobalIDs,
-		   const std::vector< std::vector<LO> > & subNodeBegin,
-		   const std::vector< std::vector<LO> > & subNodes,
-		   LO** subRowBegin,
-		   LO** subColumns,
-		   SX** subValues,
-		   LO spatialDim,
-		   RCP<Teuchos::ParameterList> & Parameters,
-		   RCP<const Teuchos::Comm<int> > Comm) :
-  m_numNodes(numNodes), 
+                   const GO* nodeGlobalIDs,
+                   const std::vector< std::vector<LO> > & subNodeBegin,
+                   const std::vector< std::vector<LO> > & subNodes,
+                   LO** subRowBegin,
+                   LO** subColumns,
+                   SX** subValues,
+                   LO spatialDim,
+                   RCP<Teuchos::ParameterList> & Parameters,
+                   RCP<const Teuchos::Comm<int> > Comm) :
+  m_numNodes(numNodes),
     m_nodeGlobalIDs(nodeGlobalIDs),
     m_subNodeBegin(subNodeBegin),
     m_subNodes(subNodes),
@@ -150,7 +148,7 @@ template <class SX,
     return m_equivCard;
   }
 
-  const std::vector<GO> & getGlobalIDs() const 
+  const std::vector<GO> & getGlobalIDs() const
   {
     return m_nodeGlobalIDsCoarse;
   }
@@ -175,7 +173,7 @@ template <class SX,
     return equivType;
   }
 
-  const std::vector< std::vector<LO> > & getEquivClassSubdomains() const 
+  const std::vector< std::vector<LO> > & getEquivClassSubdomains() const
   {
     return m_equivClassSubdomains;
   }
@@ -198,12 +196,12 @@ template <class SX,
   }
 
  private:
-  void determineAdjacentNodes(LO & numAdjNodes, 
-			      std::vector<LO> & adjNodes, 
-			      std::vector<bool> & nodeFlag,
-			      std::vector< std::vector<LO> > & subDofNodes,
-			      LO sub, 
-			      LO node) const
+  void determineAdjacentNodes(LO & numAdjNodes,
+                              std::vector<LO> & adjNodes,
+                              std::vector<bool> & nodeFlag,
+                              std::vector< std::vector<LO> > & subDofNodes,
+                              LO sub,
+                              LO node) const
   {
     const LO* rowBegin = m_subRowBegin[sub];
     const LO* columns = m_subColumns[sub];
@@ -213,15 +211,15 @@ template <class SX,
     const std::vector<LO> & subNodes = m_subNodes[sub];
     for (LO i=nodeBegin[node]; i<nodeBegin[node+1]; i++) {
       for (LO j=rowBegin[i]; j<rowBegin[i+1]; j++) {
-	LO col = columns[j];
-	LO node2 = subNodes[dofNodes[col]];
-	if (std::abs(values[j]) > 0) {
-	  if (nodeFlag[node2] == false) {
-	    nodeFlag[node2] = true;
-	    adjNodes[numAdjNodes] = node2;
-	    numAdjNodes++;
-	  }
-	}
+        LO col = columns[j];
+        LO node2 = subNodes[dofNodes[col]];
+        if (std::abs(values[j]) > 0) {
+          if (nodeFlag[node2] == false) {
+            nodeFlag[node2] = true;
+            adjNodes[numAdjNodes] = node2;
+            numAdjNodes++;
+          }
+        }
       }
     }
   }
@@ -235,8 +233,8 @@ template <class SX,
       const std::vector<LO> & subNodes = m_subNodes[i];
       LO numNodes = m_subNodes[i].size();
       for (LO j=0; j<numNodes; j++) {
-	LO node = subNodes[j];
-	if (nodeBegin[j+1] > nodeBegin[j]) m_nodeIsActive[node] = true;
+        LO node = subNodes[j];
+        if (nodeBegin[j+1] > nodeBegin[j]) m_nodeIsActive[node] = true;
       }
     }
   }
@@ -245,8 +243,8 @@ template <class SX,
   {
     int numSub = m_subNodes.size();
     int numSubScan;
-    Teuchos::scan<int, int> (*m_Comm, Teuchos::REDUCE_SUM, 1, &numSub, 
-			     &numSubScan);
+    Teuchos::scan<int, int> (*m_Comm, Teuchos::REDUCE_SUM, 1, &numSub,
+                             &numSubScan);
     m_startingSub = numSubScan - numSub;
   }
 
@@ -259,15 +257,15 @@ template <class SX,
     for (int i=0; i<numSub; i++) {
       subGIDs[i] = m_startingSub + i;
       for (size_t j=0; j<m_subNodes[i].size(); j++) {
-	nodeSubdomains[m_subNodes[i][j]].push_back(i);
+        nodeSubdomains[m_subNodes[i][j]].push_back(i);
       }
     }
     Teuchos::ArrayRCP<size_t> count(m_numNodes);
     for (LO i=0; i<m_numNodes; i++) count[i] = nodeSubdomains[i].size();
-    RCP<const Map> nodeMap = 
-      rcp(new Map(m_IGO, 
-		  Teuchos::ArrayView<const GO>(m_nodeGlobalIDs,m_numNodes), 
-		  0, m_Comm));
+    RCP<const Map> nodeMap =
+      rcp(new Map(m_IGO,
+                  Teuchos::ArrayView<const GO>(m_nodeGlobalIDs,m_numNodes),
+                  0, m_Comm));
     RCP<const Map> colMap =
       rcp( new Map(m_IGO, Teuchos::ArrayView<GO>(subGIDs), 0, m_Comm) );
     CrsGraph nodeSubs(nodeMap, colMap, count, Tpetra::StaticProfile);
@@ -290,8 +288,8 @@ template <class SX,
       LO numSubNode = Indices.size();
       nodeSubdomains[i].resize(numSubNode);
       for (LO j=0; j<numSubNode; j++) {
-	nodeSubdomains[i][j] = 
-	  nodeSubsAll.getColMap()->getGlobalElement(Indices[j]);
+        nodeSubdomains[i][j] =
+          nodeSubsAll.getColMap()->getGlobalElement(Indices[j]);
       }
       std::sort(nodeSubdomains[i].begin(), nodeSubdomains[i].end());
     }
@@ -308,11 +306,11 @@ template <class SX,
       LO numDof = m_subNodeBegin[i][numNode];
       subDofNodes[i].resize(numDof);
       for (LO j=0; j<numNode; j++) {
-	LO node = m_subNodes[i][j];
-	subsForNodes[node].push_back(std::make_pair(i, j));
-	for (LO k=m_subNodeBegin[i][j]; k<m_subNodeBegin[i][j+1]; k++) {
-	  subDofNodes[i][k] = j;
-	}
+        LO node = m_subNodes[i][j];
+        subsForNodes[node].push_back(std::make_pair(i, j));
+        for (LO k=m_subNodeBegin[i][j]; k<m_subNodeBegin[i][j+1]; k++) {
+          subDofNodes[i][k] = j;
+        }
       }
     }
     std::vector<bool> nodeFlag(m_numNodes, false);
@@ -321,15 +319,15 @@ template <class SX,
     for (LO i=0; i<m_numNodes; i++) {
       LO numAdjNodes(0);
       for (size_t j=0; j<subsForNodes[i].size(); j++) {
-	LO sub = subsForNodes[i][j].first;
-	LO node = subsForNodes[i][j].second;
-	determineAdjacentNodes(numAdjNodes, adjNodes, nodeFlag, subDofNodes, 
-			       sub, node);
+        LO sub = subsForNodes[i][j].first;
+        LO node = subsForNodes[i][j].second;
+        determineAdjacentNodes(numAdjNodes, adjNodes, nodeFlag, subDofNodes,
+                               sub, node);
       }
       nodeConnectivity[i].resize(numAdjNodes);
       for (LO j=0; j<numAdjNodes; j++) {
-	nodeConnectivity[i][j] = adjNodes[j];
-	nodeFlag[adjNodes[j]] = false;
+        nodeConnectivity[i][j] = adjNodes[j];
+        nodeFlag[adjNodes[j]] = false;
       }
     }
   }
@@ -356,7 +354,7 @@ template <class SX,
   {
     if (m_constructAdjacencyGraph == false) return;
     LO numSub = m_subNodes.size();
-    std::vector< std::vector< std::pair<LO, enum EquivType> > > 
+    std::vector< std::vector< std::pair<LO, enum EquivType> > >
       allConnections(numSub);
     determineAllSubdomainConnections(nodeSubdomains, allConnections);
     std::vector< std::vector<GO> > subdomainAdjacencies(numSub);
@@ -369,28 +367,28 @@ template <class SX,
     }
     RCP<const Map> subMap =
       rcp( new Map(m_IGO, Teuchos::ArrayView<GO>(subdomainGIDs), 0, m_Comm) );
-    m_subdomainConnectivity = 
+    m_subdomainConnectivity =
       rcp( new CrsGraph(subMap, count, Tpetra::StaticProfile) );
     for (LO i=0; i<numSub; i++) {
       m_subdomainConnectivity->insertGlobalIndices
-	(subdomainGIDs[i], Teuchos::ArrayView<GO>(subdomainAdjacencies[i]));
+        (subdomainGIDs[i], Teuchos::ArrayView<GO>(subdomainAdjacencies[i]));
     }
     m_subdomainConnectivity->fillComplete();
   }
 
   void equivalenceClasses(std::vector< std::vector<LO> > & nodeSubdomains,
-			  std::vector< std::vector<LO> > & nodeConnectivity,
-			  std::vector<int> & component)
+                          std::vector< std::vector<LO> > & nodeConnectivity,
+                          std::vector<int> & component)
   {
     std::vector< std::pair<double, LO> > subEncoding(m_numNodes);
     for (LO i=0; i<m_numNodes; i++) {
       LO numSub = nodeSubdomains[i].size();
       double sum = 0;
-      if ((numSub > 1) &&	(m_nodeIsActive[i] == true)) {
-	for (LO j=0; j<numSub; j++) {
-	  sum += sqrt(double(nodeSubdomains[i][j]+
-			     sqrt(double(7))*component[i]+1.7));
-	}
+      if ((numSub > 1) &&       (m_nodeIsActive[i] == true)) {
+        for (LO j=0; j<numSub; j++) {
+          sum += sqrt(double(nodeSubdomains[i][j]+
+                             sqrt(double(7))*component[i]+1.7));
+        }
       }
       subEncoding[i] = std::make_pair(sum, i);
     }
@@ -401,8 +399,8 @@ template <class SX,
       currentVal = subEncoding[i].first;
       localNodes[i] = subEncoding[i].second;
       if (fabs(currentVal-previousVal) > tol) {
-	start.push_back(i);
-	previousVal = currentVal;
+        start.push_back(i);
+        previousVal = currentVal;
       }
     }
     start.push_back(m_numNodes);
@@ -411,7 +409,7 @@ template <class SX,
     for (LO i=0; i<numEquivClasses; i++) {
       m_equivClasses[i].resize(start[i+1]-start[i]);
       for (LO j=start[i]; j<start[i+1]; j++) {
-	m_equivClasses[i][j-start[i]] = localNodes[j];
+        m_equivClasses[i][j-start[i]] = localNodes[j];
       }
       sortByGlobalIDs(m_equivClasses[i]);
     }
@@ -428,15 +426,15 @@ template <class SX,
       LO node = m_equivClasses[i][0];
       const std::vector<LO> & subs = nodeSubdomains[node];
       for (size_t j=0; j<subs.size(); j++) {
-	LO localSub = subs[j] - m_startingSub;
-	if ((localSub >= 0) && (localSub < numSub)) {
-	  for (size_t k=0; k<subs.size(); k++) {
-	    if (subs[k] != subs[j]) {
-	      allConnections[localSub].push_back
-		(std::make_pair(subs[k], equivT));
-	    }
-	  }
-	}
+        LO localSub = subs[j] - m_startingSub;
+        if ((localSub >= 0) && (localSub < numSub)) {
+          for (size_t k=0; k<subs.size(); k++) {
+            if (subs[k] != subs[j]) {
+              allConnections[localSub].push_back
+                (std::make_pair(subs[k], equivT));
+            }
+          }
+        }
       }
     }
   }
@@ -466,24 +464,24 @@ template <class SX,
       int previousSub = -1;
       std::vector<int> subBegin;
       for (size_t j=0; j<allConnections[i].size(); j++) {
-	if (allConnections[i][j].first != previousSub) {
-	  subBegin.push_back(j);
-	  previousSub = allConnections[i][j].first;
-	}
+        if (allConnections[i][j].first != previousSub) {
+          subBegin.push_back(j);
+          previousSub = allConnections[i][j].first;
+        }
       }
       subBegin.push_back(allConnections[i].size());
       int numSub2 = subBegin.size() - 1;
       for (int j=0; j<numSub2; j++) {
-	std::vector<int> countEquivType(3, 0);
-	for (int k=subBegin[j]; k<subBegin[j+1]; k++) {
-	  countEquivType[allConnections[i][k].second]++;
-	}
-	bool isAdjacent = checkAdjacency(countEquivType);
-	if (isAdjacent == true) {
-	  int index = subBegin[j];
-	  GO adjSubdomain = allConnections[i][index].first;
-	  subdomainAdjacencies[i].push_back(adjSubdomain);
-	}
+        std::vector<int> countEquivType(3, 0);
+        for (int k=subBegin[j]; k<subBegin[j+1]; k++) {
+          countEquivType[allConnections[i][k].second]++;
+        }
+        bool isAdjacent = checkAdjacency(countEquivType);
+        if (isAdjacent == true) {
+          int index = subBegin[j];
+          GO adjSubdomain = allConnections[i][index].first;
+          subdomainAdjacencies[i].push_back(adjSubdomain);
+        }
       }
     }
   }
@@ -539,10 +537,10 @@ template <class SX,
       const std::vector<LO> & subs = nodeSubdomains[node];
       m_equivCard[i] = subs.size();
       for (size_t j=0; j<subs.size(); j++) {
-	LO localSub = subs[j] - m_startingSub;
-	if ((localSub >= 0) && (localSub < numSub)) {
-	  m_subdomainEquivClasses[localSub].push_back(i);
-	}
+        LO localSub = subs[j] - m_startingSub;
+        if ((localSub >= 0) && (localSub < numSub)) {
+          m_subdomainEquivClasses[localSub].push_back(i);
+        }
       }
     }
   }
@@ -561,30 +559,30 @@ template <class SX,
       for (LO j=0; j<numEquivNodes; j++) nodeMap[equivNodes[j]] = j;
       A2.resize(numEquivNodes+1, 0);
       for (LO j=0; j<numEquivNodes; j++) {
-	LO node1 = equivNodes[j];
-	for (size_t k=0; k<nodeConnectivity[node1].size(); k++) {
-	  LO node2 = nodeMap[nodeConnectivity[node1][k]];
-	  if (node2 != -1) {
-	    A1.push_back(node2);
-	    numTerms++;
-	  }
-	}
-	A2[j+1] = numTerms;
+        LO node1 = equivNodes[j];
+        for (size_t k=0; k<nodeConnectivity[node1].size(); k++) {
+          LO node2 = nodeMap[nodeConnectivity[node1][k]];
+          if (node2 != -1) {
+            A1.push_back(node2);
+            numTerms++;
+          }
+        }
+        A2[j+1] = numTerms;
       }
       for (LO j=0; j<numEquivNodes; j++) nodeMap[equivNodes[j]] = -1;
       int *componentEQ(0);
       determineComponents(&A1[0], &A2[0], numEquivNodes, componentEQ);
       for (LO j=0; j<numEquivNodes; j++) {
-	component[equivNodes[j]] = componentEQ[j];
+        component[equivNodes[j]] = componentEQ[j];
       }
       delete [] componentEQ;
     }
   }
 
-  void determineComponents(LO *A1, 
-			   LO *A2, 
-			   LO N, 
-			   LO* & component) const
+  void determineComponents(LO *A1,
+                           LO *A2,
+                           LO N,
+                           LO* & component) const
   {
     LO i;
     component = new LO[N];
@@ -592,33 +590,33 @@ template <class SX,
     componentsFunction(A1, A2, N, component);
   }
 
-  void componentsFunction(LO *A1, 
-			  LO *A2, 
-			  LO N, 
-			  LO* component) const
+  void componentsFunction(LO *A1,
+                          LO *A2,
+                          LO N,
+                          LO* component) const
   {
     LO i, comp_num;
     comp_num = 0;
     for (i=0; i<N; i++) {
       if (component[i] == -1) {
-	depthFirstSearch(i, comp_num, component, A1, A2);
-	comp_num++;
+        depthFirstSearch(i, comp_num, component, A1, A2);
+        comp_num++;
       }
     }
   }
 
-  void depthFirstSearch(const LO v, 
-			const LO comp_num, 
-			LO* component,
-			LO* A1, 
-			LO* A2) const
+  void depthFirstSearch(const LO v,
+                        const LO comp_num,
+                        LO* component,
+                        LO* A1,
+                        LO* A2) const
   {
     LO i, adj_vertex;
     component[v] = comp_num;
     for (i=A2[v]; i<A2[v+1]; i++) {
       adj_vertex = A1[i];
-      if (component[adj_vertex] == -1) 
-	depthFirstSearch(adj_vertex, comp_num, component, A1, A2);
+      if (component[adj_vertex] == -1)
+        depthFirstSearch(adj_vertex, comp_num, component, A1, A2);
     }
   }
 
@@ -647,10 +645,10 @@ template <class SX,
       const std::vector<LO> & subs = nodeSubdomains[node];
       subsForEquiv[i].resize(subs.size());
       for (size_t j=0; j<subs.size(); j++) {
-	LO sub = subs[j];
-	LO localSub = findEntry(uniqueSubs, sub);
-	subsForEquiv[i][j] = localSub;
-	equivsForSub[localSub].push_back(i);
+        LO sub = subs[j];
+        LO localSub = findEntry(uniqueSubs, sub);
+        subsForEquiv[i][j] = localSub;
+        equivsForSub[localSub].push_back(i);
       }
     }
     // determine number of active ancestors for each equivalence class
@@ -660,25 +658,25 @@ template <class SX,
       LO sub = subsForEquiv[i][0];
       LO numSubEquiv = subsForEquiv[i].size();
       for (size_t j=0; j<equivsForSub[sub].size(); j++) {
-	LO equiv = equivsForSub[sub][j];
-	bool isActive = isActiveEquiv(equiv);
-	if (isActive == false) continue;
-	LO numSubEquiv2 = subsForEquiv[equiv].size();
-	if (numSubEquiv2 <= numSubEquiv) continue;
-	for (LO k=0; k<numSubEquiv2; k++) {
-	  subFlag[subsForEquiv[equiv][k]] = true;
-	}
-	bool isAncestor = true;
-	for (LO k=0; k<numSubEquiv; k++) {
-	  if (subFlag[subsForEquiv[i][k]] == false) {
-	    isAncestor = false;
-	    break;
-	  }
-	}
-	for (LO k=0; k<numSubEquiv2; k++) {
-	  subFlag[subsForEquiv[equiv][k]] = false;
-	}
-	if (isAncestor == true) m_numActiveAncestors[i]++;
+        LO equiv = equivsForSub[sub][j];
+        bool isActive = isActiveEquiv(equiv);
+        if (isActive == false) continue;
+        LO numSubEquiv2 = subsForEquiv[equiv].size();
+        if (numSubEquiv2 <= numSubEquiv) continue;
+        for (LO k=0; k<numSubEquiv2; k++) {
+          subFlag[subsForEquiv[equiv][k]] = true;
+        }
+        bool isAncestor = true;
+        for (LO k=0; k<numSubEquiv; k++) {
+          if (subFlag[subsForEquiv[i][k]] == false) {
+            isAncestor = false;
+            break;
+          }
+        }
+        for (LO k=0; k<numSubEquiv2; k++) {
+          subFlag[subsForEquiv[equiv][k]] = false;
+        }
+        if (isAncestor == true) m_numActiveAncestors[i]++;
       }
     }
   }
@@ -692,8 +690,8 @@ template <class SX,
     return false;
   }
 
-  LO findEntry(std::vector<LO> & vector, 
-	       LO value) const
+  LO findEntry(std::vector<LO> & vector,
+               LO value) const
   {
     auto iter = std::lower_bound(vector.begin(), vector.end(), value);
     assert (iter != vector.end());
@@ -709,7 +707,7 @@ template <class SX,
   LO **m_subRowBegin,  **m_subColumns;
   SX **m_subValues;
   LO m_spatialDim;
-  bool m_constructAdjacencyGraph, m_addCorners, m_useCorners, m_useEdges, 
+  bool m_constructAdjacencyGraph, m_addCorners, m_useCorners, m_useEdges,
     m_useFaces;
   RCP<const Teuchos::Comm<int> > m_Comm;
   Tpetra::global_size_t m_IGO;
@@ -728,4 +726,4 @@ template <class SX,
 } // namespace bddc
 
 #endif // PARTITIONOFUNITYBDDC_H
-  
+

--- a/packages/shylu/shylu_dd/bddc/src/shylu_WeightsBDDC.h
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_WeightsBDDC.h
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -58,15 +58,15 @@ using Teuchos::rcp;
 
 // Author: Clark R. Dohrmann
 namespace bddc {
-  
-template <class SX, class SM, class LO, class GO> 
+
+template <class SX, class SM, class LO, class GO>
   class WeightsBDDC
 {
 public:
   //
   // Convenience typedefs
   //
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+  typedef Tpetra::Map<>::node_type                                Node;
   typedef Tpetra::Map<LO,GO,Node>                                 Map;
   typedef Tpetra::CrsGraph<LO,GO,Node>                            CrsGraph;
   typedef Tpetra::CrsMatrix<SX,LO,GO,Node>                        CrsMatrix;
@@ -127,7 +127,7 @@ private:
 
   void determineEquivAndWeightTypes()
   {
-    const std::vector< std::vector<LO> > & subdomainEquivClasses = 
+    const std::vector< std::vector<LO> > & subdomainEquivClasses =
       m_Partition->getSubdomainEquivClasses();
     m_equivType.resize(m_numSub);
     m_weightType.resize(m_numSub);
@@ -136,9 +136,9 @@ private:
       m_equivType[i].resize(numEquiv);
       m_weightType[i].resize(numEquiv);
       for (LO j=0; j<numEquiv; j++) {
-	LO equiv = subdomainEquivClasses[i][j];
-	m_equivType[i][j] = m_Partition->getEquivType(equiv);
-	m_weightType[i][j] = getWeightType(m_equivType[i][j]);
+        LO equiv = subdomainEquivClasses[i][j];
+        m_equivType[i][j] = m_Partition->getEquivType(equiv);
+        m_weightType[i][j] = getWeightType(m_equivType[i][j]);
       }
     }
   }
@@ -166,12 +166,12 @@ private:
     for (LO i=0; i<m_numSub; i++) {
       LO numEquiv = m_Subdomain[i]->getNumEquiv();
       for (LO j=0; j<numEquiv; j++) {
-	if (m_weightType[i][j] == DELUXE) deluxeFlag = 1;
+        if (m_weightType[i][j] == DELUXE) deluxeFlag = 1;
       }
     }
     LO deluxeFlagMax;
-    Teuchos::reduceAll<int, LO> (*m_Comm, Teuchos::REDUCE_MAX, 1, 
-				 &deluxeFlag, &deluxeFlagMax);
+    Teuchos::reduceAll<int, LO> (*m_Comm, Teuchos::REDUCE_MAX, 1,
+                                 &deluxeFlag, &deluxeFlagMax);
     if (deluxeFlagMax == 0) return;
     // calculate equivalence class Schur complements
     deluxeWeights.resize(m_numSub);
@@ -183,24 +183,24 @@ private:
       deluxeWeights[i].resize(numEquiv);
       LO localDofB = 0;
       for (LO j=0; j<numEquiv; j++) {
-	const LO* equivDofsGlobal = &m_subBoundaryDofs[i][localDofB];
-	LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
-	if (m_weightType[i][j] == bddc::DELUXE) {
-	  std::vector<SX> & Sc = deluxeWeights[i][j];
-	  m_Subdomain[i]->calculateSchurComplement(j, Sc);
-	  columns.resize(numEquivDofs);
-	  for (LO k=0; k<numEquivDofs; k++) {
-	    columns[k] = equivDofsGlobal[k];
-	  }
-	  for (LO k=0; k<numEquivDofs; k++) {
-	    LO row = equivDofsGlobal[k];
-	    if (rowFlag[row] == false) {
-	      rowFlag[row] = true;
-	      ScGraph->insertLocalIndices(row, Teuchos::ArrayView<LO>(columns));
-	    }
-	  }
-	}
-	localDofB += numEquivDofs;
+        const LO* equivDofsGlobal = &m_subBoundaryDofs[i][localDofB];
+        LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
+        if (m_weightType[i][j] == bddc::DELUXE) {
+          std::vector<SX> & Sc = deluxeWeights[i][j];
+          m_Subdomain[i]->calculateSchurComplement(j, Sc);
+          columns.resize(numEquivDofs);
+          for (LO k=0; k<numEquivDofs; k++) {
+            columns[k] = equivDofsGlobal[k];
+          }
+          for (LO k=0; k<numEquivDofs; k++) {
+            LO row = equivDofsGlobal[k];
+            if (rowFlag[row] == false) {
+              rowFlag[row] = true;
+              ScGraph->insertLocalIndices(row, Teuchos::ArrayView<LO>(columns));
+            }
+          }
+        }
+        localDofB += numEquivDofs;
       }
     }
     ScGraph->fillComplete(m_dofMapB1to1, m_dofMapB1to1);
@@ -212,23 +212,23 @@ private:
       LO numEquiv = m_Subdomain[i]->getNumEquiv();
       LO localDofB = 0;
       for (LO j=0; j<numEquiv; j++) {
-	const LO* equivDofsGlobal = &m_subBoundaryDofs[i][localDofB];
-	LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
-	std::vector<SX> & ScSub = deluxeWeights[i][j];
-	if (ScSub.size() > 0) {
-	  values.resize(numEquivDofs);
-	  indices.resize(numEquivDofs);
-	  for (LO k=0; k<numEquivDofs; k++) {
-	    for (LO m=0; m<numEquivDofs; m++) {
-	      values[m] = ScSub[k+m*numEquivDofs];
-	      indices[m] = equivDofsGlobal[m];
-	    }
-	    LO row = equivDofsGlobal[k];
-	    Sc.sumIntoLocalValues(row, Teuchos::ArrayView<LO>(indices),
-				  Teuchos::ArrayView<SX>(values));
-	  }
-	}
-	localDofB += numEquivDofs;
+        const LO* equivDofsGlobal = &m_subBoundaryDofs[i][localDofB];
+        LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
+        std::vector<SX> & ScSub = deluxeWeights[i][j];
+        if (ScSub.size() > 0) {
+          values.resize(numEquivDofs);
+          indices.resize(numEquivDofs);
+          for (LO k=0; k<numEquivDofs; k++) {
+            for (LO m=0; m<numEquivDofs; m++) {
+              values[m] = ScSub[k+m*numEquivDofs];
+              indices[m] = equivDofsGlobal[m];
+            }
+            LO row = equivDofsGlobal[k];
+            Sc.sumIntoLocalValues(row, Teuchos::ArrayView<LO>(indices),
+                                  Teuchos::ArrayView<SX>(values));
+          }
+        }
+        localDofB += numEquivDofs;
       }
     }
     Sc.fillComplete(m_dofMapB1to1, m_dofMapB1to1);
@@ -246,36 +246,36 @@ private:
       LO numEquiv = m_Subdomain[i]->getNumEquiv();
       LO localDofB = 0;
       for (LO j=0; j<numEquiv; j++) {
-	const LO* equivDofsGlobal = &m_subBoundaryDofs[i][localDofB];
-	LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
-	std::vector<SX> & ScSub = deluxeWeights[i][j];
-	if (ScSub.size() > 0) {
-	  Teuchos::ArrayView<const LO> Indices;
-	  Teuchos::ArrayView<const SX> Values;
-	  ScEquiv.resize(numEquivDofs*numEquivDofs);
-	  for (LO k=0; k<numEquivDofs; k++) {
-	    globalToLocalMap[equivDofsGlobal[k]] = k;
-	  }
-	  for (LO k=0; k<numEquivDofs; k++) {
-	    LO row = equivDofsGlobal[k];
-	    ScSum.getLocalRowView(row, Indices, Values);
-	    assert (Indices.size() == numEquivDofs);
-	    for (LO m=0; m<numEquivDofs; m++) {
-	      LO localCol = globalToLocalMap[Indices[m]];
-	      assert (localCol != -1);
-	      ScEquiv[k+localCol*numEquivDofs] = Values[m];
-	    }
-	  }
-	  for (LO k=0; k<numEquivDofs; k++) {
-	    globalToLocalMap[equivDofsGlobal[k]] = -1;
-	  }
-	  Teuchos::LAPACK<int, SX> LAPACK;
-	  int INFO(0), N(numEquivDofs);
-	  std::vector<int> IPIV(N);
-	  LAPACK.GESV(N, N, &ScEquiv[0], N, &IPIV[0], &deluxeWeights[i][j][0], 
-		      N, &INFO);
-	}
-	localDofB += numEquivDofs;
+        const LO* equivDofsGlobal = &m_subBoundaryDofs[i][localDofB];
+        LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
+        std::vector<SX> & ScSub = deluxeWeights[i][j];
+        if (ScSub.size() > 0) {
+          Teuchos::ArrayView<const LO> Indices;
+          Teuchos::ArrayView<const SX> Values;
+          ScEquiv.resize(numEquivDofs*numEquivDofs);
+          for (LO k=0; k<numEquivDofs; k++) {
+            globalToLocalMap[equivDofsGlobal[k]] = k;
+          }
+          for (LO k=0; k<numEquivDofs; k++) {
+            LO row = equivDofsGlobal[k];
+            ScSum.getLocalRowView(row, Indices, Values);
+            assert (Indices.size() == numEquivDofs);
+            for (LO m=0; m<numEquivDofs; m++) {
+              LO localCol = globalToLocalMap[Indices[m]];
+              assert (localCol != -1);
+              ScEquiv[k+localCol*numEquivDofs] = Values[m];
+            }
+          }
+          for (LO k=0; k<numEquivDofs; k++) {
+            globalToLocalMap[equivDofsGlobal[k]] = -1;
+          }
+          Teuchos::LAPACK<int, SX> LAPACK;
+          int INFO(0), N(numEquivDofs);
+          std::vector<int> IPIV(N);
+          LAPACK.GESV(N, N, &ScEquiv[0], N, &IPIV[0], &deluxeWeights[i][j][0],
+                      N, &INFO);
+        }
+        localDofB += numEquivDofs;
       }
     }
   }
@@ -283,43 +283,43 @@ private:
   void determineEquivWeights
     (std::vector< std::vector< std::vector<SX> > > & deluxeWeights)
   {
-    const std::vector< std::vector<LO> > & subdomainEquivClasses = 
+    const std::vector< std::vector<LO> > & subdomainEquivClasses =
       m_Partition->getSubdomainEquivClasses();
     const std::vector<LO> & equivCard = m_Partition->getEquivCardinality();
     for (LO i=0; i<m_numSub; i++) {
       LO numEquiv = m_Subdomain[i]->getNumEquiv();
-      std::vector< std::vector<LO> > rowBeginWeight(numEquiv), 
-	columnsWeight(numEquiv);
+      std::vector< std::vector<LO> > rowBeginWeight(numEquiv),
+        columnsWeight(numEquiv);
       std::vector< std::vector<SX> > valuesWeight(numEquiv);
       const LO* equivDofsGlobal = &m_subBoundaryDofs[i][0];
       for (LO j=0; j<numEquiv; j++) {
-	LO equiv = subdomainEquivClasses[i][j];
-	LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
-	if (m_weightType[i][j] == CARDINALITY) {
-	  setCardinalityWeights(i, j, rowBeginWeight[j], columnsWeight[j],
-				valuesWeight[j], equivCard[equiv]);
-	}
-	else if (m_weightType[i][j] == STIFFNESS) {
-	  setStiffnessWeights(i, j, rowBeginWeight[j], columnsWeight[j],
-			      valuesWeight[j], equivDofsGlobal);
-	}
-	else {
-	  setDeluxeWeights(i, j, rowBeginWeight[j], columnsWeight[j],
-			   valuesWeight[j], deluxeWeights[i][j]);
-	}
-	equivDofsGlobal += numEquivDofs;
+        LO equiv = subdomainEquivClasses[i][j];
+        LO numEquivDofs = m_Subdomain[i]->getNumEquivDofs(j);
+        if (m_weightType[i][j] == CARDINALITY) {
+          setCardinalityWeights(i, j, rowBeginWeight[j], columnsWeight[j],
+                                valuesWeight[j], equivCard[equiv]);
+        }
+        else if (m_weightType[i][j] == STIFFNESS) {
+          setStiffnessWeights(i, j, rowBeginWeight[j], columnsWeight[j],
+                              valuesWeight[j], equivDofsGlobal);
+        }
+        else {
+          setDeluxeWeights(i, j, rowBeginWeight[j], columnsWeight[j],
+                           valuesWeight[j], deluxeWeights[i][j]);
+        }
+        equivDofsGlobal += numEquivDofs;
       }
       m_Subdomain[i]->setEquivalenceClassWeightMatrices
-	(rowBeginWeight, columnsWeight, valuesWeight);
+        (rowBeginWeight, columnsWeight, valuesWeight);
     }
   }
 
-  void setCardinalityWeights(LO sub, 
-			     LO equiv, 
-			     std::vector<LO> & rowBeginWeight, 
-			     std::vector<LO> & columnsWeight,
-			     std::vector<SX> & valuesWeight, 
-			     LO equivCard)
+  void setCardinalityWeights(LO sub,
+                             LO equiv,
+                             std::vector<LO> & rowBeginWeight,
+                             std::vector<LO> & columnsWeight,
+                             std::vector<SX> & valuesWeight,
+                             LO equivCard)
   {
     LO numEquivDofs = m_Subdomain[sub]->getNumEquivDofs(equiv);
     rowBeginWeight.resize(numEquivDofs+1, 0);
@@ -332,12 +332,12 @@ private:
     }
   }
 
-  void setStiffnessWeights(LO sub, 
-			   LO equiv, 
-			   std::vector<LO> & rowBeginWeight, 
-			   std::vector<LO> & columnsWeight,
-			   std::vector<SX> & valuesWeight,
-			   const LO* equivDofsGlobal)
+  void setStiffnessWeights(LO sub,
+                           LO equiv,
+                           std::vector<LO> & rowBeginWeight,
+                           std::vector<LO> & columnsWeight,
+                           std::vector<SX> & valuesWeight,
+                           const LO* equivDofsGlobal)
   {
     LO numEquivDofs = m_Subdomain[sub]->getNumEquivDofs(equiv);
     rowBeginWeight.resize(numEquivDofs+1, 0);
@@ -354,12 +354,12 @@ private:
     }
   }
 
-  void setDeluxeWeights(LO sub, 
-			LO equiv, 
-			std::vector<LO> & rowBeginWeight, 
-			std::vector<LO> & columnsWeight,
-			std::vector<SX> & valuesWeight,
-			std::vector<SX> & deluxeWeights)
+  void setDeluxeWeights(LO sub,
+                        LO equiv,
+                        std::vector<LO> & rowBeginWeight,
+                        std::vector<LO> & columnsWeight,
+                        std::vector<SX> & valuesWeight,
+                        std::vector<SX> & deluxeWeights)
   {
     LO numEquivDofs = m_Subdomain[sub]->getNumEquivDofs(equiv);
     LO numTerms = numEquivDofs*numEquivDofs;
@@ -370,9 +370,9 @@ private:
     numTerms = 0;
     for (LO i=0; i<numEquivDofs; i++) {
       for (LO j=0; j<numEquivDofs; j++) {
-	columnsWeight[numTerms] = j;
-	valuesWeight[numTerms] = deluxeWeights[i+j*numEquivDofs];
-	numTerms++;
+        columnsWeight[numTerms] = j;
+        valuesWeight[numTerms] = deluxeWeights[i+j*numEquivDofs];
+        numTerms++;
       }
       rowBeginWeight[i+1] = numTerms;
     }
@@ -389,8 +389,8 @@ private:
       m_Subdomain[i]->applyWeights(&x[0], applyTranspose, &Wx[0]);
       assert (m_subBoundaryDofs[i].size() == numSubDofB);
       for (LO j=0; j<numSubDofB; j++) {
-	LO dofB = m_subBoundaryDofs[i][j];
-	sumWeightsB[dofB] += Wx[j];
+        LO dofB = m_subBoundaryDofs[i][j];
+        sumWeightsB[dofB] += Wx[j];
       }
     }
     MV SumWeightsB(m_dofMapB, 1);
@@ -408,7 +408,7 @@ private:
     }
     SM maxErrorAll;
     Teuchos::reduceAll<int, SM>(*m_Comm, Teuchos::REDUCE_MAX, 1,
-				&maxError, &maxErrorAll);
+                                &maxError, &maxErrorAll);
     return maxErrorAll;
   }
 
@@ -417,4 +417,4 @@ private:
 } // namespace bddc
 
 #endif // WEIGHTSBDDC_H
-  
+

--- a/packages/shylu/shylu_dd/bddc/src/shylu_ZoltanPartition.h
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_ZoltanPartition.h
@@ -15,8 +15,7 @@
 #include <mpi.h>
 #include "Tpetra_ConfigDefs.hpp"
 #include "Teuchos_RCP.hpp"
-#include "Teuchos_ParameterList.hpp"  
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Teuchos_ParameterList.hpp"
 #include "Tpetra_Version.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsGraph.hpp"
@@ -36,21 +35,20 @@ enum PartitionOption{
 namespace bddc {
 
 template <class LO,
-	  class GO> class ZoltanPartition
+          class GO> class ZoltanPartition
 {
 public:
   //
   // Convenience typedefs
   //
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType            Platform;
-  typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+  typedef Tpetra::Map<>::node_type                                Node;
   typedef Tpetra::Map<LO,GO,Node>                                 Map;
   typedef Tpetra::CrsGraph<LO,GO,Node>                            CrsGraph;
   typedef Tpetra::Export<LO,GO,Node>                              Export;
   typedef Tpetra::Import<LO,GO,Node>                              Import;
-  
+
   ZoltanPartition(RCP<const CrsGraph> Graph,
-		  RCP< Teuchos::ParameterList > Parameters) :
+                  RCP< Teuchos::ParameterList > Parameters) :
   m_Graph(Graph),
     m_Parameters(Parameters),
     m_Comm(GetMPIComm()),
@@ -63,12 +61,12 @@ public:
   }
 
   ZoltanPartition(LO numRows,
-		  const LO* rowBegin,
-		  const LO* columns,
-		  const double* coords,
-		  const GO* globalIDs,
-		  MPI_Comm Comm,
-		  RCP< Teuchos::ParameterList > Parameters) :
+                  const LO* rowBegin,
+                  const LO* columns,
+                  const double* coords,
+                  const GO* globalIDs,
+                  MPI_Comm Comm,
+                  RCP< Teuchos::ParameterList > Parameters) :
   m_Graph(Teuchos::null),
     m_Parameters(Parameters),
     m_Comm(Comm),
@@ -95,13 +93,13 @@ public:
     if (m_LBMethod == GRAPH) {
       numEntries = m_ConnBegin[m_numMyObjects];
       if (m_edgeWeights.size() == 0) {
-	m_edgeWeights.resize(numEntries, 1); 
+        m_edgeWeights.resize(numEntries, 1);
       }
       m_vertexWeights.resize(m_numMyObjects, 1);
     }
     else {
       if (m_vertexWeights.size() == 0) {
-	m_vertexWeights.resize(m_numMyObjects, 1);
+        m_vertexWeights.resize(m_numMyObjects, 1);
       }
     }
   }
@@ -136,12 +134,12 @@ public:
     ZOLTAN_ID_PTR exportLocalIds;
     int *exportProcs;
     int *exportToPart;
-    
+
     int rc = m_zz->LB_Partition
       (changes, numGidEntries, numLidEntries,
        numImport, importGlobalIds, importLocalIds, importProcs, importToPart,
        numExport, exportGlobalIds, exportLocalIds, exportProcs, exportToPart);
-    
+
     if (rc != ZOLTAN_OK) {
       printf("Partitioning failed on process %d\n", m_MyPID);
       delete m_zz;
@@ -157,12 +155,12 @@ public:
 
     delete m_zz;
     Zoltan::LB_Free_Part(&importGlobalIds, &importLocalIds, &importProcs,
-			 &importToPart);
+                         &importToPart);
     Zoltan::LB_Free_Part(&exportGlobalIds, &exportLocalIds, &exportProcs,
-			 &exportToPart);
+                         &exportToPart);
   }
 
-  LO getNumMyObjects() 
+  LO getNumMyObjects()
   {
     return m_numMyObjects;
   }
@@ -199,23 +197,23 @@ public:
   void getVertexWeights(float* & vertexWeights) {
     vertexWeights = &m_vertexWeights[0];
   }
-  
-  static int getNumberOfObjects(void *data, 
-				int *ierr)
+
+  static int getNumberOfObjects(void *data,
+                                int *ierr)
   {
     ZoltanPartition *objs = (ZoltanPartition *)data;
     *ierr = ZOLTAN_OK;
     return objs->getNumMyObjects();
   }
 
-  static void getObjectList(void *data, 
-			    int sizeGID, 
-			    int sizeLID,
-			    ZOLTAN_ID_PTR globalID, 
-			    ZOLTAN_ID_PTR localID,
-			    int wgt_dim, 
-			    float *obj_wgts, 
-			    int *ierr)
+  static void getObjectList(void *data,
+                            int sizeGID,
+                            int sizeLID,
+                            ZOLTAN_ID_PTR globalID,
+                            ZOLTAN_ID_PTR localID,
+                            int wgt_dim,
+                            float *obj_wgts,
+                            int *ierr)
   {
     if ((sizeGID != 1) || (sizeLID != 1) || wgt_dim != 1) {
       *ierr = ZOLTAN_FATAL;
@@ -233,22 +231,22 @@ public:
     *ierr = ZOLTAN_OK;
   }
 
-  static int getSpatialDimension(void *data, 
-				 int *ierr)
+  static int getSpatialDimension(void *data,
+                                 int *ierr)
   {
     *ierr = ZOLTAN_OK;
     return 3;
   }
 
-  static void getCoordinates(void *data, 
-			     int sizeGID, 
-			     int sizeLID,
-			     int num_obj,
-			     ZOLTAN_ID_PTR globalID, 
-			     ZOLTAN_ID_PTR localID,
-			     int num_dim,
-			     double* coordinates,
-			     int *ierr)
+  static void getCoordinates(void *data,
+                             int sizeGID,
+                             int sizeLID,
+                             int num_obj,
+                             ZOLTAN_ID_PTR globalID,
+                             ZOLTAN_ID_PTR localID,
+                             int num_dim,
+                             double* coordinates,
+                             int *ierr)
   {
     if ((sizeGID != 1) || (sizeLID != 1) || (num_dim != 3)) {
       *ierr = ZOLTAN_FATAL;
@@ -259,20 +257,20 @@ public:
     int numMyObjects = objs->getNumMyObjects();
     for (int i=0; i<num_obj; i++) {
       for (int j=0; j<num_dim; j++) {
-	coordinates[num_dim*i+j] = xyz[j*numMyObjects+localID[i]];
+        coordinates[num_dim*i+j] = xyz[j*numMyObjects+localID[i]];
       }
     }
     *ierr = ZOLTAN_OK;
   }
 
-  static void getNumEdges(void *data, 
-			  int sizeGID, 
-			  int sizeLID,
-			  int num_obj,
-			  ZOLTAN_ID_PTR globalID, 
-			  ZOLTAN_ID_PTR localID,
-			  int *numEdges, 
-			  int *ierr)
+  static void getNumEdges(void *data,
+                          int sizeGID,
+                          int sizeLID,
+                          int num_obj,
+                          ZOLTAN_ID_PTR globalID,
+                          ZOLTAN_ID_PTR localID,
+                          int *numEdges,
+                          int *ierr)
   {
     ZoltanPartition *objs = (ZoltanPartition *)data;
     int n = objs->getNumMyObjects();
@@ -289,18 +287,18 @@ public:
     *ierr = ZOLTAN_OK;
   }
 
-  static void getEdgeList(void *data, 
-			  int sizeGID, 
-			  int sizeLID,
-			  int num_obj, 
-			  ZOLTAN_ID_PTR globalID, 
-			  ZOLTAN_ID_PTR localID,
-			  int *num_edges,
-			  ZOLTAN_ID_PTR nborGID, 
-			  int *nborProc,
-			  int wgt_dim, 
-			  float *ewgts, 
-			  int *ierr)
+  static void getEdgeList(void *data,
+                          int sizeGID,
+                          int sizeLID,
+                          int num_obj,
+                          ZOLTAN_ID_PTR globalID,
+                          ZOLTAN_ID_PTR localID,
+                          int *num_edges,
+                          ZOLTAN_ID_PTR nborGID,
+                          int *nborProc,
+                          int wgt_dim,
+                          float *ewgts,
+                          int *ierr)
   {
     ZoltanPartition *objs = (ZoltanPartition *)data;
     int n = objs->getNumMyObjects();
@@ -319,9 +317,9 @@ public:
     for (int i=0; i<num_obj; i++) {
       int idx = localID[i];
       for (int j=Conn2[idx]; j<Conn2[idx+1]; j++) {
-	nborGID[j] = ConnectivityGlobal[j];
-	nborProc[j] = ConnectivityOwners[j];
-	ewgts[j] = edgeWeights[j];
+        nborGID[j] = ConnectivityGlobal[j];
+        nborProc[j] = ConnectivityOwners[j];
+        ewgts[j] = edgeWeights[j];
       }
     }
   }
@@ -355,11 +353,11 @@ private:
       m_objectGIDs[i] = RowMap->getNodeElementList()[i];
       m_Graph->getLocalRowView(i, Indices);
       for (int j=0; j<Indices.size(); j++) {
-	assert (ColPIDs[Indices[j]] != nodeNotOnAnyProcessors);
-	m_ConnOwners[numEntries] = ColPIDs[Indices[j]];
-	m_ConnGlobal[numEntries] = ColGIDs[Indices[j]];
-	m_ConnLocal[numEntries] = Indices[j];
-	numEntries++;
+        assert (ColPIDs[Indices[j]] != nodeNotOnAnyProcessors);
+        m_ConnOwners[numEntries] = ColPIDs[Indices[j]];
+        m_ConnGlobal[numEntries] = ColGIDs[Indices[j]];
+        m_ConnLocal[numEntries] = Indices[j];
+        numEntries++;
       }
       m_ConnBegin[i+1] = numEntries;
       count[i] = Indices.size();
@@ -369,9 +367,9 @@ private:
   }
 
   void ConstructGraphEntitiesForZoltan(LO numRows,
-				       const LO* rowBegin,
-				       const LO* columns,
-				       const GO* globalIDs)
+                                       const LO* rowBegin,
+                                       const LO* columns,
+                                       const GO* globalIDs)
   {
     LO numMyRows = numRows;
     m_objectGIDs.resize(numMyRows);
@@ -387,13 +385,13 @@ private:
       m_ConnBegin.resize(numMyRows+1);
       numEntries = 0;
       for (LO i=0; i<numMyRows; i++) {
-	for (LO j=rowBegin[i]; j<rowBegin[i+1]; j++) {
-	  m_ConnOwners[numEntries] = 0;
-	  m_ConnGlobal[numEntries] = columns[j];
-	  m_ConnLocal[numEntries] = columns[j];
-	  numEntries++;
-	}
-	m_ConnBegin[i+1] = numEntries;
+        for (LO j=rowBegin[i]; j<rowBegin[i+1]; j++) {
+          m_ConnOwners[numEntries] = 0;
+          m_ConnGlobal[numEntries] = columns[j];
+          m_ConnLocal[numEntries] = columns[j];
+          numEntries++;
+        }
+        m_ConnBegin[i+1] = numEntries;
       }
     }
   }
@@ -412,7 +410,7 @@ private:
     /*
     if (m_MyPID == 0) {
       std::cout << "Zoltan version = " << version << std::endl;
-    } 
+    }
     */
     m_LBMethod = GRAPH;
     std::string aString = m_Parameters->get("LB Method", "Graph");
@@ -457,7 +455,7 @@ private:
       break;
     }
     //
-    // register Zoltan query functions 
+    // register Zoltan query functions
     //
     m_zz->Set_Num_Obj_Fn(ZoltanPartition::getNumberOfObjects, this);
     m_zz->Set_Obj_List_Fn(ZoltanPartition::getObjectList, this);
@@ -470,7 +468,7 @@ private:
   MPI_Comm GetMPIComm()
   {
     RCP<const Teuchos::Comm<int> > comm = m_Graph->getComm();
-    const Teuchos::MpiComm<int>* mpiComm = 
+    const Teuchos::MpiComm<int>* mpiComm =
       dynamic_cast<const Teuchos::MpiComm<int>* > (&(*comm));
     return *(mpiComm->getRawMpiComm());
   }
@@ -484,7 +482,7 @@ private:
   Tpetra::global_size_t m_IGO;
   enum PartitionOption m_inputGraphType, m_LBMethod, m_graphPackage,
     m_outputOption;
-  int m_numParts, m_numMyObjects, m_numMyHyperEdges, m_MyPID, 
+  int m_numParts, m_numMyObjects, m_numMyHyperEdges, m_MyPID,
     m_numProc;
   std::vector<LO> m_ConnOwners, m_ConnLocal, m_ConnBegin;
   std::vector<GO> m_objectGIDs, m_hyperEdgeGIDs, m_ConnGlobal,

--- a/packages/shylu/shylu_dd/bddc/test/SolverBDDCTest.C
+++ b/packages/shylu/shylu_dd/bddc/test/SolverBDDCTest.C
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -68,84 +68,84 @@ typedef double SM; // real (magnitude) for SX
 //
 // Tpetra typedefs
 //
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+typedef Tpetra::Map<>::node_type  Node;
 typedef Tpetra::Map<LO,GO,Node>                                 Map;
 typedef Tpetra::CrsMatrix<SX,LO,GO,Node>                        CrsMatrix;
 typedef Tpetra::Import<LO,GO,Node>                              Import;
 typedef Tpetra::Export<LO,GO,Node>                              Export;
 typedef Tpetra::Vector<SX,LO,GO,Node>                           Vector;
-    
+
 void openFiles
 (RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner,
  LO krylovMethod);
 
 void printTimings
-(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner, 
+(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner,
  RCP< bddc::KrylovSolver<SX,SM,LO,GO> > & Solver,
  const LO krylovMethod);
 
-void readInputFile(double & lengthDir1, 
-		   double & lengthDir2, 
-		   double & lengthDir3, 
-		   LO & numSubDir1, 
-		   LO & numSubDir2,
-		   LO & numSubDir3, 
-		   LO & numSubDir1PerProc, 
-		   LO & numSubDir2PerProc,
-		   LO & numSubDir3PerProc, 
-		   LO & Hh,
-		   LO & spatialDim,
-		   LO & problemTypeInt,
-		   LO & matrixType,
-		   double & diagScaleFactor,
-		   LO & numThreadsOuter,
-		   LO & numThreadsInner,
-		   SM & solverTolerance,
-		   LO & maxIterations,
-		   LO & krylovMethod,
-		   LO & estimateConditionNumber,
-		   LO & directSolver,
-		   LO & cornerOption,
-		   LO & edgeOption,
-		   LO & faceOption,
-		   LO & numCoarseSubdomainsPerMpiRank,
-		   LO & numSubdomainsPerCoarseSubdomain,
-		   LO & coarseningOption,
-		   LO & applyOnlyPreconditioner,
-		   LO & numberOfSolves);
+void readInputFile(double & lengthDir1,
+                   double & lengthDir2,
+                   double & lengthDir3,
+                   LO & numSubDir1,
+                   LO & numSubDir2,
+                   LO & numSubDir3,
+                   LO & numSubDir1PerProc,
+                   LO & numSubDir2PerProc,
+                   LO & numSubDir3PerProc,
+                   LO & Hh,
+                   LO & spatialDim,
+                   LO & problemTypeInt,
+                   LO & matrixType,
+                   double & diagScaleFactor,
+                   LO & numThreadsOuter,
+                   LO & numThreadsInner,
+                   SM & solverTolerance,
+                   LO & maxIterations,
+                   LO & krylovMethod,
+                   LO & estimateConditionNumber,
+                   LO & directSolver,
+                   LO & cornerOption,
+                   LO & edgeOption,
+                   LO & faceOption,
+                   LO & numCoarseSubdomainsPerMpiRank,
+                   LO & numSubdomainsPerCoarseSubdomain,
+                   LO & coarseningOption,
+                   LO & applyOnlyPreconditioner,
+                   LO & numberOfSolves);
 
-int setParameters(double lengthDir1, 
-		  double lengthDir2, 
-		  double lengthDir3, 
-		  LO numSubDir1, 
-		  LO numSubDir2,
-		  LO numSubDir3, 
-		  LO numSubDir1PerProc, 
-		  LO numSubDir2PerProc,
-		  LO numSubDir3PerProc, 
-		  LO Hh,
-		  LO spatialDim,
-		  LO problemTypeInt,
-		  LO matrixType,
-		  double diagScaleFactor,
-		  LO numThreadsOuter,
-		  SM solverTolerance,
-		  LO maxIterations,
-		  LO krylovMethod,
-		  LO estimateConditionNumber,
-		  LO directSolver,
-		  LO cornerOption,
-		  LO edgeOption,
-		  LO faceOption,
-		  LO numCoarseSubdomainsPerMpiRank,
-		  LO numSubdomainsPerCoarseSubdomain,
-		  LO coarseningOption,
-		  int numProc,
-		  int myPID,
-		  RCP<Teuchos::ParameterList> & Parameters);
+int setParameters(double lengthDir1,
+                  double lengthDir2,
+                  double lengthDir3,
+                  LO numSubDir1,
+                  LO numSubDir2,
+                  LO numSubDir3,
+                  LO numSubDir1PerProc,
+                  LO numSubDir2PerProc,
+                  LO numSubDir3PerProc,
+                  LO Hh,
+                  LO spatialDim,
+                  LO problemTypeInt,
+                  LO matrixType,
+                  double diagScaleFactor,
+                  LO numThreadsOuter,
+                  SM solverTolerance,
+                  LO maxIterations,
+                  LO krylovMethod,
+                  LO estimateConditionNumber,
+                  LO directSolver,
+                  LO cornerOption,
+                  LO edgeOption,
+                  LO faceOption,
+                  LO numCoarseSubdomainsPerMpiRank,
+                  LO numSubdomainsPerCoarseSubdomain,
+                  LO coarseningOption,
+                  int numProc,
+                  int myPID,
+                  RCP<Teuchos::ParameterList> & Parameters);
 
-void updateRhs(SX* rhs, 
-	       LO numRows);
+void updateRhs(SX* rhs,
+               LO numRows);
 
 TEST(SolverBDDC, Test1)
 {
@@ -165,7 +165,7 @@ TEST(SolverBDDC, Test1)
     numThreadsOuter, numThreadsInner, maxIterations, directSolver,
     applyOnlyPreconditioner, numberOfSolves, matrixType, cornerOption,
     edgeOption, faceOption, krylovMethod, estimateConditionNumber,
-    numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain, 
+    numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain,
     coarseningOption;
   //
   // We currently only work with structured meshes generated on-the-fly.
@@ -174,39 +174,39 @@ TEST(SolverBDDC, Test1)
   // for testing of threaded sparse direct solvers (see SparseSolverTest.C).
   //
   readInputFile(lengthDir1, lengthDir2, lengthDir3, numSubDir1, numSubDir2,
-		numSubDir3, numSubDir1PerProc, numSubDir2PerProc,
-		numSubDir3PerProc, Hh, spatialDim, problemTypeInt,
-		matrixType, diagScaleFactor, numThreadsOuter, numThreadsInner,
-		solverTolerance, maxIterations, krylovMethod, 
-		estimateConditionNumber, directSolver, cornerOption, 
-		edgeOption, faceOption, numCoarseSubdomainsPerMpiRank, 
-		numSubdomainsPerCoarseSubdomain, coarseningOption, 
-		applyOnlyPreconditioner, numberOfSolves);
+                numSubDir3, numSubDir1PerProc, numSubDir2PerProc,
+                numSubDir3PerProc, Hh, spatialDim, problemTypeInt,
+                matrixType, diagScaleFactor, numThreadsOuter, numThreadsInner,
+                solverTolerance, maxIterations, krylovMethod,
+                estimateConditionNumber, directSolver, cornerOption,
+                edgeOption, faceOption, numCoarseSubdomainsPerMpiRank,
+                numSubdomainsPerCoarseSubdomain, coarseningOption,
+                applyOnlyPreconditioner, numberOfSolves);
   RCP<Teuchos::ParameterList> Parameters;
-  int returnValue = 
+  int returnValue =
   setParameters(lengthDir1, lengthDir2, lengthDir3, numSubDir1, numSubDir2,
-		numSubDir3, numSubDir1PerProc, numSubDir2PerProc,
-		numSubDir3PerProc, Hh, spatialDim, problemTypeInt,
-		matrixType, diagScaleFactor, numThreadsOuter, solverTolerance, 
-		maxIterations, krylovMethod, estimateConditionNumber, 
-		directSolver, cornerOption, edgeOption,	faceOption, 
-		numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain, 
-		coarseningOption,numProc, myPID, Parameters);
+                numSubDir3, numSubDir1PerProc, numSubDir2PerProc,
+                numSubDir3PerProc, Hh, spatialDim, problemTypeInt,
+                matrixType, diagScaleFactor, numThreadsOuter, solverTolerance,
+                maxIterations, krylovMethod, estimateConditionNumber,
+                directSolver, cornerOption, edgeOption, faceOption,
+                numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain,
+                coarseningOption,numProc, myPID, Parameters);
   if (returnValue != 0) return;
   // generate problem
-  RCP< bddc::ProblemMaker<LO,GO,SX,SM> > Problem = 
+  RCP< bddc::ProblemMaker<LO,GO,SX,SM> > Problem =
     rcp( new bddc::ProblemMaker<LO,GO,SX,SM>(Parameters, Comm) );
-  std::vector< std::vector<LO> > subNodes, subNodeBegin, subRowBegin, 
+  std::vector< std::vector<LO> > subNodes, subNodeBegin, subRowBegin,
     subLocalDofs, subColumns, subElems;
   std::vector< std::vector<SX> > subValues;
   Problem->getSubDomainElements(numSubDir1PerProc, numSubDir2PerProc,
-				numSubDir3PerProc, subElems);
+                                numSubDir3PerProc, subElems);
   Problem->getSubDomainNodeData(subElems, subNodes, subNodeBegin,
-				subLocalDofs);
-  Problem->getSubdomainMatrices(subElems, subNodes, subNodeBegin, subRowBegin, 
-				subColumns, subValues);
+                                subLocalDofs);
+  Problem->getSubdomainMatrices(subElems, subNodes, subNodeBegin, subRowBegin,
+                                subColumns, subValues);
   Problem->addDiagonalStiffness(subRowBegin, subColumns, subValues,
-				diagScaleFactor);
+                                diagScaleFactor);
   if (matrixType == 1) {
     Problem->addAsymmetry(subRowBegin, subColumns, subValues);
   }
@@ -230,9 +230,9 @@ TEST(SolverBDDC, Test1)
     std::cout << "omp_get_nested() return " << omp_get_nested() << std::endl;
   }
   // Set number of threads (will be used for inner loops, number of threads
-  // for outer loops set manually using num_threads clause). Thanks for idea 
+  // for outer loops set manually using num_threads clause). Thanks for idea
   // suggested by Andrew Bradley who observed environment variable
-  // specifications like OMP_NUM_THREADS=2,4 are not always supported. 
+  // specifications like OMP_NUM_THREADS=2,4 are not always supported.
 #if defined(_OPENMP)
   omp_set_num_threads(numThreadsInner);
 #endif
@@ -240,9 +240,9 @@ TEST(SolverBDDC, Test1)
   int level(0);
   RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > Preconditioner =
     rcp( new bddc::PreconditionerBDDC<SX,SM,LO,GO>
-	 (numNode, nodeBegin, localDofs, nodeGlobalIDs, xCoord, yCoord, zCoord, 
-	  subNodes, subRowBeginPtr.data(), subColumnsPtr.data(), 
-	  subValuesPtr.data(), Parameters, Comm, level) );
+         (numNode, nodeBegin, localDofs, nodeGlobalIDs, xCoord, yCoord, zCoord,
+          subNodes, subRowBeginPtr.data(), subColumnsPtr.data(),
+          subValuesPtr.data(), Parameters, Comm, level) );
   RCP<const Map> dofMap = Preconditioner->getDofMap1to1();
   if (applyOnlyPreconditioner) {
     dofMap = Preconditioner->getDofMapB1to1();
@@ -282,43 +282,43 @@ TEST(SolverBDDC, Test1)
   }
 }
 
-void updateRhs(SX* rhs, 
-	       LO numRows)
+void updateRhs(SX* rhs,
+               LO numRows)
 {
   for (LO i=0; i<numRows; i++) {
     rhs[i] += 0.07*rand()/RAND_MAX;
   }
 }
 
-void readInputFile(double & lengthDir1, 
-		   double & lengthDir2, 
-		   double & lengthDir3, 
-		   LO & numSubDir1, 
-		   LO & numSubDir2,
-		   LO & numSubDir3, 
-		   LO & numSubDir1PerProc, 
-		   LO & numSubDir2PerProc,
-		   LO & numSubDir3PerProc, 
-		   LO & Hh,
-		   LO & spatialDim,
-		   LO & problemTypeInt,
-		   LO & matrixType,
-		   double & diagScaleFactor,
-		   LO & numThreadsOuter,
-		   LO & numThreadsInner,
-		   SM & solverTolerance,
-		   LO & maxIterations,
-		   LO & krylovMethod,
-		   LO & estimateConditionNumber,
-		   LO & directSolver,
-		   LO & cornerOption,
-		   LO & edgeOption,
-		   LO & faceOption,
-		   LO & numCoarseSubdomainsPerMpiRank,
-		   LO & numSubdomainsPerCoarseSubdomain,
-		   LO & coarseningOption,
-		   LO & applyOnlyPreconditioner,
-		   LO & numberOfSolves)
+void readInputFile(double & lengthDir1,
+                   double & lengthDir2,
+                   double & lengthDir3,
+                   LO & numSubDir1,
+                   LO & numSubDir2,
+                   LO & numSubDir3,
+                   LO & numSubDir1PerProc,
+                   LO & numSubDir2PerProc,
+                   LO & numSubDir3PerProc,
+                   LO & Hh,
+                   LO & spatialDim,
+                   LO & problemTypeInt,
+                   LO & matrixType,
+                   double & diagScaleFactor,
+                   LO & numThreadsOuter,
+                   LO & numThreadsInner,
+                   SM & solverTolerance,
+                   LO & maxIterations,
+                   LO & krylovMethod,
+                   LO & estimateConditionNumber,
+                   LO & directSolver,
+                   LO & cornerOption,
+                   LO & edgeOption,
+                   LO & faceOption,
+                   LO & numCoarseSubdomainsPerMpiRank,
+                   LO & numSubdomainsPerCoarseSubdomain,
+                   LO & coarseningOption,
+                   LO & applyOnlyPreconditioner,
+                   LO & numberOfSolves)
 {
   char buff[101];
   std::ifstream fin;
@@ -355,35 +355,35 @@ void readInputFile(double & lengthDir1,
   fin.close();
 }
 
-int setParameters(double lengthDir1, 
-		  double lengthDir2, 
-		  double lengthDir3, 
-		  LO numSubDir1, 
-		  LO numSubDir2,
-		  LO numSubDir3, 
-		  LO numSubDir1PerProc, 
-		  LO numSubDir2PerProc,
-		  LO numSubDir3PerProc, 
-		  LO Hh,
-		  LO spatialDim,
-		  LO problemTypeInt,
-		  LO matrixType,
-		  double diagScaleFactor,
-		  LO numThreadsOuter,
-		  SM solverTolerance,
-		  LO maxIterations,
-		  LO krylovMethod,
-		  LO estimateConditionNumber,
-		  LO directSolver,
-		  LO cornerOption,
-		  LO edgeOption,
-		  LO faceOption,
-		  LO numCoarseSubdomainsPerMpiRank,
-		  LO numSubdomainsPerCoarseSubdomain,
-		  LO coarseningOption,
-		  int numProc,
-		  int myPID,
-		  RCP<Teuchos::ParameterList> & Parameters)
+int setParameters(double lengthDir1,
+                  double lengthDir2,
+                  double lengthDir3,
+                  LO numSubDir1,
+                  LO numSubDir2,
+                  LO numSubDir3,
+                  LO numSubDir1PerProc,
+                  LO numSubDir2PerProc,
+                  LO numSubDir3PerProc,
+                  LO Hh,
+                  LO spatialDim,
+                  LO problemTypeInt,
+                  LO matrixType,
+                  double diagScaleFactor,
+                  LO numThreadsOuter,
+                  SM solverTolerance,
+                  LO maxIterations,
+                  LO krylovMethod,
+                  LO estimateConditionNumber,
+                  LO directSolver,
+                  LO cornerOption,
+                  LO edgeOption,
+                  LO faceOption,
+                  LO numCoarseSubdomainsPerMpiRank,
+                  LO numSubdomainsPerCoarseSubdomain,
+                  LO coarseningOption,
+                  int numProc,
+                  int myPID,
+                  RCP<Teuchos::ParameterList> & Parameters)
 {
   LO numElemPerSubDir1 = numSubDir1PerProc*Hh;
   LO numElemPerSubDir2 = numSubDir2PerProc*Hh;
@@ -406,7 +406,7 @@ int setParameters(double lengthDir1,
     std::cout << "number of processors not large enough\n";
     return 1;
   }
-  //  
+  //
   Parameters = Teuchos::rcp( new Teuchos::ParameterList() );
   Parameters->set("numDofPerNode", numDofPerNode);
   Parameters->set("numThreadsOuter", numThreadsOuter);
@@ -427,11 +427,11 @@ int setParameters(double lengthDir1,
   Parameters->set("Number of Subdomains Direction 2", numSubDir2);
   Parameters->set("Number of Subdomains Direction 3", numSubDir3);
   Parameters->set("Number of Elements Per Subdomain Direction 1",
-		  numElemPerSubDir1);
+                  numElemPerSubDir1);
   Parameters->set("Number of Elements Per Subdomain Direction 2",
-		  numElemPerSubDir2);
+                  numElemPerSubDir2);
   Parameters->set("Number of Elements Per Subdomain Direction 3",
-		  numElemPerSubDir3);
+                  numElemPerSubDir3);
   Parameters->set("Apply Left Side Essential BCs", true);
   Parameters->set("Apply Right Side Essential BCs", false);
   Parameters->set("Load Direction", loadDirection);
@@ -464,10 +464,10 @@ int setParameters(double lengthDir1,
   if (faceOption) Parameters->set("Use Faces", true);
   else Parameters->set("Use Faces", false);
   // coarse space parameters
-  Parameters->set("numCoarseSubdomainsPerMpiRank", 
-		  numCoarseSubdomainsPerMpiRank);
-  Parameters->set("numSubdomainsPerCoarseSubdomain", 
-		  numSubdomainsPerCoarseSubdomain);
+  Parameters->set("numCoarseSubdomainsPerMpiRank",
+                  numCoarseSubdomainsPerMpiRank);
+  Parameters->set("numSubdomainsPerCoarseSubdomain",
+                  numSubdomainsPerCoarseSubdomain);
   if (coarseningOption == 0) {
     Parameters->set("Construct Subdomain Adjacency Graph", true);
     Parameters->set("Coarsening Option", "Graph");
@@ -518,7 +518,7 @@ int setParameters(double lengthDir1,
 }
 
 void printTimings
-(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner, 
+(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner,
  RCP< bddc::KrylovSolver<SX,SM,LO,GO> > & Solver,
  const LO krylovMethod)
 {
@@ -530,25 +530,25 @@ void printTimings
   const std::vector<double> & timings = Preconditioner->getTimings();
   timingsFile << "Timings in seconds for different solver components\n";
   timingsFile << "initial static condensations = "
-	      << timings[bddc::TIME_INIT_STATIC_COND] << std::endl;
+              << timings[bddc::TIME_INIT_STATIC_COND] << std::endl;
   timingsFile << "static expansions            = "
-	      << timings[bddc::TIME_STATIC_EXPANSION] << std::endl;
+              << timings[bddc::TIME_STATIC_EXPANSION] << std::endl;
   timingsFile << "subdomain corrections        = "
-	      << timings[bddc::TIME_SUB_CORR] << std::endl;
+              << timings[bddc::TIME_SUB_CORR] << std::endl;
   timingsFile << "coarse corrections           = "
-	      << timings[bddc::TIME_COARSE_CORR] << std::endl;
+              << timings[bddc::TIME_COARSE_CORR] << std::endl;
   timingsFile << "subdomain corrections        = "
-	      << timings[bddc::TIME_SUB_CORR] << std::endl;
+              << timings[bddc::TIME_SUB_CORR] << std::endl;
   timingsFile << "apply operator               = "
-	      << timings[bddc::TIME_APPLY_OPER] << std::endl;
+              << timings[bddc::TIME_APPLY_OPER] << std::endl;
   if (krylovMethod == 0) {
     timingsFile << "OthogGCR:projections         = "
-		<< Solver->getProjectionTime() << std::endl;
+                << Solver->getProjectionTime() << std::endl;
     timingsFile << "OthogGCR:orthogonalizations  = "
-		<< Solver->getOrthogonalizationTime() << std::endl;
+                << Solver->getOrthogonalizationTime() << std::endl;
   }
   timingsFile << "initialization time          = "
-	      << timings[bddc::TIME_INITIALIZATION] << std::endl;
+              << timings[bddc::TIME_INITIALIZATION] << std::endl;
   timingsFile.close();
 }
 
@@ -561,8 +561,8 @@ void openFiles
   LO myPID = Comm->getRank();
   LO numSub = Preconditioner->getNumSub();
   LO numSubAll;
-  Teuchos::reduceAll<int, LO> (*Comm, Teuchos::REDUCE_SUM, 1, 
-			       &numSub, &numSubAll);
+  Teuchos::reduceAll<int, LO> (*Comm, Teuchos::REDUCE_SUM, 1,
+                               &numSub, &numSubAll);
   RCP<const Map> dofMap1to1 = Preconditioner->getDofMap1to1();
   RCP<const Map> dofMapB1to1 = Preconditioner->getDofMapB1to1();
   LO numDofs = dofMap1to1->getGlobalNumElements();

--- a/packages/shylu/shylu_dd/bddc/test/SolverBDDCTestSimple.C
+++ b/packages/shylu/shylu_dd/bddc/test/SolverBDDCTestSimple.C
@@ -1,10 +1,10 @@
 
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov) 
-// 
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -68,80 +68,80 @@ typedef double SM; // real (magnitude) for SX
 //
 // Tpetra typedefs
 //
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+typedef Tpetra::Map<>::node_type  Node;
 typedef Tpetra::Map<LO,GO,Node>                                 Map;
 typedef Tpetra::CrsMatrix<SX,LO,GO,Node>                        CrsMatrix;
 typedef Tpetra::Import<LO,GO,Node>                              Import;
 typedef Tpetra::Export<LO,GO,Node>                              Export;
 typedef Tpetra::Vector<SX,LO,GO,Node>                           Vector;
-    
+
 void openFiles
 (RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner,
  LO krylovMethod);
 
 void printTimings
-(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner, 
+(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner,
  RCP< bddc::KrylovSolver<SX,SM,LO,GO> > & Solver,
  const LO krylovMethod);
 
-void readInputFile(double & lengthDir1, 
-		   double & lengthDir2, 
-		   double & lengthDir3, 
-		   LO & numSubDir1, 
-		   LO & numSubDir2,
-		   LO & numSubDir3, 
-		   LO & Hh,
-		   LO & spatialDim,
-		   LO & problemTypeInt,
-		   LO & matrixType,
-		   double & diagScaleFactor,
-		   LO & numThreadsOuter,
-		   LO & numThreadsInner,
-		   SM & solverTolerance,
-		   LO & maxIterations,
-		   LO & krylovMethod,
-		   LO & estimateConditionNumber,
-		   LO & directSolver,
-		   LO & cornerOption,
-		   LO & edgeOption,
-		   LO & faceOption,
-		   LO & numCoarseSubdomainsPerMpiRank,
-		   LO & numSubdomainsPerCoarseSubdomain,
-		   LO & coarseningOption,
-		   LO & numberOfSolves);
+void readInputFile(double & lengthDir1,
+                   double & lengthDir2,
+                   double & lengthDir3,
+                   LO & numSubDir1,
+                   LO & numSubDir2,
+                   LO & numSubDir3,
+                   LO & Hh,
+                   LO & spatialDim,
+                   LO & problemTypeInt,
+                   LO & matrixType,
+                   double & diagScaleFactor,
+                   LO & numThreadsOuter,
+                   LO & numThreadsInner,
+                   SM & solverTolerance,
+                   LO & maxIterations,
+                   LO & krylovMethod,
+                   LO & estimateConditionNumber,
+                   LO & directSolver,
+                   LO & cornerOption,
+                   LO & edgeOption,
+                   LO & faceOption,
+                   LO & numCoarseSubdomainsPerMpiRank,
+                   LO & numSubdomainsPerCoarseSubdomain,
+                   LO & coarseningOption,
+                   LO & numberOfSolves);
 
-int setParameters(double lengthDir1, 
-		  double lengthDir2, 
-		  double lengthDir3, 
-		  LO numSubDir1, 
-		  LO numSubDir2,
-		  LO numSubDir3, 
-		  LO numSubDir1PerProc, 
-		  LO numSubDir2PerProc,
-		  LO numSubDir3PerProc, 
-		  LO Hh,
-		  LO spatialDim,
-		  LO problemTypeInt,
-		  LO matrixType,
-		  double diagScaleFactor,
-		  LO numThreadsOuter,
-		  SM solverTolerance,
-		  LO maxIterations,
-		  LO krylovMethod,
-		  LO estimateConditionNumber,
-		  LO directSolver,
-		  LO cornerOption,
-		  LO edgeOption,
-		  LO faceOption,
-		  LO numCoarseSubdomainsPerMpiRank,
-		  LO numSubdomainsPerCoarseSubdomain,
-		  LO coarseningOption,
-		  int numProc,
-		  int myPID,
-		  RCP<Teuchos::ParameterList> & Parameters);
+int setParameters(double lengthDir1,
+                  double lengthDir2,
+                  double lengthDir3,
+                  LO numSubDir1,
+                  LO numSubDir2,
+                  LO numSubDir3,
+                  LO numSubDir1PerProc,
+                  LO numSubDir2PerProc,
+                  LO numSubDir3PerProc,
+                  LO Hh,
+                  LO spatialDim,
+                  LO problemTypeInt,
+                  LO matrixType,
+                  double diagScaleFactor,
+                  LO numThreadsOuter,
+                  SM solverTolerance,
+                  LO maxIterations,
+                  LO krylovMethod,
+                  LO estimateConditionNumber,
+                  LO directSolver,
+                  LO cornerOption,
+                  LO edgeOption,
+                  LO faceOption,
+                  LO numCoarseSubdomainsPerMpiRank,
+                  LO numSubdomainsPerCoarseSubdomain,
+                  LO coarseningOption,
+                  int numProc,
+                  int myPID,
+                  RCP<Teuchos::ParameterList> & Parameters);
 
-void updateRhs(SX* rhs, 
-	       LO numRows);
+void updateRhs(SX* rhs,
+               LO numRows);
 
 TEST(SolverBDDCSimple, Test1)
 {
@@ -161,7 +161,7 @@ TEST(SolverBDDCSimple, Test1)
     numThreadsOuter, numThreadsInner, maxIterations, directSolver,
     numberOfSolves, matrixType, cornerOption,
     edgeOption, faceOption, krylovMethod, estimateConditionNumber,
-    numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain, 
+    numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain,
     coarseningOption;
   //
   // We currently only work with structured meshes generated on-the-fly.
@@ -170,38 +170,38 @@ TEST(SolverBDDCSimple, Test1)
   // for testing of threaded sparse direct solvers (see SparseSolverTest.C).
   //
   readInputFile(lengthDir1, lengthDir2, lengthDir3, numSubDir1, numSubDir2,
-		numSubDir3, Hh, spatialDim, problemTypeInt,
-		matrixType, diagScaleFactor, numThreadsOuter, numThreadsInner,
-		solverTolerance, maxIterations, krylovMethod, 
-		estimateConditionNumber, directSolver, cornerOption, 
-		edgeOption, faceOption, numCoarseSubdomainsPerMpiRank, 
-		numSubdomainsPerCoarseSubdomain, coarseningOption, 
-		numberOfSolves);
+                numSubDir3, Hh, spatialDim, problemTypeInt,
+                matrixType, diagScaleFactor, numThreadsOuter, numThreadsInner,
+                solverTolerance, maxIterations, krylovMethod,
+                estimateConditionNumber, directSolver, cornerOption,
+                edgeOption, faceOption, numCoarseSubdomainsPerMpiRank,
+                numSubdomainsPerCoarseSubdomain, coarseningOption,
+                numberOfSolves);
   RCP<Teuchos::ParameterList> Parameters;
-  int returnValue = 
+  int returnValue =
   setParameters(lengthDir1, lengthDir2, lengthDir3, numSubDir1, numSubDir2,
-		numSubDir3, numSubDir1PerProc, numSubDir2PerProc,
-		numSubDir3PerProc, Hh, spatialDim, problemTypeInt,
-		matrixType, diagScaleFactor, numThreadsOuter, solverTolerance, 
-		maxIterations, krylovMethod, estimateConditionNumber, 
-		directSolver, cornerOption, edgeOption,	faceOption, 
-		numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain, 
-		coarseningOption,numProc, myPID, Parameters);
+                numSubDir3, numSubDir1PerProc, numSubDir2PerProc,
+                numSubDir3PerProc, Hh, spatialDim, problemTypeInt,
+                matrixType, diagScaleFactor, numThreadsOuter, solverTolerance,
+                maxIterations, krylovMethod, estimateConditionNumber,
+                directSolver, cornerOption, edgeOption, faceOption,
+                numCoarseSubdomainsPerMpiRank, numSubdomainsPerCoarseSubdomain,
+                coarseningOption,numProc, myPID, Parameters);
   if (returnValue != 0) return;
   // generate problem
-  RCP< bddc::ProblemMaker<LO,GO,SX,SM> > Problem = 
+  RCP< bddc::ProblemMaker<LO,GO,SX,SM> > Problem =
     rcp( new bddc::ProblemMaker<LO,GO,SX,SM>(Parameters, Comm) );
-  std::vector< std::vector<LO> > subNodes, subNodeBegin, subRowBegin, 
+  std::vector< std::vector<LO> > subNodes, subNodeBegin, subRowBegin,
     subLocalDofs, subColumns, subElems;
   std::vector< std::vector<SX> > subValues;
   Problem->getSubDomainElements(numSubDir1PerProc, numSubDir2PerProc,
-				numSubDir3PerProc, subElems);
+                                numSubDir3PerProc, subElems);
   Problem->getSubDomainNodeData(subElems, subNodes, subNodeBegin,
-				subLocalDofs);
-  Problem->getSubdomainMatrices(subElems, subNodes, subNodeBegin, subRowBegin, 
-				subColumns, subValues);
+                                subLocalDofs);
+  Problem->getSubdomainMatrices(subElems, subNodes, subNodeBegin, subRowBegin,
+                                subColumns, subValues);
   Problem->addDiagonalStiffness(subRowBegin, subColumns, subValues,
-				diagScaleFactor);
+                                diagScaleFactor);
   if (matrixType == 1) {
     Problem->addAsymmetry(subRowBegin, subColumns, subValues);
   }
@@ -234,19 +234,19 @@ TEST(SolverBDDCSimple, Test1)
     std::cout << "omp_get_nested() return " << omp_get_nested() << std::endl;
   }
   // Set number of threads (will be used for inner loops, number of threads
-  // for outer loops set manually using num_threads clause). Thanks for idea 
+  // for outer loops set manually using num_threads clause). Thanks for idea
   // suggested by Andrew Bradley who observed environment variable
-  // specifications like OMP_NUM_THREADS=2,4 are not always supported. 
+  // specifications like OMP_NUM_THREADS=2,4 are not always supported.
 #if defined(_OPENMP)
   omp_set_num_threads(numThreadsInner);
 #endif
   // initialize preconditioner
   RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > Preconditioner =
     rcp( new bddc::PreconditionerBDDC<SX,SM,LO,GO>
-	 (numNode, nodeGlobalIDsUse.data(), 
-	  xUse.data(), yUse.data(), zUse.data(), 
-	  subRowBeginPtr.data()[0], subColumnsPtr.data()[0], 
-	  subValuesPtr.data()[0], Parameters, Comm) );
+         (numNode, nodeGlobalIDsUse.data(),
+          xUse.data(), yUse.data(), zUse.data(),
+          subRowBeginPtr.data()[0], subColumnsPtr.data()[0],
+          subValuesPtr.data()[0], Parameters, Comm) );
   RCP<const Map> dofMap = Preconditioner->getDofMap1to1();
   LO numDofs = dofMap->getNodeNumElements();
   // initialize right hand side
@@ -274,39 +274,39 @@ TEST(SolverBDDCSimple, Test1)
   printTimings(Preconditioner, Solver, krylovMethod);
 }
 
-void updateRhs(SX* rhs, 
-	       LO numRows)
+void updateRhs(SX* rhs,
+               LO numRows)
 {
   for (LO i=0; i<numRows; i++) {
     rhs[i] += 0.07*rand()/RAND_MAX;
   }
 }
 
-void readInputFile(double & lengthDir1, 
-		   double & lengthDir2, 
-		   double & lengthDir3, 
-		   LO & numSubDir1, 
-		   LO & numSubDir2,
-		   LO & numSubDir3, 
-		   LO & Hh,
-		   LO & spatialDim,
-		   LO & problemTypeInt,
-		   LO & matrixType,
-		   double & diagScaleFactor,
-		   LO & numThreadsOuter,
-		   LO & numThreadsInner,
-		   SM & solverTolerance,
-		   LO & maxIterations,
-		   LO & krylovMethod,
-		   LO & estimateConditionNumber,
-		   LO & directSolver,
-		   LO & cornerOption,
-		   LO & edgeOption,
-		   LO & faceOption,
-		   LO & numCoarseSubdomainsPerMpiRank,
-		   LO & numSubdomainsPerCoarseSubdomain,
-		   LO & coarseningOption,
-		   LO & numberOfSolves)
+void readInputFile(double & lengthDir1,
+                   double & lengthDir2,
+                   double & lengthDir3,
+                   LO & numSubDir1,
+                   LO & numSubDir2,
+                   LO & numSubDir3,
+                   LO & Hh,
+                   LO & spatialDim,
+                   LO & problemTypeInt,
+                   LO & matrixType,
+                   double & diagScaleFactor,
+                   LO & numThreadsOuter,
+                   LO & numThreadsInner,
+                   SM & solverTolerance,
+                   LO & maxIterations,
+                   LO & krylovMethod,
+                   LO & estimateConditionNumber,
+                   LO & directSolver,
+                   LO & cornerOption,
+                   LO & edgeOption,
+                   LO & faceOption,
+                   LO & numCoarseSubdomainsPerMpiRank,
+                   LO & numSubdomainsPerCoarseSubdomain,
+                   LO & coarseningOption,
+                   LO & numberOfSolves)
 {
   char buff[101];
   std::ifstream fin;
@@ -339,35 +339,35 @@ void readInputFile(double & lengthDir1,
   fin.close();
 }
 
-int setParameters(double lengthDir1, 
-		  double lengthDir2, 
-		  double lengthDir3, 
-		  LO numSubDir1, 
-		  LO numSubDir2,
-		  LO numSubDir3, 
-		  LO numSubDir1PerProc, 
-		  LO numSubDir2PerProc,
-		  LO numSubDir3PerProc, 
-		  LO Hh,
-		  LO spatialDim,
-		  LO problemTypeInt,
-		  LO matrixType,
-		  double diagScaleFactor,
-		  LO numThreadsOuter,
-		  SM solverTolerance,
-		  LO maxIterations,
-		  LO krylovMethod,
-		  LO estimateConditionNumber,
-		  LO directSolver,
-		  LO cornerOption,
-		  LO edgeOption,
-		  LO faceOption,
-		  LO numCoarseSubdomainsPerMpiRank,
-		  LO numSubdomainsPerCoarseSubdomain,
-		  LO coarseningOption,
-		  int numProc,
-		  int myPID,
-		  RCP<Teuchos::ParameterList> & Parameters)
+int setParameters(double lengthDir1,
+                  double lengthDir2,
+                  double lengthDir3,
+                  LO numSubDir1,
+                  LO numSubDir2,
+                  LO numSubDir3,
+                  LO numSubDir1PerProc,
+                  LO numSubDir2PerProc,
+                  LO numSubDir3PerProc,
+                  LO Hh,
+                  LO spatialDim,
+                  LO problemTypeInt,
+                  LO matrixType,
+                  double diagScaleFactor,
+                  LO numThreadsOuter,
+                  SM solverTolerance,
+                  LO maxIterations,
+                  LO krylovMethod,
+                  LO estimateConditionNumber,
+                  LO directSolver,
+                  LO cornerOption,
+                  LO edgeOption,
+                  LO faceOption,
+                  LO numCoarseSubdomainsPerMpiRank,
+                  LO numSubdomainsPerCoarseSubdomain,
+                  LO coarseningOption,
+                  int numProc,
+                  int myPID,
+                  RCP<Teuchos::ParameterList> & Parameters)
 {
   LO numElemPerSubDir1 = numSubDir1PerProc*Hh;
   LO numElemPerSubDir2 = numSubDir2PerProc*Hh;
@@ -390,7 +390,7 @@ int setParameters(double lengthDir1,
     std::cout << "number of processors not large enough\n";
     return 1;
   }
-  //  
+  //
   Parameters = Teuchos::rcp( new Teuchos::ParameterList() );
   Parameters->set("numDofPerNode", numDofPerNode);
   Parameters->set("numThreadsOuter", numThreadsOuter);
@@ -411,11 +411,11 @@ int setParameters(double lengthDir1,
   Parameters->set("Number of Subdomains Direction 2", numSubDir2);
   Parameters->set("Number of Subdomains Direction 3", numSubDir3);
   Parameters->set("Number of Elements Per Subdomain Direction 1",
-		  numElemPerSubDir1);
+                  numElemPerSubDir1);
   Parameters->set("Number of Elements Per Subdomain Direction 2",
-		  numElemPerSubDir2);
+                  numElemPerSubDir2);
   Parameters->set("Number of Elements Per Subdomain Direction 3",
-		  numElemPerSubDir3);
+                  numElemPerSubDir3);
   Parameters->set("Apply Left Side Essential BCs", false);
   Parameters->set("Apply Right Side Essential BCs", false);
   Parameters->set("Load Direction", loadDirection);
@@ -448,10 +448,10 @@ int setParameters(double lengthDir1,
   if (faceOption) Parameters->set("Use Faces", true);
   else Parameters->set("Use Faces", false);
   // coarse space parameters
-  Parameters->set("numCoarseSubdomainsPerMpiRank", 
-		  numCoarseSubdomainsPerMpiRank);
-  Parameters->set("numSubdomainsPerCoarseSubdomain", 
-		  numSubdomainsPerCoarseSubdomain);
+  Parameters->set("numCoarseSubdomainsPerMpiRank",
+                  numCoarseSubdomainsPerMpiRank);
+  Parameters->set("numSubdomainsPerCoarseSubdomain",
+                  numSubdomainsPerCoarseSubdomain);
   if (coarseningOption == 0) {
     Parameters->set("Construct Subdomain Adjacency Graph", true);
     Parameters->set("Coarsening Option", "Graph");
@@ -502,7 +502,7 @@ int setParameters(double lengthDir1,
 }
 
 void printTimings
-(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner, 
+(RCP< bddc::PreconditionerBDDC<SX,SM,LO,GO> > & Preconditioner,
  RCP< bddc::KrylovSolver<SX,SM,LO,GO> > & Solver,
  const LO krylovMethod)
 {
@@ -514,25 +514,25 @@ void printTimings
   const std::vector<double> & timings = Preconditioner->getTimings();
   timingsFile << "Timings in seconds for different solver components\n";
   timingsFile << "initial static condensations = "
-	      << timings[bddc::TIME_INIT_STATIC_COND] << std::endl;
+              << timings[bddc::TIME_INIT_STATIC_COND] << std::endl;
   timingsFile << "static expansions            = "
-	      << timings[bddc::TIME_STATIC_EXPANSION] << std::endl;
+              << timings[bddc::TIME_STATIC_EXPANSION] << std::endl;
   timingsFile << "subdomain corrections        = "
-	      << timings[bddc::TIME_SUB_CORR] << std::endl;
+              << timings[bddc::TIME_SUB_CORR] << std::endl;
   timingsFile << "coarse corrections           = "
-	      << timings[bddc::TIME_COARSE_CORR] << std::endl;
+              << timings[bddc::TIME_COARSE_CORR] << std::endl;
   timingsFile << "subdomain corrections        = "
-	      << timings[bddc::TIME_SUB_CORR] << std::endl;
+              << timings[bddc::TIME_SUB_CORR] << std::endl;
   timingsFile << "apply operator               = "
-	      << timings[bddc::TIME_APPLY_OPER] << std::endl;
+              << timings[bddc::TIME_APPLY_OPER] << std::endl;
   if (krylovMethod == 0) {
     timingsFile << "OthogGCR:projections         = "
-		<< Solver->getProjectionTime() << std::endl;
+                << Solver->getProjectionTime() << std::endl;
     timingsFile << "OthogGCR:orthogonalizations  = "
-		<< Solver->getOrthogonalizationTime() << std::endl;
+                << Solver->getOrthogonalizationTime() << std::endl;
   }
   timingsFile << "initialization time          = "
-	      << timings[bddc::TIME_INITIALIZATION] << std::endl;
+              << timings[bddc::TIME_INITIALIZATION] << std::endl;
   timingsFile.close();
 }
 
@@ -545,8 +545,8 @@ void openFiles
   LO myPID = Comm->getRank();
   LO numSub = Preconditioner->getNumSub();
   LO numSubAll;
-  Teuchos::reduceAll<int, LO> (*Comm, Teuchos::REDUCE_SUM, 1, 
-			       &numSub, &numSubAll);
+  Teuchos::reduceAll<int, LO> (*Comm, Teuchos::REDUCE_SUM, 1,
+                               &numSub, &numSubAll);
   RCP<const Map> dofMap1to1 = Preconditioner->getDofMap1to1();
   RCP<const Map> dofMapB1to1 = Preconditioner->getDofMapB1to1();
   LO numDofs = dofMap1to1->getGlobalNumElements();

--- a/packages/shylu/shylu_dd/core/test/iterative_solver_interface_test.cpp
+++ b/packages/shylu/shylu_dd/core/test/iterative_solver_interface_test.cpp
@@ -8,9 +8,8 @@
 
 //Tperta
 #ifdef HAVE_SHYLU_DDCORE_TPETRA
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -31,10 +30,8 @@
 
 // Teuchos includes
 #ifdef HAVE_SHYLU_DDCORE_TPETRA
-#include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_RCP.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
 #endif
 
 // EpetraExt includes
@@ -79,8 +76,8 @@ using namespace std;
 int main(int argc, char** argv)
 {
 
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv, 0);
-  Teuchos::RCP <const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  Tpetra::ScopeGuard mpiSession(&argc, &argv);
+  Teuchos::RCP <const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
     int myPID = comm->getRank();
   if(myPID == 0)
     {
@@ -124,7 +121,7 @@ int main(int argc, char** argv)
   b->randomize();
   x->randomize();
 
-    cout << "num_vector: " << b->getNumVectors() << " " 
+    cout << "num_vector: " << b->getNumVectors() << " "
        << x->getNumVectors() << endl;
   cout << "length: " << b->getGlobalLength() << " "
        << x->getGlobalLength() << endl;
@@ -162,7 +159,7 @@ int main(int argc, char** argv)
   cout << " \n\n--------------------BIG BREAK --------------\n\n";
   Teuchos::writeParameterListToXmlOStream(*pLUList, std::cout);
 
-  cout << "num_vector: " << b->getNumVectors() << " " 
+  cout << "num_vector: " << b->getNumVectors() << " "
        << x->getNumVectors() << endl;
   cout << "length: " << b->getGlobalLength() << " "
        << x->getGlobalLength() << endl;

--- a/packages/shylu/shylu_dd/core/test/shylu_factor_test.cpp
+++ b/packages/shylu/shylu_dd/core/test/shylu_factor_test.cpp
@@ -1,9 +1,9 @@
 /** \file shylu_sfactor_test.cpp
 
-    \brief factor test 
+    \brief factor test
 
     \author Joshua Dennis Booth
-    
+
     \remark Usage:
     \code mpirun -n np shylu_sfactor.exe
 
@@ -42,7 +42,6 @@
 #include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_RCP.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
 #endif
 
 #include "shylu.h"
@@ -77,7 +76,7 @@ int main(int argc, char* argv[])
   // int n = 0;
 
   int err = EpetraExt::MatrixMarketFileToCrsMatrix(matrixFileName.c_str(), Comm, A);
-  
+
   if(err!=0 && myPID ==0)
     {
       cout << "Error reading matrix file, info = " << err << endl;
@@ -112,10 +111,10 @@ int main(int argc, char* argv[])
   slu_config_.silent_subiter      = true; //This is
   slu_config_.inner_tolerance     = 1e-5; //This is
   slu_config_.inner_maxiters      = 100; //This is
-  slu_config_.overlap             = 0; //This is 
+  slu_config_.overlap             = 0; //This is
   slu_config_.sep_type            = 1; //1 Wide 2 Narrow
   slu_config_.amesosForDiagonal   = true;
-  
+
 
   int serr = shylu_symbolic_factor(B, &slu_sym_, &slu_data_, &slu_config_);
   cout << "shylu_symbolic_factor done:" << endl;

--- a/packages/shylu/shylu_dd/core/test/tpetra_interface_test.cpp
+++ b/packages/shylu/shylu_dd/core/test/tpetra_interface_test.cpp
@@ -8,9 +8,8 @@
 
 //Tperta
 #ifdef HAVE_SHYLU_DDCORE_TPETRA
-#include <Tpetra_DefaultPlatform.hpp>
+#include <Tpetra_Core.hpp>
 #include <Tpetra_Version.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -31,10 +30,8 @@
 
 // Teuchos includes
 #ifdef HAVE_SHYLU_DDCORE_TPETRA
-#include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_RCP.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
 #endif
 
 // EpetraExt includes
@@ -79,8 +76,8 @@ using namespace std;
 int main(int argc, char** argv)
 {
 
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv, 0);
-  Teuchos::RCP <const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+  Tpetra::ScopeGuard mpiSession(&argc, &argv);
+  Teuchos::RCP <const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
     int myPID = comm->getRank();
   if(myPID == 0)
     {
@@ -124,7 +121,7 @@ int main(int argc, char** argv)
   b->randomize();
   x->randomize();
 
-    cout << "num_vector: " << b->getNumVectors() << " " 
+    cout << "num_vector: " << b->getNumVectors() << " "
        << x->getNumVectors() << endl;
   cout << "length: " << b->getGlobalLength() << " "
        << x->getGlobalLength() << endl;
@@ -184,7 +181,7 @@ int main(int argc, char** argv)
   cout << " \n\n--------------------BIG BREAK --------------\n\n";
   Teuchos::writeParameterListToXmlOStream(*pLUList, std::cout);
 
-  cout << "num_vector: " << b->getNumVectors() << " " 
+  cout << "num_vector: " << b->getNumVectors() << " "
        << x->getNumVectors() << endl;
   cout << "length: " << b->getGlobalLength() << " "
        << x->getGlobalLength() << endl;


### PR DESCRIPTION
@trilinos/shylu @trilinos/tpetra

## Description

Purge use of `Tpetra::DefaultPlatform` from ShyLU code, tests, and examples.

## Related Issues

* Part of #3095 
* Blocks #57 

## How Has This Been Tested?

Linux, GCC, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] No new compiler warnings were introduced.
