### PR TITLE
NOX:  Fix Build Problem from 3c24e90

### DIFF
--- a/packages/nox/src-loca/src-lapack/LOCA_LAPACK_Group.C
+++ b/packages/nox/src-loca/src-lapack/LOCA_LAPACK_Group.C
@@ -405,8 +405,9 @@ LOCA::LAPACK::Group::isComplex() const
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::LAPACK::Group::computeComplex(double /* frequency */)
+LOCA::LAPACK::Group::computeComplex(double frequency)
 {
+  (void)frequency;
   std::string callingFunction = "LOCA::LAPACK::computeComplex()";
 
 #ifdef HAVE_TEUCHOS_COMPLEX
@@ -452,11 +453,15 @@ LOCA::LAPACK::Group::computeComplex(double /* frequency */)
 }
 
 NOX::Abstract::Group::ReturnType
-LOCA::LAPACK::Group::applyComplex(const NOX::Abstract::Vector& /* input_real */,
-                  const NOX::Abstract::Vector& /* input_imag */,
-                  NOX::Abstract::Vector& /* result_real */,
-                  NOX::Abstract::Vector& /* result_imag */) const
+LOCA::LAPACK::Group::applyComplex(const NOX::Abstract::Vector& input_real,
+                  const NOX::Abstract::Vector& input_imag,
+                  NOX::Abstract::Vector& result_real,
+                  NOX::Abstract::Vector& result_imag) const
 {
+  (void)input_real;
+  (void)input_imag;
+  (void)result_real;
+  (void)result_imag;
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
   if (!isComplex())
@@ -499,11 +504,15 @@ LOCA::LAPACK::Group::applyComplex(const NOX::Abstract::Vector& /* input_real */,
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexMultiVector(
-                const NOX::Abstract::MultiVector& /* input_real */,
-                const NOX::Abstract::MultiVector& /* input_imag */,
-                NOX::Abstract::MultiVector& /* result_real */,
-                NOX::Abstract::MultiVector& /* result_imag */) const
+                const NOX::Abstract::MultiVector& input_real,
+                const NOX::Abstract::MultiVector& input_imag,
+                NOX::Abstract::MultiVector& result_real,
+                NOX::Abstract::MultiVector& result_imag) const
 {
+  (void)input_real;
+  (void)input_imag;
+  (void)result_real;
+  (void)result_imag;
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
   if (!isComplex())
@@ -560,11 +569,15 @@ LOCA::LAPACK::Group::applyComplexMultiVector(
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexInverseMultiVector(
                 Teuchos::ParameterList& /* params */,
-                const NOX::Abstract::MultiVector& /* input_real */,
-                const NOX::Abstract::MultiVector& /* input_imag */,
-                NOX::Abstract::MultiVector& /* result_real */,
-                NOX::Abstract::MultiVector& /* result_imag */) const
+                const NOX::Abstract::MultiVector& input_real,
+                const NOX::Abstract::MultiVector& input_imag,
+                NOX::Abstract::MultiVector& result_real,
+                NOX::Abstract::MultiVector& result_imag) const
 {
+  (void)input_real;
+  (void)input_imag;
+  (void)result_real;
+  (void)result_imag;
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
   if (!isComplex())
@@ -622,11 +635,15 @@ LOCA::LAPACK::Group::applyComplexInverseMultiVector(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexTranspose(
-                  const NOX::Abstract::Vector& /* input_real */,
-                  const NOX::Abstract::Vector& /* input_imag */,
-                  NOX::Abstract::Vector& /* result_real */,
-                  NOX::Abstract::Vector& /* result_imag */) const
+                  const NOX::Abstract::Vector& input_real,
+                  const NOX::Abstract::Vector& input_imag,
+                  NOX::Abstract::Vector& result_real,
+                  NOX::Abstract::Vector& result_imag) const
 {
+  (void)input_real;
+  (void)input_imag;
+  (void)result_real;
+  (void)result_imag;
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
   if (!isComplex())
@@ -669,11 +686,15 @@ LOCA::LAPACK::Group::applyComplexTranspose(
 
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexTransposeMultiVector(
-                const NOX::Abstract::MultiVector& /* input_real */,
-                const NOX::Abstract::MultiVector& /* input_imag */,
-                NOX::Abstract::MultiVector& /* result_real */,
-                NOX::Abstract::MultiVector& /* result_imag */) const
+                const NOX::Abstract::MultiVector& input_real,
+                const NOX::Abstract::MultiVector& input_imag,
+                NOX::Abstract::MultiVector& result_real,
+                NOX::Abstract::MultiVector& result_imag) const
 {
+  (void)input_real;
+  (void)input_imag;
+  (void)result_real;
+  (void)result_imag;
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
   if (!isComplex())
@@ -730,11 +751,15 @@ LOCA::LAPACK::Group::applyComplexTransposeMultiVector(
 NOX::Abstract::Group::ReturnType
 LOCA::LAPACK::Group::applyComplexTransposeInverseMultiVector(
                 Teuchos::ParameterList& /* params */,
-                const NOX::Abstract::MultiVector& /* input_real */,
-                const NOX::Abstract::MultiVector& /* input_imag */,
-                NOX::Abstract::MultiVector& /* result_real */,
-                NOX::Abstract::MultiVector& /* result_imag */) const
+                const NOX::Abstract::MultiVector& input_real,
+                const NOX::Abstract::MultiVector& input_imag,
+                NOX::Abstract::MultiVector& result_real,
+                NOX::Abstract::MultiVector& result_imag) const
 {
+  (void)input_real;
+  (void)input_imag;
+  (void)result_real;
+  (void)result_imag;
 #ifdef HAVE_TEUCHOS_COMPLEX
    // Check validity of the Jacobian
   if (!isComplex())


### PR DESCRIPTION
@trilinos/nox 

## Description
Merging #3240 caused a build failure in LOCA if you happen to have `Teuchos_ENABLE_COMPLEX=ON`.  This PR makes it such that the particular file doesn't emit unused parameter warnings, but will still compile with that flag on.

## Motivation and Context
Just trying to get closer to a clean build.

## How Has This Been Tested?
Builds fine for me.  Letting @trilinos-autotester do its thing.

## Additional Information
@trilinos/framework, do we want `Teuchos_ENABLE_COMPLEX=ON` for the PR builds?