### PR TITLE
Update for 'white' upgrade to CUDA 9.2 driver (TRIL-125)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -28,8 +28,8 @@ fi
 
 export ATDM_CONFIG_KOKKOS_ARCH=Power8,Kepler37
 if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
-    module load devpack/openmpi/1.10.4/gcc/5.4.0/cuda/8.0.44
-    module swap openblas/0.2.19/gcc/5.4.0 netlib/3.8.0/gcc/5.4.0
+    module load devpack/20180308/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176
+    module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
     export OMPI_CXX=`which g++`
     export OMPI_CC=`which gcc`
     export OMPI_FC=`which gfortran`
@@ -37,8 +37,8 @@ if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
     export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
 elif [ "$ATDM_CONFIG_COMPILER" == "CUDA" ]; then
     export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
-    module load devpack/openmpi/1.10.4/gcc/5.4.0/cuda/8.0.44
-    module swap openblas/0.2.19/gcc/5.4.0 netlib/3.8.0/gcc/5.4.0
+    module load devpack/20180308/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176 
+    module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
     export OMPI_CXX=$ATDM_CONFIG_TRILNOS_DIR/packages/kokkos/bin/nvcc_wrapper
     if [ ! -x "$OMPI_CXX" ]; then
         echo "No nvcc_wrapper found"
@@ -64,13 +64,6 @@ export ATDM_CONFIG_USE_HWLOC=OFF
 
 export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
 export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
-
-module swap yamlcpp/0.3.0 yaml-cpp/20170104 
-if [ $? ]; then module load  yaml-cpp/20170104; fi
-
-module load binutils/2.27.0
-# NOTE: Above we need to use updated 'ar' from binutils 2.27 to handle big
-# object files with 'ar' that otherwise can cause "File truncated" failures (see #3069)
 
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)


### PR DESCRIPTION
CC: @fryeguy52, @nmhamster 

## Description

This loads the developer pack module:

  devpack/20180308/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176

and the updated moudle:

  netlib/3.8.0/gcc/7.2.0

I took out the logic for yaml-cpp because the updated devopack does not load
any yaml-cpp module and the ATDM Trilinos build does not need it.

I took out the moudle load for binutils/2.27.0 since the updated devpack
module loads and updated binutils/2.30.0 module which should address the build
errors for the stokhos_muelu library in #3069.

## Motivation and Context

The env on 'white' was updated and all of the ATDM Trilinos builds on 'white' have been gone for the last several days.  This gets the builds back up so that we can see what is going on with these.  See [TRIL-215](https://software-sandbox.sandia.gov/jira/browse/TRIL-215).

## How Has This Been Tested?

I tested this with on 'white' with::

```
$ ./checkin-test-atdm.sh gnu-opt-openmp \
  --enable-packages=Kokkos,Teuchos,Belos,Anasazi --local-do-all
```

and it returned:

```
100% tests passed, 0 tests failed out of 301

Subproject Time Summary:
Anasazi    = 1081.25 sec*proc (74 tests)
Belos      = 1552.56 sec*proc (71 tests)
Kokkos     = 937.07 sec*proc (27 tests)
Teuchos    = 387.22 sec*proc (129 tests)

Total Test time (real) = 500.42 sec
```

That is not full testing but that confirms that we are not using a broken BLAS and LAPACK.   There is little point in doing more testing since the env on 'white' is what it is.  Getting these builds up will help fix the env if we find more problems.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
