### PR TITLE
Panzer hcurl mass from l2projection

### DIFF
--- a/packages/panzer/adapters-stk/test/projection/projection.cpp
+++ b/packages/panzer/adapters-stk/test/projection/projection.cpp
@@ -44,6 +44,7 @@
 #include "PanzerAdaptersSTK_config.hpp"
 #include "Panzer_STK_Interface.hpp"
 #include "Panzer_STK_CubeHexMeshFactory.hpp"
+#include "Panzer_STK_SquareQuadMeshFactory.hpp"
 #include "Panzer_STK_WorksetFactory.hpp"
 #include "Panzer_STKConnManager.hpp"
 
@@ -61,9 +62,11 @@
 #include "Panzer_L2Projection.hpp"
 #include "Panzer_DOFManager.hpp"
 #include "Panzer_BlockedDOFManager.hpp"
+#include "Panzer_BlockedTpetraLinearObjFactory.hpp"
 
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_CrsMatrix.hpp"
+#include "TpetraExt_MatrixMatrix.hpp"
 
 // Teuchos
 #include "Teuchos_DefaultMpiComm.hpp"
@@ -654,4 +657,159 @@ TEUCHOS_UNIT_TEST(L2Projection, ToNodal)
   options.output_histogram = false;
   options.num_histogram = 5;
   timer->report(out,comm,options);
