### PR TITLE
Fix missing 'fi' statement (#3133)

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -242,6 +242,7 @@ else
     CONFIG_SCRIPT=PullRequestLinuxGCC4.8.4TestingSettings.cmake
   elif [ "Trilinos_pullrequest_gcc_4.9.3" == "${JOB_BASE_NAME:?}" ]; then
     CONFIG_SCRIPT=PullRequestLinuxGCC4.9.3TestingSettings.cmake
+  fi
 fi
 
 ctest -S simple_testing.cmake \


### PR DESCRIPTION
@trilinos/framework, @rppawlo 

## Description

Adds back a missing 'fi' statement got deleted accidentally when resolving a merge conflict.

This should fix this script for PR testing.

## Motivation and Context

Current PRs are crashing due to this (e.g. #3300, #3301).  Therefore, it is urgent to get this merged. 

## How Has This Been Tested?

I did not test this. I fixed this by inspection.  It is a one-line change.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
