### PR TITLE
Tempus:  Split apart DIRK FSA tests to reduce test run time.

### DIFF
--- a/packages/tempus/test/DIRK/CMakeLists.txt
+++ b/packages/tempus/test/DIRK/CMakeLists.txt
@@ -8,17 +8,155 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_EXECUTABLE(
   DIRK_Combined_FSA
-  SOURCES Tempus_DIRK_Combined_FSA.cpp Tempus_DIRK_FSA.hpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  SOURCES Tempus_DIRK_Combined_FSA.cpp Tempus_DIRK_FSA.hpp
   TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_Backward_Euler"
+  ARGS "--method=\"RK Backward Euler\""
   NUM_MPI_PROCS 1
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_IRK_1_Stage_Theta"
+  ARGS "--method=\"IRK 1 Stage Theta Method\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_SDIRK_1_Stage_1st_Order"
+  ARGS "--method=\"SDIRK 1 Stage 1st order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_SDIRK_2_Stage_2nd_Order"
+  ARGS "--method=\"SDIRK 2 Stage 2nd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_SDIRK_2_Stage_3rd_Order"
+  ARGS "--method=\"SDIRK 2 Stage 3rd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_EDIRK_2_Stage_3rd_Order"
+  ARGS "--method=\"EDIRK 2 Stage 3rd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_EDIRK_2_Stage_Theta_Method"
+  ARGS "--method=\"EDIRK 2 Stage Theta Method\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_SDIRK_3_Stage_4th_Order"
+  ARGS "--method=\"SDIRK 3 Stage 4th order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_SDIRK_5_Stage_4th_Order"
+  ARGS "--method=\"SDIRK 5 Stage 4th order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Combined_FSA
+  NAME "DIRK_Combined_FSA_SDIRK_5_Stage_5th_Order"
+  ARGS "--method=\"SDIRK 5 Stage 5th order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE(
   DIRK_Staggered_FSA
-  SOURCES Tempus_DIRK_Staggered_FSA.cpp Tempus_DIRK_FSA.hpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  SOURCES Tempus_DIRK_Staggered_FSA.cpp Tempus_DIRK_FSA.hpp
   TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_Backward_Euler"
+  ARGS "--method=\"RK Backward Euler\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_IRK_1_Stage_Theta"
+  ARGS "--method=\"IRK 1 Stage Theta Method\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_SDIRK_1_Stage_1st_Order"
+  ARGS "--method=\"SDIRK 1 Stage 1st order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_SDIRK_2_Stage_2nd_Order"
+  ARGS "--method=\"SDIRK 2 Stage 2nd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_SDIRK_2_Stage_3rd_Order"
+  ARGS "--method=\"SDIRK 2 Stage 3rd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_EDIRK_2_Stage_3rd_Order"
+  ARGS "--method=\"EDIRK 2 Stage 3rd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_EDIRK_2_Stage_Theta_Method"
+  ARGS "--method=\"EDIRK 2 Stage Theta Method\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_SDIRK_3_Stage_4th_Order"
+  ARGS "--method=\"SDIRK 3 Stage 4th order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_SDIRK_5_Stage_4th_Order"
+  ARGS "--method=\"SDIRK 5 Stage 4th order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  DIRK_Staggered_FSA
+  NAME "DIRK_Staggered_FSA_SDIRK_5_Stage_5th_Order"
+  ARGS "--method=\"SDIRK 5 Stage 5th order\""
   NUM_MPI_PROCS 1
   )
 

--- a/packages/tempus/test/DIRK/Tempus_DIRK_Combined_FSA.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_Combined_FSA.cpp
@@ -8,16 +8,34 @@
 
 #include "Tempus_DIRK_FSA.hpp"
 
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+std::string method_name;
+
 namespace Tempus_Test {
 
 TEUCHOS_UNIT_TEST(DIRK, SinCos_Combined_FSA)
 {
-  test_sincos_fsa(true, false, out, success);
+  test_sincos_fsa(method_name, true, false, out, success);
 }
 
 TEUCHOS_UNIT_TEST(DIRK, SinCos_Combined_FSA_Tangent)
 {
-  test_sincos_fsa(true, true, out, success);
+  test_sincos_fsa(method_name, true, true, out, success);
 }
 
 } // namespace Tempus_Test
+
+int main( int argc, char* argv[] )
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  // Add "--method" command line argument
+  Teuchos::CommandLineProcessor& CLP = Teuchos::UnitTestRepository::getCLP();
+  method_name = "";
+  CLP.setOption("method", &method_name, "Stepper method");
+
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/tempus/test/DIRK/Tempus_DIRK_FSA.hpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_FSA.hpp
@@ -40,7 +40,8 @@ using Tempus::SolutionState;
 
 // ************************************************************
 // ************************************************************
-void test_sincos_fsa(const bool use_combined_method,
+void test_sincos_fsa(const std::string& method_name,
+                     const bool use_combined_method,
                      const bool use_dfdp_as_tangent,
                      Teuchos::FancyOStream &out, bool &success)
 {
@@ -55,6 +56,13 @@ void test_sincos_fsa(const bool use_combined_method,
   RKMethods.push_back("SDIRK 3 Stage 4th order");
   RKMethods.push_back("SDIRK 5 Stage 4th order");
   RKMethods.push_back("SDIRK 5 Stage 5th order");
+
+  // Check that method_name is valid
+  if (method_name != "") {
+    auto it = std::find(RKMethods.begin(), RKMethods.end(), method_name);
+    TEUCHOS_TEST_FOR_EXCEPTION(it == RKMethods.end(), std::logic_error,
+                               "Invalid RK method name " << method_name);
+  }
 
   std::vector<double> RKMethodErrors;
   if (use_combined_method) {
@@ -90,6 +98,10 @@ void test_sincos_fsa(const bool use_combined_method,
   my_out->setOutputToRootOnly(0);
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
+
+    // If we were given a method to run, skip this method if it doesn't match
+    if (method_name != "" && RKMethods[m] != method_name)
+      continue;
 
     std::string RKMethod_ = RKMethods[m];
     std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');

--- a/packages/tempus/test/DIRK/Tempus_DIRK_Staggered_FSA.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_Staggered_FSA.cpp
@@ -8,16 +8,34 @@
 
 #include "Tempus_DIRK_FSA.hpp"
 
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+std::string method_name;
+
 namespace Tempus_Test {
 
 TEUCHOS_UNIT_TEST(DIRK, SinCos_Staggered_FSA)
 {
-  test_sincos_fsa(false, false, out, success);
+  test_sincos_fsa(method_name, false, false, out, success);
 }
 
 TEUCHOS_UNIT_TEST(DIRK, SinCos_Staggered_FSA_Tangent)
 {
-  test_sincos_fsa(false, true, out, success);
+  test_sincos_fsa(method_name, false, true, out, success);
 }
 
 } // namespace Tempus_Test
+
+int main( int argc, char* argv[] )
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  // Add "--method" command line argument
+  Teuchos::CommandLineProcessor& CLP = Teuchos::UnitTestRepository::getCLP();
+  method_name = "";
+  CLP.setOption("method", &method_name, "Stepper method");
+
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}


### PR DESCRIPTION
For issue #3256.

This splits apart the Combined and Staggered FSA DIRK tests so that each
test only runs a single time integration method (so now 10 separate
tests).  This was done by adding the method to run as a command-line
argument, and if the argument is not supplied, all of the methods are
run.