### PR TITLE
ADTM KNL build on mutrino to use OMP_NUM_THREADS=2

### DIFF
--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -51,7 +51,7 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HS
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "KNL"  ]; then
     module use /projects/EMPIRE/mutrino/tpls/knl/modulefiles
     export SLURM_TASKS_PER_NODE=16
-    export OMP_NUM_THREADS=16
+    export OMP_NUM_THREADS=2
     export OMP_PLACES=threads
     export OMP_PROC_BIND=spread
     export ATDM_CONFIG_MPI_POST_FLAG="--hint=nomultithread;-c 4"


### PR DESCRIPTION
@trilinos/framework @bartlettroscoe 

## Description
Change atdm KNL build on mutrino to use `OMP_NUM_THREADS=2` previously it was set to 16.  This change in local testing of the panzer test suite caused the tests to run in about 1/2 of the time.

## Motivation and Context
The panzer tests were being run in about 1/2 the time in the Empire KNL build on mutrino.  This is to get the ATDM build to finish in a comparable time

## How Has This Been Tested?
I tested this locally by runnig tests with the two different values for `OMP_NUM_THREADS`

with `OMP_NUM_THREADS=2` Total Test time is 132.80 sec
```
ctest -j8 -R PanzerAdaptersSTK_CurlLaplacianExample
Test project /lscratch1/jfrye/SRC_AND_BUILD/BUILD
    Start 133: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4
    Start 132: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3
1/5 Test #132: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3 ...   Passed   44.96 sec
    Start 131: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-2
2/5 Test #133: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 ...   Passed   77.43 sec
    Start 130: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-1
3/5 Test #131: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-2 ...   Passed   68.40 sec
    Start 129: PanzerAdaptersSTK_CurlLaplacianExample
4/5 Test #130: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-1 ...   Passed   41.77 sec
5/5 Test #129: PanzerAdaptersSTK_CurlLaplacianExample .........................   Passed   16.15 sec

100% tests passed, 0 tests failed out of 5

Subproject Time Summary:
Panzer    = 994.88 sec*proc (5 tests)

Total Test time (real) = 132.80 sec

env | sort|grep -i omp_
OMP_NUM_THREADS=2
```

with `OMP_NUM_THREADS=16` total test time is 407.84 sec
```
ctest -j8 -R PanzerAdaptersSTK_CurlLaplacianExample
Test project /lscratch1/jfrye/SRC_AND_BUILD/BUILD
    Start 133: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4
    Start 132: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3
1/5 Test #133: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 ...   Passed  269.91 sec
    Start 131: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-2
2/5 Test #132: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3 ...   Passed  315.79 sec
    Start 130: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-1
3/5 Test #131: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-2 ...   Passed  104.72 sec
    Start 129: PanzerAdaptersSTK_CurlLaplacianExample
4/5 Test #130: PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-1 ...   Passed   67.46 sec
5/5 Test #129: PanzerAdaptersSTK_CurlLaplacianExample .........................   Passed   30.81 sec

100% tests passed, 0 tests failed out of 5

Subproject Time Summary:
Panzer    = 3154.75 sec*proc (5 tests)

Total Test time (real) = 407.84 sec

env | sort|grep -i omp_
OMP_NUM_THREADS=16
```