### PR TITLE
Allow pamgen to compile with MinGW

### DIFF
--- a/packages/pamgen/src/CMakeLists.txt
+++ b/packages/pamgen/src/CMakeLists.txt
@@ -176,3 +176,8 @@ TRIBITS_ADD_LIBRARY(
 #
 
 #PACKAGE_EXPORT_DEPENDENCY_VARIABLES()
+
+if (WIN32)
+  target_compile_definitions (pamgen PRIVATE _USE_MATH_DEFINES)
+endif ()
+

--- a/packages/pamgen/src/Random.h
+++ b/packages/pamgen/src/Random.h
@@ -2,7 +2,7 @@
 
 
 // the system defined random number generator
-#ifdef _MSC_VER
+#ifdef _WIN32
 # define SRANDOM(i) srand(i)
 # define RANDOM() rand()
 #else


### PR DESCRIPTION
- USE_MATH_DEFINES macro is needed for the bessel functions j0/j1
- seems mingw has the same rand/srand apis than msvc