### PR TITLE
NOX:  Copy vector size in NOX::LAPACK::Vector::operator=()

### DIFF
--- a/packages/nox/src-lapack/NOX_LAPACK_Vector.C
+++ b/packages/nox/src-lapack/NOX_LAPACK_Vector.C
@@ -85,6 +85,7 @@ NOX::LAPACK::Vector::~Vector()
 NOX::Abstract::Vector&
 NOX::LAPACK::Vector::operator=(const std::vector<double>& source)
 {
+  n = source.size();
   x = source;
   return *this;
 }
@@ -98,6 +99,7 @@ NOX::LAPACK::Vector::operator=(const NOX::Abstract::Vector& source)
 NOX::Abstract::Vector&
 NOX::LAPACK::Vector::operator=(const NOX::LAPACK::Vector& source)
 {
+  n = source.n;
   x = source.x;
   return *this;
 }


### PR DESCRIPTION
A NOX/LOCA user was seeing strange behavior when using the LAPACK
interface, which I tracked down to inconsistent vector sizes because
operator=() doesn't copy the vector's size.  I guess this was
technically incorrect usage on his part, but I don't see any reason why
the following shouldn't work:

NOX::LAPACK::Vector x;
x = NOX::LAPACK::Vector(100);

With this change, this will now work as expected.