### PR TITLE
New ATDM Trilinos 'waterman' builds (TRIL-213)

### DIFF
--- a/cmake/ctest/drivers/atdm/README.md
+++ b/cmake/ctest/drivers/atdm/README.md
@@ -280,7 +280,9 @@ The following `<system_name>` sub-directories exist (in alphabetical order):
 
 * `shiller/`: Contains the files to drive builds on the SRN test bed machine
   `shiller` which also can be run on the SON machine `hansen`.
-  
+
+* `waterman/`: Contains files to drive builds on the SRN Test Bed machine
+  `waterman`.
 
 
 ## How add a new system

--- a/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-cuda-9.2-debug.sh
+++ b/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-cuda-9.2-debug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/waterman/local-driver.sh

--- a/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-cuda-9.2-opt.sh
+++ b/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-cuda-9.2-opt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/waterman/local-driver.sh

--- a/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-gnu-debug-openmp.sh
+++ b/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-gnu-debug-openmp.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "$Trilinos_TRACK" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/waterman/local-driver.sh

--- a/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-gnu-opt-openmp.sh
+++ b/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-gnu-opt-openmp.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/waterman/local-driver.sh

--- a/cmake/ctest/drivers/atdm/waterman/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/waterman/local-driver.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -l
+
+if [ "${BSUB_CTEST_TIME_LIMIT}" == "" ] ; then
+  export BSUB_CTEST_TIME_LIMIT=12:00
+fi
+
+if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
+  export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+fi
+
+source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
+
+set -x
+
+bsub -x -Is -n 20 -J $JOB_NAME -W $BSUB_CTEST_TIME_LIMIT \
+  $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -247,7 +247,8 @@ $ ./checkin-test-atdm.sh <job-name-0> <job-name-1> ... \
 ```
 
 However, a default `local-checkin-test-defaults.py` is created the first time
-the `checkin-test-atdm.sh` script is run (after which can be modified).
+the `checkin-test-atdm.sh` script is run and will set these as the defaults
+(after which can be modified).
 
 
 ## Specific instructions for each system
@@ -296,7 +297,6 @@ $ cd <some_build_dir>/
 $ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-atdm.sh .
 $ bsub -x -I -q rhel7F -n 16 \
   ./checkin-test-atdm.sh cuda-debug \
-  --enable-all-packages=off --no-enable-fwd-packages \
   --enable-packages=MueLu \
   --local-do-all
 ```
@@ -335,7 +335,6 @@ href="#checkin-test-atdmsh">checkin-test-atdm.sh</a> script as:
 $ cd <some_build_dir>/
 $ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-atdm.sh .
 $ srun ./checkin-test-atdm.sh intel-opt-openmp \
-  --enable-all-packages=off --no-enable-fwd-packages \
   --enable-packages=MueLu \
   --local-do-all
 ```
@@ -429,6 +428,7 @@ $ make NP=16
 
 $ ctest -j16 \
 ```
+
 
 ## Troubleshooting configuration problems
 

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -258,6 +258,7 @@ the `checkin-test-atdm.sh` script is run and will set these as the defaults
 * <a href="#chamaserrano">chama/serrano</a>
 * <a href="#mutrino">mutrino</a>
 * <a href="#sems-rhel6-environment">SEMS rhel6 environment</a>
+* <a href="#waterman">waterman</a>
 
 
 ### ride/white
@@ -427,6 +428,45 @@ $ cmake \
 $ make NP=16
 
 $ ctest -j16 \
