### PR TITLE
EpetraExt: Recursively check for existing HDF5 groups

### DIFF
--- a/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
+++ b/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
@@ -1611,7 +1611,7 @@ void EpetraExt::HDF5::Read(const std::string& GroupName,
 // ==========================================================================
 void EpetraExt::HDF5::Write(const std::string& GroupName, const std::string& DataSetName,
                          const hid_t type, const int Length,
-                         void* data)
+                         const void* data)
 {
   if (!IsContained(GroupName))
     CreateGroup(GroupName);

--- a/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
+++ b/packages/epetraext/src/inout/EpetraExt_HDF5.cpp
@@ -392,7 +392,7 @@ void EpetraExt::HDF5::Open(const std::string FileName, int AccessType)
 }
 
 // ==========================================================================
-bool EpetraExt::HDF5::IsContained(std::string Name)
+bool EpetraExt::HDF5::IsContained(std::string Name, std::string GroupName)
 {
   if (!IsOpen())
     throw(Exception(__FILE__, __LINE__, "no file open yet"));
@@ -401,8 +401,21 @@ bool EpetraExt::HDF5::IsContained(std::string Name)
   data.name = Name;
   data.found = false;
 
+  // recursively look for groups
+  size_t pos = Name.find("/");
+  if (pos != std::string::npos)
+  {
+    std::string NewGroupName = Name.substr(0, pos);
+    if (GroupName != "")
+      NewGroupName = GroupName + "/" + NewGroupName;
+    std::string NewName = Name.substr(pos + 1);
+    return IsContained(NewName, NewGroupName);
+  }
+
+  GroupName = "/" + GroupName;
+
   //int idx_f =
-  H5Giterate(file_id_, "/", NULL, FindDataset, (void*)&data);
+  H5Giterate(file_id_, GroupName.c_str(), NULL, FindDataset, (void*)&data);
 
   return(data.found);
 }

--- a/packages/epetraext/src/inout/EpetraExt_HDF5.h
+++ b/packages/epetraext/src/inout/EpetraExt_HDF5.h
@@ -374,7 +374,7 @@ class HDF5
     }
 
     //! Return \c true if \c Name is contained in the database.
-    bool IsContained(const std::string Name);
+    bool IsContained(std::string Name, std::string GroupName = "");
 
     // @}
     // @{ \name basic non-distributed data types

--- a/packages/epetraext/src/inout/EpetraExt_HDF5.h
+++ b/packages/epetraext/src/inout/EpetraExt_HDF5.h
@@ -404,7 +404,7 @@ class HDF5
     //! Write the serial array \c data, of type \c type, to group \c GroupName, using the dataset name \c DataSetName
     void Write(const std::string& GroupName, const std::string& DataSetName,
                          const hid_t type, const int Length, 
-                         void* data);
+                         const void* data);
 
     //! Associate string \c Comment with group \c GroupName.
     void WriteComment(const std::string& GroupName, std::string Comment)

--- a/packages/epetraext/test/inout/CMakeLists.txt
+++ b/packages/epetraext/test/inout/CMakeLists.txt
@@ -8,3 +8,10 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ARGS -v
   COMM serial mpi
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  inout_hdf5_test
+  SOURCES
+    EpetraExt_HDF5_UnitTest.cpp
+  COMM serial mpi
+  )

--- a/packages/epetraext/test/inout/EpetraExt_HDF5_UnitTest.cpp
+++ b/packages/epetraext/test/inout/EpetraExt_HDF5_UnitTest.cpp
@@ -80,6 +80,33 @@ TEUCHOS_UNIT_TEST(EpetraExt_HDF5, WriteReadInt)
   TEST_EQUALITY(value1, value2);
 }
 
+TEUCHOS_UNIT_TEST(EpetraExt_HDF5, NestedGroups)
+{
+#ifdef EPETRA_MPI
+  Epetra_MpiComm comm(MPI_COMM_WORLD);
+#else
+  Epetra_SerialComm comm;
+#endif
+
+  HDF5 file1(comm);
+  file1.Create("HDF5_test.h5");
+
+  const int value1 = 5;
+  file1.CreateGroup("group 1");
+  file1.CreateGroup("group 1/group 2");
+  file1.Write("group 1/group 2/data", "int", value1);
+  file1.Close();
+
+  HDF5 file2(comm);
+  file2.Open("HDF5_test.h5");
+
+  int value2 = -1;
+  file2.Read("group 1/group 2/data", "int", value2);
+  file2.Close();
+
+  TEST_EQUALITY(value1, value2);
+}
+
 } // namespace EpetraExt
 
 int main(int argc, char* argv[])

