### PR TITLE
Disable test Piro_MatrixFreeDecorator_UnitTests_MPI_4 in Intel builds (#2474)

### DIFF
--- a/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-OPENMP-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-OPENMP-HSW.cmake
@@ -2,3 +2,6 @@
 ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
   "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
   CACHE STRING )
+
+# This test fails consistently with a major numerical error (#2474)
+ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-SERIAL-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-SERIAL-HSW.cmake
@@ -6,3 +6,6 @@ ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
 # Disable some unit tests that run too slow in this DEBUG build (#2827)
 "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
   CACHE STRING )
+
+# This test fails consistently with a major numerical error (#2474)
+ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-OPENMP-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-OPENMP-HSW.cmake
@@ -1,0 +1,2 @@
+# This test fails consistently with a major numerical error (#2474)
+ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-SERIAL-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-SERIAL-HSW.cmake
@@ -1,0 +1,2 @@
+# This test fails consistently with a major numerical error (#2474)
+ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)


### PR DESCRIPTION
@trilinos/piro, @fryeguy52, @rppawlo (Trilinos Nonlinear Algorithms Product Lead)

## Description

With KOKKOS_ARCH=HSW now being set for these Intel builds, this test diffs
badly just like for the GNU builds.  Therefore, it is being disabled in these
builds as well (see #2474).

## Motivation and Context

Need to clean up failing tests in promoted ATDM builds.

## How Has This Been Tested?

On 'shiller' I ran:

```
$ ./checkin-test-atdm.sh \
  intel-debug-openmp-HSW intel-debug-serial-HSW intel-opt-openmp-HSW intel-opt-serial-HSW \
  --enable-packages=Piro --configure
```

which returned:

```
PASSED (NOT READY TO PUSH): Trilinos: shiller01

Tue Aug  7 14:58:51 MDT 2018

Enabled Packages: Piro

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT_OPENMP => Test case MPI_RELEASE_DEBUG_SHARED_PT_OPENMP was not run! => Does not affect push readiness! (-1.00 min)
1) intel-debug-openmp-HSW => passed: configure-only passed => Not ready to push! (1.62 min)
2) intel-debug-serial-HSW => passed: configure-only passed => Not ready to push! (4.06 min)
3) intel-opt-openmp-HSW => passed: configure-only passed => Not ready to push! (1.82 min)
4) intel-opt-serial-HSW => passed: configure-only passed => Not ready to push! (1.39 min)
```

And the following grep for the disables looks correct:

```
$ find . -maxdepth 2 -name configure.out -exec grep -H _DISABLE {} \; | grep intel- | grep "NOT added"
./intel-debug-serial-HSW/configure.out:-- Piro_MatrixFreeDecorator_UnitTests_MPI_4: NOT added test because Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE='ON'!
./intel-opt-serial-HSW/configure.out:-- Piro_MatrixFreeDecorator_UnitTests_MPI_4: NOT added test because Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE='ON'!
./intel-debug-openmp-HSW/configure.out:-- Piro_MatrixFreeDecorator_UnitTests_MPI_4: NOT added test because Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE='ON'!
./intel-opt-openmp-HSW/configure.out:-- Piro_MatrixFreeDecorator_UnitTests_MPI_4: NOT added test because Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE='ON'!
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
