### PR TITLE
MiniEM changes

### DIFF
--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -443,17 +443,23 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
       closure_models.sublist("electromagnetics").sublist("PERMITTIVITY").set<std::string>("DoF Name","E_edge");
       closure_models.sublist("electromagnetics").sublist("INVERSE_PERMEABILITY").set<std::string>("Type","INVERSE PERMEABILITY");
       closure_models.sublist("electromagnetics").sublist("INVERSE_PERMEABILITY").set<double>("mu",mu);
+      closure_models.sublist("electromagnetics").sublist("INVERSE_PERMEABILITY").set<std::string>("DoF Name","B_face");
       closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<std::string>("Type","CONDUCTIVITY");
       closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<double>("sigma",0.0);
       closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<std::string>("DoF Name","E_edge");
       closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<std::string>("Type","PERMITTIVITY");
       closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<double>("epsilon",epsilon);
       closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<std::string>("DoF Name","AUXILIARY_EDGE");
+      closure_models.sublist("electromagnetics_aux").sublist("INVERSE_PERMEABILITY").set<std::string>("Type","INVERSE PERMEABILITY");
+      closure_models.sublist("electromagnetics_aux").sublist("INVERSE_PERMEABILITY").set<double>("mu",mu);
+      closure_models.sublist("electromagnetics_aux").sublist("INVERSE_PERMEABILITY").set<std::string>("DoF Name","AUXILIARY_EDGE");
 
-      // constant permeability and permittivity
+      // constant permeability, permittivity and conductivity
       // closure_models.sublist("electromagnetics").sublist("PERMITTIVITY").set<double>("Value",epsilon);
       // closure_models.sublist("electromagnetics").sublist("INVERSE_PERMEABILITY").set<double>("Value",1.0/mu);
+      // closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<double>("Value",0.0);
       // closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<double>("Value",epsilon);
+      // closure_models.sublist("electromagnetics_aux").sublist("INVERSE_PERMEABILITY").set<double>("Value",1.0/mu);
 
       // electromagnetic energy: 1/2 * ((E, epsilon * E) + (B, 1/mu * B))
       closure_models.sublist("electromagnetics").sublist("EM_ENERGY").set<std::string>("Type","ELECTROMAGNETIC ENERGY");
@@ -809,6 +815,20 @@ Teuchos::RCP<Teuchos::ParameterList> auxOpsParameterList(const int basis_order, 
     p.set("Basis Order",basis_order);
     p.set("Integration Order",integration_order);
     p.set("Multiplier",1.0);
+  }
+
+  {
+    Teuchos::ParameterList& p = pl->sublist("Auxiliary Edge Curl Curl Physics");
+    p.set("Type","Auxiliary Curl Curl");
+    p.set("Model ID","electromagnetics_aux");
+    p.set("DOF Name","AUXILIARY_EDGE");
+    p.set("Basis Type","HCurl");
+    p.set("Basis Order",basis_order);
+    p.set("Integration Order",integration_order);
+    p.set("Multiplier",1.0/massMultiplier);
+    // Teuchos::RCP<std::vector<std::string> > fieldMultipliers = Teuchos::rcp(new std::vector<std::string>);
+    // fieldMultipliers->push_back("INVERSE_PERMEABILITY");
+    // p.set("Field Multipliers",fieldMultipliers.getConst());
   }
 
   {

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -266,8 +266,6 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
           xml = "solverMueLuRefMaxwell.xml";
         else
           xml = "solverMueLuRefMaxwell2D.xml";
-      } else
-        xml = "solverMueLuRefMaxwellEpetra.xml";
 #ifdef KOKKOS_ENABLE_OPENMP
       if (typeid(panzer::TpetraNodeType).name() == typeid(Kokkos::Compat::KokkosOpenMPWrapperNode).name()) {
         if (linAlgebra == "Tpetra")
@@ -282,6 +280,8 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
         }
       }
 #endif
+      } else
+        xml = "solverMueLuRefMaxwellEpetra.xml";
 #ifdef KOKKOS_ENABLE_CUDA
       if (typeid(panzer::TpetraNodeType).name() == typeid(Kokkos::Compat::KokkosCudaWrapperNode).name())
         xml = "solverMueLuRefMaxwellCuda.xml";

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -63,7 +63,7 @@
 Teuchos::RCP<Teuchos::ParameterList> maxwellParameterList(const int basis_order);
 std::vector<panzer::BC> homogeneousBoundaries(Teuchos::RCP<panzer_stk::STK_Interface> mesh);
 std::vector<panzer::BC> auxiliaryBoundaries(Teuchos::RCP<panzer_stk::STK_Interface> mesh);
