### PR TITLE
Panzer: add basis accessor to FieldPattern

### DIFF
--- a/packages/panzer/dof-mgr/src/Panzer_IntrepidFieldPattern.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_IntrepidFieldPattern.cpp
@@ -260,5 +260,9 @@ namespace panzer {
       cellTools.mapToPhysicalFrame(coords,localCoords,cellVertices,intrepidBasis_->getBaseCellTopology());
     }
   }
+
+  Teuchos::RCP< Intrepid2::Basis<PHX::Device,double,double> >
+  Intrepid2FieldPattern::getIntrepidBasis() const
+  { return intrepidBasis_; }
   
 }

--- a/packages/panzer/dof-mgr/src/Panzer_IntrepidFieldPattern.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_IntrepidFieldPattern.hpp
@@ -135,6 +135,9 @@ namespace panzer {
     void getInterpolatoryCoordinates(const Kokkos::DynRankView<double,PHX::Device> & cellVertices,
                                      Kokkos::DynRankView<double,PHX::Device> & coords) const;
 
+    /// Returns the underlying Intrepid2::Basis object
+    Teuchos::RCP< Intrepid2::Basis<PHX::Device,double,double> > getIntrepidBasis() const;
+
   protected:
     Teuchos::RCP< Intrepid2::Basis<PHX::Device,double,double> > intrepidBasis_;
 

--- a/packages/panzer/dof-mgr/test/field_pattern/tFieldPattern2.cpp
+++ b/packages/panzer/dof-mgr/test/field_pattern/tFieldPattern2.cpp
@@ -96,6 +96,10 @@ namespace panzer {
 
     TEST_ASSERT(intrepid_same_geom(basisA,basisB,__FILE__,__LINE__));
     TEST_ASSERT(not intrepid_equals(basisA,basisB,__FILE__,__LINE__));
+
+    // test basis accessor
+    panzer::Intrepid2FieldPattern fp(basisA);
+    TEST_ASSERT(basisA.get() == fp.getIntrepidBasis().get());
   }
 
   bool intrepid_equals(const RCP<Intrepid2::Basis<PHX::Device,double,double> > & basisA,


### PR DESCRIPTION
Application needed access to underlying basis from field pattern. 