### PR TITLE
Intrepid2: Improved performance by eliminating subviews in contractio…

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
@@ -80,14 +80,9 @@ namespace Intrepid2 {
                            _outputFields.extent(2),
                            iter );
 
-//        auto result = Kokkos::subview( _outputFields,  cl, lbf, rbf );
-//
-//        const auto left  = Kokkos::subview( _leftFields,  cl, lbf, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() );
-//        const auto right = Kokkos::subview( _rightFields, cl, rbf, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() );
-
-        const size_type npts = _leftFields.dimension(2);
-        const ordinal_type iend = _leftFields.dimension(3);
-        const ordinal_type jend = _leftFields.dimension(4);
+        const size_type npts = _leftFields.extent(2);
+        const ordinal_type iend = _leftFields.extent(3);
+        const ordinal_type jend = _leftFields.extent(4);
 
         value_type tmp(0);        
         for (size_type qp = 0; qp < npts; ++qp) 

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
@@ -80,24 +80,24 @@ namespace Intrepid2 {
                            _outputFields.extent(2),
                            iter );
 
-        auto result = Kokkos::subview( _outputFields,  cl, lbf, rbf );
+//        auto result = Kokkos::subview( _outputFields,  cl, lbf, rbf );
+//
+//        const auto left  = Kokkos::subview( _leftFields,  cl, lbf, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() );
+//        const auto right = Kokkos::subview( _rightFields, cl, rbf, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() );
 
-        const auto left  = Kokkos::subview( _leftFields,  cl, lbf, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() );
-        const auto right = Kokkos::subview( _rightFields, cl, rbf, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() );
-
-        const size_type npts = left.extent(0);
-        const ordinal_type iend = left.extent(1);
-        const ordinal_type jend = left.extent(2);
+        const size_type npts = _leftFields.dimension(2);
+        const ordinal_type iend = _leftFields.dimension(3);
+        const ordinal_type jend = _leftFields.dimension(4);
 
         value_type tmp(0);        
         for (size_type qp = 0; qp < npts; ++qp) 
           for (ordinal_type i = 0; i < iend; ++i) 
             for (ordinal_type j = 0; j < jend; ++j) 
-              tmp += left(qp, i, j)*right(qp, i, j);
+              tmp += _leftFields(cl, lbf, qp, i, j)*_rightFields(cl, rbf, qp, i, j);
         if (_sumInto)
-          result() = result() + tmp;
+          _outputFields( cl, lbf, rbf ) = _outputFields( cl, lbf, rbf ) + tmp;
         else
-          result() = tmp;
+          _outputFields( cl, lbf, rbf ) = tmp;
       }
     };
     } //end namespace


### PR DESCRIPTION
Intrepid2: Improved performance by eliminating subviews in contraction code.

@trilinos/intrepid2 

## Description
Changed a few lines to eliminate the use of subviews in an array contraction kernel.

## Motivation and Context
For CPU runs in particular, this makes a big difference for performance.  In a build using Apple clang run on CPU in serial, the **overall** runtime of a fifth-order Poisson assembly was improved by a factor of 1.8; first-order assembly was improved by a factor of 1.3.  (Restricting to integration time, the speedup was between 2.2x and 2.6x across several polynomial orders.)

## How Has This Been Tested?
I have run the standard Intrepid2 tests on a serial, optimized build using Apple Clang on an iMac.  They all pass.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
