### PR TITLE
Start of testing to determine what level of -j is acceptable

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -251,7 +251,7 @@ ctest -S simple_testing.cmake \
   -Dskip_update_step=ON \
   -Ddashboard_model=Experimental \
   -Ddashboard_track="${CDASH_TRACK:?}" \
-  -DPARALLEL_LEVEL=22 \
+  -DPARALLEL_LEVEL=18 \
   -Dbuild_dir="${WORKSPACE:?}/pull_request_test" \
   -Dconfigure_script=${TRILINOS_DRIVER_SRC_DIR}/cmake/std/${CONFIG_SCRIPT:?} \
   -Dpackage_enables=../packageEnables.cmake \


### PR DESCRIPTION
Started at -j22 and was overloading memory on 142
This moves to -j18 which will hopefully be a good data point.

@trilinos/framework 

## Motivation and Context
The -j22 when running two jobs on 142, 143, and 144 runs the node out of memory and swaps pretty hard.  The expectation is that this will actually produce faster runs by eliminating or reducing the swapping. We should bisect to a good point based on direct observations.

