### PR TITLE
Ifpack2,Anasazi: Fix #3139; remove Tpetra_INST_INT_INT=ON requirement from Anasazi examples

### DIFF
--- a/packages/anasazi/tpetra/example/TraceMinDavidson/CMakeLists.txt
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/CMakeLists.txt
@@ -1,28 +1,14 @@
-# FIXME (mfh 16 Jan 2016) The example doesn't currently build
-# when TSQR is enabled.  This is because the test uses a custom
-# specialization of MultiVecTraits that does not provide the
-# 'tsqr_adaptor_type' typedef.  For now, I'm disabling the tests
-# when TSQR is enabled.
-
-ASSERT_DEFINED(Anasazi_ENABLE_TSQR)
-IF(NOT Anasazi_ENABLE_TSQR)
-
 TRIBITS_ADD_EXECUTABLE(
   Tpetra_TD_Gen_example
   SOURCES TraceMinDavidsonGeneralizedEx.cpp
   COMM serial mpi
 )
 
-# FIXME (mfh 22 Oct 2015) This example requires GlobalOrdinal =
-# LocalOrdinal.  It should be easy to fix this, but for now, we
-# disable it if GlobalOrdinal = LocalOrdinal = int is disabled.
-IF (Tpetra_INST_INT_INT)
-  TRIBITS_ADD_EXECUTABLE(
-    Tpetra_TD_Fiedler_example
-    SOURCES TraceMinDavidsonLaplacianEx.cpp
-    COMM serial mpi
-    )
-ENDIF ()
+TRIBITS_ADD_EXECUTABLE(
+  Tpetra_TD_Fiedler_example
+  SOURCES TraceMinDavidsonLaplacianEx.cpp
+  COMM serial mpi
+  )
 
 TRIBITS_ADD_EXECUTABLE(
   Tpetra_TD_Trans_example
@@ -35,5 +21,3 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES TraceMinDavidsonUserOpEx.cpp
   COMM serial mpi
 )
-
-ENDIF()

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonGeneralizedEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonGeneralizedEx.cpp
@@ -67,7 +67,7 @@
 #include <MatrixMarket_Tpetra.hpp>
 
 // Include header for sparse matrix operations
-#include <TpetraExt_MatrixMatrix_def.hpp>
+//#include <TpetraExt_MatrixMatrix_def.hpp>
 
 // Include header for Teuchos serial dense matrix
 #include "Teuchos_SerialDenseMatrix.hpp"

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonLaplacianEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonLaplacianEx.cpp
@@ -38,7 +38,7 @@
 //
 // ***********************************************************************
 // @HEADER
-//  This example tests TraceMin-Davidson on the problem of finding the Fiedler 
+//  This example tests TraceMin-Davidson on the problem of finding the Fiedler
 //  vector of graph Laplacian (input from a matrix market file)
 
 // Include autoconfigured header
@@ -55,16 +55,16 @@
 #include "AnasaziOperator.hpp"
 
 // Include header for Tpetra compressed-row storage matrix
-#include "Tpetra_CrsMatrix.hpp" 
+#include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Core.hpp"
-#include "Tpetra_Version.hpp"        
-#include "Tpetra_Map.hpp"            
-#include "Tpetra_MultiVector.hpp" 
-#include "Tpetra_Operator.hpp"   
-#include "Tpetra_Vector.hpp" 
+#include "Tpetra_Version.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_MultiVector.hpp"
+#include "Tpetra_Operator.hpp"
+#include "Tpetra_Vector.hpp"
 
 // Include headers for reading and writing matrix-market files
-#include <MatrixMarket_Tpetra.hpp>           
+#include <MatrixMarket_Tpetra.hpp>
 
 // Include header for sparse matrix operations
 #include <TpetraExt_MatrixMatrix_def.hpp>
@@ -87,15 +87,14 @@
 
   //
   // Specify types used in this example
-  //                                   
-  typedef double                                           Scalar;
-  typedef int                                              Ordinal;
-  typedef Tpetra::CrsMatrix<Scalar,Ordinal,Ordinal>   CrsMatrix;
-  typedef Tpetra::Vector<Scalar,Ordinal,Ordinal>      Vector;
-  typedef Tpetra::MultiVector<Scalar,Ordinal,Ordinal> TMV;
-  typedef Tpetra::Operator<Scalar,Ordinal,Ordinal>    TOP;
-  typedef Anasazi::MultiVecTraits<Scalar, TMV>             TMVT;
-  typedef Anasazi::OperatorTraits<Scalar, TMV, TOP>        TOPT;
+  //
+  using Scalar = double;
+  using CrsMatrix = Tpetra::CrsMatrix<Scalar>;
+  using Vector = Tpetra::Vector<Scalar>;
+  using TMV = Tpetra::MultiVector<Scalar>;
+  using TOP = Tpetra::Operator<Scalar>;
+  using TMVT = Anasazi::MultiVecTraits<Scalar, TMV>;
+  using TOPT = Anasazi::OperatorTraits<Scalar, TMV, TOP>;
 
 void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const bool normalized, RCP<CrsMatrix>& L, RCP<Vector>& auxVec);
 
