### PR TITLE
Sacado:  Fix possible NaNs in CppUnit nested Fad test

### DIFF
--- a/packages/sacado/test/TestSuite/NestedFadUnitTests.hpp
+++ b/packages/sacado/test/TestSuite/NestedFadUnitTests.hpp
@@ -340,17 +340,20 @@ protected:
 
 }; // class FadFadOpsUnitTest
 
+// Set the random number generator with a specific seed to prevent NaN's
+// in the second derivatives, likely due to overflow
+
 template <class FadFadType, class ScalarType>
 FadFadOpsUnitTest<FadFadType,ScalarType>::
 FadFadOpsUnitTest() :
-  urand(), n1(5), n2(3), tol_a(1.0e-15), tol_r(1.0e-14) {}
+  urand(0.0, 1.0, 123456), n1(5), n2(3), tol_a(1.0e-15), tol_r(1.0e-14) {}
 
 template <class FadFadType, class ScalarType>
 FadFadOpsUnitTest<FadFadType,ScalarType>::
 FadFadOpsUnitTest(int numComponents1, int numComponents2,
                   ScalarType absolute_tolerance,
                   ScalarType relative_tolerance) :
-  urand(),
+  urand(0.0, 1.0, 123456),
   n1(numComponents1),
   n2(numComponents2),
   tol_a(absolute_tolerance),


### PR DESCRIPTION
Depending on what random numbers you got in the nested Fad test, you
could get NaNs in the second derviatives on some machines/compilers.
This fixes that by supplying a fixed seed.

@mhoemmen or @rppawlo, would one of you guys mind approving this?