### PR TITLE
MiniEM & RefMaxwell changes

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -256,7 +256,7 @@ namespace MueLu {
       RCP<RAPFactory> rapFact = rcp(new RAPFactory());
       Teuchos::ParameterList rapList = *(rapFact->GetValidParameterList());
       rapList.set("transpose: use implicit", parameterList_.get<bool>("transpose: use implicit", false));
-      rapList.set("rap: fix zero diagonals", parameterList_.get<bool>("rap: fix zero diagonals", false));
+      rapList.set("rap: fix zero diagonals", parameterList_.get<bool>("rap: fix zero diagonals", true));
       rapList.set("rap: triple product", parameterList_.get<bool>("rap: triple product", false));
       rapFact->SetParameterList(rapList);
 
@@ -336,7 +336,7 @@ namespace MueLu {
         RCP<RAPFactory> rapFact = rcp(new RAPFactory());
         Teuchos::ParameterList rapList = *(rapFact->GetValidParameterList());
         rapList.set("transpose: use implicit", false);
-        rapList.set("rap: fix zero diagonals", parameterList_.get<bool>("rap: fix zero diagonals", false));
+        rapList.set("rap: fix zero diagonals", parameterList_.get<bool>("rap: fix zero diagonals", true));
         rapList.set("rap: triple product", parameterList_.get<bool>("rap: triple product", false));
         rapFact->SetParameterList(rapList);
 
@@ -474,6 +474,7 @@ namespace MueLu {
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("A_nodal.mat"), *A_nodal_Matrix_);
       Xpetra::IO<SC, LO, GO, NO>::Write(std::string("P11.mat"), *P11_);
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("AH.mat"), *AH_);
+      Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("A22.mat"), *A22_);
     }
   }
 
@@ -1018,9 +1019,7 @@ namespace MueLu {
           MultiplyRAP(*Z, true, *M0inv_Matrix_, false, *Z, false, *Matrix2, true, true);
       }
       // add matrices together
