### PR TITLE
superlu_dist: compile fix for v5.4.0

### DIFF
--- a/packages/amesos/src/Amesos_Superludist.cpp
+++ b/packages/amesos/src/Amesos_Superludist.cpp
@@ -135,7 +135,7 @@ Amesos_Superludist::Amesos_Superludist(const Epetra_LinearProblem &prob) :
   Equil_ = true;
   ColPerm_ = "MMD_AT_PLUS_A";
   perm_c_ = 0;
-  RowPerm_ = "LargeDiag";
+  RowPerm_ = "LargeDiag_MC64";
   perm_r_ = 0;
   IterRefine_ = "DOUBLE";
   ReplaceTinyPivot_ = true;
@@ -472,7 +472,7 @@ int Amesos_Superludist::Factor()
     }
 
     if( RowPerm_ == "NATURAL" ) PrivateSuperluData_->options_.RowPerm = (rowperm_t)NATURAL;
-    if( RowPerm_ == "LargeDiag" ) PrivateSuperluData_->options_.RowPerm = LargeDiag;
+    if( RowPerm_ == "LargeDiag_MC64" ) PrivateSuperluData_->options_.RowPerm = LargeDiag_MC64;
     else if( ColPerm_ == "MY_PERMR" ) {
       PrivateSuperluData_->options_.RowPerm = MY_PERMR;
       PrivateSuperluData_->ScalePermstruct_.perm_r = perm_r_;

--- a/packages/amesos/src/Amesos_Superludist.cpp
+++ b/packages/amesos/src/Amesos_Superludist.cpp
@@ -135,7 +135,11 @@ Amesos_Superludist::Amesos_Superludist(const Epetra_LinearProblem &prob) :
   Equil_ = true;
   ColPerm_ = "MMD_AT_PLUS_A";
   perm_c_ = 0;
+#if (SUPERLU_DIST_MAJOR_VERSION > 5) || ( SUPERLU_DIST_MAJOR_VERSION == 5 && SUPERLU_DIST_MINOR_VERSION > 3)
   RowPerm_ = "LargeDiag_MC64";
+#else
+  RowPerm_ = "LargeDiag";
+#endif
   perm_r_ = 0;
   IterRefine_ = "DOUBLE";
   ReplaceTinyPivot_ = true;
@@ -472,7 +476,11 @@ int Amesos_Superludist::Factor()
     }
 
     if( RowPerm_ == "NATURAL" ) PrivateSuperluData_->options_.RowPerm = (rowperm_t)NATURAL;
+#if (SUPERLU_DIST_MAJOR_VERSION > 5) || ( SUPERLU_DIST_MAJOR_VERSION == 5 && SUPERLU_DIST_MINOR_VERSION > 3)
     if( RowPerm_ == "LargeDiag_MC64" ) PrivateSuperluData_->options_.RowPerm = LargeDiag_MC64;
