### PR TITLE
Teko: getInvDiagonalOp for Thyra::DiagonalLinearOpBase

### DIFF
--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -991,6 +991,15 @@ const MultiVector getDiagonal(const Teko::LinearOp & A,const DiagonalType & dt)
   */
 const ModifiableLinearOp getInvDiagonalOp(const LinearOp & op)
 {
+   // if this is a diagonal linear op already, just take the reciprocal
+   auto diagonal_op = rcp_dynamic_cast<const Thyra::DiagonalLinearOpBase<double>>(op);
+   if(diagonal_op != Teuchos::null){
+     auto diag = diagonal_op->getDiag();
+     auto inv_diag = diag->clone_v();
+     Thyra::reciprocal(*diag,inv_diag.ptr());
+     return rcp(new Thyra::DefaultDiagonalLinearOp<double>(inv_diag));
+   }
+
    // if this is a blocked operator, extract diagonals block by block
    RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_op = rcp_dynamic_cast<const Thyra::PhysicallyBlockedLinearOpBase<double> >(op);
    if(blocked_op != Teuchos::null){


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Description
<!--- Please describe your changes in detail. -->
getInvDiagonalOp would only work on linear ops with underlying Epetra or Tpetra CRS matrices, so this would fail if you tried to get the inverse diagonal of a Thyra diagonal linear op. All I did was get the vector from the diagonal linear op and return a new diagonal linear op formed from its reciprocal.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This situation came up in EMPIRE, so this is a small change to address it.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Checked that this doesn't break any existing Teko tests. Also demonstrated that the same convergence is obtained in EMPIRE when compared to Ifpack2's inverse diagonal preconditioner.


<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