@@ -105,15 +104,15 @@ int main(int argc, char *argv[]) {
   //
   Tpetra::ScopeGuard tpetraScope(&argc, &argv);
 
-  // 
+  //
   // Get the default communicator
-  //                                      
+  //
   RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
-  const int myRank = comm->getRank();  
+  const int myRank = comm->getRank();
 
   //
   // Get parameters from command-line processor
-  // 
+  //
   std::string inputFilename("/home/amklinv/matrices/mesh1em6_Laplacian.mtx");
   std::string outputFilename("/home/amklinv/matrices/mesh1em6_Fiedler.mtx");
   Scalar tol = 1e-6;
@@ -124,7 +123,7 @@ int main(int argc, char *argv[]) {
   bool useWeightedLaplacian = false;
   bool verbose = true;
   std::string whenToShift = "Always";
-  Teuchos::CommandLineProcessor cmdp(false,true); 
+  Teuchos::CommandLineProcessor cmdp(false,true);
   cmdp.setOption("fin",&inputFilename, "Filename for Matrix-Market test matrix.");
   cmdp.setOption("fout",&outputFilename, "Filename for Fiedler vector.");
   cmdp.setOption("tolerance",&tol, "Relative residual used for solver.");
@@ -142,9 +141,9 @@ int main(int argc, char *argv[]) {
   //
   // Read the matrix from a file
   //
-  RCP<Tpetra::Map<>::node_type> node; // can be null
-  RCP<const CrsMatrix> fileMat = Tpetra::MatrixMarket::Reader<CrsMatrix>::readSparseFile(inputFilename, comm, node);
-  
+  RCP<const CrsMatrix> fileMat =
+    Tpetra::MatrixMarket::Reader<CrsMatrix>::readSparseFile(inputFilename, comm);
+
   //
   // Form the graph Laplacian and get a const pointer to the data
   //
@@ -157,7 +156,7 @@ int main(int argc, char *argv[]) {
   // Compute the norm of the matrix
   //
   Scalar mat_norm = K->getFrobeniusNorm();
-  
+
   //
   // ************************************
   // Start the block Arnoldi iteration
@@ -187,7 +186,7 @@ int main(int argc, char *argv[]) {
   MyPL.set("Num Blocks", numBlocks);                   // Maximum number of blocks in the subspace
   MyPL.set("When To Shift", whenToShift);
   MyPL.set("Saddle Solver Type", "Block Diagonal Preconditioned Minres");
-  
+
   //
   // Create an Epetra_MultiVector for an initial vector to start the solver.
   // Note:  This needs to have the same number of columns as the blocksize.
@@ -198,20 +197,20 @@ int main(int argc, char *argv[]) {
   //
   // Create the eigenproblem
   //
-  RCP<Anasazi::BasicEigenproblem<Scalar,TMV,TOP> > MyProblem = 
+  RCP<Anasazi::BasicEigenproblem<Scalar,TMV,TOP> > MyProblem =
       Teuchos::rcp( new Anasazi::BasicEigenproblem<Scalar,TMV,TOP>(K, ivec) );
-  
+
   //
   // Inform the eigenproblem that the matrix pencil (K,M) is symmetric
   //
   MyProblem->setHermitian(true);
-  
+
   //
-  // Set the number of eigenvalues requested 
+  // Set the number of eigenvalues requested
   //
   MyProblem->setNEV( nev );
 
-  if(usePrec) 
+  if(usePrec)
   {
     #ifdef HAVE_ANASAZI_IFPACK2
     //
@@ -221,7 +220,7 @@ int main(int argc, char *argv[]) {
     const std::string precType = "RELAXATION";
     Teuchos::ParameterList PrecPL;
     PrecPL.set( "relaxation: type", "Jacobi");
-    RCP<Ifpack2::Preconditioner<double,int,int> > Prec = factory.create(precType, K);
+    RCP<Ifpack2::Preconditioner<Scalar> > Prec = factory.create(precType, K);
     assert(Prec != Teuchos::null);
     Prec->setParameters(PrecPL);
     Prec->initialize();
@@ -242,7 +241,7 @@ int main(int argc, char *argv[]) {
   // Since we are computing the Fiedler vector, we want it to be orthogonal to the null space of the laplacian
   //
   MyProblem->setAuxVecs(auxVec);
-  
+
   //
   // Inform the eigenproblem that you are finished passing it information
   //
@@ -258,7 +257,7 @@ int main(int argc, char *argv[]) {
   // Initialize the TraceMin-Davidson solver
   //
   Anasazi::Experimental::TraceMinDavidsonSolMgr<Scalar, TMV, TOP> MySolverMgr(MyProblem, MyPL);
- 
+
   //
   // Solve the problem to the specified tolerances
   //
@@ -268,7 +267,7 @@ int main(int argc, char *argv[]) {
   }
   else if (myRank == 0)
     cout << "Anasazi::EigensolverMgr::solve() returned converged." << std::endl;
-  
+
   //
   // Get the eigenvalues and eigenvectors from the eigenproblem
   //
@@ -276,22 +275,22 @@ int main(int argc, char *argv[]) {
   std::vector<Anasazi::Value<Scalar> > evals = sol.Evals;
   RCP<TMV> evecs = sol.Evecs;
   int numev = sol.numVecs;
-  
+
   //
   // Compute the residual, just as a precaution
   //
   if (numev > 0) {
-    
+
     Teuchos::SerialDenseMatrix<int,Scalar> T(numev,numev);
     TMV tempvec(K->getRowMap(), TMVT::GetNumberVecs( *evecs ));
     std::vector<Scalar> normR(sol.numVecs);
     TMV Kvec( K->getRowMap(), TMVT::GetNumberVecs( *evecs ) );
 
-    TOPT::Apply( *K, *evecs, Kvec ); 
+    TOPT::Apply( *K, *evecs, Kvec );
     TMVT::MvTransMv( 1.0, Kvec, *evecs, T );
     TMVT::MvTimesMatAddMv( -1.0, *evecs, T, 1.0, Kvec );
     TMVT::MvNorm( Kvec, normR );
-  
+
     if (myRank == 0) {
       cout.setf(std::ios_base::right, std::ios_base::adjustfield);
       cout<<"Actual Eigenvalues (obtained by Rayleigh quotient) : "<<std::endl;
@@ -313,7 +312,7 @@ int main(int argc, char *argv[]) {
   //
   if (numev > 0) {
     Tpetra::MatrixMarket::Writer<CrsMatrix>::writeDenseFile(outputFilename,evecs,"","Fiedler vector of "+inputFilename);
-  }  
+  }
 
   return 0;
 }
@@ -350,19 +349,23 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
   //
   // Set a few convenient constants
   //
-  typedef Teuchos::ScalarTraits<Scalar>                           SCT;
+  using SCT = Teuchos::ScalarTraits<Scalar>;
+  using LO = Tpetra::Map<>::local_ordinal_type;
+  using GO = Tpetra::Map<>::global_ordinal_type;
   Scalar ONE = SCT::one();
   Scalar ZERO = SCT::zero();
 
-  std::vector<Ordinal> diagIndex(1);
+  std::vector<GO> diagIndex(static_cast<GO>(1));
+  std::vector<LO> diagIndexLcl(static_cast<LO>(1));
   std::vector<Scalar> value(1,ONE);
-  Teuchos::ArrayView<const Ordinal> cols(diagIndex);
+  Teuchos::ArrayView<const GO> cols(diagIndex);
+  Teuchos::ArrayView<const LO> colsLcl(diagIndexLcl);
   Teuchos::ArrayView<const Scalar> vals(value);
 
   //
   // Get the number of rows of A
   //
-  int n = A->getGlobalNumRows();
+  const GO n = A->getGlobalNumRows();
 
   //
   // Construct the unweighted Laplacian
@@ -373,7 +376,7 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
   // L = A + A'
   //
   L = Tpetra::MatrixMatrix::add(ONE,false,*A,ONE,true,*A);
-  RCP<const Tpetra::Map<Ordinal,Ordinal> > rowMap = L->getRowMap();
+  RCP<const Tpetra::Map<> > rowMap = L->getRowMap();
 
   // This line tells L that we are going to modify its entries
   L->resumeFill();
@@ -382,9 +385,9 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
   {
     // These vectors hold the actual data
     // The ArrayView objects just point to them
-    std::vector<Ordinal> colIndices;
+    std::vector<GO> colIndices;
     std::vector<Scalar> values;
-    Teuchos::ArrayView<Ordinal> colIndicesView;
+    Teuchos::ArrayView<GO> colIndicesView;
     Teuchos::ArrayView<Scalar> valuesView;
 
     // This vector holds the diagonal
@@ -395,7 +398,7 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
     // Also delete diagonal entries
     // Also compute the sum of off-diagonal entries
     //
-    for(Ordinal i=0; i<n; i++)
+    for(GO i=0; i<n; i++)
     {
       // If this process does not own that row of the matrix, do nothing
       // Each process handles its own rows
@@ -433,21 +436,18 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
 
     // Get a view of the LOCAL diagonal
     Teuchos::ArrayRCP<const Scalar> diagView = diagonal->getData();
+    using size_type = Teuchos::ArrayRCP<const Scalar>::size_type;
 
     // Create the auxiliary vector and set its values
     auxVec = Teuchos::rcp(new Vector(rowMap,false));
-    if(normalized)
-    {
+    if (normalized) {
       // auxVec[i] = sqrt(L(i,i))
-      for(Ordinal i=0; i<diagView.size(); i++)
-      {
-        auxVec->replaceLocalValue(i,sqrt(diagView[i]));
+      for (size_type i = 0; i < diagView.size (); ++i) {
+        auxVec->replaceLocalValue (static_cast<LO> (i), sqrt (diagView[i]));
       }
     }
-    else
-    {
-      // auxVec[i] = ONE
-      auxVec->putScalar(ONE);
+    else {
+      auxVec->putScalar(ONE); // auxVec[i] = ONE for all i
     }
 
     // Compute the norm of the vector
@@ -457,13 +457,12 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
     auxVec->scale(ONE/vecNorm);
 
     // Finish computing the Laplacian
-    if(normalized)
-    {
+    if (normalized) {
       // Compute D^{-1/2}
-      RCP<Vector> scaleVec = Teuchos::rcp( new Vector(rowMap,false) );
-      for(Ordinal i=0; i<diagView.size(); i++)
+      Vector scaleVec (rowMap, false);
+      for(size_type i=0; i<diagView.size(); i++)
       {
-        scaleVec->replaceLocalValue(i,ONE/sqrt(diagView[i]));
+        scaleVec.replaceLocalValue(static_cast<LO>(i),ONE/sqrt(diagView[i]));
       }
 
       // Must be called before scaling
@@ -471,14 +470,14 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
       L->fillComplete();
 
       // Premultiply L by D^{-1/2}
-      L->leftScale(*scaleVec);
+      L->leftScale(scaleVec);
 
       // Postmultiply L by D^{-1/2}
-      L->rightScale(*scaleVec);
+      L->rightScale(scaleVec);
       L->resumeFill();
 
       // Set diagonal entries to 1
-      for(Ordinal i=0; i<n; i++)
+      for(GO i=0; i<n; i++)
       {
         diagIndex[0] = i;
         if(rowMap->isNodeGlobalElement(i)) L->replaceGlobalValues(i,cols,vals);
@@ -487,28 +486,28 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
     else
     {
       // Set diagonal entries
-      for(Ordinal i=0; i<diagView.size(); i++)
+      for(size_type i=0; i<diagView.size(); i++)
       {
         diagIndex[0] = rowMap->getGlobalElement(i);
         value[0] = diagView[i];
-        L->replaceLocalValues(i,cols,vals);
+        L->replaceLocalValues(i,colsLcl,vals);
       }
     }
 
     // Tell the matrix we're done modifying its entries
     L->fillComplete();
   }
-  else
-  {
+  else {
     //
     // Construct the adjacency matrix by removing the diagonal and setting all off-diagonal entries to 1
     //
 
     // Here, we ensure that space is reserved for the diagonal entries
-    for(Ordinal i=0; i<n; i++)
-    {
+    for (GO i = 0; i < n; ++i) {
       diagIndex[0] = i;
-      if(rowMap->isNodeGlobalElement(i)) L->replaceGlobalValues(i,cols,vals);
+      if(rowMap->isNodeGlobalElement(i)) {
+        L->replaceGlobalValues(i,cols,vals);
+      }
     }
 
     // Set all entries of the matrix to -1
@@ -518,21 +517,18 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
     L->fillComplete();
 
     // Create the auxiliary vector and set its values
-    auxVec = Teuchos::rcp( new Tpetra::Vector<Scalar,Ordinal,Ordinal>(rowMap,false) );
-    if(normalized)
-    {
-      // Computes the degree of each vertex of the graph
-      for(Ordinal i=0; i<n; i++)
-      {
+    auxVec = Teuchos::rcp( new Vector (rowMap,false) );
+    if (normalized) {
+      // Compute the degree of each vertex of the graph
+      for (GO i = 0; i < n; ++i) {
         // If this process does not own that row of the matrix, do nothing
         // Each process handles its own rows
-        if(rowMap->isNodeGlobalElement(i)) 
-        {
+        if (rowMap->isNodeGlobalElement(i)) {
           Scalar temp;
 
-          // Because we insisted on having a diagonal, the degree is really 1 less than 
+          // Because we insisted on having a diagonal, the degree is really 1 less than
           // the number of entries in the row
-          size_t nnzInRow = L->getNumEntriesInGlobalRow(i)-1;
+          size_t nnzInRow = L->getNumEntriesInGlobalRow(i) - static_cast<size_t> (1);
           temp = sqrt(nnzInRow);
 
           // auxVec[i] = sqrt(degree of node i)
@@ -540,12 +536,10 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
         }
       }
     }
-    else
-    {
-      // auxVec[i] = 1
-      auxVec->putScalar(ONE);
+    else {
+      auxVec->putScalar(ONE); // auxVec[i] = 1 for all i
     }
-      
+
     // Compute the norm of the vector
     Scalar vecNorm = auxVec->norm2();
 
@@ -553,22 +547,19 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
     auxVec->scale(ONE/vecNorm);
 
     // Finish computing the Laplacian
-    if(normalized)
-    {
+    if (normalized) {
       // Compute the degree of each node so we can normalize the Laplacian
       // normalizedL = D^{-1/2} L D^{-1/2}
-      Tpetra::Vector<Scalar,Ordinal,Ordinal> scalars(rowMap,false);
-      for(Ordinal i=0; i<n; i++)
-      {
+      Vector scalars(rowMap,false);
+      for (GO i = 0; i < n; ++i) {
         // If this process does not own that row of the matrix, do nothing
         // Each process handles its own rows
-        if(rowMap->isNodeGlobalElement(i)) 
-        {
+        if(rowMap->isNodeGlobalElement(i)) {
           Scalar temp;
 
-          // Because we insisted on having a diagonal, the degree is really 1 less than 
+          // Because we insisted on having a diagonal, the degree is really 1 less than
           // the number of entries in the row
-          size_t nnzInRow = L->getNumEntriesInGlobalRow(i)-1;
+          size_t nnzInRow = L->getNumEntriesInGlobalRow(i) - static_cast<size_t> (1);
           temp = ONE/sqrt(nnzInRow);
 
           // scalars[i] = 1/sqrt(degree of node i)
@@ -584,24 +575,20 @@ void formLaplacian(const RCP<const CrsMatrix>& A, const bool weighted, const boo
       L->resumeFill();
 
       // Set diagonal entries to 1
-      for(Ordinal i=0; i<n; i++)
-      {
+      for (GO i = 0; i < n; ++i) {
         diagIndex[0] = i;
         if(rowMap->isNodeGlobalElement(i)) L->replaceGlobalValues(i,cols,vals);
       }
     }
-    else
-    {
+    else {
       L->resumeFill();
-      for(Ordinal i=0; i<n; i++)
-      {
+      for (GO i = 0; i < n; ++i) {
         // If this process does not own that row of the matrix, do nothing
         // Each process handles its own rows
-        if(rowMap->isNodeGlobalElement(i)) 
-        {
-          // Because we insisted on having a diagonal, the degree is really 1 less than 
+        if(rowMap->isNodeGlobalElement(i)) {
+          // Because we insisted on having a diagonal, the degree is really 1 less than
           // the number of entries in the row
-          size_t nnzInRow = L->getNumEntriesInGlobalRow(i)-1;
+          size_t nnzInRow = L->getNumEntriesInGlobalRow(i) - static_cast<size_t> (1);
 
           // L[i,i] = degree of node i
           diagIndex[0] = i;

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -11,7 +11,7 @@ IF (Tpetra_INST_DOUBLE)
     )
 ENDIF()
 
-IF(Ifpack2_ENABLE_QD AND Tpetra_INST_INT_INT)
+IF(Ifpack2_ENABLE_QD)
   TRIBITS_ADD_EXECUTABLE(
     tif_extprec_belos
     SOURCES belos_extprec_solve.cpp

--- a/packages/ifpack2/test/belos/belos_extprec_solve.cpp
+++ b/packages/ifpack2/test/belos/belos_extprec_solve.cpp
@@ -75,11 +75,11 @@ int main(int argc, char*argv[])
   Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   typedef dd_real Scalar;
-  typedef int LO; //LocalOrdinal
-  typedef int GO; //GlobalOrdinal
-  typedef Tpetra::Map<LO, GO>::node_type Node;
-  typedef Tpetra::MultiVector<Scalar,LO,GO> TMV;
-  typedef Tpetra::Operator<Scalar,LO,GO>    TOP;
+  typedef Tpetra::Map<>::local_ordinal_type LO; //LocalOrdinal
+  typedef Tpetra::Map<>::global_ordinal_type GO; //GlobalOrdinal
+  typedef Tpetra::Map<>::node_type Node;
+  typedef Tpetra::MultiVector<Scalar> TMV;
+  typedef Tpetra::Operator<Scalar>    TOP;
   typedef Belos::LinearProblem<Scalar,TMV,TOP>   BLinProb;
   typedef Belos::SolverManager<Scalar,TMV,TOP>   BSolverMgr;
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxationPerf.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxationPerf.cpp
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <stdexcept>
 
-#include <Teuchos_ConfigDefs.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 #include <Teuchos_Time.hpp>
 
@@ -25,8 +24,6 @@
 #include <Tpetra_Experimental_BlockMultiVector.hpp>
 #include <Tpetra_Experimental_BlockCrsMatrix.hpp>
 
-#include <Ifpack2_ConfigDefs.hpp>
-#include <Ifpack2_Version.hpp>
 #include <Ifpack2_UnitTestHelpers.hpp>
 #include <Ifpack2_BlockRelaxation.hpp>
 #include <Ifpack2_SparseContainer.hpp>
@@ -38,7 +35,6 @@
 #include <Ifpack2_LinePartitioner.hpp>
 #include <Ifpack2_ILUT.hpp>
 #include <Ifpack2_Factory.hpp>
-#include "Ifpack2_ETIHelperMacros.h"
 
 namespace
 {
@@ -47,33 +43,33 @@ using std::vector;
 using std::string;
 using Teuchos::RCP;
 using Teuchos::rcp;
-typedef unsigned long long u64;
-typedef Tpetra::Map<>::node_type NO;
-typedef Tpetra::CrsMatrix<double,int,int,NO> TMat;
-typedef Tpetra::Map<int,int,NO> TMap;
+using tpetra_crs_matrix_type = Tpetra::CrsMatrix<double>;
+using tpetra_map_type = Tpetra::Map<>;
 
 /**************************************************************
  * Create a Tpetra 2D laplacian matrix for testing relaxation *
  **************************************************************/
 
-RCP<const TMat> create_testmat_t(const RCP<const TMap>& rowmap)
+RCP<const tpetra_crs_matrix_type> create_testmat_t(const RCP<const tpetra_map_type>& rowmap)
 {
+  using GO = tpetra_map_type::global_ordinal_type;
+
   //tile this over each diagonal element:
   // 0 -1  0
   //-1  4 -1
   // 0 -1  0
-  RCP<TMat> crsmatrix = rcp(new TMat(rowmap, 3));
-  int numRows = rowmap->getGlobalNumElements();
+  RCP<tpetra_crs_matrix_type> crsmatrix = rcp(new tpetra_crs_matrix_type(rowmap, 3));
+  GO numRows = rowmap->getGlobalNumElements();
   double tile[3] = {-2, 4, -2};
-  int firstCols[] = {0, 1};
+  GO firstCols[] = {0, 1};
   crsmatrix->insertGlobalValues(0, 2, tile + 1, firstCols);
-  for(int row = 1; row < numRows - 1; row++)
+  for(GO row = 1; row < numRows - GO(1); row++)
   {
-    int cols[] = {row - 1, row, row + 1};
+    GO cols[] = {row - 1, row, row + 1};
     crsmatrix->insertGlobalValues(row, 3, tile, cols);
   }
-  int lastCols[] = {numRows - 2, numRows - 1};
-  crsmatrix->insertGlobalValues(numRows - 1, 2, tile, lastCols);
+  GO lastCols[] = {numRows - GO(2), numRows - GO(1)};
+  crsmatrix->insertGlobalValues(numRows - GO(1), 2, tile, lastCols);
   crsmatrix->fillComplete();
   return crsmatrix;
 }
@@ -106,33 +102,95 @@ RCP<const Epetra_CrsMatrix> create_testmat_e(const Epetra_Map& rowmap)
 
 TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
 {
+  constexpr bool debug = true;
+  auto myOutPtr = debug ?
+    Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr)) :
+    Teuchos::rcpFromRef (out);
+  auto& myOut = *myOutPtr;
+
+  myOut << "Ifpack2 BlockRelaxation performance comparison: Epetra vs. Tpetra"
+        << std::endl;
+
   using Teuchos::ArrayRCP;
   //use the same types as epetra for fair comparison
-  auto tcomm = Tpetra::getDefaultComm();
+
+  decltype (Tpetra::getDefaultComm()) tcomm;
+  try {
+    tcomm = Tpetra::getDefaultComm();
+  }
+  catch (std::exception& e) {
+    myOut << "Tpetra::getDefaultComm() threw an exception: " << e.what () << std::endl;
+    TEST_ASSERT( false );
+    return;
+  }
+  catch (...) {
+    myOut << "Tpetra::getDefaultComm() threw an exception "
+      "not a subclass of std::exception" << std::endl;
+    TEST_ASSERT( false );
+    return;
+  }
+
   if(tcomm->getSize() == 1)
   {
     //Configure ranges of testing
     const vector<int> blockSizes = {2, 4, 5, 8, 10, 20, 50};
     string container = "TriDi";
-    const int localRows = 5000;
-    auto tmap = rcp(new TMap(localRows, 0, tcomm));
+    using GO = tpetra_map_type::global_ordinal_type;
+    const GO localRows = 5000;
+
+    myOut << "Create Tpetra test matrix" << std::endl;
+
+    auto tmap = rcp(new tpetra_map_type(localRows, 0, tcomm));
     auto tmat = create_testmat_t(tmap);
+
+    myOut << "Create Epetra test matrix" << std::endl;
 #ifdef EPETRA_MPI
     Epetra_MpiComm ecomm(MPI_COMM_WORLD);
 #else
     Epetra_SerialComm ecomm;
 #endif
-    Epetra_Map emap(localRows, 0, ecomm);
-    auto emat = create_testmat_e(emap);
+    Epetra_Map emap(static_cast<int> (localRows), 0, ecomm);
+    Teuchos::RCP<const Epetra_CrsMatrix> emat;
+    try {
+      // mfh 26 Jul 2018: This function call throws.  That means the
+      // test is broken; I didn't write that code.  This blocks #3139,
+      // so I'm going to just let this test build for now, but not
+      // actually run it.
+      emat = create_testmat_e(emap);
+    }
+    catch (std::exception& e) {
+      myOut << "create_testmat_e threw an exception: " << e.what () << std::endl;
+      TEST_ASSERT( false );
+      return;
+    }
+    catch (...) {
+      myOut << "create_testmat_e threw an exception "
+        "not a subclass of std::exception" << std::endl;
+      TEST_ASSERT( false );
+      return;
+    }
+
+    myOut << "Create and fill Tpetra Vector(s)" << std::endl;
+
     //set up matrix
-    typedef Tpetra::RowMatrix<double,int,int,NO> ROW;
-    typedef Tpetra::Vector<double,int,int,NO> TVec;
+    typedef Tpetra::RowMatrix<double> ROW;
+    typedef Tpetra::Vector<double> TVec;
     TVec lhs(tmap);
     TVec rhs(tmap);
     rhs.putScalar(2.0);
+
+    myOut << "Open output file" << std::endl;
+
     //set up output file
     FILE* csv = fopen("BlockRelax.csv", "w");
+    if (csv == nullptr) {
+      TEST_ASSERT( false );
+      myOut << "Failed to open output file \"BlockRelax.csv\"!" << std::endl;
+      return;
+    }
     fputs("lib,blockSize,setup,apply\n", csv);
+
+    myOut << "Benchmark Ifpack2" << std::endl;
     //////////////////////
     //-- Ifpack2 test --//
     //////////////////////
@@ -142,7 +200,7 @@ TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
     ilist.set("relaxation: type", "Gauss-Seidel");
     int* partMap = new int[localRows];
     Teuchos::Time timer("");
-    out << "Testing Ifpack2 block G-S\n";
+    myOut << "Testing Ifpack2 block G-S\n";
     //target for total running time
     const double maxTotalTime = 6.0;
     //proportion of total time to spend on ifpack2
@@ -152,7 +210,7 @@ TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
     const double mlTimePerSet = ((1.0 - ifpack2TimeProportion) * maxTotalTime) / blockSizes.size();
     for(auto blockSize : blockSizes)
     {
-      out << "    Testing block size: " << blockSize << '\n';
+      myOut << "    Testing block size: " << blockSize << '\n';
       for(int i = 0; i < localRows; i++)
         partMap[i] = i / blockSize;
       ArrayRCP<int> PMrcp(partMap, 0, localRows, false);
@@ -173,15 +231,17 @@ TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
       }
       while(timer.totalElapsedTime(true) < ifpack2TimePerSet);
       timer.stop();
-      out << '(' << trials << " trials)\n";
+      myOut << '(' << trials << " trials)\n";
       double applyTime = timer.totalElapsedTime() / trials;
       fprintf(csv, "Ifpack2,%i,%f\n", blockSize, applyTime);
     }
     delete[] partMap;
+
+    myOut << "Benchmark ML" << std::endl;
     /////////////////
     //-- ML test --//
     /////////////////
-    out << "Testing ML block gs\n";
+    myOut << "Testing ML block gs\n";
     {
       using ML_Epetra::MultiLevelPreconditioner;
       Epetra_Vector X(emap);
@@ -207,7 +267,7 @@ TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
         prec.ComputePreconditioner();
         auto ml = prec.GetML();
         auto sm = ml->pre_smoother;
-        out << "    Testing block size: " << blockSize << '\n';
+        myOut << "    Testing block size: " << blockSize << '\n';
         timer.reset();
         timer.start();
         int trials = 0;
@@ -218,16 +278,15 @@ TEUCHOS_UNIT_TEST(Ifpack2BlockRelaxation, Performance)
         }
         while(timer.totalElapsedTime(true) < mlTimePerSet);
         timer.stop();
-        out << '(' << trials << " trials)\n";
+        myOut << '(' << trials << " trials)\n";
         double applyTime = timer.totalElapsedTime() / trials;
         fprintf(csv,"ML,%i,%f\n", blockSize, applyTime);
       }
     }
-    out << "Done with performance testing: data written to BlockRelax.csv\n";
+    myOut << "Done with performance testing: data written to BlockRelax.csv"
+          << std::endl;
     fclose(csv);
   }
 }
-
-IFPACK2_ETI_MANGLING_TYPEDEFS()
 
 } //anonymous namespace

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
@@ -310,15 +310,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
 
   Array<scalar_type> val(3);
   Array<global_ordinal_type> ind(3);
-  scalar_type zero=0;
-  scalar_type one=1;
-  val[0] = as<scalar_type>(-1);
-  val[1] = as<scalar_type>(2);
-  val[2] = as<scalar_type>(-1);
+  scalar_type zero=0.0;
+  scalar_type one=1.0;
+  val[0] = static_cast<scalar_type>(-1.0);
+  val[1] = static_cast<scalar_type>(2.0);
+  val[2] = static_cast<scalar_type>(-1.0);
 
   GO gidOffset;
-  int nlr = Teuchos::as<int>(numLocalRows);
-  Teuchos::scan(*comm,Teuchos::REDUCE_SUM,1,&nlr,&gidOffset);
+  GO nlr = static_cast<GO>(numLocalRows);
+  Teuchos::scan (*comm, Teuchos::REDUCE_SUM, nlr, Teuchos::outArg (gidOffset));
   gidOffset -= numLocalRows;
 
   if (myRank == 0) {
@@ -330,7 +330,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
     A->insertGlobalValues(0, ind.view(1, 2), val.view(1, 2));
 
     val[0] = val[2] = -one;
-    for (LO i=1; i<Teuchos::as<int>(numLocalRows); ++i) {
+    for (LO i=1; i<static_cast<int>(numLocalRows); ++i) {
       ind[0]=gidOffset+i-1;
       ind[1]=gidOffset+i;
       ind[2]=gidOffset+i+1;
@@ -342,7 +342,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
   } else if (myRank == comm->getSize()-1) {
 
     val[0] = val[2] = -one;
-    for (LO i=0; i<Teuchos::as<int>(numLocalRows)-1; ++i) {
+    for (LO i=0; i<static_cast<int>(numLocalRows)-1; ++i) {
       ind[0]=gidOffset+i-1;
       ind[1]=gidOffset+i;
       ind[2]=gidOffset+i+1;
@@ -360,7 +360,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
   else {
 
     val[0] = val[2] = -one;
-    for (LO i=0; i<Teuchos::as<int>(numLocalRows); ++i) {
+    for (LO i=0; i<static_cast<int>(numLocalRows); ++i) {
       ind[0]=gidOffset+i-1;
       ind[1]=gidOffset+i;
       ind[2]=gidOffset+i+1;
@@ -403,7 +403,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2OverlappingRowMatrix, getLocalDiag, Sca
   localDiag->get1dCopy(ldGids());
   auto ovrmGids = ovRowMap->getMyGlobalIndices();
 
-  TEST_EQUALITY(Teuchos::as<GO>(ldGids.size()),Teuchos::as<GO>(ovrmGids.size()));
+  TEST_EQUALITY(static_cast<GO>(ldGids.size()),static_cast<GO>(ovrmGids.size()));
   for (size_t i=0; i<ovrmGids.size(); ++i)
     TEST_EQUALITY(ldGids[i],ovrmGids[i]);
 }


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/anasazi 

## Description

Ifpack2: Fix #3139; work around #3192

  - Ifpack2 now builds with `Tpetra_INST_INT_INT=OFF`; this fixes #3139
  - Removed `Tpetra_INST_INT_INT=ON` requirement from an unrelated test
  - Found a likely Epetra64 bug (#3192) and worked around it

Anasazi: Remove `Tpetra_INST_INT_INT` requirement from examples

Remove `Tpetra_INST_INT_INT AND NOT Anasazi_ENABLE_TSQR` requirement.
For `Tpetra_INST_INT_INT`, see #2548.

## Motivation and Context

Fix #3139; work around #3192; work on #2548.

## Related Issues

* Closes #3139 
* Related to #3192 
* Part of #2548 

## How Has This Been Tested?

Linux, GCC, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.