+#else
+    if( RowPerm_ == "LargeDiag" ) PrivateSuperluData_->options_.RowPerm = LargeDiag;
+#endif
     else if( ColPerm_ == "MY_PERMR" ) {
       PrivateSuperluData_->options_.RowPerm = MY_PERMR;
       PrivateSuperluData_->ScalePermstruct_.perm_r = perm_r_;

--- a/packages/amesos/test/TestOptions/TestSuperludist.cpp
+++ b/packages/amesos/test/TestOptions/TestSuperludist.cpp
@@ -14,32 +14,32 @@
 //  always return 0
 //
 //  TestSuperludist performs the following tests:
-//                         Redistribute   AddZeroToDiag   SUB:  ReuseSymbolic MaxProcesses
+//                            Redistribute   AddZeroToDiag   SUB:  ReuseSymbolic MaxProcesses
 //  Test number:
-//   1 disabled AddToDiag=100 true           true                   true           2
-//   2 disabled AddToDiag=100 true           false                  true           2
-//   3                        true           true                   false          2
-//   4                        true           true                   true           1
-//   5                        true           true                   false          1
-//   6                        true           true                   false          10
-//   7                        true           false                  true           -1
-//   8                        true           false                  true           -2
-//   9                        true           false                  true           -3
-//   10                       true           false                  false          4
-//   11                       false/true     true                   true           4
-//   12                       false/true     true                   true           2
+//   1 disabled AddToDiag=100    true           true                   true           2
+//   2 disabled AddToDiag=100    true           false                  true           2
+//   3                           true           true                   false          2
+//   4                           true           true                   true           1
+//   5                           true           true                   false          1
+//   6                           true           true                   false          10
+//   7                           true           false                  true           -1
+//   8                           true           false                  true           -2
+//   9                           true           false                  true           -3
+//   10                          true           false                  false          4
+//   11                          false/true     true                   true           4
+//   12                          false/true     true                   true           2
 //     Test #12 appears to duplicate test #11 and perhaps #4
-//   13                       false/true     true                   false          1
-//   14                       false/true     true                   false          2
-//   15                       false/true     false                  true           1
-//   16                       false/true     false                  true           2
-//   17 SamePattern           true           false                  true           10
-//   18 RowPerm - NATURAL     true           false                  false          10
-//   19 RowPerm - LargeDiag_MC64 true        false                  false          10
-//   20 RowPerm - NATURAL     true           false                  false          10
-//   21 RowPerm - LargeDiag_MC64 true        false                  false          10
-//   22 RowPerm - TinyPivot=t true           false                  false          10
-//   23 RowPerm - TinyPivot=f true           false                  false          10
+//   13                          false/true     true                   false          1
+//   14                          false/true     true                   false          2
+//   15                          false/true     false                  true           1
+//   16                          false/true     false                  true           2
+//   17 SamePattern              true           false                  true           10
+//   18 RowPerm - NATURAL        true           false                  false          10
+//   19 RowPerm - LargeDiag_MC64 true           false                  false          10
+//   20 RowPerm - NATURAL        true           false                  false          10
+//   21 RowPerm - LargeDiag_MC64 true           false                  false          10
+//   22 RowPerm - TinyPivot=t    true           false                  false          10
+//   23 RowPerm - TinyPivot=f    true           false                  false          10
 //
 
 
@@ -703,7 +703,11 @@ int TestSuperludist( Epetra_CrsMatrix *& Amat,
       ParamList.set( "AddZeroToDiag", false );
       Teuchos::ParameterList& SuperludistParams = ParamList.sublist("Superludist") ;
       SuperludistParams.set( "ReuseSymbolic", false );
+#if (SUPERLU_DIST_MAJOR_VERSION > 5) || ( SUPERLU_DIST_MAJOR_VERSION == 5 && SUPERLU_DIST_MINOR_VERSION > 3)
       SuperludistParams.set( "RowPerm", "LargeDiag_MC64" );
+#else
+      SuperludistParams.set( "RowPerm", "LargeDiag" );
+#endif
       SuperludistParams.set( "MaxProcesses", 10 );
       //  ParamList.print( std::cerr, 10 ) ;
 
@@ -772,7 +776,11 @@ int TestSuperludist( Epetra_CrsMatrix *& Amat,
       ParamList.set( "AddZeroToDiag", false );
       Teuchos::ParameterList& SuperludistParams = ParamList.sublist("Superludist") ;
       SuperludistParams.set( "ReuseSymbolic", true );
+#if (SUPERLU_DIST_MAJOR_VERSION > 5) || ( SUPERLU_DIST_MAJOR_VERSION == 5 && SUPERLU_DIST_MINOR_VERSION > 3)
       SuperludistParams.set( "RowPerm", "LargeDiag_MC64" );
+#else
+      SuperludistParams.set( "RowPerm", "LargeDiag" );
+#endif
       SuperludistParams.set( "MaxProcesses", 10 );
       //  ParamList.print( std::cerr, 10 ) ;
 

--- a/packages/amesos/test/TestOptions/TestSuperludist.cpp
+++ b/packages/amesos/test/TestOptions/TestSuperludist.cpp
@@ -35,9 +35,9 @@
 //   16                       false/true     false                  true           2
 //   17 SamePattern           true           false                  true           10
 //   18 RowPerm - NATURAL     true           false                  false          10
-//   19 RowPerm - LargeDiag   true           false                  false          10
+//   19 RowPerm - LargeDiag_MC64 true        false                  false          10
 //   20 RowPerm - NATURAL     true           false                  false          10
-//   21 RowPerm - LargeDiag   true           false                  false          10
+//   21 RowPerm - LargeDiag_MC64 true        false                  false          10
 //   22 RowPerm - TinyPivot=t true           false                  false          10
 //   23 RowPerm - TinyPivot=f true           false                  false          10
 //
@@ -703,7 +703,7 @@ int TestSuperludist( Epetra_CrsMatrix *& Amat,
       ParamList.set( "AddZeroToDiag", false );
       Teuchos::ParameterList& SuperludistParams = ParamList.sublist("Superludist") ;
       SuperludistParams.set( "ReuseSymbolic", false );
-      SuperludistParams.set( "RowPerm", "LargeDiag" );
+      SuperludistParams.set( "RowPerm", "LargeDiag_MC64" );
       SuperludistParams.set( "MaxProcesses", 10 );
       //  ParamList.print( std::cerr, 10 ) ;
 
@@ -772,7 +772,7 @@ int TestSuperludist( Epetra_CrsMatrix *& Amat,
       ParamList.set( "AddZeroToDiag", false );
       Teuchos::ParameterList& SuperludistParams = ParamList.sublist("Superludist") ;
       SuperludistParams.set( "ReuseSymbolic", true );
-      SuperludistParams.set( "RowPerm", "LargeDiag" );
+      SuperludistParams.set( "RowPerm", "LargeDiag_MC64" );
       SuperludistParams.set( "MaxProcesses", 10 );
       //  ParamList.print( std::cerr, 10 ) ;
 


### PR DESCRIPTION
This issue is with xsdk build of trilinos with latest superlu_dist [version 5.4.0

This patch fixes this issue for me.

Either a merge  - or  a more appropriate patch - that gets the trilinos build working with superlu_dist v5.4.0 would be great!

This incompatibility also prevents petsc from using trilinos with superlu_dist-v5.4.0

cc: @keitat  as xsdk liaison to trilinos - please follow-up on this issue - and fill up all the necessary trilinos requirements  so that PR gets accepted or this incompatibility is resolved via a different patch

cc: @jwillenbring, @curfman