### PR TITLE
Belos:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/belos/epetra/src/BelosEpetraOperator.h
+++ b/packages/belos/epetra/src/BelosEpetraOperator.h
@@ -97,7 +97,7 @@ public:
   //@{ 
   
   //! Set whether the operator or its inverse should be applied. [ This option is not implemented ]
-  int SetUseTranspose( bool UseTranspose_in ) { return(-1); };
+  int SetUseTranspose( bool /* UseTranspose_in */ ) { return(-1); };
   //@}
   
   //! @name Operator application methods

--- a/packages/belos/src/BelosBiCGStabIter.hpp
+++ b/packages/belos/src/BelosBiCGStabIter.hpp
@@ -224,7 +224,7 @@ namespace Belos {
     //! Get the norms of the residuals native to the solver.
     //! \return A std::vector of length blockSize containing the native residuals.
     // amk TODO: are the residuals actually being set?  What is a native residual?
-    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
     //! Get the current update to the linear system.
     /*! \note This method returns a null pointer because the linear problem is current.
@@ -307,7 +307,7 @@ namespace Belos {
   BiCGStabIter<ScalarType,MV,OP>::BiCGStabIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                                                const Teuchos::RCP<OutputManager<ScalarType> > &printer,
                                                                const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                                                               Teuchos::ParameterList &params ):
+                                                               Teuchos::ParameterList &/* params */ ):
     lp_(problem),
     om_(printer),
     stest_(tester),

--- a/packages/belos/src/BelosBlockCGIter.hpp
+++ b/packages/belos/src/BelosBlockCGIter.hpp
@@ -265,7 +265,7 @@ public:
 
   //! Get the norms of the residuals native to the solver.
   //! \return A std::vector of length blockSize containing the native residuals.
-  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
   //! Get the current update to the linear system.
   /*! \note This method returns a null pointer because the linear problem is current.
@@ -290,7 +290,7 @@ public:
   bool isInitialized() { return initialized_; }
 
   //! Sets whether or not to store the diagonal for condition estimation
-  void setDoCondEst(bool val){/*ignored*/}
+  void setDoCondEst(bool /* val */){/*ignored*/}
 
   //! Gets the diagonal for condition estimation (NOT_IMPLEMENTED)
   Teuchos::ArrayView<MagnitudeType> getDiag() { 

--- a/packages/belos/src/BelosCGIter.hpp
+++ b/packages/belos/src/BelosCGIter.hpp
@@ -176,7 +176,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //! Get the norms of the residuals native to the solver.
   //! \return A std::vector of length blockSize containing the native residuals.
-  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
   //! Get the current update to the linear system.
   /*! \note This method returns a null pointer because the linear problem is current.

--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -176,7 +176,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //! Get the norms of the residuals native to the solver.
   //! \return A std::vector of length blockSize containing the native residuals.
-  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
   //! Get the current update to the linear system.
   /*! \note This method returns a null pointer because the linear problem is current.
@@ -204,7 +204,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   bool isInitialized() { return initialized_; }
 
   //! Sets whether or not to store the diagonal for condition estimation
-  void setDoCondEst(bool val){/*ignored*/}
+  void setDoCondEst(bool /* val */){/*ignored*/}
 
   //! Gets the diagonal for condition estimation (NOT_IMPLEMENTED)
   Teuchos::ArrayView<MagnitudeType> getDiag() { 
@@ -281,7 +281,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   CGSingleRedIter<ScalarType,MV,OP>::CGSingleRedIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 						     const Teuchos::RCP<OutputManager<ScalarType> > &printer,
 						     const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-						     Teuchos::ParameterList &params ):
+						     Teuchos::ParameterList &/* params */ ):
     lp_(problem),
     om_(printer),
     stest_(tester),

--- a/packages/belos/src/BelosFixedPointIter.hpp
+++ b/packages/belos/src/BelosFixedPointIter.hpp
@@ -173,7 +173,7 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
 
   //! Get the norms of the residuals native to the solver.
   //! \return A std::vector of length blockSize containing the native residuals.