-      RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-      out->setOutputToRootOnly(0);
-      Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::TwoMatrixAdd(*Matrix1,false,(Scalar)1.0,*Matrix2,false,(Scalar)1.0,AH_,*out);
+      Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::TwoMatrixAdd(*Matrix1,false,(Scalar)1.0,*Matrix2,false,(Scalar)1.0,AH_,GetOStream(Runtime0));
       AH_->fillComplete();
     }
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -1005,7 +1005,14 @@ namespace MueLu {
 #endif
         RCP<Vector> diag = VectorFactory::Build(M0inv_Matrix_->getRowMap());
         M0inv_Matrix_->getLocalDiagCopy(*diag);
-        Z->leftScale(*diag);
+        if (Z->getRowMap()->isSameAs(*(diag->getMap())))
+          Z->leftScale(*diag);
+        else {
+          RCP<Import> importer = ImportFactory::Build(diag->getMap(),Z->getRowMap());
+          RCP<Vector> diag2 = VectorFactory::Build(Z->getRowMap());
+          diag2->doImport(*diag,*importer,Xpetra::INSERT);
+          Z->leftScale(*diag2);
+        }
         Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*ZT,false,*Z,false,*Matrix2,true,true);
       } else if (parameterList_.get<bool>("rap: triple product", false) == false) {
         Teuchos::RCP<Matrix> C2 = MatrixFactory::Build(M0inv_Matrix_->getRowMap(),0);

--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -12,7 +12,7 @@ TRIBITS_ADD_EXECUTABLE(
 TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyBlockPrecFiles
   SOURCE_FILES
   solverAugmentation.xml solverAugmentationEpetra.xml
-  solverMueLuRefMaxwell.xml solverMueLuRefMaxwellEpetra.xml
+  solverMueLuRefMaxwell.xml solverMueLuRefMaxwell2D.xml solverMueLuRefMaxwellEpetra.xml
   solverMueLuRefMaxwellOpenMP.xml solverMueLuRefMaxwellCuda.xml
   solverAugmentationUseILU.xml
   solverMLRefMaxwell.xml
@@ -78,6 +78,18 @@ TRIBITS_ADD_TEST(
    COMM mpi
    NUM_MPI_PROCS 4
    )
+
+IF(NOT Kokkos_ENABLE_Cuda AND NOT Kokkos_ENABLE_OpenMP)
+
+  TRIBITS_ADD_TEST(
+    BlockPrec
+    NAME "MiniEM-BlockPrec_RefMaxwell2D"
+    ARGS "--solver=MueLu-RefMaxwell --numTimeSteps=1 --linAlgebra=Tpetra --spatialDim=2"
+    COMM mpi
+    NUM_MPI_PROCS 4
+    )
+
+ENDIF()
 
 IF(NOT Kokkos_ENABLE_Cuda AND NOT Kokkos_ENABLE_OpenMP AND MueLu_ENABLE_Epetra)
 

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell2D.xml
@@ -1,0 +1,207 @@
+<ParameterList name="Linear Solver">
+  <Parameter name="Linear Solver Type" type="string" value="Belos"/>
+  <ParameterList name="Linear Solver Types">
+    <ParameterList name="Belos">
+      <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+      <!-- <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/> -->
+      <ParameterList name="Solver Types">
+        <ParameterList name="Block GMRES">
+          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
+          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+          <Parameter name="Output Frequency" type="int" value="1"/>
+          <Parameter name="Output Style" type="int" value="1"/>
+          <Parameter name="Verbosity" type="int" value="33"/>
+          <Parameter name="Maximum Iterations" type="int" value="100"/>
+          <Parameter name="Block Size" type="int" value="1"/>
+          <Parameter name="Num Blocks" type="int" value="40"/>
+          <Parameter name="Flexible Gmres" type="bool" value="true"/>
+          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+        </ParameterList>
+        <ParameterList name="Pseudo Block GMRES">
+          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
+          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+          <Parameter name="Output Frequency" type="int" value="1"/>
+          <Parameter name="Output Style" type="int" value="1"/>
+          <Parameter name="Verbosity" type="int" value="33"/>
+          <Parameter name="Maximum Iterations" type="int" value="100"/>
+          <Parameter name="Block Size" type="int" value="1"/>
+          <Parameter name="Num Blocks" type="int" value="40"/>
+          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="VerboseObject">
+        <Parameter name="Verbosity Level" type="string" value="medium"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+
+  <Parameter name="Preconditioner Type" type="string" value="Teko"/>
+  <ParameterList name="Preconditioner Types">
+    <ParameterList name="Teko">
+      <Parameter name="Inverse Type" type="string" value="Maxwell"/>
+      <ParameterList name="Inverse Factory Library">
+        <ParameterList name="Maxwell">
+          <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
+          <Parameter name="Use refMaxwell" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="true"/>
+          <Parameter name="Debug" type="bool" value="false"/>
+          <Parameter name="Dump" type="bool" value="false"/>
+          <Parameter name="Use discrete gradient" type="bool" value="true"/>
+          <Parameter name="Solve lower triangular" type="bool" value="true"/>
+
+          <ParameterList name="Q_B Solve">
+            <Parameter name="Type" type="string" value="Belos"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <ParameterList name="Solver Types">
+              <ParameterList name="Block CG">
+                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Maximum Iterations" type="int" value="100"/>
+                <Parameter name="Timer Label" type="string" value="CG Q_B"/>
+                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Style" type="int" value="1"/>
+                <Parameter name="Verbosity" type="int" value="33"/>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="VerboseObject">
+              <Parameter name="Verbosity Level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+
+          <!-- In 2D Q_B is block-diagonal, for lowest order elements even diagonal. -->
+          <ParameterList name="Q_B Preconditioner">
+            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
+            <ParameterList name="Prec Types">
+              <ParameterList name="Ifpack2">
+                <Parameter name="Prec Type" type="string" value="relaxation"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+
+          <ParameterList name="S_E Solve">
+            <Parameter name="Type" type="string" value="Belos"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <ParameterList name="Solver Types">
+              <ParameterList name="Block CG">
+                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Maximum Iterations" type="int" value="100"/>
+                <Parameter name="Timer Label" type="string" value="CG S_E"/>
+                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Style" type="int" value="1"/>
+                <Parameter name="Verbosity" type="int" value="33"/>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="VerboseObject">
+              <Parameter name="Verbosity Level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+
+          <ParameterList name="S_E Preconditioner">
+            <Parameter name="Type" type="string" value="MueLuRefMaxwell-Tpetra"/>
+            <ParameterList name="Preconditioner Types">
+              <ParameterList name="MueLuRefMaxwell-Tpetra">
+                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
+                <Parameter name="refmaxwell: mode" type="string" value="additive"/>
+                <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
+                <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
+                <Parameter name="refmaxwell: max coarse size" type="int" value="1000"/>
+
+                <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
+                <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
+
+                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
+                <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
+
+                <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
+                <!-- <ParameterList name="smoother: params"> -->
+                <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
+                <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
+                <!-- </ParameterList> -->
+
+                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                </ParameterList>
+
+                <ParameterList name="refmaxwell: 11list">
+                  <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="number of equations" type="int" value="2"/>
+                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
+                  <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
+
+                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
+                  <!-- <ParameterList name="smoother: params"> -->
+                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
+                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
+                  <!-- </ParameterList> -->
+
+                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  </ParameterList>
+
+                  <Parameter name="repartition: enable" type="bool" value="true"/>
+                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
+                  <Parameter name="repartition: start level" type="int" value="1"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
+                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
+                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <ParameterList name="repartition: params">
+                    <Parameter name="algorithm" type="string" value="multijagged"/>
+                  </ParameterList>
+                </ParameterList>
+
+                <ParameterList name="refmaxwell: 22list">
+                  <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
+                  <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
+
+                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
+                  <!-- <ParameterList name="smoother: params"> -->
+                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
+                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
+                  <!-- </ParameterList> -->
+
+                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  </ParameterList>
+
+                  <Parameter name="repartition: enable" type="bool" value="true"/>
+                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
+                  <Parameter name="repartition: start level" type="int" value="1"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
+                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
+                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <ParameterList name="repartition: params">
+                    <Parameter name="algorithm" type="string" value="multijagged"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="Required Parameters">
+              <Parameter name="Coordinates" type="string" value="AUXILIARY_NODE"/>
+            </ParameterList>
+          </ParameterList>
+
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_TemplateBuilder.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_TemplateBuilder.hpp
@@ -2,7 +2,7 @@
 #define __MiniEM_ClosureModel_Factory_TemplateBuilder_hpp__
 
 #include <string>
-#include "Sacado_mpl_apply.hpp"
+// #include "Sacado_mpl_apply.hpp"
 #include "Teuchos_RCP.hpp"
 #include "MiniEM_ClosureModel_Factory.hpp"
 

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
@@ -15,6 +15,8 @@
 #include "Teuchos_TypeNameTraits.hpp"
 
 #include "MiniEM_GaussianPulse.hpp"
+#include "MiniEM_InversePermeability.hpp"
+#include "MiniEM_Permittivity.hpp"
 
 // ********************************************************************
 // ********************************************************************
@@ -96,24 +98,39 @@ buildClosureModels(const std::string& model_id,
 
         found = true;
       }
-      if(type=="ELECTROMAGNETIC ENERGY") {
+      if(type=="INVERSE PERMEABILITY") {
         double mu = plist.get<double>("mu");
-        double epsilon = plist.get<double>("epsilon");
+	RCP< Evaluator<panzer::Traits> > e =
+	  rcp(new mini_em::InversePermeability<EvalT,panzer::Traits>(key,*ir,fl,mu));
+	evaluators->push_back(e);
 
-        // compute ||E||^2
+        found = true;
+      }
+      if(type=="PERMITTIVITY") {
+        double epsilon = plist.get<double>("epsilon");
+        std::string DoF = plist.get<std::string>("DoF Name");
+	RCP< Evaluator<panzer::Traits> > e =
+	  rcp(new mini_em::Permittivity<EvalT,panzer::Traits>(key,*ir,fl,epsilon,DoF));
+	evaluators->push_back(e);
+
+        found = true;
+      }
+      if(type=="ELECTROMAGNETIC ENERGY") {
+        // compute (E, epsilon*E)
         {
           Teuchos::ParameterList input;
           input.set("Result Name", "E_SQUARED");
           input.set<Teuchos::RCP<const panzer::PointRule> >("Point Rule", ir);
           input.set("Vector A Name", "E_edge");
           input.set("Vector B Name", "E_edge");
+          input.set("Field Multiplier", "PERMITTIVITY");
 
           RCP< Evaluator<panzer::Traits> > e = 
 	    rcp(new panzer::DotProduct<EvalT,panzer::Traits>(input));
 	  evaluators->push_back(e);
         }
 
-        // compute ||B||^2
+        // compute (B, 1/mu * B)
         {
           if (ir->spatial_dimension == 3) {
             Teuchos::ParameterList input;
@@ -121,6 +138,7 @@ buildClosureModels(const std::string& model_id,
             input.set<Teuchos::RCP<const panzer::PointRule> >("Point Rule", ir);
             input.set("Vector A Name", "B_face");
             input.set("Vector B Name", "B_face");
+            input.set("Field Multiplier", "INVERSE_PERMEABILITY");
 
             RCP< Evaluator<panzer::Traits> > e =
               rcp(new panzer::DotProduct<EvalT,panzer::Traits>(input));
@@ -133,6 +151,7 @@ buildClosureModels(const std::string& model_id,
             valuesNames->push_back("B_face");
             input.set("Values Names",valuesNames);
             input.set("Data Layout",ir->dl_scalar);
+            input.set("Field Multiplier", "INVERSE_PERMEABILITY");
 
             RCP< Evaluator<panzer::Traits> > e =
               rcp(new panzer::Product<EvalT,panzer::Traits>(input));
@@ -140,11 +159,11 @@ buildClosureModels(const std::string& model_id,
           }
         }
 
-        // compute epsilon/2*||E||^2 + 1/(2*mu)*||B||^2
+        // compute 1/2*(E, epsilon * E) + 1/2*(B, 1/mu * B)
         {
           RCP<std::vector<double> > coeffs = rcp(new std::vector<double>);
-          coeffs->push_back(0.5*epsilon);
-          coeffs->push_back(0.5/mu);
+          coeffs->push_back(0.5);
+          coeffs->push_back(0.5);
   
           RCP<std::vector<std::string> > valuesNames = rcp(new std::vector<std::string>);
           valuesNames->push_back("E_SQUARED");
@@ -155,7 +174,7 @@ buildClosureModels(const std::string& model_id,
           input.set("Values Names",valuesNames);
           input.set("Data Layout",ir->dl_scalar);
           input.set<RCP<const std::vector<double> > >("Scalars", coeffs);
-        
+
           RCP< Evaluator<panzer::Traits> > e = 
 	    rcp(new panzer::Sum<EvalT,panzer::Traits>(input));
 	  evaluators->push_back(e);

--- a/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse.hpp
@@ -45,7 +45,7 @@ private:
   // Simulation source
   PHX::MDField<ScalarT,Cell,Point,Dim> current;
   PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
-  int ir_degree, ir_index;
+  int ir_degree, ir_index, ir_dim;
   double alpha, beta;
 };
 

--- a/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse_impl.hpp
@@ -21,6 +21,7 @@ GaussianPulse<EvalT,Traits>::GaussianPulse(const std::string & name,
 
   Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_vector;
   ir_degree = ir.cubature_degree;
+  ir_dim = ir.spatial_dimension;
 
   current = PHX::MDField<ScalarT,Cell,Point,Dim>(name, data_layout);
   this->addEvaluatedField(current);
@@ -47,15 +48,27 @@ void GaussianPulse<EvalT,Traits>::evaluateFields(typename Traits::EvalData works
 
   const ScalarT factor = std::exp(-(time-2.0*beta)*(time-2.0*beta)/beta/beta);
   const ScalarT scale = 1.0/alpha/alpha;
-  for (index_t cell = 0; cell < workset.num_cells; ++cell) {
-    for (int point = 0; point < current.extent_int(1); ++point) {
-      const ScalarT& x = coords(cell,point,0);
-      const ScalarT& y = coords(cell,point,1);
-      const ScalarT& z = coords(cell,point,2);
-      const ScalarT  r2 = (x-0.5)*(x-0.5) + (y-0.5)*(y-0.5) + (z-0.5)*(z-0.5);
-      current(cell,point,0) = 0.0;
-      current(cell,point,1) = 0.0;
-      current(cell,point,2) = std::exp(-r2*scale)*factor;
+  if (ir_dim == 3) {
+    for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+      for (int point = 0; point < current.extent_int(1); ++point) {
+        const ScalarT& x = coords(cell,point,0);
+        const ScalarT& y = coords(cell,point,1);
+        const ScalarT& z = coords(cell,point,2);
+        const ScalarT  r2 = (x-0.5)*(x-0.5) + (y-0.5)*(y-0.5) + (z-0.5)*(z-0.5);
+        current(cell,point,0) = 0.0;
+        current(cell,point,1) = 0.0;
+        current(cell,point,2) = std::exp(-r2*scale)*factor;
+      }
+    }
+  } else {
+    for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+      for (int point = 0; point < current.extent_int(1); ++point) {
+        const ScalarT& x = coords(cell,point,0);
+        const ScalarT& y = coords(cell,point,1);
+        const ScalarT  r2 = (x-0.5)*(x-0.5) + (y-0.5)*(y-0.5);
+        current(cell,point,0) = 0.0;
+        current(cell,point,1) = std::exp(-r2*scale)*factor;
+      }
     }
   }
 }

--- a/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability.hpp
@@ -1,0 +1,48 @@
+#ifndef MINIEM_INVERSEPERMEABILITY_DECL_HPP
+#define MINIEM_INVERSEPERMEABILITY_DECL_HPP
+
+#include "PanzerAdaptersSTK_config.hpp"
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_FieldLibrary.hpp"
+
+#include <string>
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace mini_em {
+    
+  using panzer::Cell;
+  using panzer::Point;
+
+  template<typename EvalT, typename Traits>
+  class InversePermeability : public panzer::EvaluatorWithBaseImpl<Traits>,
+                              public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+  public:
+    InversePermeability(const std::string & name,
+                        const panzer::IntegrationRule & ir,
+                        const panzer::FieldLayoutLibrary & fl,
+                        const double & mu_);
+                                                                        
+    void evaluateFields(typename Traits::EvalData d);
+
+
+  private:
+    typedef typename EvalT::ScalarT ScalarT;
+
+    PHX::MDField<ScalarT,Cell,Point> permeability;
+    PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
+    int ir_degree;
+    double mu;
+  };
+
+}
+
+#include "MiniEM_InversePermeability_impl.hpp"
+
+#endif

--- a/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability_impl.hpp
@@ -1,0 +1,58 @@
+#ifndef MINIEM_INVERSEPERMEABILITY_IMPL_HPP
+#define MINIEM_INVERSEPERMEABILITY_IMPL_HPP
+
+#include <cmath>
+
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+#include "Panzer_GatherBasisCoordinates.hpp"
+
+namespace mini_em {
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+InversePermeability<EvalT,Traits>::InversePermeability(const std::string & name,
+                                                       const panzer::IntegrationRule & ir,
+                                                       const panzer::FieldLayoutLibrary & fl,
+                                                       const double & mu_)
+{
+  using Teuchos::RCP;
+
+  Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_scalar;
+  ir_degree = ir.cubature_degree;
+
+  permeability = PHX::MDField<ScalarT,Cell,Point>(name, data_layout);
+  this->addEvaluatedField(permeability);
+  
+  mu = mu_;
+
+  Teuchos::RCP<const panzer::PureBasis> basis = fl.lookupBasis("B_face");
+  const std::string coordName = panzer::GatherBasisCoordinates<EvalT,Traits>::fieldName(basis->name());
+  coords = PHX::MDField<const ScalarT,Cell,Point,Dim>(coordName, basis->coordinates); 
+  this->addDependentField(coords);
+
+  std::string n = "InversePermeability";
+  this->setName(n);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void InversePermeability<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+{ 
+  using panzer::index_t;
+
+  for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+    for (int point = 0; point < permeability.extent_int(1); ++point) {
+      // const ScalarT& x = coords(cell,point,0);
+      // const ScalarT& y = coords(cell,point,1);
+      // const ScalarT& z = coords(cell,point,2);
+      permeability(cell,point) = 1.0/mu;
+    }
+  }
+}
+
+//**********************************************************************
+}
+
+#endif

--- a/packages/panzer/mini-em/src/closures/MiniEM_Permittivity.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_Permittivity.hpp
@@ -1,0 +1,49 @@
+#ifndef MINIEM_PERMITTIVITY_DECL_HPP
+#define MINIEM_PERMITTIVITY_DECL_HPP
+
+#include "PanzerAdaptersSTK_config.hpp"
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_FieldLibrary.hpp"
+
+#include <string>
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace mini_em {
+    
+  using panzer::Cell;
+  using panzer::Point;
+
+  template<typename EvalT, typename Traits>
+  class Permittivity : public panzer::EvaluatorWithBaseImpl<Traits>,
+                       public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+  public:
+    Permittivity(const std::string & name,
+                 const panzer::IntegrationRule & ir,
+                 const panzer::FieldLayoutLibrary & fl,
+                 const double & epsilon_,
+                 const std::string& DoF_);
+                                                                        
+    void evaluateFields(typename Traits::EvalData d);
+
+
+  private:
+    typedef typename EvalT::ScalarT ScalarT;
+
+    PHX::MDField<ScalarT,Cell,Point> permittivity;
+    PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
+    int ir_degree;
+    double epsilon;
+  };
+
+}
+
+#include "MiniEM_Permittivity_impl.hpp"
+
+#endif

--- a/packages/panzer/mini-em/src/closures/MiniEM_Permittivity_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_Permittivity_impl.hpp
@@ -1,0 +1,59 @@
+#ifndef MINIEM_PERMITTIVITY_IMPL_HPP
+#define MINIEM_PERMITTIVITY_IMPL_HPP
+
+#include <cmath>
+
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+#include "Panzer_GatherBasisCoordinates.hpp"
+
+namespace mini_em {
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+Permittivity<EvalT,Traits>::Permittivity(const std::string & name,
+                                         const panzer::IntegrationRule & ir,
+                                         const panzer::FieldLayoutLibrary & fl,
+                                         const double & epsilon_,
+                                         const std::string& DoF_)
+{
+  using Teuchos::RCP;
+
+  Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_scalar;
+  ir_degree = ir.cubature_degree;
+
+  permittivity = PHX::MDField<ScalarT,Cell,Point>(name, data_layout);
+  this->addEvaluatedField(permittivity);
+  
+  epsilon = epsilon_;
+
+  Teuchos::RCP<const panzer::PureBasis> basis = fl.lookupBasis(DoF_);
+  const std::string coordName = panzer::GatherBasisCoordinates<EvalT,Traits>::fieldName(basis->name());
+  coords = PHX::MDField<const ScalarT,Cell,Point,Dim>(coordName, basis->coordinates); 
+  this->addDependentField(coords);
+
+  std::string n = "Permittivity";
+  this->setName(n);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void Permittivity<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+{ 
+  using panzer::index_t;
+
+  for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+    for (int point = 0; point < permittivity.extent_int(1); ++point) {
+      // const ScalarT& x = coords(cell,point,0);
+      // const ScalarT& y = coords(cell,point,1);
+      // const ScalarT& z = coords(cell,point,2);
+      permittivity(cell,point) = epsilon;
+    }
+  }
+}
+
+//**********************************************************************
+}
+
+#endif

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_MassMatrix.hpp
@@ -35,6 +35,7 @@ namespace mini_em {
   protected:
     std::string dof_name;
     double multiplier;
+    Teuchos::RCP<const std::vector<std::string> > fieldMultipliers;
     Teuchos::RCP<panzer::GlobalEvaluationDataContainer> m_gedc;
     Teuchos::RCP<std::vector<std::string> > m_dof_names;
   };

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSet_Maxwell.hpp
@@ -28,7 +28,6 @@ namespace mini_em {
       std::string BFieldName() const {return m_Bfield_dof_name;}
   private:
       int dimension;
-      double eps, mu;
       std::string m_Efield_dof_name;
       std::string m_Bfield_dof_name;
  };

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -850,7 +850,10 @@ public:
   }
 
   //! Get a copy of the diagonal entries owned by this node, with local row indices.
-  void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const { XPETRA_MONITOR("EpetraCrsMatrixT::getLocalDiagCopy"); mtx_->ExtractDiagonalCopy(toEpetra<GlobalOrdinal,Node>(diag)); }
+  void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const {
+    XPETRA_MONITOR("EpetraCrsMatrixT::getLocalDiagCopy");
+    XPETRA_ERR_CHECK(mtx_->ExtractDiagonalCopy(toEpetra<GlobalOrdinal,Node>(diag)));
+  }
 
   //! Get offsets of the diagonal entries in the matrix.
   void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {


### PR DESCRIPTION
@trilinos/panzer 

## Description
- Fix zero diagonals in RefMaxwell (2,2) block by default. Usually this is not necessary, but some problems with periodic BCs it seems to be a requirement.
- Add command line options to MiniEM for running 2D and periodic problems.
- Allow permeability and permittivity to vary spatially.
- Fix issue in RefMaxwell Epetra code path by allowing non-matching maps