### PR TITLE
Disable KokkosKernels_sparse_openmp_MPI_1 in gnu-debug-openmp on white/ride (#3168)

### DIFF
--- a/cmake/std/atdm/ride/tweaks/GNU-DEBUG-OPENMP.cmake
+++ b/cmake/std/atdm/ride/tweaks/GNU-DEBUG-OPENMP.cmake
@@ -26,6 +26,10 @@ ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
   "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_block_gauss_seidel_double_int_size_t_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
   CACHE STRING )
 
+# Disable entire test that is timing out (or nearly timing out) at 10 minutes
+# in debug-openmp build (#3168)
+ATDM_SET_ENABLE(KokkosKernels_sparse_openmp_MPI_1_DISABLE ON)
+
 # Disable randomly failing tests for this build (#2920)
 ATDM_SET_ENABLE(Belos_pseudo_stochastic_pcg_hb_0_MPI_4_DISABLE ON)
 ATDM_SET_ENABLE(Belos_pseudo_stochastic_pcg_hb_1_MPI_4_DISABLE ON)


### PR DESCRIPTION
@trilinos/kokkos-kernels 

## Description

This test is run with a debug-openmp on other platforms and the test in the
gnu-opt-openmp build runs fine on this machine so this is not much of a
testing loss.

We really need to get away from these full debug-debug builds across all of
these platforms.

## Motivation and Context

See #3168.

## How Has This Been Tested?

On 'white' I ran:

```
$ ./checkin-test-atdm.sh gnu-debug-openmp --enable-packages=KokkosKernels --configure
```

and the configure output showed:

```
-- KokkosKernels_sparse_openmp_MPI_1: NOT added test because KokkosKernels_sparse_openmp_MPI_1_DISABLE='ON'!
```

That is enough of a test.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
