### PR TITLE
Tempus:  Add potential full-space optimization interface.

### DIFF
--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -121,6 +121,12 @@ public:
       const Teuchos::Array<Scalar>& t,
       const Thyra::VectorBase<Scalar>& p,
       const int param_index) const;
+    virtual void computeStepSolver(
+      Thyra::LinearOpWithSolveBase<Scalar>& jacobian_solver,
+      const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+      const Teuchos::Array<Scalar>& t,
+      const Thyra::VectorBase<Scalar>& p,
+      const int param_index) const;
   //@}
 
 private:

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -12,6 +12,7 @@
 #include "Tempus_StepperImplicit.hpp"
 #include "Tempus_WrapperModelEvaluator.hpp"
 #include "Tempus_StepperBackwardEulerObserver.hpp"
+#include "Tempus_StepperOptimizationInterface.hpp"
 
 
 namespace Tempus {
@@ -29,7 +30,9 @@ namespace Tempus {
  *   - Solve \f$f(\dot{x}_n,x_n,t_n)=0\f$ for \f$\dot{x}_n\f$ [Optional]
  */
 template<class Scalar>
-class StepperBackwardEuler : virtual public Tempus::StepperImplicit<Scalar>
+class StepperBackwardEuler :
+    virtual public Tempus::StepperImplicit<Scalar>,
+    virtual public Tempus::StepperOptimizationInterface<Scalar>
 {
 public:
 
@@ -78,7 +81,7 @@ public:
 
   /// Provide temporary xDot memory for Stepper if SolutionState doesn't.
   virtual Teuchos::RCP<Thyra::VectorBase<Scalar> > getXDotTemp(
-    Teuchos::RCP<Thyra::VectorBase<Scalar> > x);
+    Teuchos::RCP<const Thyra::VectorBase<Scalar> > x) const;
 
   /// \name ParameterList methods
   //@{
@@ -96,10 +99,43 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  /// \name Implementation of StepperOptimizationInterface
+  //@{
+    virtual int stencilLength() const;
+    virtual void computeStepResidual(
+      Thyra::VectorBase<Scalar>& residual,
+      const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+      const Teuchos::Array<Scalar>& t,
+      const Thyra::VectorBase<Scalar>& p,
+      const int param_index) const;
+    virtual void computeStepJacobian(
+      Thyra::LinearOpBase<Scalar>& jacobian,
+      const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+      const Teuchos::Array<Scalar>& t,
+      const Thyra::VectorBase<Scalar>& p,
+      const int param_index,
+      const int deriv_index) const;
+    virtual void computeStepParamDeriv(
+      Thyra::LinearOpBase<Scalar>& deriv,
+      const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+      const Teuchos::Array<Scalar>& t,
+      const Thyra::VectorBase<Scalar>& p,
+      const int param_index) const;
+  //@}
+
 private:
 
   /// Default Constructor -- not allowed
   StepperBackwardEuler();
+
+  /// Implementation of computeStep*() methods
+  void computeStepResidDerivImpl(
+    const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs,
+    const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+    const Teuchos::Array<Scalar>& t,
+    const Thyra::VectorBase<Scalar>& p,
+    const int param_index,
+    const int deriv_index = 0) const;
 
 private:
 
@@ -107,7 +143,7 @@ private:
   Teuchos::RCP<StepperObserver<Scalar> >              stepperObserver_;
   Teuchos::RCP<StepperBackwardEulerObserver<Scalar> > stepperBEObserver_;
 
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >            xDotTemp_;
+  mutable Teuchos::RCP<Thyra::VectorBase<Scalar> >    xDotTemp_;
   Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
 };
 

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -414,6 +414,22 @@ StepperBackwardEuler<Scalar>::computeStepParamDeriv(
 
 template <class Scalar>
 void
+StepperBackwardEuler<Scalar>::computeStepSolver(
+  Thyra::LinearOpWithSolveBase<Scalar>& jacobian_solver,
+  const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+  const Teuchos::Array<Scalar>& t,
+  const Thyra::VectorBase<Scalar>& p,
+  const int param_index) const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  TEUCHOS_ASSERT(outArgs.supports(MEB::OUT_ARG_W));
+  outArgs.set_W(Teuchos::rcpFromRef(jacobian_solver));
+  computeStepResidDerivImpl(outArgs, x, t, p, param_index, 0);
+}
+
+template <class Scalar>
+void
 StepperBackwardEuler<Scalar>::computeStepResidDerivImpl(
   const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs,
   const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -207,7 +207,7 @@ void StepperBackwardEuler<Scalar>::takeStep(
 template<class Scalar>
 Teuchos::RCP<Thyra::VectorBase<Scalar> >
 StepperBackwardEuler<Scalar>::
-getXDotTemp(Teuchos::RCP<Thyra::VectorBase<Scalar> > x)
+getXDotTemp(Teuchos::RCP<const Thyra::VectorBase<Scalar> > x) const
 {
   if (xDotTemp_ == Teuchos::null) {
     xDotTemp_ = x->clone_v();
@@ -354,6 +354,112 @@ StepperBackwardEuler<Scalar>::unsetParameterList()
   return(temp_plist);
 }
 
+
+template <class Scalar>
+int
+StepperBackwardEuler<Scalar>::stencilLength() const
+{
+  return 2;
+}
+
+
+template <class Scalar>
+void
+StepperBackwardEuler<Scalar>::computeStepResidual(
+  Thyra::VectorBase<Scalar>& residual,
+  const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+  const Teuchos::Array<Scalar>& t,
+  const Thyra::VectorBase<Scalar>& p,
+  const int param_index) const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  outArgs.set_f(Teuchos::rcpFromRef(residual));
+  computeStepResidDerivImpl(outArgs, x, t, p, param_index);
+}
+
+template <class Scalar>
+void
+StepperBackwardEuler<Scalar>::computeStepJacobian(
+  Thyra::LinearOpBase<Scalar>& jacobian,
+  const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+  const Teuchos::Array<Scalar>& t,
+  const Thyra::VectorBase<Scalar>& p,
+  const int param_index,
+  const int deriv_index) const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  TEUCHOS_ASSERT(outArgs.supports(MEB::OUT_ARG_W_op));
+  outArgs.set_W_op(Teuchos::rcpFromRef(jacobian));
+  computeStepResidDerivImpl(outArgs, x, t, p, param_index, deriv_index);
+}
+
+template <class Scalar>
+void
+StepperBackwardEuler<Scalar>::computeStepParamDeriv(
+  Thyra::LinearOpBase<Scalar>& deriv,
+  const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+  const Teuchos::Array<Scalar>& t,
+  const Thyra::VectorBase<Scalar>& p,
+  const int param_index) const
+{
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  TEUCHOS_ASSERT(outArgs.supports(MEB::OUT_ARG_DfDp, param_index).supports(MEB::DERIV_LINEAR_OP));
+  outArgs.set_DfDp(param_index,
+                   MEB::Derivative<Scalar>(Teuchos::rcpFromRef(deriv)));
+  computeStepResidDerivImpl(outArgs, x, t, p, param_index);
+}
+
+template <class Scalar>
+void
+StepperBackwardEuler<Scalar>::computeStepResidDerivImpl(
+  const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs,
+  const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+  const Teuchos::Array<Scalar>& t,
+  const Thyra::VectorBase<Scalar>& p,
+  const int param_index,
+  const int deriv_index) const
+{
+  using Teuchos::RCP;
+  typedef Thyra::ModelEvaluatorBase MEB;
+
+  TEUCHOS_ASSERT(x.size() == 2);
+  TEUCHOS_ASSERT(t.size() == 2);
+  RCP<const Thyra::VectorBase<Scalar> > xn = x[0];
+  RCP<const Thyra::VectorBase<Scalar> > xo = x[1];
+  const Scalar tn = t[0];
+  const Scalar to = t[1];
+  const Scalar dt = tn-to;
+
+  // compute x_dot
+  RCP<Thyra::VectorBase<Scalar> > x_dot = getXDotTemp(xn);
+  Teuchos::RCP<TimeDerivative<Scalar> > timeDer =
+    Teuchos::rcp(new StepperBackwardEulerTimeDerivative<Scalar>(1.0/dt,xo));
+  timeDer->compute(xn, x_dot);
+
+  // evaluate model
+  MEB::InArgs<Scalar>  inArgs  = this->wrapperModel_->getInArgs();
+  inArgs.set_x(xn);
+  if (inArgs.supports(MEB::IN_ARG_x_dot         )) inArgs.set_x_dot    (x_dot);
+  if (inArgs.supports(MEB::IN_ARG_t             )) inArgs.set_t        (tn);
+  if (inArgs.supports(MEB::IN_ARG_step_size     )) inArgs.set_step_size(dt);
+  inArgs.set_p(param_index, Teuchos::rcpFromRef(p));
+  TEUCHOS_ASSERT(inArgs.supports(MEB::IN_ARG_alpha));
+  TEUCHOS_ASSERT(inArgs.supports(MEB::IN_ARG_beta));
+  if (deriv_index == 0) {
+    // df/dx_n = df/dx_dot * dx_dot/dx_n + df/dx_n = 1/dt*df/dx_dot + df/dx_n
+    inArgs.set_alpha(1.0/dt);
+    inArgs.set_beta(1.0);
+  }
+  else if (deriv_index == 1) {
+    // df/dx_{n-1} = df/dx_dot * dx_dot/dx_{n-1} = -1/dt*df/dx_dot
+    inArgs.set_alpha(-1.0/dt);
+    inArgs.set_beta(0.0);
+  }
+  this->wrapperModel_->getAppModel()->evalModel(inArgs, outArgs);
+}
 
 } // namespace Tempus
 #endif // Tempus_StepperBackwardEuler_impl_hpp

--- a/packages/tempus/src/Tempus_StepperOptimizationInterface.hpp
+++ b/packages/tempus/src/Tempus_StepperOptimizationInterface.hpp
@@ -16,6 +16,7 @@
 // Thyra
 #include "Thyra_VectorBase.hpp"
 #include "Thyra_LinearOpBase.hpp"
+#include "Thyra_LinearOpWithSolveBase.hpp"
 
 namespace Tempus {
 
@@ -70,6 +71,17 @@ public:
   //! Compute time step derivative w.r.t. model parameters
   virtual void computeStepParamDeriv(
     Thyra::LinearOpBase<Scalar>& deriv,
+    const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+    const Teuchos::Array<Scalar>& t,
+    const Thyra::VectorBase<Scalar>& p,
+    const int param_index) const = 0;
+
+  //! Compute time step Jacobian solver
+  /*!
+   * Derivative is always w.r.t. the most current solution vector
+   */
+  virtual void computeStepSolver(
+    Thyra::LinearOpWithSolveBase<Scalar>& jacobian_solver,
     const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
     const Teuchos::Array<Scalar>& t,
     const Thyra::VectorBase<Scalar>& p,

--- a/packages/tempus/src/Tempus_StepperOptimizationInterface.hpp
+++ b/packages/tempus/src/Tempus_StepperOptimizationInterface.hpp
@@ -1,0 +1,81 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_Stepper_Optimization_Interface_hpp
+#define Tempus_Stepper_Optimization_Interface_hpp
+
+//Teuchos
+#include "Teuchos_Array.hpp"
+#include "Teuchos_RCP.hpp"
+
+// Thyra
+#include "Thyra_VectorBase.hpp"
+#include "Thyra_LinearOpBase.hpp"
+
+namespace Tempus {
+
+/** \brief Stepper interface to support full-space optimization */
+/*!
+ * This is a potential interface to support transient full-space optimizations
+ * methods such as those implemented by ROL through its DynamicConstraint
+ * interface.  This interface is subject to major revision!
+ *
+ * Design consideration:  Take array of solution vectors as input, or
+ * solution history, or array of states?
+ *
+ * The length of x is determined by the time step stencil, e.g., in an m-step
+ * BDF method x would contain x_n,...,x_{n-m} at time step n in x[0],...,x[m]
+ * with time values stored in t similarly.  p is the vector of design
+ * parameters and param_index determines which model parameter this
+ * corresponds to.
+ */
+template<class Scalar>
+class StepperOptimizationInterface
+{
+public:
+
+  StepperOptimizationInterface() {}
+
+  virtual ~StepperOptimizationInterface() {}
+
+  //! Return the number of solution vectors in the time step stencil
+  virtual int stencilLength() const = 0;
+
+  //! Compute time step residual
+  virtual void computeStepResidual(
+    Thyra::VectorBase<Scalar>& residual,
+    const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+    const Teuchos::Array<Scalar>& t,
+    const Thyra::VectorBase<Scalar>& p,
+    const int param_index) const = 0;
+
+  //! Compute time step Jacobian
+  /*!
+   * deriv_index determines which component of x the derivative should be
+   * computed with respect to.
+   */
+  virtual void computeStepJacobian(
+    Thyra::LinearOpBase<Scalar>& jacobian,
+    const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+    const Teuchos::Array<Scalar>& t,
+    const Thyra::VectorBase<Scalar>& p,
+    const int param_index,
+    const int deriv_index) const = 0;
+
+  //! Compute time step derivative w.r.t. model parameters
+  virtual void computeStepParamDeriv(
+    Thyra::LinearOpBase<Scalar>& deriv,
+    const Teuchos::Array< Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x,
+    const Teuchos::Array<Scalar>& t,
+    const Thyra::VectorBase<Scalar>& p,
+    const int param_index) const = 0;
+};
+
+} // namespace Tempus
+
+#endif // Tempus_Stepper_hpp

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -51,6 +51,7 @@ using Tempus::SolutionState;
 #define TEST_SINCOS
 #define TEST_CDR
 #define TEST_VANDERPOL
+#define TEST_OPT_INTERFACE
 
 
 #ifdef TEST_PARAMETERLIST
@@ -568,6 +569,149 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
   Teuchos::TimeMonitor::summarize();
 }
 #endif // TEST_VANDERPOL
+
+#ifdef TEST_OPT_INTERFACE
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
+{
+  // Read params from .xml file
+  RCP<ParameterList> pList =
+    getParametersFromXmlFile("Tempus_BackwardEuler_SinCos.xml");
+
+  // Setup the SinCosModel
+  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+  RCP<SinCosModel<double> > model =
+    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+
+  // Setup the Integrator
+  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  RCP<Tempus::IntegratorBasic<double> >integrator =
+    Tempus::integratorBasic<double>(pl, model);
+
+  // Integrate to timeMax
+  bool integratorStatus = integrator->advanceTime();
+  TEST_ASSERT(integratorStatus);
+
+  // Get solution history
+  RCP<const SolutionHistory<double> > solutionHistory =
+    integrator->getSolutionHistory();
+
+  // Get the stepper and cast to optimization interface
+  RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+  RCP<Tempus::StepperOptimizationInterface<double> > opt_stepper =
+    Teuchos::rcp_dynamic_cast< Tempus::StepperOptimizationInterface<double> >(
+      stepper, true);
+
+  // Check stencil length
+  TEST_EQUALITY( opt_stepper->stencilLength(), 2);
+
+  // Create needed vectors/multivectors
+  Teuchos::Array< RCP<const Thyra::VectorBase<double> > > x(2);
+  Teuchos::Array<double> t(2);
+  RCP< const Thyra::VectorBase<double> > p =
+    model->getNominalValues().get_p(0);
+  RCP< Thyra::VectorBase<double> > x_dot =
+    Thyra::createMember(model->get_x_space());
+  RCP< Thyra::VectorBase<double> > f =
+    Thyra::createMember(model->get_f_space());
+  RCP< Thyra::VectorBase<double> > f2 =
+    Thyra::createMember(model->get_f_space());
+  RCP< Thyra::LinearOpBase<double> > dfdx =
+    model->create_W_op();
+  RCP< Thyra::LinearOpBase<double> > dfdx2 =
+    model->create_W_op();
+  RCP< Thyra::MultiVectorBase<double> > dfdx_mv =
+    Teuchos::rcp_dynamic_cast< Thyra::MultiVectorBase<double> >(dfdx,true);
+  RCP< Thyra::MultiVectorBase<double> > dfdx_mv2 =
+    Teuchos::rcp_dynamic_cast< Thyra::MultiVectorBase<double> >(dfdx2,true);
+  const int num_p = p->range()->dim();
+  RCP< Thyra::MultiVectorBase<double> > dfdp =
+    Thyra::createMembers(model->get_f_space(), num_p);
+  RCP< Thyra::MultiVectorBase<double> > dfdp2 =
+    Thyra::createMembers(model->get_f_space(), num_p);
+  Teuchos::Array<double> nrms(num_p);
+  double err;
+
+  // Loop over states, checking residuals and derivatives
+  const int n = solutionHistory->getNumStates();
+  for (int i=1; i<n; ++i) {
+    RCP<const SolutionState<double> > state = (*solutionHistory)[i];
+    RCP<const SolutionState<double> > prev_state = (*solutionHistory)[i-1];
+
+    // Fill x, t stencils
+    x[0] = state->getX();
+    x[1] = prev_state->getX();
+    t[0] = state->getTime();
+    t[1] = prev_state->getTime();
+
+    // Compute x_dot
+    const double dt = t[0]-t[1];
+    Thyra::V_StVpStV(x_dot.ptr(), 1.0/dt, *(x[0]), -1.0/dt, *(x[1]));
+
+    // Create model inargs
+    typedef Thyra::ModelEvaluatorBase MEB;
+    MEB::InArgs<double> in_args = model->createInArgs();
+    MEB::OutArgs<double> out_args = model->createOutArgs();
+    in_args.set_x(x[0]);
+    in_args.set_x_dot(x_dot);
+    in_args.set_t(t[0]);
+    in_args.set_p(0,p);
+
+    const double tol = 1.0e-14;
+
+    // Check residual
+    opt_stepper->computeStepResidual(*f, x, t, *p, 0);
+    out_args.set_f(f2);
+    model->evalModel(in_args, out_args);
+    out_args.set_f(Teuchos::null);
+    Thyra::V_VmV(f.ptr(), *f, *f2);
+    err = Thyra::norm(*f);
+    TEST_FLOATING_EQUALITY(err, 0.0, tol);
+
+    // Check df/dx_n
+    // df/dx_n = df/dx_dot * dx_dot/dx_n + df/dx_n = 1/dt*df/dx_dot + df/dx_n
+    opt_stepper->computeStepJacobian(*dfdx, x, t, *p, 0, 0);
+    out_args.set_W_op(dfdx2);
+    in_args.set_alpha(1.0/dt);
+    in_args.set_beta(1.0);
+    model->evalModel(in_args, out_args);
+    out_args.set_W_op(Teuchos::null);
+    Thyra::V_VmV(dfdx_mv.ptr(), *dfdx_mv, *dfdx_mv2);
+    Thyra::norms(*dfdx_mv, nrms());
+    err = 0.0;
+    for (auto nrm : nrms) err += nrm;
+    TEST_FLOATING_EQUALITY(err, 0.0, tol);
+
+    // Check df/dx_{n-1}
+    // df/dx_{n-1} = df/dx_dot * dx_dot/dx_{n-1} = -1/dt*df/dx_dot
+    opt_stepper->computeStepJacobian(*dfdx, x, t, *p, 0, 1);
+    out_args.set_W_op(dfdx2);
+    in_args.set_alpha(-1.0/dt);
+    in_args.set_beta(0.0);
+    model->evalModel(in_args, out_args);
+    out_args.set_W_op(Teuchos::null);
+    Thyra::V_VmV(dfdx_mv.ptr(), *dfdx_mv, *dfdx_mv2);
+    Thyra::norms(*dfdx_mv, nrms());
+    err = 0.0;
+    for (auto nrm : nrms) err += nrm;
+    TEST_FLOATING_EQUALITY(err, 0.0, tol);
+
+    // Check df/dp
+    out_args.set_DfDp(
+      0, MEB::Derivative<double>(dfdp2, MEB::DERIV_MV_JACOBIAN_FORM));
+    opt_stepper->computeStepParamDeriv(*dfdp, x, t, *p, 0);
+    model->evalModel(in_args, out_args);
+    Thyra::V_VmV(dfdp.ptr(), *dfdp, *dfdp2);
+    Thyra::norms(*dfdp, nrms());
+    err = 0.0;
+    for (auto nrm : nrms) err += nrm;
+    TEST_FLOATING_EQUALITY(err, 0.0, tol);
+  }
+
+  Teuchos::TimeMonitor::summarize();
+}
+#endif // TEST_OPT_INTERFACE
 
 
 } // namespace Tempus_Test

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -630,7 +630,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     Thyra::createMembers(model->get_f_space(), num_p);
   RCP< Thyra::MultiVectorBase<double> > dfdp2 =
     Thyra::createMembers(model->get_f_space(), num_p);
-  Teuchos::Array<double> nrms(num_p);
+  std::vector<double> nrms(num_p);
   double err;
 
   // Loop over states, checking residuals and derivatives
@@ -678,7 +678,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     model->evalModel(in_args, out_args);
     out_args.set_W_op(Teuchos::null);
     Thyra::V_VmV(dfdx_mv.ptr(), *dfdx_mv, *dfdx_mv2);
-    Thyra::norms(*dfdx_mv, nrms());
+    Thyra::norms(*dfdx_mv, nrms);
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);
@@ -692,7 +692,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     model->evalModel(in_args, out_args);
     out_args.set_W_op(Teuchos::null);
     Thyra::V_VmV(dfdx_mv.ptr(), *dfdx_mv, *dfdx_mv2);
