### PR TITLE
kokkos: typo on case-sensitive fs

### DIFF
--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Windows.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Windows.hpp
@@ -47,7 +47,7 @@
 
 #define NOMINMAX
 #include <winsock2.h>
-#include <Windows.h>
+#include <windows.h>
 
 namespace Kokkos {
   namespace Impl {


### PR DESCRIPTION
This fixes windows build of Trilinos on case-sensitive filesystems (ext4) as the correct name of the header is lowercase.
