### PR TITLE
Panzer:  Remove Unnecessary setFieldData() Calls

### DIFF
--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_SimpleSource_impl.hpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/Example_SimpleSource_impl.hpp
@@ -72,11 +72,8 @@ SimpleSource<EvalT,Traits>::SimpleSource(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void SimpleSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(source,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_SineSolution_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_SineSolution_impl.hpp
@@ -72,11 +72,8 @@ SineSolution<EvalT,Traits>::SineSolution(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void SineSolution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(solution,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_SineSource_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/Example_SineSource_impl.hpp
@@ -72,11 +72,8 @@ SineSource<EvalT,Traits>::SineSource(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void SineSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(source,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_SimpleSolution_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_SimpleSolution_impl.hpp
@@ -75,11 +75,8 @@ SimpleSolution<EvalT,Traits>::SimpleSolution(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void SimpleSolution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(solution,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/example/PoissonExample/Example_SimpleSource_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonExample/Example_SimpleSource_impl.hpp
@@ -72,11 +72,8 @@ SimpleSource<EvalT,Traits>::SimpleSource(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void SimpleSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(source,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_SimpleSource_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_SimpleSource_impl.hpp
@@ -72,11 +72,8 @@ SimpleSource<EvalT,Traits>::SimpleSource(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void SimpleSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                       PHX::FieldManager<Traits>& fm)
+                                                       PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(source,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_Solution_impl.hpp
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/Example_Solution_impl.hpp
@@ -67,10 +67,8 @@ Solution<EvalT,Traits>::Solution(const std::string& name,
 
 template <typename EvalT,typename Traits>
 void Solution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                   PHX::FieldManager<Traits>& fm)
+                                                   PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(solution,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherFields_impl.hpp
@@ -85,7 +85,7 @@ panzer_stk::GatherFields<EvalT, Traits>::
 template<typename EvalT, typename Traits> 
 void panzer_stk::GatherFields<EvalT, Traits>::
 postRegistrationSetup(typename Traits::SetupData /* d */, 
-		      PHX::FieldManager<Traits>& fm)
+		      PHX::FieldManager<Traits>& /* fm */)
 {
   for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {
     std::string fieldName = gatherFields_[fd].fieldTag().name();
@@ -99,10 +99,6 @@ postRegistrationSetup(typename Traits::SetupData /* d */,
                                  "panzer_stk::GatherFields: STK field " << "\"" << fieldName << "\" " 
                                  "not found.\n STK meta data follows: \n\n" << ss.str());
     }
-     
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherRefCoords.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherRefCoords.hpp
@@ -76,9 +76,6 @@ public:
                   const panzer::BasisIRLayout & basis,
                   const std::string & fieldName);
   
-  void postRegistrationSetup(typename Traits::SetupData d,
-			     PHX::FieldManager<Traits>& vm);
-  
   void evaluateFields(typename Traits::EvalData d);
 
 private:

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherRefCoords_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherRefCoords_impl.hpp
@@ -74,16 +74,6 @@ GatherRefCoords(const Teuchos::RCP<const STK_Interface> & mesh,
 // **********************************************************************
 template<typename EvalT, typename Traits> 
 void panzer_stk::GatherRefCoords<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData /* d */, 
-		      PHX::FieldManager<Traits>& fm)
-{
-  // setup the field data object
-  this->utils.setFieldData(coordField_,fm);
-}
-
-// **********************************************************************
-template<typename EvalT, typename Traits> 
-void panzer_stk::GatherRefCoords<EvalT, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 { 
    const std::vector<stk::mesh::Entity> & localElements = *mesh_->getElementsOrderedByLID();

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgQuantity_impl.hpp
@@ -96,16 +96,13 @@ template<typename EvalT, typename Traits>
 void
 ScatterCellAvgQuantity<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* d */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* d */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
     std::string fieldName = scatterFields_[fd].fieldTag().name();
 
     stkFields_[fd] = mesh_->getMetaData()->get_field<VariableField>(stk::topology::ELEMENT_RANK, fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellAvgVector_impl.hpp
@@ -98,17 +98,14 @@ template<typename EvalT, typename Traits>
 void
 ScatterCellAvgVector<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* d */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* d */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
   for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) 
   {
     std::string fieldName = scatterFields_[fd].fieldTag().name();
 
     stkFields_[fd] = mesh_->getMetaData()->get_field<VariableField>(stk::topology::ELEMENT_RANK, fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterCellQuantity_impl.hpp
@@ -94,15 +94,11 @@ template<typename EvalT, typename Traits>
 void
 ScatterCellQuantity<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* d */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* d */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
+  for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd)
     std::string fieldName = scatterFields_[fd].fieldTag().name();
-
-    // setup the field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-  }
 }
 
 template<typename EvalT, typename Traits>

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterFields_impl.hpp
@@ -121,14 +121,10 @@ initialize(const std::string & scatterName,
 template <typename EvalT,typename TraitsT>
 void ScatterFields<EvalT,TraitsT>::
 postRegistrationSetup(typename TraitsT::SetupData /* d */, 
-                      PHX::FieldManager<TraitsT>& fm)
+                      PHX::FieldManager<TraitsT>& /* fm */)
 {
-  for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
+  for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd)
     std::string fieldName = scatterFields_[fd].fieldTag().name();
-
-    // setup the field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-  }
 }
 
 template <typename EvalT,typename TraitsT>

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_decl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_decl.hpp
@@ -80,11 +80,6 @@ class ScatterVectorFields
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_ScatterVectorFields_impl.hpp
@@ -105,21 +105,6 @@ ScatterVectorFields(const std::string & scatterName,
 template<typename EvalT, typename Traits>
 void
 ScatterVectorFields<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* d */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  // this->utils.setFieldData(pointField_,fm);
-
-  for (std::size_t fd = 0; fd < scatterFields_.size(); ++fd) {
-    // setup the field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-  }
-}
-
-template<typename EvalT, typename Traits>
-void
-ScatterVectorFields<EvalT, Traits>::
 evaluateFields(
   typename Traits::EvalData  /* workset */)
 {

--- a/packages/panzer/adapters-stk/test/evaluator_tests/PointEvaluator.hpp
+++ b/packages/panzer/adapters-stk/test/evaluator_tests/PointEvaluator.hpp
@@ -128,13 +128,8 @@ void
 PointEvaluator<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  if(isVector)
-     this->utils.setFieldData(vectorField,fm);
-  else
-     this->utils.setFieldData(scalar,fm);
-
   quad_index =  panzer::getIntegrationRuleIndex(quad_order,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/adapters-stk/test/gather_scatter_evaluators/scatter_field_evaluator.cpp
+++ b/packages/panzer/adapters-stk/test/gather_scatter_evaluators/scatter_field_evaluator.cpp
@@ -101,11 +101,6 @@ namespace panzer {
         const Teuchos::ParameterList& p);
 
       void
-      postRegistrationSetup(
-        typename Traits::SetupData d,
-        PHX::FieldManager<Traits>& fm);
-
-      void
       evaluateFields(
         typename Traits::EvalData d);
 
@@ -129,14 +124,6 @@ namespace panzer {
      xcoord = PHX::MDField<ScalarT,Cell,NODE>("x-coord",p.get<Teuchos::RCP<PHX::DataLayout> >("Data Layout"));
      this->addEvaluatedField(xcoord);
   }
-
-  template<typename EvalT, typename Traits>
-  void
-  XCoordinate<EvalT, Traits>::
-  postRegistrationSetup(
-    typename Traits::SetupData  /* sd */,
-    PHX::FieldManager<Traits>&  fm)
-  { this->utils.setFieldData(xcoord,fm); }
 
   template<typename EvalT, typename Traits>
   void

--- a/packages/panzer/adapters-stk/test/response_library/TestEvaluators.hpp
+++ b/packages/panzer/adapters-stk/test/response_library/TestEvaluators.hpp
@@ -63,11 +63,6 @@ class TestEvaluator
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 
@@ -100,18 +95,6 @@ TestEvaluator(
   
   std::string n = "TestEvaluator";
   this->setName(n);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-TestEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(dogValues,fm);
-  this->utils.setFieldData(hrsValues,fm);
 }
 
 //**********************************************************************

--- a/packages/panzer/adapters-stk/tutorial/step01/Step01_LinearFunction_impl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step01/Step01_LinearFunction_impl.hpp
@@ -31,11 +31,8 @@ LinearFunction<EvalT,Traits>::LinearFunction(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void LinearFunction<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                          PHX::FieldManager<Traits>& fm)
+                                                          PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(result,fm);
-
   ir_index_ = panzer::getIntegrationRuleIndex(ir_degree_,(*sd.worksets_)[0]);
 }
 

--- a/packages/panzer/adapters-stk/tutorial/step02/Step02_LinearFunction_impl.hpp
+++ b/packages/panzer/adapters-stk/tutorial/step02/Step02_LinearFunction_impl.hpp
@@ -31,11 +31,8 @@ LinearFunction<EvalT,Traits>::LinearFunction(const std::string & name,
 //**********************************************************************
 template <typename EvalT,typename Traits>
 void LinearFunction<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
-                                                          PHX::FieldManager<Traits>& fm)
+                                                          PHX::FieldManager<Traits>& /* fm */)
 {
-
-  this->utils.setFieldData(result,fm);
-
   ir_index_ = panzer::getIntegrationRuleIndex(ir_degree_,(*sd.worksets_)[0]);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CellAverage_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CellAverage_impl.hpp
@@ -101,17 +101,9 @@ void
 CellAverage<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(average,fm);
-  this->utils.setFieldData(scalar,fm);
-  
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->utils.setFieldData(*field,fm);
-
   num_qp = scalar.extent(1);
-
   quad_index =  panzer::getIntegrationRuleIndex(quad_order,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CellExtreme_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CellExtreme_impl.hpp
@@ -106,17 +106,9 @@ void
 CellExtreme<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(extreme,fm);
-  this->utils.setFieldData(scalar,fm);
-  
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->utils.setFieldData(*field,fm);
-
   num_qp = scalar.extent(1);
-
   quad_index =  panzer::getIntegrationRuleIndex(quad_order,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CoordinatesEvaluator_impl.hpp
@@ -65,10 +65,9 @@ template<typename EvalT, typename Traits>
 void
 CoordinatesEvaluator<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* worksets */,
+  PHX::FieldManager<Traits>& fm)
 {
-  using namespace PHX;
   this->utils.setFieldData(coordinate,fm);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Copy_impl.hpp
@@ -74,12 +74,9 @@ template<typename EvalT, typename Traits>
 void
 Copy<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* worksets */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(input,fm);
-  this->utils.setFieldData(output,fm);
-
   TEUCHOS_ASSERT(input.size()==output.size());
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_CrossProduct_impl.hpp
@@ -89,13 +89,9 @@ template<typename EvalT, typename Traits>
 void
 CrossProduct<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* sd */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(vec_a_cross_vec_b,fm);
-  this->utils.setFieldData(vec_a,fm);
-  this->utils.setFieldData(vec_b,fm);
-
   num_pts = vec_a.extent(1);
   num_dim = vec_a.extent(2);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_BasisToBasis_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_BasisToBasis_decl.hpp
@@ -72,9 +72,6 @@ public:
 		   const PureBasis & sourceBasis,
 		   const PureBasis & targetBasis);
 
-  void postRegistrationSetup(typename TRAITST::SetupData d,
-			     PHX::FieldManager<TRAITST>& vm);
-
   void evaluateFields(typename TRAITST::EvalData workset);
 
 private:

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_BasisToBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_BasisToBasis_impl.hpp
@@ -98,16 +98,6 @@ DOF_BasisToBasis(const std::string & fieldName,
 
 //**********************************************************************
 template <typename EvalT, typename TRAITST>
-void DOF_BasisToBasis<EvalT,TRAITST>::postRegistrationSetup(typename TRAITST::SetupData /* d */,
-			                                  PHX::FieldManager<TRAITST>& /* fm */)
-{
-  // not needed anymore
-  // this->utils.setFieldData(dof_source_coeff,fm);
-  // this->utils.setFieldData(dof_target_coeff,fm);
-}
-
-//**********************************************************************
-template <typename EvalT, typename TRAITST>
 void DOF_BasisToBasis<EvalT,TRAITST>::evaluateFields(typename TRAITST::EvalData workset)
 { 
   // Zero out arrays (intrepid does a sum!)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointField_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointField_decl.hpp
@@ -109,9 +109,6 @@ public:
   { std::string postfixFieldName = (useCoordPostfix ? coordinateName : ""); 
     initialize(fieldName,fieldBasis,coordinateName,coordLayout,quadLayout,postfixFieldName); }
   
-  void postRegistrationSetup(typename TRAITST::SetupData d,
-			     PHX::FieldManager<TRAITST>& vm);
-
   void evaluateFields(typename TRAITST::EvalData workset);
 
 private:

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointField_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointField_impl.hpp
@@ -89,16 +89,6 @@ void DOF_PointField<EvalT,TRAITST>::initialize(const std::string & fieldName,
 
 //**********************************************************************
 template <typename EvalT, typename TRAITST>
-void DOF_PointField<EvalT,TRAITST>::postRegistrationSetup(typename TRAITST::SetupData /* d */,
-			                                  PHX::FieldManager<TRAITST>& fm)
-{
-  this->utils.setFieldData(coordinates,fm);
-  this->utils.setFieldData(dof_coeff,fm);
-  this->utils.setFieldData(dof_field,fm);
-}
-
-//**********************************************************************
-template <typename EvalT, typename TRAITST>
 void DOF_PointField<EvalT,TRAITST>::evaluateFields(typename TRAITST::EvalData workset)
 { 
   // Zero out arrays (intrepid does a sum! 1/17/2012)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointValues_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_PointValues_impl.hpp
@@ -122,19 +122,11 @@ void DOF_PointValues<EvalT, TRAITS>::
 postRegistrationSetup(typename TRAITS::SetupData /* sd */,
                       PHX::FieldManager<TRAITS>& fm)
 {
-  this->utils.setFieldData(dof_basis,fm);
-
   if(!is_vector_basis) {
-    this->utils.setFieldData(dof_ip_scalar,fm);
-
-    // setup the pointers for the basis values data structure
     this->utils.setFieldData(basisValues->basis_ref_scalar,fm);      
     this->utils.setFieldData(basisValues->basis_scalar,fm);           
   }
   else {
-    this->utils.setFieldData(dof_ip_vector,fm);
-
-    // setup the pointers for the basis values data structure
     this->utils.setFieldData(basisValues->basis_ref_vector,fm);      
     this->utils.setFieldData(basisValues->basis_vector,fm);           
   }
@@ -241,19 +233,11 @@ void DOF_PointValues<typename TRAITS::Jacobian, TRAITS>::
 postRegistrationSetup(typename TRAITS::SetupData /* sd */,
                       PHX::FieldManager<TRAITS>& fm)
 {
-  this->utils.setFieldData(dof_basis,fm);
-
   if(!is_vector_basis) {
-    this->utils.setFieldData(dof_ip_scalar,fm);
-
-    // setup the pointers for the basis values data structure
     this->utils.setFieldData(basisValues->basis_ref_scalar,fm);      
     this->utils.setFieldData(basisValues->basis_scalar,fm);           
   }
   else {
-    this->utils.setFieldData(dof_ip_vector,fm);
-
-    // setup the pointers for the basis values data structure
     this->utils.setFieldData(basisValues->basis_ref_vector,fm);      
     this->utils.setFieldData(basisValues->basis_vector,fm);           
   }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_EdgeBasis_impl.hpp
@@ -117,10 +117,6 @@ postRegistrationSetup(
   PHX::FieldManager<Traits>& fm)
 {
   orientations = sd.orientations_;
-
-  this->utils.setFieldData(residual,fm);
-  this->utils.setFieldData(dof,fm);
-  this->utils.setFieldData(value,fm);
   this->utils.setFieldData(pointValues.jac,fm);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_FaceBasis_impl.hpp
@@ -111,12 +111,7 @@ postRegistrationSetup(
   PHX::FieldManager<Traits>& fm)
 {
   orientations = sd.orientations_;
-
-  this->utils.setFieldData(residual,fm);
-  this->utils.setFieldData(dof,fm);
-  this->utils.setFieldData(value,fm);
   this->utils.setFieldData(pointValues.jac,fm);
-
   faceNormal = Kokkos::createDynRankView(residual.get_static_view(),"faceNormal",dof.extent(0),dof.extent(1),dof.extent(2));
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Dirichlet_Residual_impl.hpp
@@ -80,12 +80,8 @@ void
 DirichletResidual<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
+  PHX::FieldManager<Traits>&  /* fm */)
 {
-  this->utils.setFieldData(residual,fm);
-  this->utils.setFieldData(dof,fm);
-  this->utils.setFieldData(value,fm);
-
   cell_data_size = residual.fieldTag().dataLayout().extent(1);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DotProduct_impl.hpp
@@ -117,16 +117,9 @@ template<typename EvalT, typename Traits>
 void
 DotProduct<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* sd */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(vec_a_dot_vec_b,fm);
-  this->utils.setFieldData(vec_a,fm);
-  this->utils.setFieldData(vec_b,fm);
-
-  if(multiplier_field_on)
-    this->utils.setFieldData(multiplier_field,fm);
-
   num_pts = vec_a.extent(1);
   num_dim = vec_a.extent(2);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_FieldSpy.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_FieldSpy.hpp
@@ -63,9 +63,6 @@ public:
     FieldSpy(const std::string & name,
              const Teuchos::RCP<PHX::DataLayout> & data_layout);
                                                                         
-    void postRegistrationSetup(typename Traits::SetupData d,           
-                               PHX::FieldManager<Traits>& fm);        
-                                                                     
     void evaluateFields(typename Traits::EvalData d);               
 
     const PHX::FieldTag & getRequiredFieldTag() const 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_FieldSpy_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_FieldSpy_impl.hpp
@@ -71,15 +71,6 @@ FieldSpy<EvalT,Traits>::FieldSpy(const std::string & name,
 
 //**********************************************************************
 template <typename EvalT,typename Traits>
-void FieldSpy<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData /* sd */,
-                                                       PHX::FieldManager<Traits>& fm)
-{
-
-  this->utils.setFieldData(source,fm);
-}
-
-//**********************************************************************
-template <typename EvalT,typename Traits>
 void FieldSpy<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
 { 
   std::cout << "SPY: Name = \"" << source.fieldTag().identifier() << "\" at t = " << workset.time << "\n";

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherBasisCoordinates_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherBasisCoordinates_impl.hpp
@@ -79,10 +79,8 @@ GatherBasisCoordinates(const panzer::PureBasis & basis)
 template<typename EvalT,typename TRAITS>
 void panzer::GatherBasisCoordinates<EvalT, TRAITS>::
 postRegistrationSetup(typename TRAITS::SetupData sd, 
-		      PHX::FieldManager<TRAITS>& fm)
+		      PHX::FieldManager<TRAITS>& /* fm */)
 {
-  this->utils.setFieldData(basisCoordinates_,fm);
-
   basisIndex_ = panzer::getPureBasisIndex(basisName_, (*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherIntegrationCoordinates_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherIntegrationCoordinates_impl.hpp
@@ -78,10 +78,8 @@ GatherIntegrationCoordinates(const panzer::IntegrationRule & quad)
 template<typename EvalT,typename TRAITS>
 void panzer::GatherIntegrationCoordinates<EvalT, TRAITS>::
 postRegistrationSetup(typename TRAITS::SetupData sd, 
-		      PHX::FieldManager<TRAITS>& fm)
+		      PHX::FieldManager<TRAITS>& /* fm */)
 {
-  this->utils.setFieldData(quadCoordinates_,fm);
-
   quadIndex_ = panzer::getIntegrationRuleIndex(quadDegree_, (*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherNormals_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherNormals_impl.hpp
@@ -98,11 +98,7 @@ postRegistrationSetup(typename Traits::SetupData d,
 		      PHX::FieldManager<Traits>& fm)
 {
   orientations = d.orientations_;
-
-  // setup the field data object
-  this->utils.setFieldData(gatherFieldNormals,fm);
   this->utils.setFieldData(pointValues.jac,fm);
-
   faceNormal = Kokkos::createDynRankView(gatherFieldNormals.get_static_view(),
 					 "faceNormal",
 					 gatherFieldNormals.extent(0),

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherOrientation_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherOrientation_impl.hpp
@@ -115,7 +115,7 @@ GatherOrientation(const std::vector<Teuchos::RCP<const UniqueGlobalIndexer<LO,GO
 template<typename EvalT,typename TRAITS,typename LO,typename GO>
 void panzer::GatherOrientation<EvalT, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-		      PHX::FieldManager<TRAITS>& fm)
+		      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFieldOrientations_.size() == indexerNames_->size());
 
@@ -128,9 +128,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,indexers_);
     subFieldIds_[fd] = indexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFieldOrientations_[fd],fm);
   }
 
   indexerNames_ = Teuchos::null;  // Don't need this anymore

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_BlockedTpetra_impl.hpp
@@ -300,7 +300,7 @@ GatherSolution_BlockedTpetra(
 template <typename TRAITS,typename S,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_BlockedTpetra<panzer::Traits::Tangent, TRAITS,S,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
 
@@ -310,15 +310,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     const std::string& fieldName = indexerNames_[fd];
     fieldIds_[fd] = gidIndexer_->getFieldNum(fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
-  }
-
-  if (has_tangent_fields_) {
-    for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd)
-      for (std::size_t i=0; i<tangentFields_[fd].size(); ++i)
-        this->utils.setFieldData(tangentFields_[fd][i],fm);
   }
 
   indexerNames_.clear();  // Don't need this anymore

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_impl.hpp
@@ -120,8 +120,8 @@ GatherSolution_Tpetra(
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_Tpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData  d ,
-                      PHX::FieldManager<TRAITS>& fm)
+postRegistrationSetup(typename TRAITS::SetupData d,
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
 
@@ -135,19 +135,11 @@ postRegistrationSetup(typename TRAITS::SetupData  d ,
     const std::string& fieldName = indexerNames_[fd];
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
 
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
     int fieldNum = fieldIds_[fd];
     const std::vector<int> & offsets = globalIndexer_->getGIDFieldOffsets(blockId,fieldNum);
     scratch_offsets_[fd] = Kokkos::View<int*,PHX::Device>("offsets",offsets.size());
     for(std::size_t i=0;i<offsets.size();i++)
       scratch_offsets_[fd](i) = offsets[i];
-  }
-
-  if (has_tangent_fields_) {
-    for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd)
-      for (std::size_t i=0; i<tangentFields_[fd].size(); ++i)
-        this->utils.setFieldData(tangentFields_[fd][i],fm);
   }
 
   scratch_lids_ = Kokkos::View<LO**,PHX::Device>("lids",gatherFields_[0].extent(0),
@@ -281,7 +273,7 @@ GatherSolution_Tpetra(
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_Tpetra<panzer::Traits::Tangent, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
 
@@ -290,15 +282,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
   for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {
     const std::string& fieldName = indexerNames_[fd];
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
-  }
-
-  if (has_tangent_fields_) {
-    for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd)
-      for (std::size_t i=0; i<tangentFields_[fd].size(); ++i)
-        this->utils.setFieldData(tangentFields_[fd][i],fm);
   }
 
   indexerNames_.clear();  // Don't need this anymore
@@ -455,7 +438,7 @@ GatherSolution_Tpetra(
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherSolution_Tpetra<panzer::Traits::Jacobian, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_.size());
 
@@ -468,9 +451,6 @@ postRegistrationSetup(typename TRAITS::SetupData d,
     // get field ID from DOF manager
     const std::string& fieldName = indexerNames_[fd];
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
 
     int fieldNum = fieldIds_[fd];
     const std::vector<int> & offsets = globalIndexer_->getGIDFieldOffsets(blockId,fieldNum);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_BlockedTpetra_impl.hpp
@@ -97,7 +97,7 @@ GatherTangent_BlockedTpetra(
 template <typename EvalT,typename TRAITS,typename S,typename LO,typename GO,typename NodeT>
 void panzer::GatherTangent_BlockedTpetra<EvalT, TRAITS,S,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_->size());
 
@@ -107,9 +107,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     const std::string& fieldName = (*indexerNames_)[fd];
     fieldIds_[fd] = gidIndexer_->getFieldNum(fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
   }
 
   indexerNames_ = Teuchos::null;  // Don't need this anymore

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Tpetra_impl.hpp
@@ -98,7 +98,7 @@ GatherTangent_Tpetra(
 template<typename EvalT,typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::GatherTangent_Tpetra<EvalT, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   TEUCHOS_ASSERT(gatherFields_.size() == indexerNames_->size());
 
@@ -107,9 +107,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
   for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {
     const std::string& fieldName = (*indexerNames_)[fd];
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // setup the field data object
-    this->utils.setFieldData(gatherFields_[fd],fm);
   }
 
   indexerNames_ = Teuchos::null;  // Don't need this anymore

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangents_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangents_impl.hpp
@@ -98,9 +98,6 @@ postRegistrationSetup(typename Traits::SetupData d,
 		      PHX::FieldManager<Traits>& fm)
 {
   orientations = d.orientations_;
-
-  // setup the field data object
-  this->utils.setFieldData(gatherFieldTangents,fm);
   this->utils.setFieldData(pointValues.jac,fm);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GlobalStatistics_impl.hpp
@@ -112,18 +112,9 @@ void
 GlobalStatistics<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(volumes,fm);
-  this->utils.setFieldData(tmp,fm);
-  this->utils.setFieldData(ones,fm);
-  
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_values.begin();
-       field != field_values.end(); ++field)
-    this->utils.setFieldData(*field,fm);
-
   ir_index = panzer::getIntegrationRuleIndex(ir_order,(*sd.worksets_)[0], this->wda);
-
   for (typename PHX::MDField<ScalarT,Cell,IP>::size_type cell = 0; cell < ones.extent(0); ++cell)
     for (typename PHX::MDField<ScalarT,Cell,IP>::size_type ip = 0; ip < ones.extent(1); ++ip)
       ones(cell,ip) = 1.0;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisCrossVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisCrossVector_impl.hpp
@@ -127,19 +127,8 @@ void
 Integrator_GradBasisCrossVector<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-
-  for (auto & residual : _residuals){
-    this->utils.setFieldData(residual,fm);
-  }
-
-  this->utils.setFieldData(_vector,fm);
-
-  for (auto & field : _field_multipliers){
-    this->utils.setFieldData(field,fm);
-  }
-
   _num_basis_nodes = _residuals[0].extent(1);
   _num_quadrature_points = _vector.extent(1);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisTimesScalar_impl.hpp
@@ -120,19 +120,8 @@ void
 Integrator_GradBasisTimesScalar<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-
-  for (auto & residual : _residuals){
-    this->utils.setFieldData(residual,fm);
-  }
-
-  this->utils.setFieldData(_scalar,fm);
-
-  for (auto & field : _field_multipliers){
-    this->utils.setFieldData(field,fm);
-  }
-
   _num_basis_nodes = _residuals[0].extent(1);
   _num_quadrature_points = _scalar.extent(1);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_Scalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_Scalar_impl.hpp
@@ -100,19 +100,10 @@ void
 Integrator_Scalar<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(integral,fm);
-  this->utils.setFieldData(scalar,fm);
-  
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->utils.setFieldData(*field,fm);
-
   num_qp = scalar.extent(1);
-
   tmp = Kokkos::createDynRankView(scalar.get_static_view(),"tmp", scalar.extent(0), num_qp);
-
   quad_index =  panzer::getIntegrationRuleIndex(quad_order,(*sd.worksets_)[0], this->wda);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_TransientBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_TransientBasisTimesScalar_impl.hpp
@@ -110,10 +110,6 @@ postRegistrationSetup(
   this->utils.setFieldData(residual,fm);
   this->utils.setFieldData(scalar,fm);
   
-  for (typename std::vector<PHX::MDField<const ScalarT,Cell,IP> >::iterator field = field_multipliers.begin();
-       field != field_multipliers.end(); ++field)
-    this->utils.setFieldData(*field,fm);
-
   num_nodes = residual.extent(1);
   num_qp = scalar.extent(1);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Interface_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Interface_Residual_impl.hpp
@@ -93,13 +93,8 @@ void
 InterfaceResidual<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(residual,fm);
-  this->utils.setFieldData(normal_dot_flux,fm);
-  this->utils.setFieldData(flux,fm);
-  this->utils.setFieldData(normal,fm);
-
   num_ip = flux.extent(1);
   num_dim = flux.extent(2);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_MultiVariateParameter_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_MultiVariateParameter_decl.hpp
@@ -75,9 +75,6 @@ namespace panzer {
                           const Teuchos::RCP<PHX::DataLayout>& data_layout,
                           panzer::ParamLib& param_lib);
 
-    void postRegistrationSetup(typename TRAITS::SetupData d,
-                               PHX::FieldManager<TRAITS>& vm);
-
     void evaluateFields(typename TRAITS::EvalData ud);
 
   private:

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_MultiVariateParameter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_MultiVariateParameter_impl.hpp
@@ -82,15 +82,6 @@ MultiVariateParameter(const std::string parameter_name,
 //**********************************************************************
 template<typename EvalT, typename TRAITS>
 void MultiVariateParameter<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData /* worksets */,
-                      PHX::FieldManager<TRAITS>& fm)
-{
-  this->utils.setFieldData(target_field,fm);
-}
-
-//**********************************************************************
-template<typename EvalT, typename TRAITS>
-void MultiVariateParameter<EvalT, TRAITS>::
 evaluateFields(typename TRAITS::EvalData workset)
 {
   ScalarT sum = 0;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Neumann_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Neumann_Residual_impl.hpp
@@ -93,13 +93,8 @@ void
 NeumannResidual<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(residual,fm);
-  this->utils.setFieldData(normal_dot_flux,fm);
-  this->utils.setFieldData(flux,fm);
-  this->utils.setFieldData(normal,fm);
-
   num_ip = flux.extent(1);
   num_dim = flux.extent(2);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Normals_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Normals_impl.hpp
@@ -84,10 +84,8 @@ void
 Normals<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(normals,fm);
-
   num_qp  = normals.extent(1);
   num_dim = normals.extent(2);
   

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Parameter_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Parameter_decl.hpp
@@ -70,9 +70,6 @@ namespace panzer {
 	      const Teuchos::RCP<PHX::DataLayout>& data_layout,
 	      panzer::ParamLib& param_lib);
     
-    void postRegistrationSetup(typename TRAITS::SetupData d,
-			       PHX::FieldManager<TRAITS>& vm);
-    
     void evaluateFields(typename TRAITS::EvalData ud);
     
   private:

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Parameter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Parameter_impl.hpp
@@ -75,15 +75,6 @@ Parameter(const std::string parameter_name,
 //**********************************************************************
 template<typename EvalT, typename TRAITS>
 void Parameter<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData /* worksets */,
-		      PHX::FieldManager<TRAITS>& fm)
-{
-  this->utils.setFieldData(target_field,fm);
-}
-
-//**********************************************************************
-template<typename EvalT, typename TRAITS>
-void Parameter<EvalT, TRAITS>::
 evaluateFields(typename TRAITS::EvalData workset)
 { 
   //std::cout << "ROGER ParamValue = " << param->getValue() << std::endl;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Product_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Product_decl.hpp
@@ -73,11 +73,6 @@ class Product
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Product_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Product_impl.hpp
@@ -83,19 +83,6 @@ Product(
 template<typename EvalT, typename Traits>
 void
 Product<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(product,fm);
-  for (std::size_t i=0; i < values.size(); ++i)
-    this->utils.setFieldData(values[i],fm);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-Product<EvalT, Traits>::
 evaluateFields(
   typename Traits::EvalData  /* workset */)
 { 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToEdges_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToEdges_impl.hpp
@@ -120,20 +120,9 @@ ProjectToEdges(
 template<typename EvalT,typename Traits>
 void panzer::ProjectToEdges<EvalT, Traits>::
 postRegistrationSetup(typename Traits::SetupData  d, 
-		      PHX::FieldManager<Traits>& fm)
+		      PHX::FieldManager<Traits>& /* fm */)
 {
   orientations = d.orientations_;
-
-  // setup the field data object
-  this->utils.setFieldData(result,fm);
-  for(unsigned qp = 0; qp < vector_values.size(); ++qp)
-    this->utils.setFieldData(vector_values[qp],fm);
-  this->utils.setFieldData(tangents,fm);
-
-  if(quad_degree > 0){
-    this->utils.setFieldData(dof_orientation,fm);
-    this->utils.setFieldData(gatherFieldTangents,fm);
-  }
 
   num_pts = vector_values[0].extent(1);
   num_dim = vector_values[0].extent(2);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToFaces_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ProjectToFaces_impl.hpp
@@ -118,19 +118,9 @@ ProjectToFaces(
 template<typename EvalT,typename Traits>
 void panzer::ProjectToFaces<EvalT, Traits>::
 postRegistrationSetup(typename Traits::SetupData d, 
-		      PHX::FieldManager<Traits>& fm)
+		      PHX::FieldManager<Traits>& /* fm */)
 {
   orientations = d.orientations_;
-
-  // setup the field data object
-  this->utils.setFieldData(result,fm);
-  for(unsigned qp = 0; qp < vector_values.size(); ++qp)
-    this->utils.setFieldData(vector_values[qp],fm);
-  this->utils.setFieldData(normals,fm);
-
-  if(quad_degree > 0){
-    this->utils.setFieldData(gatherFieldNormals,fm);
-  }
 
   num_pts  = result.extent(1);
   num_dim  = vector_values[0].extent(2);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ReorderADValues_Evaluator_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ReorderADValues_Evaluator_decl.hpp
@@ -89,8 +89,6 @@ public:
                             const UniqueGlobalIndexerBase & indexerSrc,
                             const UniqueGlobalIndexerBase & indexerDest);
 
-  void postRegistrationSetup(typename TRAITS::SetupData d, PHX::FieldManager<TRAITS>& vm);
-
   void evaluateFields(typename TRAITS::EvalData d);
 
 private:
@@ -134,9 +132,6 @@ public:
                             const UniqueGlobalIndexerBase & indexerSrc,
                             const UniqueGlobalIndexerBase & indexerDest);
   
-  void postRegistrationSetup(typename TRAITS::SetupData d,
-			     PHX::FieldManager<TRAITS>& vm);
-
   void evaluateFields(typename TRAITS::EvalData workset);
   
 private:

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ReorderADValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ReorderADValues_Evaluator_impl.hpp
@@ -107,20 +107,6 @@ ReorderADValues_Evaluator(const std::string & outPrefix,
 // **********************************************************************
 template<typename EvalT,typename TRAITS>
 void panzer::ReorderADValues_Evaluator<EvalT, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-		      PHX::FieldManager<TRAITS>& fm)
-{
-  // load required field numbers for fast use
-  for(std::size_t fd=0;fd<inFields_.size();++fd) {
-    // fill field data object
-    this->utils.setFieldData(inFields_[fd],fm);
-    this->utils.setFieldData(outFields_[fd],fm);
-  }
-}
-
-// **********************************************************************
-template<typename EvalT,typename TRAITS>
-void panzer::ReorderADValues_Evaluator<EvalT, TRAITS>::
 evaluateFields(typename TRAITS::EvalData /* workset */)
 {
   // just copy fields if there is no AD data
@@ -208,20 +194,6 @@ ReorderADValues_Evaluator(const std::string & outPrefix,
                     indexerDest);
 
   this->setName("Reorder AD Values");
-}
-
-// **********************************************************************
-template<typename TRAITS>
-void panzer::ReorderADValues_Evaluator<typename TRAITS::Jacobian, TRAITS>::
-postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-		      PHX::FieldManager<TRAITS>& fm)
-{
-  // load required field numbers for fast use
-  for(std::size_t fd=0;fd<inFields_.size();++fd) {
-    // fill field data object
-    this->utils.setFieldData(inFields_[fd],fm);
-    this->utils.setFieldData(outFields_[fd],fm);
-  }
 }
 
 // **********************************************************************

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_Hessian_impl.hpp
@@ -116,7 +116,7 @@ template<typename TRAITS,typename LO,typename GO>
 void
 ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm) 
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -128,12 +128,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedEpetra_impl.hpp
@@ -139,7 +139,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -151,12 +151,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)
@@ -357,7 +351,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -369,12 +363,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)
@@ -574,7 +562,7 @@ ScatterDirichletResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const Uniq
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_BlockedEpetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -586,12 +574,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_Hessian_impl.hpp
@@ -117,7 +117,7 @@ template<typename TRAITS,typename LO,typename GO>
 void
 ScatterDirichletResidual_Epetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm) 
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -126,11 +126,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Epetra_impl.hpp
@@ -129,7 +129,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -138,11 +138,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)
@@ -316,7 +311,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -325,11 +320,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)
@@ -538,7 +528,7 @@ ScatterDirichletResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterDirichletResidual_Epetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -547,11 +537,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_Tpetra_impl.hpp
@@ -124,7 +124,7 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO,typename NodeT> 
 void panzer::ScatterDirichletResidual_Tpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -133,12 +133,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)
@@ -321,7 +315,7 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO,typename NodeT> 
 void panzer::ScatterDirichletResidual_Tpetra<panzer::Traits::Tangent, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -330,12 +324,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)
@@ -549,7 +537,7 @@ ScatterDirichletResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,
 template<typename TRAITS,typename LO,typename GO,typename NodeT> 
 void panzer::ScatterDirichletResidual_Tpetra<panzer::Traits::Jacobian, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
   // load required field numbers for fast use
@@ -557,12 +545,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
-
-    if (checkApplyBC_)
-      this->utils.setFieldData(applyBC_[fd],fm);
   }
 
   // get the number of nodes (Should be renamed basis)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_Hessian_impl.hpp
@@ -110,7 +110,7 @@ template<typename TRAITS,typename LO,typename GO>
 void
 ScatterResidual_BlockedEpetra<panzer::Traits::Hessian,TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm) 
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -122,9 +122,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedEpetra_impl.hpp
@@ -121,7 +121,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-		      PHX::FieldManager<TRAITS>& fm)
+		      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -133,9 +133,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 
@@ -260,7 +257,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-		      PHX::FieldManager<TRAITS>& fm)
+		      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -272,9 +269,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 
@@ -411,7 +405,7 @@ ScatterResidual_BlockedEpetra(const std::vector<Teuchos::RCP<const UniqueGlobalI
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_BlockedEpetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-		      PHX::FieldManager<TRAITS>& fm)
+		      PHX::FieldManager<TRAITS>& /* fm */)
 {
   indexerIds_.resize(scatterFields_.size());
   subFieldIds_.resize(scatterFields_.size());
@@ -423,9 +417,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
 
     indexerIds_[fd]  = getFieldBlock(fieldName,rowIndexers_);
     subFieldIds_[fd] = rowIndexers_[indexerIds_[fd]]->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_Hessian_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_Hessian_impl.hpp
@@ -124,7 +124,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & i
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Hessian, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
   // load required field numbers for fast use
@@ -132,9 +132,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Epetra_impl.hpp
@@ -114,7 +114,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Residual, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
   // load required field numbers for fast use
@@ -122,9 +122,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 
@@ -225,7 +222,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Tangent, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */, 
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
   // load required field numbers for fast use
@@ -233,9 +230,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 
@@ -354,7 +348,7 @@ ScatterResidual_Epetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & i
 template<typename TRAITS,typename LO,typename GO> 
 void panzer::ScatterResidual_Epetra<panzer::Traits::Jacobian, TRAITS,LO,GO>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   // globalIndexer_ = d.globalIndexer_;
 
@@ -364,9 +358,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_Tpetra_impl.hpp
@@ -110,8 +110,8 @@ ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 // **********************************************************************
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_Tpetra<panzer::Traits::Residual, TRAITS,LO,GO,NodeT>::
-postRegistrationSetup(typename TRAITS::SetupData  d ,
-                      PHX::FieldManager<TRAITS>& fm)
+postRegistrationSetup(typename TRAITS::SetupData d,
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
   const Workset & workset_0 = (*d.worksets_)[0];
@@ -124,8 +124,6 @@ postRegistrationSetup(typename TRAITS::SetupData  d ,
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
 
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
     const std::vector<int> & offsets = globalIndexer_->getGIDFieldOffsets(blockId,fieldIds_[fd]);
     scratch_offsets_[fd] = Kokkos::View<int*,PHX::Device>("offsets",offsets.size());
     for(std::size_t i=0;i<offsets.size();i++)
@@ -201,7 +199,7 @@ ScatterResidual_Tpetra(const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,G
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_Tpetra<panzer::Traits::Tangent, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
   // load required field numbers for fast use
@@ -209,9 +207,6 @@ postRegistrationSetup(typename TRAITS::SetupData /* d */,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
   }
 }
 
@@ -323,7 +318,7 @@ ScatterResidual_Tpetra(const Teuchos::RCP<const UniqueGlobalIndexer<LO,GO> > & i
 template<typename TRAITS,typename LO,typename GO,typename NodeT>
 void panzer::ScatterResidual_Tpetra<panzer::Traits::Jacobian, TRAITS,LO,GO,NodeT>::
 postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
   fieldIds_.resize(scatterFields_.size());
 
@@ -335,9 +330,6 @@ postRegistrationSetup(typename TRAITS::SetupData d,
     // get field ID from DOF manager
     std::string fieldName = fieldMap_->find(scatterFields_[fd].fieldTag().name())->second;
     fieldIds_[fd] = globalIndexer_->getFieldNum(fieldName);
-
-    // fill field data object
-    this->utils.setFieldData(scatterFields_[fd],fm);
 
     int fieldNum = fieldIds_[fd];
     const std::vector<int> & offsets = globalIndexer_->getGIDFieldOffsets(blockId,fieldNum);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_decl.hpp
@@ -89,11 +89,6 @@ class SubcellSum
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_SubcellSum_impl.hpp
@@ -85,18 +85,6 @@ SubcellSum(
 template<typename EvalT, typename Traits>
 void
 SubcellSum<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(inField,fm);
-  this->utils.setFieldData(outField,fm);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-SubcellSum<EvalT, Traits>::
 evaluateFields(
   typename Traits::EvalData workset)
 { 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Sum.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Sum.hpp
@@ -115,8 +115,6 @@ class SumStatic : public panzer::EvaluatorWithBaseImpl<TRAITS>,
             public PHX::EvaluatorDerived<EvalT, TRAITS>  {
 public:
   SumStatic(const Teuchos::ParameterList& p);
-  void postRegistrationSetup(typename TRAITS::SetupData d,
-                             PHX::FieldManager<TRAITS>& fm);
   void evaluateFields(typename TRAITS::EvalData d);
 private:
   typedef typename EvalT::ScalarT ScalarT;
@@ -127,8 +125,6 @@ class SumStatic<EvalT,TRAITS,Tag0,void,void> : public panzer::EvaluatorWithBaseI
                                          public PHX::EvaluatorDerived<EvalT, TRAITS>  {
 public:
   SumStatic(const Teuchos::ParameterList& p);
-  void postRegistrationSetup(typename TRAITS::SetupData d,
-                             PHX::FieldManager<TRAITS>& fm);
   void evaluateFields(typename TRAITS::EvalData d);
 private:
   typedef typename EvalT::ScalarT ScalarT;
@@ -192,8 +188,6 @@ class SumStatic<EvalT,TRAITS,Tag0,Tag1,Tag2> : public panzer::EvaluatorWithBaseI
                                          public PHX::EvaluatorDerived<EvalT, TRAITS>  {
 public:
   SumStatic(const Teuchos::ParameterList& p);
-  void postRegistrationSetup(typename TRAITS::SetupData d,
-                             PHX::FieldManager<TRAITS>& fm);
   void evaluateFields(typename TRAITS::EvalData d);
 private:
   typedef typename EvalT::ScalarT ScalarT;

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Sum_impl.hpp
@@ -112,12 +112,8 @@ void
 Sum<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
+  PHX::FieldManager<Traits>&  /* fm */)
 {
-  this->utils.setFieldData(sum,fm);
-  for (std::size_t i=0; i < scalars.extent(0); ++i)
-    this->utils.setFieldData(values[i],fm);
-
   cell_data_size = sum.size() / sum.fieldTag().dataLayout().extent(0);
 }
 
@@ -273,18 +269,6 @@ SumStatic(const Teuchos::ParameterList& p)
 
 template<typename EvalT, typename TRAITS,typename Tag0>
 void SumStatic<EvalT,TRAITS,Tag0,void,void>::
-postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
-{
-  this->utils.setFieldData(sum,fm);
-  for (std::size_t i=0; i < values.size(); ++i)
-    this->utils.setFieldData(values[i],fm);
-}
-
-//**********************************************************************
-
-template<typename EvalT, typename TRAITS,typename Tag0>
-void SumStatic<EvalT,TRAITS,Tag0,void,void>::
 evaluateFields(typename TRAITS::EvalData /* d */)
 {
   sum.deep_copy(ScalarT(0.0));
@@ -395,13 +379,10 @@ SumStatic(const std::vector<PHX::Tag<typename EvalT::ScalarT>> & inputs,
 template<typename EvalT, typename TRAITS,typename Tag0,typename Tag1>
 void SumStatic<EvalT,TRAITS,Tag0,Tag1,void>::
 postRegistrationSetup(typename TRAITS::SetupData /* d */,
-                      PHX::FieldManager<TRAITS>& fm)
+                      PHX::FieldManager<TRAITS>& /* fm */)
 {
-  this->utils.setFieldData(sum,fm);
-  for (std::size_t i=0; i < values.size(); ++i) {
-    this->utils.setFieldData(values[i],fm);
+  for (std::size_t i=0; i < values.size(); ++i)
     value_views[i] = values[i].get_static_view();
-  }
 }
 
 //**********************************************************************
@@ -475,20 +456,6 @@ SumStatic(const Teuchos::ParameterList& p)
  
   std::string n = "Sum Evaluator";
   this->setName(n);
-}
-*/
-
-//**********************************************************************
-/*
-
-template<typename EvalT, typename TRAITS,typename Tag0,typename Tag1,typename Tag2>
-void SumStatic<EvalT,TRAITS,Tag0,Tag1,Tag2>::
-postRegistrationSetup(typename TRAITS::SetupData d,
-                      PHX::FieldManager<TRAITS>& fm)
-{
-  this->utils.setFieldData(sum,fm);
-  for (std::size_t i=0; i < values.size(); ++i)
-    this->utils.setFieldData(values[i],fm);
 }
 */
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_decl.hpp
@@ -73,11 +73,6 @@ class TensorToStdVector
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TensorToStdVector_impl.hpp
@@ -84,20 +84,6 @@ TensorToStdVector(
 template<typename EvalT, typename Traits>
 void
 TensorToStdVector<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  for (std::size_t i=0; i < vector_fields.size(); ++i)
-    this->utils.setFieldData(vector_fields[i], fm);
-
-  this->utils.setFieldData(tensor_field, fm);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-TensorToStdVector<EvalT, Traits>::
 evaluateFields(
   typename Traits::EvalData  workset)
 { 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_TestScatter_impl.hpp
@@ -75,12 +75,9 @@ template<typename EvalT, typename Traits>
 void
 TestScatter<EvalT, Traits>::
 postRegistrationSetup(
-  typename Traits::SetupData  /* setupData */,
-  PHX::FieldManager<Traits>&  fm)
+  typename Traits::SetupData /* setupData */,
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(scatter_value,fm);
-  this->utils.setFieldData(value,fm);
-
   num_nodes = scatter_value.extent(1);
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_WeakDirichlet_Residual_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_WeakDirichlet_Residual_impl.hpp
@@ -102,16 +102,8 @@ void
 WeakDirichletResidual<EvalT, Traits>::
 postRegistrationSetup(
   typename Traits::SetupData sd,
-  PHX::FieldManager<Traits>& fm)
+  PHX::FieldManager<Traits>& /* fm */)
 {
-  this->utils.setFieldData(residual,fm);
-  this->utils.setFieldData(normal_dot_flux_plus_pen,fm);
-  this->utils.setFieldData(flux,fm);
-  this->utils.setFieldData(normal,fm);
-  this->utils.setFieldData(dof,fm);
-  this->utils.setFieldData(value,fm);
-  this->utils.setFieldData(sigma,fm);
-
   num_ip = flux.extent(1);
   num_dim = flux.extent(2);
 

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue.hpp
@@ -100,9 +100,6 @@ public:
                                         bool useMax,
                                         const Teuchos::RCP<ExtremeValueScatterBase> & functionalScatter);
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                             PHX::FieldManager<Traits>& fm);
-
   void evaluateFields(typename Traits::EvalData d);
 
   void preEvaluate(typename Traits::PreEvalData d);

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_ExtremeValue_impl.hpp
@@ -135,14 +135,6 @@ preEvaluate(typename Traits::PreEvalData d)
 
 template<typename EvalT, typename Traits>
 void ResponseScatterEvaluator_ExtremeValue<EvalT,Traits>::
-postRegistrationSetup(typename Traits::SetupData /* d */,
-                      PHX::FieldManager<Traits>& fm)
-{
-  this->utils.setFieldData(cellExtremeValue_,fm);
-}
-
-template<typename EvalT, typename Traits>
-void ResponseScatterEvaluator_ExtremeValue<EvalT,Traits>::
 evaluateFields(typename Traits::EvalData d)
 {
   for(index_t i=0;i<d.num_cells;i++) {

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Functional.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Functional.hpp
@@ -120,9 +120,6 @@ public:
   ResponseScatterEvaluator_Functional(const std::string & integrandName,const std::string & responseName,const CellData & cd,
                                       const Teuchos::RCP<FunctionalScatterBase> & functionalScatter);
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                             PHX::FieldManager<Traits>& fm);
-
   void evaluateFields(typename Traits::EvalData d);
 
   void preEvaluate(typename Traits::PreEvalData d);

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Functional_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Functional_impl.hpp
@@ -134,14 +134,6 @@ preEvaluate(typename Traits::PreEvalData d)
 
 template<typename EvalT, typename Traits>
 void ResponseScatterEvaluator_Functional<EvalT,Traits>::
-postRegistrationSetup(typename Traits::SetupData /* d */,
-                      PHX::FieldManager<Traits>& fm)
-{
-  this->utils.setFieldData(cellIntegral_,fm);
-}
-
-template<typename EvalT, typename Traits>
-void ResponseScatterEvaluator_Functional<EvalT,Traits>::
 evaluateFields(typename Traits::EvalData d)
 {
   for(index_t i=0;i<d.num_cells;i++) {

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Probe.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Probe.hpp
@@ -110,9 +110,6 @@ public:
     const Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO> >& indexer,
     const Teuchos::RCP<ProbeScatterBase> & probeScatter);
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                             PHX::FieldManager<Traits>& fm);
-
   void evaluateFields(typename Traits::EvalData d);
 
   void preEvaluate(typename Traits::PreEvalData d);

--- a/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Probe_impl.hpp
+++ b/packages/panzer/disc-fe/src/responses/Panzer_ResponseScatterEvaluator_Probe_impl.hpp
@@ -127,14 +127,6 @@ preEvaluate(typename Traits::PreEvalData d)
 
 
 template<typename EvalT, typename Traits, typename LO, typename GO>
-void ResponseScatterEvaluator_ProbeBase<EvalT,Traits,LO,GO>::
-postRegistrationSetup(typename Traits::SetupData /* d */,
-                      PHX::FieldManager<Traits>& fm)
-{
-  this->utils.setFieldData(field_,fm);
-}
-
-template<typename EvalT, typename Traits, typename LO, typename GO>
 bool ResponseScatterEvaluator_ProbeBase<EvalT,Traits,LO,GO>::
 computeBasisValues(typename Traits::EvalData d)
 {

--- a/packages/panzer/disc-fe/test/equation_set/user_app_Convection.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_Convection.hpp
@@ -68,11 +68,6 @@ class Convection
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 

--- a/packages/panzer/disc-fe/test/equation_set/user_app_Convection_impl.hpp
+++ b/packages/panzer/disc-fe/test/equation_set/user_app_Convection_impl.hpp
@@ -87,19 +87,6 @@ Convection(
 template<typename EvalT, typename Traits>
 void
 Convection<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* worksets */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(conv,fm);
-  this->utils.setFieldData(a,fm);
-  this->utils.setFieldData(grad_x,fm);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-Convection<EvalT, Traits>::
 evaluateFields(
   typename Traits::EvalData workset)
 { 

--- a/packages/panzer/disc-fe/test/evaluator_tests/UnitValueEvaluator.hpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/UnitValueEvaluator.hpp
@@ -62,11 +62,6 @@ class UnitValueEvaluator
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 
@@ -97,17 +92,6 @@ UnitValueEvaluator(
   
   std::string n = "UnitValueEvaluator: " + name;
   this->setName(n);
-}
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void
-UnitValueEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(unitValue,fm);
 }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_basistobasis.cpp
@@ -96,11 +96,6 @@ class DummyFieldEvaluator
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 
@@ -127,17 +122,6 @@ DummyFieldEvaluator(
   
   std::string n = "DummyFieldEvaluator: " + name;
   this->setName(n);
-}
-template<typename EvalT, typename Traits>
-void
-DummyFieldEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(fieldValue,fm);
-
-  
 }
 
 template<typename EvalT, typename Traits>

--- a/packages/panzer/disc-fe/test/evaluator_tests/dof_pointfield.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/dof_pointfield.cpp
@@ -96,11 +96,6 @@ class DummyFieldEvaluator
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 
@@ -131,13 +126,6 @@ DummyFieldEvaluator(
 template<typename EvalT, typename Traits>
 void
 DummyFieldEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{ this->utils.setFieldData(fieldValue,fm); }
-template<typename EvalT, typename Traits>
-void
-DummyFieldEvaluator<EvalT, Traits>::
 evaluateFields(
   typename Traits::EvalData  /* workset */)
 { 
@@ -160,11 +148,6 @@ class RefCoordEvaluator
 
     RefCoordEvaluator(
       const Teuchos::ParameterList& p);
-
-    void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
 
     void
     evaluateFields(
@@ -198,13 +181,6 @@ RefCoordEvaluator(
   std::string n = "RefCoordEvaluator: " + name;
   this->setName(n);
 }
-template<typename EvalT, typename Traits>
-void
-RefCoordEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{ this->utils.setFieldData(fieldValue,fm); }
 template<typename EvalT, typename Traits>
 void
 RefCoordEvaluator<EvalT, Traits>::

--- a/packages/panzer/disc-fe/test/evaluator_tests/hessian_test.cpp
+++ b/packages/panzer/disc-fe/test/evaluator_tests/hessian_test.cpp
@@ -107,11 +107,6 @@ class InputConditionsEvaluator
       const Teuchos::ParameterList& p);
 
     void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
-
-    void
     evaluateFields(
       typename Traits::EvalData d);
 
@@ -159,21 +154,6 @@ InputConditionsEvaluator(
 }
 
 //**********************************************************************
-
-template<typename EvalT, typename Traits>
-void
-InputConditionsEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(x,fm);
-  this->utils.setFieldData(y,fm);
-  this->utils.setFieldData(dx,fm);
-  this->utils.setFieldData(dy,fm);
-}
-
-//**********************************************************************
 template<typename EvalT, typename Traits>
 void
 InputConditionsEvaluator<EvalT, Traits>::
@@ -204,11 +184,6 @@ class HessianTestEvaluator
 
     HessianTestEvaluator(
       const Teuchos::ParameterList& p);
-
-    void
-    postRegistrationSetup(
-      typename Traits::SetupData d,
-      PHX::FieldManager<Traits>& fm);
 
     void
     evaluateFields(
@@ -253,20 +228,6 @@ HessianTestEvaluator(
   
   std::string n = "Hessian test evaluator (" + PHX::typeAsString<ScalarT>()+")";
   this->setName(n);
-}
-
-//**********************************************************************
-
-template<typename EvalT, typename Traits>
-void
-HessianTestEvaluator<EvalT, Traits>::
-postRegistrationSetup(
-  typename Traits::SetupData  /* sd */,
-  PHX::FieldManager<Traits>&  fm)
-{
-  this->utils.setFieldData(x,fm);
-  this->utils.setFieldData(y,fm);
-  this->utils.setFieldData(result,fm);
 }
 
 //**********************************************************************


### PR DESCRIPTION
@trilinos/panzer 

## Description
It's no longer necessary to call `setFieldData()` in an `Evaluator`'s `postRegistrationSetup()` routine, as long as the field in question was created with the `PHX::MDField` constructor.  That change was made to Phalanx ages ago; this brings us up-to-date.

## Motivation and Context
1. I'm tired of seeing `setFieldData()`s all over the place.
1. I'm more tired of seeing them being copied and pasted as new code gets created.

## How Has This Been Tested?
Ran `ctest` on Panzer, Drekar, and Charon on my RHEL7 machine&mdash;all is well.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.