-  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
   //! Get the current update to the linear system.
   /*! \note This method returns a null pointer because the linear problem is current.

--- a/packages/belos/src/BelosLSQRIter.hpp
+++ b/packages/belos/src/BelosLSQRIter.hpp
@@ -180,7 +180,7 @@ class LSQRIter : virtual public Belos::Iteration<ScalarType,MV,OP> {
 
   //! Get the norms of the residuals native to the solver.
   //! \return This method returns a null pointer because residuals aren't used with LSQR.
-  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return Teuchos::null; }
+  Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return Teuchos::null; }
 
   //! Get the current update to the linear system.
   /*! \note This method returns a null pointer because the linear problem is current.
@@ -343,7 +343,7 @@ class LSQRIter : virtual public Belos::Iteration<ScalarType,MV,OP> {
   /////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
   template <class ScalarType, class MV, class OP>
-  void LSQRIter<ScalarType,MV,OP>::initializeLSQR(LSQRIterationState<ScalarType,MV>& newstate)
+  void LSQRIter<ScalarType,MV,OP>::initializeLSQR(LSQRIterationState<ScalarType,MV>& /* newstate */)
   {
     using Teuchos::RCP;
 

--- a/packages/belos/src/BelosMinresIter.hpp
+++ b/packages/belos/src/BelosMinresIter.hpp
@@ -326,7 +326,7 @@ class MinresIter : virtual public MinresIteration<ScalarType,MV,OP> {
   MinresIter<ScalarType,MV,OP>::MinresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                                    const Teuchos::RCP<OutputManager<ScalarType> > &printer,
                                                    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                                                   const Teuchos::ParameterList &params ):
+                                                   const Teuchos::ParameterList &/* params */ ):
     lp_(problem),
     om_(printer),
     stest_(tester),

