### PR TITLE
Fix CUDA 9.0 build with module tweak (TRIL-215)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -37,7 +37,8 @@ if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
     export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
 elif [ "$ATDM_CONFIG_COMPILER" == "CUDA" ]; then
     export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
-    module load devpack/20180308/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176 
+    module load devpack/20180308/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176
+    module unload gcc/7.2.0
     module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
     export OMPI_CXX=$ATDM_CONFIG_TRILNOS_DIR/packages/kokkos/bin/nvcc_wrapper
     if [ ! -x "$OMPI_CXX" ]; then


### PR DESCRIPTION
CC: @fryeguy52 

## Description

Get this CUDA 9.0 build on 'white' working again by switching from the GCC 7.2.0 compiler to the 4.8.5 compiler.  This is part of the effort to get things working after the upgrade of 'white' (see [TRIL-215](https://software-sandbox.sandia.gov/jira/browse/TRIL-215)).

## Motivation and Context

We have not had a successful CUDA build on 'white' since 7/17/2018.  This to get that CUDA build running again while the Test Bed team fixes the CUDA 9.0 build env to work with GCC 7.2.0.


## How Has This Been Tested?

I tested this on 'white' with:

```
$ bsub -x -Is -q rhel7F -n 16 \
  ./checkin-test-atdm.sh cuda-opt --enable-packages=Kokkos --local-do-all
```