+}
+
+TEUCHOS_UNIT_TEST(L2Projection, CurlMassMatrix)
+{
+  using namespace Teuchos;
+  using namespace panzer;
+  using namespace panzer_stk;
+
+  RCP<MpiComm<int>> comm = rcp(new MpiComm<int>(MPI_COMM_WORLD));
+
+  auto timer = Teuchos::TimeMonitor::getStackedTimer();
+  timer->start("Total Time");
+
+  const int myRank = comm->getRank();
+  const int numProcs = comm->getSize();
+  const int numXElements = 4;
+  const int numYElements = 2;
+  const double boxLength = 1.0;
+  const double boxHeight = 0.5;
+  TEUCHOS_ASSERT(numXElements >= numProcs);
+
+  RCP<panzer_stk::STK_Interface> mesh;
+  {
+    PANZER_FUNC_TIME_MONITOR("L2Projection: mesh construction");
+    Teuchos::RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+    pl->set("X Blocks",1);
+    pl->set("Y Blocks",1);
+    pl->set("X Elements",numXElements);
+    pl->set("Y Elements",numYElements);
+    pl->set("X Procs",numProcs);
+    pl->set("Y Procs",1);
+    pl->set("X0",0.0);
+    pl->set("Y0",0.0);
+    pl->set("Xf",boxLength);
+    pl->set("Yf",boxHeight);
+    panzer_stk::SquareQuadMeshFactory factory;
+    factory.setParameterList(pl);
+    mesh = factory.buildUncommitedMesh(MPI_COMM_WORLD);
+    factory.completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+  }
+
+  // Build Worksets
+
+  const int basisOrder = 1;
+  BasisDescriptor hcurlBD(basisOrder,"HCurl");
+  BasisDescriptor hdivBD(basisOrder,"HDiv");
+
+  const int intOrder = 2;
+  IntegrationDescriptor integrationDescriptor(intOrder,IntegrationDescriptor::VOLUME);
+
+  WorksetNeeds worksetNeeds;
+  worksetNeeds.addBasis(hcurlBD);
+  worksetNeeds.addBasis(hdivBD);
+  worksetNeeds.addIntegrator(integrationDescriptor);
+
+  RCP<WorksetFactory> worksetFactory(new WorksetFactory(mesh));
+  std::vector<std::string> eBlockNames;
+  mesh->getElementBlockNames(eBlockNames);
+  std::map<std::string,WorksetNeeds> eblockNeeds;
+  for (const auto& block : eBlockNames)
+    eblockNeeds[block] = worksetNeeds;
+  RCP<WorksetContainer> worksetContainer(new WorksetContainer(worksetFactory,eblockNeeds));
+
+  // Build Connection Manager
+  using LO = int;
+  using GO = panzer::Ordinal64;
+  timer->start("ConnManager ctor");
+  const RCP<panzer::ConnManager<LO,GO> > connManager = rcp(new panzer_stk::STKConnManager<GO>(mesh));
+  timer->stop("ConnManager ctor");
+
+  // Set up bases for projections
+  auto cellTopology = mesh->getCellTopology(eBlockNames[0]);
+
+  auto curlBasis = panzer::createIntrepid2Basis<PHX::Device,double,double>(hcurlBD.getType(),hcurlBD.getOrder(),*cellTopology);
+  RCP<const panzer::FieldPattern> hcurlFP(new panzer::Intrepid2FieldPattern(curlBasis));
+
+  auto divBasis = panzer::createIntrepid2Basis<PHX::Device,double,double>(hdivBD.getType(),hdivBD.getOrder(),*cellTopology);
+  RCP<const panzer::FieldPattern> hdivFP(new panzer::Intrepid2FieldPattern(divBasis));
+
+  // Build source DOF Manager for edge and face DOFs
+  timer->start("Build sourceGlobalIndexer");
+  RCP<panzer::BlockedDOFManager<LO,GO>> sourceGlobalIndexer = rcp(new panzer::BlockedDOFManager<LO,GO>(connManager,*comm->getRawMpiComm()));
+  sourceGlobalIndexer->addField("E_Field",hcurlFP); // Electric Field for EM
+  sourceGlobalIndexer->addField("B_Field",hdivFP); // Magnetic Field for EM
+  sourceGlobalIndexer->buildGlobalUnknowns();
+  timer->stop("Build sourceGlobalIndexer");
+
+  // Build projection factory
+  timer->start("projectionFactory.setup()");
+  panzer::L2Projection<LO,GO> projectionFactory;
+  worksetContainer->setGlobalIndexer(sourceGlobalIndexer);
+  projectionFactory.setup(hcurlBD,integrationDescriptor,comm,connManager,eBlockNames,worksetContainer);
+  timer->stop("projectionFactory.setup()");
+
+  TEST_ASSERT(nonnull(projectionFactory.getTargetGlobalIndexer()));
+
+  // Build mass matrix
+  timer->start("projectionFactory.buildMassMatrix()");
+  auto curlMassMatrix = projectionFactory.buildMassMatrix();
+  timer->stop("projectionFactory.buildMassMatrix()");
+  curlMassMatrix->print(out);
+  curlMassMatrix->getRowMap()->describe(out,Teuchos::EVerbosityLevel::VERB_EXTREME);
+  curlMassMatrix->getColMap()->describe(out,Teuchos::EVerbosityLevel::VERB_EXTREME);
+
+  // Build the mass matrix from connectivity knowing that this is a regular quad mesh
+  timer->start("build mass matrix from connectivity");
+
+  // get local ids
+  auto e_ugi = sourceGlobalIndexer->getFieldDOFManagers()[sourceGlobalIndexer->getFieldBlock(sourceGlobalIndexer->getFieldNum("E_Field"))];
+  auto lids = e_ugi->getLIDs();
+
+  // set up a global and ghosted mass matrix 
+  std::vector<Teuchos::RCP<const panzer::UniqueGlobalIndexer<LO,GO>>> indexers;
+  indexers.push_back(e_ugi);
+  panzer::BlockedTpetraLinearObjFactory<panzer::Traits,double,LO,GO,panzer::TpetraNodeType> factory(comm,indexers);
+  auto connMassMatrix = factory.getTpetraMatrix(0,0);
+  auto ghostedMatrix = factory.getGhostedTpetraMatrix(0,0);
+  connMassMatrix->resumeFill();
+  connMassMatrix->setAllToScalar(0.0);
+  ghostedMatrix->resumeFill();
+  ghostedMatrix->setAllToScalar(0.0);
+  PHX::Device::fence();
+
+  // fill in the mass matrix
+  // the integral of the edge basis squared over one cell is 1/3
+  // the integral of the edge basis times the basis function across from it in the element is 1/6
+  const auto localMass = ghostedMatrix->getLocalMatrix();
+  const int numElems = lids.extent(0);
+  Kokkos::parallel_for(numElems, KOKKOS_LAMBDA (const int& i) {
+    double row_values[2]={1.0/3.0,1.0/6.0};
+    LO cols[2];
+    for(int r = 0; r < 4; r++){
+      cols[0] = lids(i,r);
+      cols[1] = lids(i,(r+2)%4);
+      int num_insert =  localMass.sumIntoValues(lids(i,r),cols,2,row_values,false,true);
+    }
+  });
+  PHX::Device::fence();
+  ghostedMatrix->fillComplete();
+  const auto exporter = factory.getGhostedExport(0);
+  connMassMatrix->doExport(*ghostedMatrix, *exporter, Tpetra::ADD);
+  connMassMatrix->fillComplete();
+  timer->stop("build mass matrix from connectivity");
+
+  connMassMatrix->print(out);
+  connMassMatrix->getRowMap()->describe(out,Teuchos::EVerbosityLevel::VERB_EXTREME);
+  connMassMatrix->getColMap()->describe(out,Teuchos::EVerbosityLevel::VERB_EXTREME);
+
+  // compute difference between the two versions of the mass matrix
+  using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device>;
+  auto difference = Tpetra::MatrixMatrix::add<double,LO,GO,NodeType>(1.0,false,*curlMassMatrix,-1.0,false,*connMassMatrix);
+  double error = difference->getFrobeniusNorm();
+  double norm = connMassMatrix->getFrobeniusNorm();
+  double tol = 1.0e-14;
+  TEST_COMPARE(error,<,tol*norm);
 }

