### PR TITLE
Write region data files into subdirectory (#3061)

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/mk1DRegionFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mk1DRegionFile.m
@@ -12,8 +12,14 @@
 % - Number of nodes per region needs to be (k*3^L + 1) with k=1...N and L being
 %   the numberOfLevels-1.
 %
-
-function [] = mk1DRegionFile(filename)
+% Input
+%   filename  filename of case file
+%   outDir    path to output directory
+%
+% Output
+%   [none]
+%
+function [] = mk1DRegionFile(filename, outDir)
 
 %% User-defined cases
 
@@ -80,7 +86,10 @@ whichCase = 'MultipleRegionsPerProc';
 
 
 %% Print data to file
-fp = fopen(filename,'w');
+fp = fopen(sprintf('%s/%s', outDir, filename), 'w');
+if fp == -1
+  error('Could not open file at %s/%s.', outDir, filename);
+end
 if fp ~= -1
   fprintf(fp,'     #nodes  #regions   #procs   #which case\n');
   fprintf(fp,'%8d %8d %8d       %s\n',nNodes,nRegions,nProcs,whichCase);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mk2DAppData.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mk2DAppData.m
@@ -1,5 +1,5 @@
 function [] = mk2DAppData(allMyNodes,allMyRegions,nProcs,whichCase,...
-                       globalDims,localDims,relcorners,abscorners)
+                       globalDims,localDims,relcorners,abscorners, outDir)
 %
 % Most of this information is computed in the mk2DRegionfile() and so
 % here we basically need to just print it.
