### PR TITLE
Disable failing SEACAS tests on Mutrino (#2815)

### DIFF
--- a/cmake/std/atdm/mutrino/tweaks/INTEL-DEBUG-OPENMP.cmake
+++ b/cmake/std/atdm/mutrino/tweaks/INTEL-DEBUG-OPENMP.cmake
@@ -10,4 +10,12 @@ ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)
 ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_4_DISABLE ON)
 
 # Disable SEACAS test that fails on mutrino (#2815)
+# Issue is with parallel build running serial -- extra data to stderr which affects gold comparison
 ATDM_SET_ENABLE(SEACASExodus_exodus_unit_tests_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_array_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_command_line_include_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_command_line_vars_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_unit_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_lib_aprepro_lib_array_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_lib_aprepro_lib_unit_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASExodus_exodus_unit_tests_nc5_env_DISABLE ON)

--- a/cmake/std/atdm/mutrino/tweaks/INTEL-RELEASE-OPENMP.cmake
+++ b/cmake/std/atdm/mutrino/tweaks/INTEL-RELEASE-OPENMP.cmake
@@ -10,4 +10,12 @@ ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)
 ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_4_DISABLE ON)
 
 # Disable SEACAS test that fails on mutrino (#2815)
+# Issue is with parallel build running serial -- extra data to stderr which affects gold comparison
 ATDM_SET_ENABLE(SEACASExodus_exodus_unit_tests_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_array_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_command_line_include_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_command_line_vars_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_unit_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_lib_aprepro_lib_array_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASAprepro_lib_aprepro_lib_unit_test_DISABLE ON)
+ATDM_SET_ENABLE(SEACASExodus_exodus_unit_tests_nc5_env_DISABLE ON)


### PR DESCRIPTION
The executables are built in a parallel build, but they are
really serial so when run there is some extra info that is
output to stderr which ends up messing with the textual comparison
with the expected "gold" output files.  For now disable the tests
until can figure out a better way of running them.

This should address #3183.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