+```
+
+
+### waterman
+
+Once logged on to `waterman` (SRN), one can directly configure and build on
+the login node (being careful not to overload the node).  But to run the
+tests, one must run on the compute nodes using the `bsub` command to run if
+using a CUDA build.  For example, to configure, build and run the tests for
+the default `cuda-debug` build for say `MueLu` (after cloning Trilinos on the
+`develop` branch) one would do:
+
+```
+$ cd <some_build_dir>/
+
+$ source $TRILINOS_DIR/cmake/std/atdm/load-env.sh cuda-debug
+
+$ cmake \
+  -GNinja \
+  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
+  -DTrilinos_ENABLE_TESTS=ON -DTrilinos_ENABLE_MueLu=ON \
+  $TRILINOS_DIR
+
+$ make NP=20
+
+$ bsub -x -Is -n 20 ctest -j20
+```
+
+Note that one can also run the same build a tests using the <a
+href="#checkin-test-atdmsh">checkin-test-atdm.sh</a> script as:
+
+```
+$ cd <some_build_dir>/
+$ ln -s $TRILINOS_DIR/cmake/std/atdm/checkin-test-atdm.sh .
+$ bsub -x -Is -n 20 \
+  ./checkin-test-atdm.sh cuda-debug \
+  --enable-all-packages=off --no-enable-fwd-packages \
+  --enable-packages=MueLu \
+  --local-do-all
 ```
 
 
@@ -728,3 +768,5 @@ they support are:
 
 * `shiller/`: Supports GNU, Intel, and CUDA builds on both the SRN machine
   `shiller` and the mirror SON machine `hansen`.
+
+* `wateman/`: Supports GNU and CUDA builds on the SRN machine `waterman`.

--- a/cmake/std/atdm/utils/get_known_system_name.sh
+++ b/cmake/std/atdm/utils/get_known_system_name.sh
@@ -38,6 +38,9 @@ elif [[ $THIS_HOSTNAME == "serrano"* ]] ; then
 elif [[ $THIS_HOSTNAME == "mutrino"* ]] ; then
   ATDM_HOSTNAME=mutrino
   ATDM_SYSTEM_NAME=mutrino
+elif [[ $THIS_HOSTNAME == "waterman"* ]] ; then
+  ATDM_HOSTNAME=waterman
+  ATDM_SYSTEM_NAME=waterman
 elif [[ -f /projects/sems/modulefiles/utils/get-platform ]] ; then
   ATDM_SYSTEM_NAME=`source /projects/sems/modulefiles/utils/get-platform`
   if [[ $ATDM_SYSTEM_NAME == "rhel6-x86_64" ]] ; then

--- a/cmake/std/atdm/waterman/all_supported_builds.sh
+++ b/cmake/std/atdm/waterman/all_supported_builds.sh
@@ -1,0 +1,1 @@
+export ATDM_CONFIG_ALL_SUPPORTED_BUILDS="gnu-debug-openmp-Power8-Kepler37 gnu-opt-openmp-Power8-Kepler37 cuda-debug-Power8-Kepler37 cuda-opt-Power8-Kepler37"

--- a/cmake/std/atdm/waterman/all_supported_builds.sh
+++ b/cmake/std/atdm/waterman/all_supported_builds.sh
@@ -1,1 +1,1 @@
-export ATDM_CONFIG_ALL_SUPPORTED_BUILDS="gnu-debug-openmp-Power8-Kepler37 gnu-opt-openmp-Power8-Kepler37 cuda-debug-Power8-Kepler37 cuda-opt-Power8-Kepler37"
+export ATDM_CONFIG_ALL_SUPPORTED_BUILDS="gnu-debug-openmp-Power9-Volta70 gnu-opt-openmp-Power9-Volta70 cuda-debug-Power9-Volta70 cuda-opt-Power9-Volta70"

--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -1,0 +1,99 @@
+################################################################################
+#
+# Set up env on ride/white for ATMD builds of Trilinos
+#
+# This source script gets the settings from the JOB_NAME var.
+#
+################################################################################
+
+if [ "$ATDM_CONFIG_COMPILER" == "DEFAULT" ] ; then
+  export ATDM_CONFIG_COMPILER=GNU
+fi
+
+if [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "DEFAULT" ]] ; then
+  export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
+  export ATDM_CONFIG_QUEUE=rhel7W
+elif [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "Power9" ]] ; then
+  export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
+  export ATDM_CONFIG_QUEUE=rhel7W
+fi
+
+if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "Power9,Volta70" ]  && \
+   [ "$ATDM_CONFIG_KOKKOS_ARCH" != "Power9,Volta72" ]; then
+     echo "***"
+     echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option on this system."
+     echo "*** Replace '$ATDM_CONFIG_KOKKOS_ARCH' in the job name with one of the following options:"
+     echo "*** 'Volta70' Power9 with Volta V-100 GPU (Default)"
+     echo "*** 'Volta72' Power9 with Volta V-100 GPU"
+     echo "***"
+   return
+fi
+
+
+echo "Using white/ride compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
+
+export ATDM_CONFIG_USE_NINJA=ON
+export ATDM_CONFIG_BUILD_COUNT=128
+# NOTE: Above settings are used for running on a single rhel7F (Firestone,
+# Dual-Socket POWER8, 8 cores per socket, K80 GPUs) node.
+
+module purge
+
+if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+  export OMP_NUM_THREADS=2
+else
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=32
+fi
+
+if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
+    module load devpack/20180517/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
+    module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+    export OMPI_CXX=`which g++`
+    export OMPI_CC=`which gcc`
+    export OMPI_FC=`which gfortran`
+    export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
+    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
+elif [ "$ATDM_CONFIG_COMPILER" == "CUDA" ]; then
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+    module load devpack/20180517/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
+    module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+    export OMPI_CXX=$ATDM_CONFIG_TRILNOS_DIR/packages/kokkos/bin/nvcc_wrapper
+    if [ ! -x "$OMPI_CXX" ]; then
+        echo "No nvcc_wrapper found"
+        return
+    fi
+    export OMPI_CC=`which gcc`
+    export OMPI_FC=`which gfortran`
+    export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
+    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
+    export ATDM_CONFIG_USE_CUDA=ON
+    export CUDA_LAUNCH_BLOCKING=1
+    export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+    # Avoids timeouts due to not running on separate GPUs (see #2446)
+else
+    echo "***"
+    echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
+    echo "***"
+    return
+fi
+
+export ATDM_CONFIG_USE_HWLOC=OFF
+
+export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+
+# Use manually installed cmake and ninja to try to avoid module loading
+# problems (see TRIL-208)
+export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+
+# Set MPI wrappers
+export MPICC=`which mpicc`
+export MPICXX=`which mpicxx`
+export MPIF90=`which mpif90`
+
+export ATDM_CONFIG_MPI_PRE_FLAGS="--mca;orte_abort_on_non_zero_status;0"
+export ATDM_CONFIG_MPI_POST_FLAG="-map-by;socket:PE=4"
+
+export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE

--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Set up env on ride/white for ATMD builds of Trilinos
+# Set up env on waterman for ATMD builds of Trilinos
 #
 # This source script gets the settings from the JOB_NAME var.
 #
@@ -10,40 +10,64 @@ if [ "$ATDM_CONFIG_COMPILER" == "DEFAULT" ] ; then
   export ATDM_CONFIG_COMPILER=GNU
 fi
 
-if [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "DEFAULT" ]] ; then
-  export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
-  export ATDM_CONFIG_QUEUE=rhel7W
-elif [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "Power9" ]] ; then
-  export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
-  export ATDM_CONFIG_QUEUE=rhel7W
+if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
+  if [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "DEFAULT" ]] ; then
+    export ATDM_CONFIG_KOKKOS_ARCH=Power9
+  elif [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "Power9" ]] ; then
+    export ATDM_CONFIG_KOKKOS_ARCH=Power9
+  else
+    echo
+    echo "***"
+    echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option"
+    echo "*** for the compiler GNU.  Replace '$ATDM_CONFIG_KOKKOS_ARCH' in the"
+    echo "*** job name with 'Power9'"
+    echo "***"
+    return
+  fi
+elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] ; then
+  if [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "DEFAULT" ]] ; then
+    export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
+  elif [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "Power9" ]] ; then
+    export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
+  elif [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "Volta70" ]] ; then
+    export ATDM_CONFIG_KOKKOS_ARCH=Power9,Volta70
+  else
+    echo
+    echo "***"
+    echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option"
+    echo "*** for the CUDA compiler.  Replace '$ATDM_CONFIG_KOKKOS_ARCH' in the"
+    echo "*** job name with one of the following options:"
+    echo "***"
+    echo "***   'Volta70' Power9 with Volta V-100 GPU (Default)"
+    echo "***"
+    return
+  fi
+else
+  echo
+  echo "***"
+  echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
+  echo "***"
+  return
 fi
 
-if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "Power9,Volta70" ]  && \
-   [ "$ATDM_CONFIG_KOKKOS_ARCH" != "Power9,Volta72" ]; then
-     echo "***"
-     echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option on this system."
-     echo "*** Replace '$ATDM_CONFIG_KOKKOS_ARCH' in the job name with one of the following options:"
-     echo "*** 'Volta70' Power9 with Volta V-100 GPU (Default)"
-     echo "*** 'Volta72' Power9 with Volta V-100 GPU"
-     echo "***"
-   return
-fi
-
-
-echo "Using white/ride compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
+echo "Using waterman compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
 
 export ATDM_CONFIG_USE_NINJA=ON
 export ATDM_CONFIG_BUILD_COUNT=128
-# NOTE: Above settings are used for running on a single rhel7F (Firestone,
-# Dual-Socket POWER8, 8 cores per socket, K80 GPUs) node.
+# NOTE: Above settings are used for building on a Dual-Socket POWER9 with 8
+# cores per socket.
 
 module purge
 
+module load git/2.10.1
+# NOTE: Must load a git module since /usr/bin/git does not exist on the
+# compute nodes.
+
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=20
   export OMP_NUM_THREADS=2
 else
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=32
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=40
 fi
 
 if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
@@ -54,28 +78,39 @@ if [ "$ATDM_CONFIG_COMPILER" == "GNU" ]; then
     export OMPI_FC=`which gfortran`
     export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
     export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
-elif [ "$ATDM_CONFIG_COMPILER" == "CUDA" ]; then
-    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] ; then
+  if [[ "$ATDM_CONFIG_COMPILER" == "CUDA" ]] ; then
+    export ATDM_CONFIG_COMPILER=CUDA-9.2  # The default CUDA version currently
+  fi
+  if [[ "$ATDM_CONFIG_COMPILER" == "CUDA-9.2" ]] ; then
     module load devpack/20180517/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
     module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
-    export OMPI_CXX=$ATDM_CONFIG_TRILNOS_DIR/packages/kokkos/bin/nvcc_wrapper
-    if [ ! -x "$OMPI_CXX" ]; then
-        echo "No nvcc_wrapper found"
-        return
-    fi
-    export OMPI_CC=`which gcc`
-    export OMPI_FC=`which gfortran`
-    export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
-    export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
-    export ATDM_CONFIG_USE_CUDA=ON
-    export CUDA_LAUNCH_BLOCKING=1
-    export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
-    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
-    # Avoids timeouts due to not running on separate GPUs (see #2446)
+  else
+    echo
+    echo "***"
+    echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not a supported version of CUDA on this system!"
+    echo "***"
+    return
+  fi
+  export OMPI_CXX=$ATDM_CONFIG_TRILNOS_DIR/packages/kokkos/bin/nvcc_wrapper
+  if [ ! -x "$OMPI_CXX" ]; then
+      echo "No nvcc_wrapper found"
+      return
+  fi
+  export OMPI_CC=`which gcc`
+  export OMPI_FC=`which gfortran`
+  export ATDM_CONFIG_LAPACK_LIB="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"
+  export ATDM_CONFIG_BLAS_LIB="-L${BLAS_ROOT}/lib;-lblas;-lgfortran;-lgomp;-lm"
+  export ATDM_CONFIG_USE_CUDA=ON
+  export CUDA_LAUNCH_BLOCKING=1
+  export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+  # Avoids timeouts due to not running on separate GPUs (see #2446)
 else
-    echo "***"
-    echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
-    echo "***"
+  echo
+  echo "***"
+  echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
+  echo "***"
     return
 fi
 
@@ -85,7 +120,8 @@ export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;$
 export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
 
 # Use manually installed cmake and ninja to try to avoid module loading
-# problems (see TRIL-208)
+# problems (see TRIL-208).  NOTE: These were build for Power8 on 'white' and
+# 'ride' but they also seem to work just fine on Power9 'waterman' as well :-)
 export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
@@ -93,7 +129,6 @@ export MPICC=`which mpicc`
 export MPICXX=`which mpicxx`
 export MPIF90=`which mpif90`
 
-export ATDM_CONFIG_MPI_PRE_FLAGS="--mca;orte_abort_on_non_zero_status;0"
 export ATDM_CONFIG_MPI_POST_FLAG="-map-by;socket:PE=4"
 
 export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE

--- a/cmake/std/atdm/waterman/tweaks/ALL_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/ALL_COMMON_TWEAKS.cmake
@@ -1,0 +1,3 @@
+# Disable randomly failing Belos tests (#3007)
+ATDM_SET_ENABLE(Belos_pseudo_pcg_hb_0_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Belos_pseudo_pcg_hb_1_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/waterman/tweaks/ALL_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/ALL_COMMON_TWEAKS.cmake
@@ -1,3 +1,0 @@
-# Disable randomly failing Belos tests (#3007)
-ATDM_SET_ENABLE(Belos_pseudo_pcg_hb_0_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(Belos_pseudo_pcg_hb_1_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,6 +1,0 @@
-# Disable test that runs over 30 min currently (#2446)
-ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
-
-# Disable randomly failing MueLu tests (#2311)
-ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)

--- a/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,0 +1,6 @@
+# Disable test that runs over 30 min currently (#2446)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
+
+# Disable randomly failing MueLu tests (#2311)
+ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON)
+ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)


### PR DESCRIPTION
CC: @fryeguy52, @mhoemmen, @nmhamster 

## Description

This PR branch adds set of GCC and CUDA 9.2 builds for 'waterman' (see [TRIL-213](https://software-sandbox.sandia.gov/jira/browse/TRIL-213)).

## Motivation and Context

The Test Bed machine 'waterman' is an important ATS-2-like test machine for the 'Sierra' machine and ATDM codes need to be able to run on that platform and they need Trilinos builds to do that.

## How Has This Been Tested?

I tested this locally on 'waterman' with both the `checkin-test-atdm.sh` script and the smart Jenkins driver.

On 'watermain' I did:

```
$ bsub -x -Is -n 20 ./checkin-test-atdm.sh all --enable-packages=Kokkos --local-do-all
```

and it passed showing with:

```
PASSED (NOT READY TO PUSH): Trilinos: waterman2