-    Thyra::norms(*dfdx_mv, nrms());
+    Thyra::norms(*dfdx_mv, nrms);
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);
@@ -703,7 +703,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     opt_stepper->computeStepParamDeriv(*dfdp, x, t, *p, 0);
     model->evalModel(in_args, out_args);
     Thyra::V_VmV(dfdp.ptr(), *dfdp, *dfdp2);
-    Thyra::norms(*dfdp, nrms());
+    Thyra::norms(*dfdp, nrms);
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -686,7 +686,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     model->evalModel(in_args, out_args);
     out_args.set_W_op(Teuchos::null);
     Thyra::V_VmV(dfdx_mv.ptr(), *dfdx_mv, *dfdx_mv2);
-    Thyra::norms(*dfdx_mv, nrms);
+    Thyra::norms(*dfdx_mv, Teuchos::arrayViewFromVector(nrms));
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);
@@ -700,7 +700,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     model->evalModel(in_args, out_args);
     out_args.set_W_op(Teuchos::null);
     Thyra::V_VmV(dfdx_mv.ptr(), *dfdx_mv, *dfdx_mv2);
-    Thyra::norms(*dfdx_mv, nrms);
+    Thyra::norms(*dfdx_mv, Teuchos::arrayViewFromVector(nrms));
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);
@@ -712,7 +712,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     model->evalModel(in_args, out_args);
     out_args.set_DfDp(0, MEB::Derivative<double>());
     Thyra::V_VmV(dfdp.ptr(), *dfdp, *dfdp2);
