### PR TITLE
Increase KNL testing timeout from 5 to 9 hours (TRIL-196)

### DIFF
--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-KNL.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-KNL.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=ATDM
 fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=300 # 5 hour time limit
+
+if [ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
+  export SALLOC_CTEST_TIME_LIMIT_MINUTES=540 # 9 hour time limit
+fi
+
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh

--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-opt-openmp-KNL.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-opt-openmp-KNL.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=ATDM
 fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=300 # 5 hour time limit
+
+if [ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
+  export SALLOC_CTEST_TIME_LIMIT_MINUTES=540 # 9 hour time limit
+fi
+
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh


### PR DESCRIPTION
@fryeguy52 

## Description

The tests on the KNL build are taking an absurd amount of time but let's see
if we can get them to complete in 9 hours!  AT the old timeout of 5 hours it
the debug build ran 1504 out of 1801 tests so I am hopeful this will allow
them to complete.

This is only taking up one compute node on 'mutrino' so this is not such a
crime at this point.

This is being driven by [TRIL-196](https://software-sandbox.sandia.gov/jira/browse/TRIL-196)

## Motivation and Context

Want to see if we can get these tests to complete to see if there are errors.  We can fix the runtime problem later.

## How Has This Been Tested?

I did not test this but the changes are simple and super safe and can only impact these two KNL build (which are just "Specialized" builds currently).
