### PR TITLE
Zoltan2:  fix compiler warning from gcc8.1

### DIFF
--- a/packages/zoltan2/src/problems/Zoltan2_PartitioningProblem.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_PartitioningProblem.hpp
@@ -583,7 +583,7 @@ void PartitioningProblem<Adapter>::solve(bool updateInputData)
       Teuchos::ParameterList &pl = this->env_->getParametersNonConst();
       Teuchos::ParameterList &zparams = pl.sublist("zoltan_parameters",false);
       if (numberOfWeights_ > 0) {
-        char strval[10];
+        char strval[20];
         sprintf(strval, "%d", numberOfWeights_);
         zparams.set("OBJ_WEIGHT_DIM", strval);
       }
@@ -797,7 +797,7 @@ void PartitioningProblem<Adapter>::createPartitioningProblem(bool newData)
       Teuchos::ParameterList &zparams = pl.sublist("zoltan_parameters",false);
       zparams.set("LB_METHOD", algorithm);
       if (numberOfWeights_ > 0) {
-        char strval[10];
+        char strval[20];
         sprintf(strval, "%d", numberOfWeights_);
         zparams.set("OBJ_WEIGHT_DIM", strval);
       }


### PR DESCRIPTION

@trilinos/zoltan2 

## Description
Made trivial changes intended to fix two reported compiler warnings generated by gcc8.1.



## How Has This Been Tested?
I do not have easy access to gcc 8.1, but tests still pass using older compilers.

<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
