### PR TITLE
Stratimikos,Teko: Purge use of Tpetra::DefaultPlatform

### DIFF
--- a/packages/stratimikos/adapters/amesos2/test/test_single_amesos2_tpetra_solver.cpp
+++ b/packages/stratimikos/adapters/amesos2/test/test_single_amesos2_tpetra_solver.cpp
@@ -1,13 +1,13 @@
 /*
 // @HEADER
 // ***********************************************************************
-// 
+//
 //         Stratimikos: Thyra-based strategies for linear solvers
 //                Copyright (2006) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Roscoe A. Bartlett (rabartl@sandia.gov) 
-// 
+// Questions? Contact Roscoe A. Bartlett (rabartl@sandia.gov)
+//
 // ***********************************************************************
 // @HEADER
 */
@@ -66,6 +66,7 @@ bool Thyra::test_single_amesos2_tpetra_solver(
   ,const bool                             dumpAll
   ,Teuchos::ParameterList                 *amesos2LOWSFPL
   ,Teuchos::FancyOStream                  *out_arg
+  ,const Teuchos::RCP<const Teuchos::Comm<int> >& comm
   )
 {
   using Teuchos::rcp;
@@ -92,8 +93,7 @@ bool Thyra::test_single_amesos2_tpetra_solver(
     }
 
     if(out.get()) *out << "\nA) Reading in a tpetra matrix A from the file \'"<<matrixFile<<"\' ...\n";
-  
-    auto comm = Tpetra::DefaultPlatform::getDefaultPlatform().getComm();
+
     using Scalar = double;
     using LOWS = Thyra::Amesos2LinearOpWithSolve<Scalar>;
     using MAT = typename LOWS::MAT;
@@ -153,7 +153,7 @@ bool Thyra::test_single_amesos2_tpetra_solver(
     if(!result) success = false;
 
     if(out.get()) *out << "\nE) Testing the LinearOpWithSolveBase interface of nsA ...\n";
-    
+
     LinearOpWithSolveTester<Scalar> linearOpWithSolveTester;
     linearOpWithSolveTester.num_rhs(numRhs);
     linearOpWithSolveTester.turn_off_all_tests();
@@ -185,7 +185,7 @@ bool Thyra::test_single_amesos2_tpetra_solver(
     std::cerr << "*** Caught standard exception : " << excpt.what() << std::endl;
     success = false;
   }
-   
+
   return success;
-    
+
 }

--- a/packages/stratimikos/adapters/amesos2/test/test_single_amesos2_tpetra_solver.hpp
+++ b/packages/stratimikos/adapters/amesos2/test/test_single_amesos2_tpetra_solver.hpp
@@ -1,13 +1,13 @@
 /*
 // @HEADER
 // ***********************************************************************
-// 
+//
 //         Stratimikos: Thyra-based strategies for linear solvers
 //                Copyright (2006) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Roscoe A. Bartlett (rabartl@sandia.gov) 
-// 
+// Questions? Contact Roscoe A. Bartlett (rabartl@sandia.gov)
+//
 // ***********************************************************************
 // @HEADER
 */
@@ -46,8 +46,14 @@
 #define TEST_SINGLE_AMESOS2_TPETRA_SOLVER_HPP
 
 #include "Teuchos_FancyOStream.hpp"
+#include "Teuchos_RCP.hpp"
 
-namespace Teuchos { class ParameterList; }
+namespace Teuchos {
+  class ParameterList;
+
+  template<class OrdinalType>
+  class Comm;
+}
 
 namespace Thyra {
 
@@ -65,6 +71,7 @@ bool test_single_amesos2_tpetra_solver(
   ,const bool                             dumpAll
   ,Teuchos::ParameterList                 *amesos2LOWSFPL
   ,Teuchos::FancyOStream                  *out
+  ,const Teuchos::RCP<const Teuchos::Comm<int> >& comm
   );
 
 } // namespace Thyra

--- a/packages/stratimikos/adapters/amesos2/test/test_single_amesos2_tpetra_solver_driver.cpp
+++ b/packages/stratimikos/adapters/amesos2/test/test_single_amesos2_tpetra_solver_driver.cpp
@@ -1,13 +1,13 @@
 /*
 // @HEADER
 // ***********************************************************************
-// 
+//
 //         Stratimikos: Thyra-based strategies for linear solvers
 //                Copyright (2006) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -35,8 +35,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Roscoe A. Bartlett (rabartl@sandia.gov) 
-// 
+// Questions? Contact Roscoe A. Bartlett (rabartl@sandia.gov)
+//
 // ***********************************************************************
 // @HEADER
 */
@@ -46,19 +46,20 @@
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_VerboseObject.hpp"
-#include "Teuchos_GlobalMPISession.hpp"
+#include "Tpetra_Core.hpp"
 #include "Teuchos_StandardCatchMacros.hpp"
 
 
 int main(int argc, char* argv[])
 {
-  
+
   using Teuchos::CommandLineProcessor;
 
   bool success = true;
   bool verbose = true;
 
-  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
+  auto comm = Tpetra::getDefaultComm();
 
   Teuchos::RCP<Teuchos::FancyOStream>
     out = Teuchos::VerboseObjectBase::getDefaultOStream();
@@ -68,7 +69,7 @@ int main(int argc, char* argv[])
     //
     // Read options from command-line
     //
-    
+
     std::string     matrixFile             = "";
     std::string     solverType             = "";
     int             numRhs                 = 1;
@@ -112,11 +113,12 @@ int main(int argc, char* argv[])
         ,maxFwdError,maxResid,maxSolutionError,showAllTests,dumpAll
         ,&amesos2LOWSFPL
         ,verbose?&*out:0
+        ,comm
         );
 
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success)
-  
+
   if (verbose) {
     if(success)  *out << "\nCongratulations! All of the tests checked out!\n";
     else         *out << "\nOh no! At least one of the tests failed!\n";

--- a/packages/teko/examples/BuildPreconditioner/example-driver-belos.cpp
+++ b/packages/teko/examples/BuildPreconditioner/example-driver-belos.cpp
@@ -60,7 +60,7 @@
 #include "Epetra_Vector.h"
 
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 
 // EpetraExt includes
@@ -127,10 +127,9 @@ int main(int argc,char * argv[])
    /////////////////////////////////////////////////////////
 
    // read in the CRS matrix
-   RCP<NT> node = Tpetra::DefaultPlatform::getDefaultPlatform ().getNode ();
-   RCP<TP_Crs> crsMat = Tpetra::MatrixMarket::Reader<TP_Crs>::readSparseFile("../data/nsjac.mm",
-                                                                         Teuchos::DefaultComm<int>::getComm(),
-                                                                         node);
+   RCP<TP_Crs> crsMat = Tpetra::MatrixMarket::Reader<TP_Crs>::readSparseFile("../data/nsjac.mm", Tpetra::getDefaultComm());
+
+   Teuchos::RCP<NT> node; // only for type deduction; null ok
    RCP<TP_Crs> zeroCrsMat = crsMat->clone(node);
    zeroCrsMat->resumeFill();
    zeroCrsMat->setAllToScalar(0.0);

--- a/packages/teko/src/Teko_ConfigDefs.hpp
+++ b/packages/teko/src/Teko_ConfigDefs.hpp
@@ -48,7 +48,8 @@
 #define __Teko_ConfigDefs_hpp__
 
 #include "Teko_Config.h"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Map_decl.hpp"
 
 namespace Teko {
 
@@ -69,7 +70,7 @@ typedef unsigned GO;
 #else
 #  error "Teko wants to use a GlobalOrdinal type which Tpetra does not enable.  None of the following types are enabled: int, long, long long, unsigned long, unsigned."
 #endif
-typedef Tpetra::DefaultPlatform::DefaultPlatformType::NodeType NT;
+typedef Tpetra::Map<>::node_type NT;
 
 }
 

--- a/packages/teko/src/Tpetra/Teko_TpetraThyraConverter.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraThyraConverter.cpp
@@ -45,7 +45,7 @@
 */
 
 #include "Teko_TpetraThyraConverter.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 
 // Teuchos includes
 #include "Teuchos_Array.hpp"
@@ -283,10 +283,11 @@ const RCP<Tpetra::Map<LO,GO,NT> > thyraVSToTpetraMap(const Thyra::VectorSpaceBas
 
    TEUCHOS_ASSERT(myGIDs.size() == (size_t) localDim);
 
-   const RCP<const Teuchos::Comm<int> > tpetraComm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
-
+   // FIXME (mfh 12 Jul 2018) This ignores the input comm, so it can't
+   // be right.
+   
    // create the map
-   return rcp(new Tpetra::Map<LO,GO,NT>(vs.dim(), Teuchos::ArrayView<const GO>(myGIDs), 0, tpetraComm));
+   return rcp(new Tpetra::Map<LO,GO,NT>(vs.dim(), Teuchos::ArrayView<const GO>(myGIDs), 0, Tpetra::getDefaultComm()));
 }
 
 } // end namespace Tpetra

