### PR TITLE
Tpetra: Deprecate DefaultPlatform, MpiPlatform, & SerialPlatform

### DIFF
--- a/packages/tpetra/core/example/Additive-Schwarz-Halo/AdditiveSchwarzHalo.cpp
+++ b/packages/tpetra/core/example/Additive-Schwarz-Halo/AdditiveSchwarzHalo.cpp
@@ -53,7 +53,7 @@
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_MultiVector.hpp>
 
-int main (int argc, char *argv[]) 
+int main (int argc, char *argv[])
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -71,11 +71,11 @@ int main (int argc, char *argv[])
     // object's lifetime.
     auto comm = Tpetra::getDefaultComm ();
 
-    int num_halo_expansions = 1;  
+    int num_halo_expansions = 1;
     Teuchos::CommandLineProcessor clp;
     clp.addOutputSetupOptions(true);
     clp.setOption("halo-expansions", &num_halo_expansions ,
-		  "Number of times to expand the halo for Additive Schwarz");
+                  "Number of times to expand the halo for Additive Schwarz");
     switch (clp.parse(argc, argv)) {
     case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:        return EXIT_SUCCESS;
     case Teuchos::CommandLineProcessor::PARSE_ERROR:
@@ -89,9 +89,9 @@ int main (int argc, char *argv[])
     using Node = Tpetra::Map<>::node_type;
     using ST = Teuchos::ScalarTraits<Scalar>;
     using MAT = Tpetra::CrsMatrix<Scalar>;
-    using MV = Tpetra::MultiVector<Scalar>;
+    //using MV = Tpetra::MultiVector<Scalar>;
     using IMP = Tpetra::Import<>;
-  
+
     const GO ONE = Teuchos::OrdinalTraits<GO>::one();
     const GO GO_INVALID = Teuchos::OrdinalTraits<GO>::invalid();
 
@@ -101,52 +101,52 @@ int main (int argc, char *argv[])
 
       const size_t numImages = comm->getSize();
       const size_t myImageID = comm->getRank();
-   
+
       if (numImages < 2) return -1;
       // create a Map
-      RCP<const Tpetra::Map<> > map = 
-	Tpetra::createContigMapWithNode<LO,GO,Node>(GO_INVALID, ONE, comm);
+      RCP<const Tpetra::Map<> > map =
+        Tpetra::createContigMapWithNode<LO,GO,Node>(GO_INVALID, ONE, comm);
       /* create the following matrix:
-	 [2 1           ]
-	 [1 1 1         ]
-	 [  1 1 1       ]
-	 [   . . .      ]
-	 [     . . .    ]
-	 [       . . .  ]
-	 [         1 1 1]
-	 [           1 2]
-	 this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
+         [2 1           ]
+         [1 1 1         ]
+         [  1 1 1       ]
+         [   . . .      ]
+         [     . . .    ]
+         [       . . .  ]
+         [         1 1 1]
+         [           1 2]
+         this matrix has an eigenvalue lambda=3, with eigenvector v = [1 ... 1]
       */
       A = rcp (new MAT(map, 3, Tpetra::StaticProfile));
       if (myImageID == 0) {
-	Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*ST::one(), ST::one()));
-	Array<GO> cols(tuple<GO>(myImageID, myImageID+1));
-	A->insertGlobalValues(myImageID,cols(),vals());
+        Array<Scalar> vals(tuple<Scalar>(static_cast<Scalar>(2)*ST::one(), ST::one()));
+        Array<GO> cols(tuple<GO>(myImageID, myImageID+1));
+        A->insertGlobalValues(myImageID,cols(),vals());
       }
       else if (myImageID == numImages-1) {
-	Array<Scalar> vals(tuple<Scalar>(ST::one(), static_cast<Scalar>(2)*ST::one()));
-	Array<GO> cols(tuple<GO>(myImageID-1,myImageID));
-	A->insertGlobalValues(myImageID,cols(),vals());
+        Array<Scalar> vals(tuple<Scalar>(ST::one(), static_cast<Scalar>(2)*ST::one()));
+        Array<GO> cols(tuple<GO>(myImageID-1,myImageID));
+        A->insertGlobalValues(myImageID,cols(),vals());
       }
       else {
-	Array<Scalar> vals(3,ST::one());
-	Array<GO> cols(tuple<GO>(myImageID-1, myImageID, myImageID+1));
-	A->insertGlobalValues(myImageID,cols(),vals());
+        Array<Scalar> vals(3,ST::one());
+        Array<GO> cols(tuple<GO>(myImageID-1, myImageID, myImageID+1));
+        A->insertGlobalValues(myImageID,cols(),vals());
       }
       A->fillComplete();
     }
 
-    RCP<MAT> Mold, Mnew;    
+    RCP<MAT> Mold, Mnew;
     {
       TimeMonitor tm (*TimeMonitor::getNewTimer("2) Halo Generation"));
 
       Mold = A;
       Mnew = Mold;
-  
+
       for (int i=0; i<num_halo_expansions; ++i) {
-	RCP<const IMP> rowImporter = Mold->getGraph()->getImporter();
-	Mnew = Tpetra::importAndFillCompleteCrsMatrix<MAT>(Mold,*rowImporter);
-	Mold = Mnew;
+        RCP<const IMP> rowImporter = Mold->getGraph()->getImporter();
+        Mnew = Tpetra::importAndFillCompleteCrsMatrix<MAT>(Mold,*rowImporter);
+        Mold = Mnew;
       }
     }
 

--- a/packages/tpetra/core/example/Lesson01-Init/lesson01_no_mpi.cpp
+++ b/packages/tpetra/core/example/Lesson01-Init/lesson01_no_mpi.cpp
@@ -26,7 +26,6 @@ main (int argc, char *argv[])
   using std::cout;
   using std::endl;
   using Teuchos::Comm;
-  using Teuchos::SerialComm;
   using Teuchos::RCP;
   using Teuchos::rcp;
 
@@ -36,7 +35,7 @@ main (int argc, char *argv[])
 #else
   // Not building with MPI, so default comm won't use MPI.
   Tpetra::ScopeGuard tpetraScope (&argc, &argv);
-#endif // HAVE_TPETRA_MPI  
+#endif // HAVE_TPETRA_MPI
   {
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_init_map_vec.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_init_map_vec.cpp
@@ -50,6 +50,8 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Version.hpp>
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_OrdinalTraits.hpp>
 
 void
 exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
@@ -363,7 +365,7 @@ main (int argc, char *argv[])
     // destructor.
     auto comm = Tpetra::getDefaultComm ();
     exampleRoutine (comm, std::cout);
-    
+
     // This tells the Trilinos test framework that the test passed.
     if (comm->getRank () == 0) {
       std::cout << "End Result: TEST PASSED" << std::endl;

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec.cpp
@@ -50,6 +50,7 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Version.hpp>
+#include <Teuchos_CommHelpers.hpp>
 
 void
 exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
@@ -73,27 +74,21 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   }
 
   // Type of the Tpetra::Map specialization to use.
-  typedef Tpetra::Map<> map_type;
+  using map_type = Tpetra::Map<>;
 
   // The type of the Tpetra::Vector specialization to use.
-  typedef Tpetra::Vector<> vector_type;
+  using vector_type = Tpetra::Vector<>;
 
   // The "Scalar" type is the type of the values stored in the Tpetra::Vector.
-  typedef Tpetra::Vector<>::scalar_type scalar_type;
+  using scalar_type = Tpetra::Vector<>::scalar_type;
 
   // The "LocalOrdinal" (LO) type is the type of "local" indices.
   // The typedef is commented out to avoid "unused typedef" warnings.
   //
-  //typedef Tpetra::Vector<>::local_ordinal_type local_ordinal_type;
+  //using local_ordinal_type = Tpetra::Vector<>::local_ordinal_type;
 
   // The "GlobalOrdinal" (GO) type is the type of "global" indices.
-  typedef Tpetra::Vector<>::global_ordinal_type global_ordinal_type;
-
-  // The Kokkos "Node" type describes the type of shared-memory
-  // parallelism that Tpetra will use _within_ an MPI process.
-  // The typedef is commented out to avoid "unused typedef" warnings.
-  //
-  //typedef Tpetra::Vector<>::node_type node_type;
+  using global_ordinal_type = Tpetra::Vector<>::global_ordinal_type;
 
   //////////////////////////////////////////////////////////////////////
   // Create a Tpetra Map
@@ -197,8 +192,8 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // pluralizing the word "entry" conditionally on globalCount.
     if (myRank == 0) {
       out << "x has " << globalCount << " entr"
-	  << (globalCount != 1 ? "ies" : "y")
-	  << " less than 0.5." << endl;
+          << (globalCount != 1 ? "ies" : "y")
+          << " less than 0.5." << endl;
     }
   }
 

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
@@ -50,6 +50,7 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Version.hpp>
+#include <Teuchos_CommHelpers.hpp>
 
 void
 exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
