### PR TITLE
SEACAS: Install explore on all systems; symlink on SEACAS only

### DIFF
--- a/packages/seacas/applications/explore/CMakeLists.txt
+++ b/packages/seacas/applications/explore/CMakeLists.txt
@@ -24,8 +24,9 @@ TRIBITS_ADD_EXECUTABLE(
 
 if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")
 InstallSymLink(explore ${CMAKE_INSTALL_PREFIX}/bin/grope)
-install_executable(explore)
 endif()
+
+install_executable(explore)
 
 TRIBITS_SUBPACKAGE_POSTPROCESS()
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Description
<!--- Please describe your changes in detail. -->
The `explore` executable was not being installed in a Trilinos build due to an incorrect logic
in the CMakeLists.txt file.  In SEACAS, the `explore` executable is also symlinked to `grope` which was the previous name of the `explore` executable.  This symlink is not installed in a Trilinos build, but the logic to avoid this also incorrectly included not installing the `explore` executable also.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