-    Thyra::norms(*dfdp, nrms);
+    Thyra::norms(*dfdp, Teuchos::arrayViewFromVector(nrms));
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);
@@ -728,7 +728,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
     Thyra::solve(*W, Thyra::NOTRANS, *dfdp2, tmp.ptr());
     Thyra::solve(*W2, Thyra::NOTRANS, *dfdp2, tmp2.ptr());
     Thyra::V_VmV(tmp.ptr(), *tmp, *tmp2);
-    Thyra::norms(*tmp, nrms);
+    Thyra::norms(*tmp, Teuchos::arrayViewFromVector(nrms));
     err = 0.0;
     for (auto nrm : nrms) err += nrm;
     TEST_FLOATING_EQUALITY(err, 0.0, tol);


### PR DESCRIPTION
This PR adds a transient full-space optimization interface to be
used with packages such as ROL with its DynamicConstraint interface.  An
implementation of the interface is provided by BackwardEuler only
(currently).  A test that the interface computes what one would expect
for BackwardEuler is also provided.  The idea is to then implement ROL's
DynamicConstraint interface using Tempus, and then continue to develop
and refine the interface.

The interface should easy to implement for any multistep method.  It is not yet clear how multistage, 1-step methods should be handled.  This PR also does nothing with the objective, since Tempus has no interface for integrating responses (as far as I can tell).