--- a/packages/teko/tests/Test_Utils.cpp
+++ b/packages/teko/tests/Test_Utils.cpp
@@ -74,7 +74,7 @@
 #include "Epetra_CrsMatrix.h"
 
 #include "Tpetra_Vector.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Thyra_TpetraThyraWrappers.hpp"
 
 #include <iostream>
@@ -273,7 +273,7 @@ const Teuchos::RCP<const Thyra::LinearOpBase<double> > DiagMatrix(int cnt,double
 
 const Teuchos::RCP<const Thyra::LinearOpBase<double> > DiagMatrix_tpetra(GO cnt,ST * vec,std::string label)
 {
-   const RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   const RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
    const RCP<const Tpetra::Map<LO,GO,NT> > map = rcp(new const Tpetra::Map<LO,GO,NT>(cnt,0,comm));
    const RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> >ptrF  = Tpetra::createCrsMatrix<ST,LO,GO,NT>(map, 1);
 

--- a/packages/teko/tests/testdriver_tpetra.cpp
+++ b/packages/teko/tests/testdriver_tpetra.cpp
@@ -92,7 +92,7 @@
 #include "src/Tpetra/tBlockedTpetraOperator.hpp"
 #include "src/Tpetra/tTpetraThyraConverter.hpp"
 
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 
 void gdbIn()
 {
@@ -121,7 +121,7 @@ int main(int argc,char * argv[])
      #else
         Epetra_SerialComm Comm_epetra;
      #endif
-     Teuchos::RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+     Teuchos::RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
   
      Teko::Test::UnitTest::SetComm(Teuchos::rcpFromRef(Comm_epetra));
      Teko::Test::UnitTest::SetComm_tpetra(Comm);

--- a/packages/teko/tests/unit_tests/tDiagnosticLinearOp.cpp
+++ b/packages/teko/tests/unit_tests/tDiagnosticLinearOp.cpp
@@ -196,7 +196,7 @@ TEUCHOS_UNIT_TEST(tDiagnosticLinearOp, application_test)
 TEUCHOS_UNIT_TEST(tDiagnosticLinearOp, application_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm();
 
    RCP<Teko::InverseLibrary> invLibrary = Teko::InverseLibrary::buildFromStratimikos();
    RCP<Teko::InverseFactory> invFact = invLibrary->getInverseFactory("Ifpack2");
@@ -255,7 +255,7 @@ TEUCHOS_UNIT_TEST(tDiagnosticPreconditionerFactory, inverse_lib_test)
 TEUCHOS_UNIT_TEST(tDiagnosticPreconditionerFactory, inverse_lib_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm();
 
    // setup diagnostic inverse parameter list: uses Amesos under neady
    Teuchos::ParameterList pl;
@@ -332,7 +332,7 @@ TEUCHOS_UNIT_TEST(tDiagnosticPreconditionerFactory, construction_test)
 TEUCHOS_UNIT_TEST(tDiagnosticPreconditionerFactory, construction_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm();
 
    // build operator and solver
    Teko::LinearOp A = buildSystem(Comm,2000);
@@ -438,7 +438,7 @@ TEUCHOS_UNIT_TEST(tDiagnosticLinearOp, residual_test)
 TEUCHOS_UNIT_TEST(tDiagnosticLinearOp, residual_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    RCP<Teko::InverseLibrary> invLibrary = Teko::InverseLibrary::buildFromStratimikos();
    RCP<Teko::InverseFactory> invFact = invLibrary->getInverseFactory("Ifpack2");

--- a/packages/teko/tests/unit_tests/tDiagonallyScaledPreconditioner.cpp
+++ b/packages/teko/tests/unit_tests/tDiagonallyScaledPreconditioner.cpp
@@ -201,7 +201,7 @@ TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, invfactory_test)
 TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, invfactory_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm();
 
    Teuchos::ParameterList pl;
    Teuchos::ParameterList & diagList = pl.sublist("DiagScal");
@@ -288,7 +288,7 @@ TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, application_test_row)
 TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, application_test_row_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    // build linear op tester
    bool result;
@@ -392,7 +392,7 @@ TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, application_test_column)
 TEUCHOS_UNIT_TEST(tDiagonallyScaledPreconditioner, application_test_column_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    // build linear op tester
    bool result;
@@ -455,7 +455,7 @@ TEUCHOS_UNIT_TEST(tDiagonalOperator, replaceValues)
 
 TEUCHOS_UNIT_TEST(tDiagonalOperator, replaceValues_tpetra)
 {
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    RCP<Thyra::LinearOpBase<ST> > A =  buildSystem(Comm,50);
 

--- a/packages/teko/tests/unit_tests/tInverseFactoryOperator.cpp
+++ b/packages/teko/tests/unit_tests/tInverseFactoryOperator.cpp
@@ -228,7 +228,7 @@ TEUCHOS_UNIT_TEST(tInverseFactoryOperator, test_Direct_Solve)
 TEUCHOS_UNIT_TEST(tInverseFactoryOperator, test_Direct_Solve_tpetra) 
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
    Teuchos::RCP<Teko::InverseLibrary> invLib = Teko::InverseLibrary::buildFromStratimikos();
    Teuchos::RCP<Teko::InverseFactory> invFactory
@@ -351,7 +351,7 @@ TEUCHOS_UNIT_TEST(tInverseFactoryOperator, test_Block_Solve)
 TEUCHOS_UNIT_TEST(tInverseFactoryOperator, test_Block_Solve_tpetra) 
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
 
    Teuchos::RCP<Teko::InverseLibrary> invLib = Teko::InverseLibrary::buildFromStratimikos();
    Teuchos::RCP<Teko::InverseFactory> amesosFactory

--- a/packages/teko/tests/unit_tests/tIterativePreconditionerFactory.cpp
+++ b/packages/teko/tests/unit_tests/tIterativePreconditionerFactory.cpp
@@ -74,7 +74,7 @@
 // Tpetra includes
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Thyra_TpetraLinearOp.hpp"
 #include "Thyra_TpetraVectorSpace.hpp"
 
@@ -218,7 +218,7 @@ TEUCHOS_UNIT_TEST(tIterativePreconditionerFactory, parameter_list_init)
 TEUCHOS_UNIT_TEST(tIterativePreconditionerFactory, parameter_list_init_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    Teko::LinearOp  A = build2x2(Comm,1,2,3,4);
 
@@ -320,7 +320,7 @@ TEUCHOS_UNIT_TEST(tIterativePreconditionerFactory, inverse_test)
 TEUCHOS_UNIT_TEST(tIterativePreconditionerFactory, inverse_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    Teko::LinearOp  A = build2x2(Comm,1,2,3,4);
    RCP<Teko::InverseLibrary> invLib = Teko::InverseLibrary::buildFromStratimikos();
@@ -404,7 +404,7 @@ TEUCHOS_UNIT_TEST(tIterativePreconditionerFactory, constructor_test)
 TEUCHOS_UNIT_TEST(tIterativePreconditionerFactory, constructor_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    Teko::LinearOp  A = build2x2(Comm,1,2,3,4);
    Teko::LinearOp iP = build2x2(Comm,1.0,0.0,0.0,1.0/4.0);

--- a/packages/teko/tests/unit_tests/tLU2x2InverseOp.cpp
+++ b/packages/teko/tests/unit_tests/tLU2x2InverseOp.cpp
@@ -73,7 +73,7 @@
 // Tpetra includes
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Core.hpp"
 #include "Thyra_TpetraLinearOp.hpp"
 #include "Thyra_TpetraVectorSpace.hpp"
 
@@ -182,7 +182,7 @@ TEUCHOS_UNIT_TEST(tLU2x2InverseOp, exact_test)
 TEUCHOS_UNIT_TEST(tLU2x2InverseOp, exact_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    Teko::LinearOp  A_00 = build2x2(Comm,1,2,3,4);
    Teko::LinearOp  A_01 = build2x2(Comm,5,6,7,8);

--- a/packages/teko/tests/unit_tests/tReorderBlocking.cpp
+++ b/packages/teko/tests/unit_tests/tReorderBlocking.cpp
@@ -188,7 +188,7 @@ TEUCHOS_UNIT_TEST(tLU2x2InverseOp, exact_test)
 TEUCHOS_UNIT_TEST(tLU2x2InverseOp, exact_test_tpetra)
 {
    // build global (or serial communicator)
-   RCP<const Teuchos::Comm<int> > Comm = Tpetra::DefaultPlatform::getDefaultPlatform ().getComm ();
+   RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm ();
 
    Teko::LinearOp  A_00 = build2x2(Comm,1,2,3,4);
    Teko::LinearOp  A_01 = build2x2(Comm,5,6,7,8);


### PR DESCRIPTION
@trilinos/stratimikos @trilinos/teko @trilinos/tpetra

## Description

Purge use of Tpetra::DefaultPlatform from Stratimikos and Teko.  This replaces #3114.

## Related Issues

* Part of #3095 

## How Has This Been Tested?

Mac, Clang, OpenMPI 3.0.0; Linux, GCC, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.