### PR TITLE
Teuchos: ensure all YAML params get root name

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -966,11 +966,11 @@ void updateParametersFromYamlFile(const std::string& yamlFileName,
 {
   //load the YAML file in as a new param list
   Teuchos::RCP<Teuchos::ParameterList> updated = YAMLParameterList::parseYamlFile(yamlFileName);
-  //now update the original list (overwriting values with same key)
-  paramList->setParameters(*updated);
   if (paramList->name() == "ANONYMOUS") {
     paramList->setName(updated->name());
   }
+  //now update the original list (overwriting values with same key)
+  paramList->setParameters(*updated);
 }
 
 void updateParametersFromYamlCString(const char* const data,

--- a/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_YamlParser.cpp
@@ -980,10 +980,10 @@ void updateParametersFromYamlCString(const char* const data,
   Teuchos::RCP<Teuchos::ParameterList> updated = YAMLParameterList::parseYamlText(data, "CString");
   if(overwrite)
   {
-    paramList->setParameters(*updated);
     if (paramList->name() == "ANONYMOUS") {
       paramList->setName(updated->name());
     }
+    paramList->setParameters(*updated);
   }
   else
   {
@@ -999,10 +999,10 @@ void updateParametersFromYamlString(const std::string& yamlData,
   Teuchos::RCP<Teuchos::ParameterList> updated = YAMLParameterList::parseYamlText(yamlData, name);
   if(overwrite)
   {
-    paramList->setParameters(*updated);
     if (paramList->name() == "ANONYMOUS") {
       paramList->setName(updated->name());
     }
+    paramList->setParameters(*updated);
   }
   else
   {

--- a/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
+++ b/packages/teuchos/parameterlist/test/yaml/YamlParameterList.cpp
@@ -294,5 +294,20 @@ namespace TeuchosTests
     TEST_EQUALITY(field_pl.get<double>("rho"), 0.125);
   }
 
+  TEUCHOS_UNIT_TEST(YAML, root_name)
+  {
+    Teuchos::ParameterList pl;
+    Teuchos::updateParametersFromYamlString(
+      "mycode:\n"
+      "  sublist:\n"
+      "    param1: foo\n",
+      Teuchos::ptr(&pl),
+      true,
+      "root_name test"
+      );
+    auto& sublist = pl.sublist("sublist");
+    TEST_EQUALITY(sublist.name(), "mycode->sublist");
+  }
+
 } //namespace TeuchosTests
 


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos
## Description
<!--- Please describe your changes in detail. -->
This is a fix of a previous change, which would ensure
that if the YAML file read:

mycode:
  param1: foo

That the top-level ParameterList would be named "mycode"
instead of "ANONYMOUS".
This change ensures that that is propagated to the names
of all subparameters, e.g. "mycode -> param1" instead of
"ANONYMOUS -> param1".
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->


This prevents user confusion in seeing "ANONYMOUS" despite never writing it in their input file.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

