### PR TITLE
Panzer: Fix for apparently uninitialized values

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -490,6 +490,7 @@ convertNormalToRotationMatrix(const T normal[3], T transverse[3], T binormal[3])
     binormal[1] = 0.;
     binormal[2] = 0.;
 
+    // TEUCHOS_ASSERT(false);
   }
 
 }
@@ -601,7 +602,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
 
   // We get to build up our cubature one face at a time
   int point_offset=0;
-  for(int subcell_index=0; subcell_index<num_subcells; ++subcell_index){
+  for(int subcell_index=0; subcell_index<num_subcells; ++subcell_index) {
 
     // Default for 1D
     int num_points_on_face = 1;
@@ -770,6 +771,10 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
   for(int cell=0; cell<num_cells; ++cell){
     for(int subcell_index=0; subcell_index<num_subcells; ++subcell_index){
       for(int point=0; point<num_points; ++point){
+
+        for(int dim=0; dim<3; ++dim)
+          normal[dim] = 0.0;
+
         for(int dim=0; dim<cell_dim; ++dim){
           normal[dim] = surface_normals(cell,point,dim);
         }
@@ -1080,7 +1085,7 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
 
     evaluateValuesCV(in_node_coordinates);
   }
-               }
+}
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::


### PR DESCRIPTION
This is a speculative change that these values were uninitialized. This is work that @krcb and others did in exploring some bugs.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer
## Description
Added an initialization for normal directions to zero. The normal is allocated as a 3-vector; however, all values can be used. This ensures that the values are initialized to zero appropriately.