--- a/packages/epetraext/test/inout/EpetraExt_HDF5_UnitTest.cpp
+++ b/packages/epetraext/test/inout/EpetraExt_HDF5_UnitTest.cpp
@@ -1,0 +1,89 @@
+//@HEADER
+// ***********************************************************************
+//
+//     EpetraExt: Epetra Extended - Linear Algebra Services Package
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+//@HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+
+#ifdef HAVE_MPI
+#include "mpi.h"
+#include "Epetra_MpiComm.h"
+#else
+#include "Epetra_SerialComm.h"
+#endif
+
+#include "Epetra_Vector.h"
+
+#include "EpetraExt_HDF5.h"
+
+namespace EpetraExt {
+
+TEUCHOS_UNIT_TEST(EpetraExt_HDF5, WriteReadInt)
+{
+#ifdef EPETRA_MPI
+  Epetra_MpiComm comm(MPI_COMM_WORLD);
+#else
+  Epetra_SerialComm comm;
+#endif
+
+  HDF5 file1(comm);
+  file1.Create("HDF5_test.h5");
+
+  const int value1 = 5;
+  file1.Write("data", "int", value1);
+  file1.Close();
+
+  HDF5 file2(comm);
+  file2.Open("HDF5_test.h5");
+
+  int value2 = -1;
+  file2.Read("data", "int", value2);
+  file2.Close();
+
+  TEST_EQUALITY(value1, value2);
+}
+
+} // namespace EpetraExt
+
+int main(int argc, char* argv[])
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/epetraext/test/inout/EpetraExt_HDF5_UnitTest.cpp
+++ b/packages/epetraext/test/inout/EpetraExt_HDF5_UnitTest.cpp
@@ -49,8 +49,6 @@
 #include "Epetra_SerialComm.h"
 #endif
 
-#include "Epetra_Vector.h"
-
 #include "EpetraExt_HDF5.h"
 
 namespace EpetraExt {
@@ -78,6 +76,32 @@ TEUCHOS_UNIT_TEST(EpetraExt_HDF5, WriteReadInt)
   file2.Close();
 
   TEST_EQUALITY(value1, value2);
+}
+
+TEUCHOS_UNIT_TEST(EpetraExt_HDF5, WriteReadSerialData)
+{
+#ifdef EPETRA_MPI
+  Epetra_MpiComm comm(MPI_COMM_WORLD);
+#else
+  Epetra_SerialComm comm;
+#endif
+
+  HDF5 file1(comm);
+  file1.Create("HDF5_test.h5");
+
+  const int data1[2] = {1, 2};
+  file1.Write("data", "values", H5T_NATIVE_INT, 2, data1);
+  file1.Close();
+
+  HDF5 file2(comm);
+  file2.Open("HDF5_test.h5");
+
+  int data2[2] = {-1, -1};
+  file2.Read("data", "values", H5T_NATIVE_INT, 2, data2);
+  file2.Close();
+
+  TEST_EQUALITY(data1[0], data2[0]);
+  TEST_EQUALITY(data1[1], data2[1]);
 }
 
 TEUCHOS_UNIT_TEST(EpetraExt_HDF5, NestedGroups)


### PR DESCRIPTION
@trilinos/EpetraExt

## Description
Nested groups are not handled correctly in EpetraExt_HDF5. These groups are denoted by `/Group A/Group B/Group C/data`. Writing and reading from these groups actually works fine, just the `IsContained` method, which only does some safety checks, does not handle them correctly.

I also added a missing const while I was working on the code anyway.

## Motivation and Context
Reason why one might need this is when writing a data structure which contains an array of `Epetra_Vectors`. Doing this without nested groups would look like a mess since all data is sorted alphabetically.

## How Has This Been Tested?
A new unit test file was added and tests were added to confirm the behaviour of the changed functionality.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