@@ -73,7 +74,7 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   }
 
   // Type of the Tpetra::Map specialization to use.
-  typedef Tpetra::Map<> map_type;
+  using map_type = Tpetra::Map<>;
 
   // The type of the Tpetra::Vector specialization to use.  The first
   // template parameter is the Scalar type.  The "Scalar" type is the
@@ -81,16 +82,16 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
   // Tpetra::Vector<>::scalar_type to get the default Scalar type.  We
   // will assume that it's double.
   //
-  // typedef Tpetra::Vector<>::scalar_type scalar_type;
-  typedef Tpetra::Vector<double> vector_type;
+  // using scalar_type = Tpetra::Vector<>::scalar_type;
+  using vector_type = Tpetra::Vector<double>;
 
   // The "LocalOrdinal" (LO) type is the type of "local" indices.
   // The typedef is commented out to avoid "unused typedef" warnings.
   //
-  //typedef vector_type::local_ordinal_type local_ordinal_type;
+  //using local_ordinal_type = vector_type::local_ordinal_type;
 
   // The "GlobalOrdinal" (GO) type is the type of "global" indices.
-  typedef vector_type::global_ordinal_type global_ordinal_type;
+  using global_ordinal_type = vector_type::global_ordinal_type;
 
   //////////////////////////////////////////////////////////////////////
   // Create a Tpetra Map
@@ -196,8 +197,8 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // pluralizing the word "entry" conditionally on globalCount.
     if (myRank == 0) {
       out << "x has " << globalCount << " entr"
-	  << (globalCount != 1 ? "ies" : "y")
-	  << " less than 0.5." << endl;
+          << (globalCount != 1 ? "ies" : "y")
+          << " less than 0.5." << endl;
     }
   }
 
@@ -229,9 +230,7 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
       // as a function to convert k (an integer) to double.
       x_1d(k) += double (k);
     }
-    // Vector now has a device_type typedef that you could use
-    // instead of node_type here.
-    typedef vector_type::node_type::memory_space memory_space;
+    using memory_space = vector_type::device_type::memory_space;
     x.sync<memory_space> ();
   }
 

--- a/packages/tpetra/core/example/advanced/Benchmarks/import.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/import.cpp
@@ -50,6 +50,7 @@
 #    include <mpi.h>
 #  else
 #    include <Epetra_SerialComm.h>
+#    include <Teuchos_DefaultSerialComm.hpp>
 #  endif // EPETRA_MPI
 #endif // HAVE_TPETRACORE_EPETRA
 
@@ -57,6 +58,7 @@
 #include <Tpetra_Import.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_OrdinalTraits.hpp>
 #include <Teuchos_TimeMonitor.hpp>
 
 using Tpetra::global_size_t;
@@ -290,7 +292,7 @@ int main (int argc, char* argv[]) {
 #ifdef HAVE_TPETRACORE_EPETRA
 #ifdef EPETRA_MPI
     Epetra_MpiComm epetraComm (MPI_COMM_WORLD);
-    tpetraComm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+    tpetraComm = Tpetra::getDefaultComm ();
 #  else
     Epetra_SerialComm epetraComm;
     tpetraComm = rcp (new Teuchos::SerialComm<int>);
@@ -313,15 +315,15 @@ int main (int argc, char* argv[]) {
 
     CommandLineProcessor cmdp;
     cmdp.setOption ("numEltsPerProc", &numEltsPerProc,
-		    "Number of global indices "
-		    "owned by each process");
+                    "Number of global indices "
+                    "owned by each process");
     cmdp.setOption ("numTrials", &numTrials,
-		    "Number of times to repeat each "
-		    "operation in a timing loop");
+                    "Number of times to repeat each "
+                    "operation in a timing loop");
     cmdp.setOption ("runEpetra", "noEpetra", &runEpetra,
-		    "Whether to run the Epetra benchmark");
+                    "Whether to run the Epetra benchmark");
     cmdp.setOption ("runTpetra", "noTpetra", &runTpetra,
-		    "Whether to run the Tpetra benchmark");
+                    "Whether to run the Tpetra benchmark");
     const CommandLineProcessor::EParseCommandLineReturn parseResult =
       cmdp.parse (argc, argv);
     if (parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
@@ -332,19 +334,19 @@ int main (int argc, char* argv[]) {
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION
-	(parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
-	 std::invalid_argument,
-	 "Failed to parse command-line arguments.");
+        (parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
+         std::invalid_argument,
+         "Failed to parse command-line arguments.");
       TEUCHOS_TEST_FOR_EXCEPTION
-	(numTrials < 0, std::invalid_argument,
-	 "numTrials must be nonnegative.");
+        (numTrials < 0, std::invalid_argument,
+         "numTrials must be nonnegative.");
       TEUCHOS_TEST_FOR_EXCEPTION
-	(numEltsPerProc < 0, std::invalid_argument,
-	 "numEltsPerProc must be nonnegative.");
+        (numEltsPerProc < 0, std::invalid_argument,
+         "numEltsPerProc must be nonnegative.");
 #ifndef HAVE_TPETRACORE_EPETRA
       TEUCHOS_TEST_FOR_EXCEPTION
-	(runEpetra, std::invalid_argument, "Tpetra was not built with "
-	 "Epetra enable, so you cannot run the Epetra benchmark." );
+        (runEpetra, std::invalid_argument, "Tpetra was not built with "
+         "Epetra enable, so you cannot run the Epetra benchmark." );
 #endif // HAVE_TPETRACORE_EPETRA
     }
 
@@ -356,24 +358,24 @@ int main (int argc, char* argv[]) {
 
     if (myRank == 0) {
       cout << endl << "---" << endl
-	   << "Command-line options:" << endl
-	   << "  numEltsPerProc: " << numEltsPerProc << endl
-	   << "  numTrials: " << numTrials << endl
-	   << "  runEpetra: " << (runEpetra ? "true" : "false") << endl
-	   << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
-	   << endl;
+           << "Command-line options:" << endl
+           << "  numEltsPerProc: " << numEltsPerProc << endl
+           << "  numTrials: " << numTrials << endl
+           << "  runEpetra: " << (runEpetra ? "true" : "false") << endl
+           << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
+           << endl;
     }
 
     // Run the benchmark
     Array<GO> srcGlobalElts, destGlobalElts;
     createGidLists (srcGlobalElts, destGlobalElts, numProcs, myRank,
-		    numEltsPerProc, indexBase);
+                    numEltsPerProc, indexBase);
 #ifdef HAVE_TPETRACORE_EPETRA
     if (runEpetra) {
       benchmarkEpetraImport (srcGlobalElts, destGlobalElts, indexBase,
-			     epetraComm,
-			     numMapCreateTrials, numImportCreateTrials,
-			     numVectorCreateTrials, numImportExecTrials);
+                             epetraComm,
+                             numMapCreateTrials, numImportCreateTrials,
+                             numVectorCreateTrials, numImportExecTrials);
     }
 #endif // HAVE_TPETRACORE_EPETRA
     if (runTpetra) {

--- a/packages/tpetra/core/example/advanced/Benchmarks/vector.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/vector.cpp
@@ -57,6 +57,7 @@
 #    include <mpi.h>
 #  else
 #    include <Epetra_SerialComm.h>
+#    include <Teuchos_DefaultSerialComm.hpp>
 #  endif // EPETRA_MPI
 #endif // HAVE_TPETRACORE_EPETRA
 
@@ -64,8 +65,9 @@
 #include <Tpetra_Map.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 #include <Teuchos_oblackholestream.hpp>
+#include <Teuchos_OrdinalTraits.hpp>
+#include <Teuchos_TimeMonitor.hpp>
 
 typedef Tpetra::global_size_t GST;
 using Teuchos::Array;
@@ -316,7 +318,7 @@ main (int argc, char* argv[])
 #ifdef HAVE_TPETRACORE_EPETRA
 #  ifdef EPETRA_MPI
     Epetra_MpiComm epetraComm (MPI_COMM_WORLD);
-    tpetraComm = rcp (new Teuchos::MpiComm<int> (MPI_COMM_WORLD));
+    tpetraComm = Tpetra::getDefaultComm ();
 #  else
     Epetra_SerialComm epetraComm;
     tpetraComm = rcp (new Teuchos::SerialComm<int>);
@@ -340,12 +342,12 @@ main (int argc, char* argv[])
 
     CommandLineProcessor cmdp;
     cmdp.setOption ("numIndsPerProc", &numIndsPerProc, "Number of global indices "
-		    "owned by each process");
+                    "owned by each process");
     cmdp.setOption ("numTrials", &numTrials, "Number of timing loop iterations for each event to time");
     cmdp.setOption ("runEpetra", "noEpetra", &runEpetra,
-		    "Whether to run the Epetra benchmark");
+                    "Whether to run the Epetra benchmark");
     cmdp.setOption ("runTpetra", "noTpetra", &runTpetra,
-		    "Whether to run the Tpetra benchmark");
+                    "Whether to run the Tpetra benchmark");
     const CommandLineProcessor::EParseCommandLineReturn parseResult =
       cmdp.parse (argc, argv);
     if (parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
@@ -356,30 +358,30 @@ main (int argc, char* argv[])
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION
-	(parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
-	 std::invalid_argument, "Failed to parse command-line arguments.");
+        (parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
+         std::invalid_argument, "Failed to parse command-line arguments.");
       TEUCHOS_TEST_FOR_EXCEPTION
-	(numIndsPerProc < 0, std::invalid_argument,
-	 "numIndsPerProc must be nonnegative.");
+        (numIndsPerProc < 0, std::invalid_argument,
+         "numIndsPerProc must be nonnegative.");
 #ifndef HAVE_TPETRACORE_EPETRA
       TEUCHOS_TEST_FOR_EXCEPTION
-	(runEpetra, std::invalid_argument, "Tpetra was not built with Epetra "
-	 "enabled, so you cannot run the Epetra benchmark." );
+        (runEpetra, std::invalid_argument, "Tpetra was not built with Epetra "
+         "enabled, so you cannot run the Epetra benchmark." );
 #endif // HAVE_TPETRACORE_EPETRA
     }
 
     if (myRank == 0) {
       cout << endl << "---" << endl
-	   << "Command-line options:" << endl
-	   << "  numIndsPerProc: " << numIndsPerProc << endl
-	   << "  numTrials: " << numTrials << endl;
+           << "Command-line options:" << endl
+           << "  numIndsPerProc: " << numIndsPerProc << endl
+           << "  numTrials: " << numTrials << endl;
 #ifdef HAVE_TPETRACORE_EPETRA
       cout << "  runEpetra: " << (runEpetra ? "true" : "false") << endl;
 #else
       cout << "  runEpetra: " << (runEpetra ? "true" : "false") << endl;
 #endif // HAVE_TPETRACORE_EPETRA
       cout << "  runTpetra: " << (runTpetra ? "true" : "false") << endl
-	   << endl;
+           << endl;
     }
 
     const int numMapCreateTrials = numTrials;