Wed Aug 15 16:30:39 MDT 2018

Enabled Packages: Kokkos

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT_OPENMP => Test case MPI_RELEASE_DEBUG_SHARED_PT_OPENMP was not run! => Does not affect push readiness! (-1.00 min)
1) gnu-debug-openmp-Power9-Volta70 => passed: passed=27,notpassed=0 (9.79 min)
2) gnu-opt-openmp-Power9-Volta70 => passed: passed=27,notpassed=0 (3.10 min)
3) cuda-debug-Power9-Volta70 => passed: passed=27,notpassed=0 (10.92 min)
4) cuda-opt-Power9-Volta70 => passed: passed=27,notpassed=0 (4.73 min)
```

I also tested a few packages, including Panzer to see what happens:

```
$ bsub -x -Is -n 20 ./checkin-test-atdm.sh cuda-opt-Power9-Volta70 \
    --enable-packages=Kokkos,Teuchos,Tpetra,Ifpack2,Panzer --local-do-all
```

and it returned:

```
  99% tests passed, 4 tests failed out of 523
  
  Subproject Time Summary:
  Ifpack2    = 650.38 sec*proc (36 tests)
  Kokkos     = 322.32 sec*proc (27 tests)
  Panzer     = 9271.22 sec*proc (158 tests)
  Teuchos    = 275.50 sec*proc (129 tests)
  Tpetra     = 2229.35 sec*proc (173 tests)
  
  Total Test time (real) = 1617.26 sec
  
  The following tests FAILED:
  	230 - TpetraCore_Issue1454_MPI_4 (Failed)
  	492 - PanzerAdaptersSTK_PoissonExample-ConvTest-Tri-Order-4 (Failed)
  	497 - PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 (Failed)
  	501 - PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3 (Timeout)
  Errors while running CTest