@@ -7,14 +7,11 @@ function [] = mk2DAppData(allMyNodes,allMyRegions,nProcs,whichCase,...
 
 for myRank=0:nProcs-1
    % open file
-   fp = fopen(sprintf('myAppData_%d',myRank),'w');
+   fp = fopen(sprintf('%s/myAppData_%d', outDir, myRank), 'w');
    if fp == -1
      error('mkAppData: cannot open myAppData_%d\n',myRank);
    end
    
-   % write to file
-%    fprintf(fp,'LoadAppDataForLIDregion()\n');
-
    curRegionList = allMyRegions{myRank+1}.myRegions;
 
    nRegions = length(curRegionList);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mk2DRegionFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mk2DRegionFile.m
@@ -1,4 +1,16 @@
-function [globalDims,localDims,relCorner,regionCorner] = mk2RegionFile(filename)
+% mk2DRegionFile.m
+%
+% Input
+%   filename  filename of case file
+%   outDir    path to output directory
+%
+% Output
+%   globalDims
+%   localDims
+%   relCorner
+%   regionCorner
+%
+function [globalDims,localDims,relCorner,regionCorner] = mk2RegionFile(filename, outDir)
 %
 %  writes mapping to a file based on information below.
 %
@@ -276,7 +288,7 @@ relCorner   = -ones(nRegions,nProcs,2);
 regionCorner= -ones(nRegions,2);
 localDims =  -ones(nRegions,nProcs,2);
 
-fp = fopen(filename,'w');
+fp = fopen(sprintf('%s/%s', outDir, filename), 'w');
 if fp ~= -1, 
     fprintf(fp,'     #nodes  #regions   #procs   #which case\n');
     fprintf(fp,'%8d %8d %8d       %s\n',nNodes,nRegions,nProcs,whichCase);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkAppData.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkAppData.m
@@ -1,9 +1,17 @@
-function [] = mkAppData(allMyNodes,allMyRegions,nProcs,whichCase)
+%
+% Input
+%   allMyNodes
+%   allMyRegions
+%   nProcs          total number of processors
+%   whichCase       
+%   outDir          path to output directory
+%
+function [] = mkAppData(allMyNodes,allMyRegions,nProcs,whichCase,outDir)
 
 for myRank=0:nProcs-1
    
    % open file
-   fp = fopen(sprintf('myAppData_%d',myRank),'w');
+   fp = fopen(sprintf('%s/myAppData_%d',outDir,myRank),'w');
    if fp == -1
      error('mkAppData: cannot open myAppData_%d\n',myRank);
    end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkCompositeMap.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkCompositeMap.m
@@ -1,7 +1,19 @@
-function [] = mkCompositeMap(myNodes,myRank)
+% mkCompositeMap.m
+%
+% Write composite map to file 'myCompositeMap_*' on each processor.
+%
+% Input:
+%   myNodes   list of all nodes owned by this processor
+%   myRank    rank of this processor
+%   outDir    path to output directory
+%
+% Output: 
+%   [none]
+%
+function [] = mkCompositeMap(myNodes,myRank,outDir)
 
   % open file
-  filename = 'myCompositeMap_';
+  filename = sprintf('%s/myCompositeMap_', outDir);
   fp = fopen(sprintf('%s%d',filename,myRank),'w');
   if fp == -1
     error('mkCompositeMap: cannot open myData_%d\n',myRank);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkMatrixFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkMatrixFile.m
@@ -1,14 +1,18 @@
 % writeMatrixFile
 %
-% Write matrix to file
+% Write matrix to file 'Amat.mm'
+%
+% Input:
+%   A       matrix to be written
+%   outDir  path to output directory
 %
 
 % now send matrix to C++
 
-function [] = writeMatrixFile(A)
+function [] = writeMatrixFile(A, outDir)
 
 % open file
-fp = fopen('Amat.mm','w');
+fp = fopen(sprintf('%s/Amat.mm', outDir), 'w');
 if (fp == -1)
   error('Cannot open file.');
 end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/mkRegionsPerGID.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/mkRegionsPerGID.m
@@ -1,6 +1,17 @@
-function [] = mkRegionsPerGID(myNodes,myRank,maxRegPerGID)
+% mkRegionsPerGID.m
+%
+% Input:
+%   myNodes         list of nodes owned by this processor
+%   myRank          rank of this processor
+%   maxRegPerGID    max number of regions that a single GID belongs to
+%   outDir          path to output directory
+%
+% Outpu:
+%   [none]
+%
+function [] = mkRegionsPerGID(myNodes, myRank, maxRegPerGID, outDir)
 
-   fp = fopen(sprintf('myRegionAssignment_%d',myRank),'w');
+   fp = fopen(sprintf('%s/myRegionAssignment_%d', outDir, myRank), 'w');
    if fp == -1
       error('mkRegionsPerGID: cannot open myRegAssignment_%d\n',myRank);
    end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/muelu_structured.xml
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/muelu_structured.xml
@@ -1,11 +1,73 @@
-<ParameterList name="MueLu">  <!-- Configuration of the Xpetra operator (fine level) -->  <ParameterList name="Matrix">    <Parameter name="PDE equations"                   type="int" value="1"/> <!-- Number of PDE equations at each grid node.-->  </ParameterList>  <!-- Factory collection -->  <ParameterList name="Factories">    <ParameterList name="myCoalesceDropFact">      <Parameter name="factory"                             type="string" value="CoalesceDropFactory"/>      <Parameter name="lightweight wrap"                    type="bool"   value="true"/>      <Parameter name="aggregation: drop tol"               type="double" value="0.00"/>    </ParameterList>    <ParameterList name="myAggregationFact">      <Parameter name="factory"                             type="string" value="StructuredAggregationFactory"/>      <Parameter name="aggregation: coupling"               type="string" value="uncoupled"/>      <Parameter name="Graph"                               type="string" value="myCoalesceDropFact"/>    </ParameterList>
+<ParameterList name="MueLu">
+  
+  <!-- Configuration of the Xpetra operator (fine level) -->
+  <ParameterList name="Matrix">
+    <Parameter name="PDE equations"                   type="int" value="1"/> <!-- Number of PDE equations at each grid node.-->
+  </ParameterList>
+
+  <!-- Factory collection -->
+  <ParameterList name="Factories">
+
+    <ParameterList name="myCoalesceDropFact">
+      <Parameter name="factory"                             type="string" value="CoalesceDropFactory"/>
+      <Parameter name="lightweight wrap"                    type="bool"   value="true"/>
+      <Parameter name="aggregation: drop tol"               type="double" value="0.00"/>
+    </ParameterList>
+
+    <ParameterList name="myAggregationFact">
+      <Parameter name="factory"                             type="string" value="StructuredAggregationFactory"/>
+      <Parameter name="aggregation: coupling"               type="string" value="uncoupled"/>
+      <Parameter name="Graph"                               type="string" value="myCoalesceDropFact"/>
+    </ParameterList>
     
     <ParameterList name="myCoarseMapFact">
       <Parameter name="factory" type="string" value="CoarseMapFactory"/>
       <Parameter name="Aggregates" type="string" value="myAggregationFact"/>
-    </ParameterList>    <!-- Note that ParameterLists must be defined prior to being used -->    <ParameterList name="myProlongatorFact">      <Parameter name="factory"                             type="string" value="TentativePFactory"/>      <!-- Parameter name="P"                                   type="string" value="myProlongatorFact"/ -->      <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <!-- Note that ParameterLists must be defined prior to being used -->
+    <ParameterList name="myProlongatorFact">
+      <Parameter name="factory"                             type="string" value="TentativePFactory"/>
+      <!-- Parameter name="P"                                   type="string" value="myProlongatorFact"/ -->
+      <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/>
       <Parameter name="CoarseMap" type="string" value="myCoarseMapFact"/>
-      <Parameter name="tentative: calculate qr" type="bool" value="false"/>    </ParameterList>    <ParameterList name="myRestrictorFact">      <Parameter name="factory"                             type="string" value="TransPFactory"/>      <!-- Parameter name="R"                                   type="string" value="myRestrictorFact"/ -->    </ParameterList>    <ParameterList name="myCoordTransferFact">      <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>      <Parameter name="structured aggregation"              type="bool"   value="true"/>      <Parameter name="gCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>      <Parameter name="lCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>    </ParameterList>    <ParameterList name="myRAPFact">      <Parameter name="factory"                             type="string" value="RAPFactory"/>      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>      <Parameter name="R"                                   type="string" value="myRestrictorFact"/>      <ParameterList name="TransferFactories">        <Parameter name="CoordinateTransfer"                type="string" value="myCoordTransferFact"/>      </ParameterList>    </ParameterList>    <ParameterList name="myILU">      <Parameter name="factory" type="string" value="TrilinosSmoother"/>      <Parameter name="type"  type="string" value="RILUK"/>      <ParameterList name="ParameterList">        <Parameter name="schwarz: overlap level"            type="int"    value="1"/>        <Parameter name="schwarz: combine mode"             type="string" value="Zero"/>        <Parameter name="schwarz: use reordering"           type="bool"   value="false"/>        <Parameter name="fact: iluk level-of-fill"         type="int"    value="0"/>        <Parameter name="fact: absolute threshold"         type="double" value="0."/>        <Parameter name="fact: relative threshold"         type="double" value="1."/>        <Parameter name="fact: relax value"                type="double" value="0."/>      </ParameterList>    </ParameterList>
+      <Parameter name="tentative: calculate qr" type="bool" value="false"/>
+    </ParameterList>
+
+    <ParameterList name="myRestrictorFact">
+      <Parameter name="factory"                             type="string" value="TransPFactory"/>
+      <!-- Parameter name="R"                                   type="string" value="myRestrictorFact"/ -->
+    </ParameterList>
+
+    <ParameterList name="myCoordTransferFact">
+      <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>
+      <Parameter name="structured aggregation"              type="bool"   value="true"/>
+      <Parameter name="gCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>
+      <Parameter name="lCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
+      <ParameterList name="TransferFactories">
+        <Parameter name="CoordinateTransfer"                type="string" value="myCoordTransferFact"/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="myILU">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"  type="string" value="RILUK"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="schwarz: overlap level"            type="int"    value="1"/>
+        <Parameter name="schwarz: combine mode"             type="string" value="Zero"/>
+        <Parameter name="schwarz: use reordering"           type="bool"   value="false"/>
+        <Parameter name="fact: iluk level-of-fill"         type="int"    value="0"/>
+        <Parameter name="fact: absolute threshold"         type="double" value="0."/>
+        <Parameter name="fact: relative threshold"         type="double" value="1."/>
+        <Parameter name="fact: relax value"                type="double" value="0."/>
+      </ParameterList>
+    </ParameterList>
     
     <ParameterList name="myJacobi">
       <Parameter name="factory" type="string" value="TrilinosSmoother"/>
@@ -16,4 +78,32 @@
         <Parameter name="relaxation: sweeps" type="int" value="1"/>
         <Parameter name="relaxation: damping factor" type="double" value="1.0"/>
       </ParameterList>
-    </ParameterList>  </ParameterList>  <!-- Definition of the multigrid preconditioner -->  <ParameterList name="Hierarchy">    <Parameter name="max levels"                            type="int"      value="3"/> <!-- Max number of levels -->    <Parameter name="cycle type"                            type="string"   value="V"/>    <Parameter name="coarse: max size"                      type="int"      value="2"/> <!-- Min number of rows on coarsest level -->    <Parameter name="verbosity"                             type="string"   value="Extreme"/>    <ParameterList name="All">      <Parameter name="Smoother"                         type="string"   value="myJacobi"/>      <Parameter name="Nullspace"                           type="string"   value="myProlongatorFact"/>      <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>      <Parameter name="A"                                   type="string"   value="myRAPFact"/>      <Parameter name="CoarseSolver"                        type="string"   value="myJacobi"/>      <!--Parameter name="Coordinates"                         type="string"   value="myCoordTransferFact"/-->      <Parameter name="gNodesPerDim"                        type="string"   value="myCoordTransferFact"/>      <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>      <!--Parameter name="CoarseNumZLayers"                    type="string"   value="myLineDetectionFact"/-->      <!--Parameter name="LineDetection_Layers"                type="string"   value="myLineDetectionFact"/-->      <!--Parameter name="LineDetection_VertLineIds"           type="string"   value="myLineDetectionFact"/-->    </ParameterList>  </ParameterList></ParameterList>
+    </ParameterList>
+
+  </ParameterList>
+
+  <!-- Definition of the multigrid preconditioner -->
+  <ParameterList name="Hierarchy">
+    <Parameter name="max levels"                            type="int"      value="2"/> <!-- Max number of levels -->
+    <Parameter name="cycle type"                            type="string"   value="V"/>
+    <Parameter name="coarse: max size"                      type="int"      value="2"/> <!-- Min number of rows on coarsest level -->
+    <Parameter name="verbosity"                             type="string"   value="Extreme"/>
+
+    <ParameterList name="All">
+      <Parameter name="Smoother"                         type="string"   value="myJacobi"/>
+      <Parameter name="Nullspace"                           type="string"   value="myProlongatorFact"/>
+      <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
+      <Parameter name="CoarseSolver"                        type="string"   value="myJacobi"/>
+      <!--Parameter name="Coordinates"                         type="string"   value="myCoordTransferFact"/-->
+      <Parameter name="gNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
+      <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
+      <!--Parameter name="CoarseNumZLayers"                    type="string"   value="myLineDetectionFact"/-->
+      <!--Parameter name="LineDetection_Layers"                type="string"   value="myLineDetectionFact"/-->
+      <!--Parameter name="LineDetection_VertLineIds"           type="string"   value="myLineDetectionFact"/-->
+    </ParameterList>
+  </ParameterList>
+
+</ParameterList>
+

--- a/packages/muelu/research/mmayr/composite_to_regions/src/readRegionFile.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/readRegionFile.m
@@ -1,4 +1,16 @@
-function [myNodes] = readRegionFile(filename,myRank)
+% readRegionFile.m
+%
+% Read region information from file.
+%
+% Input
+%   filename  filename of case file to read
+%   myRank    rank of this processor
+%   inputDir  path to directory with region information
+%
+% Output
+%   myNodes   list of nodes owned by this processor
+%
+function [myNodes] = readRegionFile(filename,myRank,inputDir)
 
 %
 % Construct the list myNodes of ndoes that I own or share for proc 'myRank'.
@@ -16,7 +28,7 @@ function [myNodes] = readRegionFile(filename,myRank)
 % entries corresponding to shared ids are consecutive.
 
 
-fp = fopen(filename,'r');
+fp = fopen(sprintf('%s/%s', inputDir, filename), 'r');
 if (fp == -1)
   error('Cannot read %s \n',filename);
 end

--- a/packages/muelu/research/mmayr/composite_to_regions/src/regionToProcMap.m
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/regionToProcMap.m
@@ -1,5 +1,4 @@
-function [RegionToProc] = regionToProcMap(myNodes,myRank,filename)
-
+% regionToProcMap.m
 %
 % This function fills
 %
@@ -13,7 +12,17 @@ function [RegionToProc] = regionToProcMap(myNodes,myRank,filename)
 % Normally, this calculation might be a bit involved in parallel with some
 % communication or fancy Trilinos calls. In this case, we just compute it
 % from the file.
-
+%
+% Input
+%   mynodes   list of nodes owned by this processor
+%   myRank    rank of this processor
+%   filename  name of file with region-to-proc mapping data
+%   inputDir  path to directory with input data
+%
+% Output
+%   RegionToProc  mapping of regions to processors
+%
+function [RegionToProc] = regionToProcMap(myNodes,myRank,filename,inputDir)
 
 %
 % figure out the number of regions that I at least partially own
@@ -49,7 +58,7 @@ regionList = sort(regionList);
 % Trilinos function to compute. Here, we just read it from the file and 
 % figure things out in a slow clumsy way.
 
-fp = fopen(filename,'r');
+fp = fopen(sprintf('%s/%s', inputDir, filename), 'r');
 if (fp == -1)
   error('Cannot read %s \n',filename);
 end


### PR DESCRIPTION
@trilinos/muelu 

## Description
All region-related data files are now written into a user-specified subdirectory to keep the directory structure clean.

* Specify path directory for region data files in Matlab script `createInput.m`
as well as on the command line (command line argument --regDataDir)
* Save/read all region-related input data from this directory
* Rename file `readRegionalFile.m` to `readRegionFile.m` to avoid Matlab warning

## Motivation and Context
Keeping the directory structure clean and moving problem specific output to a subdirectory.

## Related Issues
* Closes #3061 
* Related to #2709 

## How Has This Been Tested?
Results of toy problems did not change. However, there is no actual test yet.

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.