@@ -392,20 +394,20 @@ main (int argc, char* argv[])
 #ifdef HAVE_TPETRACORE_EPETRA
     if (runEpetra) {
       benchmarkEpetra (epetraComm, numIndsPerProc, indexBase,
-		       numMapCreateTrials,
-		       numVecCreateTrials,
-		       numVecRandTrials,
-		       numVecNormTrials,
-		       numVecDotTrials);
+                       numMapCreateTrials,
+                       numVecCreateTrials,
+                       numVecRandTrials,
+                       numVecNormTrials,
+                       numVecDotTrials);
     }
 #endif // HAVE_TPETRACORE_EPETRA
     if (runTpetra) {
       benchmarkTpetra (tpetraComm, numIndsPerProc, indexBase,
-		       numMapCreateTrials,
-		       numVecCreateTrials,
-		       numVecRandTrials,
-		       numVecNormTrials,
-		       numVecDotTrials);
+                       numMapCreateTrials,
+                       numVecCreateTrials,
+                       numVecRandTrials,
+                       numVecNormTrials,
+                       numVecDotTrials);
     }
     TimeMonitor::report (tpetraComm.ptr (), std::cout);
   }

--- a/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
+++ b/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
@@ -43,7 +43,9 @@
 #define TPETRA_CONFIGDEFS_HPP
 
 #include "TpetraCore_config.h"
