### PR TITLE
NOX:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/nox/src-epetra/NOX_Epetra_BroydenOperator.C
+++ b/packages/nox/src-epetra/NOX_Epetra_BroydenOperator.C
@@ -342,7 +342,7 @@ const Epetra_BlockMap& BroydenOperator::Map() const
 //-----------------------------------------------------------------------------
 
 bool
-BroydenOperator::computeJacobian( const Epetra_Vector & x, Epetra_Operator& Jac )
+BroydenOperator::computeJacobian( const Epetra_Vector & x, Epetra_Operator& /* Jac */ )
 {
   bool ok = false;
 
@@ -365,8 +365,8 @@ BroydenOperator::computeJacobian( const Epetra_Vector & x, Epetra_Operator& Jac 
 
 bool
 BroydenOperator::computePreconditioner( const Epetra_Vector & x,
-                    Epetra_Operator& Prec,
-                                        Teuchos::ParameterList * pList )
+                    Epetra_Operator& /* Prec */,
+                                        Teuchos::ParameterList * /* pList */ )
 {
   bool ok = false;
 

--- a/packages/nox/src-epetra/NOX_Epetra_FiniteDifference.C
+++ b/packages/nox/src-epetra/NOX_Epetra_FiniteDifference.C
@@ -480,14 +480,14 @@ bool FiniteDifference::computeJacobian(const Epetra_Vector& x, Epetra_Operator& 
 }
 
 bool FiniteDifference::computePreconditioner(const Epetra_Vector& x,
-                         Epetra_Operator& Prec,
-                         Teuchos::ParameterList* precParams)
+                         Epetra_Operator& /* Prec */,
+                         Teuchos::ParameterList* /* precParams */)
 {
   return computeJacobian(x, *this);
 }
 
 Teuchos::RCP<Epetra_CrsMatrix> FiniteDifference::
-createGraphAndJacobian(Interface::Required& i, const Epetra_Vector& x)
+createGraphAndJacobian(Interface::Required& /* i */, const Epetra_Vector& x)
 {
 
   const Epetra_BlockMap& map = fo.Map();

--- a/packages/nox/src-epetra/NOX_Epetra_LinearSystem_Amesos.C
+++ b/packages/nox/src-epetra/NOX_Epetra_LinearSystem_Amesos.C
@@ -60,7 +60,7 @@ NOX::Epetra::LinearSystemAmesos::
 LinearSystemAmesos(
   Teuchos::ParameterList& printingParams,
   Teuchos::ParameterList& linearSolverParams,
-  const Teuchos::RCP<NOX::Epetra::Interface::Required>& iReq,
+  const Teuchos::RCP<NOX::Epetra::Interface::Required>& /* iReq */,
   const Teuchos::RCP<NOX::Epetra::Interface::Jacobian>& iJac,
   const Teuchos::RCP<Epetra_Operator>& J,
   const NOX::Epetra::Vector& cloneVector,
@@ -119,7 +119,7 @@ applyJacobianTranspose(const NOX::Epetra::Vector& input,
 }
 
 bool NOX::Epetra::LinearSystemAmesos::
-applyJacobianInverse(Teuchos::ParameterList &params,
+applyJacobianInverse(Teuchos::ParameterList &/* params */,
                       const NOX::Epetra::Vector &input,
                       NOX::Epetra::Vector &result)
 {
@@ -156,10 +156,10 @@ applyJacobianInverse(Teuchos::ParameterList &params,
 }
 
 bool NOX::Epetra::LinearSystemAmesos::
-applyRightPreconditioning(bool useTranspose,
-                        Teuchos::ParameterList& params,
-                        const NOX::Epetra::Vector& input,
-                        NOX::Epetra::Vector& result) const
+applyRightPreconditioning(bool /* useTranspose */,
+                        Teuchos::ParameterList& /* params */,
+                        const NOX::Epetra::Vector& /* input */,
+                        NOX::Epetra::Vector& /* result */) const
 {
   return false;
 }
@@ -187,9 +187,9 @@ computeJacobian(const NOX::Epetra::Vector& x)
 }
 
 bool NOX::Epetra::LinearSystemAmesos::
-createPreconditioner(const NOX::Epetra::Vector& x,
-                      Teuchos::ParameterList& p,
-                      bool recomputeGraph) const
+createPreconditioner(const NOX::Epetra::Vector& /* x */,
+                      Teuchos::ParameterList& /* p */,
+                      bool /* recomputeGraph */) const
 {
   return false;
 }
@@ -201,15 +201,15 @@ destroyPreconditioner() const
 }
 
 bool NOX::Epetra::LinearSystemAmesos::
-recomputePreconditioner(const NOX::Epetra::Vector& x,
-              Teuchos::ParameterList& linearSolverParams) const
+recomputePreconditioner(const NOX::Epetra::Vector& /* x */,
+              Teuchos::ParameterList& /* linearSolverParams */) const
 {
   return false;
 }
 
 NOX::Epetra::LinearSystem::PreconditionerReusePolicyType
 NOX::Epetra::LinearSystemAmesos::
-getPreconditionerPolicy(bool advanceReuseCounter)
+getPreconditionerPolicy(bool /* advanceReuseCounter */)
 {
   return PRPT_REUSE;
 }
@@ -261,7 +261,7 @@ setJacobianOperatorForSolve(const
 
 void NOX::Epetra::LinearSystemAmesos::
 setPrecOperatorForSolve(const
-           Teuchos::RCP<const Epetra_Operator>& solvePrecOp)
+           Teuchos::RCP<const Epetra_Operator>& /* solvePrecOp */)
 {
   return;
 }

--- a/packages/nox/src-epetra/NOX_Epetra_LinearSystem_AztecOO.C
+++ b/packages/nox/src-epetra/NOX_Epetra_LinearSystem_AztecOO.C
@@ -880,7 +880,7 @@ bool NOX::Epetra::LinearSystemAztecOO::checkPreconditionerValidity()
 //***********************************************************************
 bool NOX::Epetra::LinearSystemAztecOO::
 createPreconditioner(const NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
-             bool recomputeGraph) const
+             bool /* recomputeGraph */) const
 {
   double startTime = timer.WallTime();
 

--- a/packages/nox/src-epetra/NOX_Epetra_LinearSystem_Stratimikos.C
+++ b/packages/nox/src-epetra/NOX_Epetra_LinearSystem_Stratimikos.C
@@ -423,10 +423,10 @@ applyJacobianInverse(Teuchos::ParameterList &p,
 
 //***********************************************************************
 bool NOX::Epetra::LinearSystemStratimikos::
-applyRightPreconditioning(bool useTranspose,
-              Teuchos::ParameterList& params,
-              const NOX::Epetra::Vector& input,
-              NOX::Epetra::Vector& result) const
+applyRightPreconditioning(bool /* useTranspose */,
+              Teuchos::ParameterList& /* params */,
+              const NOX::Epetra::Vector& /* input */,
+              NOX::Epetra::Vector& /* result */) const
 {
 
 std::cout << " NOX::Epetra::LinearSystemStratimikos::applyRightPreconditioning\n"
@@ -437,7 +437,7 @@ return false;
 //***********************************************************************
 bool NOX::Epetra::LinearSystemStratimikos::
 createPreconditioner(const NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
-             bool recomputeGraph) const
+             bool /* recomputeGraph */) const
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -557,8 +557,8 @@ createPreconditioner(const NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
 
 //***********************************************************************
 bool NOX::Epetra::LinearSystemStratimikos::
-recomputePreconditioner(const NOX::Epetra::Vector& x,
-            Teuchos::ParameterList& linearSolverParams) const
+recomputePreconditioner(const NOX::Epetra::Vector& /* x */,
+            Teuchos::ParameterList& /* linearSolverParams */) const
 {
 std::cout << " NOX::Epetra::LinearSystemStratimikos::recomputePreconditioner\n"
      << " NOT IMPLEMENTED " << std::endl;

--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -227,7 +227,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
   return 0;
 }
 
-int MatrixFree::ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+int MatrixFree::ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   utils.out() << "ERROR: NOX::MatrixFree::ApplyInverse - Not available for Matrix Free!"
        << std::endl;
@@ -273,7 +273,7 @@ const Epetra_Map& MatrixFree::OperatorRangeMap() const
   return *epetraMap;
 }
 
-bool MatrixFree::computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)
+bool MatrixFree::computeJacobian(const Epetra_Vector& x, Epetra_Operator& /* Jac */)
 {
   // Since we have no explicit Jacobian we set our currentX to the
   // incoming value and evaluate the RHS.  When the Jacobian is applied,

--- a/packages/nox/src-epetra/NOX_Epetra_ModelEvaluatorInterface.C
+++ b/packages/nox/src-epetra/NOX_Epetra_ModelEvaluatorInterface.C
@@ -121,7 +121,7 @@ computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jaco)
 bool NOX::Epetra::ModelEvaluatorInterface::
 computePreconditioner(const Epetra_Vector& x,
               Epetra_Operator& M,
-              Teuchos::ParameterList* precParams)
+              Teuchos::ParameterList* /* precParams */)
 {
   EpetraExt::ModelEvaluator::OutArgs outargs = model_->createOutArgs();
 

--- a/packages/nox/src-epetra/NOX_Epetra_Observer.H
+++ b/packages/nox/src-epetra/NOX_Epetra_Observer.H
@@ -64,7 +64,7 @@ public:
   virtual void observeSolution(const Epetra_Vector& soln) = 0;
 
   //! LOCA calls this version, which will discard param info in this default implementation
-  virtual void observeSolution(const Epetra_Vector& soln, double time_or_param_val)
+  virtual void observeSolution(const Epetra_Vector& soln, double /* time_or_param_val */)
   { observeSolution(soln); };
 
 private:

--- a/packages/nox/src-epetra/NOX_Epetra_Vector.C
+++ b/packages/nox/src-epetra/NOX_Epetra_Vector.C
@@ -326,7 +326,7 @@ double NOX::Epetra::Vector::norm(const NOX::Abstract::Vector& weights) const
   return norm(dynamic_cast<const NOX::Epetra::Vector&>(weights));
 }
 
-double NOX::Epetra::Vector::norm(const NOX::Epetra::Vector& weights) const
+double NOX::Epetra::Vector::norm(const NOX::Epetra::Vector& /* weights */) const
 {
     std::cerr << "NOX::Epetra::Vector - Weighted norm not supported" << std::endl;
     throw "NOX-Epetra Error";

--- a/packages/nox/src-lapack/NOX_LAPACK_Group.C
+++ b/packages/nox/src-lapack/NOX_LAPACK_Group.C
@@ -307,7 +307,7 @@ NOX::LAPACK::Group::applyJacobianInverse(Teuchos::ParameterList& p,
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::LAPACK::Group::applyJacobianInverse(Teuchos::ParameterList& p,
+NOX::LAPACK::Group::applyJacobianInverse(Teuchos::ParameterList& /* p */,
                      const Vector& input,
                      Vector& result) const
 {
@@ -326,7 +326,7 @@ NOX::LAPACK::Group::applyJacobianInverse(Teuchos::ParameterList& p,
 
 NOX::Abstract::Group::ReturnType
 NOX::LAPACK::Group::applyJacobianInverseMultiVector(
-                     Teuchos::ParameterList& p,
+                     Teuchos::ParameterList& /* p */,
                      const NOX::Abstract::MultiVector& input,
                      NOX::Abstract::MultiVector& result) const
 {

--- a/packages/nox/src-lapack/NOX_LAPACK_Vector.C
+++ b/packages/nox/src-lapack/NOX_LAPACK_Vector.C
@@ -72,7 +72,7 @@ NOX::LAPACK::Vector::Vector(int N, double *v) :
 }
 
 NOX::LAPACK::Vector::Vector(const NOX::LAPACK::Vector& source,
-                NOX::CopyType type) :
+                NOX::CopyType /* type */) :
   n(source.n),
   x(source.x)
 {

--- a/packages/nox/src-loca/src-epetra/LOCA_BorderedSolver_EpetraAugmented.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_BorderedSolver_EpetraAugmented.C
@@ -63,7 +63,7 @@
 
 LOCA::BorderedSolver::EpetraAugmented::EpetraAugmented(
      const Teuchos::RCP<LOCA::GlobalData>& global_data,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
      const Teuchos::RCP<Teuchos::ParameterList>& slvrParams):
   globalData(global_data),
   solverParams(slvrParams),

--- a/packages/nox/src-loca/src-epetra/LOCA_BorderedSolver_EpetraAugmented.H
+++ b/packages/nox/src-loca/src-epetra/LOCA_BorderedSolver_EpetraAugmented.H
@@ -234,11 +234,11 @@ namespace LOCA {
        * The \em params argument is the linear solver parameters.
        */
       virtual NOX::Abstract::Group::ReturnType
-      applyInverseTranspose(Teuchos::ParameterList& params,
-                const NOX::Abstract::MultiVector* F,
-                const NOX::Abstract::MultiVector::DenseMatrix* G,
-                NOX::Abstract::MultiVector& X,
-                NOX::Abstract::MultiVector::DenseMatrix& Y) const {
+      applyInverseTranspose(Teuchos::ParameterList& /* params */,
+                const NOX::Abstract::MultiVector* /* F */,
+                const NOX::Abstract::MultiVector::DenseMatrix* /* G */,
+                NOX::Abstract::MultiVector& /* X */,
+                NOX::Abstract::MultiVector::DenseMatrix& /* Y */) const {
     return NOX::Abstract::Group::NotDefined;
       }
 

--- a/packages/nox/src-loca/src-epetra/LOCA_BorderedSolver_EpetraHouseholder.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_BorderedSolver_EpetraHouseholder.C
@@ -79,7 +79,7 @@
 
 LOCA::BorderedSolver::EpetraHouseholder::EpetraHouseholder(
      const Teuchos::RCP<LOCA::GlobalData>& global_data,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
      const Teuchos::RCP<Teuchos::ParameterList>& slvrParams):
   globalData(global_data),
   solverParams(slvrParams),

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_AdaptiveStepper.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_AdaptiveStepper.C
@@ -393,7 +393,7 @@ LOCA::Epetra::AdaptiveStepper::start() {
 }
 
 LOCA::Abstract::Iterator::IteratorStatus
-LOCA::Epetra::AdaptiveStepper::finish(LOCA::Abstract::Iterator::IteratorStatus itStatus)
+LOCA::Epetra::AdaptiveStepper::finish(LOCA::Abstract::Iterator::IteratorStatus /* itStatus */)
 {
   std::string callingFunction = "LOCA_AdaptiveStepper::finish()";
 
@@ -786,7 +786,7 @@ LOCA::Epetra::AdaptiveStepper::iterate()
 }
 
 LOCA::Abstract::Iterator::StepStatus
-LOCA::Epetra::AdaptiveStepper::compute(LOCA::Abstract::Iterator::StepStatus stepStatus)
+LOCA::Epetra::AdaptiveStepper::compute(LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
   NOX::StatusTest::StatusType solverStatus;
 

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_AnasaziOperator_Floquet.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_AnasaziOperator_Floquet.C
@@ -53,7 +53,7 @@
 
 LOCA::Epetra::AnasaziOperator::Floquet::Floquet(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams_,
     const Teuchos::RCP<Teuchos::ParameterList>& solverParams_,
     const Teuchos::RCP<NOX::Abstract::Group>& grp_)
@@ -158,8 +158,8 @@ LOCA::Epetra::AnasaziOperator::Floquet::apply(const NOX::Abstract::MultiVector& 
 }
 
 void
-LOCA::Epetra::AnasaziOperator::Floquet::transformEigenvalue(double& ev_r,
-                           double& ev_i) const
+LOCA::Epetra::AnasaziOperator::Floquet::transformEigenvalue(double& /* ev_r */,
+                           double& /* ev_i */) const
 {
   // Floquet multipliers need no transformations
 }

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_CompactWYOp.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_CompactWYOp.C
@@ -125,8 +125,8 @@ LOCA::Epetra::CompactWYOp::Apply(const Epetra_MultiVector& Input,
 }
 
 int
-LOCA::Epetra::CompactWYOp::ApplyInverse(const Epetra_MultiVector& cInput,
-                    Epetra_MultiVector& Result) const
+LOCA::Epetra::CompactWYOp::ApplyInverse(const Epetra_MultiVector& /* cInput */,
+                    Epetra_MultiVector& /* Result */) const
 {
   globalData->locaErrorCheck->throwError(
       "LOCA::Epetra::CompactWYOp::ApplyInverse",

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_MultiPoint.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_MultiPoint.C
@@ -159,7 +159,7 @@ computeF(const Epetra_Vector& x, Epetra_Vector& F, const FillType fillFlag)
 }
 
 bool LOCA::Epetra::Interface::MultiPoint::
-computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)
+computeJacobian(const Epetra_Vector& x, Epetra_Operator& /* Jac */)
 {
   bool stat = true;
   jacobian->PutScalar(0.0);

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_Required.H
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_Required.H
@@ -103,8 +103,8 @@ namespace LOCA {
     virtual void setParameters(const ParameterVector& p) = 0;
 
     //! Call user's own print routine for vector-parameter pair
-    virtual void printSolution(const Epetra_Vector& x_,
-                   double conParam) {}
+    virtual void printSolution(const Epetra_Vector& /* x_ */,
+                   double /* conParam */) {}
 
         /*!
           \brief Provides data to application for output files.
@@ -114,15 +114,15 @@ namespace LOCA {
           and gives the application some indices that can be used for
           creating a unique name/index for the output files.
         */
-        virtual void dataForPrintSolution(const int conStep, const int timeStep,
-                                          const int totalTimeSteps) {};
+        virtual void dataForPrintSolution(const int /* conStep */, const int /* timeStep */,
+                                          const int /* totalTimeSteps */) {};
 
     /*!
       \brief Set multipoint parameter in the user's application.
 
       Should be called prior to calling one of the compute functions.
     */
-        virtual void setMultiPointParameter(const int stepNum) {};
+        virtual void setMultiPointParameter(const int /* stepNum */) {};
 
 
     //! Perform any preprocessing before a continuation step starts.
@@ -132,8 +132,8 @@ namespace LOCA {
      */
     virtual void
     preProcessContinuationStep(
-                 LOCA::Abstract::Iterator::StepStatus stepStatus,
-                 LOCA::Epetra::Group& group) {}
+                 LOCA::Abstract::Iterator::StepStatus /* stepStatus */,
+                 LOCA::Epetra::Group& /* group */) {}
 
     //! Perform any postprocessing after a continuation step finishes.
     /*!
@@ -142,8 +142,8 @@ namespace LOCA {
      */
     virtual void
     postProcessContinuationStep(
-                 LOCA::Abstract::Iterator::StepStatus stepStatus,
-                 LOCA::Epetra::Group& group) {}
+                 LOCA::Abstract::Iterator::StepStatus /* stepStatus */,
+                 LOCA::Epetra::Group& /* group */) {}
 
     /*!
       \brief Projects solution to a few scalars for

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_TimeDependent.H
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_TimeDependent.H
@@ -103,7 +103,7 @@ namespace LOCA {
           for cases when computeF, computeJacobian, computeMassMatrix fills
           are functions of time (nonautonomous systems).
         */
-        virtual void setXdot(const Epetra_Vector& xdot, const double time) {
+        virtual void setXdot(const Epetra_Vector& /* xdot */, const double /* time */) {
       std::cout << "WARNING: "
             << "LOCA::Epetra::Interface::TimeDependent::setXdot"
             << "\n\tempty default implementation not overloaded!" << std::endl;

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_xyzt.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_Interface_xyzt.C
@@ -214,7 +214,7 @@ computeF(const Epetra_Vector& x, Epetra_Vector& F, const FillType fillFlag)
 }
 
 bool LOCA::Epetra::Interface::xyzt::
-computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)
+computeJacobian(const Epetra_Vector& x, Epetra_Operator& /* Jac */)
 {
   bool stat = true;
   jacobian->PutScalar(0.0);

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_ModelEvaluatorInterface.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_ModelEvaluatorInterface.C
@@ -170,7 +170,7 @@ computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)
 bool LOCA::Epetra::ModelEvaluatorInterface::
 computePreconditioner(const Epetra_Vector& x,
               Epetra_Operator& M,
-              Teuchos::ParameterList* precParams)
+              Teuchos::ParameterList* /* precParams */)
 {
   // Create inargs
   EpetraExt::ModelEvaluator::InArgs inargs = model_->createInArgs();
@@ -250,7 +250,7 @@ computeShiftedMatrix(double alpha, double beta, const Epetra_Vector& x,
 // *****************************************************************
 // *****************************************************************
 void LOCA::Epetra::ModelEvaluatorInterface::
-setXdot(const Epetra_Vector& xdot_, const double time_)
+setXdot(const Epetra_Vector& xdot_, const double /* time_ */)
 {
   if (x_dot == NULL)
     x_dot = new Epetra_Vector(xdot_.Map());
@@ -340,7 +340,7 @@ ModelEvaluatorInterface(const LOCA::Epetra::ModelEvaluatorInterface& m) :
 
 Teuchos::RCP<LOCA::DerivUtils>
 LOCA::Epetra::ModelEvaluatorInterface::
-clone(NOX::CopyType type) const
+clone(NOX::CopyType /* type */) const
 {
   return Teuchos::rcp(new LOCA::Epetra::ModelEvaluatorInterface(*this));
 }

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_ShiftInvertOperator.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_ShiftInvertOperator.C
@@ -111,8 +111,8 @@ LOCA::Epetra::ShiftInvertOperator::Apply(const Epetra_MultiVector& X,
 }
 
 int
-LOCA::Epetra::ShiftInvertOperator::ApplyInverse(const Epetra_MultiVector& X,
-                        Epetra_MultiVector&Y) const
+LOCA::Epetra::ShiftInvertOperator::ApplyInverse(const Epetra_MultiVector& /* X */,
+                        Epetra_MultiVector&/* Y */) const
 {
   globalData->locaErrorCheck->throwError(
       "LOCA::Epetra::ShiftInvertOperator::ApplyInverse",

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_ShiftInvertOperator.H
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_ShiftInvertOperator.H
@@ -78,8 +78,8 @@ namespace LOCA {
       ~ShiftInvertInterface() {};
 
       //! Compute Jacobian \f$J\f$.
-      bool computeJacobian(const Epetra_Vector &x,
-               Epetra_Operator& Jac) {return true;};
+      bool computeJacobian(const Epetra_Vector &/* x */,
+               Epetra_Operator& /* Jac */) {return true;};
     };
 
     //! Epetra operator for \f$(J-\sigma M)^{-1}\f$.

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_TransposeLinearSystem_LeftPreconditioning.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_TransposeLinearSystem_LeftPreconditioning.C
@@ -62,7 +62,7 @@
 LOCA::Epetra::TransposeLinearSystem::LeftPreconditioning::
 LeftPreconditioning(
          const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& solverParams,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* solverParams */,
          const Teuchos::RCP<NOX::Epetra::LinearSystem>& linsys_) :
   globalData(global_data),
   linsys(linsys_),

--- a/packages/nox/src-loca/src-epetra/LOCA_Epetra_xyztPrec.C
+++ b/packages/nox/src-loca/src-epetra/LOCA_Epetra_xyztPrec.C
@@ -188,14 +188,14 @@ LOCA::Epetra::xyztPrec::
 
 
 int LOCA::Epetra::xyztPrec::
-SetUseTranspose(bool UseTranspose)
+SetUseTranspose(bool /* UseTranspose */)
 {
   // Disable this option
   return false;
 }
 
 int LOCA::Epetra::xyztPrec::
-Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   // Not implemented: Throw an error!
   std::cout << "ERROR: LOCA::Epetra::xyztPrec::Apply() - "
@@ -536,8 +536,8 @@ computeJacobian(const Epetra_Vector&, Epetra_Operator&)
 
 bool LOCA::Epetra::xyztPrec::
 computePreconditioner(const Epetra_Vector& x,
-              Epetra_Operator& Prec,
-              Teuchos::ParameterList* p)
+              Epetra_Operator& /* Prec */,
+              Teuchos::ParameterList* /* p */)
 {
   //std::cout << "LOCA::Epetra::xyztPrec::computePreconditioner called - ";
   std::string prec = lsParams.get("XYZTPreconditioner","None");

--- a/packages/nox/src-loca/src-epetra/continuation-manager/LOCAInterface.C
+++ b/packages/nox/src-loca/src-epetra/continuation-manager/LOCAInterface.C
@@ -65,14 +65,14 @@ LOCAInterface::
 
 bool LOCAInterface::
 computeF(const Epetra_Vector& x, Epetra_Vector& f,
-     const NOX::Epetra::Interface::Required::FillType F)
+     const NOX::Epetra::Interface::Required::FillType /* F */)
 {
   problem->ComputeF(x,f);
   return true;
 }
 
 bool LOCAInterface::
-computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)
+computeJacobian(const Epetra_Vector& x, Epetra_Operator& /* Jac */)
 {
   problem->ComputeJacF(x);
   return true;
@@ -90,7 +90,7 @@ setParameters(const LOCA::ParameterVector& params)
 }
 
 void LOCAInterface::
-printSolution (const Epetra_Vector &x, const double conParam)
+printSolution (const Epetra_Vector &x, const double /* conParam */)
 {
 
   // Printing a Solution file ****************************************
@@ -133,8 +133,8 @@ printSolution (const Epetra_Vector &x, const double conParam)
 }
 
 bool LOCAInterface::
-computeShiftedMatrix (double alpha, double beta,
-                           const Epetra_Vector &x, Epetra_Operator &A)
+computeShiftedMatrix (double alpha, double /* beta */,
+                           const Epetra_Vector &x, Epetra_Operator &/* A */)
 {
 
 std::cout << " AGS HACK -- LOCAInterface::computeShiftedMatrix RETURNS JACOBIAN!!! " << std::endl;
@@ -147,7 +147,7 @@ std::cout << " AGS HACK -- LOCAInterface::computeShiftedMatrix RETURNS JACOBIAN!
   return true;
 }
 
-void LOCAInterface::setXdot(const Epetra_Vector& xdot, const double time) {
+void LOCAInterface::setXdot(const Epetra_Vector& /* xdot */, const double time) {
   // current problem does not depend on xdot or t
   t = time;
 }

--- a/packages/nox/src-loca/src-epetra/continuation-manager/ProblemLOCAPrototype.C
+++ b/packages/nox/src-loca/src-epetra/continuation-manager/ProblemLOCAPrototype.C
@@ -59,14 +59,14 @@ ProblemLOCAPrototype::~ProblemLOCAPrototype()
 
 
 bool ProblemLOCAPrototype::
-PrintSolutionFile( const std::string & fileName, const Epetra_Vector & x,
-  const Teuchos::ParameterList & xParams)
+PrintSolutionFile( const std::string & /* fileName */, const Epetra_Vector & /* x */,
+  const Teuchos::ParameterList & /* xParams */)
 {
   return true;
 }
 
 bool ProblemLOCAPrototype::
-SetSolutionFileParameters(const Epetra_Vector & x)
+SetSolutionFileParameters(const Epetra_Vector & /* x */)
 {
   return true;
 }
@@ -82,7 +82,7 @@ GetSolutionFileParameters()
 }
 
 bool ProblemLOCAPrototype::
-SetContinuationFileParameters(const Epetra_Vector & x)
+SetContinuationFileParameters(const Epetra_Vector & /* x */)
 {
   return true;
 }
@@ -98,16 +98,16 @@ GetContinuationFileParameters()
 }
 
 bool ProblemLOCAPrototype::
-UpdateContinuationFile( const std::string & fileName,
-  const int & idStep,
-  const Teuchos::ParameterList & continuationFileParams)
+UpdateContinuationFile( const std::string & /* fileName */,
+  const int & /* idStep */,
+  const Teuchos::ParameterList & /* continuationFileParams */)
 {
   return true;
 }
 
 bool ProblemLOCAPrototype::
-ComputePeriodicDirectionDerivative(const Epetra_Vector & x,
-    Epetra_Vector & dx)
+ComputePeriodicDirectionDerivative(const Epetra_Vector & /* x */,
+    Epetra_Vector & /* dx */)
 {
   return true;
 }

--- a/packages/nox/src-loca/src-lapack/LOCA_BorderedSolver_LAPACKDirectSolve.C
+++ b/packages/nox/src-loca/src-lapack/LOCA_BorderedSolver_LAPACKDirectSolve.C
@@ -60,7 +60,7 @@
 
 LOCA::BorderedSolver::LAPACKDirectSolve::LAPACKDirectSolve(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& slvrParams):
   globalData(global_data),
   solverParams(slvrParams),
@@ -527,7 +527,7 @@ LOCA::BorderedSolver::LAPACKDirectSolve::applyInverseTranspose(
 NOX::Abstract::Group::ReturnType
 LOCA::BorderedSolver::LAPACKDirectSolve::solve(
     bool trans,
-    Teuchos::ParameterList& params,
+    Teuchos::ParameterList& /* params */,
     const NOX::Abstract::MultiVector* F,
     const NOX::Abstract::MultiVector::DenseMatrix* G,
     NOX::Abstract::MultiVector& X,

--- a/packages/nox/src-loca/src-lapack/LOCA_LAPACK_Group.C
+++ b/packages/nox/src-loca/src-lapack/LOCA_LAPACK_Group.C
@@ -138,7 +138,7 @@ LOCA::LAPACK::Group::computeJacobian() {
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyJacobianTransposeInverse(
-                     Teuchos::ParameterList& p,
+                     Teuchos::ParameterList& /* p */,
                      const NOX::Abstract::Vector& input,
                      NOX::Abstract::Vector& result) const
 {
@@ -164,7 +164,7 @@ LOCA::LAPACK::Group::applyJacobianTransposeInverse(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyJacobianTransposeInverseMultiVector(
-                     Teuchos::ParameterList& p,
+                     Teuchos::ParameterList& /* p */,
                      const NOX::Abstract::MultiVector& input,
                      NOX::Abstract::MultiVector& result) const
 {
@@ -363,7 +363,7 @@ LOCA::LAPACK::Group::applyShiftedMatrixMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyShiftedMatrixInverseMultiVector(
-                         Teuchos::ParameterList& params,
+                         Teuchos::ParameterList& /* params */,
                      const NOX::Abstract::MultiVector& input,
                      NOX::Abstract::MultiVector& result) const
 {
@@ -405,7 +405,7 @@ LOCA::LAPACK::Group::isComplex() const
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::LAPACK::Group::computeComplex(double frequency)
+LOCA::LAPACK::Group::computeComplex(double /* frequency */)
 {
   std::string callingFunction = "LOCA::LAPACK::computeComplex()";
 
@@ -452,10 +452,10 @@ LOCA::LAPACK::Group::computeComplex(double frequency)
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::LAPACK::Group::applyComplex(const NOX::Abstract::Vector& input_real,
-                  const NOX::Abstract::Vector& input_imag,
-                  NOX::Abstract::Vector& result_real,
-                  NOX::Abstract::Vector& result_imag) const
+LOCA::LAPACK::Group::applyComplex(const NOX::Abstract::Vector& /* input_real */,
+                  const NOX::Abstract::Vector& /* input_imag */,
+                  NOX::Abstract::Vector& /* result_real */,
+                  NOX::Abstract::Vector& /* result_imag */) const
 {
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
@@ -499,10 +499,10 @@ LOCA::LAPACK::Group::applyComplex(const NOX::Abstract::Vector& input_real,
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexMultiVector(
-                const NOX::Abstract::MultiVector& input_real,
-                const NOX::Abstract::MultiVector& input_imag,
-                NOX::Abstract::MultiVector& result_real,
-                NOX::Abstract::MultiVector& result_imag) const
+                const NOX::Abstract::MultiVector& /* input_real */,
+                const NOX::Abstract::MultiVector& /* input_imag */,
+                NOX::Abstract::MultiVector& /* result_real */,
+                NOX::Abstract::MultiVector& /* result_imag */) const
 {
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
@@ -559,11 +559,11 @@ LOCA::LAPACK::Group::applyComplexMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexInverseMultiVector(
-                Teuchos::ParameterList& params,
-                const NOX::Abstract::MultiVector& input_real,
-                const NOX::Abstract::MultiVector& input_imag,
-                NOX::Abstract::MultiVector& result_real,
-                NOX::Abstract::MultiVector& result_imag) const
+                Teuchos::ParameterList& /* params */,
+                const NOX::Abstract::MultiVector& /* input_real */,
+                const NOX::Abstract::MultiVector& /* input_imag */,
+                NOX::Abstract::MultiVector& /* result_real */,
+                NOX::Abstract::MultiVector& /* result_imag */) const
 {
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
@@ -622,10 +622,10 @@ LOCA::LAPACK::Group::applyComplexInverseMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexTranspose(
-                  const NOX::Abstract::Vector& input_real,
-                  const NOX::Abstract::Vector& input_imag,
-                  NOX::Abstract::Vector& result_real,
-                  NOX::Abstract::Vector& result_imag) const
+                  const NOX::Abstract::Vector& /* input_real */,
+                  const NOX::Abstract::Vector& /* input_imag */,
+                  NOX::Abstract::Vector& /* result_real */,
+                  NOX::Abstract::Vector& /* result_imag */) const
 {
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
@@ -669,10 +669,10 @@ LOCA::LAPACK::Group::applyComplexTranspose(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexTransposeMultiVector(
-                const NOX::Abstract::MultiVector& input_real,
-                const NOX::Abstract::MultiVector& input_imag,
-                NOX::Abstract::MultiVector& result_real,
-                NOX::Abstract::MultiVector& result_imag) const
+                const NOX::Abstract::MultiVector& /* input_real */,
+                const NOX::Abstract::MultiVector& /* input_imag */,
+                NOX::Abstract::MultiVector& /* result_real */,
+                NOX::Abstract::MultiVector& /* result_imag */) const
 {
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
@@ -729,11 +729,11 @@ LOCA::LAPACK::Group::applyComplexTransposeMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexTransposeInverseMultiVector(
-                Teuchos::ParameterList& params,
-                const NOX::Abstract::MultiVector& input_real,
-                const NOX::Abstract::MultiVector& input_imag,
-                NOX::Abstract::MultiVector& result_real,
-                NOX::Abstract::MultiVector& result_imag) const
+                Teuchos::ParameterList& /* params */,
+                const NOX::Abstract::MultiVector& /* input_real */,
+                const NOX::Abstract::MultiVector& /* input_imag */,
+                NOX::Abstract::MultiVector& /* result_real */,
+                NOX::Abstract::MultiVector& /* result_imag */) const
 {
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian

--- a/packages/nox/src-loca/src-lapack/LOCA_LAPACK_Interface.H
+++ b/packages/nox/src-loca/src-lapack/LOCA_LAPACK_Interface.H
@@ -85,8 +85,8 @@ namespace LOCA {
       virtual void setParams(const ParameterVector& p) = 0;
 
       //! Call user's own print routine for vector-parameter pair
-      virtual void printSolution(const NOX::LAPACK::Vector& x_,
-                                 const double conParam) {}
+      virtual void printSolution(const NOX::LAPACK::Vector& /* x_ */,
+                                 const double /* conParam */) {}
 
       /*!
        * \brief Compute shifted matrix alpha*J + beta*M where J is the

--- a/packages/nox/src-loca/src-thyra/LOCA_AdaptiveStepper.C
+++ b/packages/nox/src-loca/src-thyra/LOCA_AdaptiveStepper.C
@@ -391,7 +391,7 @@ LOCA::AdaptiveStepper::start() {
 }
 
 LOCA::Abstract::Iterator::IteratorStatus
-LOCA::AdaptiveStepper::finish(LOCA::Abstract::Iterator::IteratorStatus itStatus)
+LOCA::AdaptiveStepper::finish(LOCA::Abstract::Iterator::IteratorStatus /* itStatus */)
 {
   std::string callingFunction = "LOCA_AdaptiveStepper::finish()";
 
@@ -819,7 +819,7 @@ LOCA::AdaptiveStepper::iterate()
 }
 
 LOCA::Abstract::Iterator::StepStatus
-LOCA::AdaptiveStepper::compute(LOCA::Abstract::Iterator::StepStatus stepStatus)
+LOCA::AdaptiveStepper::compute(LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
   NOX::StatusTest::StatusType solverStatus;
 

--- a/packages/nox/src-loca/src-thyra/LOCA_Thyra_SaveDataStrategy.H
+++ b/packages/nox/src-loca/src-thyra/LOCA_Thyra_SaveDataStrategy.H
@@ -77,7 +77,7 @@ namespace LOCA {
        * \returns ReturnType code indicating success or failure
        */
       virtual void
-      saveSolution(const NOX::Abstract::Vector& x, double p) {}
+      saveSolution(const NOX::Abstract::Vector& /* x */, double /* p */) {}
 
       //! Perform any preprocessing before a continuation step starts.
       /*!
@@ -86,7 +86,7 @@ namespace LOCA {
        */
       virtual void
       preProcessContinuationStep(
-                LOCA::Abstract::Iterator::StepStatus stepStatus) {}
+                LOCA::Abstract::Iterator::StepStatus /* stepStatus */) {}
 
       //! Perform any postprocessing after a continuation step finishes.
       /*!
@@ -95,7 +95,7 @@ namespace LOCA {
        */
       virtual void
       postProcessContinuationStep(
-                LOCA::Abstract::Iterator::StepStatus stepStatus) {}
+                LOCA::Abstract::Iterator::StepStatus /* stepStatus */) {}
 
       //! Projects solution to a few scalars for multiparameter continuation
       /*!
@@ -105,8 +105,8 @@ namespace LOCA {
        * The array \c px will be preallocated to the proper length
        * given by projectToDrawDimension().
        */
-      virtual void projectToDraw(const NOX::Abstract::Vector& x,
-                 double *px) const {}
+      virtual void projectToDraw(const NOX::Abstract::Vector& /* x */,
+                 double */* px */) const {}
 
       //! Returns the dimension of the project to draw array
       virtual int projectToDrawDimension() const { return 0; }

--- a/packages/nox/src-loca/src/LOCA_Abstract_Factory.C
+++ b/packages/nox/src-loca/src/LOCA_Abstract_Factory.C
@@ -52,126 +52,126 @@
 
 bool
 LOCA::Abstract::Factory::createPredictorStrategy(
-        const std::string& strategyName,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& predictorParams,
-    Teuchos::RCP<LOCA::MultiPredictor::AbstractStrategy>& strategy)
+        const std::string& /* strategyName */,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* predictorParams */,
+    Teuchos::RCP<LOCA::MultiPredictor::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createContinuationStrategy(
-    const std::string& strategyName,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& stepperParams,
-    const Teuchos::RCP<LOCA::MultiContinuation::AbstractGroup>& grp,
-    const Teuchos::RCP<LOCA::MultiPredictor::AbstractStrategy>& pred,
-    const std::vector<int>& paramIDs,
-    Teuchos::RCP<LOCA::MultiContinuation::AbstractStrategy>& strategy)
+    const std::string& /* strategyName */,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* stepperParams */,
+    const Teuchos::RCP<LOCA::MultiContinuation::AbstractGroup>& /* grp */,
+    const Teuchos::RCP<LOCA::MultiPredictor::AbstractStrategy>& /* pred */,
+    const std::vector<int>& /* paramIDs */,
+    Teuchos::RCP<LOCA::MultiContinuation::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createBifurcationStrategy(
-    const std::string& strategyName,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& bifurcationParams,
-    const Teuchos::RCP<LOCA::MultiContinuation::AbstractGroup>& grp,
-    Teuchos::RCP<LOCA::MultiContinuation::AbstractGroup>& strategy)
+    const std::string& /* strategyName */,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* bifurcationParams */,
+    const Teuchos::RCP<LOCA::MultiContinuation::AbstractGroup>& /* grp */,
+    Teuchos::RCP<LOCA::MultiContinuation::AbstractGroup>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createStepSizeStrategy(
-        const std::string& strategyName,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& stepsizeParams,
-    Teuchos::RCP<LOCA::StepSize::AbstractStrategy>& strategy)
+        const std::string& /* strategyName */,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* stepsizeParams */,
+    Teuchos::RCP<LOCA::StepSize::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createBorderedSolverStrategy(
-        const std::string& strategyName,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& solverParams,
-    Teuchos::RCP<LOCA::BorderedSolver::AbstractStrategy>& strategy)
+        const std::string& /* strategyName */,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* solverParams */,
+    Teuchos::RCP<LOCA::BorderedSolver::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createEigensolverStrategy(
-         const std::string& strategyName,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams,
-     Teuchos::RCP<LOCA::Eigensolver::AbstractStrategy>& strategy)
+         const std::string& /* strategyName */,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+     const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */,
+     Teuchos::RCP<LOCA::Eigensolver::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createEigenvalueSortStrategy(
-        const std::string& strategyName,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& eigenParams,
-    Teuchos::RCP<LOCA::EigenvalueSort::AbstractStrategy>& strategy)
+        const std::string& /* strategyName */,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */,
+    Teuchos::RCP<LOCA::EigenvalueSort::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createSaveEigenDataStrategy(
-         const std::string& strategyName,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams,
-     Teuchos::RCP<LOCA::SaveEigenData::AbstractStrategy>& strategy)
+         const std::string& /* strategyName */,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+     const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */,
+     Teuchos::RCP<LOCA::SaveEigenData::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createAnasaziOperatorStrategy(
-      const std::string& strategyName,
-      const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-      const Teuchos::RCP<Teuchos::ParameterList>& eigenParams,
-      const Teuchos::RCP<Teuchos::ParameterList>& solverParams,
-      const Teuchos::RCP<NOX::Abstract::Group>& grp,
-      Teuchos::RCP<LOCA::AnasaziOperator::AbstractStrategy>& strategy)
+      const std::string& /* strategyName */,
+      const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+      const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */,
+      const Teuchos::RCP<Teuchos::ParameterList>& /* solverParams */,
+      const Teuchos::RCP<NOX::Abstract::Group>& /* grp */,
+      Teuchos::RCP<LOCA::AnasaziOperator::AbstractStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createMooreSpenceTurningPointSolverStrategy(
-       const std::string& strategyName,
-       const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-       const Teuchos::RCP<Teuchos::ParameterList>& solverParams,
-       Teuchos::RCP<LOCA::TurningPoint::MooreSpence::SolverStrategy>& strategy)
+       const std::string& /* strategyName */,
+       const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+       const Teuchos::RCP<Teuchos::ParameterList>& /* solverParams */,
+       Teuchos::RCP<LOCA::TurningPoint::MooreSpence::SolverStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createMooreSpencePitchforkSolverStrategy(
-       const std::string& strategyName,
-       const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-       const Teuchos::RCP<Teuchos::ParameterList>& solverParams,
-       Teuchos::RCP<LOCA::Pitchfork::MooreSpence::SolverStrategy>& strategy)
+       const std::string& /* strategyName */,
+       const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+       const Teuchos::RCP<Teuchos::ParameterList>& /* solverParams */,
+       Teuchos::RCP<LOCA::Pitchfork::MooreSpence::SolverStrategy>& /* strategy */)
 {
   return false;
 }
 
 bool
 LOCA::Abstract::Factory::createMooreSpenceHopfSolverStrategy(
-       const std::string& strategyName,
-       const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-       const Teuchos::RCP<Teuchos::ParameterList>& solverParams,
-       Teuchos::RCP<LOCA::Hopf::MooreSpence::SolverStrategy>& strategy)
+       const std::string& /* strategyName */,
+       const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+       const Teuchos::RCP<Teuchos::ParameterList>& /* solverParams */,
+       Teuchos::RCP<LOCA::Hopf::MooreSpence::SolverStrategy>& /* strategy */)
 {
   return false;
 }

--- a/packages/nox/src-loca/src/LOCA_Abstract_Group.C
+++ b/packages/nox/src-loca/src/LOCA_Abstract_Group.C
@@ -69,7 +69,7 @@ LOCA::Abstract::Group::Group(
 }
 
 LOCA::Abstract::Group::Group(const LOCA::Abstract::Group& source,
-                 NOX::CopyType type) :
+                 NOX::CopyType /* type */) :
   globalData(source.globalData)
 {
   // We use copy here instead of copy constructors to avoid issues with
@@ -83,13 +83,13 @@ LOCA::Abstract::Group::~Group()
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::augmentJacobianForHomotopy(double a, double b)
+LOCA::Abstract::Group::augmentJacobianForHomotopy(double /* a */, double /* b */)
 {
   return NOX::Abstract::Group::NotDefined;
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::computeShiftedMatrix(double alpha, double beta)
+LOCA::Abstract::Group::computeShiftedMatrix(double /* alpha */, double /* beta */)
 {
   globalData->locaErrorCheck->throwError(
                "LOCA::Abstract::Group::computeShiftedMatrix",
@@ -98,8 +98,8 @@ LOCA::Abstract::Group::computeShiftedMatrix(double alpha, double beta)
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::applyShiftedMatrix(const NOX::Abstract::Vector& input,
-                      NOX::Abstract::Vector& result) const
+LOCA::Abstract::Group::applyShiftedMatrix(const NOX::Abstract::Vector& /* input */,
+                      NOX::Abstract::Vector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
                "LOCA::Abstract::Group::applyShiftedMatrix",
@@ -109,8 +109,8 @@ LOCA::Abstract::Group::applyShiftedMatrix(const NOX::Abstract::Vector& input,
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyShiftedMatrixMultiVector(
-                const NOX::Abstract::MultiVector& input,
-                NOX::Abstract::MultiVector& result) const
+                const NOX::Abstract::MultiVector& /* input */,
+                NOX::Abstract::MultiVector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
             "LOCA::Abstract::Group::applyShiftedMatrixMultiVector",
@@ -120,9 +120,9 @@ LOCA::Abstract::Group::applyShiftedMatrixMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyShiftedMatrixInverseMultiVector(
-                    Teuchos::ParameterList& params,
-                const NOX::Abstract::MultiVector& input,
-                NOX::Abstract::MultiVector& result) const
+                    Teuchos::ParameterList& /* params */,
+                const NOX::Abstract::MultiVector& /* input */,
+                NOX::Abstract::MultiVector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
         "LOCA::Abstract::Group::applyShiftedMatrixInverseMultiVector",
@@ -131,7 +131,7 @@ LOCA::Abstract::Group::applyShiftedMatrixInverseMultiVector(
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::computeSecondShiftedMatrix(double alpha, double beta)
+LOCA::Abstract::Group::computeSecondShiftedMatrix(double /* alpha */, double /* beta */)
 {
   globalData->locaErrorCheck->throwError(
                "LOCA::Abstract::Group::computeSecondShiftedMatrix",
@@ -140,8 +140,8 @@ LOCA::Abstract::Group::computeSecondShiftedMatrix(double alpha, double beta)
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::applySecondShiftedMatrix(const NOX::Abstract::Vector& input,
-                      NOX::Abstract::Vector& result) const
+LOCA::Abstract::Group::applySecondShiftedMatrix(const NOX::Abstract::Vector& /* input */,
+                      NOX::Abstract::Vector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
                "LOCA::Abstract::Group::applySecondShiftedMatrix",
@@ -151,8 +151,8 @@ LOCA::Abstract::Group::applySecondShiftedMatrix(const NOX::Abstract::Vector& inp
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applySecondShiftedMatrixMultiVector(
-                const NOX::Abstract::MultiVector& input,
-                NOX::Abstract::MultiVector& result) const
+                const NOX::Abstract::MultiVector& /* input */,
+                NOX::Abstract::MultiVector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
             "LOCA::Abstract::Group::applySecondShiftedMatrixMultiVector",
@@ -167,7 +167,7 @@ LOCA::Abstract::Group::isComplex() const
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::computeComplex(double frequency)
+LOCA::Abstract::Group::computeComplex(double /* frequency */)
 {
   globalData->locaErrorCheck->throwError(
                    "LOCA::Abstract::Group::computeComplex",
@@ -176,10 +176,10 @@ LOCA::Abstract::Group::computeComplex(double frequency)
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::Abstract::Group::applyComplex(const NOX::Abstract::Vector& input_real,
-                    const NOX::Abstract::Vector& input_imag,
-                    NOX::Abstract::Vector& result_real,
-                    NOX::Abstract::Vector& result_imag) const
+LOCA::Abstract::Group::applyComplex(const NOX::Abstract::Vector& /* input_real */,
+                    const NOX::Abstract::Vector& /* input_imag */,
+                    NOX::Abstract::Vector& /* result_real */,
+                    NOX::Abstract::Vector& /* result_imag */) const
 {
   globalData->locaErrorCheck->throwError("LOCA::Abstract::Group::applyComplex",
                      "Method not defined for group");
@@ -188,10 +188,10 @@ LOCA::Abstract::Group::applyComplex(const NOX::Abstract::Vector& input_real,
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyComplexMultiVector(
-                  const NOX::Abstract::MultiVector& input_real,
-                  const NOX::Abstract::MultiVector& input_imag,
-                  NOX::Abstract::MultiVector& result_real,
-                  NOX::Abstract::MultiVector& result_imag) const
+                  const NOX::Abstract::MultiVector& /* input_real */,
+                  const NOX::Abstract::MultiVector& /* input_imag */,
+                  NOX::Abstract::MultiVector& /* result_real */,
+                  NOX::Abstract::MultiVector& /* result_imag */) const
 {
   globalData->locaErrorCheck->throwError(
                  "LOCA::Abstract::Group::applyComplexMultiVector",
@@ -201,11 +201,11 @@ LOCA::Abstract::Group::applyComplexMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyComplexInverseMultiVector(
-                   Teuchos::ParameterList& params,
-                   const NOX::Abstract::MultiVector& input_real,
-                   const NOX::Abstract::MultiVector& input_imag,
-                   NOX::Abstract::MultiVector& result_real,
-                   NOX::Abstract::MultiVector& result_imag) const
+                   Teuchos::ParameterList& /* params */,
+                   const NOX::Abstract::MultiVector& /* input_real */,
+                   const NOX::Abstract::MultiVector& /* input_imag */,
+                   NOX::Abstract::MultiVector& /* result_real */,
+                   NOX::Abstract::MultiVector& /* result_imag */) const
 {
   globalData->locaErrorCheck->throwError(
                    "LOCA::Abstract::Group::applyComplexInverse",
@@ -215,10 +215,10 @@ LOCA::Abstract::Group::applyComplexInverseMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyComplexTranspose(
-                      const NOX::Abstract::Vector& input_real,
-                      const NOX::Abstract::Vector& input_imag,
-                      NOX::Abstract::Vector& result_real,
-                      NOX::Abstract::Vector& result_imag) const
+                      const NOX::Abstract::Vector& /* input_real */,
+                      const NOX::Abstract::Vector& /* input_imag */,
+                      NOX::Abstract::Vector& /* result_real */,
+                      NOX::Abstract::Vector& /* result_imag */) const
 {
   globalData->locaErrorCheck->throwError(
                  "LOCA::Abstract::Group::applyComplexTranspose",
@@ -228,10 +228,10 @@ LOCA::Abstract::Group::applyComplexTranspose(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyComplexTransposeMultiVector(
-                const NOX::Abstract::MultiVector& input_real,
-                const NOX::Abstract::MultiVector& input_imag,
-                NOX::Abstract::MultiVector& result_real,
-                NOX::Abstract::MultiVector& result_imag) const
+                const NOX::Abstract::MultiVector& /* input_real */,
+                const NOX::Abstract::MultiVector& /* input_imag */,
+                NOX::Abstract::MultiVector& /* result_real */,
+                NOX::Abstract::MultiVector& /* result_imag */) const
 {
   globalData->locaErrorCheck->throwError(
             "LOCA::Abstract::Group::applyComplexTransposeMultiVector",
@@ -241,11 +241,11 @@ LOCA::Abstract::Group::applyComplexTransposeMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Abstract::Group::applyComplexTransposeInverseMultiVector(
-                Teuchos::ParameterList& params,
-                const NOX::Abstract::MultiVector& input_real,
-                const NOX::Abstract::MultiVector& input_imag,
-                NOX::Abstract::MultiVector& result_real,
-                NOX::Abstract::MultiVector& result_imag) const
+                Teuchos::ParameterList& /* params */,
+                const NOX::Abstract::MultiVector& /* input_real */,
+                const NOX::Abstract::MultiVector& /* input_imag */,
+                NOX::Abstract::MultiVector& /* result_real */,
+                NOX::Abstract::MultiVector& /* result_imag */) const
 {
   globalData->locaErrorCheck->throwError(
           "LOCA::Abstract::Group::applyComplexTransposeInverseMultiVector",

--- a/packages/nox/src-loca/src/LOCA_Abstract_Iterator.C
+++ b/packages/nox/src-loca/src/LOCA_Abstract_Iterator.C
@@ -167,7 +167,7 @@ LOCA::Abstract::Iterator::iterate()
 }
 
 LOCA::Abstract::Iterator::IteratorStatus
-LOCA::Abstract::Iterator::stop(LOCA::Abstract::Iterator::StepStatus stepStatus)
+LOCA::Abstract::Iterator::stop(LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
   if (numTotalSteps >= maxSteps)
     return LOCA::Abstract::Iterator::Finished;

--- a/packages/nox/src-loca/src/LOCA_AnasaziOperator_AbstractStrategy.H
+++ b/packages/nox/src-loca/src/LOCA_AnasaziOperator_AbstractStrategy.H
@@ -122,7 +122,7 @@ namespace LOCA {
        * \brief Give strategy an opportunit to massage the random seed vector
        */
       virtual void
-      preProcessSeedVector(NOX::Abstract::MultiVector& ivec) {};
+      preProcessSeedVector(NOX::Abstract::MultiVector& /* ivec */) {};
 
       /*!
        * \brief Hook to precompute info for subsequent repeated calls to

--- a/packages/nox/src-loca/src/LOCA_AnasaziOperator_Cayley.C
+++ b/packages/nox/src-loca/src/LOCA_AnasaziOperator_Cayley.C
@@ -55,7 +55,7 @@
 
 LOCA::AnasaziOperator::Cayley::Cayley(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams_,
     const Teuchos::RCP<Teuchos::ParameterList>& solverParams_,
     const Teuchos::RCP<LOCA::TimeDependent::AbstractGroup>& grp_)

--- a/packages/nox/src-loca/src/LOCA_AnasaziOperator_Cayley2Matrix.C
+++ b/packages/nox/src-loca/src/LOCA_AnasaziOperator_Cayley2Matrix.C
@@ -55,7 +55,7 @@
 
 LOCA::AnasaziOperator::Cayley2Matrix::Cayley2Matrix(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams_,
     const Teuchos::RCP<Teuchos::ParameterList>& solverParams_,
     const Teuchos::RCP<LOCA::TimeDependent::AbstractGroup>& grp_)

--- a/packages/nox/src-loca/src/LOCA_AnasaziOperator_JacobianInverse.C
+++ b/packages/nox/src-loca/src/LOCA_AnasaziOperator_JacobianInverse.C
@@ -55,7 +55,7 @@
 
 LOCA::AnasaziOperator::JacobianInverse::JacobianInverse(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams_,
     const Teuchos::RCP<Teuchos::ParameterList>& solverParams_,
     const Teuchos::RCP<NOX::Abstract::Group>& grp_)

--- a/packages/nox/src-loca/src/LOCA_AnasaziOperator_ShiftInvert.C
+++ b/packages/nox/src-loca/src/LOCA_AnasaziOperator_ShiftInvert.C
@@ -55,7 +55,7 @@
 
 LOCA::AnasaziOperator::ShiftInvert::ShiftInvert(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams_,
     const Teuchos::RCP<Teuchos::ParameterList>& solverParams_,
     const Teuchos::RCP<LOCA::TimeDependent::AbstractGroup>& grp_)

--- a/packages/nox/src-loca/src/LOCA_AnasaziOperator_ShiftInvert2Matrix.C
+++ b/packages/nox/src-loca/src/LOCA_AnasaziOperator_ShiftInvert2Matrix.C
@@ -55,7 +55,7 @@
 
 LOCA::AnasaziOperator::ShiftInvert2Matrix::ShiftInvert2Matrix(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams_,
     const Teuchos::RCP<Teuchos::ParameterList>& solverParams_,
     const Teuchos::RCP<LOCA::TimeDependent::AbstractGroup>& grp_)

--- a/packages/nox/src-loca/src/LOCA_BorderedSolver_BorderedOperator.H
+++ b/packages/nox/src-loca/src/LOCA_BorderedSolver_BorderedOperator.H
@@ -79,31 +79,31 @@ namespace LOCA {
 
       //! Apply the operator
       virtual NOX::Abstract::Group::ReturnType
-      apply(const NOX::Abstract::MultiVector& X,
-        NOX::Abstract::MultiVector& Y) const {
+      apply(const NOX::Abstract::MultiVector& /* X */,
+        NOX::Abstract::MultiVector& /* Y */) const {
     return NOX::Abstract::Group::NotDefined;
       }
 
       //! Apply transpose of the operator
       virtual NOX::Abstract::Group::ReturnType
-      applyTranspose(const NOX::Abstract::MultiVector& X,
-             NOX::Abstract::MultiVector& Y) const {
+      applyTranspose(const NOX::Abstract::MultiVector& /* X */,
+             NOX::Abstract::MultiVector& /* Y */) const {
     return NOX::Abstract::Group::NotDefined;
       }
 
       //! Apply inverse of the operator
       virtual NOX::Abstract::Group::ReturnType
-      applyInverse(Teuchos::ParameterList& params,
-           const NOX::Abstract::MultiVector& B,
-           NOX::Abstract::MultiVector& X) const {
+      applyInverse(Teuchos::ParameterList& /* params */,
+           const NOX::Abstract::MultiVector& /* B */,
+           NOX::Abstract::MultiVector& /* X */) const {
     return NOX::Abstract::Group::NotDefined;
       }
 
       //! Apply inverse transpose of the operator
       virtual NOX::Abstract::Group::ReturnType
-      applyInverseTranspose(Teuchos::ParameterList& params,
-                const NOX::Abstract::MultiVector& B,
-                NOX::Abstract::MultiVector& X) const {
+      applyInverseTranspose(Teuchos::ParameterList& /* params */,
+                const NOX::Abstract::MultiVector& /* B */,
+                NOX::Abstract::MultiVector& /* X */) const {
     return NOX::Abstract::Group::NotDefined;
       }
 

--- a/packages/nox/src-loca/src/LOCA_BorderedSolver_Bordering.C
+++ b/packages/nox/src-loca/src/LOCA_BorderedSolver_Bordering.C
@@ -61,7 +61,7 @@
 
 LOCA::BorderedSolver::Bordering::Bordering(
      const Teuchos::RCP<LOCA::GlobalData>& global_data,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
      const Teuchos::RCP<Teuchos::ParameterList>& slvrParams):
   globalData(global_data),
   solverParams(slvrParams),
@@ -399,7 +399,7 @@ LOCA::BorderedSolver::Bordering::solveFZero(
 NOX::Abstract::Group::ReturnType
 LOCA::BorderedSolver::Bordering::solveContiguous(
                Teuchos::ParameterList& params,
-               const NOX::Abstract::MultiVector* AA,
+               const NOX::Abstract::MultiVector* /* AA */,
                const LOCA::MultiContinuation::ConstraintInterface* BB,
                const NOX::Abstract::MultiVector::DenseMatrix* CC,
                std::vector<int>& indexF,
@@ -534,7 +534,7 @@ NOX::Abstract::Group::ReturnType
 LOCA::BorderedSolver::Bordering::solveContiguousTrans(
                Teuchos::ParameterList& params,
                const NOX::Abstract::MultiVector* AA,
-               const NOX::Abstract::MultiVector* BB,
+               const NOX::Abstract::MultiVector* /* BB */,
                const NOX::Abstract::MultiVector::DenseMatrix* CC,
                std::vector<int>& indexF,
                std::vector<int>& indexB,

--- a/packages/nox/src-loca/src/LOCA_DerivUtils.C
+++ b/packages/nox/src-loca/src/LOCA_DerivUtils.C
@@ -83,7 +83,7 @@ LOCA::DerivUtils::~DerivUtils()
 }
 
 Teuchos::RCP<LOCA::DerivUtils>
-LOCA::DerivUtils::clone(NOX::CopyType type) const
+LOCA::DerivUtils::clone(NOX::CopyType /* type */) const
 {
   return Teuchos::rcp(new DerivUtils(*this));  //Call Copy Constructor
 }

--- a/packages/nox/src-loca/src/LOCA_Eigensolver_DefaultStrategy.C
+++ b/packages/nox/src-loca/src/LOCA_Eigensolver_DefaultStrategy.C
@@ -55,8 +55,8 @@
 
 LOCA::Eigensolver::DefaultStrategy::DefaultStrategy(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) :
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) :
   globalData(global_data)
 {
 }
@@ -67,11 +67,11 @@ LOCA::Eigensolver::DefaultStrategy::~DefaultStrategy()
 
 NOX::Abstract::Group::ReturnType
 LOCA::Eigensolver::DefaultStrategy::computeEigenvalues(
-         NOX::Abstract::Group& group,
-         Teuchos::RCP< std::vector<double> >& evals_r,
-         Teuchos::RCP< std::vector<double> >& evals_i,
-         Teuchos::RCP< NOX::Abstract::MultiVector >& evecs_r,
-             Teuchos::RCP< NOX::Abstract::MultiVector >& evecs_i)
+         NOX::Abstract::Group& /* group */,
+         Teuchos::RCP< std::vector<double> >& /* evals_r */,
+         Teuchos::RCP< std::vector<double> >& /* evals_i */,
+         Teuchos::RCP< NOX::Abstract::MultiVector >& /* evecs_r */,
+             Teuchos::RCP< NOX::Abstract::MultiVector >& /* evecs_i */)
 {
   // Print a warning that this eigensolver strategy doesn't do anything
   globalData->locaErrorCheck->printWarning(

--- a/packages/nox/src-loca/src/LOCA_EigenvalueSort_Factory.C
+++ b/packages/nox/src-loca/src/LOCA_EigenvalueSort_Factory.C
@@ -67,7 +67,7 @@ LOCA::EigenvalueSort::Factory::~Factory()
 
 Teuchos::RCP<LOCA::EigenvalueSort::AbstractStrategy>
 LOCA::EigenvalueSort::Factory::create(
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& eigenParams)
 {
   std::string methodName = "LOCA::EigenvalueSort::Factory::create()";

--- a/packages/nox/src-loca/src/LOCA_EigenvalueSort_Strategies.C
+++ b/packages/nox/src-loca/src/LOCA_EigenvalueSort_Strategies.C
@@ -345,8 +345,8 @@ LOCA::EigenvalueSort::SmallestReal::sort(int n, double* r_evals,
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::EigenvalueSort::LargestImaginary::sort(int n, double* evals,
-                         std::vector<int>* perm) const
+LOCA::EigenvalueSort::LargestImaginary::sort(int /* n */, double* /* evals */,
+                         std::vector<int>* /* perm */) const
 {
   return NOX::Abstract::Group::NotDefined;
 }
@@ -388,8 +388,8 @@ LOCA::EigenvalueSort::LargestImaginary::sort(int n, double* r_evals,
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::EigenvalueSort::SmallestImaginary::sort(int n, double* evals,
-                          std::vector<int>* perm) const
+LOCA::EigenvalueSort::SmallestImaginary::sort(int /* n */, double* /* evals */,
+                          std::vector<int>* /* perm */) const
 {
   return NOX::Abstract::Group::NotDefined;
 }
@@ -431,7 +431,7 @@ LOCA::EigenvalueSort::SmallestImaginary::sort(int n, double* r_evals,
 }
 
 LOCA::EigenvalueSort::LargestRealInverseCayley::LargestRealInverseCayley(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
          const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) :
   sigma(0.0),
   mu(0.0)

--- a/packages/nox/src-loca/src/LOCA_EigenvalueSort_Strategies.H
+++ b/packages/nox/src-loca/src/LOCA_EigenvalueSort_Strategies.H
@@ -165,8 +165,8 @@ namespace LOCA {
        * \param eigenParams [in] Eigensolver parameters.
        */
       LargestMagnitude(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) {}
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) {}
 
       //! Destructor
       ~LargestMagnitude() {}
@@ -206,8 +206,8 @@ namespace LOCA {
        * \param eigenParams [in] Eigensolver parameters.
        */
       SmallestMagnitude(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) {}
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) {}
 
       //! Destructor
       ~SmallestMagnitude() {}
@@ -247,8 +247,8 @@ namespace LOCA {
        * \param eigenParams [in] Eigensolver parameters.
        */
       LargestReal(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) {}
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) {}
 
       //! Destructor
       ~LargestReal() {}
@@ -288,8 +288,8 @@ namespace LOCA {
        * \param eigenParams [in] Eigensolver parameters.
        */
       SmallestReal(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) {}
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) {}
 
       //! Destructor
       ~SmallestReal() {}
@@ -329,8 +329,8 @@ namespace LOCA {
        * \param eigenParams [in] Eigensolver parameters.
        */
       LargestImaginary(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) {}
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) {}
 
       //! Destructor
       ~LargestImaginary() {}
@@ -370,8 +370,8 @@ namespace LOCA {
        * \param eigenParams [in] Eigensolver parameters.
        */
       SmallestImaginary(
-         const Teuchos::RCP<LOCA::GlobalData>& global_data,
-         const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) {}
+         const Teuchos::RCP<LOCA::GlobalData>& /* global_data */,
+         const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) {}
 
       //! Destructor
       ~SmallestImaginary() {}

--- a/packages/nox/src-loca/src/LOCA_Homotopy_Group.C
+++ b/packages/nox/src-loca/src/LOCA_Homotopy_Group.C
@@ -600,7 +600,7 @@ LOCA::Homotopy::Group::getParam(std::string paramID) const
 NOX::Abstract::Group::ReturnType
 LOCA::Homotopy::Group::computeDfDpMulti(const std::vector<int>& paramIDs,
                     NOX::Abstract::MultiVector& dfdp,
-                    bool isValidF)
+                    bool /* isValidF */)
 {
   // g = conParam * f(x) + ((1.0 - conParam) * (x - randomVec))
   // dg/dp = f(x) - (x - randomVec) when p = conParam
@@ -675,7 +675,7 @@ LOCA::Homotopy::Group::projectToDrawDimension() const
 }
 
 void
-LOCA::Homotopy::Group::printSolution(const double conParm) const
+LOCA::Homotopy::Group::printSolution(const double /* conParm */) const
 {
   if (globalData->locaUtils->isPrintType(NOX::Utils::StepperDetails)) {
     globalData->locaUtils->out() <<
@@ -687,8 +687,8 @@ LOCA::Homotopy::Group::printSolution(const double conParm) const
 }
 
 void
-LOCA::Homotopy::Group::printSolution(const NOX::Abstract::Vector& x_,
-                     const double conParm) const
+LOCA::Homotopy::Group::printSolution(const NOX::Abstract::Vector& /* x_ */,
+                     const double /* conParm */) const
 {
   if (globalData->locaUtils->isPrintType(NOX::Utils::StepperDetails)) {
     globalData->locaUtils->out() <<

--- a/packages/nox/src-loca/src/LOCA_Hopf_ComplexMultiVector.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_ComplexMultiVector.C
@@ -184,8 +184,8 @@ LOCA::Hopf::ComplexMultiVector::ComplexMultiVector(
 }
 
 Teuchos::RCP<LOCA::Extended::Vector>
-LOCA::Hopf::ComplexMultiVector::generateVector(int nVecs,
-                           int nScalarRows) const
+LOCA::Hopf::ComplexMultiVector::generateVector(int /* nVecs */,
+                           int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::Hopf::ComplexVector(globalData));

--- a/packages/nox/src-loca/src/LOCA_Hopf_ComplexVector.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_ComplexVector.C
@@ -139,8 +139,8 @@ LOCA::Hopf::ComplexVector::ComplexVector(
 
 Teuchos::RCP<LOCA::Extended::MultiVector>
 LOCA::Hopf::ComplexVector::generateMultiVector(int nColumns,
-                           int nVectorRows,
-                           int nScalarRows) const
+                           int /* nVectorRows */,
+                           int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::Hopf::ComplexMultiVector(globalData, nColumns));

--- a/packages/nox/src-loca/src/LOCA_Hopf_MinimallyAugmented_Constraint.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_MinimallyAugmented_Constraint.C
@@ -71,7 +71,7 @@ Constraint(
     const NOX::Abstract::Vector& a_imag,
     const NOX::Abstract::Vector* b_real,
     const NOX::Abstract::Vector* b_imag,
-    int bif_param,
+    int /* bif_param */,
     double freq) :
   globalData(global_data),
   parsedParams(topParams),
@@ -585,7 +585,7 @@ NOX::Abstract::Group::ReturnType
 LOCA::Hopf::MinimallyAugmented::Constraint::
 computeDP(const std::vector<int>& paramIDs,
       NOX::Abstract::MultiVector::DenseMatrix& dgdp,
-      bool isValidG)
+      bool /* isValidG */)
 {
   std::string callingFunction =
     "LOCA::Hopf::MinimallyAugmented::Constraint::computeDP()";

--- a/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_ExtendedGroup.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_ExtendedGroup.C
@@ -617,8 +617,8 @@ LOCA::Hopf::MooreSpence::ExtendedGroup::applyJacobianMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Hopf::MooreSpence::ExtendedGroup::applyJacobianTransposeMultiVector(
-                     const NOX::Abstract::MultiVector& input,
-                     NOX::Abstract::MultiVector& result) const
+                     const NOX::Abstract::MultiVector& /* input */,
+                     NOX::Abstract::MultiVector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
           "LOCA::Hopf::MooreSpence::ExtendedGroup::applyJacobianTransposeMultiVector()",

--- a/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_ExtendedMultiVector.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_ExtendedMultiVector.C
@@ -232,8 +232,8 @@ LOCA::Hopf::MooreSpence::ExtendedMultiVector::ExtendedMultiVector(
 
 Teuchos::RCP<LOCA::Extended::Vector>
 LOCA::Hopf::MooreSpence::ExtendedMultiVector::generateVector(
-                            int nVecs,
-                            int nScalarRows) const
+                            int /* nVecs */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::Hopf::MooreSpence::ExtendedVector(globalData));

--- a/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_ExtendedVector.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_ExtendedVector.C
@@ -192,8 +192,8 @@ LOCA::Hopf::MooreSpence::ExtendedVector::ExtendedVector(
 Teuchos::RCP<LOCA::Extended::MultiVector>
 LOCA::Hopf::MooreSpence::ExtendedVector::generateMultiVector(
                             int nColumns,
-                            int nVectorRows,
-                            int nScalarRows) const
+                            int /* nVectorRows */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::Hopf::MooreSpence::ExtendedMultiVector(globalData,

--- a/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_SalingerBordering.C
+++ b/packages/nox/src-loca/src/LOCA_Hopf_MooreSpence_SalingerBordering.C
@@ -56,7 +56,7 @@
 
 LOCA::Hopf::MooreSpence::SalingerBordering::SalingerBordering(
      const Teuchos::RCP<LOCA::GlobalData>& global_data,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
      const Teuchos::RCP<Teuchos::ParameterList>& slvrParams) :
   globalData(global_data),
   solverParams(slvrParams),

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_AbstractGroup.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_AbstractGroup.C
@@ -52,13 +52,13 @@
 
 void
 LOCA::MultiContinuation::AbstractGroup::preProcessContinuationStep(
-                 LOCA::Abstract::Iterator::StepStatus stepStatus)
+                 LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
 }
 
 void
 LOCA::MultiContinuation::AbstractGroup::postProcessContinuationStep(
-                 LOCA::Abstract::Iterator::StepStatus stepStatus)
+                 LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
 }
 
@@ -85,6 +85,6 @@ LOCA::MultiContinuation::AbstractGroup::computeScaledDotProduct(
 }
 
 void
-LOCA::MultiContinuation::AbstractGroup::scaleVector(NOX::Abstract::Vector& x) const
+LOCA::MultiContinuation::AbstractGroup::scaleVector(NOX::Abstract::Vector& /* x */) const
 {
 }

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_AbstractGroup.H
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_AbstractGroup.H
@@ -201,14 +201,14 @@ namespace LOCA {
       /*!
        * Empty default definition.
        */
-      virtual void printSolution(const double conParam) const {};
+      virtual void printSolution(const double /* conParam */) const {};
 
       //! Function to print out a vector and parameter after successful step
       /*!
        * Empty default definition.
        */
-      virtual void printSolution(const NOX::Abstract::Vector& x_,
-                                 const double conParam) const  {}
+      virtual void printSolution(const NOX::Abstract::Vector& /* x_ */,
+                                 const double /* conParam */) const  {}
 
       //! Scales a vector using scaling vector
       /*!

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_ArcLengthConstraint.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_ArcLengthConstraint.C
@@ -116,21 +116,21 @@ LOCA::MultiContinuation::ArcLengthConstraint::numConstraints() const
 
 void
 LOCA::MultiContinuation::ArcLengthConstraint::setX(
-                          const NOX::Abstract::Vector& y)
+                          const NOX::Abstract::Vector& /* y */)
 {
   isValidConstraints = false;
 }
 
 void
-LOCA::MultiContinuation::ArcLengthConstraint::setParam(int paramID, double val)
+LOCA::MultiContinuation::ArcLengthConstraint::setParam(int /* paramID */, double /* val */)
 {
   isValidConstraints = false;
 }
 
 void
 LOCA::MultiContinuation::ArcLengthConstraint::setParams(
-             const std::vector<int>& paramIDs,
-             const NOX::Abstract::MultiVector::DenseMatrix& vals)
+             const std::vector<int>& /* paramIDs */,
+             const NOX::Abstract::MultiVector::DenseMatrix& /* vals */)
 {
   isValidConstraints = false;
 }

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_CompositeConstraint.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_CompositeConstraint.C
@@ -82,7 +82,7 @@ LOCA::MultiContinuation::CompositeConstraint::CompositeConstraint(
 
 LOCA::MultiContinuation::CompositeConstraint::CompositeConstraint(
           const LOCA::MultiContinuation::CompositeConstraint& source,
-          NOX::CopyType type) :
+          NOX::CopyType /* type */) :
   globalData(source.globalData),
   numConstraintObjects(source.numConstraintObjects),
   constraintPtrs(source.constraintPtrs),

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_ConstraintInterface.H
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_ConstraintInterface.H
@@ -192,7 +192,7 @@ namespace LOCA {
        */
       virtual void
       preProcessContinuationStep(
-               LOCA::Abstract::Iterator::StepStatus stepStatus) {}
+               LOCA::Abstract::Iterator::StepStatus /* stepStatus */) {}
 
       //! Perform any postprocessing after a continuation step finishes.
       /*!
@@ -201,7 +201,7 @@ namespace LOCA {
        */
       virtual void
       postProcessContinuationStep(
-               LOCA::Abstract::Iterator::StepStatus stepStatus) {}
+               LOCA::Abstract::Iterator::StepStatus /* stepStatus */) {}
 
     }; // Class ConstraintInterface
 

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_ExtendedMultiVector.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_ExtendedMultiVector.C
@@ -191,7 +191,7 @@ LOCA::MultiContinuation::ExtendedMultiVector::ExtendedMultiVector(
 
 Teuchos::RCP<LOCA::Extended::Vector>
 LOCA::MultiContinuation::ExtendedMultiVector::generateVector(
-                            int nVecs,
+                            int /* nVecs */,
                             int nScalarRows) const
 {
   return

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_ExtendedVector.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_ExtendedVector.C
@@ -124,7 +124,7 @@ LOCA::MultiContinuation::ExtendedVector::ExtendedVector(
 Teuchos::RCP<LOCA::Extended::MultiVector>
 LOCA::MultiContinuation::ExtendedVector::generateMultiVector(
                             int nColumns,
-                            int nVectorRows,
+                            int /* nVectorRows */,
                             int nScalarRows) const
 {
   return

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_MultiVecConstraint.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_MultiVecConstraint.C
@@ -118,14 +118,14 @@ LOCA::MultiContinuation::MultiVecConstraint::setX(
 }
 
 void
-LOCA::MultiContinuation::MultiVecConstraint::setParam(int paramID, double val)
+LOCA::MultiContinuation::MultiVecConstraint::setParam(int /* paramID */, double /* val */)
 {
 }
 
 void
 LOCA::MultiContinuation::MultiVecConstraint::setParams(
-             const std::vector<int>& paramIDs,
-             const NOX::Abstract::MultiVector::DenseMatrix& vals)
+             const std::vector<int>& /* paramIDs */,
+             const NOX::Abstract::MultiVector::DenseMatrix& /* vals */)
 {
 }
 

--- a/packages/nox/src-loca/src/LOCA_MultiContinuation_NaturalConstraint.C
+++ b/packages/nox/src-loca/src/LOCA_MultiContinuation_NaturalConstraint.C
@@ -116,21 +116,21 @@ LOCA::MultiContinuation::NaturalConstraint::numConstraints() const
 
 void
 LOCA::MultiContinuation::NaturalConstraint::setX(
-                        const NOX::Abstract::Vector& y)
+                        const NOX::Abstract::Vector& /* y */)
 {
   isValidConstraints = false;
 }
 
 void
-LOCA::MultiContinuation::NaturalConstraint::setParam(int paramID, double val)
+LOCA::MultiContinuation::NaturalConstraint::setParam(int /* paramID */, double /* val */)
 {
   isValidConstraints = false;
 }
 
 void
 LOCA::MultiContinuation::NaturalConstraint::setParams(
-             const std::vector<int>& paramIDs,
-             const NOX::Abstract::MultiVector::DenseMatrix& vals)
+             const std::vector<int>& /* paramIDs */,
+             const NOX::Abstract::MultiVector::DenseMatrix& /* vals */)
 {
   isValidConstraints = false;
 }

--- a/packages/nox/src-loca/src/LOCA_MultiPredictor_Constant.C
+++ b/packages/nox/src-loca/src/LOCA_MultiPredictor_Constant.C
@@ -56,7 +56,7 @@
 
 LOCA::MultiPredictor::Constant::Constant(
           const Teuchos::RCP<LOCA::GlobalData>& global_data,
-          const Teuchos::RCP<Teuchos::ParameterList>& predParams) :
+          const Teuchos::RCP<Teuchos::ParameterList>& /* predParams */) :
   globalData(global_data),
   predictor(),
   secant(),

--- a/packages/nox/src-loca/src/LOCA_MultiPredictor_Restart.C
+++ b/packages/nox/src-loca/src/LOCA_MultiPredictor_Restart.C
@@ -94,7 +94,7 @@ LOCA::MultiPredictor::Restart::~Restart()
 
 LOCA::MultiPredictor::Restart::Restart(
                  const LOCA::MultiPredictor::Restart& source,
-                 NOX::CopyType type) :
+                 NOX::CopyType /* type */) :
   globalData(source.globalData),
   predictor(source.predictor)
 {
@@ -123,10 +123,10 @@ LOCA::MultiPredictor::Restart::clone(NOX::CopyType type) const
 
 NOX::Abstract::Group::ReturnType
 LOCA::MultiPredictor::Restart::compute(
-          bool baseOnSecant, const std::vector<double>& stepSize,
-          LOCA::MultiContinuation::ExtendedGroup& grp,
-          const LOCA::MultiContinuation::ExtendedVector& prevXVec,
-          const LOCA::MultiContinuation::ExtendedVector& xVec)
+          bool /* baseOnSecant */, const std::vector<double>& /* stepSize */,
+          LOCA::MultiContinuation::ExtendedGroup& /* grp */,
+          const LOCA::MultiContinuation::ExtendedVector& /* prevXVec */,
+          const LOCA::MultiContinuation::ExtendedVector& /* xVec */)
 {
   if (globalData->locaUtils->isPrintType(NOX::Utils::StepperDetails))
     globalData->locaUtils->out() <<

--- a/packages/nox/src-loca/src/LOCA_MultiPredictor_Secant.C
+++ b/packages/nox/src-loca/src/LOCA_MultiPredictor_Secant.C
@@ -61,7 +61,7 @@
 LOCA::MultiPredictor::Secant::Secant(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& predParams) :
+    const Teuchos::RCP<Teuchos::ParameterList>& /* predParams */) :
   globalData(global_data),
   firstStepPredictor(),
   isFirstStep(true),

--- a/packages/nox/src-loca/src/LOCA_MultiPredictor_Tangent.C
+++ b/packages/nox/src-loca/src/LOCA_MultiPredictor_Tangent.C
@@ -60,7 +60,7 @@
 
 LOCA::MultiPredictor::Tangent::Tangent(
           const Teuchos::RCP<LOCA::GlobalData>& global_data,
-          const Teuchos::RCP<Teuchos::ParameterList>& predParams,
+          const Teuchos::RCP<Teuchos::ParameterList>& /* predParams */,
           const Teuchos::RCP<Teuchos::ParameterList>& solverParams) :
   globalData(global_data),
   linSolverParams(solverParams),

--- a/packages/nox/src-loca/src/LOCA_PhaseTransition_ExtendedGroup.C
+++ b/packages/nox/src-loca/src/LOCA_PhaseTransition_ExtendedGroup.C
@@ -281,8 +281,8 @@ LOCA::PhaseTransition::ExtendedGroup::applyJacobian(const NOX::Abstract::Vector&
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::PhaseTransition::ExtendedGroup::applyJacobian(const LOCA::PhaseTransition::ExtendedVector& input,
-                                          LOCA::PhaseTransition::ExtendedVector& result) const
+LOCA::PhaseTransition::ExtendedGroup::applyJacobian(const LOCA::PhaseTransition::ExtendedVector& /* input */,
+                                          LOCA::PhaseTransition::ExtendedVector& /* result */) const
 {
   std::cout << "ERROR:  Apply Jacobian not implemented for ExtendedGroup !!!!" << std::endl;
 
@@ -519,9 +519,9 @@ LOCA::PhaseTransition::ExtendedGroup::setParamsMulti(
 
 NOX::Abstract::Group::ReturnType
 LOCA::PhaseTransition::ExtendedGroup::computeDfDpMulti(
-                                            const std::vector<int>& paramIDs,
-                                            NOX::Abstract::MultiVector& dfdp,
-                                            bool isValid_F)
+                                            const std::vector<int>& /* paramIDs */,
+                                            NOX::Abstract::MultiVector& /* dfdp */,
+                                            bool /* isValid_F */)
 {
    std::string callingFunction =
     "LOCA::TurningPoint::MooreSpence::ExtendedGroup::computeDfDpMulti()";

--- a/packages/nox/src-loca/src/LOCA_PhaseTransition_ExtendedMultiVector.C
+++ b/packages/nox/src-loca/src/LOCA_PhaseTransition_ExtendedMultiVector.C
@@ -190,8 +190,8 @@ LOCA::PhaseTransition::ExtendedMultiVector::ExtendedMultiVector(
 
 Teuchos::RCP<LOCA::Extended::Vector>
 LOCA::PhaseTransition::ExtendedMultiVector::generateVector(
-                            int nVecs,
-                            int nScalarRows) const
+                            int /* nVecs */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::PhaseTransition::ExtendedVector(

--- a/packages/nox/src-loca/src/LOCA_PhaseTransition_ExtendedVector.C
+++ b/packages/nox/src-loca/src/LOCA_PhaseTransition_ExtendedVector.C
@@ -164,8 +164,8 @@ LOCA::PhaseTransition::ExtendedVector::ExtendedVector(
 Teuchos::RCP<LOCA::Extended::MultiVector>
 LOCA::PhaseTransition::ExtendedVector::generateMultiVector(
                             int nColumns,
-                            int nVectorRows,
-                            int nScalarRows) const
+                            int /* nVectorRows */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::PhaseTransition::ExtendedMultiVector(

--- a/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_ExtendedGroup.C
+++ b/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_ExtendedGroup.C
@@ -574,8 +574,8 @@ LOCA::Pitchfork::MooreSpence::ExtendedGroup::applyJacobianMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::Pitchfork::MooreSpence::ExtendedGroup::applyJacobianTransposeMultiVector(
-                     const NOX::Abstract::MultiVector& input,
-                     NOX::Abstract::MultiVector& result) const
+                     const NOX::Abstract::MultiVector& /* input */,
+                     NOX::Abstract::MultiVector& /* result */) const
 {
   globalData->locaErrorCheck->throwError(
           "LOCA::Pitchfork::MooreSpence::ExtendedGroup::applyJacobianTransposeMultiVector()",

--- a/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_ExtendedMultiVector.C
+++ b/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_ExtendedMultiVector.C
@@ -217,8 +217,8 @@ LOCA::Pitchfork::MooreSpence::ExtendedMultiVector::ExtendedMultiVector(
 
 Teuchos::RCP<LOCA::Extended::Vector>
 LOCA::Pitchfork::MooreSpence::ExtendedMultiVector::generateVector(
-                            int nVecs,
-                            int nScalarRows) const
+                            int /* nVecs */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::Pitchfork::MooreSpence::ExtendedVector(

--- a/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_ExtendedVector.C
+++ b/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_ExtendedVector.C
@@ -180,8 +180,8 @@ LOCA::Pitchfork::MooreSpence::ExtendedVector::ExtendedVector(
 Teuchos::RCP<LOCA::Extended::MultiVector>
 LOCA::Pitchfork::MooreSpence::ExtendedVector::generateMultiVector(
                             int nColumns,
-                            int nVectorRows,
-                            int nScalarRows) const
+                            int /* nVectorRows */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::Pitchfork::MooreSpence::ExtendedMultiVector(

--- a/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_SalingerBordering.C
+++ b/packages/nox/src-loca/src/LOCA_Pitchfork_MooreSpence_SalingerBordering.C
@@ -57,7 +57,7 @@
 
 LOCA::Pitchfork::MooreSpence::SalingerBordering::SalingerBordering(
      const Teuchos::RCP<LOCA::GlobalData>& global_data,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
      const Teuchos::RCP<Teuchos::ParameterList>& slvrParams) :
   globalData(global_data),
   solverParams(slvrParams),

--- a/packages/nox/src-loca/src/LOCA_SaveEigenData_DefaultStrategy.C
+++ b/packages/nox/src-loca/src/LOCA_SaveEigenData_DefaultStrategy.C
@@ -55,8 +55,8 @@
 
 LOCA::SaveEigenData::DefaultStrategy::DefaultStrategy(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
-    const Teuchos::RCP<Teuchos::ParameterList>& eigenParams) :
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
+    const Teuchos::RCP<Teuchos::ParameterList>& /* eigenParams */) :
   globalData(global_data)
 {
 }
@@ -67,10 +67,10 @@ LOCA::SaveEigenData::DefaultStrategy::~DefaultStrategy()
 
 NOX::Abstract::Group::ReturnType
 LOCA::SaveEigenData::DefaultStrategy::save(
-         Teuchos::RCP< std::vector<double> >& evals_r,
-         Teuchos::RCP< std::vector<double> >& evals_i,
-         Teuchos::RCP< NOX::Abstract::MultiVector >& evecs_r,
-             Teuchos::RCP< NOX::Abstract::MultiVector >& evecs_i)
+         Teuchos::RCP< std::vector<double> >& /* evals_r */,
+         Teuchos::RCP< std::vector<double> >& /* evals_i */,
+         Teuchos::RCP< NOX::Abstract::MultiVector >& /* evecs_r */,
+             Teuchos::RCP< NOX::Abstract::MultiVector >& /* evecs_i */)
 {
   return NOX::Abstract::Group::Ok;
 }

--- a/packages/nox/src-loca/src/LOCA_StepSize_Adaptive.C
+++ b/packages/nox/src-loca/src/LOCA_StepSize_Adaptive.C
@@ -84,7 +84,7 @@ LOCA::StepSize::Adaptive::computeStepSize(
              const NOX::Solver::Generic& solver,
              const LOCA::Abstract::Iterator::StepStatus& stepStatus,
 //             const LOCA::Stepper& stepper,
-             const LOCA::Abstract::Iterator& stepper,
+             const LOCA::Abstract::Iterator& /* stepper */,
              double& stepSize)
 {
   // If this is the first step, set step size to initial value

--- a/packages/nox/src-loca/src/LOCA_StepSize_Constant.C
+++ b/packages/nox/src-loca/src/LOCA_StepSize_Constant.C
@@ -59,7 +59,7 @@
 
 LOCA::StepSize::Constant::Constant(
     const Teuchos::RCP<LOCA::GlobalData>& global_data,
-    const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+    const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
     const Teuchos::RCP<Teuchos::ParameterList>& stepsizeParams) :
   globalData(global_data),
   maxStepSize(1.0e+12),
@@ -87,10 +87,10 @@ NOX::Abstract::Group::ReturnType
 LOCA::StepSize::Constant::computeStepSize(
              LOCA::MultiContinuation::AbstractStrategy& curGroup,
              const LOCA::MultiContinuation::ExtendedVector& predictor,
-             const NOX::Solver::Generic& solver,
+             const NOX::Solver::Generic& /* solver */,
              const LOCA::Abstract::Iterator::StepStatus& stepStatus,
 //             const LOCA::Stepper& stepper,
-             const LOCA::Abstract::Iterator& stepper,
+             const LOCA::Abstract::Iterator& /* stepper */,
              double& stepSize)
 {
 

--- a/packages/nox/src-loca/src/LOCA_Stepper.C
+++ b/packages/nox/src-loca/src/LOCA_Stepper.C
@@ -581,7 +581,7 @@ LOCA::Stepper::preprocess(LOCA::Abstract::Iterator::StepStatus stepStatus)
 }
 
 LOCA::Abstract::Iterator::StepStatus
-LOCA::Stepper::compute(LOCA::Abstract::Iterator::StepStatus stepStatus)
+LOCA::Stepper::compute(LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
   NOX::StatusTest::StatusType solverStatus;
 
@@ -676,7 +676,7 @@ LOCA::Stepper::stop(LOCA::Abstract::Iterator::StepStatus stepStatus)
 }
 
 LOCA::Abstract::Iterator::IteratorStatus
-LOCA::Stepper::stopLocaStatus(LOCA::Abstract::Iterator::StepStatus stepStatus)
+LOCA::Stepper::stopLocaStatus(LOCA::Abstract::Iterator::StepStatus /* stepStatus */)
 {
   // FIXME Remove this.
   LOCA::StatusTest::CheckType checkType = LOCA::StatusTest::Complete;

--- a/packages/nox/src-loca/src/LOCA_TurningPoint_MinimallyAugmented_Constraint.C
+++ b/packages/nox/src-loca/src/LOCA_TurningPoint_MinimallyAugmented_Constraint.C
@@ -494,7 +494,7 @@ NOX::Abstract::Group::ReturnType
 LOCA::TurningPoint::MinimallyAugmented::Constraint::
 computeDP(const std::vector<int>& paramIDs,
       NOX::Abstract::MultiVector::DenseMatrix& dgdp,
-      bool isValidG)
+      bool /* isValidG */)
 {
   std::string callingFunction =
     "LOCA::TurningPoint::MinimallyAugmented::Constraint::computeDP()";

--- a/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_ExtendedMultiVector.C
+++ b/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_ExtendedMultiVector.C
@@ -190,8 +190,8 @@ LOCA::TurningPoint::MooreSpence::ExtendedMultiVector::ExtendedMultiVector(
 
 Teuchos::RCP<LOCA::Extended::Vector>
 LOCA::TurningPoint::MooreSpence::ExtendedMultiVector::generateVector(
-                            int nVecs,
-                            int nScalarRows) const
+                            int /* nVecs */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::TurningPoint::MooreSpence::ExtendedVector(

--- a/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_ExtendedVector.C
+++ b/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_ExtendedVector.C
@@ -164,8 +164,8 @@ LOCA::TurningPoint::MooreSpence::ExtendedVector::ExtendedVector(
 Teuchos::RCP<LOCA::Extended::MultiVector>
 LOCA::TurningPoint::MooreSpence::ExtendedVector::generateMultiVector(
                             int nColumns,
-                            int nVectorRows,
-                            int nScalarRows) const
+                            int /* nVectorRows */,
+                            int /* nScalarRows */) const
 {
   return
     Teuchos::rcp(new LOCA::TurningPoint::MooreSpence::ExtendedMultiVector(

--- a/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_PhippsBordering.C
+++ b/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_PhippsBordering.C
@@ -453,7 +453,7 @@ LOCA::TurningPoint::MooreSpence::PhippsBordering::solveTransposeContiguous(
           Teuchos::ParameterList& params,
           const NOX::Abstract::MultiVector& input_x,
           const NOX::Abstract::MultiVector& input_null,
-              const NOX::Abstract::MultiVector::DenseMatrix& input_param,
+              const NOX::Abstract::MultiVector::DenseMatrix& /* input_param */,
           NOX::Abstract::MultiVector& result_x,
           NOX::Abstract::MultiVector& result_null,
               NOX::Abstract::MultiVector::DenseMatrix& result_param) const

--- a/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_SalingerBordering.C
+++ b/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_SalingerBordering.C
@@ -57,7 +57,7 @@
 
 LOCA::TurningPoint::MooreSpence::SalingerBordering::SalingerBordering(
      const Teuchos::RCP<LOCA::GlobalData>& global_data,
-     const Teuchos::RCP<LOCA::Parameter::SublistParser>& topParams,
+     const Teuchos::RCP<LOCA::Parameter::SublistParser>& /* topParams */,
      const Teuchos::RCP<Teuchos::ParameterList>& slvrParams) :
   globalData(global_data),
   solverParams(slvrParams),

--- a/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_SolverStrategy.H
+++ b/packages/nox/src-loca/src/LOCA_TurningPoint_MooreSpence_SolverStrategy.H
@@ -148,9 +148,9 @@ namespace LOCA {
      */
     virtual NOX::Abstract::Group::ReturnType
     solveTranspose(
-      Teuchos::ParameterList& params,
-      const LOCA::TurningPoint::MooreSpence::ExtendedMultiVector& input,
-      LOCA::TurningPoint::MooreSpence::ExtendedMultiVector& result) const {
+      Teuchos::ParameterList& /* params */,
+      const LOCA::TurningPoint::MooreSpence::ExtendedMultiVector& /* input */,
+      LOCA::TurningPoint::MooreSpence::ExtendedMultiVector& /* result */) const {
       return NOX::Abstract::Group::NotDefined;
     }
 

--- a/packages/nox/src-thyra/NOX_LineSearch_SafeguardedDirection.cpp
+++ b/packages/nox/src-thyra/NOX_LineSearch_SafeguardedDirection.cpp
@@ -108,7 +108,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 bool NOX::LineSearch::SafeguardedDirection::compute(Abstract::Group& newGrp,
                             double& step,
                             const Abstract::Vector& dir,
-                            const Solver::Generic& s)
+                            const Solver::Generic& /* s */)
 {
   printOpeningRemarks();
 

--- a/packages/nox/src-thyra/NOX_MeritFunction_Weighted.cpp
+++ b/packages/nox/src-thyra/NOX_MeritFunction_Weighted.cpp
@@ -84,7 +84,7 @@ const std::string& NOX::Thyra::WeightedMeritFunction::name() const
   return name_;
 }
 
-std::ostream& NOX::Thyra::WeightedMeritFunction::print(std::ostream& os, int indent) const
+std::ostream& NOX::Thyra::WeightedMeritFunction::print(std::ostream& os, int /* indent */) const
 {
   return os;
 }
@@ -242,8 +242,8 @@ computeQuadraticModel(const NOX::Abstract::Vector& dir,
 }
 
 void NOX::Thyra::WeightedMeritFunction::
-computeQuadraticMinimizer(const NOX::Abstract::Group &grp,
-              NOX::Abstract::Vector &result) const
+computeQuadraticMinimizer(const NOX::Abstract::Group &/* grp */,
+              NOX::Abstract::Vector &/* result */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
                  "NOX::Thyra::WeightedMeritFunction::computeQuadraticMinimizer() method has not been implemented yet!");

--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -809,8 +809,8 @@ applyJacobianInverseMultiVector(Teuchos::ParameterList& p,
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Thyra::Group::applyRightPreconditioning(bool useTranspose,
-                         Teuchos::ParameterList& params,
+NOX::Thyra::Group::applyRightPreconditioning(bool /* useTranspose */,
+                         Teuchos::ParameterList& /* params */,
                          const NOX::Abstract::Vector& input,
                          NOX::Abstract::Vector& result) const
 {

--- a/packages/nox/src-thyra/NOX_Thyra_MultiVector.C
+++ b/packages/nox/src-thyra/NOX_Thyra_MultiVector.C
@@ -73,7 +73,7 @@ MultiVector(const ::Thyra::MultiVectorBase<double>& source)
 }
 
 NOX::Thyra::MultiVector::
-MultiVector(const NOX::Thyra::MultiVector& source, NOX::CopyType type)
+MultiVector(const NOX::Thyra::MultiVector& source, NOX::CopyType /* type */)
   : thyraMultiVec(source.thyraMultiVec->clone_mv()),
     noxThyraVectors(thyraMultiVec->domain()->dim()),
     do_implicit_weighting_(false)

--- a/packages/nox/src-thyra/NOX_Thyra_Vector.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Vector.C
@@ -70,7 +70,7 @@ Vector(const ::Thyra::VectorBase<double>& source) :
 }
 
 NOX::Thyra::Vector::
-Vector(const NOX::Thyra::Vector& source, NOX::CopyType type) :
+Vector(const NOX::Thyra::Vector& source, NOX::CopyType /* type */) :
   thyraVec(source.thyraVec->clone_v()),
   do_implicit_weighting_(false)
 {

--- a/packages/nox/src/NOX_Abstract_Group.C
+++ b/packages/nox/src/NOX_Abstract_Group.C
@@ -66,38 +66,38 @@ NOX::Abstract::Group::computeGradient()
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Abstract::Group::computeNewton(Teuchos::ParameterList& params)
+NOX::Abstract::Group::computeNewton(Teuchos::ParameterList& /* params */)
 {
   return NOX::Abstract::Group::NotDefined;
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Abstract::Group::applyJacobian(const NOX::Abstract::Vector& input,
-                    NOX::Abstract::Vector& result) const
+NOX::Abstract::Group::applyJacobian(const NOX::Abstract::Vector& /* input */,
+                    NOX::Abstract::Vector& /* result */) const
 {
   return NOX::Abstract::Group::NotDefined;
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Abstract::Group::applyJacobianTranspose(const NOX::Abstract::Vector& input,
-                         NOX::Abstract::Vector& result) const
+NOX::Abstract::Group::applyJacobianTranspose(const NOX::Abstract::Vector& /* input */,
+                         NOX::Abstract::Vector& /* result */) const
 {
   return NOX::Abstract::Group::NotDefined;
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Abstract::Group::applyJacobianInverse(Teuchos::ParameterList& params,
-                       const NOX::Abstract::Vector& input,
-                       NOX::Abstract::Vector& result) const
+NOX::Abstract::Group::applyJacobianInverse(Teuchos::ParameterList& /* params */,
+                       const NOX::Abstract::Vector& /* input */,
+                       NOX::Abstract::Vector& /* result */) const
 {
   return NOX::Abstract::Group::NotDefined;
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Abstract::Group::applyRightPreconditioning(bool useTranspose,
-                        Teuchos::ParameterList& params,
-                        const NOX::Abstract::Vector& input,
-                        NOX::Abstract::Vector& result
+NOX::Abstract::Group::applyRightPreconditioning(bool /* useTranspose */,
+                        Teuchos::ParameterList& /* params */,
+                        const NOX::Abstract::Vector& /* input */,
+                        NOX::Abstract::Vector& /* result */
                         ) const
 {
   return NOX::Abstract::Group::NotDefined;
@@ -211,7 +211,7 @@ bool NOX::Abstract::Group::isNewton() const
 }
 
 NOX::Abstract::Group::ReturnType
-NOX::Abstract::Group::getNormLastLinearSolveResidual(double& residual) const
+NOX::Abstract::Group::getNormLastLinearSolveResidual(double& /* residual */) const
 {
   return NOX::Abstract::Group::NotDefined;
 }

--- a/packages/nox/src/NOX_Abstract_Vector.C
+++ b/packages/nox/src/NOX_Abstract_Vector.C
@@ -53,7 +53,7 @@
 // Included multivector declarations
 #include "NOX_MultiVector.H"
 
-void NOX::Abstract::Vector::print(std::ostream& stream) const
+void NOX::Abstract::Vector::print(std::ostream& /* stream */) const
 {
   return;
 }

--- a/packages/nox/src/NOX_Direction_Broyden.C
+++ b/packages/nox/src/NOX_Direction_Broyden.C
@@ -238,9 +238,9 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
   return true;
 }
 
-bool NOX::Direction::Broyden::compute(NOX::Abstract::Vector& dir,
-                      NOX::Abstract::Group& soln,
-                      const NOX::Solver::Generic& solver)
+bool NOX::Direction::Broyden::compute(NOX::Abstract::Vector& /* dir */,
+                      NOX::Abstract::Group& /* soln */,
+                      const NOX::Solver::Generic& /* solver */)
 {
   throwError("compute", "This direction can only be used with a line search based solver.");
   return false;

--- a/packages/nox/src/NOX_Direction_SteepestDescent.C
+++ b/packages/nox/src/NOX_Direction_SteepestDescent.C
@@ -99,7 +99,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 
 bool NOX::Direction::SteepestDescent::compute(Abstract::Vector& dir,
                  Abstract::Group& soln,
-                 const Solver::Generic& solver)
+                 const Solver::Generic& /* solver */)
 {
   NOX::Abstract::Group::ReturnType status;
 

--- a/packages/nox/src/NOX_LineSearch_FullStep.C
+++ b/packages/nox/src/NOX_LineSearch_FullStep.C
@@ -60,7 +60,7 @@
 using namespace NOX;
 using namespace NOX::LineSearch;
 
-FullStep::FullStep(const Teuchos::RCP<NOX::GlobalData>& gd,
+FullStep::FullStep(const Teuchos::RCP<NOX::GlobalData>& /* gd */,
            Teuchos::ParameterList& params)
 {
   Teuchos::ParameterList& p = params.sublist("Full Step");
@@ -72,7 +72,7 @@ FullStep::~FullStep()
 
 }
 
-bool FullStep::reset(const Teuchos::RCP<NOX::GlobalData>& gd,
+bool FullStep::reset(const Teuchos::RCP<NOX::GlobalData>& /* gd */,
              Teuchos::ParameterList& params)
 {
   Teuchos::ParameterList& p = params.sublist("Full Step");

--- a/packages/nox/src/NOX_LineSearch_NonlinearCG.C
+++ b/packages/nox/src/NOX_LineSearch_NonlinearCG.C
@@ -71,7 +71,7 @@ NOX::LineSearch::NonlinearCG::~NonlinearCG()
 
 bool NOX::LineSearch::NonlinearCG::
 reset(const Teuchos::RCP<NOX::GlobalData>& gd,
-      Teuchos::ParameterList& params)
+      Teuchos::ParameterList& /* params */)
 {
   utils = gd->getUtils();
   //Teuchos::ParameterList& p = params.sublist("NonlinearCG");

--- a/packages/nox/src/NOX_LineSearch_SafeguardedStep.C
+++ b/packages/nox/src/NOX_LineSearch_SafeguardedStep.C
@@ -108,7 +108,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 bool NOX::LineSearch::SafeguardedStep::compute(Abstract::Group& newGrp,
                            double& step,
                            const Abstract::Vector& dir,
-                           const Solver::Generic& s)
+                           const Solver::Generic& /* s */)
 {
   printOpeningRemarks();
 

--- a/packages/nox/src/NOX_Multiphysics_Group.C
+++ b/packages/nox/src/NOX_Multiphysics_Group.C
@@ -50,8 +50,8 @@
 
 NOX::Multiphysics::Group::Group(
           const Teuchos::RCP<std::vector<Teuchos::RCP<NOX::Solver::Generic> > >& solvers,
-          const Teuchos::RCP<NOX::StatusTest::Generic>& t,
-          const Teuchos::RCP<Teuchos::ParameterList>& p) :
+          const Teuchos::RCP<NOX::StatusTest::Generic>& /* t */,
+          const Teuchos::RCP<Teuchos::ParameterList>& /* p */) :
   solversVecPtr(solvers),
   normRHS(0.0)
 {
@@ -107,20 +107,20 @@ NOX::Multiphysics::Group::operator=(const NOX::Abstract::Group& source)
 }
 
 NOX::Abstract::Group &
-NOX::Multiphysics::Group::operator=(const Group& source)
+NOX::Multiphysics::Group::operator=(const Group& /* source */)
 {
   return *this;
 }
 
 void
-NOX::Multiphysics::Group::setX(const NOX::Abstract::Vector& y)
+NOX::Multiphysics::Group::setX(const NOX::Abstract::Vector& /* y */)
 {
   resetIsValid();
 }
 
 void
-NOX::Multiphysics::Group::computeX(const NOX::Abstract::Group& grp,
-             const NOX::Abstract::Vector& d, double step)
+NOX::Multiphysics::Group::computeX(const NOX::Abstract::Group& /* grp */,
+             const NOX::Abstract::Vector& /* d */, double /* step */)
 {
   resetIsValid();
 }

--- a/packages/nox/src/NOX_Multiphysics_Solver_FixedPointBased.C
+++ b/packages/nox/src/NOX_Multiphysics_Solver_FixedPointBased.C
@@ -124,7 +124,7 @@ NOX::Multiphysics::Solver::FixedPointBased::init()
 bool
 NOX::Multiphysics::Solver::FixedPointBased::reset(
       const Teuchos::RCP<std::vector<Teuchos::RCP<NOX::Solver::Generic> > >& solvers,
-      const Teuchos::RCP<NOX::Multiphysics::DataExchange::Interface>& i,
+      const Teuchos::RCP<NOX::Multiphysics::DataExchange::Interface>& /* i */,
       const Teuchos::RCP<NOX::StatusTest::Generic>& t,
       const Teuchos::RCP<Teuchos::ParameterList>& p)
 {
@@ -143,8 +143,8 @@ NOX::Multiphysics::Solver::FixedPointBased::reset(
 
 void
 NOX::Multiphysics::Solver::FixedPointBased::reset(
-      const NOX::Abstract::Vector& initialGuess,
-      const Teuchos::RCP<NOX::StatusTest::Generic>& t)
+      const NOX::Abstract::Vector& /* initialGuess */,
+      const Teuchos::RCP<NOX::StatusTest::Generic>& /* t */)
 {
   std::string msg = "Error - NOX::Multiphysics::Solver::FixedPointBased::reset() - this reset method is not valid for a Multiphysics Solver!";
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, msg);
@@ -152,7 +152,7 @@ NOX::Multiphysics::Solver::FixedPointBased::reset(
 
 void
 NOX::Multiphysics::Solver::FixedPointBased::reset(
-      const NOX::Abstract::Vector& initialGuess)
+      const NOX::Abstract::Vector& /* initialGuess */)
 {
   std::string msg = "Error - NOX::Multiphysics::Solver::FixedPointBased::reset() - this reset method is not valid for a Multiphysics Solver!";
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, msg);

--- a/packages/nox/src/NOX_Multiphysics_Solver_Manager.C
+++ b/packages/nox/src/NOX_Multiphysics_Solver_Manager.C
@@ -65,8 +65,8 @@ NOX::Multiphysics::Solver::Manager::Manager(
 }
 
 NOX::Multiphysics::Solver::Manager::Manager(
-        const Teuchos::RCP<NOX::Abstract::Group>& grp,
-    const Teuchos::RCP<NOX::StatusTest::Generic>& t,
+        const Teuchos::RCP<NOX::Abstract::Group>& /* grp */,
+    const Teuchos::RCP<NOX::StatusTest::Generic>& /* t */,
     const Teuchos::RCP<Teuchos::ParameterList>& p) :
   utils(p->sublist("Printing")),
   method(""),

--- a/packages/nox/src/NOX_Random.C
+++ b/packages/nox/src/NOX_Random.C
@@ -86,7 +86,7 @@ double NOX::Random::number()
   return 2.0*(seed/bigInt)-1.0;
 }
 
-int NOX::Random::checkSeed(const std::string& func, int s)
+int NOX::Random::checkSeed(const std::string& /* func */, int s)
 {
   if ((s < 1) || (s > 2147483646)) {
     std::cerr << "Error in NOX::Random::" << s << "():  " << "supplied seed "

--- a/packages/nox/src/NOX_Solver_InexactTrustRegionBased.C
+++ b/packages/nox/src/NOX_Solver_InexactTrustRegionBased.C
@@ -1004,8 +1004,8 @@ NOX::Solver::InexactTrustRegionBased::iterateInexact()
 //*************************************************************************
 NOX::StatusTest::StatusType
 NOX::Solver::InexactTrustRegionBased::
-checkStep(const NOX::Abstract::Vector& step,
-      double& radius)
+checkStep(const NOX::Abstract::Vector& /* step */,
+      double& /* radius */)
 {
   return NOX::StatusTest::Converged;
 }

--- a/packages/nox/src/NOX_Solver_PrePostOperator.C
+++ b/packages/nox/src/NOX_Solver_PrePostOperator.C
@@ -55,13 +55,13 @@
 #include "NOX_Solver_Generic.H"
 
 // Disallowed
-NOX::Solver::PrePostOperator::PrePostOperator(const PrePostOperator& p):
+NOX::Solver::PrePostOperator::PrePostOperator(const PrePostOperator& /* p */):
   havePrePostOperator(false)
 { }
 
 // Disallowed
 NOX::Solver::PrePostOperator& NOX::Solver::PrePostOperator::
-operator=(const PrePostOperator& p)
+operator=(const PrePostOperator& /* p */)
 { return *this; }
 
 NOX::Solver::PrePostOperator::PrePostOperator():
@@ -78,7 +78,7 @@ NOX::Solver::PrePostOperator::~PrePostOperator()
 { }
 
 void NOX::Solver::PrePostOperator::
-reset(const Teuchos::RCP<NOX::Utils>& utils, Teuchos::ParameterList& p)
+reset(const Teuchos::RCP<NOX::Utils>& /* utils */, Teuchos::ParameterList& p)
 {
   havePrePostOperator = false;
 

--- a/packages/nox/src/NOX_Solver_TensorBased.C
+++ b/packages/nox/src/NOX_Solver_TensorBased.C
@@ -784,8 +784,8 @@ double NOX::Solver::TensorBased::calculateBeta(double qa,
 
 bool
 NOX::Solver::TensorBased::computeCurvilinearStep(NOX::Abstract::Vector& dir,
-                     const NOX::Abstract::Group& soln,
-                     const NOX::Solver::Generic& s,
+                     const NOX::Abstract::Group& /* soln */,
+                     const NOX::Solver::Generic& /* s */,
                      double& lambda)
 {
   double qval = 0;

--- a/packages/nox/src/NOX_StatusTest_Divergence.C
+++ b/packages/nox/src/NOX_StatusTest_Divergence.C
@@ -65,7 +65,7 @@ NOX::StatusTest::Divergence::~Divergence()
 
 NOX::StatusTest::StatusType NOX::StatusTest::Divergence::
 checkStatus(const Solver::Generic& problem,
-        NOX::StatusTest::CheckType checkType)
+        NOX::StatusTest::CheckType /* checkType */)
 {
   status = Unconverged;
 

--- a/packages/nox/src/NOX_StatusTest_Factory.C
+++ b/packages/nox/src/NOX_StatusTest_Factory.C
@@ -90,7 +90,7 @@ NOX::StatusTest::Factory::~Factory()
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildStatusTests(const std::string& file_name , const NOX::Utils& u,
+buildStatusTests(const std::string& /* file_name */ , const NOX::Utils& u,
           std::map<std::string, Teuchos::RCP<NOX::StatusTest::Generic> >*
          tagged_tests) const
 {
@@ -261,7 +261,7 @@ buildNormFTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildNormUpdateTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildNormUpdateTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   double tolerance = p.get("Tolerance", 1.0e-3);
 
@@ -302,7 +302,7 @@ buildNormUpdateTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildNormWRMSTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildNormWRMSTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   double bdf_multiplier = p.get("BDF Multiplier", 1.0);
   double tolerance = p.get("Tolerance", 1.0);
@@ -351,7 +351,7 @@ buildNormWRMSTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildFiniteValueTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildFiniteValueTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   std::string vector_type_string = p.get("Vector Type","F Vector");
   std::string norm_type_string = p.get("Norm Type", "Two Norm");
@@ -389,7 +389,7 @@ buildFiniteValueTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildDivergenceTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildDivergenceTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   double tolerance = p.get("Tolerance", 1.0e+12);
   int iterations = p.get("Consecutive Iterations", 1);
@@ -403,7 +403,7 @@ buildDivergenceTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildStagnationTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildStagnationTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   double tolerance = p.get("Tolerance", 1.0e+12);
   int iterations = p.get("Consecutive Iterations", 1);
@@ -447,7 +447,7 @@ buildRelativeNormFTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildNStepTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildNStepTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   int num_iters = p.get<int>("Number of Nonlinear Iterations", 1);
   int num_ramping_steps = p.get<int>("Number of Initial Ramping Steps", 0);
@@ -464,7 +464,7 @@ buildNStepTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
 // ************************************************************************
 // ************************************************************************
 Teuchos::RCP<NOX::StatusTest::Generic> NOX::StatusTest::Factory::
-buildUserDefinedTest(Teuchos::ParameterList& p, const NOX::Utils& u) const
+buildUserDefinedTest(Teuchos::ParameterList& p, const NOX::Utils& /* u */) const
 {
   RCP<NOX::StatusTest::Generic> status_test;
 

--- a/packages/nox/src/NOX_StatusTest_Stagnation.C
+++ b/packages/nox/src/NOX_StatusTest_Stagnation.C
@@ -71,7 +71,7 @@ NOX::StatusTest::Stagnation::~Stagnation()
 NOX::StatusTest::StatusType
 NOX::StatusTest::Stagnation::
 checkStatus(const Solver::Generic& problem,
-        NOX::StatusTest::CheckType checkType)
+        NOX::StatusTest::CheckType /* checkType */)
 {
   status = Unconverged;
 


### PR DESCRIPTION
@trilinos/nox

## Description
Compiling Trilinos with gcc-7.2.0 shows a great many unused parameter warnings.  This PR comments out the parameter names in function definitions to avoid those warnings.

## Motivation and Context
Just wanting to get closer to a clean build.

## How Has This Been Tested?
NOX still builds just fine.  Letting @trilinos-autotester do its thing.
 
## Additional Information
These changes were made via a Python script I wrote.  I looked through the majority of the changes and it looks like all cases are being handled appropriately, but it may be the case that something went wrong and I didn't see it.