### PR TITLE
Ifpack2:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/ifpack2/adapters/thyra/Thyra_Ifpack2PreconditionerFactory_def.hpp
+++ b/packages/ifpack2/adapters/thyra/Thyra_Ifpack2PreconditionerFactory_def.hpp
@@ -113,7 +113,7 @@ template <typename MatrixType>
 void Ifpack2PreconditionerFactory<MatrixType>::initializePrec(
   const Teuchos::RCP<const LinearOpSourceBase<scalar_type> > &fwdOpSrc,
   PreconditionerBase<scalar_type> *prec,
-  const ESupportSolveUse supportSolveUse
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   // Check precondition

--- a/packages/ifpack2/src/Ifpack2_BandedContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BandedContainer_def.hpp
@@ -516,14 +516,14 @@ apply (HostView& X,
 template<class MatrixType, class LocalScalarType>
 void
 BandedContainer<MatrixType, LocalScalarType, true>::
-weightedApply (HostView& X,
-               HostView& Y,
-               HostView& D,
-               int blockIndex,
-               int stride,
-               Teuchos::ETransp mode,
-               scalar_type alpha,
-               scalar_type beta) const
+weightedApply (HostView& /* X */,
+               HostView& /* Y */,
+               HostView& /* D */,
+               int /* blockIndex */,
+               int /* stride */,
+               Teuchos::ETransp /* mode */,
+               scalar_type /* alpha */,
+               scalar_type /* beta */) const
 {
   using Teuchos::ArrayRCP;
   using Teuchos::ArrayView;

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
@@ -352,8 +352,8 @@ namespace Ifpack2 {
   template <typename MatrixType>
   void 
   BlockTriDiContainer<MatrixType, BlockTriDiContainerDetails::ImplSimdTag>
-  ::apply (HostView& X, HostView& Y, int blockIndex, int stride, Teuchos::ETransp mode,
-           scalar_type alpha, scalar_type beta) const
+  ::apply (HostView& /* X */, HostView& /* Y */, int /* blockIndex */, int /* stride */, Teuchos::ETransp /* mode */,
+           scalar_type /* alpha */, scalar_type /* beta */) const
   {
     TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "BlockTriDiContainer::apply is not implemented. You may have reached this message "
                                 << "because you want to use this container's performance-portable Jacobi iteration. In "
@@ -363,8 +363,8 @@ namespace Ifpack2 {
   template <typename MatrixType>
   void 
   BlockTriDiContainer<MatrixType, BlockTriDiContainerDetails::ImplSimdTag>
-  ::weightedApply (HostView& X, HostView& Y, HostView& D, int blockIndex, int stride,
-                   Teuchos::ETransp mode, scalar_type alpha, scalar_type beta) const
+  ::weightedApply (HostView& /* X */, HostView& /* Y */, HostView& /* D */, int /* blockIndex */, int /* stride */,
+                   Teuchos::ETransp /* mode */, scalar_type /* alpha */, scalar_type /* beta */) const
   {
     TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "BlockTriDiContainer::weightedApply is not implemented.");
   }

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1762,7 +1762,7 @@ namespace Ifpack2 {
       void copy_multivectors(const local_ordinal_type &j, 
                              const local_ordinal_type &vi, 
                              const local_ordinal_type &pri, 
-                             const local_ordinal_type &nrow,  
+                             const local_ordinal_type &/* nrow */,  
                              const local_ordinal_type &ri0) const {
         if (TagType::id == 0) { // ToPackedMultiVectorTag
           for (local_ordinal_type col=0;col<num_vectors;++col) 
@@ -1785,7 +1785,7 @@ namespace Ifpack2 {
       void copy_multivectors_with_norm(const local_ordinal_type &j, 
                                        const local_ordinal_type &vi, 
                                        const local_ordinal_type &pri, 
-                                       const local_ordinal_type &nrow,  
+                                       const local_ordinal_type &/* nrow */,  
                                        const local_ordinal_type &ri0,
                                        /* */ magnitude_type *norm) const {
         if (TagType::id > 0) { //ToScalarMultiVector
@@ -2151,7 +2151,7 @@ namespace Ifpack2 {
 
       inline
       void 
-      serialSolveMultiVector(const local_ordinal_type &blocksize, 
+      serialSolveMultiVector(const local_ordinal_type &/* blocksize */, 
                              const local_ordinal_type &packidx) const {
         namespace KB = KokkosBatched::Experimental;
         using AlgoType = KB::Algo::Level3::Blocked;

--- a/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
@@ -417,7 +417,7 @@ void
 Chebyshev<MatrixType>::
 applyImpl (const MV& X,
            MV& Y,
-           Teuchos::ETransp mode,
+           Teuchos::ETransp /* mode */,
            scalar_type alpha,
            scalar_type beta) const
 {

--- a/packages/ifpack2/src/Ifpack2_Container.hpp
+++ b/packages/ifpack2/src/Ifpack2_Container.hpp
@@ -336,9 +336,9 @@ public:
   //
   // This is the first performance-portable implementation of a block
   // relaxation, and it is supported currently only by BlockTriDiContainer.
-  virtual void applyInverseJacobi (const mv_type& X, mv_type& Y,
-                                   bool zeroStartingSolution = false,
-                                   int numSweeps = 1) const
+  virtual void applyInverseJacobi (const mv_type& /* X */, mv_type& /* Y */,
+                                   bool /* zeroStartingSolution = false */,
+                                   int /* numSweeps = 1 */) const
   { TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Not implemented."); }
 
   //! Wrapper for apply with MVs, used in unit tests (never called by BlockRelaxation)

--- a/packages/ifpack2/src/Ifpack2_DiagonalFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_DiagonalFilter_def.hpp
@@ -275,18 +275,18 @@ getLocalRowCopy (LocalOrdinal LocalRow,
 
 template<class MatrixType>
 void DiagonalFilter<MatrixType>::
-getGlobalRowView (GlobalOrdinal GlobalRow,
-                  Teuchos::ArrayView<const GlobalOrdinal> &indices,
-                  Teuchos::ArrayView<const Scalar> &values) const
+getGlobalRowView (GlobalOrdinal /* GlobalRow */,
+                  Teuchos::ArrayView<const GlobalOrdinal> &/* indices */,
+                  Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::DiagonalFilter: does not support getGlobalRowView.");
 }
 
 template<class MatrixType>
 void DiagonalFilter<MatrixType>::
-getLocalRowView (LocalOrdinal LocalRow,
-                 Teuchos::ArrayView<const LocalOrdinal> &indices,
-                 Teuchos::ArrayView<const Scalar> &values) const
+getLocalRowView (LocalOrdinal /* LocalRow */,
+                 Teuchos::ArrayView<const LocalOrdinal> &/* indices */,
+                 Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::DiagonalFilter: does not support getLocalRowView.");
 }
@@ -300,13 +300,13 @@ void DiagonalFilter<MatrixType>::getLocalDiagCopy(Tpetra::Vector<Scalar,LocalOrd
 }
 
 template<class MatrixType>
-void DiagonalFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void DiagonalFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::DiagonalFilter does not support leftScale.");
 }
 
 template<class MatrixType>
-void DiagonalFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void DiagonalFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::DiagonalFilter does not support rightScale.");
 }

--- a/packages/ifpack2/src/Ifpack2_DropFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_DropFilter_def.hpp
@@ -229,7 +229,7 @@ size_t DropFilter<MatrixType>::getNodeNumEntries() const
 
 //==========================================================================
 template<class MatrixType>
-size_t DropFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal globalRow) const
+size_t DropFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal /* globalRow */) const
 {
   throw std::runtime_error("Ifpack2::DropFilter does not implement getNumEntriesInGlobalRow.");
 }
@@ -285,10 +285,10 @@ bool DropFilter<MatrixType>::isFillComplete() const
 
 //==========================================================================
 template<class MatrixType>
-void DropFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal GlobalRow,
-                                                  const Teuchos::ArrayView<GlobalOrdinal> &Indices,
-                                                  const Teuchos::ArrayView<Scalar> &Values,
-                                                  size_t &NumEntries) const
+void DropFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal /* GlobalRow */,
+                                                  const Teuchos::ArrayView<GlobalOrdinal> &/* Indices */,
+                                                  const Teuchos::ArrayView<Scalar> &/* Values */,
+                                                  size_t &/* NumEntries */) const
 {
   throw std::runtime_error("Ifpack2::DropFilter does not implement getGlobalRowCopy.");
 }
@@ -329,18 +329,18 @@ void DropFilter<MatrixType>::getLocalRowCopy(LocalOrdinal LocalRow,
 
 //==========================================================================
 template<class MatrixType>
-void DropFilter<MatrixType>::getGlobalRowView(GlobalOrdinal GlobalRow,
-                                                  Teuchos::ArrayView<const GlobalOrdinal> &indices,
-                                                  Teuchos::ArrayView<const Scalar> &values) const
+void DropFilter<MatrixType>::getGlobalRowView(GlobalOrdinal /* GlobalRow */,
+                                                  Teuchos::ArrayView<const GlobalOrdinal> &/* indices */,
+                                                  Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::DropFilter: does not support getGlobalRowView.");
 }
 
 //==========================================================================
 template<class MatrixType>
-void DropFilter<MatrixType>::getLocalRowView(LocalOrdinal LocalRow,
-                                                 Teuchos::ArrayView<const LocalOrdinal> &indices,
-                                                 Teuchos::ArrayView<const Scalar> &values) const
+void DropFilter<MatrixType>::getLocalRowView(LocalOrdinal /* LocalRow */,
+                                                 Teuchos::ArrayView<const LocalOrdinal> &/* indices */,
+                                                 Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::DropFilter: does not support getLocalRowView.");
 }
@@ -355,14 +355,14 @@ void DropFilter<MatrixType>::getLocalDiagCopy(Tpetra::Vector<Scalar,LocalOrdinal
 
 //==========================================================================
 template<class MatrixType>
-void DropFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void DropFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::DropFilter does not support leftScale.");
 }
 
 //==========================================================================
 template<class MatrixType>
-void DropFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void DropFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::DropFilter does not support rightScale.");
 }
@@ -372,8 +372,8 @@ template<class MatrixType>
 void DropFilter<MatrixType>::apply(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &X,
                                        Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &Y,
                                        Teuchos::ETransp mode,
-                                       Scalar alpha,
-                                       Scalar beta) const
+                                       Scalar /* alpha */,
+                                       Scalar /* beta */) const
 {
   // Note: This isn't AztecOO compliant.  But neither was Ifpack's version.
   // Note: The localized maps mean the matvec is trivial (and has no import)

--- a/packages/ifpack2/src/Ifpack2_LinearPartitioner_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LinearPartitioner_def.hpp
@@ -63,7 +63,7 @@ LinearPartitioner<GraphType>::~LinearPartitioner() {}
 template<class GraphType>
 void
 LinearPartitioner<GraphType>::
-setPartitionParameters (Teuchos::ParameterList& List) {}
+setPartitionParameters (Teuchos::ParameterList& /* List */) {}
 
 
 template<class GraphType>

--- a/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
@@ -583,9 +583,9 @@ getLocalRowCopy (local_ordinal_type LocalRow,
 template<class MatrixType>
 void
 LocalFilter<MatrixType>::
-getGlobalRowView (global_ordinal_type GlobalRow,
-                  Teuchos::ArrayView<const global_ordinal_type> &indices,
-                  Teuchos::ArrayView<const scalar_type> &values) const
+getGlobalRowView (global_ordinal_type /* GlobalRow */,
+                  Teuchos::ArrayView<const global_ordinal_type> &/* indices */,
+                  Teuchos::ArrayView<const scalar_type> &/* values */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
     "Ifpack2::LocalFilter does not implement getGlobalRowView.");
@@ -595,9 +595,9 @@ getGlobalRowView (global_ordinal_type GlobalRow,
 template<class MatrixType>
 void
 LocalFilter<MatrixType>::
-getLocalRowView (local_ordinal_type LocalRow,
-                 Teuchos::ArrayView<const local_ordinal_type> &indices,
-                 Teuchos::ArrayView<const scalar_type> &values) const
+getLocalRowView (local_ordinal_type /* LocalRow */,
+                 Teuchos::ArrayView<const local_ordinal_type> &/* indices */,
+                 Teuchos::ArrayView<const scalar_type> &/* values */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
     "Ifpack2::LocalFilter does not implement getLocalRowView.");
@@ -622,7 +622,7 @@ getLocalDiagCopy (Tpetra::Vector<scalar_type,local_ordinal_type,global_ordinal_t
 template<class MatrixType>
 void
 LocalFilter<MatrixType>::
-leftScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& x)
+leftScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& /* x */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
     "Ifpack2::LocalFilter does not implement leftScale.");
@@ -632,7 +632,7 @@ leftScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_
 template<class MatrixType>
 void
 LocalFilter<MatrixType>::
-rightScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& x)
+rightScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& /* x */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
     "Ifpack2::LocalFilter does not implement rightScale.");

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -85,6 +85,7 @@ public:
   }
 
   void setParameters (const Teuchos::ParameterList& pl) {
+    (void)pl;
 #ifdef HAVE_IFPACK2_SHYLU_NODEHTS
     const char* block_size_s = "trisolver: block size";
     if (pl.isParameter(block_size_s)) {
@@ -109,6 +110,8 @@ public:
   }
 
   void compute (const crs_matrix_type& T_in, const Teuchos::RCP<Teuchos::FancyOStream>& out) {
+    (void)T_in;
+    (void)out;
 #ifdef HAVE_IFPACK2_SHYLU_NODEHTS
     using Teuchos::ArrayRCP;
 
@@ -179,8 +182,12 @@ public:
 
   // Y := beta * Y + alpha * (M * X)
   void localApply (const MV& X, MV& Y,
-                   const Teuchos::ETransp mode,
+                   const Teuchos::ETransp /* mode */,
                    const scalar_type& alpha, const scalar_type& beta) const {
+    (void)X;
+    (void)Y;
+    (void)alpha;
+    (void)beta;
 #ifdef HAVE_IFPACK2_SHYLU_NODEHTS
     const auto& X_view = X.template getLocalView<Kokkos::HostSpace>();
     const auto& Y_view = Y.template getLocalView<Kokkos::HostSpace>();

--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
@@ -532,7 +532,7 @@ getLocalDiagCopy (Tpetra::Vector<scalar_type,local_ordinal_type,global_ordinal_t
 template<class MatrixType>
 void
 OverlappingRowMatrix<MatrixType>::
-leftScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& x)
+leftScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& /* x */)
 {
   throw std::runtime_error("Ifpack2::OverlappingRowMatrix does not support leftScale.");
 }
@@ -541,7 +541,7 @@ leftScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_
 template<class MatrixType>
 void
 OverlappingRowMatrix<MatrixType>::
-rightScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& x)
+rightScale (const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& /* x */)
 {
   throw std::runtime_error("Ifpack2::OverlappingRowMatrix does not support leftScale.");
 }

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -483,7 +483,7 @@ void
 Relaxation<MatrixType>::
 apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& X,
        Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& Y,
-       Teuchos::ETransp mode,
+       Teuchos::ETransp /* mode */,
        scalar_type alpha,
        scalar_type beta) const
 {
@@ -1728,8 +1728,8 @@ Relaxation<MatrixType>::
 MTGaussSeidel (const crs_matrix_type* crsMat,
                Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type>& X,
                const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type>& B,
-               const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type>& D,
-               const scalar_type& dampingFactor,
+               const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type>& /* D */,
+               const scalar_type& /* dampingFactor */,
                const Tpetra::ESweepDirection direction,
                const int numSweeps,
                const bool zeroInitialGuess) const

--- a/packages/ifpack2/src/Ifpack2_ReorderFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ReorderFilter_def.hpp
@@ -379,9 +379,9 @@ getLocalRowCopy (local_ordinal_type LocalRow,
 
 template<class MatrixType>
 void ReorderFilter<MatrixType>::
-getGlobalRowView (global_ordinal_type GlobalRow,
-                  Teuchos::ArrayView<const global_ordinal_type> &indices,
-                  Teuchos::ArrayView<const scalar_type> &values) const
+getGlobalRowView (global_ordinal_type /* GlobalRow */,
+                  Teuchos::ArrayView<const global_ordinal_type> &/* indices */,
+                  Teuchos::ArrayView<const scalar_type> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::ReorderFilter: does not support getGlobalRowView.");
 }
@@ -389,9 +389,9 @@ getGlobalRowView (global_ordinal_type GlobalRow,
 
 template<class MatrixType>
 void ReorderFilter<MatrixType>::
-getLocalRowView (local_ordinal_type LocalRow,
-                 Teuchos::ArrayView<const local_ordinal_type> &indices,
-                 Teuchos::ArrayView<const scalar_type> &values) const
+getLocalRowView (local_ordinal_type /* LocalRow */,
+                 Teuchos::ArrayView<const local_ordinal_type> &/* indices */,
+                 Teuchos::ArrayView<const scalar_type> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::ReorderFilter: does not support getLocalRowView.");
 }
@@ -407,14 +407,14 @@ getLocalDiagCopy (Tpetra::Vector<scalar_type,local_ordinal_type,global_ordinal_t
 
 
 template<class MatrixType>
-void ReorderFilter<MatrixType>::leftScale(const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& x)
+void ReorderFilter<MatrixType>::leftScale(const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& /* x */)
 {
   throw std::runtime_error("Ifpack2::ReorderFilter does not support leftScale.");
 }
 
 
 template<class MatrixType>
-void ReorderFilter<MatrixType>::rightScale(const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& x)
+void ReorderFilter<MatrixType>::rightScale(const Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type>& /* x */)
 {
   throw std::runtime_error("Ifpack2::ReorderFilter does not support rightScale.");
 }

--- a/packages/ifpack2/src/Ifpack2_SingletonFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SingletonFilter_def.hpp
@@ -244,7 +244,7 @@ size_t SingletonFilter<MatrixType>::getNodeNumEntries() const
 }
 
 template<class MatrixType>
-size_t SingletonFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal globalRow) const
+size_t SingletonFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal /* globalRow */) const
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not implement getNumEntriesInGlobalRow.");
 }
@@ -292,10 +292,10 @@ bool SingletonFilter<MatrixType>::isFillComplete() const
 }
 
 template<class MatrixType>
-void SingletonFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal GlobalRow,
-                                                  const Teuchos::ArrayView<GlobalOrdinal> &Indices,
-                                                  const Teuchos::ArrayView<Scalar> &Values,
-                                                  size_t &NumEntries) const
+void SingletonFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal /* GlobalRow */,
+                                                  const Teuchos::ArrayView<GlobalOrdinal> &/* Indices */,
+                                                  const Teuchos::ArrayView<Scalar> &/* Values */,
+                                                  size_t &/* NumEntries */) const
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not implement getGlobalRowCopy.");
 }
@@ -326,17 +326,17 @@ void SingletonFilter<MatrixType>::getLocalRowCopy(LocalOrdinal LocalRow,
 }
 
 template<class MatrixType>
-void SingletonFilter<MatrixType>::getGlobalRowView(GlobalOrdinal GlobalRow,
-                                                  Teuchos::ArrayView<const GlobalOrdinal> &indices,
-                                                  Teuchos::ArrayView<const Scalar> &values) const
+void SingletonFilter<MatrixType>::getGlobalRowView(GlobalOrdinal /* GlobalRow */,
+                                                  Teuchos::ArrayView<const GlobalOrdinal> &/* indices */,
+                                                  Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::SingletonFilter: does not support getGlobalRowView.");
 }
 
 template<class MatrixType>
-void SingletonFilter<MatrixType>::getLocalRowView(LocalOrdinal LocalRow,
-                                                 Teuchos::ArrayView<const LocalOrdinal> &indices,
-                                                 Teuchos::ArrayView<const Scalar> &values) const
+void SingletonFilter<MatrixType>::getLocalRowView(LocalOrdinal /* LocalRow */,
+                                                 Teuchos::ArrayView<const LocalOrdinal> &/* indices */,
+                                                 Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::SingletonFilter: does not support getLocalRowView.");
 }
@@ -349,13 +349,13 @@ void SingletonFilter<MatrixType>::getLocalDiagCopy(Tpetra::Vector<Scalar,LocalOr
 }
 
 template<class MatrixType>
-void SingletonFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void SingletonFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not support leftScale.");
 }
 
 template<class MatrixType>
-void SingletonFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void SingletonFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::SingletonFilter does not support rightScale.");
 }
@@ -364,8 +364,8 @@ template<class MatrixType>
 void SingletonFilter<MatrixType>::apply(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &X,
                                        Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &Y,
                                        Teuchos::ETransp mode,
-                                       Scalar alpha,
-                                       Scalar beta) const
+                                       Scalar /* alpha */,
+                                       Scalar /* beta */) const
 {
   typedef Scalar DomainScalar;
   typedef Scalar RangeScalar;

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
@@ -195,7 +195,7 @@ void SparseContainer<MatrixType,InverseType>::
 applyImpl (inverse_mv_type& X,
            inverse_mv_type& Y,
            int blockIndex,
-           int stride,
+           int /* stride */,
            Teuchos::ETransp mode,
            InverseScalar alpha,
            InverseScalar beta) const
@@ -335,7 +335,7 @@ weightedApply (HostView& X,
                HostView& Y,
                HostView& D,
                int blockIndex,
-               int stride,
+               int /* stride */,
                Teuchos::ETransp mode,
                scalar_type alpha,
                scalar_type beta) const

--- a/packages/ifpack2/src/Ifpack2_SparsityFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparsityFilter_def.hpp
@@ -224,7 +224,7 @@ size_t SparsityFilter<MatrixType>::getNodeNumEntries() const
 
 //==========================================================================
 template<class MatrixType>
-size_t SparsityFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal globalRow) const
+size_t SparsityFilter<MatrixType>::getNumEntriesInGlobalRow(GlobalOrdinal /* globalRow */) const
 {
   throw std::runtime_error("Ifpack2::SparsityFilter does not implement getNumEntriesInGlobalRow.");
 }
@@ -280,10 +280,10 @@ bool SparsityFilter<MatrixType>::isFillComplete() const
 
 //==========================================================================
 template<class MatrixType>
-void SparsityFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal GlobalRow,
-                                                  const Teuchos::ArrayView<GlobalOrdinal> &Indices,
-                                                  const Teuchos::ArrayView<Scalar> &Values,
-                                                  size_t &NumEntries) const
+void SparsityFilter<MatrixType>::getGlobalRowCopy(GlobalOrdinal /* GlobalRow */,
+                                                  const Teuchos::ArrayView<GlobalOrdinal> &/* Indices */,
+                                                  const Teuchos::ArrayView<Scalar> &/* Values */,
+                                                  size_t &/* NumEntries */) const
 {
   throw std::runtime_error("Ifpack2::SparsityFilter does not implement getGlobalRowCopy.");
 }
@@ -349,18 +349,18 @@ void SparsityFilter<MatrixType>::getLocalRowCopy(LocalOrdinal LocalRow,
 
 //==========================================================================
 template<class MatrixType>
-void SparsityFilter<MatrixType>::getGlobalRowView(GlobalOrdinal GlobalRow,
-                                                  Teuchos::ArrayView<const GlobalOrdinal> &indices,
-                                                  Teuchos::ArrayView<const Scalar> &values) const
+void SparsityFilter<MatrixType>::getGlobalRowView(GlobalOrdinal /* GlobalRow */,
+                                                  Teuchos::ArrayView<const GlobalOrdinal> &/* indices */,
+                                                  Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::SparsityFilter: does not support getGlobalRowView.");
 }
 
 //==========================================================================
 template<class MatrixType>
-void SparsityFilter<MatrixType>::getLocalRowView(LocalOrdinal LocalRow,
-                                                 Teuchos::ArrayView<const LocalOrdinal> &indices,
-                                                 Teuchos::ArrayView<const Scalar> &values) const
+void SparsityFilter<MatrixType>::getLocalRowView(LocalOrdinal /* LocalRow */,
+                                                 Teuchos::ArrayView<const LocalOrdinal> &/* indices */,
+                                                 Teuchos::ArrayView<const Scalar> &/* values */) const
 {
   throw std::runtime_error("Ifpack2::SparsityFilter: does not support getLocalRowView.");
 }
@@ -375,14 +375,14 @@ void SparsityFilter<MatrixType>::getLocalDiagCopy(Tpetra::Vector<Scalar,LocalOrd
 
 //==========================================================================
 template<class MatrixType>
-void SparsityFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void SparsityFilter<MatrixType>::leftScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::SparsityFilter does not support leftScale.");
 }
 
 //==========================================================================
 template<class MatrixType>
-void SparsityFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x)
+void SparsityFilter<MatrixType>::rightScale(const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& /* x */)
 {
   throw std::runtime_error("Ifpack2::SparsityFilter does not support rightScale.");
 }
@@ -392,8 +392,8 @@ template<class MatrixType>
 void SparsityFilter<MatrixType>::apply(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &X,
                                        Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &Y,
                                        Teuchos::ETransp mode,
-                                       Scalar alpha,
-                                       Scalar beta) const
+                                       Scalar /* alpha */,
+                                       Scalar /* beta */) const
 {
   // Note: This isn't AztecOO compliant.  But neither was Ifpack's version.
   // Note: The localized maps mean the matvec is trivial (and has no import)


### PR DESCRIPTION
@trilinos/ifpack2 

## Description
Compiling Trilinos with gcc-7.2.0 yields quite a number of unused parameter warnings.  This PR comments out parameter names in function definitions to avoid those warnings.

## Motivation and Context
Just trying to get closer to a clean build.

## How Has This Been Tested?
Ifpack2 still builds just fine.  Letting the @trilinos-autotester do its thing.

## Additional Information
These changes were made via a script I wrote.  I've looked over them, but something might've gone wrong that I didn't catch.