-Teuchos::RCP<Teuchos::ParameterList> auxOpsParameterList(const int basis_order, const double massMultiplier, Teuchos::RCP<const std::vector<std::string> > fieldMultipliers);
+Teuchos::RCP<Teuchos::ParameterList> auxOpsParameterList(const int basis_order, const double massMultiplier);
 void createExodusFile(const std::vector<Teuchos::RCP<panzer::PhysicsBlock> >& physicsBlocks,
                       Teuchos::RCP<panzer_stk::STK_MeshFactory> mesh_factory,
                       Teuchos::RCP<panzer_stk::STK_Interface> mesh,
@@ -352,16 +352,10 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
 
     // build the auxiliary physics blocks objects
     Teuchos::RCP<Teuchos::ParameterList> auxPhysicsBlock_pl;
-    Teuchos::RCP<std::vector<std::string> > fieldMultipliers;
     if (use_refmaxwell) {
-      fieldMultipliers = rcp(new std::vector<std::string>);
-      fieldMultipliers->push_back("PERMITTIVITY");
-      auxPhysicsBlock_pl = auxOpsParameterList(basis_order, 1.0 / dt / cfl / cfl / min_dx / min_dx, fieldMultipliers.getConst());
-      // We actually want Q_rho with weight 1/mu but for that we
-      // would need to be able to request a Q_E with weight 1
-      // instead of eps/dt.
+      auxPhysicsBlock_pl = auxOpsParameterList(basis_order, mu/dt);
     } else
-      auxPhysicsBlock_pl = auxOpsParameterList(basis_order, 1.0, fieldMultipliers.getConst());
+      auxPhysicsBlock_pl = auxOpsParameterList(basis_order, 1.0);
     std::vector<RCP<panzer::PhysicsBlock> > auxPhysicsBlocks;
     {
       Teuchos::TimeMonitor tMaux_physics(*Teuchos::TimeMonitor::getNewTimer(std::string("Mini-EM: build auxiliary physics blocks")));
@@ -790,7 +784,7 @@ std::vector<panzer::BC> auxiliaryBoundaries(Teuchos::RCP<panzer_stk::STK_Interfa
 }
 
 //! Create parameter list defining nodal mass matrix and node-edge weak gradient
-Teuchos::RCP<Teuchos::ParameterList> auxOpsParameterList(const int basis_order, const double massMultiplier, Teuchos::RCP<const std::vector<std::string> > fieldMultipliers)
+Teuchos::RCP<Teuchos::ParameterList> auxOpsParameterList(const int basis_order, const double massMultiplier)
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::rcp(new Teuchos::ParameterList("Aux Physics Block"));
   const int integration_order = 2*basis_order;
@@ -804,7 +798,17 @@ Teuchos::RCP<Teuchos::ParameterList> auxOpsParameterList(const int basis_order, 
     p.set("Basis Order",basis_order);
     p.set("Integration Order",integration_order);
     p.set("Multiplier",massMultiplier);
-    p.set("Field Multipliers",fieldMultipliers);
+  }
+
+  {
+    Teuchos::ParameterList& p = pl->sublist("Auxiliary Edge Mass Physics");
+    p.set("Type","Auxiliary Mass Matrix");
+    p.set("Model ID","electromagnetics_aux");
+    p.set("DOF Name","AUXILIARY_EDGE");
+    p.set("Basis Type","HCurl");
+    p.set("Basis Order",basis_order);
+    p.set("Integration Order",integration_order);
+    p.set("Multiplier",1.0);
   }
 
   {

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -449,6 +449,9 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
       closure_models.sublist("electromagnetics").sublist("PERMITTIVITY").set<std::string>("DoF Name","E_edge");
       closure_models.sublist("electromagnetics").sublist("INVERSE_PERMEABILITY").set<std::string>("Type","INVERSE PERMEABILITY");
       closure_models.sublist("electromagnetics").sublist("INVERSE_PERMEABILITY").set<double>("mu",mu);
+      closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<std::string>("Type","CONDUCTIVITY");
+      closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<double>("sigma",0.0);
+      closure_models.sublist("electromagnetics").sublist("CONDUCTIVITY").set<std::string>("DoF Name","E_edge");
       closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<std::string>("Type","PERMITTIVITY");
       closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<double>("epsilon",epsilon);
       closure_models.sublist("electromagnetics_aux").sublist("PERMITTIVITY").set<std::string>("DoF Name","AUXILIARY_EDGE");

--- a/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
@@ -16,6 +16,7 @@
           <Parameter name="Num Blocks" type="int" value="40"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
         </ParameterList>
         <ParameterList name="Pseudo Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
@@ -43,7 +44,7 @@
         <ParameterList name="Maxwell">
           <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
           <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="false"/>
           <Parameter name="Debug" type="bool" value="false"/>
           <Parameter name="Dump" type="bool" value="false"/>
           <Parameter name="Use discrete gradient" type="bool" value="true"/>
@@ -61,10 +62,11 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -113,10 +115,11 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -163,8 +166,7 @@
                   <Parameter name="smoother: Gauss-Seidel efficient symmetric" type="bool" value="true"/>
                   <Parameter name="smoother: use l1 Gauss-Seidel" type="bool" value="true"/>
 
-                  <!-- Repartitioning switched off, since EdgeMatrixFreePreconditioner::BuildProlongator does not forward coordinates to the coarse level -->
-                  <Parameter name="repartition: enable" type="int" value="0"/>
+                  <Parameter name="repartition: enable" type="int" value="1"/>
                   <Parameter name="repartition: partitioner" type="string" value="Zoltan"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
                   <Parameter name="repartition: min per proc" type="int" value="800"/>
@@ -194,7 +196,7 @@
                 <Parameter name="repartition: start level" type="int" value="1"/>
                 <Parameter name="repartition: min per proc" type="int" value="800"/>
                 <Parameter name="repartition: max min ratio" type="double" value="1.1"/>
-                <Parameter name="repartition: Zoltan dimensions" type="int" value="3"/>
+                <Parameter name="repartition: Zoltan dimensions" type="int" value="1"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Required Parameters">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
@@ -71,37 +71,50 @@
           </ParameterList>
 
           <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="ML"/>
+            <Parameter name="Prec Type" type="string" value="Ifpack"/>
             <ParameterList name="Prec Types">
-              <ParameterList name="ML">
-                <ParameterList name="ML Settings">
-                  <Parameter name="ML output" type="int" value="10"/>
-                  <Parameter name="ML label" type="string" value="Q_B"/>
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
-                  <Parameter name="aggregation: smoothing sweeps" type="int" value="0"/>
-                  <Parameter name="aggregation: threshold" type="double" value="0.0"/>
-
-                  <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="smoother: sweeps" type="int" value="2"/>
-                  <Parameter name="smoother: Gauss-Seidel efficient symmetric" type="bool" value="true"/>
-                  <Parameter name="smoother: use l1 Gauss-Seidel" type="bool" value="true"/>
-
-                  <Parameter name="repartition: enable" type="int" value="1"/>
-                  <Parameter name="repartition: partitioner" type="string" value="Zoltan"/>
-                  <Parameter name="repartition: start level" type="int" value="2"/>
-                  <Parameter name="repartition: min per proc" type="int" value="800"/>
-                  <Parameter name="repartition: max min ratio" type="double" value="1.1"/>
-                  <Parameter name="repartition: Zoltan dimensions" type="int" value="3"/>
-                </ParameterList>
-
-                <ParameterList name="Required Parameters">
-                  <Parameter name="x-coordinates" type="string" value="B_face"/>
-                  <Parameter name="y-coordinates" type="string" value="B_face"/>
-                  <Parameter name="z-coordinates" type="string" value="B_face"/>
+              <ParameterList name="Ifpack">
+                <Parameter name="Prec Type" type="string" value="point relaxation"/>
+                <ParameterList name="Ifpack Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
+
+          <!-- <ParameterList name="Q_B Preconditioner"> -->
+          <!--   <Parameter name="Prec Type" type="string" value="ML"/> -->
+          <!--   <ParameterList name="Prec Types"> -->
+          <!--     <ParameterList name="ML"> -->
+          <!--       <ParameterList name="ML Settings"> -->
+          <!--         <Parameter name="ML output" type="int" value="10"/> -->
+          <!--         <Parameter name="ML label" type="string" value="Q_B"/> -->
+          <!--         <Parameter name="coarse: max size" type="int" value="2500"/> -->
+          <!--         <Parameter name="aggregation: smoothing sweeps" type="int" value="0"/> -->
+          <!--         <Parameter name="aggregation: threshold" type="double" value="0.0"/> -->
+
+          <!--         <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="smoother: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="smoother: Gauss-Seidel efficient symmetric" type="bool" value="true"/> -->
+          <!--         <Parameter name="smoother: use l1 Gauss-Seidel" type="bool" value="true"/> -->
+
+          <!--         <Parameter name="repartition: enable" type="int" value="1"/> -->
+          <!--         <Parameter name="repartition: partitioner" type="string" value="Zoltan"/> -->
+          <!--         <Parameter name="repartition: start level" type="int" value="2"/> -->
+          <!--         <Parameter name="repartition: min per proc" type="int" value="800"/> -->
+          <!--         <Parameter name="repartition: max min ratio" type="double" value="1.1"/> -->
+          <!--         <Parameter name="repartition: Zoltan dimensions" type="int" value="3"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <ParameterList name="Required Parameters"> -->
+          <!--         <Parameter name="x-coordinates" type="string" value="B_face"/> -->
+          <!--         <Parameter name="y-coordinates" type="string" value="B_face"/> -->
+          <!--         <Parameter name="z-coordinates" type="string" value="B_face"/> -->
+          <!--       </ParameterList> -->
+          <!--     </ParameterList> -->
+          <!--   </ParameterList> -->
+          <!-- </ParameterList> -->
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
@@ -132,10 +145,10 @@
               <Parameter name="refmaxwell: mode" type="string" value="additive"/>
               <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
 
-              <!-- <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/> -->
-              <!-- <Parameter name="smoother: sweeps" type="int" value="2"/> -->
-              <!-- <Parameter name="smoother: Gauss-Seidel efficient symmetric" type="bool" value="false"/> -->
-              <!-- <Parameter name="smoother: use l1 Gauss-Seidel" type="bool" value="true"/> -->
+              <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
+              <Parameter name="smoother: sweeps" type="int" value="2"/>
+              <Parameter name="smoother: Gauss-Seidel efficient symmetric" type="bool" value="false"/>
+              <Parameter name="smoother: use l1 Gauss-Seidel" type="bool" value="true"/>
 
               <ParameterList name="refmaxwell: 11list">
                 <Parameter name="ML output" type="int" value="10"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
@@ -52,11 +52,10 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
                 <Parameter name="Output Frequency" type="int" value="1"/>
@@ -118,14 +117,13 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block GMRES">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
@@ -52,14 +52,14 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
                 <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
@@ -136,18 +136,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block GMRES">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
@@ -16,6 +16,7 @@
           <Parameter name="Num Blocks" type="int" value="40"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
         </ParameterList>
         <ParameterList name="Pseudo Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
@@ -43,7 +44,7 @@
         <ParameterList name="Maxwell">
           <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
           <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="false"/>
           <Parameter name="Debug" type="bool" value="false"/>
           <Parameter name="Dump" type="bool" value="false"/>
           <Parameter name="Use discrete gradient" type="bool" value="true"/>
@@ -61,10 +62,11 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -97,14 +99,21 @@
                 <Parameter name="rap: triple product" type="bool" value="true"/>
                 <Parameter name="transpose: use implicit" type="bool" value="true"/>
 
-                <Parameter name="smoother: pre or post" type="string" value="both"/>
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
                   <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: damping factor" type="double" value="1.0"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -127,9 +136,9 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Block GMRES">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
                 <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
@@ -137,10 +146,12 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
+                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -152,7 +163,7 @@
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
                 <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
-                <Parameter name="refmaxwell: max coarse size" type="int" value="1000"/>
+                <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
 
                 <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
                 <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
@@ -166,12 +177,21 @@
                 <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                 <!-- </ParameterList> -->
 
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
                   <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 11list">
@@ -186,12 +206,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
                     <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -217,12 +246,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
                     <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
@@ -70,69 +70,69 @@
             </ParameterList>
           </ParameterList>
 
-          <!-- <ParameterList name="Q_B Preconditioner"> -->
-          <!--   <Parameter name="Prec Type" type="string" value="Ifpack2"/> -->
-          <!--   <ParameterList name="Prec Types"> -->
-          <!--     <ParameterList name="Ifpack2"> -->
-          <!--       <Parameter name="Prec Type" type="string" value="relaxation"/> -->
-          <!--       <ParameterList name="Ifpack2 Settings"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Jacobi"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="1"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-
           <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/>
+            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
             <ParameterList name="Prec Types">
-              <ParameterList name="MueLu-Tpetra">
-                <Parameter name="verbosity" type="string" value="high"/>
-                <Parameter name="hierarchy label" type="string" value="Q_B"/>
-                <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                <Parameter name="coarse: type" type="string" value="KLU2"/>
-                <Parameter name="coarse: max size" type="int" value="2500"/>
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop scheme" type="string" value="classical"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                <Parameter name="rap: triple product" type="bool" value="true"/>
-                <Parameter name="transpose: use implicit" type="bool" value="true"/>
-
-                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: pre params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                </ParameterList>
-                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: post params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                </ParameterList>
-
-                <Parameter name="repartition: enable" type="bool" value="true"/>
-                <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                <Parameter name="repartition: start level" type="int" value="2"/>
-                <Parameter name="repartition: min rows per proc" type="int" value="800"/>
-                <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                <ParameterList name="repartition: params">
-                  <Parameter name="algorithm" type="string" value="multijagged"/>
-                </ParameterList>
-
-                <ParameterList name="Required Parameters">
-                  <Parameter name="Coordinates" type="string" value="B_face"/>
+              <ParameterList name="Ifpack2">
+                <Parameter name="Prec Type" type="string" value="relaxation"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
+
+          <!-- <ParameterList name="Q_B Preconditioner"> -->
+          <!--   <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/> -->
+          <!--   <ParameterList name="Prec Types"> -->
+          <!--     <ParameterList name="MueLu-Tpetra"> -->
+          <!--       <Parameter name="verbosity" type="string" value="high"/> -->
+          <!--       <Parameter name="hierarchy label" type="string" value="Q_B"/> -->
+          <!--       <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/> -->
+          <!--       <Parameter name="coarse: type" type="string" value="KLU2"/> -->
+          <!--       <Parameter name="coarse: max size" type="int" value="2500"/> -->
+          <!--       <Parameter name="aggregation: type" type="string" value="uncoupled"/> -->
+          <!--       <Parameter name="aggregation: drop scheme" type="string" value="classical"/> -->
+          <!--       <Parameter name="aggregation: drop tol" type="double" value="0.0"/> -->
+
+          <!--       <Parameter name="rap: triple product" type="bool" value="true"/> -->
+          <!--       <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
+
+          <!--       <Parameter name="smoother: pre type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: pre params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="false"/> -->
+          <!--       </ParameterList> -->
+          <!--       <Parameter name="smoother: post type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: post params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="true"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <Parameter name="repartition: enable" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: partitioner" type="string" value="zoltan2"/> -->
+          <!--       <Parameter name="repartition: start level" type="int" value="2"/> -->
+          <!--       <Parameter name="repartition: min rows per proc" type="int" value="800"/> -->
+          <!--       <Parameter name="repartition: max imbalance" type="double" value="1.1"/> -->
+          <!--       <Parameter name="repartition: remap parts" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: rebalance P and R" type="bool" value="false"/> -->
+          <!--       <ParameterList name="repartition: params"> -->
+          <!--         <Parameter name="algorithm" type="string" value="multijagged"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <ParameterList name="Required Parameters"> -->
+          <!--         <Parameter name="Coordinates" type="string" value="B_face"/> -->
+          <!--       </ParameterList> -->
+          <!--     </ParameterList> -->
+          <!--   </ParameterList> -->
+          <!-- </ParameterList> -->
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell2D.xml
@@ -51,11 +51,10 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
                 <Parameter name="Output Frequency" type="int" value="1"/>
@@ -84,16 +83,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
@@ -70,67 +70,67 @@
             </ParameterList>
           </ParameterList>
 
-          <!-- <ParameterList name="Q_B Preconditioner"> -->
-          <!--   <Parameter name="Prec Type" type="string" value="Ifpack2"/> -->
-          <!--   <ParameterList name="Prec Types"> -->
-          <!--     <ParameterList name="Ifpack2"> -->
-          <!--       <Parameter name="Prec Type" type="string" value="relaxation"/> -->
-          <!--       <ParameterList name="Ifpack2 Settings"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Jacobi"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="1"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-
           <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/>
+            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
             <ParameterList name="Prec Types">
-              <ParameterList name="MueLu-Tpetra">
-                <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                <Parameter name="verbosity" type="string" value="high"/>
-                <Parameter name="hierarchy label" type="string" value="Q_B"/>
-                <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                <Parameter name="coarse: type" type="string" value="KLU2"/>
-                <Parameter name="coarse: max size" type="int" value="2500"/>
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop scheme" type="string" value="classical"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: pre params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                </ParameterList>
-                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: post params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                </ParameterList>
-
-                <Parameter name="repartition: enable" type="bool" value="true"/>
-                <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                <Parameter name="repartition: start level" type="int" value="2"/>
-                <Parameter name="repartition: min rows per proc" type="int" value="800"/>
-                <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                <ParameterList name="repartition: params">
-                  <Parameter name="algorithm" type="string" value="multijagged"/>
-                </ParameterList>
-
-                <ParameterList name="Required Parameters">
-                  <Parameter name="Coordinates" type="string" value="B_face"/>
+              <ParameterList name="Ifpack2">
+                <Parameter name="Prec Type" type="string" value="relaxation"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
+
+          <!-- <ParameterList name="Q_B Preconditioner"> -->
+          <!--   <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/> -->
+          <!--   <ParameterList name="Prec Types"> -->
+          <!--     <ParameterList name="MueLu-Tpetra"> -->
+          <!--       <Parameter name="use kokkos refactor" type="bool" value="true"/> -->
+          <!--       <Parameter name="verbosity" type="string" value="high"/> -->
+          <!--       <Parameter name="hierarchy label" type="string" value="Q_B"/> -->
+          <!--       <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/> -->
+          <!--       <Parameter name="coarse: type" type="string" value="KLU2"/> -->
+          <!--       <Parameter name="coarse: max size" type="int" value="2500"/> -->
+          <!--       <Parameter name="aggregation: type" type="string" value="uncoupled"/> -->
+          <!--       <Parameter name="aggregation: drop scheme" type="string" value="classical"/> -->
+          <!--       <Parameter name="aggregation: drop tol" type="double" value="0.0"/> -->
+
+          <!--       <Parameter name="smoother: pre type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: pre params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="false"/> -->
+          <!--       </ParameterList> -->
+          <!--       <Parameter name="smoother: post type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: post params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="true"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <Parameter name="repartition: enable" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: partitioner" type="string" value="zoltan2"/> -->
+          <!--       <Parameter name="repartition: start level" type="int" value="2"/> -->
+          <!--       <Parameter name="repartition: min rows per proc" type="int" value="800"/> -->
+          <!--       <Parameter name="repartition: max imbalance" type="double" value="1.1"/> -->
+          <!--       <Parameter name="repartition: remap parts" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: rebalance P and R" type="bool" value="false"/> -->
+          <!--       <ParameterList name="repartition: params"> -->
+          <!--         <Parameter name="algorithm" type="string" value="multijagged"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <ParameterList name="Required Parameters"> -->
+          <!--         <Parameter name="Coordinates" type="string" value="B_face"/> -->
+          <!--       </ParameterList> -->
+          <!--     </ParameterList> -->
+          <!--   </ParameterList> -->
+          <!-- </ParameterList> -->
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
@@ -16,6 +16,7 @@
           <Parameter name="Num Blocks" type="int" value="40"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
         </ParameterList>
         <ParameterList name="Pseudo Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
@@ -43,7 +44,7 @@
         <ParameterList name="Maxwell">
           <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
           <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="false"/>
           <Parameter name="Debug" type="bool" value="false"/>
           <Parameter name="Dump" type="bool" value="false"/>
           <Parameter name="Use discrete gradient" type="bool" value="true"/>
@@ -61,10 +62,11 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -95,14 +97,21 @@
                 <Parameter name="aggregation: drop scheme" type="string" value="classical"/>
                 <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
 
-                <Parameter name="smoother: pre or post" type="string" value="both"/>
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
-                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: damping factor" type="double" value="1.0"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -125,9 +134,9 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Block GMRES">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
                 <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
@@ -135,10 +144,12 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
+                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -161,12 +172,21 @@
                 <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                 <!-- </ParameterList> -->
 
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
-                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 11list">
@@ -184,12 +204,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
-                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -216,12 +245,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
-                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
@@ -52,14 +52,13 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
@@ -134,18 +133,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block GMRES">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
@@ -16,6 +16,7 @@
           <Parameter name="Num Blocks" type="int" value="40"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
         </ParameterList>
         <ParameterList name="Pseudo Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
@@ -43,7 +44,7 @@
         <ParameterList name="Maxwell">
           <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
           <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="false"/>
           <Parameter name="Debug" type="bool" value="false"/>
           <Parameter name="Dump" type="bool" value="false"/>
           <Parameter name="Use discrete gradient" type="bool" value="true"/>
@@ -61,10 +62,11 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -85,6 +87,7 @@
             <Parameter name="Prec Type" type="string" value="MueLu"/>
             <ParameterList name="Prec Types">
               <ParameterList name="MueLu">
+                <Parameter name="use kokkos refactor" type="bool" value="false"/>
                 <Parameter name="verbosity" type="string" value="high"/>
                 <Parameter name="hierarchy label" type="string" value="Q_B"/>
                 <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
@@ -94,14 +97,21 @@
                 <Parameter name="aggregation: drop scheme" type="string" value="classical"/>
                 <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
 
-                <Parameter name="smoother: pre or post" type="string" value="both"/>
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
                   <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: damping factor" type="double" value="1.0"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -124,9 +134,9 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Block GMRES">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
                 <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
@@ -134,10 +144,12 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
+                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -145,6 +157,7 @@
             <Parameter name="Type" type="string" value="MueLuRefMaxwell"/>
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell">
+                <Parameter name="use kokkos refactor" type="bool" value="false"/>
                 <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
@@ -163,15 +176,25 @@
                 <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                 <!-- </ParameterList> -->
 
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
                   <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 11list">
+                  <Parameter name="use kokkos refactor" type="bool" value="false"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="3"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
@@ -183,12 +206,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
                     <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -204,6 +236,7 @@
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 22list">
+                  <Parameter name="use kokkos refactor" type="bool" value="false"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
@@ -214,12 +247,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
                     <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
@@ -70,67 +70,67 @@
             </ParameterList>
           </ParameterList>
 
-          <!-- <ParameterList name="Q_B Preconditioner"> -->
-          <!--   <Parameter name="Prec Type" type="string" value="Ifpack2"/> -->
-          <!--   <ParameterList name="Prec Types"> -->
-          <!--     <ParameterList name="Ifpack2"> -->
-          <!--       <Parameter name="Prec Type" type="string" value="relaxation"/> -->
-          <!--       <ParameterList name="Ifpack2 Settings"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Jacobi"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="1"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-
           <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="MueLu"/>
+            <Parameter name="Prec Type" type="string" value="Ifpack"/>
             <ParameterList name="Prec Types">
-              <ParameterList name="MueLu">
-                <Parameter name="use kokkos refactor" type="bool" value="false"/>
-                <Parameter name="verbosity" type="string" value="high"/>
-                <Parameter name="hierarchy label" type="string" value="Q_B"/>
-                <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                <Parameter name="coarse: type" type="string" value="KLU2"/>
-                <Parameter name="coarse: max size" type="int" value="2500"/>
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop scheme" type="string" value="classical"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: pre params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                </ParameterList>
-                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: post params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                </ParameterList>
-
-                <Parameter name="repartition: enable" type="bool" value="true"/>
-                <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                <Parameter name="repartition: start level" type="int" value="2"/>
-                <Parameter name="repartition: min rows per proc" type="int" value="800"/>
-                <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                <ParameterList name="repartition: params">
-                  <Parameter name="algorithm" type="string" value="multijagged"/>
-                </ParameterList>
-
-                <ParameterList name="Required Parameters">
-                  <Parameter name="Coordinates-Epetra" type="string" value="B_face"/>
+              <ParameterList name="Ifpack">
+                <Parameter name="Prec Type" type="string" value="point relaxation"/>
+                <ParameterList name="Ifpack Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
+
+          <!-- <ParameterList name="Q_B Preconditioner"> -->
+          <!--   <Parameter name="Prec Type" type="string" value="MueLu"/> -->
+          <!--   <ParameterList name="Prec Types"> -->
+          <!--     <ParameterList name="MueLu"> -->
+          <!--       <Parameter name="use kokkos refactor" type="bool" value="false"/> -->
+          <!--       <Parameter name="verbosity" type="string" value="high"/> -->
+          <!--       <Parameter name="hierarchy label" type="string" value="Q_B"/> -->
+          <!--       <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/> -->
+          <!--       <Parameter name="coarse: type" type="string" value="KLU2"/> -->
+          <!--       <Parameter name="coarse: max size" type="int" value="2500"/> -->
+          <!--       <Parameter name="aggregation: type" type="string" value="uncoupled"/> -->
+          <!--       <Parameter name="aggregation: drop scheme" type="string" value="classical"/> -->
+          <!--       <Parameter name="aggregation: drop tol" type="double" value="0.0"/> -->
+
+          <!--       <Parameter name="smoother: pre type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: pre params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="false"/> -->
+          <!--       </ParameterList> -->
+          <!--       <Parameter name="smoother: post type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: post params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="true"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <Parameter name="repartition: enable" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: partitioner" type="string" value="zoltan2"/> -->
+          <!--       <Parameter name="repartition: start level" type="int" value="2"/> -->
+          <!--       <Parameter name="repartition: min rows per proc" type="int" value="800"/> -->
+          <!--       <Parameter name="repartition: max imbalance" type="double" value="1.1"/> -->
+          <!--       <Parameter name="repartition: remap parts" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: rebalance P and R" type="bool" value="false"/> -->
+          <!--       <ParameterList name="repartition: params"> -->
+          <!--         <Parameter name="algorithm" type="string" value="multijagged"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <ParameterList name="Required Parameters"> -->
+          <!--         <Parameter name="Coordinates-Epetra" type="string" value="B_face"/> -->
+          <!--       </ParameterList> -->
+          <!--     </ParameterList> -->
+          <!--   </ParameterList> -->
+          <!-- </ParameterList> -->
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
@@ -52,11 +52,10 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
                 <Parameter name="Output Frequency" type="int" value="1"/>
@@ -134,18 +133,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block GMRES">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
@@ -52,14 +52,13 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
@@ -137,18 +136,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block GMRES">
+              <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
@@ -70,70 +70,70 @@
             </ParameterList>
           </ParameterList>
 
-          <!-- <ParameterList name="Q_B Preconditioner"> -->
-          <!--   <Parameter name="Prec Type" type="string" value="Ifpack2"/> -->
-          <!--   <ParameterList name="Prec Types"> -->
-          <!--     <ParameterList name="Ifpack2"> -->
-          <!--       <Parameter name="Prec Type" type="string" value="relaxation"/> -->
-          <!--       <ParameterList name="Ifpack2 Settings"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Jacobi"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="1"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-
           <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/>
+            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
             <ParameterList name="Prec Types">
-              <ParameterList name="MueLu-Tpetra">
-                <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                <Parameter name="verbosity" type="string" value="high"/>
-                <Parameter name="hierarchy label" type="string" value="Q_B"/>
-                <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                <Parameter name="coarse: type" type="string" value="KLU2"/>
-                <Parameter name="coarse: max size" type="int" value="2500"/>
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop scheme" type="string" value="classical"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                <Parameter name="rap: triple product" type="bool" value="true"/>
-                <Parameter name="transpose: use implicit" type="bool" value="true"/>
-
-                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: pre params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                </ParameterList>
-                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: post params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                </ParameterList>
-
-                <Parameter name="repartition: enable" type="bool" value="true"/>
-                <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                <Parameter name="repartition: start level" type="int" value="2"/>
-                <Parameter name="repartition: min rows per proc" type="int" value="800"/>
-                <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                <ParameterList name="repartition: params">
-                  <Parameter name="algorithm" type="string" value="multijagged"/>
-                </ParameterList>
-
-                <ParameterList name="Required Parameters">
-                  <Parameter name="Coordinates" type="string" value="B_face"/>
+              <ParameterList name="Ifpack2">
+                <Parameter name="Prec Type" type="string" value="relaxation"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
+
+          <!-- <ParameterList name="Q_B Preconditioner"> -->
+          <!--   <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/> -->
+          <!--   <ParameterList name="Prec Types"> -->
+          <!--     <ParameterList name="MueLu-Tpetra"> -->
+          <!--       <Parameter name="use kokkos refactor" type="bool" value="true"/> -->
+          <!--       <Parameter name="verbosity" type="string" value="high"/> -->
+          <!--       <Parameter name="hierarchy label" type="string" value="Q_B"/> -->
+          <!--       <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/> -->
+          <!--       <Parameter name="coarse: type" type="string" value="KLU2"/> -->
+          <!--       <Parameter name="coarse: max size" type="int" value="2500"/> -->
+          <!--       <Parameter name="aggregation: type" type="string" value="uncoupled"/> -->
+          <!--       <Parameter name="aggregation: drop scheme" type="string" value="classical"/> -->
+          <!--       <Parameter name="aggregation: drop tol" type="double" value="0.0"/> -->
+
+          <!--       <Parameter name="rap: triple product" type="bool" value="true"/> -->
+          <!--       <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
+
+          <!--       <Parameter name="smoother: pre type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: pre params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="false"/> -->
+          <!--       </ParameterList> -->
+          <!--       <Parameter name="smoother: post type" type="string" value="RELAXATION"/> -->
+          <!--       <ParameterList name="smoother: post params"> -->
+          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
+          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
+          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
+          <!--         <Parameter name="relaxation: backward mode" type="bool" value="true"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <Parameter name="repartition: enable" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: partitioner" type="string" value="zoltan2"/> -->
+          <!--       <Parameter name="repartition: start level" type="int" value="2"/> -->
+          <!--       <Parameter name="repartition: min rows per proc" type="int" value="800"/> -->
+          <!--       <Parameter name="repartition: max imbalance" type="double" value="1.1"/> -->
+          <!--       <Parameter name="repartition: remap parts" type="bool" value="true"/> -->
+          <!--       <Parameter name="repartition: rebalance P and R" type="bool" value="false"/> -->
+          <!--       <ParameterList name="repartition: params"> -->
+          <!--         <Parameter name="algorithm" type="string" value="multijagged"/> -->
+          <!--       </ParameterList> -->
+
+          <!--       <ParameterList name="Required Parameters"> -->
+          <!--         <Parameter name="Coordinates" type="string" value="B_face"/> -->
+          <!--       </ParameterList> -->
+          <!--     </ParameterList> -->
+          <!--   </ParameterList> -->
+          <!-- </ParameterList> -->
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
@@ -16,6 +16,7 @@
           <Parameter name="Num Blocks" type="int" value="40"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
         </ParameterList>
         <ParameterList name="Pseudo Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
@@ -43,7 +44,7 @@
         <ParameterList name="Maxwell">
           <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
           <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="false"/>
           <Parameter name="Debug" type="bool" value="false"/>
           <Parameter name="Dump" type="bool" value="false"/>
           <Parameter name="Use discrete gradient" type="bool" value="true"/>
@@ -61,10 +62,11 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -98,14 +100,21 @@
                 <Parameter name="rap: triple product" type="bool" value="true"/>
                 <Parameter name="transpose: use implicit" type="bool" value="true"/>
 
-                <Parameter name="smoother: pre or post" type="string" value="both"/>
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
-                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                  <Parameter name="relaxation: damping factor" type="double" value="1.0"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -128,9 +137,9 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
+              <ParameterList name="Block GMRES">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
                 <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
@@ -138,10 +147,12 @@
                 <Parameter name="Output Frequency" type="int" value="1"/>
                 <Parameter name="Output Style" type="int" value="1"/>
                 <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
+                <Parameter name="Flexible Gmres" type="bool" value="true"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="none"/>
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
 
@@ -167,12 +178,21 @@
                 <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                 <!-- </ParameterList> -->
 
-                <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                <ParameterList name="smoother: params">
-                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: pre params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                </ParameterList>
+                <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                <ParameterList name="smoother: post params">
+                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                  <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 11list">
@@ -188,12 +208,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
-                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>
@@ -220,12 +249,21 @@
                   <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
                   <!-- </ParameterList> -->
 
-                  <Parameter name="smoother: type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: params">
-                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
+                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: pre params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
+                  </ParameterList>
+                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
+                  <ParameterList name="smoother: post params">
+                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
+                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
+                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
 
                   <Parameter name="repartition: enable" type="bool" value="true"/>

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
@@ -101,8 +101,9 @@ buildClosureModels(const std::string& model_id,
       }
       if(type=="INVERSE PERMEABILITY") {
         double mu = plist.get<double>("mu");
+        std::string DoF = plist.get<std::string>("DoF Name");
 	RCP< Evaluator<panzer::Traits> > e =
-	  rcp(new mini_em::InversePermeability<EvalT,panzer::Traits>(key,*ir,fl,mu));
+	  rcp(new mini_em::InversePermeability<EvalT,panzer::Traits>(key,*ir,fl,mu,DoF));
 	evaluators->push_back(e);
 
         found = true;

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
@@ -17,6 +17,7 @@
 #include "MiniEM_GaussianPulse.hpp"
 #include "MiniEM_InversePermeability.hpp"
 #include "MiniEM_Permittivity.hpp"
+#include "MiniEM_Conductivity.hpp"
 
 // ********************************************************************
 // ********************************************************************
@@ -111,6 +112,15 @@ buildClosureModels(const std::string& model_id,
         std::string DoF = plist.get<std::string>("DoF Name");
 	RCP< Evaluator<panzer::Traits> > e =
 	  rcp(new mini_em::Permittivity<EvalT,panzer::Traits>(key,*ir,fl,epsilon,DoF));
+	evaluators->push_back(e);
+
+        found = true;
+      }
+      if(type=="CONDUCTIVITY") {
+        double sigma = plist.get<double>("sigma");
+        std::string DoF = plist.get<std::string>("DoF Name");
+	RCP< Evaluator<panzer::Traits> > e =
+	  rcp(new mini_em::Conductivity<EvalT,panzer::Traits>(key,*ir,fl,sigma,DoF));
 	evaluators->push_back(e);
 
         found = true;

--- a/packages/panzer/mini-em/src/closures/MiniEM_Conductivity.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_Conductivity.hpp
@@ -1,0 +1,49 @@
+#ifndef MINIEM_CONDUCTIVITY_DECL_HPP
+#define MINIEM_CONDUCTIVITY_DECL_HPP
+
+#include "PanzerAdaptersSTK_config.hpp"
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_FieldLibrary.hpp"
+
+#include <string>
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace mini_em {
+
+  using panzer::Cell;
+  using panzer::Point;
+
+  template<typename EvalT, typename Traits>
+  class Conductivity : public panzer::EvaluatorWithBaseImpl<Traits>,
+                       public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+  public:
+    Conductivity(const std::string & name,
+                 const panzer::IntegrationRule & ir,
+                 const panzer::FieldLayoutLibrary & fl,
+                 const double & sigma_,
+                 const std::string& DoF_);
+
+    void evaluateFields(typename Traits::EvalData d);
+
+
+  private:
+    typedef typename EvalT::ScalarT ScalarT;
+
+    PHX::MDField<ScalarT,Cell,Point> conductivity;
+    PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
+    int ir_degree;
+    double sigma;
+  };
+
+}
+
+#include "MiniEM_Conductivity_impl.hpp"
+
+#endif

--- a/packages/panzer/mini-em/src/closures/MiniEM_Conductivity_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_Conductivity_impl.hpp
@@ -1,0 +1,59 @@
+#ifndef MINIEM_CONDUCTIVITY_IMPL_HPP
+#define MINIEM_CONDUCTIVITY_IMPL_HPP
+
+#include <cmath>
+
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+#include "Panzer_GatherBasisCoordinates.hpp"
+
+namespace mini_em {
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+Conductivity<EvalT,Traits>::Conductivity(const std::string & name,
+                                         const panzer::IntegrationRule & ir,
+                                         const panzer::FieldLayoutLibrary & fl,
+                                         const double & sigma_,
+                                         const std::string& DoF_)
+{
+  using Teuchos::RCP;
+
+  Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_scalar;
+  ir_degree = ir.cubature_degree;
+
+  conductivity = PHX::MDField<ScalarT,Cell,Point>(name, data_layout);
+  this->addEvaluatedField(conductivity);
+
+  sigma = sigma_;
+
+  Teuchos::RCP<const panzer::PureBasis> basis = fl.lookupBasis(DoF_);
+  const std::string coordName = panzer::GatherBasisCoordinates<EvalT,Traits>::fieldName(basis->name());
+  coords = PHX::MDField<const ScalarT,Cell,Point,Dim>(coordName, basis->coordinates);
+  this->addDependentField(coords);
+
+  std::string n = "Conductivity";
+  this->setName(n);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void Conductivity<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+{
+  using panzer::index_t;
+
+  for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+    for (int point = 0; point < conductivity.extent_int(1); ++point) {
+      // const ScalarT& x = coords(cell,point,0);
+      // const ScalarT& y = coords(cell,point,1);
+      // const ScalarT& z = coords(cell,point,2);
+      conductivity(cell,point) = sigma;
+    }
+  }
+}
+
+//**********************************************************************
+}
+
+#endif

--- a/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability.hpp
@@ -27,7 +27,8 @@ namespace mini_em {
     InversePermeability(const std::string & name,
                         const panzer::IntegrationRule & ir,
                         const panzer::FieldLayoutLibrary & fl,
-                        const double & mu_);
+                        const double & mu_,
+                        const std::string& DoF_);
                                                                         
     void evaluateFields(typename Traits::EvalData d);
 

--- a/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_InversePermeability_impl.hpp
@@ -15,7 +15,8 @@ template <typename EvalT,typename Traits>
 InversePermeability<EvalT,Traits>::InversePermeability(const std::string & name,
                                                        const panzer::IntegrationRule & ir,
                                                        const panzer::FieldLayoutLibrary & fl,
-                                                       const double & mu_)
+                                                       const double & mu_,
+                                                       const std::string& DoF_)
 {
   using Teuchos::RCP;
 
@@ -27,7 +28,7 @@ InversePermeability<EvalT,Traits>::InversePermeability(const std::string & name,
   
   mu = mu_;
 
-  Teuchos::RCP<const panzer::PureBasis> basis = fl.lookupBasis("B_face");
+  Teuchos::RCP<const panzer::PureBasis> basis = fl.lookupBasis(DoF_);
   const std::string coordName = panzer::GatherBasisCoordinates<EvalT,Traits>::fieldName(basis->name());
   coords = PHX::MDField<const ScalarT,Cell,Point,Dim>(coordName, basis->coordinates); 
   this->addDependentField(coords);

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_CurlCurl.cpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_CurlCurl.cpp
@@ -1,0 +1,6 @@
+#include "Panzer_ExplicitTemplateInstantiation.hpp"
+
+#include "MiniEM_AuxiliaryEquationSet_CurlCurl.hpp"
+#include "MiniEM_AuxiliaryEquationSet_CurlCurl_impl.hpp"
+
+PANZER_INSTANTIATE_TEMPLATE_CLASS_ONE_T(mini_em::AuxiliaryEquationSet_CurlCurl)

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_CurlCurl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_CurlCurl.hpp
@@ -1,0 +1,52 @@
+#ifndef _MiniEM_AuxiliaryEquationSet_CurlCurl_hpp_
+#define _MiniEM_AuxiliaryEquationSet_CurlCurl_hpp_
+
+#include <vector>
+#include <string>
+
+#include "Teuchos_RCP.hpp"
+#include "Panzer_EquationSet_DefaultImpl.hpp"
+#include "Panzer_Traits.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+namespace mini_em {
+
+  template <typename EvalT>
+  class AuxiliaryEquationSet_CurlCurl : public panzer::EquationSet_DefaultImpl<EvalT> {
+
+  public:
+
+    AuxiliaryEquationSet_CurlCurl(const Teuchos::RCP<panzer::GlobalEvaluationDataContainer> & gedc,
+                             const Teuchos::RCP<Teuchos::ParameterList>& params,
+			     const int& default_integration_order,
+			     const panzer::CellData& cell_data,
+		             const Teuchos::RCP<panzer::GlobalData>& global_data,
+		             const bool build_transient_support);
+
+    void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+					       const panzer::FieldLibrary& /* field_library */,
+                                               const Teuchos::ParameterList& /* user_data */) const;
+
+    void buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+					   const panzer::FieldLibrary& field_library,
+                                           const panzer::LinearObjFactory<panzer::Traits> & lof,
+                                           const Teuchos::ParameterList& user_data) const;
+
+  protected:
+    std::string dof_name;
+    double multiplier;
+    Teuchos::RCP<const std::vector<std::string> > fieldMultipliers;
+    Teuchos::RCP<panzer::GlobalEvaluationDataContainer> m_gedc;
+    Teuchos::RCP<std::vector<std::string> > m_dof_names;
+  };
+
+template < >
+void AuxiliaryEquationSet_CurlCurl<panzer::Traits::Jacobian>::
+buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+				  const panzer::FieldLibrary& field_library,
+                                  const panzer::LinearObjFactory<panzer::Traits> & lof,
+                                  const Teuchos::ParameterList& user_data) const;
+
+}
+
+#endif

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_CurlCurl_impl.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_AuxiliaryEquationSet_CurlCurl_impl.hpp
@@ -1,0 +1,268 @@
+#ifndef _MiniEM_AuxiliaryEquationSet_CurlCurl_impl_hpp_
+#define _MiniEM_AuxiliaryEquationSet_CurlCurl_impl_hpp_
+
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+
+#include "Phalanx_DataLayout_MDALayout.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_IntegrationRule.hpp"
+#include "Panzer_BasisIRLayout.hpp"
+
+// include evaluators here
+#include "Panzer_Integrator_BasisTimesScalar.hpp"
+#include "Panzer_Integrator_BasisTimesVector.hpp"
+#include "Panzer_Integrator_CurlBasisDotVector.hpp"
+#include "Panzer_ScalarToVector.hpp"
+#include "Panzer_Sum.hpp"
+#include "Panzer_Constant.hpp"
+#include "Panzer_BlockedDOFManager.hpp"
+#include "Panzer_BlockedTpetraLinearObjFactory.hpp"
+#include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#include "Panzer_ReorderADValues_Evaluator.hpp"
+#include "Panzer_LOCPair_GlobalEvaluationData.hpp"
+
+// ***********************************************************************
+template <typename EvalT>
+mini_em::AuxiliaryEquationSet_CurlCurl<EvalT>::
+AuxiliaryEquationSet_CurlCurl(
+                   const Teuchos::RCP<panzer::GlobalEvaluationDataContainer> & gedc,
+                   const Teuchos::RCP<Teuchos::ParameterList>& params,
+		   const int& default_integration_order,
+		   const panzer::CellData& cell_data,
+		   const Teuchos::RCP<panzer::GlobalData>& global_data,
+		   const bool build_transient_support) :
+  panzer::EquationSet_DefaultImpl<EvalT>(params, default_integration_order, cell_data, global_data, build_transient_support)
+{
+  // Options
+  {
+    Teuchos::ParameterList valid_parameters;
+    this->setDefaultValidParameters(valid_parameters);
+    valid_parameters.set("Model ID","","Closure model id associated with this equation set");
+    valid_parameters.set("DOF Name","","Name of DOF to construct time derivative for");
+    valid_parameters.set("Multiplier",1.0,"Scale the operator");
+    Teuchos::RCP<const std::vector<std::string> > fieldMultiplier;
+    valid_parameters.set("Field Multipliers",fieldMultiplier,"Scale the operator");
+    valid_parameters.set("Basis Type","HCurl","Type of Basis to use");
+    valid_parameters.set("Basis Order",1,"Order of the basis");
+    valid_parameters.set("Integration Order",default_integration_order,"Order of the integration rule");
+
+    params->validateParametersAndSetDefaults(valid_parameters);
+  }
+  std::string model_id = params->get<std::string>("Model ID");
+  dof_name = params->get<std::string>("DOF Name");
+  multiplier = params->get<double>("Multiplier");
+  fieldMultipliers = params->get<Teuchos::RCP<const std::vector<std::string> > >("Field Multipliers");
+  std::string basis_type = params->get<std::string>("Basis Type");
+  int basis_order = params->get<int>("Basis Order");
+  int integration_order = params->get<int>("Integration Order");
+
+  // ********************
+  // Assemble DOF names and Residual names
+  // ********************
+
+  m_gedc = gedc;
+
+  m_dof_names = Teuchos::rcp(new std::vector<std::string>);
+  m_dof_names->push_back(dof_name);
+
+  this->addDOF(dof_name,basis_type,basis_order,integration_order,"AUX_MASS_RESIDUAL_"+dof_name);
+  this->addDOFCurl(dof_name,"Curl_"+dof_name);
+
+  this->addClosureModel(model_id);
+
+  this->setupDOFs();
+}
+
+// ***********************************************************************
+template <typename EvalT>
+void mini_em::AuxiliaryEquationSet_CurlCurl<EvalT>::
+buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+				      const panzer::FieldLibrary& /* field_library */,
+				      const Teuchos::ParameterList& /* user_data */) const
+{
+  using panzer::BasisIRLayout;
+  using panzer::EvaluatorStyle;
+  using panzer::IntegrationRule;
+  using panzer::Integrator_CurlBasisDotVector;
+  using panzer::Traits;
+  using PHX::Evaluator;
+  using std::string;
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  RCP<IntegrationRule> ir = this->getIntRuleForDOF(dof_name);
+  RCP<BasisIRLayout> basis = this->getBasisIRLayoutForDOF(dof_name);
+
+  // Curl curl Operator
+  {
+    {
+      ParameterList p("Curl Curl " + dof_name + " Residual");
+      p.set("Residual Name", "AUX_CURL_CURL_RESIDUAL_"+dof_name);
+      p.set("Value Name", "Curl_"+dof_name);
+      p.set("Basis", basis);
+      p.set("IR", ir);
+      p.set("Multiplier", multiplier);
+      if (fieldMultipliers != Teuchos::null)
+        p.set("Field Multipliers", fieldMultipliers);
+      RCP<Evaluator<Traits> > op = rcp(new
+        Integrator_CurlBasisDotVector<EvalT, Traits>(p));
+      fm.template registerEvaluator<EvalT>(op);
+    }
+  }
+}
+
+// ***********************************************************************
+template <typename EvalT >
+void mini_em::AuxiliaryEquationSet_CurlCurl<EvalT>::
+buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& /* fm */,
+				  const panzer::FieldLibrary& /* field_library */,
+                                  const panzer::LinearObjFactory<panzer::Traits> & /* lof */,
+                                  const Teuchos::ParameterList& /* user_data */) const
+{
+}
+
+// ***********************************************************************
+template < >
+void mini_em::AuxiliaryEquationSet_CurlCurl<panzer::Traits::Jacobian>::
+buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+				  const panzer::FieldLibrary& field_library,
+                                  const panzer::LinearObjFactory<panzer::Traits> & lof,
+                                  const Teuchos::ParameterList& /* user_data */) const
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+
+   typedef panzer::Traits::Jacobian EvalT;
+
+   typedef double Scalar;
+   typedef int LocalOrdinalEpetra;
+   typedef int GlobalOrdinalEpetra;
+   typedef int LocalOrdinalTpetra;
+   typedef panzer::Ordinal64 GlobalOrdinalTpetra;
+
+   typedef typename panzer::BlockedTpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> blockedTpetraLinObjFactory;
+   typedef typename panzer::TpetraLinearObjFactory<panzer::Traits,Scalar,LocalOrdinalTpetra,GlobalOrdinalTpetra> tpetraLinObjFactory;
+   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> blockedEpetraLinObjFactory;
+   typedef typename panzer::BlockedEpetraLinearObjFactory<panzer::Traits,LocalOrdinalEpetra> epetraLinObjFactory;
+
+   std::string fieldStr = (*this->m_dof_names)[0];
+   const std::string residualField = "AUX_CURL_CURL_RESIDUAL_"+dof_name;
+   int pFieldNum;
+   int blockIndex;
+
+   std::string outPrefix = "ScatterReordered_";
+
+   Teuchos::RCP<panzer::LinearObjFactory<panzer::Traits> > nlof;
+
+   // must be able to cast to a block linear object factory
+   Teuchos::RCP<const blockedTpetraLinObjFactory> tblof
+      = Teuchos::rcp_dynamic_cast<const blockedTpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+   Teuchos::RCP<const blockedEpetraLinObjFactory> eblof
+      = Teuchos::rcp_dynamic_cast<const blockedEpetraLinObjFactory>(Teuchos::rcpFromRef(lof));
+
+   if(tblof != Teuchos::null) {
+     Teuchos::RCP<const panzer::BlockedDOFManager<LocalOrdinalTpetra,GlobalOrdinalTpetra> > blockedDOFMngr = tblof->getGlobalIndexer();
+     TEUCHOS_ASSERT(blockedDOFMngr!=Teuchos::null);
+
+     pFieldNum = blockedDOFMngr->getFieldNum(fieldStr);
+     blockIndex = blockedDOFMngr->getFieldBlock(pFieldNum);
+
+     // get the unique global indexer for just this field
+     Teuchos::RCP<panzer::UniqueGlobalIndexer<LocalOrdinalTpetra,GlobalOrdinalTpetra> > ugi = blockedDOFMngr->getFieldDOFManagers()[blockIndex];
+
+     // build a new linear object factory
+     nlof = Teuchos::rcp(new tpetraLinObjFactory(Teuchos::rcp(new Teuchos::MpiComm<int>(tblof->getComm())).getConst(),ugi));
+
+     // first build a reordering evaluator to take it to the new sub global indexer
+     {
+        std::vector<Teuchos::RCP<PHX::DataLayout> > fieldLayouts;
+        fieldLayouts.push_back(field_library.lookupBasis(fieldStr)->functional);
+
+        std::vector<std::string> resNames;
+        resNames.push_back(residualField);
+
+        RCP< PHX::Evaluator<panzer::Traits> > op = Teuchos::rcp(
+              new panzer::ReorderADValues_Evaluator<EvalT,panzer::Traits>(outPrefix,
+                                                    resNames,
+                                                    fieldLayouts,
+                                                    this->getElementBlockId(),
+                                                    *blockedDOFMngr,
+                                                    *ugi));
+
+        fm.registerEvaluator<EvalT>(op);
+     }
+
+   } else if(eblof != Teuchos::null) {
+     Teuchos::RCP<const panzer::BlockedDOFManager<LocalOrdinalEpetra,GlobalOrdinalEpetra> > blockedDOFMngr = eblof->getGlobalIndexer();
+     TEUCHOS_ASSERT(blockedDOFMngr!=Teuchos::null);
+
+     pFieldNum = blockedDOFMngr->getFieldNum(fieldStr);
+     blockIndex = blockedDOFMngr->getFieldBlock(pFieldNum);
+
+     // get the unique global indexer for just this field
+     Teuchos::RCP<panzer::UniqueGlobalIndexer<LocalOrdinalEpetra,GlobalOrdinalEpetra> > ugi = blockedDOFMngr->getFieldDOFManagers()[blockIndex];
+
+     // build a new linear object factory
+     nlof = Teuchos::rcp(new epetraLinObjFactory(Teuchos::rcp(new Teuchos::MpiComm<int>(eblof->getComm())).getConst(),ugi));
+
+     // first build a reordering evaluator to take it to the new sub global indexer
+     {
+        std::vector<Teuchos::RCP<PHX::DataLayout> > fieldLayouts;
+        fieldLayouts.push_back(field_library.lookupBasis(fieldStr)->functional);
+
+        std::vector<std::string> resNames;
+        resNames.push_back(residualField);
+
+        RCP< PHX::Evaluator<panzer::Traits> > op = Teuchos::rcp(
+              new panzer::ReorderADValues_Evaluator<EvalT,panzer::Traits>(outPrefix,
+                                                    resNames,
+                                                    fieldLayouts,
+                                                    this->getElementBlockId(),
+                                                    *blockedDOFMngr,
+                                                    *ugi));
+
+        fm.registerEvaluator<EvalT>(op);
+     }
+   } else
+     TEUCHOS_ASSERT(false);
+
+   {
+      RCP<std::map<std::string,std::string> > resToField
+         = rcp(new std::map<std::string,std::string>);
+      (*resToField)[outPrefix+residualField] = dof_name;
+
+      RCP<std::vector<std::string> > inFieldNames
+         = rcp(new std::vector<std::string>);
+      inFieldNames->push_back(outPrefix+residualField);
+
+      std::string scatterName = "AUX_"+dof_name+"_CurlCurl";
+
+      Teuchos::ParameterList p("Scatter:" + scatterName);
+      p.set("Scatter Name", scatterName);
+      p.set("Basis",field_library.lookupBasis(fieldStr));
+      p.set("Dependent Names", inFieldNames);
+      p.set("Dependent Map", resToField);
+      p.set("Global Data Key", "Curl Curl " + dof_name + " Scatter Container");
+
+      RCP< PHX::Evaluator<panzer::Traits> > op = nlof->buildScatter<EvalT>(p);
+
+      fm.registerEvaluator<EvalT>(op);
+
+      PHX::Tag<EvalT::ScalarT> tag(scatterName, Teuchos::rcp(new PHX::MDALayout<panzer::Dummy>(0)));
+      fm.requireField<EvalT>(tag);
+   }
+
+   if(!m_gedc->containsDataObject("Curl Curl " + dof_name + " Scatter Container")) {
+      Teuchos::RCP<panzer::GlobalEvaluationData> dataObject
+         = Teuchos::rcp(new panzer::LOCPair_GlobalEvaluationData(nlof,panzer::LinearObjContainer::Mat));
+      m_gedc->addDataObject("Curl Curl " + dof_name + " Scatter Container",dataObject);
+   }
+}
+
+// ***********************************************************************
+#endif

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSetFactory.hpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_EquationSetFactory.hpp
@@ -8,6 +8,7 @@
 #include "MiniEM_EquationSet_Maxwell.hpp"
 
 #include "MiniEM_AuxiliaryEquationSet_MassMatrix.hpp"
