### PR TITLE
Zoltan2:  fixed RCPNode error #2848 and re-enabled test #2849

### DIFF
--- a/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
@@ -15,7 +15,6 @@ set (MueLu_UnitTestsEpetra_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in 
 set (MueLu_UnitTestsEpetra_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set (MueLu_UnitTestsTpetra_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set (KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set (Zoltan2_simplePamgenTest_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 
 # (Temporarily) Disable randomly failing ROL test (#3103)
 set (ROL_example_poisson-inversion_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")

--- a/packages/zoltan2/test/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/helpers/UserInputForTests.hpp
@@ -2859,8 +2859,11 @@ void UserInputForTests::setPamgenAdjacencyGraph()
   this->M_ = rcp(new tcrsMatrix_t(rowMap,0));
 
 //  if(rank == 0) std::cout << "\nSetting graph of connectivity..." << std::endl;
-  for(zgno_t gid : rowMap->getNodeElementList())
+  Teuchos::ArrayView<const zgno_t> rowMapElementList = 
+                                        rowMap->getNodeElementList();
+  for (size_t ii = 0; ii < rowMapElementList.size(); ii++)
   {
+    zgno_t gid = rowMapElementList[ii];
     size_t numEntriesInRow = A->getNumEntriesInGlobalRow (gid);
     Array<zscalar_t> rowvals (numEntriesInRow);
     Array<zgno_t> rowinds (numEntriesInRow);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @prwolfe 

## Description
<!--- Please describe your changes in detail. -->
A Teuchos::ArrayView was being used in a for-loop; something about that construct caused the RCPNode error reported in #2848.
I don't understand why the changes in this PR are any better than the original code, but they do prevent the reported error.
I am re-enabling the test.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
#2848 and #2849 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Used @prwolfe 's configuration in #2848 on linux workstation using SEMS modules.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