-#include "Kokkos_DefaultNode.hpp"
+#include "Teuchos_ConfigDefs.hpp"
+#include "KokkosClassic_DefaultNode_config.h"
+#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
 
 //! %Tpetra namespace
 namespace Tpetra {
@@ -145,7 +147,10 @@ namespace Tpetra {
   /// \warning Do NOT rely on the contents of this namespace.
   namespace Details {
 
-    //! Declarations of values of Tpetra classes' default template parameters.
+    /// \brief Declarations of values of Tpetra classes' default template parameters.
+    ///
+    /// \warning Don't use this directly.  Get defaults from Tpetra classes.
+    ///   For example: <tt>Tpetra::MultiVector<>::scalar_type</tt>.
     namespace DefaultTypes {
       //! Default value of Scalar template parameter.
       typedef double scalar_type;
@@ -167,8 +172,23 @@ namespace Tpetra {
 #else
 #  error "Tpetra: No global ordinal types in the set {int, long long, long, unsigned long, unsigned} have been enabled."
 #endif
+
+      /// \typedef execution_space
+      /// \brief Default Tpetra execution space.
+#if defined(HAVE_TPETRA_DEFAULTNODE_CUDAWRAPPERNODE)
+      using execution_space = ::Kokkos::Cuda;
+#elif defined(HAVE_TPETRA_DEFAULTNODE_OPENMPWRAPPERNODE)
+      using execution_space = ::Kokkos::OpenMP;
+#elif defined(HAVE_TPETRA_DEFAULTNODE_THREADSWRAPPERNODE)
+      using execution_space = ::Kokkos::Threads;
+#elif defined(HAVE_TPETRA_DEFAULTNODE_SERIALWRAPPERNODE)
+      using execution_space = ::Kokkos::Serial;
+#else
+#    error "No default Tpetra Node type specified.  Please set the CMake option Tpetra_DefaultNode to a valid Node type."
+#endif
+
       //! Default value of Node template parameter.
-      typedef KokkosClassic::DefaultNode::DefaultNodeType node_type;
+      using node_type = ::Kokkos::Compat::KokkosDeviceWrapperNode<execution_space>;
     } // namespace DefaultTypes
 
   } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Core.hpp
+++ b/packages/tpetra/core/src/Tpetra_Core.hpp
@@ -53,6 +53,9 @@
 
 #include <Tpetra_ConfigDefs.hpp>
 #include <Teuchos_Comm.hpp>
+#ifdef HAVE_TPETRACORE_MPI
+#  include "mpi.h"
+#endif // HAVE_TPETRACORE_MPI
 
 namespace Tpetra {
 

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -59,6 +59,7 @@
 #include "Kokkos_DualView.hpp"
 #include "Kokkos_StaticCrsGraph.hpp"
 
+#include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_Describable.hpp"
 #include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
 

--- a/packages/tpetra/core/src/Tpetra_DefaultPlatform.hpp
+++ b/packages/tpetra/core/src/Tpetra_DefaultPlatform.hpp
@@ -53,25 +53,30 @@ namespace Tpetra {
 
 /** \brief Returns a default platform appropriate for the enviroment.
 
-  The DefaultPlatform mechanism is useful for easily accessing default
-  Comm and Node types on a particular system.
-
-  If HAVE_MPI is defined, then an instance of <tt>MpiPlatform</tt> will be
-  created.  Otherwise, a <tt>SerialPlatform</tt> is returned.
+    \warning This class is DEPRECATED and will be REMOVED SOON.  Do
+      not use <tt>*Platform</tt> classes any more.  To initialize
+      Tpetra, include <tt>Tpetra_Core.hpp</tt> and use
+      Tpetra::ScopeGuard, or Tpetra::initialize and Tpetra::finalize.
+      To get Tpetra's default Comm instance, include
+      <tt>Tpetra_Core.hpp</tt> and call
+      <tt>Tpetra::getDefaultComm()</tt>.  For the default Node type,
+      use <tt>Tpetra::Map<>::node_type</tt>.  Do not create Node
+      instances yourself.  It is OK for Node instances to be null.
  */
-class DefaultPlatform {
+class TPETRA_DEPRECATED DefaultPlatform {
 public:
   /// \brief The default platform type specified at compile time.
   ///
-  /// For a serial build, this will be SerialPlatform. Otherwise, it
-  /// will be MpiPlatform.
+  /// \warning This typedef is DEPRECATED and will be removed soon!
 #ifdef HAVE_TPETRA_MPI
   typedef MpiPlatform< ::Tpetra::Details::DefaultTypes::node_type> DefaultPlatformType;
 #else
   typedef SerialPlatform< ::Tpetra::Details::DefaultTypes::node_type> DefaultPlatformType;
 #endif
 
-  //! Return a reference to the default platform singleton.
+  /// \brief Return a reference to the default platform singleton.
+  ///
+  /// \warning This method is DEPRECATED and will be removed soon!
   static DefaultPlatformType& getDefaultPlatform ();
 
 private:

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -47,8 +47,9 @@
 #include "Tpetra_Details_Hash.hpp"
 #include "Tpetra_Details_OrdinalTraits.hpp"
 #include "Tpetra_Details_copyOffsets.hpp"
-#include "Teuchos_VerbosityLevel.hpp"
+#include "Teuchos_Describable.hpp"
 #include "Teuchos_FancyOStream.hpp"
+#include "Teuchos_VerbosityLevel.hpp"
 #include "Kokkos_Core.hpp"
 
 namespace Tpetra {

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
@@ -66,6 +66,13 @@
 
 #include <Tpetra_Details_FixedHashTable_decl.hpp>
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+// Forward declaration of Teuchos::Comm
+namespace Teuchos {
+  template<class OrdinalType>
+  class Comm;
+} // namespace Teuchos
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 namespace Tpetra {
   // Forward declaration.

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
@@ -52,14 +52,13 @@
 
 #include <Tpetra_Details_FixedHashTable.hpp>
 #include <Tpetra_HashTable.hpp>
-
+#include "Teuchos_Comm.hpp"
 
 // FIXME (mfh 16 Apr 2013) GIANT HACK BELOW
-#ifdef HAVE_MPI
+#ifdef HAVE_TPETRACORE_MPI
 #  include <mpi.h>
-#endif // HAVE_MPI
+#endif // HAVE_TPETRACORE_MPI
 // FIXME (mfh 16 Apr 2013) GIANT HACK ABOVE
-
 
 namespace Tpetra {
   namespace Details {
@@ -327,7 +326,7 @@ namespace Tpetra {
       // MPI_Allgather does.  Matt Bettencourt reports Valgrind issues
       // (memcpy with overlapping data) with MpiComm<int>::gatherAll,
       // which could relate either to this, or to OpenMPI.
-#ifdef HAVE_MPI
+#ifdef HAVE_TPETRACORE_MPI
       MPI_Datatype rawMpiType = MPI_INT;
       bool useRawMpi = true;
       if (typeid (GO) == typeid (int)) {
@@ -358,9 +357,9 @@ namespace Tpetra {
       } else {
         gatherAll<int, GO> (*comm, 1, &minMyGID, numProcs, allMinGIDs_.getRawPtr ());
       }
-#else // NOT HAVE_MPI
+#else // NOT HAVE_TPETRACORE_MPI
       gatherAll<int, GO> (*comm, 1, &minMyGID, numProcs, allMinGIDs_.getRawPtr ());
-#endif // HAVE_MPI
+#endif // HAVE_TPETRACORE_MPI
       // FIXME (mfh 16 Apr 2013) GIANT HACK ABOVE
 
       //gatherAll<int, GO> (*comm, 1, &minMyGID, numProcs, allMinGIDs_.getRawPtr ());
@@ -905,7 +904,7 @@ namespace Tpetra {
             const std::vector<std::pair<int, LO> >& pidLidList =
               ownedPidLidPairs[i];
             const size_t listLen = pidLidList.size();
-            if (listLen == 0) continue;  // KDD will happen for GIDs not in 
+            if (listLen == 0) continue;  // KDD will happen for GIDs not in
                                          // KDD the user's source map
             const LO dirMapLid = static_cast<LO> (i);
             const GO dirMapGid = directoryMap_->getGlobalElement (dirMapLid);

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
@@ -44,6 +44,7 @@
 
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Experimental_BlockView.hpp>
+#include "Teuchos_OrdinalTraits.hpp"
 
 namespace Tpetra {
 namespace Experimental {

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -50,6 +50,8 @@
 #include "Tpetra_Details_LocalMap.hpp"
 #include "Kokkos_DefaultNode.hpp"
 #include "Kokkos_DualView.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_Comm.hpp"
 #include "Teuchos_Describable.hpp"
 
 namespace Tpetra {
@@ -1430,7 +1432,7 @@ namespace Tpetra {
   ///   Kokkos Node type.
   ///
   /// The Map is configured to use zero-based indexing.
-  /// 
+  ///
   /// \relatesalso Map
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -55,6 +55,7 @@
 #include "Tpetra_Util.hpp"
 #include "Teuchos_as.hpp"
 #include "Teuchos_TypeNameTraits.hpp"
+#include "Teuchos_CommHelpers.hpp"
 #include "Tpetra_Details_mpiIsInitialized.hpp"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp" // teuchosCommIsAnMpiComm
 #include "Tpetra_Details_initializeKokkos.hpp"

--- a/packages/tpetra/core/src/Tpetra_MpiPlatform.hpp
+++ b/packages/tpetra/core/src/Tpetra_MpiPlatform.hpp
@@ -53,35 +53,18 @@ namespace Tpetra {
   /// \brief Implementation of the Platform concept for MPI-based
   ///   platforms.
   ///
-  /// \warning This class will be DEPRECATED, in favor of the
-  ///   initialize() functions in Tpetra_Core.hpp.  Please use those
-  ///   functions for safe, consistent initialization of MPI and
-  ///   Kokkos, on which Tpetra depends.  If you must use this class,
-  ///   please prefer the constructors that take \c argc and \c argv.
-  ///   Those constructors will call initialize() for you.
-  ///
-  /// MpiPlatform is an implementation of Tpetra's Platform concept.
-  /// Classes implementing the Platform concept are templated on the
-  /// Kokkos Node type.  They have at least the following public
-  /// interface:
-  /// \code
-  /// // This is not a real class; it just illustrates the concept.
-  /// template<class Node>
-  /// class Platform {
-  /// public:
-  ///   typedef Node NodeType;
-  ///   explicit Platform (const RCP<Node>& node);
-  ///   RCP<const Comm<int> > getComm() const;
-  ///   RCP<Node> getNode() const;
-  /// };
-  /// \endcode
-  /// MpiPlatform also has a constructor that accepts an MPI
-  /// communicator, over which the application using the platform
-  /// should perform communication.  The default communicator is
-  /// MPI_COMM_WORLD.  MpiPlatform is only available if Trilinos was
-  /// built with MPI.
+  ///  \warning This class is DEPRECATED and will be REMOVED SOON.  Do
+  ///    not use <tt>*Platform</tt> classes any more.  To initialize
+  ///    Tpetra, include <tt>Tpetra_Core.hpp</tt> and use
+  ///    Tpetra::ScopeGuard, or Tpetra::initialize and
+  ///    Tpetra::finalize.  To get Tpetra's default Comm instance,
+  ///    include <tt>Tpetra_Core.hpp</tt> and call
+  ///    <tt>Tpetra::getDefaultComm()</tt>.  For the default Node
+  ///    type, use <tt>Tpetra::Map<>::node_type</tt>.  Do not create
+  ///    Node instances yourself.  It is OK for Node instances to be
+  ///    null.
   template <class Node>
-  class MpiPlatform : public Teuchos::Describable {
+  class TPETRA_DEPRECATED MpiPlatform : public Teuchos::Describable {
   public:
     //! @name Typedefs
     //@{
@@ -303,10 +286,18 @@ namespace Tpetra {
   /// \class MpiPlatform< ::Tpetra::Details::DefaultTypes::node_type>
   /// \brief MpiPlatform specialization for the default Node type.
   ///
-  /// \note <tt>::Tpetra::Details::DefaultTypes::node_type</tt> is a
-  ///   typedef.  Its actual type depends on Trilinos' build options.
+  ///  \warning This class is DEPRECATED and will be REMOVED SOON.  Do
+  ///    not use <tt>*Platform</tt> classes any more.  To initialize
+  ///    Tpetra, include <tt>Tpetra_Core.hpp</tt> and use
+  ///    Tpetra::ScopeGuard, or Tpetra::initialize and
+  ///    Tpetra::finalize.  To get Tpetra's default Comm instance,
+  ///    include <tt>Tpetra_Core.hpp</tt> and call
+  ///    <tt>Tpetra::getDefaultComm()</tt>.  For the default Node
+  ///    type, use <tt>Tpetra::Map<>::node_type</tt>.  Do not create
+  ///    Node instances yourself.  It is OK for Node instances to be
+  ///    null.
   template <>
-  class MpiPlatform< ::Tpetra::Details::DefaultTypes::node_type> :
+  class TPETRA_DEPRECATED MpiPlatform< ::Tpetra::Details::DefaultTypes::node_type> :
     public Teuchos::Describable {
   public:
     //! @name Typedefs

--- a/packages/tpetra/core/src/Tpetra_SerialPlatform.hpp
+++ b/packages/tpetra/core/src/Tpetra_SerialPlatform.hpp
@@ -52,34 +52,18 @@ namespace Tpetra {
 
   /// \brief Implementation of the Platform concept for non-MPI platforms.
   ///
-  /// \warning This class will be DEPRECATED, in favor of the
-  ///   initialize() functions in Tpetra_Core.hpp.  Please use those
-  ///   functions for safe, consistent initialization Kokkos, on which
-  ///   Tpetra depends.  If you must use this class, please prefer the
-  ///   constructors that take \c argc and \c argv.  Those
-  ///   constructors will call initialize() for you.
-  ///
-  /// SerialPlatform is an implementation of Tpetra's Platform
-  /// concept.  Classes implementing the Platform concept are
-  /// templated on the Kokkos Node type.  They have at least the
-  /// following public interface:
-  /// \code
-  /// // This is not a real class; it just illustrates the concept.
-  /// template<class Node>
-  /// class Platform {
-  /// public:
-  ///   typedef Node NodeType;
-  ///   explicit Platform (const RCP<Node>& node);
-  ///   RCP<const Comm<int> > getComm() const;
-  ///   RCP<Node> getNode() const;
-  /// };
-  /// \endcode
-  /// SerialPlatform uses a "communicator" containing one process.  It
-  /// is available whether or not Trilinos was built with MPI (the
-  /// Message-Passing Interface which provides a distributed-memory
-  /// parallel programming model).
+  ///  \warning This class is DEPRECATED and will be REMOVED SOON.  Do
+  ///    not use <tt>*Platform</tt> classes any more.  To initialize
+  ///    Tpetra, include <tt>Tpetra_Core.hpp</tt> and use
+  ///    Tpetra::ScopeGuard, or Tpetra::initialize and
+  ///    Tpetra::finalize.  To get Tpetra's default Comm instance,
+  ///    include <tt>Tpetra_Core.hpp</tt> and call
+  ///    <tt>Tpetra::getDefaultComm()</tt>.  For the default Node
+  ///    type, use <tt>Tpetra::Map<>::node_type</tt>.  Do not create
+  ///    Node instances yourself.  It is OK for Node instances to be
+  ///    null.
   template <class Node>
-  class SerialPlatform : public Teuchos::Describable {
+  class TPETRA_DEPRECATED SerialPlatform : public Teuchos::Describable {
   public:
     //! @name Typedefs
     //@{
@@ -170,7 +154,7 @@ namespace Tpetra {
   ///   may have a different type, depending on Trilinos' build
   ///   options.
   template <>
-  class SerialPlatform<Tpetra::Details::DefaultTypes::node_type> :
+  class TPETRA_DEPRECATED SerialPlatform<Tpetra::Details::DefaultTypes::node_type> :
     public Teuchos::Describable {
   public:
     //! @name Typedefs

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -51,10 +51,13 @@
   here so that they can be updated and maintained in a single spot.
 */
 
-#include "Tpetra_ConfigDefs.hpp" // for map, vector, string, and iostream
+#include "Tpetra_ConfigDefs.hpp"
 #include "Kokkos_DualView.hpp"
-#include "Teuchos_Utils.hpp"
 #include "Teuchos_Assert.hpp"
+#include "Teuchos_CommHelpers.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
+#include "Teuchos_Utils.hpp"
 #include <algorithm>
 #include <iterator>
 #include <sstream>

--- a/packages/tpetra/core/src/Tpetra_Vector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_def.hpp
@@ -54,6 +54,7 @@
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "KokkosCompat_View.hpp"
 #include "KokkosBlas1_nrm2w_squared.hpp"
+#include "Teuchos_CommHelpers.hpp"
 
 namespace Tpetra {
 

--- a/packages/tpetra/core/test/FEMultiVector/Fix3101.cpp
+++ b/packages/tpetra/core/test/FEMultiVector/Fix3101.cpp
@@ -2,6 +2,7 @@
 
 #include "Tpetra_Core.hpp"
 #include "Tpetra_FEMultiVector.hpp"
+#include "Teuchos_CommHelpers.hpp"
 
 #include <string>
 #include <sstream>
@@ -10,7 +11,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Each processor owns ten vertices and copies five from another processor.
 // Each processor contributes values to all fifteen vertices it stores.
-// Tpetra::FEMultiVector pushes the copies to their owning processors, and 
+// Tpetra::FEMultiVector pushes the copies to their owning processors, and
 // ADDs them to the owned values.
 // Tpetra::FEMultiVector updates copies from their owning processors.
 
@@ -45,19 +46,19 @@ private:
 };
 
 //////////////////////////////////////////////////////////////////////////////
-// Constructor 
-// -  assigns vertices to processors 
-// -  builds map with owned vertices and 
+// Constructor
+// -  assigns vertices to processors
+// -  builds map with owned vertices and
 //           map with owned+ghosted (copied) vertices
 // -  then builds a Tpetra::FEMultiVector with two vectors using the maps
 FEMultiVectorTest::FEMultiVectorTest(
   Teuchos::RCP<const Teuchos::Comm<int> > &comm_
 ) :
-  me(comm_->getRank()), 
+  me(comm_->getRank()),
   np(comm_->getSize()),
-  nLocalOwned(10), 
-  nLocalCopy( np > 1 ? 5 : 0), 
-  nVec(2), 
+  nLocalOwned(10),
+  nLocalCopy( np > 1 ? 5 : 0),
+  nVec(2),
   comm(comm_)
 {
   // Each rank has 15 IDs, the last five of which overlap with the next rank.
@@ -100,7 +101,7 @@ FEMultiVectorTest::FEMultiVectorTest(
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Test FEMultiVector 
+// Test FEMultiVector
 // Fill first vector with GIDs of vertices
 // Fill second vector with processor rank (me)
 // Perform communication to add copies' contributions to their owned vertices
@@ -109,7 +110,7 @@ int FEMultiVectorTest::intTest()
 {
   int ierr = 0;
 
-  
+
   // Add contributions to owned vertices and copies of off-processor vertices
   try {
     femv->beginFill();
@@ -118,7 +119,7 @@ int FEMultiVectorTest::intTest()
       femv->replaceGlobalValue(gid, 0, gid);
       femv->replaceGlobalValue(gid, 1, me);
     }
-    femv->endFill(); 
+    femv->endFill();
   }
   catch (std::exception &e) {
     std::cout << "FAIL:  Exception thrown in Fill:  " << e.what() << std::endl;
@@ -132,14 +133,14 @@ int FEMultiVectorTest::intTest()
     femv->doSourceToTarget(Tpetra::REPLACE);
   }
   catch (std::exception &e) {
-    std::cout << "FAIL:  Exception thrown in doSourceToTarget:  " 
+    std::cout << "FAIL:  Exception thrown in doSourceToTarget:  "
               << e.what() << std::endl;
     throw e;
   }
 
   printFEMV("After doSourceToTarget ");
 
-  // Check results:  after ADD in endFill, 
+  // Check results:  after ADD in endFill,
   // -  overlapping entries of vec 0 should be 2 * gid
   //    nonoverlapping entries of vec 0 should be gid
   // -  overlapping entries of vec 1 should be me + (np + me-1) % np;
@@ -150,7 +151,7 @@ int FEMultiVectorTest::intTest()
   for (lno_t i = 0; i < nLocalCopy; i++){
     gno_t gid = femv->getMap()->getGlobalElement(i);
     if (value[i] != 2*gid) {
-      std::cout << me << " Error in SOURCE vec 0 overlap: gid=" << gid 
+      std::cout << me << " Error in SOURCE vec 0 overlap: gid=" << gid
                       << " value= " << value[i] << " should be " << 2*gid
                       << std::endl;
       ierr++;
@@ -172,7 +173,7 @@ int FEMultiVectorTest::intTest()
   for (lno_t i = 0; i < nLocalCopy; i++){
     gno_t gid = femv->getMap()->getGlobalElement(i);
     if (value[i] != 2*gid) {
-      std::cout << me << " Error in TARGET vec 0 overlap: gid=" << gid 
+      std::cout << me << " Error in TARGET vec 0 overlap: gid=" << gid
                       << " value= " << value[i] << " should be " << 2*gid
                       << std::endl;
       ierr++;
@@ -258,10 +259,10 @@ int FEMultiVectorTest::intTest()
 
 //////////////////////////////////////////////////////////////////////////////
 // Print the SOURCE and TARGET multivector entries
-void FEMultiVectorTest::printFEMV(const char *msg) 
+void FEMultiVectorTest::printFEMV(const char *msg)
 {
   // print Source MV (Owned only)
-  for (int v = 0; v < nVec; v++) {  
+  for (int v = 0; v < nVec; v++) {
     std::cout << me << " SOURCE " << msg << " FEMV[" << v << "] Owned: ";
     auto value = femv->getData(v);
     for (lno_t i = 0; i < nLocalOwned; i++) std::cout << value[i] << " ";
@@ -275,7 +276,7 @@ void FEMultiVectorTest::printFEMV(const char *msg)
     auto value = femv->getData(v);
     for (lno_t i = 0; i < nLocalOwned; i++) std::cout << value[i] << " ";
     std::cout << " Copies: ";
-    for (lno_t i = nLocalOwned; i < nLocalOwned+nLocalCopy; i++) 
+    for (lno_t i = nLocalOwned; i < nLocalOwned+nLocalCopy; i++)
       std::cout << value[i] << " ";
     std::cout << std::endl;
   }
@@ -308,6 +309,6 @@ int main(int narg, char **arg)
     if (gerr == 0) std::cout << "PASS" << std::endl;
     else std::cout << "FAIL:  " << gerr << " failures" << std::endl;
   }
-  
+
   return 0;
 }

--- a/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
+++ b/packages/tpetra/core/test/HashTable/FixedHashTableTest.cpp
@@ -45,6 +45,7 @@
 #include <TpetraCore_ETIHelperMacros.h>
 #include <Tpetra_Details_FixedHashTable.hpp>
 #include <Kokkos_Core.hpp>
+#include "Teuchos_OrdinalTraits.hpp"
 #include <cstdlib> // atexit
 
 namespace { // (anonymous)

--- a/packages/tpetra/core/test/ImportExport/Issue_114.cpp
+++ b/packages/tpetra/core/test/ImportExport/Issue_114.cpp
@@ -45,16 +45,17 @@
 // Test for Github Issue #114.
 //
 
+#include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Import.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 
 #include "Teuchos_CommandLineProcessor.hpp"
-#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_FancyOStream.hpp"
-#include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_RCP.hpp"
+
 
 int
 main (int argc, char *argv[])
@@ -65,20 +66,18 @@ main (int argc, char *argv[])
   using Teuchos::REDUCE_MIN;
   using Teuchos::reduceAll;
   using std::endl;
-  typedef Tpetra::Map<>::local_ordinal_type LO;
-  typedef Tpetra::Map<>::global_ordinal_type GO;
-  typedef Tpetra::global_size_t GST;
-  typedef Tpetra::Map<LO, GO> map_type;
-  typedef Tpetra::Import<LO, GO> import_type;
+  using map_type = Tpetra::Map<>;
+  using import_type = Tpetra::Import<>;
+  using GO = Tpetra::Map<>::global_ordinal_type;
+  using GST = Tpetra::global_size_t;
+
   // mfh 09 Aug 2017: Tpetra instantiates Vector with Scalar=int even
   // if GO=int is disabled, because users (e.g., in MueLu and Zoltan2)
   // want to be able to communicate MPI process ranks.
-  typedef Tpetra::Vector<int, LO, GO> IntVector;
+  using IntVector = Tpetra::Vector<int>;
 
-  Teuchos::oblackholestream blackhole;
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &blackhole);
-
-  auto comm = Teuchos::DefaultComm<int>::getComm ();
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  auto comm = Tpetra::getDefaultComm ();
   auto outPtr = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cout));
   auto& out = *outPtr;
   out.setOutputToRootOnly (0);

--- a/packages/tpetra/core/test/Map/Map_Bug2431.cpp
+++ b/packages/tpetra/core/test/Map/Map_Bug2431.cpp
@@ -43,6 +43,7 @@
 
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Core.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
 
 #include <vector>
 #include <unordered_map>
@@ -56,8 +57,8 @@
 // has a copy.
 namespace {
 template <typename LO, typename GO>
-class GreedyTieBreak : 
-      public Tpetra::Details::TieBreak<LO,GO> 
+class GreedyTieBreak :
+      public Tpetra::Details::TieBreak<LO,GO>
 {
 public:
   GreedyTieBreak() { }
@@ -91,7 +92,7 @@ public:
 // Given input IDs vecP0, vecP1, vecP2, vecP3, build a (probably overlapping)
 // map with these IDs on the respective processors P0-P3.
 // Then create one-to-one maps from the overlapping map, with and without
-// use of the tie-break function.  
+// use of the tie-break function.
 // Compare the number of unique IDs in the three maps; the test passes if
 // the number of unique IDs matches.
 
@@ -131,9 +132,9 @@ int runTest(
       overlapMap = Teuchos::rcp(new map_t(dummy, arrP3(), 0, comm));
     }
 
-    std::cout << message 
-              << ": Before Tpetra::createOneToOne on " << "Proc " 
-              << overlapMap->getComm()->getRank() 
+    std::cout << message
+              << ": Before Tpetra::createOneToOne on " << "Proc "
+              << overlapMap->getComm()->getRank()
               << "; nGids = " << overlapMap->getNodeNumElements() << "\n";
 
     auto myidx_o =  overlapMap->getMyGlobalIndices();
@@ -147,9 +148,9 @@ int runTest(
     Teuchos::RCP<const map_t> nonOverlapMapTB =
              Tpetra::createOneToOne<LO,GO,NO>(overlapMap, greedy_tie_break);
 
-    std::cout << message 
-              << ": After Tpetra::createOneToOne with TieBreak on Proc " 
-              << overlapMap->getComm()->getRank() 
+    std::cout << message
+              << ": After Tpetra::createOneToOne with TieBreak on Proc "
+              << overlapMap->getComm()->getRank()
               << "; nGids = " << nonOverlapMapTB->getNodeNumElements() << "\n";
 
     auto myidx_notb =  nonOverlapMapTB->getMyGlobalIndices();
@@ -163,9 +164,9 @@ int runTest(
     Teuchos::RCP<const map_t> nonOverlapMap =
              Tpetra::createOneToOne<LO,GO,NO>(overlapMap);
 
-    std::cout << message 
-              << ": After Tpetra::createOneToOne without TieBreak on Proc " 
-              << overlapMap->getComm()->getRank() 
+    std::cout << message
+              << ": After Tpetra::createOneToOne without TieBreak on Proc "
+              << overlapMap->getComm()->getRank()
               << "; nGids = " << nonOverlapMap->getNodeNumElements() << "\n";
 
     auto myidx_no =  nonOverlapMap->getMyGlobalIndices();
@@ -179,25 +180,25 @@ int runTest(
     std::unordered_map<GO,int> uniqueGids;
 
     for (auto i = arrP0.begin(); i != arrP0.end(); i++) {
-      if (uniqueGids.find(*i) != uniqueGids.end()) 
+      if (uniqueGids.find(*i) != uniqueGids.end())
         uniqueGids[*i]++;
       else
         uniqueGids[*i] = 1;
     }
     for (auto i = arrP1.begin(); i != arrP1.end(); i++) {
-      if (uniqueGids.find(*i) != uniqueGids.end()) 
+      if (uniqueGids.find(*i) != uniqueGids.end())
         uniqueGids[*i]++;
       else
         uniqueGids[*i] = 1;
     }
     for (auto i = arrP2.begin(); i != arrP2.end(); i++) {
-      if (uniqueGids.find(*i) != uniqueGids.end()) 
+      if (uniqueGids.find(*i) != uniqueGids.end())
         uniqueGids[*i]++;
       else
         uniqueGids[*i] = 1;
     }
     for (auto i = arrP3.begin(); i != arrP3.end(); i++) {
-      if (uniqueGids.find(*i) != uniqueGids.end()) 
+      if (uniqueGids.find(*i) != uniqueGids.end())
         uniqueGids[*i]++;
       else
         uniqueGids[*i] = 1;
@@ -209,13 +210,13 @@ int runTest(
 
     if (pid == 0) {
       std::cout << "\n\n" << message
-                << ": Before Tpetra::createOneToOne, there are " 
-                << uniqueGids.size() << " ids, with " 
+                << ": Before Tpetra::createOneToOne, there are "
+                << uniqueGids.size() << " ids, with "
                 << ncopies << " copies.\n";
-      std::cout << message 
-                << ": After Tpetra::createOneToOne with TieBreak, there are " 
+      std::cout << message
+                << ": After Tpetra::createOneToOne with TieBreak, there are "
                 << nonOverlapMapTB->getGlobalNumElements() << " ids.\n";
-      std::cout << message 
+      std::cout << message
                 << ": After Tpetra::createOneToOne without TieBreak, there are "
                 << nonOverlapMap->getGlobalNumElements() << " ids.\n";
       std::cout << "\n\n";
@@ -243,11 +244,11 @@ int main(int narg, char *arg[]) {
   typedef Tpetra::Map<>::global_ordinal_type GO;
   typedef Tpetra::Map<>::node_type NO;
 
-  Tpetra::initialize(&narg, &arg);
-  Teuchos::RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
+  Tpetra::ScopeGuard tpetraScope(&narg, &arg);
+  auto comm = Tpetra::getDefaultComm();
 
   if (comm->getSize() != 4) {
-    if (comm->getRank() == 0) 
+    if (comm->getRank() == 0)
       std::cout << "TEST FAILED: This test is written for four processes only. "
                 << "You are running on " << comm->getSize() << " processes."
                 << std::endl;
@@ -256,7 +257,7 @@ int main(int narg, char *arg[]) {
 
   int errorFlag  = 0;
 
-  // This little trick lets us print to std::cout only 
+  // This little trick lets us print to std::cout only
   // if a (dummy) command-line argument is provided.
   int iprint     = narg - 1;
   Teuchos::oblackholestream bhs; // outputs nothing
@@ -264,24 +265,24 @@ int main(int narg, char *arg[]) {
 
   // Sparse test that uses hash tables in directory
   {
-    std::vector<GO> vecP0 = 
+    std::vector<GO> vecP0 =
       { 0, 1, 3, 4, 9, 10, 12, 13, 18, 19, 21, 22, 27, 31, 36, 37, 38, 39, 40,
         41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 79, 80, 81, 82};
-    std::vector<GO> vecP1 = 
+    std::vector<GO> vecP1 =
       { 1, 2, 4, 5, 10, 11, 13, 14, 19, 20, 22, 23, 28, 32, 37, 46, 55, 56,
         58, 67, 76, 77, 79, 996, 997, 998, 999, 1000, 1001, 1002, 1004, 1005,
         1006, 1007, 1009, 1010, 1013, 1015, 1016, 1017, 1018, 1019, 1020, 1021,
         1022, 1023, 1024, 1025, 1026, 1027, 1028, 1030, 1031, 1034, 1036, 1037,
         1038, 1039, 1040, 1041, 1042};
-    std::vector<GO> vecP2 = 
+    std::vector<GO> vecP2 =
       { 3, 4, 6, 7, 12, 13, 15, 16, 21, 22, 24, 25, 29, 33, 42, 54, 58, 59,
         60, 75, 79, 80, 81, 1957, 1958, 1959, 1960, 1961, 1962, 1963, 1964,
         1967, 1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
         1981, 1982, 1983, 1984, 1985, 1988, 1991, 1992, 1993, 1994, 1995, 1996,
         1997, 1998, 1999, 2000, 2001, 2002};
-    std::vector<GO> vecP3 = 
+    std::vector<GO> vecP3 =
       { 4, 5, 7, 8, 13, 14, 16, 17, 22, 23, 25, 26, 30, 34, 58, 79, 1002,
         1018, 1019, 1020, 1039, 1040, 1041, 1957, 1975, 1976, 1978, 1996, 1997,
         1999, 2917, 2918, 2919, 2920, 2921, 2922, 2924, 2927, 2930, 2933, 2935,
@@ -299,27 +300,27 @@ int main(int narg, char *arg[]) {
 
   // Dense test that does not use hash tables in directory.
   // Keep same number of IDs and structure of overlap, but
-  // narrow the range of global ID values so that processors more than 
+  // narrow the range of global ID values so that processors more than
   // 0.1 * (max ID - min ID).
   {
-    std::vector<GO> vecP0 = 
+    std::vector<GO> vecP0 =
       { 0, 1, 3, 4, 9, 10, 12, 13, 18, 19, 21, 22, 27, 31, 36, 37, 38, 39, 40,
         41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 79, 80, 81, 82};
-    std::vector<GO> vecP1 = 
+    std::vector<GO> vecP1 =
       { 1, 2, 4, 5, 10, 11, 13, 14, 19, 20, 22, 23, 28, 32, 37, 46, 55, 56,
         58, 67, 76, 77, 79, 396, 397, 398, 399, 400, 401, 402, 404, 405,
         406, 407, 409, 410, 413, 415, 416, 417, 418, 419, 420, 421,
         422, 423, 424, 425, 426, 427, 428, 430, 431, 434, 436, 437,
         438, 439, 440, 441, 442};
-    std::vector<GO> vecP2 = 
+    std::vector<GO> vecP2 =
       { 3, 4, 6, 7, 12, 13, 15, 16, 21, 22, 24, 25, 29, 33, 42, 54, 58, 59,
         60, 75, 79, 80, 81, 557, 558, 559, 560, 561, 562, 563, 564,
         567, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580,
         581, 582, 583, 584, 585, 588, 591, 592, 593, 594, 595, 596,
         597, 598, 599, 600, 601, 602};
-    std::vector<GO> vecP3 = 
+    std::vector<GO> vecP3 =
       { 4, 5, 7, 8, 13, 14, 16, 17, 22, 23, 25, 26, 30, 34, 58, 79, 402,
         418, 419, 420, 439, 440, 441, 557, 575, 576, 578, 596, 597,
         599, 617, 618, 619, 620, 621, 622, 624, 627, 630, 633, 635,
@@ -335,8 +336,6 @@ int main(int narg, char *arg[]) {
                                    vecP0, vecP1, empty, vecP3);
   }
 
-  Tpetra::finalize();
-
   if (errorFlag != 0) {
     std::cout << "End Result: TEST FAILED" << std::endl;
     return EXIT_FAILURE;
@@ -345,5 +344,4 @@ int main(int narg, char *arg[]) {
     std::cout << "End Result: TEST PASSED" << std::endl;
     return EXIT_SUCCESS;
   }
-
 }

--- a/packages/tpetra/core/test/Map/Map_Bug5399.cpp
+++ b/packages/tpetra/core/test/Map/Map_Bug5399.cpp
@@ -41,11 +41,10 @@
 // @HEADER
 */
 
-#include <Tpetra_ConfigDefs.hpp>
-#include <Teuchos_ConfigDefs.hpp>
-#include <Teuchos_UnitTestHarness.hpp>
-#include <Teuchos_DefaultComm.hpp>
-#include <Tpetra_Map.hpp>
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+#include "Teuchos_CommHelpers.hpp"
 
 // Unit tests like to be in an anonymous namespace.
 namespace {
@@ -70,23 +69,21 @@ TEUCHOS_UNIT_TEST( Map, Bug5399 )
   using std::cerr;
   using std::endl;
 #ifdef HAVE_TPETRA_INT_LONG_LONG
-  typedef long long GO;
-  if (sizeof (long long) <= 4) {
-    out << "sizeof (long long) = " << sizeof (long long) << " <= 4.  "
-        << "This test only makes sense if sizeof (long long) >= 8." << endl;
-    return;
-  }
+  // C++11 guarantees that sizeof(long long) >= 8.
+  using GO = long long;
 #else // NOT HAVE_TPETRA_INT_LONG_LONG
-  typedef long GO;
+  using GO = long;
+  // long is 32 bits on some platforms, including Windows.
   if (sizeof (long) <= 4) {
     out << "sizeof (long) = " << sizeof (long) << " <= 4.  "
         << "This test only makes sense if sizeof (long) >= 8." << endl;
     return;
   }
 #endif // HAVE_TPETRA_INT_LONG_LONG
-  typedef Tpetra::Map<int, GO> map_type;
+  using LO = Tpetra::Map<>::local_ordinal_type;
+  using map_type = Tpetra::Map<LO, GO>;
 
-  RCP<const Comm<int> > comm = Teuchos::DefaultComm<int>::getComm ();
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
   const int myRank = comm->getRank ();
   const int numProcs = comm->getSize ();
 

--- a/packages/tpetra/core/test/Map/Map_Bug6051.cpp
+++ b/packages/tpetra/core/test/Map/Map_Bug6051.cpp
@@ -41,12 +41,12 @@
 // @HEADER
 */
 
-#include <Tpetra_ConfigDefs.hpp>
-#include <Teuchos_UnitTestHarness.hpp>
-#include <Teuchos_Tuple.hpp>
-#include <Tpetra_Core.hpp>
-#include <Tpetra_Map.hpp>
-#include <Tpetra_TieBreak.hpp>
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_TieBreak.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
+#include "Teuchos_Tuple.hpp"
 
 #define NUM_GLOBAL_ELEMENTS 100
 

--- a/packages/tpetra/core/test/Map/NegativeBaseIndexTest.cpp
+++ b/packages/tpetra/core/test/Map/NegativeBaseIndexTest.cpp
@@ -44,6 +44,8 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Tpetra_Core.hpp"
 #include "Tpetra_Map.hpp"
+#include "Teuchos_CommHelpers.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
 
 namespace {
 
@@ -68,7 +70,7 @@ namespace {
     using map_type = Tpetra::Map<>;
     using GO = Tpetra::Map<>::global_ordinal_type;
     using size_type = Teuchos::Array<GO>::size_type;
-    
+
     out << "Bug 5401 (negative index base) test" << endl;
     Teuchos::OSTab tab0 (out);
 
@@ -82,14 +84,14 @@ namespace {
     TEST_EQUALITY( numProcs, 2 );
     if (numProcs != 2) {
       out << "This test only works when running with exactly "
-	"2 MPI processes." << endl;
+        "2 MPI processes." << endl;
       return;
     }
-    
+
     TEST_ASSERT( std::is_signed<GO>::value );
     if (! std::is_signed<GO>::value) {
       out << "This test only works when the default GlobalOrdinal "
-	"type is signed." << endl;
+        "type is signed." << endl;
       return;
     }
 
@@ -110,29 +112,29 @@ namespace {
 
     //int localMapCtorSuccess = 0;
     RCP<map_type> map (new map_type (GINV, elements (),
-				     baseIndexIsNegOne, comm));
+                                     baseIndexIsNegOne, comm));
     out << "Process " << myRank << ":" << endl;
     {
       Teuchos::OSTab tab1 (out);
       out << "My number of global indices: " << map->getNodeNumElements ()
-	  << endl
+          << endl
           << "Global number of global indices: " << map->getGlobalNumElements ()
-	  << endl
+          << endl
           << "Index base: " << map->getIndexBase () << endl
           << "My min global index: " << map->getMinGlobalIndex () << endl
           << "Global min global index: " << map->getMinAllGlobalIndex () << endl;
     }
 
     TEST_EQUALITY( map->getNodeNumElements(),
-		   static_cast<size_t> (numElements) );
+                   static_cast<size_t> (numElements) );
     TEST_EQUALITY( map->getGlobalNumElements(),
-		   static_cast<global_size_t> (numElements*numProcs) );
+                   static_cast<global_size_t> (numElements*numProcs) );
     TEST_EQUALITY( map->getIndexBase(), static_cast<GO> (-1) );
     TEST_EQUALITY( map->getMinGlobalIndex(),    static_cast<GO> (-1) );
     TEST_EQUALITY( map->getMinAllGlobalIndex(), static_cast<GO> (-1) );
 
     // All procs fail if any proc fails
-    using Teuchos::outArg;    
+    using Teuchos::outArg;
     using Teuchos::REDUCE_MIN;
     using Teuchos::reduceAll;
     const int lclSuccess = success ? 1 : 0;

--- a/packages/tpetra/core/test/MultiVector/Bug5474.cpp
+++ b/packages/tpetra/core/test/MultiVector/Bug5474.cpp
@@ -41,11 +41,12 @@
 // @HEADER
 */
 
-#include <Tpetra_Map.hpp>
-#include <Tpetra_Vector.hpp>
-#include <Tpetra_Core.hpp>
-#include <Teuchos_UnitTestHarness.hpp>
-#include <TpetraCore_ETIHelperMacros.h>
+#include "Tpetra_Map.hpp"
+#include "Tpetra_Vector.hpp"
+#include "Tpetra_Core.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_CommHelpers.hpp"
 
 namespace { // (anonymous)
 

--- a/packages/tpetra/core/test/MultiVector/MV_subViewSomeZeroRows.cpp
+++ b/packages/tpetra/core/test/MultiVector/MV_subViewSomeZeroRows.cpp
@@ -41,12 +41,13 @@
 // @HEADER
 */
 
-#include <Tpetra_ConfigDefs.hpp>
-#include <Tpetra_Map.hpp>
-#include <Tpetra_MultiVector.hpp>
-#include <Tpetra_Core.hpp>
-#include <Teuchos_UnitTestHarness.hpp>
-#include <TpetraCore_ETIHelperMacros.h>
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_MultiVector.hpp"
+#include "Teuchos_CommHelpers.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
 
 namespace {
 

--- a/packages/tpetra/core/test/Tpetra_TestingUtilities.hpp
+++ b/packages/tpetra/core/test/Tpetra_TestingUtilities.hpp
@@ -54,6 +54,8 @@
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Tpetra_Core.hpp"
 #include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_DefaultSerialComm.hpp"
+#include "Teuchos_CommHelpers.hpp"
 
 namespace Tpetra {
   namespace TestingUtilities {

--- a/packages/tpetra/core/test/Utils/TpetraUtils_gathervPrint.cpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_gathervPrint.cpp
@@ -41,10 +41,10 @@
 // @HEADER
 */
 
-#include <Tpetra_ConfigDefs.hpp>
-#include <Tpetra_Details_gathervPrint.hpp>
-#include <Tpetra_Core.hpp>
-#include <Teuchos_UnitTestHarness.hpp>
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Details_gathervPrint.hpp"
+#include "Teuchos_CommHelpers.hpp"
 #include <sstream>
 
 namespace {
@@ -71,7 +71,6 @@ namespace {
 
   TEUCHOS_UNIT_TEST( TpetraUtils, gathervPrint )
   {
-    using Teuchos::Comm;
     using Teuchos::outArg;
     using Teuchos::RCP;
     using Teuchos::REDUCE_MIN;
@@ -82,7 +81,7 @@ namespace {
     int lclSuccess = 1;
     int gblSuccess = 1;
 
-    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
+    auto comm = Tpetra::getDefaultComm ();
     const int myRank = comm->getRank ();
     const int numProcs = comm->getSize ();
 


### PR DESCRIPTION
@trilinos/tpetra 

## Description

  - Deprecate DefaultPlatform, MpiPlatform, & SerialPlatform (part of #3095) 
  - Remove `Kokkos_DefaultNode.hpp` include from `Tpetra_ConfigDefs.hpp` (part of #57)
  - Add includes to Tpetra, to make progress on #3159 
  - Fix a build warning in a Tpetra test

## Related Issues

* Part of #3095, #57, #3159 

## How Has This Been Tested?

Linux, GCC, OpenMP, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.

There is only a slight possibility that these changes break backwards compatibility, due to the removed header file.