### PR TITLE
Try to address jumbled output for terminate message (#3163)

### DIFF
--- a/packages/teuchos/core/src/Teuchos_TestForException.cpp
+++ b/packages/teuchos/core/src/Teuchos_TestForException.cpp
@@ -92,9 +92,9 @@ void Teuchos::TestForException_break( const std::string &errorMsg )
   // a good time to examine the stack trace and look at the error message in
   // 'errorMsg' to see what happened.  In GDB just type 'where' or you can go
   // up by typing 'up' and moving up in the stack trace to see where you are
-  // and how you got to this point in the code where you are throwning this
+  // and how you got to this point in the code where you are throwing this
   // exception!  Typing in a 'p errorMsg' will show you what the error message
-  // is.  Also, you should consider adding a conditional breakpoint in this
+  // is.  Also, you should consider adding a conditional break-point in this
   // function based on a specific value of 'throwNumber' if the exception you
   // want to examine is not the first exception thrown.
 }
@@ -112,9 +112,14 @@ bool Teuchos::TestForException_getEnableStacktrace()
 }
 
 void Teuchos::TestForTermination_terminate(const std::string &msg) {
+  std::ostringstream omsg;
   if (GlobalMPISession::getNProc() > 1) {
-    std::cerr << "p="<<GlobalMPISession::getRank()<<": ";
+    omsg << "p="<<GlobalMPISession::getRank()<<": ";
   }
-  std::cerr << msg << "\n";
+  omsg << msg << "\n";
+  std::cerr << omsg.str();
   std::terminate();
 }
+// NOTE: The above usage of ostringstream is so that the output to std::cerr
+// is done as one string.  This should help to avoid jumbled output like is
+// occurring in tests that grep for this output (see #3163).


### PR DESCRIPTION
@trilinos/teuchos 

## Description

Send output to `std::cerr` all in one string to try to avoid jumbled output.

I also fixed a typo that I noticed in a comment not related to this code in
this file.

## Motivation and Context

This might fix the randomly failing test TeuchosCore_testTeuchosTestForTermination_2_MPI_4 for the CUDA builds on platform 'hansen' (see #3163).

## How Has This Been Tested?

I just did a local build on my machine to make sure the code builds and passes all of the TeuchosCore tests (which it did).  The real test will take place over the coming weeks and months to see if this test fails anymore.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