+#include "MiniEM_AuxiliaryEquationSet_CurlCurl.hpp"
 #include "MiniEM_AuxiliaryEquationSet_WeakGradient.hpp"
 #include "MiniEM_AuxiliaryEquationSet_MACROS.hpp"
 
@@ -16,6 +17,8 @@ namespace mini_em {
   PANZER_DECLARE_EQSET_TEMPLATE_BUILDER(EquationSet_Maxwell, EquationSet_Maxwell)
 
   AUX_DECLARE_EQSET_TEMPLATE_BUILDER(AuxiliaryEquationSet_MassMatrix, AuxiliaryEquationSet_MassMatrix)
+
+  AUX_DECLARE_EQSET_TEMPLATE_BUILDER(AuxiliaryEquationSet_CurlCurl, AuxiliaryEquationSet_CurlCurl)
 
   AUX_DECLARE_EQSET_TEMPLATE_BUILDER(AuxiliaryEquationSet_WeakGradient, AuxiliaryEquationSet_WeakGradient)
 
@@ -41,6 +44,8 @@ namespace mini_em {
       PANZER_BUILD_EQSET_OBJECTS("Maxwell",              EquationSet_Maxwell)
 
       AUX_BUILD_EQSET_OBJECTS("Auxiliary Mass Matrix",   AuxiliaryEquationSet_MassMatrix)
+
+      AUX_BUILD_EQSET_OBJECTS("Auxiliary Curl Curl",   AuxiliaryEquationSet_CurlCurl)
 
       AUX_BUILD_EQSET_OBJECTS("Auxiliary Weak Gradient", AuxiliaryEquationSet_WeakGradient)
 

--- a/packages/panzer/mini-em/src/eqn_sets/MiniEM_OperatorRequestCallback.cpp
+++ b/packages/panzer/mini-em/src/eqn_sets/MiniEM_OperatorRequestCallback.cpp
@@ -35,6 +35,12 @@ Teko::LinearOp OperatorRequestCallback::request(const Teko::RequestMesg & rm)
      if (matrix_output)
        writeOut("MassMatrix.mm", *Teuchos::rcp_dynamic_cast<panzer::ThyraObjContainer<double> >(loc,true)->get_A_th());
    }
+   else if(name.substr(0,9)=="Curl Curl") {
+     loc = Teuchos::rcp_dynamic_cast<panzer::LOCPair_GlobalEvaluationData>(gedc_->getDataObject("Curl Curl " + name.substr(10,name.length()-10)+" Scatter Container"),true)->getGlobalLOC();
+
+     if (matrix_output)
+       writeOut("CurlCurl.mm", *Teuchos::rcp_dynamic_cast<panzer::ThyraObjContainer<double> >(loc,true)->get_A_th());
+   }
    else if(name=="Weak Gradient") {
      loc = Teuchos::rcp_dynamic_cast<panzer::LOCPair_GlobalEvaluationData>(gedc_->getDataObject("Weak Gradient Scatter Container"),true)->getGlobalLOC();
 
@@ -66,6 +72,10 @@ bool OperatorRequestCallback::handlesRequest(const Teko::RequestMesg & rm)
 
    if(name.substr(0,11)=="Mass Matrix") {
      if(gedc_->containsDataObject("Mass Matrix " + name.substr(12,name.length()-12)+" Scatter Container"))
+       return true;
+   }
+   else if(name.substr(0,9)=="Curl Curl") {
+     if(gedc_->containsDataObject("Curl Curl " + name.substr(10,name.length()-10)+" Scatter Container"))
        return true;
    }
    else if(name=="Weak Gradient") {

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -167,13 +167,10 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
    describeMatrix("Q_E",*Q_E,debug);
    describeMatrix("Q_rho",*Q_rho,debug);
 
-   //for refmaxwell: Q_rho = M_0(epsilon / dt / cfl^2 / min_dx^2)
+   //for refmaxwell: Q_rho = M_0(mu / dt)
    // S_E = Q_E - Kt * Q_B^-1 * K
    //     = 1/dt * M_1(eps) + dt * D_1^T * M_2(1/mu) * D_1
-   // addon in paper: dt * M_1(1) * D_0 * M_0(mu)^-1 * D_0^T * M_1(1)
-   // addon here:     1/dt * M_1(eps) * D_0 * M_0(epsilon / dt / cfl^2 / min_dx^2)^-1 * D_0^T * 1/dt * M_1(eps)
-   //               = Q_E * D_0 * Q_rho^-1 * D_0^T * Q_E
-
+   // addon: M_1(1) * D_0 * M_0(mu / dt)^-1 * D_0^T * M_1(1)
 
    bool useDiscreteGradient = false;
    if (params.isParameter("Use discrete gradient"))
@@ -274,6 +271,8 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
        // Teko::LinearOp KT = Teko::explicitMultiply(K,T);
        // TEUCHOS_ASSERT(Teko::infNorm(KT) < 1.0e-14 * Teko::infNorm(T) * Teko::infNorm(K));
 
+       Teko::LinearOp Q_E_aux = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Mass Matrix AUXILIARY_EDGE"));
+
        Teuchos::RCP<Teko::InverseFactory> S_E_prec_factory;
        Teuchos::ParameterList S_E_prec_pl;
        { 
@@ -328,20 +327,20 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
          
          Teko::InverseLibrary myInvLib = invLib;
          if (S_E_prec_type_ == "ML") {
-           // Set M1 = Q_E.
+           // Set M1 = Q_E_aux.
            // We do this here, since we cannot get it from the request handler.
-           RCP<const Epetra_CrsMatrix> eQ_E = get_Epetra_CrsMatrix(*Q_E);
-           S_E_prec_pl.sublist("ML Settings").set("M1",eQ_E);
-           S_E_prec_pl.sublist("ML Settings").set("Ms",eQ_E);
-           RCP<const Epetra_CrsMatrix> eInvDiagQ_rho = get_Epetra_CrsMatrix(*invDiagQ_rho,eQ_E->RowMap().Comm());
+           RCP<const Epetra_CrsMatrix> eQ_E_aux = get_Epetra_CrsMatrix(*Q_E_aux);
+           S_E_prec_pl.sublist("ML Settings").set("M1",eQ_E_aux);
+           S_E_prec_pl.sublist("ML Settings").set("Ms",eQ_E_aux);
+           RCP<const Epetra_CrsMatrix> eInvDiagQ_rho = get_Epetra_CrsMatrix(*invDiagQ_rho,eQ_E_aux->RowMap().Comm());
            S_E_prec_pl.sublist("ML Settings").set("M0inv",eInvDiagQ_rho);
 
            S_E_prec_pl.set("Type",S_E_prec_type_);
            myInvLib.addInverse("S_E Preconditioner",S_E_prec_pl);
          } else {
-           // Set M1 = Q_E.
+           // Set M1 = Q_E_aux.
            // We do this here, since we cannot get it from the request handler.
-           S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("M1",Q_E);
+           S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("M1",Q_E_aux);
            S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("M0inv",invDiagQ_rho);
 
            S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("Type",S_E_prec_type_);

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -186,11 +186,9 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
    Teko::LinearOp idQ_B, KtK, S_E;
    {
      Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MaxwellPreconditioner: Schur complement"));
-     idQ_B = Teko::getInvDiagonalOp(Q_B,Teko::AbsRowSum);
-     KtK   = Teko::explicitMultiply(Kt,idQ_B,K);
-     if (debug != Teuchos::null)
-       *debug << "Adding up S_E" << std::endl;
-     S_E   = Teko::explicitAdd(Q_E, Thyra::scale(-1.0,KtK));
+     Teko::LinearOp CurlCurl = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Curl Curl AUXILIARY_EDGE"));
+     S_E = Teko::explicitAdd(Q_E, CurlCurl);
+
      if (debug != Teuchos::null)
        *debug << "Added up S_E" << std::endl;
      if (dump)


### PR DESCRIPTION
@trilinos/panzer 

## Description
- Add conductivity term. (Defaults to zero.)
- Build Schur complement directly instead of approximating it.
- Solve sub-blocks of EM system one-by-one instead of using a block-preconditioner.
- Solve face mass matrix using diagonal preconditoner instead of multigrid.