```

(FYI: Looks like #3289 is still an issue on 'waterman' but perhaps #3290 is not.  We will see once the full builds post to CDash.)

I then tested once of the Jenkins drivers with:

```
$ env \
    JOB_NAME=Trilinos-atdm-waterman-cuda-9.2-opt \
    WORKSPACE=$PWD \
    Trilinos_PACKAGES=Kokkos,Teuchos \
    CTEST_TEST_TYPE=Experimental \
    CTEST_DO_UPDATES=OFF \
    CTEST_DO_SUBMIT=OFF \
    CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
  ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
    &> console.out
```

That worked just fine.  I then posted results with:

```
$ env \
    JOB_NAME=Trilinos-atdm-waterman-cuda-9.2-opt \
    WORKSPACE=$PWD \
    Trilinos_PACKAGES=Kokkos,Teuchos \
    CTEST_TEST_TYPE=Experimental \
    CTEST_DO_UPDATES=OFF \
    CTEST_DO_SUBMIT=OFF \
    CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
  ~/Trilinos.base/Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
    &> console.out
```

and it submitted to CDash:

* https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&date=2018-08-16&filtercombine=and&filtercount=3&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=Trilinos-atdm-waterman-cuda-9.2-opt&field2=buildstamp&compare2=61&value2=20180816-1414-Experimental&field3=site&compare3=61&value3=waterman
