### PR TITLE
Zoltan2: Fix #3194 (build w/ Tpetra_INST_INT_INT=OFF)

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
@@ -42,7 +42,7 @@ private:
 public:
   /*! \brief Default Constructor
    */
-  Zoltan2_ReduceBestMapping ():_EPSILON (std::numeric_limits<T>::epsilon()){}
+  Zoltan2_ReduceBestMapping():_EPSILON(std::numeric_limits<T>::epsilon()){}
 
   /*! \brief Implement Teuchos::ValueTypeReductionOp interface
    */
@@ -109,7 +109,7 @@ void ithPermutation(const IT n, IT i, IT *perm)
 }
 
 template <typename part_t>
-void getGridCommunicationGraph(part_t taskCount, part_t *&task_comm_xadj, part_t *&task_comm_adj, std::vector <int> grid_dims){
+void getGridCommunicationGraph(part_t taskCount, part_t *&task_comm_xadj, part_t *&task_comm_adj, std::vector<int> grid_dims){
   int dim = grid_dims.size();
   int neighborCount = 2 * dim;
   task_comm_xadj = allocMemory<part_t>(taskCount+1);
@@ -175,7 +175,7 @@ void getSolutionCenterCoordinates(
     ArrayRCP<const scalar_t> ar;
     xyz[dim].getInputArray(ar);
     //multiJagged coordinate values assignment
-    multiJagged_coordinates[dim] =  (scalar_t *)ar.getRawPtr();
+    multiJagged_coordinates[dim] = (scalar_t *)ar.getRawPtr();
     memset(partCenters[dim], 0, sizeof(scalar_t) * ntasks);
   }
 
@@ -224,10 +224,10 @@ void getSolutionCenterCoordinates(
   }
   envConst->timerStop(MACRO_TIMERS, "Mapping - Center Calculation");
 
-  freeArray<gno_t> (point_counts);
-  freeArray<gno_t> (global_point_counts);
+  freeArray<gno_t>(point_counts);
+  freeArray<gno_t>(global_point_counts);
 
-  freeArray<scalar_t> (tmpCoords);
+  freeArray<scalar_t>(tmpCoords);
   freeArray<scalar_t *>(multiJagged_coordinates);
 }
 
@@ -259,7 +259,7 @@ void getCoarsenedPartGraph(
   const part_t *parts = soln_->getPartListView();
 
   part_t np = soln_->getActualGlobalNumberOfParts();
-  if (part_t (soln_->getTargetGlobalNumberOfParts()) > np){
+  if (part_t(soln_->getTargetGlobalNumberOfParts()) > np){
     np = soln_->getTargetGlobalNumberOfParts();
   }
   */
@@ -280,11 +280,11 @@ void getCoarsenedPartGraph(
   graph->getEdgeList(edgeIds, offsets, e_wgts);
 
 
-  std::vector <t_scalar_t> edge_weights;
+  std::vector<t_scalar_t> edge_weights;
   int numWeightPerEdge = graph->getNumWeightsPerEdge();
 
   if (numWeightPerEdge > 0){
-    edge_weights =  std::vector <t_scalar_t> (localNumEdges);
+    edge_weights =  std::vector<t_scalar_t>(localNumEdges);
     for (t_lno_t i = 0; i < localNumEdges; ++i){
       edge_weights[i] = e_wgts[0][i];
     }
@@ -292,7 +292,7 @@ void getCoarsenedPartGraph(
 
   //create a zoltan dictionary to get the parts of the vertices
   //at the other end of edges
-  std::vector <part_t> e_parts (localNumEdges);
+  std::vector<part_t> e_parts(localNumEdges);
 #ifdef HAVE_ZOLTAN2_MPI
   if (comm->getSize() > 1)
   {
@@ -343,8 +343,8 @@ void getCoarsenedPartGraph(
     }
 
     //get the vertices in each part in my part.
-    std::vector <t_lno_t> part_begins(np, -1);
-    std::vector <t_lno_t> part_nexts(localNumVertices, -1);
+    std::vector<t_lno_t> part_begins(np, -1);
+    std::vector<t_lno_t> part_nexts(localNumVertices, -1);
 
     //cluster vertices according to their parts.
     //create local part graph.
@@ -355,14 +355,14 @@ void getCoarsenedPartGraph(
     }
 
 
-    g_part_xadj = ArrayRCP<part_t> (np + 1);
-    g_part_adj = ArrayRCP<part_t> (localNumEdges);
-    g_part_ew = ArrayRCP<t_scalar_t> (localNumEdges);
+    g_part_xadj = ArrayRCP<part_t>(np + 1);
+    g_part_adj = ArrayRCP<part_t>(localNumEdges);
+    g_part_ew = ArrayRCP<t_scalar_t>(localNumEdges);
     part_t nindex = 0;
     g_part_xadj[0] = 0;
-    std::vector <part_t> part_neighbors (np);
-    std::vector <t_scalar_t> part_neighbor_weights(np, 0);
-    std::vector <t_scalar_t> part_neighbor_weights_ordered(np);
+    std::vector<part_t> part_neighbors(np);
+    std::vector<t_scalar_t> part_neighbor_weights(np, 0);
+    std::vector<t_scalar_t> part_neighbor_weights_ordered(np);
 
     //coarsen for all vertices in my part in order with parts.
     for (t_lno_t i = 0; i < np; ++i){
@@ -403,19 +403,24 @@ void getCoarsenedPartGraph(
   }
 
   RCP<const Teuchos::Comm<int> > tcomm = rcpFromRef(*comm);
-  typedef Tpetra::Map<>::node_type t_node_t;
-  typedef Tpetra::Map<part_t, part_t, t_node_t> t_map_t;
-  Teuchos::RCP<const t_map_t> map = Teuchos::rcp (new t_map_t (np, 0, tcomm));
-  typedef Tpetra::CrsMatrix<t_scalar_t, part_t, part_t, t_node_t> tcrsMatrix_t;
-  Teuchos::RCP<tcrsMatrix_t> tMatrix(new tcrsMatrix_t (map, 0));
+  // KDD 8/8/18:  Ideally, we'd use part_t as the global ordinal in our map
+  //     typedef part_t use_this_gno_t;
+  // But when Tpetra is built without global ordinal = int, part_t will not
+  // link.  And changing part_t would affect backward compatibility.  
+  // So we'll use the Tpetra default here.
+  typedef Tpetra::Map<>::global_ordinal_type use_this_gno_t;
+  typedef Tpetra::Map<part_t, use_this_gno_t> t_map_t;
+  Teuchos::RCP<const t_map_t> map = Teuchos::rcp(new t_map_t(np, 0, tcomm));
+  typedef Tpetra::CrsMatrix<t_scalar_t, part_t, use_this_gno_t> tcrsMatrix_t;
+  Teuchos::RCP<tcrsMatrix_t> tMatrix(new tcrsMatrix_t(map, 0));
 
 
 
   envConst->timerStart(MACRO_TIMERS, "GRAPHCREATE Coarsen");
   {
     //get the vertices in each part in my part.
-    std::vector <t_lno_t> part_begins(np, -1);
-    std::vector <t_lno_t> part_nexts(localNumVertices, -1);
+    std::vector<t_lno_t> part_begins(np, -1);
+    std::vector<t_lno_t> part_nexts(localNumVertices, -1);
 
     //cluster vertices according to their parts.
     //create local part graph.
@@ -425,9 +430,9 @@ void getCoarsenedPartGraph(
       part_begins[ap] = i;
     }
 
-    std::vector <part_t> part_neighbors (np);
-    std::vector <t_scalar_t> part_neighbor_weights(np, 0);
-    std::vector <t_scalar_t> part_neighbor_weights_ordered(np);
+    std::vector<use_this_gno_t> part_neighbors(np);
+    std::vector<t_scalar_t> part_neighbor_weights(np, 0);
+    std::vector<t_scalar_t> part_neighbor_weights_ordered(np);
 
     //coarsen for all vertices in my part in order with parts.
     for (t_lno_t i = 0; i < np; ++i){
@@ -455,56 +460,56 @@ void getCoarsenedPartGraph(
 
       //now get the part list.
       for (t_lno_t j = 0; j < num_neighbor_parts; ++j){
-        part_t neighbor_part = part_neighbors[j];
+        use_this_gno_t neighbor_part = part_neighbors[j];
         part_neighbor_weights_ordered[j] = part_neighbor_weights[neighbor_part];
         part_neighbor_weights[neighbor_part] = 0;
       }
 
       //insert it to tpetra crsmatrix.
       if (num_neighbor_parts > 0){
-        Teuchos::ArrayView<const part_t> destinations(
+        Teuchos::ArrayView<const use_this_gno_t> destinations(
             &(part_neighbors[0]), num_neighbor_parts);
-        Teuchos::ArrayView<const t_scalar_t>
-        vals(&(part_neighbor_weights_ordered[0]), num_neighbor_parts);
-        tMatrix->insertGlobalValues (i,destinations, vals);
+        Teuchos::ArrayView<const t_scalar_t> vals(
+            &(part_neighbor_weights_ordered[0]), num_neighbor_parts);
+        tMatrix->insertGlobalValues(i,destinations, vals);
       }
     }
   }
   envConst->timerStop(MACRO_TIMERS, "GRAPHCREATE Coarsen");
   envConst->timerStart(MACRO_TIMERS, "GRAPHCREATE fillComplete");
-  tMatrix->fillComplete ();
+  tMatrix->fillComplete();
   envConst->timerStop(MACRO_TIMERS, "GRAPHCREATE fillComplete");
 
 
-  std::vector <part_t> part_indices(np);
+  std::vector<use_this_gno_t> part_indices(np);
 
-  for (part_t i = 0; i < np; ++i) part_indices[i] = i;
+  for (use_this_gno_t i = 0; i < np; ++i) part_indices[i] = i;
 
-  Teuchos::ArrayView<const part_t>
-    global_ids( &(part_indices[0]), np);
+  Teuchos::ArrayView<const use_this_gno_t> global_ids(&(part_indices[0]), np);
 
   //create a map where all processors own all rows.
   //so that we do a gatherAll for crsMatrix.
-  Teuchos::RCP<const t_map_t> gatherRowMap(new t_map_t (
-      Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), global_ids, 0, tcomm));
+  Teuchos::RCP<const t_map_t> gatherRowMap(new t_map_t(
+      Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
+      global_ids, 0, tcomm));
 
   envConst->timerStart(MACRO_TIMERS, "GRAPHCREATE Import");
   //create the importer for gatherAll
   Teuchos::RCP<tcrsMatrix_t> A_gather =
-      Teuchos::rcp (new tcrsMatrix_t (gatherRowMap, 0));
+      Teuchos::rcp(new tcrsMatrix_t(gatherRowMap, 0));
   typedef Tpetra::Import<typename t_map_t::local_ordinal_type,
                          typename t_map_t::global_ordinal_type,
                          typename t_map_t::node_type> import_type;
-  import_type import (map, gatherRowMap);
-  A_gather->doImport (*tMatrix, import, Tpetra::INSERT);
-  A_gather->fillComplete ();
+  import_type import(map, gatherRowMap);
+  A_gather->doImport(*tMatrix, import, Tpetra::INSERT);
+  A_gather->fillComplete();
   envConst->timerStop(MACRO_TIMERS, "GRAPHCREATE Import");
 
   //create the output part arrays.
   //all processors owns whole copy.
-  g_part_xadj = ArrayRCP<part_t> (np + 1);
-  g_part_adj = ArrayRCP<part_t> (A_gather->getNodeNumEntries ());
-  g_part_ew = ArrayRCP<t_scalar_t> (A_gather->getNodeNumEntries ());
+  g_part_xadj = ArrayRCP<part_t>(np + 1);
+  g_part_adj = ArrayRCP<part_t>(A_gather->getNodeNumEntries());
+  g_part_ew = ArrayRCP<t_scalar_t>(A_gather->getNodeNumEntries());
 
   part_t *taskidx = g_part_xadj.getRawPtr();
   part_t *taskadj = g_part_adj.getRawPtr();
@@ -702,12 +707,12 @@ class KMeansAlgorithm{
   WT **elementCoords;
   IT numClusters;
   IT required_elements;
-  KMeansCluster <IT,WT> *clusters;
+  KMeansCluster<IT,WT> *clusters;
   WT *maxCoordinates;
   WT *minCoordinates;
 public:
   ~KMeansAlgorithm(){
-    freeArray<KMeansCluster <IT,WT> >(clusters);
+    freeArray<KMeansCluster<IT,WT> >(clusters);
     freeArray<WT>(maxCoordinates);
     freeArray<WT>(minCoordinates);
   }
@@ -722,17 +727,17 @@ public:
         dim(dim_),
         numElements(numElements_),
         elementCoords(elementCoords_),
-        numClusters ((1 << dim_) + 1),
+        numClusters((1 << dim_) + 1),
         required_elements(required_elements_)
   {
-    this->clusters  = allocMemory<KMeansCluster <IT,WT> >(this->numClusters);
+    this->clusters  = allocMemory<KMeansCluster<IT,WT> >(this->numClusters);
     //set dimension and the number of required elements for all clusters.
     for (int i = 0; i < numClusters; ++i){
       this->clusters[i].setParams(this->dim, this->required_elements);
     }
 
-    this->maxCoordinates = allocMemory <WT> (this->dim);
-    this->minCoordinates = allocMemory <WT> (this->dim);
+    this->maxCoordinates = allocMemory <WT>(this->dim);
+    this->minCoordinates = allocMemory <WT>(this->dim);
 
     //obtain the min and max coordiantes for each dimension.
     for (int j = 0; j < dim; ++j){
@@ -1162,9 +1167,9 @@ public:
       ,const Teuchos::RCP <const Teuchos::Comm<int> > comm_
   ) const{
 
-    rcp_proc_to_task_xadj = ArrayRCP <part_t> (this->no_procs+1);
-    rcp_proc_to_task_adj = ArrayRCP <part_t> (this->no_tasks);
-    rcp_task_to_proc = ArrayRCP <part_t> (this->no_tasks);
+    rcp_proc_to_task_xadj = ArrayRCP <part_t>(this->no_procs+1);
+    rcp_proc_to_task_adj = ArrayRCP <part_t>(this->no_tasks);
+    rcp_task_to_proc = ArrayRCP <part_t>(this->no_tasks);
 
     part_t *proc_to_task_xadj = rcp_proc_to_task_xadj.getRawPtr(); //holds the pointer to the task array
     part_t *proc_to_task_adj = rcp_proc_to_task_adj.getRawPtr(); //holds the indices of tasks wrt to proc_to_task_xadj array.
@@ -1172,7 +1177,7 @@ public:
 
 
     part_t invalid = 0;
-    fillContinousArray<part_t> (proc_to_task_xadj, this->no_procs+1, &invalid);
+    fillContinousArray<part_t>(proc_to_task_xadj, this->no_procs+1, &invalid);
 
     //obtain the number of parts that should be divided.
     part_t num_parts = MINOF(this->no_procs, this->no_tasks);
@@ -1213,7 +1218,7 @@ public:
     //add one also that partitions based the longest dimension.
 
     //holds the pointers to proc_adjList
-    part_t *proc_xadj = allocMemory<part_t> (num_parts+1);
+    part_t *proc_xadj = allocMemory<part_t>(num_parts+1);
     //holds the processors in parts according to the result of partitioning algorithm.
     //the processors assigned to part x is at proc_adjList[ proc_xadj[x] : proc_xadj[x+1] ]
     part_t *proc_adjList = allocMemory<part_t>(this->no_procs);
@@ -1281,7 +1286,7 @@ public:
 
 
 
-    int *permutation = allocMemory<int> ((this->proc_coord_dim > this->task_coord_dim)
+    int *permutation = allocMemory<int>((this->proc_coord_dim > this->task_coord_dim)
         ? this->proc_coord_dim : this->task_coord_dim);
 
     //get the permutation order from the proc permutation index.
@@ -1289,7 +1294,7 @@ public:
 
     /*
     //reorder the coordinate dimensions.
-    pcoord_t **pcoords = allocMemory<pcoord_t *> (this->proc_coord_dim);
+    pcoord_t **pcoords = allocMemory<pcoord_t *>(this->proc_coord_dim);
     for(int i = 0; i < this->proc_coord_dim; ++i){
       pcoords[i] = this->proc_coords[permutation[i]];
       //cout << permutation[i] << " ";
@@ -1301,7 +1306,7 @@ public:
     int procdim  = this->proc_coord_dim;
     procdim  = 6;
     //reorder the coordinate dimensions.
-    pcoord_t **pcoords = allocMemory<pcoord_t *> (procdim);
+    pcoord_t **pcoords = allocMemory<pcoord_t *>(procdim);
     for(int i = 0; i < procdim; ++i){
       pcoords[i] = new pcoord_t[used_num_procs] ;//this->proc_coords[permutation[i]];
     }
@@ -1362,10 +1367,10 @@ public:
     //std::cout << "mj_partitioner.for procs over" << std::endl;
 
 
-    //freeArray<pcoord_t *> (pcoords);
+    //freeArray<pcoord_t *>(pcoords);
 
 
-    part_t *task_xadj = allocMemory<part_t> (num_parts+1);
+    part_t *task_xadj = allocMemory<part_t>(num_parts+1);
     part_t *task_adjList = allocMemory<part_t>(this->no_tasks);
     //fill task_adjList st: task_adjList[i] <- i.
     fillContinousArray<part_t>(task_adjList,this->no_tasks, NULL);
@@ -1374,7 +1379,7 @@ public:
     ithPermutation<int>(this->task_coord_dim, myTaskPerm, permutation);
 
     //reorder task coordinate dimensions.
-    tcoord_t **tcoords = allocMemory<tcoord_t *> (this->task_coord_dim);
+    tcoord_t **tcoords = allocMemory<tcoord_t *>(this->task_coord_dim);
     for(int i = 0; i < this->task_coord_dim; ++i){
       tcoords[i] = this->task_coords[permutation[i]];
     }
@@ -1406,8 +1411,8 @@ public:
     //comm_->barrier();
     //std::cout << "mj_partitioner.sequential_task_partitioning over" << std::endl;
 
-    freeArray<pcoord_t *> (tcoords);
-    freeArray<int> (permutation);
+    freeArray<pcoord_t *>(tcoords);
+    freeArray<int>(permutation);
 
 
     //filling proc_to_task_xadj, proc_to_task_adj, task_to_proc arrays.
@@ -1431,7 +1436,7 @@ public:
 
     //holds the pointer to the task array
     //convert proc_to_task_xadj to CSR index array
-    part_t *proc_to_task_xadj_work = allocMemory<part_t> (this->no_procs);
+    part_t *proc_to_task_xadj_work = allocMemory<part_t>(this->no_procs);
     part_t sum = 0;
     for(part_t i = 0; i < this->no_procs; ++i){
       part_t tmp = proc_to_task_xadj[i];
@@ -1643,16 +1648,16 @@ protected:
     */
     //cout << "me:" << localCost[1] << " localcost:" << localCost[0]<< " bestcost:" << globalCost[0] << endl;
     //cout << "me:" << localCost[1] << " proc:" << globalCost[1] << endl;
-    broadcast (*subComm, sender, this->ntasks, this->task_to_proc.getRawPtr());
-    broadcast (*subComm, sender, this->nprocs, this->proc_to_task_xadj.getRawPtr());
-    broadcast (*subComm, sender, this->ntasks, this->proc_to_task_adj.getRawPtr());
+    broadcast(*subComm, sender, this->ntasks, this->task_to_proc.getRawPtr());
+    broadcast(*subComm, sender, this->nprocs, this->proc_to_task_xadj.getRawPtr());
+    broadcast(*subComm, sender, this->ntasks, this->proc_to_task_adj.getRawPtr());
   }
 
 
 
   //write mapping to gnuPlot code to visualize.
   void writeMapping(){
-    std::ofstream gnuPlotCode ("gnuPlot.plot", std::ofstream::out);
+    std::ofstream gnuPlotCode("gnuPlot.plot", std::ofstream::out);
 
     int mindim = MINOF(proc_task_comm->proc_coord_dim, proc_task_comm->task_coord_dim);
     std::string ss = "";
@@ -1666,7 +1671,7 @@ protected:
         gnuPlotCode << "replot \"" << procFile << "\"\n";
       }
 
-      std::ofstream inpFile (procFile.c_str(), std::ofstream::out);
+      std::ofstream inpFile(procFile.c_str(), std::ofstream::out);
 
       std::string gnuPlotArrow = "set arrow from ";
       for(int j = 0; j <  mindim; ++j){
@@ -1718,7 +1723,7 @@ protected:
     std::string rankStr = Teuchos::toString<int>(myRank);
     std::string gnuPlots = "gnuPlot", extentionS = ".plot";
     std::string outF = gnuPlots + rankStr+ extentionS;
-    std::ofstream gnuPlotCode ( outF.c_str(), std::ofstream::out);
+    std::ofstream gnuPlotCode(outF.c_str(), std::ofstream::out);
 
     CoordinateCommunicationModel<pcoord_t, tcoord_t, part_t> *tmpproc_task_comm =
         static_cast <CoordinateCommunicationModel<pcoord_t, tcoord_t, part_t> * > (proc_task_comm);
@@ -1766,17 +1771,17 @@ protected:
           int neighbor_rank = this->getAssignedProcForTask(neighbor_task);
 
           for(int j = 0; j <  mindim; ++j){
-            if (int (tmpproc_task_comm->proc_coords[j][origin_rank]) != int (tmpproc_task_comm->proc_coords[j][neighbor_rank])){
+            if (int(tmpproc_task_comm->proc_coords[j][origin_rank]) != int(tmpproc_task_comm->proc_coords[j][neighbor_rank])){
               differentnode = true; break;
             }
           }
-          std::tuple<int,int,int, int, int, int> foo (
-              int (tmpproc_task_comm->proc_coords[0][origin_rank]),
-              int (tmpproc_task_comm->proc_coords[1][origin_rank]),
-              int (tmpproc_task_comm->proc_coords[2][origin_rank]),
-              int (tmpproc_task_comm->proc_coords[0][neighbor_rank]),
-              int (tmpproc_task_comm->proc_coords[1][neighbor_rank]),
-              int (tmpproc_task_comm->proc_coords[2][neighbor_rank]));
+          std::tuple<int,int,int, int, int, int> foo(
+              int(tmpproc_task_comm->proc_coords[0][origin_rank]),
+              int(tmpproc_task_comm->proc_coords[1][origin_rank]),
+              int(tmpproc_task_comm->proc_coords[2][origin_rank]),
+              int(tmpproc_task_comm->proc_coords[0][neighbor_rank]),
+              int(tmpproc_task_comm->proc_coords[1][neighbor_rank]),
+              int(tmpproc_task_comm->proc_coords[2][neighbor_rank]));
 
 
           if (differentnode && my_arrows.find(foo) == my_arrows.end()){
@@ -1799,7 +1804,7 @@ protected:
     }
 
 
-    std::ofstream procFile ("procPlot.plot", std::ofstream::out);
+    std::ofstream procFile("procPlot.plot", std::ofstream::out);
     procFile << procs << "\n";
     procFile.close();
 
@@ -1828,8 +1833,8 @@ protected:
     std::ofstream mm("2d.txt");
     file += Teuchos::toString<int>(comm_->getRank()) + exten;
     std::ofstream ff(file.c_str());
-    //ff.seekg (0, ff.end);
-    std::vector <Zoltan2::coordinateModelPartBox <tcoord_t, part_t> > outPartBoxes = ((Zoltan2::PartitioningSolution<Adapter> *)soln_)->getPartBoxesView();
+    //ff.seekg(0, ff.end);
+    std::vector<Zoltan2::coordinateModelPartBox <tcoord_t, part_t> > outPartBoxes = ((Zoltan2::PartitioningSolution<Adapter> *)soln_)->getPartBoxesView();
 
     for (part_t i = 0; i < this->ntasks;++i){
       outPartBoxes[i].writeGnuPlot(ff, mm);
@@ -1896,9 +1901,9 @@ public:
 
 
   virtual ~CoordinateTaskMapper(){
-    //freeArray<part_t> (proc_to_task_xadj);
-    //freeArray<part_t> (proc_to_task_adj);
-    //freeArray<part_t> (task_to_proc);
+    //freeArray<part_t>(proc_to_task_xadj);
+    //freeArray<part_t>(proc_to_task_adj);
+    //freeArray<part_t>(task_to_proc);
     if(this->isOwnerofModel){
       delete this->proc_task_comm;
     }
@@ -1908,7 +1913,7 @@ public:
       const lno_t num_local_coords,
       const part_t *local_coord_parts,
       const ArrayRCP<part_t> task_to_proc_){
-    local_task_to_rank = ArrayRCP <part_t> (num_local_coords);
+    local_task_to_rank = ArrayRCP <part_t>(num_local_coords);
 
     for (lno_t i = 0; i < num_local_coords; ++i){
       part_t local_coord_part = local_coord_parts[i];
@@ -1938,7 +1943,7 @@ public:
       bool is_input_adapter_distributed = true,
       int num_ranks_per_node = 1,
       bool divide_to_prime_first = false, bool reduce_best_mapping = true):
-        PartitionMapping<Adapter> (comm_, machine_, input_adapter_, soln_, envConst),
+        PartitionMapping<Adapter>(comm_, machine_, input_adapter_, soln_, envConst),
         proc_to_task_xadj(0),
         proc_to_task_adj(0),
         task_to_proc(0),
@@ -1961,7 +1966,7 @@ public:
 
     RCP<const Environment> envConst_ = envConst;
 
-    RCP<const ctm_base_adapter_t> baseInputAdapter_ (
+    RCP<const ctm_base_adapter_t> baseInputAdapter_(
         rcp(dynamic_cast<const ctm_base_adapter_t *>(input_adapter_.getRawPtr()), false));
 
     modelFlag_t coordFlags_, graphFlags_;
@@ -2004,8 +2009,8 @@ public:
     //if we have machine extent,
     //if the machine has wrap-around links, we would like to shift the coordinates,
     //so that the largest hap would be the wrap-around.
-    std::vector <int> machine_extent_vec (procDim);
-    //std::vector <bool> machine_extent_wrap_around_vec(procDim, 0);
+    std::vector<int> machine_extent_vec(procDim);
+    //std::vector<bool> machine_extent_wrap_around_vec(procDim, 0);
     int *machine_extent = &(machine_extent_vec[0]);
     bool *machine_extent_wrap_around = new bool[procDim];
     for (int i = 0; i < procDim; ++i)machine_extent_wrap_around[i] = false;
@@ -2019,7 +2024,7 @@ public:
     // MD: Yes, I ADDED BELOW:
     if (machine_->getMachineExtent(machine_extent)) {
       procCoordinates =
-          this->shiftMachineCoordinates (
+          this->shiftMachineCoordinates(
               procDim,
               machine_extent,
               machine_extent_wrap_around,
@@ -2034,7 +2039,7 @@ public:
 
 
     this->ntasks = soln_->getActualGlobalNumberOfParts();
-    if (part_t (soln_->getTargetGlobalNumberOfParts()) > this->ntasks){
+    if (part_t(soln_->getTargetGlobalNumberOfParts()) > this->ntasks){
       this->ntasks = soln_->getTargetGlobalNumberOfParts();
     }
     this->solution_parts = soln_->getPartListView();
@@ -2068,7 +2073,7 @@ public:
 
     //create the part graph
     if (graph_model_.getRawPtr() != NULL){
-      getCoarsenedPartGraph<Adapter, t_scalar_t, part_t> (
+      getCoarsenedPartGraph<Adapter, t_scalar_t, part_t>(
           envConst.getRawPtr(),
           ia_comm.getRawPtr(),
           graph_model_.getRawPtr(),
@@ -2205,7 +2210,7 @@ public:
       bool is_input_adapter_distributed = true,
       int num_ranks_per_node = 1,
       bool divide_to_prime_first = false, bool reduce_best_mapping = true):
-        PartitionMapping<Adapter> (comm_, machine_, input_adapter_, num_parts_, result_parts, envConst),
+        PartitionMapping<Adapter>(comm_, machine_, input_adapter_, num_parts_, result_parts, envConst),
         proc_to_task_xadj(0),
         proc_to_task_adj(0),
         task_to_proc(0),
@@ -2227,7 +2232,7 @@ public:
     }
     RCP<const Environment> envConst_ = envConst;
 
-    RCP<const ctm_base_adapter_t> baseInputAdapter_ (
+    RCP<const ctm_base_adapter_t> baseInputAdapter_(
         rcp(dynamic_cast<const ctm_base_adapter_t *>(input_adapter_.getRawPtr()), false));
 
     modelFlag_t coordFlags_, graphFlags_;
@@ -2270,8 +2275,8 @@ public:
     //if we have machine extent,
     //if the machine has wrap-around links, we would like to shift the coordinates,
     //so that the largest hap would be the wrap-around.
-    std::vector <int> machine_extent_vec (procDim);
-    //std::vector <bool> machine_extent_wrap_around_vec(procDim, 0);
+    std::vector<int> machine_extent_vec(procDim);
+    //std::vector<bool> machine_extent_wrap_around_vec(procDim, 0);
     int *machine_extent = &(machine_extent_vec[0]);
     bool *machine_extent_wrap_around = new bool[procDim];
     machine_->getMachineExtentWrapArounds(machine_extent_wrap_around);
@@ -2284,7 +2289,7 @@ public:
     // MD: Yes, I ADDED BELOW:
     if (machine_->getMachineExtent(machine_extent)) {
       procCoordinates =
-          this->shiftMachineCoordinates (
+          this->shiftMachineCoordinates(
               procDim,
               machine_extent,
               machine_extent_wrap_around,
@@ -2330,7 +2335,7 @@ public:
     envConst->timerStart(MACRO_TIMERS, "GRAPHCREATE");
     //create the part graph
     if (graph_model_.getRawPtr() != NULL){
-      getCoarsenedPartGraph<Adapter, t_scalar_t, part_t> (
+      getCoarsenedPartGraph<Adapter, t_scalar_t, part_t>(
           envConst.getRawPtr(),
           ia_comm.getRawPtr(),
           graph_model_.getRawPtr(),
@@ -2522,7 +2527,7 @@ public:
       bool divide_to_prime_first = false, bool reduce_best_mapping = true
   ):  PartitionMapping<Adapter>(
       Teuchos::rcpFromRef<const Teuchos::Comm<int> >(*problemComm),
-      Teuchos::rcpFromRef<const Environment> (*env_const_)),
+      Teuchos::rcpFromRef<const Environment>(*env_const_)),
       proc_to_task_xadj(0),
       proc_to_task_adj(0),
       task_to_proc(0),
@@ -2538,7 +2543,7 @@ public:
 
     if (machine_dimensions){
       virtual_machine_coordinates =
-          this->shiftMachineCoordinates (
+          this->shiftMachineCoordinates(
               proc_dim,
               machine_dimensions,
               wrap_arounds,
@@ -2878,17 +2883,17 @@ void coordinateTaskMapperInterface(
   // default Node.
   typedef Tpetra::MultiVector<tcoord_t, part_t, part_t> tMVector_t;
 
-  Teuchos::ArrayRCP<part_t> task_communication_xadj (task_comm_xadj, 0, num_tasks+1, false);
+  Teuchos::ArrayRCP<part_t> task_communication_xadj(task_comm_xadj, 0, num_tasks+1, false);
 
   Teuchos::ArrayRCP<part_t> task_communication_adj;
   if (task_comm_xadj){
-    Teuchos::ArrayRCP<part_t> tmp_task_communication_adj (task_comm_adj, 0, task_comm_xadj[num_tasks], false);
+    Teuchos::ArrayRCP<part_t> tmp_task_communication_adj(task_comm_adj, 0, task_comm_xadj[num_tasks], false);
     task_communication_adj = tmp_task_communication_adj;
   }
 
 
-  CoordinateTaskMapper<XpetraMultiVectorAdapter <tMVector_t>, part_t> *ctm =
-      new CoordinateTaskMapper<XpetraMultiVectorAdapter <tMVector_t>, part_t>(
+  CoordinateTaskMapper<XpetraMultiVectorAdapter<tMVector_t>, part_t> *ctm =
+      new CoordinateTaskMapper<XpetraMultiVectorAdapter<tMVector_t>, part_t>(
       envConst_,
       problemComm.getRawPtr(),
       proc_dim,
@@ -2934,7 +2939,7 @@ inline void visualize_mapping(int myRank,
   std::string rankStr = Teuchos::toString<int>(myRank);
   std::string gnuPlots = "gnuPlot", extentionS = ".plot";
   std::string outF = gnuPlots + rankStr+ extentionS;
-  std::ofstream gnuPlotCode ( outF.c_str(), std::ofstream::out);
+  std::ofstream gnuPlotCode( outF.c_str(), std::ofstream::out);
 
   if (machine_coord_dim != 3) {
     std::cerr << "Mapping Write is only good for 3 dim" << std::endl;
@@ -2971,17 +2976,17 @@ inline void visualize_mapping(int myRank,
       int neighbor_rank = task_to_rank[neighbor_task];
 
       for(int j = 0; j <  machine_coord_dim; ++j){
-        if (int (machine_coords[j][origin_rank]) != int (machine_coords[j][neighbor_rank])){
+        if (int(machine_coords[j][origin_rank]) != int(machine_coords[j][neighbor_rank])){
           differentnode = true; break;
         }
       }
-      std::tuple<int,int,int, int, int, int> foo (
-          (int) (machine_coords[0][origin_rank]),
-          (int)  (machine_coords[1][origin_rank]),
-          (int) (machine_coords[2][origin_rank]),
-          (int) (machine_coords[0][neighbor_rank]),
-          (int) (machine_coords[1][neighbor_rank]),
-          (int) (machine_coords[2][neighbor_rank]));
+      std::tuple<int,int,int, int, int, int> foo(
+          (int)(machine_coords[0][origin_rank]),
+          (int)(machine_coords[1][origin_rank]),
+          (int)(machine_coords[2][origin_rank]),
+          (int)(machine_coords[0][neighbor_rank]),
+          (int)(machine_coords[1][neighbor_rank]),
+          (int)(machine_coords[2][neighbor_rank]));
 
 
       if (differentnode && my_arrows.find(foo) == my_arrows.end()){
@@ -3001,7 +3006,7 @@ inline void visualize_mapping(int myRank,
     }
   }
 
-  std::ofstream procFile ("procPlot.plot", std::ofstream::out);
+  std::ofstream procFile("procPlot.plot", std::ofstream::out);
   procFile << procs << "\n";
   procFile.close();
 

--- a/packages/zoltan2/src/environment/Zoltan2_Parameters.cpp
+++ b/packages/zoltan2/src/environment/Zoltan2_Parameters.cpp
@@ -76,7 +76,7 @@ void createAllParameters(Teuchos::ParameterList &pList)
   // The dummy adapter is arbitrary
   // It allows us to keep the getValidParameters method in the class
   // However currently that has no template dependence
-  typedef Zoltan2::BasicUserTypes<int, int, int> dummyTypes;
+  typedef Zoltan2::BasicUserTypes<> dummyTypes;
   typedef Zoltan2::BasicIdentifierAdapter< dummyTypes > dummyAdapter;
 
   // environment has some of it's own parameters to provide

--- a/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_InputTraits.hpp
@@ -134,7 +134,9 @@ typedef Tpetra::Map<>::node_type default_node_t;
     \li \c gno (global number) is the integral data type used by the application and Zoltan2 to represent global identifiers and global counts.
  */
 
-template <typename scalar=double, typename lno=int, typename gno=int>
+template <typename scalar=double, 
+          typename lno=Tpetra::Map<>::local_ordinal_type, 
+          typename gno=Tpetra::Map<>::global_ordinal_type>
 class BasicUserTypes{
 };
 

--- a/packages/zoltan2/test/temp/ddirectoryTest.cpp
+++ b/packages/zoltan2/test/temp/ddirectoryTest.cpp
@@ -397,6 +397,37 @@ int main(int narg, char **arg)
   Tpetra::ScopeGuard tscope(&narg, &arg);
   Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
+  // Test with contiguous IDs of default Tpetra GO type
+  {
+    size_t nIds = 5;        // Number of IDs per processor
+    float fracShared = 0.2; // Fraction of IDs that should be shared
+    size_t idBase = 0;      // Smallest possible ID
+    int idStride = 1;       // Offset between IDs; 1 gives contiguous numbering
+
+    typedef Tpetra::Map<>::global_ordinal_type gno_t;
+    IDs<gno_t> myIds(nIds, fracShared, idBase, idStride, comm);
+
+    myIds.TpetraDDTest();
+
+    myIds.ZoltanDDTest();
+  }
+
+  // Test with non-contiguous IDs of default Tpetra GO starting at 20
+  {
+    size_t nIds = 5;        // Number of IDs per processor
+    float fracShared = 0.2; // Fraction of IDs that should be shared
+    size_t idBase = 20;      // Smallest possible ID
+    int idStride = 3;       // Offset between IDs; 1 gives contiguous numbering
+
+    typedef Tpetra::Map<>::global_ordinal_type gno_t;
+    IDs<gno_t> myIds(nIds, fracShared, idBase, idStride, comm);
+
+    myIds.TpetraDDTest();
+
+    myIds.ZoltanDDTest();
+  }
+
+#ifdef HAVE_TPETRA_INT_INT
   // Test with contiguous integer IDs
   {
     size_t nIds = 5;        // Number of IDs per processor
@@ -424,6 +455,7 @@ int main(int narg, char **arg)
 
     myIds.ZoltanDDTest();
   }
+#endif
 
 #ifdef HAVE_TPETRA_INT_LONG_LONG
   // Test with non-contiguous long long IDs starting at 200

--- a/packages/zoltan2/test/unit/input/PamgenMeshInput.cpp
+++ b/packages/zoltan2/test/unit/input/PamgenMeshInput.cpp
@@ -57,7 +57,7 @@
 /*********************************************************/
 /*                     Typedefs                          */
 /*********************************************************/
-typedef Zoltan2::BasicUserTypes<double, int, int>           basic_user_t;
+typedef Zoltan2::BasicUserTypes<double> basic_user_t;
 
 /*****************************************************************************/
 /******************************** MAIN ***************************************/
@@ -163,7 +163,7 @@ int main(int narg, char *arg[]) {
   int *element_num_map = new int [num_elem];
   error += im_ex_get_elem_num_map(exoid, element_num_map);
 
-  inputAdapter_t::gno_t *node_num_map = new int [num_nodes];
+  int *node_num_map = new int [num_nodes];
   error += im_ex_get_node_num_map(exoid, node_num_map);
 
   int *elem_blk_ids = new int [num_elem_blk];
@@ -217,7 +217,7 @@ int main(int narg, char *arg[]) {
         for (int j = 0; j < num_nodes_per_elem[b]; j++) {
           ssize_t in_list = -1;
 
-          for(inputAdapter_t::offset_t k=offsets[telct];k<offsets[telct+1];k++) {
+          for(inputAdapter_t::offset_t k=offsets[telct];k<offsets[telct+1];k++){
             if(adjacencyIds[k] ==
                node_num_map[connect[b][i*num_nodes_per_elem[b]+j]-1]) {
               in_list = k;


### PR DESCRIPTION
@trilinos/zoltan2 @trilinos/tpetra 

## Description

Fix Zoltan2 so that it builds with `Tpetra_INST_INT_INT:BOOL=OFF`, that is, with no integer global ordinals.

@kddevin worked on these changes.  Everything builds, but Karen says that one test fails:

https://github.com/trilinos/Trilinos/issues/3194#issuecomment-411569927

I built Zoltan2 (with almost no TPLs) on my laptop with `Tpetra_INST_INT_INT=OFF`, and all 101 tests passed.  Thus, I'm making this pull request mainly to see which test might fail.

## Motivation and Context

We want to deprecate and remove Tpetra's GlobalOrdinal template parameter (#2548).  This means that downstream code needs to build correctly using Tpetra's default `global_ordinal_type`, which may not necessarily be `int`.  This will improve build times and sizes by reducing the number of instantiations.

## Related Issues

* Blocks #2548 
* Closes #3194 

## How Has This Been Tested?

Mac, Clang, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] No new compiler warnings were introduced.