--- a/packages/belos/src/BelosOrthoManagerFactory.hpp
+++ b/packages/belos/src/BelosOrthoManagerFactory.hpp
@@ -291,7 +291,7 @@ namespace Belos {
     Teuchos::RCP<Belos::MatOrthoManager<Scalar, MV, OP> >
     makeMatOrthoManager (const std::string& ortho, 
 			 const Teuchos::RCP<const OP>& M,
-			 const Teuchos::RCP<OutputManager<Scalar> >& outMan,
+			 const Teuchos::RCP<OutputManager<Scalar> >& /* outMan */,
 			 const std::string& label,
 			 const Teuchos::RCP<Teuchos::ParameterList>& params)
     {

--- a/packages/belos/src/BelosPCPGIter.hpp
+++ b/packages/belos/src/BelosPCPGIter.hpp
@@ -302,7 +302,7 @@ namespace Belos {
     
     //! Get the norms of the residuals native to the solver.
     //! \return A std::vector of length blockSize containing the native residuals.
-    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
     //! Get the current update to the linear system solution?.
     /*! \note getCurrentUpdate returns a null pointer indicating that the linear problem

--- a/packages/belos/src/BelosPseudoBlockCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGIter.hpp
@@ -187,7 +187,7 @@ namespace Belos {
 
     //! Get the norms of the residuals native to the solver.
     //! \return A std::vector of length blockSize containing the native residuals.
-    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
 
     //! Get the current update to the linear system.
     /*! \note This method returns a null pointer because the linear problem is current.

--- a/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
@@ -343,7 +343,7 @@ namespace Belos {
   PseudoBlockTFQMRIter<ScalarType,MV,OP>::PseudoBlockTFQMRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 					 const Teuchos::RCP<OutputManager<ScalarType> > &printer,
 					 const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-					 Teuchos::ParameterList &params 
+					 Teuchos::ParameterList &/* params */ 
 					 ) : 
     lp_(problem), 
     om_(printer),

--- a/packages/belos/src/BelosRCGIter.hpp
+++ b/packages/belos/src/BelosRCGIter.hpp
@@ -280,7 +280,7 @@ namespace Belos {
 
     //! Get the norms of the residuals native to the solver.
     //! \return A std::vector of length blockSize containing the native residuals.
-    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return r_; }
+    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return r_; }
 
     //! Get the current update to the linear system.
     /*! \note Some solvers, like GMRES, do not compute updates to the solution every iteration.

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -1888,7 +1888,7 @@ ReturnType RCGSolMgr<ScalarType,MV,OP,true>::solve() {
 //  Compute the harmonic eigenpairs of the projected, dense system.
 template<class ScalarType, class MV, class OP>
 void RCGSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs(const Teuchos::SerialDenseMatrix<int,ScalarType>& F,
-                                                  const Teuchos::SerialDenseMatrix<int,ScalarType>& G,
+                                                  const Teuchos::SerialDenseMatrix<int,ScalarType>& /* G */,
                                                         Teuchos::SerialDenseMatrix<int,ScalarType>& Y) {
   // order of F,G
   int n = F.numCols();

--- a/packages/belos/src/BelosSolverManager.hpp
+++ b/packages/belos/src/BelosSolverManager.hpp
@@ -145,8 +145,8 @@ class SolverManager : virtual public Teuchos::Describable {
 
   //! Set user-defined convergence status test.
   virtual void setUserConvStatusTest(
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &userConvStatusTest,
-    const typename StatusTestCombo<ScalarType,MV,OP>::ComboType &comboType =
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &/* userConvStatusTest */,
+    const typename StatusTestCombo<ScalarType,MV,OP>::ComboType &/* comboType */ =
         StatusTestCombo<ScalarType,MV,OP>::SEQ
     )
     {
@@ -156,7 +156,7 @@ class SolverManager : virtual public Teuchos::Describable {
 
   //! Set user-defined debug status test.
   virtual void setDebugStatusTest(
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &debugStatusTest
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &/* debugStatusTest */
     )
     {
       TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error, the function setDebugStatusTest() has not been"

--- a/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
@@ -93,7 +93,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
     @param showMaxResNormOnly: for output only
 
   */
-  StatusTestGenResSubNorm( MagnitudeType Tolerance, size_t subIdx, int quorum = -1, bool showMaxResNormOnly = false ) {
+  StatusTestGenResSubNorm( MagnitudeType /* Tolerance */, size_t /* subIdx */, int /* quorum */ = -1, bool /* showMaxResNormOnly */ = false ) {
     TEUCHOS_TEST_FOR_EXCEPTION(true,StatusTestError,
           "StatusTestGenResSubNorm::StatusTestGenResSubNorm(): StatusTestGenResSubNorm only available for blocked operators (e.g., Thyra).");
   }
@@ -112,7 +112,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
     DefineScaleForm()).
     </ul>
   */
-  int defineResForm(  NormType TypeOfNorm) {
+  int defineResForm(  NormType /* TypeOfNorm */) {
     TEUCHOS_TEST_FOR_EXCEPTION(true,StatusTestError,
           "StatusTestGenResSubNorm::defineResForm(): StatusTestGenResSubNorm only available for blocked operators (e.g., Thyra).");
     TEUCHOS_UNREACHABLE_RETURN(0);
@@ -139,7 +139,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
     </ul>
     </ol>
   */
-  int defineScaleForm( ScaleType TypeOfScaling, NormType TypeOfNorm, MagnitudeType ScaleValue = Teuchos::ScalarTraits<MagnitudeType>::one()) {
+  int defineScaleForm( ScaleType /* TypeOfScaling */, NormType /* TypeOfNorm */, MagnitudeType /* ScaleValue */ = Teuchos::ScalarTraits<MagnitudeType>::one()) {
     TEUCHOS_TEST_FOR_EXCEPTION(true,StatusTestError,
           "StatusTestGenResSubNorm::defineScaleForm(): StatusTestGenResSubNorm only available for blocked operators (e.g., Thyra).");
     TEUCHOS_UNREACHABLE_RETURN(0);
@@ -149,7 +149,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
   /*! We allow the tolerance to be reset for cases where, in the process of testing the residual,
     we find that the initial tolerance was too tight or too lax.
   */
-  int setTolerance(MagnitudeType tolerance) { return 0; }
+  int setTolerance(MagnitudeType /* tolerance */) { return 0; }
 
   //! Set the block index of which we want to check the norm of the sub-residuals
   /*! It does not really make sense to change/reset the index during the solution process
@@ -158,10 +158,10 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
   //! Sets the number of residuals that must pass the convergence test before Passed is returned.
   //! \note If \c quorum=-1 then all residuals must pass the convergence test before Passed is returned.
-  int setQuorum(int quorum) { return 0; }
+  int setQuorum(int /* quorum */) { return 0; }
 
   //! Set whether the only maximum residual norm is displayed when the print() method is called
-  int setShowMaxResNormOnly(bool showMaxResNormOnly) { return 0; }
+  int setShowMaxResNormOnly(bool /* showMaxResNormOnly */) { return 0; }
 
   //@}
 
@@ -174,7 +174,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
     \return StatusType: Passed, Failed, or Undefined.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP>* iSolver) { return Undefined; }
+  StatusType checkStatus(Iteration<ScalarType,MV,OP>* /* iSolver */) { return Undefined; }
 
   //! Return the result of the most recent CheckStatus call.
   StatusType getStatus() const {return Undefined;}
@@ -192,10 +192,10 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
   //@{
 
   //! Output formatted description of stopping test to output stream.
-  void print(std::ostream& os, int indent = 0) const { }
+  void print(std::ostream& /* os */, int /* indent */ = 0) const { }
 
   //! Print message for each status specific to this stopping test.
-  void printStatus(std::ostream& os, StatusType type) const { }
+  void printStatus(std::ostream& /* os */, StatusType /* type */) const { }
   //@}
 
   //! @name Methods to access data members.

--- a/packages/belos/src/BelosTFQMRIter.hpp
+++ b/packages/belos/src/BelosTFQMRIter.hpp
@@ -339,7 +339,7 @@ namespace Belos {
   TFQMRIter<ScalarType,MV,OP>::TFQMRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 					 const Teuchos::RCP<OutputManager<ScalarType> > &printer,
 					 const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-					 Teuchos::ParameterList &params 
+					 Teuchos::ParameterList &/* params */ 
 					 ) : 
     lp_(problem), 
     om_(printer),


### PR DESCRIPTION
@trilinos/belos

## Description
When compiling with all warning turned on with gcc-7.2.0, I see these `unused-parameter` warnings all over the place.  Commenting out the parameter names in the function definitions usually does the trick.

## Motivation and Context
Just trying to get to a cleaner build.