### PR TITLE
Panzer: added global indexer accessor to L2 projection class

### DIFF
--- a/packages/panzer/adapters-stk/test/projection/projection.cpp
+++ b/packages/panzer/adapters-stk/test/projection/projection.cpp
@@ -239,6 +239,8 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
   projectionFactory.setup(hgradBD,integrationDescriptor,comm,connManager,eBlockNames,worksetContainer);
   timer->stop("projectionFactory.setup()");
 
+  TEST_ASSERT(nonnull(projectionFactory.getTargetGlobalIndexer()));
+
   // Build mass matrix
   timer->start("projectionFactory.buildMassMatrix()");
   auto massMatrix = projectionFactory.buildMassMatrix();

--- a/packages/panzer/disc-fe/src/Panzer_L2Projection.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_L2Projection.hpp
@@ -69,6 +69,9 @@ namespace panzer {
                const std::vector<std::string>& elementBlockNames,
                const Teuchos::RCP<panzer::WorksetContainer> worksetContainer = Teuchos::null);
 
+    /// Returns the target global indexer. Will be null if setup() has not been called.
+    Teuchos::RCP<panzer::UniqueGlobalIndexer<LO,GO>> getTargetGlobalIndexer() const;
+
     /** \brief Allocates, fills and returns a mass matrix for L2
         projection onto a target basis.
 

--- a/packages/panzer/disc-fe/src/Panzer_L2Projection_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_L2Projection_impl.hpp
@@ -67,6 +67,11 @@ namespace panzer {
   }
 
   template<typename LO, typename GO>
+  Teuchos::RCP<panzer::UniqueGlobalIndexer<LO,GO>>
+  panzer::L2Projection<LO,GO>::getTargetGlobalIndexer() const 
+  {return targetGlobalIndexer_;}
+
+  template<typename LO, typename GO>
   Teuchos::RCP<Tpetra::CrsMatrix<double,LO,GO,Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device>>>
   panzer::L2Projection<LO,GO>::buildMassMatrix()
   {


### PR DESCRIPTION
Application needs access to the target DOF Manager in the L2 projection class.
