### PR TITLE
Ifpack2 - remove return type from Ifpack2_BlockTriDiContainer_impl.hpp

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -147,22 +147,20 @@ namespace Ifpack2 {
     template<typename T, int N>
     static 
     KOKKOS_INLINE_FUNCTION 
-    volatile ArrayValueType<T,N>& 
+    void
     operator+=(volatile ArrayValueType<T,N> &a, 
                volatile const ArrayValueType<T,N> &b) {
       for (int i=0;i<N;++i) 
         a.v[i] += b.v[i];
-      return a;
     }
     template<typename T, int N>
     static 
     KOKKOS_INLINE_FUNCTION
-    ArrayValueType<T,N>& 
+    void
     operator+=(ArrayValueType<T,N> &a, 
                const ArrayValueType<T,N> &b) {
       for (int i=0;i<N;++i) 
         a.v[i] += b.v[i];
-      return a;
     }
 
     ///


### PR DESCRIPTION
Fix  #3304

## Description

Unnecessary return type (probably typo from when I change the operator as a static function) produces an warning which turns into an error in sierra build.

## How Has This Been Tested?

I confirmed the error is gone in my workstation using gcc pull request script.