--- a/packages/panzer/disc-fe/src/Panzer_L2Projection_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_L2Projection_impl.hpp
@@ -94,61 +94,125 @@ namespace panzer {
     auto M = ghostedMatrix->getLocalMatrix();
     const int fieldIndex = targetGlobalIndexer_->getFieldNum(targetBasisDescriptor_.getType());
 
+    const bool is_scalar = targetBasisDescriptor_.getType()=="HGrad" || targetBasisDescriptor_.getType()=="Const";
+
     // Loop over element blocks and fill mass matrix
-    for (const auto& block : elementBlockNames_) {
+    if(is_scalar){
+      for (const auto& block : elementBlockNames_) {
 
-      // Based on descriptor, currently assumes there should only be one workset
-      panzer::WorksetDescriptor wd(block,panzer::WorksetSizeType::ALL_ELEMENTS,true,true);
-      const auto& worksets = worksetContainer_->getWorksets(wd);
+        // Based on descriptor, currently assumes there should only be one workset
+        panzer::WorksetDescriptor wd(block,panzer::WorksetSizeType::ALL_ELEMENTS,true,true);
+        const auto& worksets = worksetContainer_->getWorksets(wd);
 
-      for (const auto& workset : *worksets) {
+        for (const auto& workset : *worksets) {
 
-        const auto& basisValues = workset.getBasisValues(targetBasisDescriptor_,integrationDescriptor_);
+          const auto& basisValues = workset.getBasisValues(targetBasisDescriptor_,integrationDescriptor_);
         
-        const auto& unweightedBasis = basisValues.basis_scalar;
-        const auto& weightedBasis = basisValues.weighted_basis_scalar;
+          const auto& unweightedBasis = basisValues.basis_scalar;
+          const auto& weightedBasis = basisValues.weighted_basis_scalar;
         
-        // Offsets (this assumes UVM, need to fix)
-        const std::vector<LO>& offsets = targetGlobalIndexer_->getGIDFieldOffsets(block,fieldIndex);
-        PHX::View<LO*> kOffsets("MassMatrix: Offsets",offsets.size());
-        for(const auto& i : offsets)
-          kOffsets(i) = offsets[i];
+          // Offsets (this assumes UVM, need to fix)
+          const std::vector<LO>& offsets = targetGlobalIndexer_->getGIDFieldOffsets(block,fieldIndex);
+          PHX::View<LO*> kOffsets("MassMatrix: Offsets",offsets.size());
+          for(const auto& i : offsets)
+            kOffsets(i) = offsets[i];
         
-        PHX::Device::fence();
+          PHX::Device::fence();
         
-        // Local Ids
-        Kokkos::View<LO**,PHX::Device> localIds("MassMatrix: LocalIds", workset.numOwnedCells()+workset.numGhostCells()+workset.numVirtualCells(),
-                                                targetGlobalIndexer_->getElementBlockGIDCount(block));
+          // Local Ids
+          Kokkos::View<LO**,PHX::Device> localIds("MassMatrix: LocalIds", workset.numOwnedCells()+workset.numGhostCells()+workset.numVirtualCells(),
+                                                  targetGlobalIndexer_->getElementBlockGIDCount(block));
         
-        // Remove the ghosted cell ids or the call to getElementLocalIds will spill array bounds
-        const auto cellLocalIdsNoGhost = Kokkos::subview(workset.cell_local_ids_k,std::make_pair(0,workset.numOwnedCells()));
+          // Remove the ghosted cell ids or the call to getElementLocalIds will spill array bounds
+          const auto cellLocalIdsNoGhost = Kokkos::subview(workset.cell_local_ids_k,std::make_pair(0,workset.numOwnedCells()));
         
-        targetGlobalIndexer_->getElementLIDs(cellLocalIdsNoGhost,localIds);
+          targetGlobalIndexer_->getElementLIDs(cellLocalIdsNoGhost,localIds);
         
-        const int numBasisPoints = static_cast<int>(weightedBasis.extent(1));
-        Kokkos::parallel_for(workset.numOwnedCells(),KOKKOS_LAMBDA (const int& cell) {
+          const int numBasisPoints = static_cast<int>(weightedBasis.extent(1));
+          Kokkos::parallel_for(workset.numOwnedCells(),KOKKOS_LAMBDA (const int& cell) {
             
-          LO cLIDs[256];
-          const int numIds = static_cast<int>(localIds.extent(1));
-          for(int i=0;i<numIds;++i)
-            cLIDs[i] = localIds(cell,i);
+            LO cLIDs[256];
+            const int numIds = static_cast<int>(localIds.extent(1));
+            for(int i=0;i<numIds;++i)
+              cLIDs[i] = localIds(cell,i);
           
-          double vals[256];
-          const int numQP = static_cast<int>(unweightedBasis.extent(2));
+            double vals[256];
+            const int numQP = static_cast<int>(unweightedBasis.extent(2));
           
-          for (int qp=0; qp < numQP; ++qp) {
-            for (int row=0; row < numBasisPoints; ++row) {
-              int offset = kOffsets(row);
-              LO lid = localIds(cell,offset);
+            for (int qp=0; qp < numQP; ++qp) {
+              for (int row=0; row < numBasisPoints; ++row) {
+                int offset = kOffsets(row);
+                LO lid = localIds(cell,offset);
               
-              for (int col=0; col < numIds; ++col)
-                vals[col] = unweightedBasis(cell,row,qp) * weightedBasis(cell,col,qp);
+                for (int col=0; col < numIds; ++col)
+                  vals[col] = unweightedBasis(cell,row,qp) * weightedBasis(cell,col,qp);
               
-              M.sumIntoValues(lid,cLIDs,numIds,vals,true,true);
+                M.sumIntoValues(lid,cLIDs,numIds,vals,true,true);
+              }
             }
-          }
    
-        });
+          });
+        }
+      }
+    } else {
+      for (const auto& block : elementBlockNames_) {
+
+        // Based on descriptor, currently assumes there should only be one workset
+        panzer::WorksetDescriptor wd(block,panzer::WorksetSizeType::ALL_ELEMENTS,true,true);
+        const auto& worksets = worksetContainer_->getWorksets(wd);
+
+        for (const auto& workset : *worksets) {
+
+          const auto& basisValues = workset.getBasisValues(targetBasisDescriptor_,integrationDescriptor_);
+        
+          const auto& unweightedBasis = basisValues.basis_vector;
+          const auto& weightedBasis = basisValues.weighted_basis_vector;
+        
+          // Offsets (this assumes UVM, need to fix)
+          const std::vector<LO>& offsets = targetGlobalIndexer_->getGIDFieldOffsets(block,fieldIndex);
+          PHX::View<LO*> kOffsets("MassMatrix: Offsets",offsets.size());
+          for(const auto& i : offsets)
+            kOffsets(i) = offsets[i];
+        
+          PHX::Device::fence();
+        
+          // Local Ids
+          Kokkos::View<LO**,PHX::Device> localIds("MassMatrix: LocalIds", workset.numOwnedCells()+workset.numGhostCells()+workset.numVirtualCells(),
+                                                  targetGlobalIndexer_->getElementBlockGIDCount(block));
+        
+          // Remove the ghosted cell ids or the call to getElementLocalIds will spill array bounds
+          const auto cellLocalIdsNoGhost = Kokkos::subview(workset.cell_local_ids_k,std::make_pair(0,workset.numOwnedCells()));
+        
+          targetGlobalIndexer_->getElementLIDs(cellLocalIdsNoGhost,localIds);
+        
+          const int numBasisPoints = static_cast<int>(weightedBasis.extent(1));
+          Kokkos::parallel_for(workset.numOwnedCells(),KOKKOS_LAMBDA (const int& cell) {
+            
+            LO cLIDs[256];
+            const int numIds = static_cast<int>(localIds.extent(1));
+            for(int i=0;i<numIds;++i)
+              cLIDs[i] = localIds(cell,i);
+          
+            double vals[256];
+            const int numQP = static_cast<int>(unweightedBasis.extent(2));
+          
+            for (int qp=0; qp < numQP; ++qp) {
+              for (int row=0; row < numBasisPoints; ++row) {
+                int offset = kOffsets(row);
+                LO lid = localIds(cell,offset);
+              
+                for (int col=0; col < numIds; ++col){
+                  vals[col] = 0.0;
+                  for(int dim=0; dim < weightedBasis.extent(3); dim++)
+                    vals[col] += unweightedBasis(cell,row,qp,dim) * weightedBasis(cell,col,qp,dim);
+                }             
+ 
+                M.sumIntoValues(lid,cLIDs,numIds,vals,true,true);
+              }
+            }
+   
+          });
+        }
       }
     }
     PHX::exec_space::fence();


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

## Description
<!--- Please describe your changes in detail. -->
Added computation of mass matrix for vector DOFs to L2Projection. This really just amounted to using basis_vector instead of basis_scalar in a few places.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This provides a nice, simple interface to construct mass matrices for HCurl and HDiv fields now.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
I added a test to the projection unit test that uses L2Projection to build an HCurl mass matrix. It's on a uniform quad mesh, so I know exactly what the mass matrix should look like, so I construct the mass matrix that way as well. The matrices are the same to a tolerance of 1e-14.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
