### PR TITLE
Switch SEMS env default to match GCC 4.8.4 OpenMPI 1.10.1 CI build (#3407)

### DIFF
--- a/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
+++ b/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
@@ -15,5 +15,4 @@ else
   return
 fi
 
-source ${_SCRIPT_DIR}/../load_sems_dev_env.sh \
-  sems-gcc/4.8.4 sems-openmpi/1.10.1 atdm-cmake/3.11.1
+source ${_SCRIPT_DIR}/../load_sems_dev_env.sh

--- a/cmake/std/sems/get_default_modules.sh
+++ b/cmake/std/sems/get_default_modules.sh
@@ -9,9 +9,9 @@ else
   exit 1
 fi
 
-sems_mpi_and_version_default=sems-openmpi/1.6.5
+sems_mpi_and_version_default=sems-openmpi/1.10.1
 sems_python_and_version_default=sems-python/2.7.9
-sems_cmake_and_version_default=sems-cmake/3.5.2
+sems_cmake_and_version_default=atdm-cmake/3.11.1
 sems_git_and_version_default=sems-git/2.10.1
 sems_boost_and_version_default=sems-boost/1.63.0/base
 sems_zlib_and_version_default=sems-zlib/1.2.8/base 


### PR DESCRIPTION
@dridzal, @mhoemmen

## Description

The default SEMS env should match the env used in the post-push CI build.
This change should have been made when the CI build was updated to use OpenMPI
1.10.1.

NOTE: This also updates the default CMake to 3.11.1.

This should resolve the errors reported in #3407.

## Motivation and Context

STK no longer supports OpenMPI 1.6.5 (see #3407)

## How Has This Been Tested?

I just loaded the env manually with:

```
$ . cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh

$ module list
Currently Loaded Modulefiles:
  1) sems-env
  2) atdm-env
  3) sems-python/2.7.9
  4) atdm-cmake/3.11.1
  5) sems-git/2.10.1
  6) atdm-ninja_fortran/1.7.2
  7) sems-gcc/4.8.4
  8) sems-openmpi/1.10.1
  9) sems-boost/1.63.0/base
 10) sems-zlib/1.2.8/base
 11) sems-hdf5/1.8.12/parallel
 12) sems-netcdf/4.4.1/exo_parallel
 13) sems-parmetis/4.0.3/parallel
 14) sems-scotch/6.0.3/nopthread_64bit_parallel
 15) sems-superlu/4.3/base
```

and

```
. cmake/load_sems_dev_env.sh default

$ module list
Currently Loaded Modulefiles:
  1) sems-env
  2) atdm-env
  3) sems-python/2.7.9
  4) atdm-cmake/3.11.1
  5) sems-git/2.10.1
  6) atdm-ninja_fortran/1.7.2
  7) sems-gcc/4.8.4
  8) sems-openmpi/1.10.1
  9) sems-boost/1.63.0/base
 10) sems-zlib/1.2.8/base
 11) sems-hdf5/1.8.12/parallel
 12) sems-netcdf/4.4.1/exo_parallel
 13) sems-parmetis/4.0.3/parallel
 14) sems-scotch/6.0.3/nopthread_64bit_parallel
 15) sems-superlu/4.3/base
```

<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
