### PR TITLE
Teuchos:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_DefaultSerialComm.hpp
+++ b/packages/teuchos/comm/src/Teuchos_DefaultSerialComm.hpp
@@ -236,7 +236,7 @@ SerialComm<Ordinal>::SerialComm()
 {}
 
 template<typename Ordinal>
-SerialComm<Ordinal>::SerialComm(const SerialComm<Ordinal>& other)
+SerialComm<Ordinal>::SerialComm(const SerialComm<Ordinal>& /* other */)
 {}
 
 
@@ -372,10 +372,10 @@ void SerialComm<Ordinal>::ssend(
 
 template<typename Ordinal>
 void
-SerialComm<Ordinal>::ssend (const Ordinal bytes,
-                            const char sendBuffer[],
-                            const int destRank,
-                            const int tag) const
+SerialComm<Ordinal>::ssend (const Ordinal /* bytes */,
+                            const char* /* sendBuffer */,
+                            const int /* destRank */,
+                            const int /* tag */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     true, std::logic_error

--- a/packages/teuchos/core/src/Teuchos_Describable.cpp
+++ b/packages/teuchos/core/src/Teuchos_Describable.cpp
@@ -62,7 +62,7 @@ std::string Describable::description () const
 
 void
 Describable::describe (FancyOStream& out_arg,
-                       const EVerbosityLevel verbLevel) const
+                       const EVerbosityLevel /* verbLevel */) const
 {
   RCP<FancyOStream> out = rcpFromRef (out_arg);
   OSTab tab (out);

--- a/packages/teuchos/core/src/Teuchos_RCPNode.cpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.cpp
@@ -218,6 +218,7 @@ void RCPNode::set_extra_data(
   ,bool force_unique
   )
 {
+  (void)force_unique;
   if(extra_data_map_==NULL) {
     extra_data_map_ = new extra_data_map_t;
   }

--- a/packages/teuchos/core/src/Teuchos_ScalarTraits.cpp
+++ b/packages/teuchos/core/src/Teuchos_ScalarTraits.cpp
@@ -84,6 +84,7 @@ operator>> (std::istream& in, __float128& x)
 
 void Teuchos::throwScalarTraitsNanInfError( const std::string &errMsg )
 {
+  (void)errMsg;
 #ifdef TEUCHOS_SCALAR_TRAITS_THROW_NAN_INF_ERR
   TEUCHOS_TEST_FOR_EXCEPTION( true, std::runtime_error, errMsg );
 #endif

--- a/packages/teuchos/core/src/Teuchos_StrUtils.cpp
+++ b/packages/teuchos/core/src/Teuchos_StrUtils.cpp
@@ -369,7 +369,7 @@ std::string StrUtils::subString(const std::string& str, int begin, int end)
 }
 
 
-std::string StrUtils::readFromStream(std::istream& is)
+std::string StrUtils::readFromStream(std::istream& /* is */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
     "StrUtils::readFromStream isn't implemented yet");

--- a/packages/teuchos/numerics/src/Teuchos_Flops.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_Flops.cpp
@@ -53,7 +53,7 @@ Flops::Flops(void) : flops_(0.0)
 
 // 2007/11/26: rabartl: Below, is it correct that flops_in does not have its
 // flops copied into the data member flops_?
-Flops::Flops(const Flops& flops_in) : flops_(0.0)
+Flops::Flops(const Flops& /* flops_in */) : flops_(0.0)
 {
 }
 

--- a/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_LAPACK.cpp
@@ -336,11 +336,11 @@ namespace Teuchos
   { SSYGV_F77(&itype, CHAR_MACRO(JOBZ), CHAR_MACRO(UPLO), &n, A, &lda, B, &ldb, W, WORK, &lwork, info); }
 
 
-  void LAPACK<int,float>::HEEV(const char& JOBZ, const char& UPLO, const int& n, float* A, const int& lda, float* W, float* WORK, const int& lwork, float* RWORK, int* info) const
+  void LAPACK<int,float>::HEEV(const char& JOBZ, const char& UPLO, const int& n, float* A, const int& lda, float* W, float* WORK, const int& lwork, float* /* RWORK */, int* info) const
   { SSYEV_F77(CHAR_MACRO(JOBZ), CHAR_MACRO(UPLO), &n, A, &lda, W, WORK, &lwork, info); }
 
 
-  void LAPACK<int,float>::HEGV(const int& itype, const char& JOBZ, const char& UPLO, const int& n, float* A, const int& lda, float* B, const int& ldb, float* W, float* WORK, const int& lwork, float* RWORK, int* info) const
+  void LAPACK<int,float>::HEGV(const int& itype, const char& JOBZ, const char& UPLO, const int& n, float* A, const int& lda, float* B, const int& ldb, float* W, float* WORK, const int& lwork, float* /* RWORK */, int* info) const
   { SSYGV_F77(&itype, CHAR_MACRO(JOBZ), CHAR_MACRO(UPLO), &n, A, &lda, B, &ldb, W, WORK, &lwork, info); }
 
 
@@ -360,7 +360,7 @@ namespace Teuchos
   { SGEES_F77(CHAR_MACRO(JOBVS), CHAR_MACRO(SORT), ptr2func, &n, A, &lda, sdim, WR, WI, VS, &ldvs, WORK, &lwork, BWORK, info); }
 
 
-  void LAPACK<int, float>::GEES(const char& JOBVS, const int& n, float* A, const int& lda, int* sdim, float* WR, float* WI, float* VS, const int& ldvs, float* WORK, const int& lwork, float* RWORK, int* BWORK, int* info) const
+  void LAPACK<int, float>::GEES(const char& JOBVS, const int& n, float* A, const int& lda, int* sdim, float* WR, float* WI, float* VS, const int& ldvs, float* WORK, const int& lwork, float* /* RWORK */, int* BWORK, int* info) const
   {
     int (*nullfptr)(float*,float*) = NULL;
     const char sort = 'N';
@@ -377,7 +377,7 @@ namespace Teuchos
   }
 
 
-  void LAPACK<int, float>::GESVD(const char& JOBU, const char& JOBVT, const int& m, const int& n, float* A, const int& lda, float* S, float* U, const int& ldu, float* V, const int& ldv, float* WORK, const int& lwork, float* RWORK, int* info) const
+  void LAPACK<int, float>::GESVD(const char& JOBU, const char& JOBVT, const int& m, const int& n, float* A, const int& lda, float* S, float* U, const int& ldu, float* V, const int& ldv, float* WORK, const int& lwork, float* /* RWORK */, int* info) const
   { SGESVD_F77(CHAR_MACRO(JOBU), CHAR_MACRO(JOBVT), &m, &n, A, &lda, S, U, &ldu, V, &ldv, WORK, &lwork, info); }
 
 
@@ -454,7 +454,7 @@ namespace Teuchos
   { STREVC_F77(CHAR_MACRO(SIDE), CHAR_MACRO(HOWMNY), select, &n, T, &ldt, VL, &ldvl, VR, &ldvr, &mm, m, WORK, info); }
 
 
-  void LAPACK<int, float>::TREVC(const char& SIDE, const int& n, const float* T, const int& ldt, float* VL, const int& ldvl, float* VR, const int& ldvr, const int& mm, int* m, float* WORK, float* RWORK, int* info) const
+  void LAPACK<int, float>::TREVC(const char& SIDE, const int& n, const float* T, const int& ldt, float* VL, const int& ldvl, float* VR, const int& ldvr, const int& mm, int* m, float* WORK, float* /* RWORK */, int* info) const
   {
     std::vector<int> select(1);
     const char whch = 'A';
@@ -764,13 +764,13 @@ namespace Teuchos
   }
 
 
-  void LAPACK<int,double>::HEEV(const char& JOBZ, const char& UPLO, const int& n, double* A, const int& lda, double* W, double* WORK, const int& lwork, double* RWORK, int* info) const
+  void LAPACK<int,double>::HEEV(const char& JOBZ, const char& UPLO, const int& n, double* A, const int& lda, double* W, double* WORK, const int& lwork, double* /* RWORK */, int* info) const
   {
     DSYEV_F77(CHAR_MACRO(JOBZ), CHAR_MACRO(UPLO), &n, A, &lda, W, WORK, &lwork, info);
   }
 
 
-  void LAPACK<int,double>::HEGV(const int& itype, const char& JOBZ, const char& UPLO, const int& n, double* A, const int& lda, double* B, const int& ldb, double* W, double* WORK, const int& lwork, double* RWORK, int* info) const
+  void LAPACK<int,double>::HEGV(const int& itype, const char& JOBZ, const char& UPLO, const int& n, double* A, const int& lda, double* B, const int& ldb, double* W, double* WORK, const int& lwork, double* /* RWORK */, int* info) const
   {
     DSYGV_F77(&itype, CHAR_MACRO(JOBZ), CHAR_MACRO(UPLO), &n, A, &lda, B, &ldb, W, WORK, &lwork, info);
   }
@@ -796,7 +796,7 @@ namespace Teuchos
   }
 
 
-  void LAPACK<int, double>::GEES(const char& JOBVS, const int& n, double* A, const int& lda, int* sdim, double* WR, double* WI, double* VS, const int& ldvs, double* WORK, const int& lwork, double* RWORK, int* BWORK, int* info) const
+  void LAPACK<int, double>::GEES(const char& JOBVS, const int& n, double* A, const int& lda, int* sdim, double* WR, double* WI, double* VS, const int& ldvs, double* WORK, const int& lwork, double* /* RWORK */, int* BWORK, int* info) const
   {
     //int (*nullfptr)(double*,double*) = NULL;
     gees_nullfptr_t nullfptr = 0;
@@ -816,7 +816,7 @@ namespace Teuchos
   }
 
 
-  void LAPACK<int, double>::GESVD(const char& JOBU, const char& JOBVT, const int& m, const int& n, double* A, const int& lda, double* S, double* U, const int& ldu, double* V, const int& ldv, double* WORK, const int& lwork, double* RWORK, int* info) const {
+  void LAPACK<int, double>::GESVD(const char& JOBU, const char& JOBVT, const int& m, const int& n, double* A, const int& lda, double* S, double* U, const int& ldu, double* V, const int& ldv, double* WORK, const int& lwork, double* /* RWORK */, int* info) const {
     DGESVD_F77(CHAR_MACRO(JOBU), CHAR_MACRO(JOBVT), &m, &n, A, &lda, S, U, &ldu, V, &ldv, WORK, &lwork, info);
   }
 
@@ -910,7 +910,7 @@ namespace Teuchos
   }
 
 
-  void LAPACK<int, double>::TREVC(const char& SIDE, const int& n, const double* T, const int& ldt, double* VL, const int& ldvl, double* VR, const int& ldvr, const int& mm, int* m, double* WORK, double* RWORK, int* info) const
+  void LAPACK<int, double>::TREVC(const char& SIDE, const int& n, const double* T, const int& ldt, double* VL, const int& ldvl, double* VR, const int& ldvr, const int& mm, int* m, double* WORK, double* /* RWORK */, int* info) const
   {
     std::vector<int> select(1);
     const char whch = 'A';

--- a/packages/teuchos/numerics/src/Teuchos_MatrixMarket_Banner.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_MatrixMarket_Banner.cpp
@@ -75,7 +75,7 @@ namespace Teuchos {
     }
 
     std::string
-    Banner::validateMatrixType (const std::string& matrixType, const bool tolerant)
+    Banner::validateMatrixType (const std::string& matrixType, const bool /* tolerant */)
     {
       // Canonical representation is lowercase
       std::string out = trim_and_lowercase (matrixType);
@@ -89,7 +89,7 @@ namespace Teuchos {
     }
 
     std::string
-    Banner::validateDataType (const std::string& dataType, const bool tolerant)
+    Banner::validateDataType (const std::string& dataType, const bool /* tolerant */)
     {
       // Canonical representation is lowercase
       std::string out = trim_and_lowercase (dataType);

--- a/packages/teuchos/numerics/src/Teuchos_Object.cpp
+++ b/packages/teuchos/numerics/src/Teuchos_Object.cpp
@@ -87,7 +87,7 @@ int Object::getTracebackMode()
   return(temp);
 }
 
-void Object::print (std::ostream& os) const
+void Object::print (std::ostream& /* os */) const
 {
   // os << label_; // No need to print label, since std::ostream does it already
 }

--- a/packages/teuchos/parameterlist/src/Teuchos_StandardConditionXMLConverters.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_StandardConditionXMLConverters.cpp
@@ -196,14 +196,14 @@ void StringConditionConverter::addSpecificXMLTraits(
 
 RCP<ParameterCondition>
 BoolConditionConverter::getSpecificParameterCondition(
-  const XMLObject& xmlObj,
+  const XMLObject& /* xmlObj */,
   RCP<ParameterEntry> parameterEntry) const
 {
   return rcp(new BoolCondition(parameterEntry));
 }
 
 void BoolConditionConverter::addSpecificXMLTraits(
-  RCP<const ParameterCondition> condition, XMLObject& xmlObj) const
+  RCP<const ParameterCondition> /* condition */, XMLObject& /* xmlObj */) const
 {}
 
 

--- a/packages/teuchos/parameterlist/src/Teuchos_StandardDependencyXMLConverters.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_StandardDependencyXMLConverters.cpp
@@ -161,14 +161,14 @@ StringVisualDependencyXMLConverter::convertSpecialVisualAttributes(
 }
 
 void BoolVisualDependencyXMLConverter::convertSpecialVisualAttributes(
-  RCP<const VisualDependency> dependency,
-  XMLObject& xmlObj,
+  RCP<const VisualDependency> /* dependency */,
+  XMLObject& /* xmlObj */,
   const XMLParameterListWriter::EntryIDsMap& /*entryIDsMap*/) const
 {}
 
 RCP<VisualDependency>
 BoolVisualDependencyXMLConverter::convertSpecialVisualAttributes(
-  const XMLObject& xmlObj,
+  const XMLObject& /* xmlObj */,
   const Dependency::ConstParameterEntryList dependees,
   const Dependency::ParameterEntryList dependents,
   bool showIf,
@@ -197,7 +197,7 @@ void ConditionVisualDependencyXMLConverter::convertSpecialVisualAttributes(
 RCP<VisualDependency>
 ConditionVisualDependencyXMLConverter::convertSpecialVisualAttributes(
   const XMLObject& xmlObj,
-  const Dependency::ConstParameterEntryList dependees,
+  const Dependency::ConstParameterEntryList /* dependees */,
   const Dependency::ParameterEntryList dependents,
   bool showIf,
   const XMLParameterListReader::EntryIDsMap& entryIDsMap) const

--- a/packages/teuchos/parameterlist/src/Teuchos_StandardDependencyXMLConverters.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_StandardDependencyXMLConverters.hpp
@@ -351,7 +351,7 @@ template<class T>
 void NumberVisualDependencyXMLConverter<T>::convertSpecialVisualAttributes(
   RCP<const VisualDependency> dependency,
   XMLObject& xmlObj,
-  const XMLParameterListWriter::EntryIDsMap& entryIDsMap) const
+  const XMLParameterListWriter::EntryIDsMap& /* entryIDsMap */) const
 {
   RCP<const NumberVisualDependency<T> > castedDependency =
     rcp_dynamic_cast<const NumberVisualDependency<T> >(dependency);
@@ -373,7 +373,7 @@ NumberVisualDependencyXMLConverter<T>::convertSpecialVisualAttributes(
   const Dependency::ConstParameterEntryList dependees,
   const Dependency::ParameterEntryList dependents,
   bool showIf,
-  const XMLParameterListReader::EntryIDsMap& entryIDsMap) const
+  const XMLParameterListReader::EntryIDsMap& /* entryIDsMap */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(dependees.size() > 1,
     TooManyDependeesException,
@@ -834,8 +834,8 @@ ArrayModifierDependencyXMLConverter<DependeeType, DependentType>::convertXML(
   const XMLObject& xmlObj,
   const Dependency::ConstParameterEntryList dependees,
   const Dependency::ParameterEntryList dependents,
-  const XMLParameterListReader::EntryIDsMap& entryIDsMap,
-  const IDtoValidatorMap& validatorIDsMap) const
+  const XMLParameterListReader::EntryIDsMap& /* entryIDsMap */,
+  const IDtoValidatorMap& /* validatorIDsMap */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(dependees.size() > 1,
     TooManyDependeesException,
@@ -856,8 +856,8 @@ void
 ArrayModifierDependencyXMLConverter<DependeeType, DependentType>::convertDependency(
     const RCP<const Dependency> dependency,
     XMLObject& xmlObj,
-    const XMLParameterListWriter::EntryIDsMap& entryIDsMap,
-    ValidatortoIDMap& validatorIDsMap) const
+    const XMLParameterListWriter::EntryIDsMap& /* entryIDsMap */,
+    ValidatortoIDMap& /* validatorIDsMap */) const
 {
   RCP<const ArrayModifierDependency<DependeeType, DependentType> > castedDep =
     rcp_dynamic_cast<const ArrayModifierDependency<DependeeType, DependentType> >(

--- a/packages/teuchos/parameterlist/src/Teuchos_StandardFunctionObjectXMLConverters.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_StandardFunctionObjectXMLConverters.hpp
@@ -80,8 +80,8 @@ public:
    * @param xmlObj The XMLObject to which any special traits should be added.
    */
   virtual void getSpecialSimpleFunctionXMLTraits(
-    const RCP<const SimpleFunctionObject<OperandType> > functionObject,
-    XMLObject& xmlObj) const{}
+    const RCP<const SimpleFunctionObject<OperandType> > /* functionObject */,
+    XMLObject& /* xmlObj */) const{}
 
   //@}
 

--- a/packages/teuchos/parameterlist/src/Teuchos_StandardValidatorXMLConverters.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_StandardValidatorXMLConverters.cpp
@@ -49,7 +49,7 @@
 namespace Teuchos {
 
 RCP<ParameterEntryValidator> BoolValidatorXMLConverter::convertXML(
-  const XMLObject& xmlObj,
+  const XMLObject& /* xmlObj */,
   const IDtoValidatorMap& /*validatorIDsMap*/) const
 {
   return boolParameterEntryValidator();
@@ -57,8 +57,8 @@ RCP<ParameterEntryValidator> BoolValidatorXMLConverter::convertXML(
 
 
 void BoolValidatorXMLConverter::convertValidator(
-  const RCP<const ParameterEntryValidator> validator,
-  XMLObject& xmlObj,
+  const RCP<const ParameterEntryValidator> /* validator */,
+  XMLObject& /* xmlObj */,
   const ValidatortoIDMap& /*validatorIDsMap*/) const
 {
   //RCP<const AnyNumberParameterEntryValidator> castedValidator =

--- a/packages/teuchos/parameterlist/src/Teuchos_XMLParameterListWriter.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_XMLParameterListWriter.cpp
@@ -103,7 +103,7 @@ void XMLParameterListWriter::buildInitialValidatorMap(
 
 
 XMLObject XMLParameterListWriter::convertValidators(
-  const ParameterList& p, ValidatortoIDMap& validatorIDsMap) const
+  const ParameterList& /* p */, ValidatortoIDMap& validatorIDsMap) const
 {
   XMLObject validators(getValidatorsTagName());
   for(

--- a/packages/teuchos/parameterlist/src/Teuchos_XMLParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_XMLParser.cpp
@@ -442,7 +442,7 @@ void XMLParser::getSTag(unsigned char lookahead, std::string &tag, Teuchos::map<
 }
 
 
-void XMLParser::getComment(long startLine)
+void XMLParser::getComment(long /* startLine */)
 {
   /* Recall from the specification:
         Comment   ::= '<!--' ((Char - '-') | ('-' (Char - '-')))* '-->'

--- a/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
+++ b/packages/teuchos/parser/src/Teuchos_MathExpr.cpp
@@ -106,7 +106,7 @@ void SymbolSetReader::at_shift(any& result, int token, std::string& text) {
   if (token == TOK_NAME) result = text;
 }
 
-void SymbolSetReader::at_reduce(any& result, int prod, std::vector<any>& rhs) {
+void SymbolSetReader::at_reduce(any& /* result */, int prod, std::vector<any>& rhs) {
   if (prod == PROD_VAR) {
     std::string& name = any_ref_cast<std::string>(rhs.at(0));
     variable_names.insert(name);

--- a/packages/teuchos/parser/src/Teuchos_make_lalr1_parser.cpp
+++ b/packages/teuchos/parser/src/Teuchos_make_lalr1_parser.cpp
@@ -436,7 +436,7 @@ static std::string escape_dot(std::string const& s) {
 void print_graphviz(
     std::string const& filepath,
     ParserInProgress const& pip,
-    bool verbose,
+    bool /* verbose */,
     std::ostream& os
     ) {
   const StatesInProgress& sips = pip.states;


### PR DESCRIPTION
@trilinos/teuchos 

## Description
Compiling Trilinos with all warning on with gcc-7.2.0 yields a ton of unused parameter warnings.  This PR comments out the parameter names in function definitions to avoid those warnings.

## Motivation and Context
Just hoping for a clean build one day&hellip;