### PR TITLE
TrilinosCouplings: Purge use of Tpetra::DefaultPlatform

### DIFF
--- a/packages/trilinoscouplings/examples/scaling/IntrepidPoisson_Pamgen_EpetraAztecOO_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/IntrepidPoisson_Pamgen_EpetraAztecOO_main.cpp
@@ -96,7 +96,6 @@ main (int argc, char *argv[])
   using IntrepidPoissonExample::setCommandLineArgumentDefaults;
   using IntrepidPoissonExample::setUpCommandLineArguments;
   using IntrepidPoissonExample::parseCommandLineArguments;
-  //using Tpetra::DefaultPlatform;
   //using Teuchos::Comm;
   using Teuchos::outArg;
   using Teuchos::ParameterList;

--- a/packages/trilinoscouplings/examples/scaling/IntrepidPoisson_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/IntrepidPoisson_Pamgen_Tpetra_main.cpp
@@ -58,7 +58,6 @@
 */
 
 #include "Teuchos_oblackholestream.hpp"
-#include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
 #include "Teuchos_StandardCatchMacros.hpp"
@@ -71,7 +70,8 @@
 #  include "MueLu_CreateTpetraPreconditioner.hpp"
 #endif // HAVE_TRILINOSCOUPLINGS_MUELU
 
-#include <MatrixMarket_Tpetra.hpp>
+#include "Tpetra_Core.hpp"
+#include "MatrixMarket_Tpetra.hpp"
 
 int
 main (int argc, char *argv[])
@@ -87,7 +87,6 @@ main (int argc, char *argv[])
   using IntrepidPoissonExample::setCommandLineArgumentDefaults;
   using IntrepidPoissonExample::setMaterialTensorOffDiagonalValue;
   using IntrepidPoissonExample::setUpCommandLineArguments;
-  using Tpetra::DefaultPlatform;
   using Teuchos::Comm;
   using Teuchos::outArg;
   using Teuchos::ParameterList;
@@ -116,14 +115,12 @@ main (int argc, char *argv[])
   bool success = true;
   try {
     Teuchos::oblackholestream blackHole;
-    Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackHole);
-    const int myRank = mpiSession.getRank ();
-    //const int numProcs = mpiSession.getNProc ();
+    Tpetra::ScopeGuard mpiSession (&argc, &argv);
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
+    RCP<Node> node; // OK to be null; just needed for type deduction; eventually remove this
 
-    // Get the default communicator and Kokkos Node instance
-    RCP<const Comm<int> > comm =
-      DefaultPlatform::getDefaultPlatform ().getComm ();
-    RCP<Node> node = DefaultPlatform::getDefaultPlatform ().getNode ();
+    const int myRank = comm->getRank ();
+    //const int numProcs = comm->getSize ();
 
     // Did the user specify --help at the command line to print help
     // with command-line arguments?
@@ -139,11 +136,11 @@ main (int argc, char *argv[])
     Teuchos::ParameterList problemStatistics;
 
     // Set default values of command-line arguments.
-    setCommandLineArgumentDefaults (nx, ny, nz, xmlInputParamsFile, 
+    setCommandLineArgumentDefaults (nx, ny, nz, xmlInputParamsFile,
                                     solverName, verbose, debug);
     // Parse and validate command-line arguments.
     Teuchos::CommandLineProcessor cmdp (false, true);
-    setUpCommandLineArguments (cmdp, nx, ny, nz, xmlInputParamsFile, 
+    setUpCommandLineArguments (cmdp, nx, ny, nz, xmlInputParamsFile,
                                solverName, tolFromCmdLine,
                                maxNumItersFromCmdLine,
                                verbose, debug);
@@ -299,7 +296,7 @@ main (int argc, char *argv[])
            << "||B||_2 = " << norms[1] << endl
            << "||A||_F = " << norms[2] << endl;
 
-   
+
       // Setup preconditioner
       std::string prec_type = inputList.get ("Preconditioner", "None");
       RCP<operator_type> M;
@@ -308,15 +305,15 @@ main (int argc, char *argv[])
 
         if (prec_type == "MueLu") {
 #ifdef HAVE_TRILINOSCOUPLINGS_MUELU
-	  for(int i=0; i<numMueluRebuilds+1; i++) {
-	    if (inputList.isSublist("MueLu")) {
-	      ParameterList mueluParams = inputList.sublist("MueLu");
+          for(int i=0; i<numMueluRebuilds+1; i++) {
+            if (inputList.isSublist("MueLu")) {
+              ParameterList mueluParams = inputList.sublist("MueLu");
               mueluParams.sublist("user data").set("Coordinates",coords);
-	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams);
-	    } else {
-	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A);
-	    }
-	  }
+              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams);
+            } else {
+              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A);
+            }
+          }
 #else // NOT HAVE_TRILINOSCOUPLINGS_MUELU
           TEUCHOS_TEST_FOR_EXCEPTION(
             prec_type == "MueLu", std::runtime_error, "Tpetra scaling example: "

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidPoissonExample.hpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidPoissonExample.hpp
@@ -31,7 +31,6 @@
 #ifndef __TrilinosCouplings_TpetraIntrepidPoissonExample_hpp
 #define __TrilinosCouplings_TpetraIntrepidPoissonExample_hpp
 
-#include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Teuchos_FancyOStream.hpp"
@@ -83,7 +82,7 @@ namespace TpetraIntrepidPoissonExample {
 typedef double ST;
 typedef int    LO;
 typedef int    GO;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+typedef Tpetra::Map<>::node_type  Node;
 
 //
 // mfh 19 Apr 2012: If you want to change the template parameters of

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidStructuredPoissonExample.hpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidStructuredPoissonExample.hpp
@@ -31,7 +31,6 @@
 #ifndef __TrilinosCouplings_TpetraIntrepidStructuredPoissonExample_hpp
 #define __TrilinosCouplings_TpetraIntrepidStructuredPoissonExample_hpp
 
-#include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Teuchos_FancyOStream.hpp"
@@ -83,7 +82,7 @@ namespace TpetraIntrepidPoissonExample {
 typedef double ST;
 typedef int    LO;
 typedef int    GO;
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType  Node;
+typedef Tpetra::Map<>::node_type  Node;
 
 //
 // mfh 19 Apr 2012: If you want to change the template parameters of


### PR DESCRIPTION
@trilinos/trilinoscouplings @trilinos/tpetra 

## Description

Purge use of `Tpetra::DefaultPlatform` from TrilinosCouplings.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Linux, GCC, OpenMPI.