### PR TITLE
Import of stk development from Sierra stream

### DIFF
--- a/packages/stk/stk_io/stk_io/SidesetTranslator.hpp
+++ b/packages/stk/stk_io/stk_io/SidesetTranslator.hpp
@@ -52,7 +52,7 @@ inline size_t get_number_sides_in_sideset(OutputParams &params,
 {
     const mesh::BulkData &bulk = params.bulk_data();
     const stk::mesh::Selector *subset_selector = params.get_subset_selector();
-    const stk::mesh::Selector *output_selector = params.get_output_selector();
+    const stk::mesh::Selector *output_selector = params.get_output_selector(stk::topology::ELEM_RANK);
 
     const stk::mesh::Part &parentPart = stk::io::get_sideset_parent(ssPart);
 
@@ -111,7 +111,7 @@ void fill_element_and_side_ids(stk::io::OutputParams &params,
 {
     const mesh::BulkData &bulk_data = params.bulk_data();
     const stk::mesh::Selector *subset_selector = params.get_subset_selector();
-    const stk::mesh::Selector *output_selector = params.get_output_selector();
+    const stk::mesh::Selector *output_selector = params.get_output_selector(stk::topology::ELEM_RANK);
 
     const stk::mesh::Part &parentPart = stk::io::get_sideset_parent(*part);
 

--- a/packages/stk/stk_io/stk_io/StkIoUtils.cpp
+++ b/packages/stk/stk_io/stk_io/StkIoUtils.cpp
@@ -73,7 +73,7 @@ size_t get_entities_for_nodeblock(stk::io::OutputParams &params,
                     bool include_shared)
 {
     stk::mesh::Selector selector =  internal_build_selector(params.get_subset_selector(),
-                                                            params.get_output_selector(),
+                                                            params.get_output_selector(type),
                                                             params.get_shared_selector(),
                                                             part,
                                                             include_shared);
@@ -89,7 +89,7 @@ size_t get_entities(stk::io::OutputParams &params,
                         bool include_shared)
 {
     stk::mesh::Selector selector =  internal_build_selector(params.get_subset_selector(),
-                                                            params.get_output_selector(),
+                                                            params.get_output_selector(type),
                                                             nullptr,
                                                             part,
                                                             include_shared);


### PR DESCRIPTION
This imports stk development as of

commit e27c191218c3e6412114091434afae1417cb74d0
Author: Alan Williams <william@sandia.gov>
Date:   Sun Sep 9 13:03:52 2018 -0600

    Add ifdefs for MPI_VERSION in stk CommNeighbors class.

    CommNeighbors uses MPI_Neighbor* functions, which only exist in
    MPI implementations which support the MPI 3 standard. In the case
    of building with an MPI implementation older than that (which is
    rare, but Trilinos still has a build for OpenMPI 1.6),
    the code will still build but a run-time error will occur,
    stating that the user must use a newer MPI if they wish to use
    the stk CommNeighbors class.

    Change-Id: I365923bb52ae6aef5ef73dd69470d104b650c357
    Reviewed-on: https://sierra-git.sandia.gov:4443/349628
    Tested-by: Mark E Hamilton <sierra@sandia.gov>
    Reviewed-by: Kendall Hugh Pierson <khpiers@sandia.gov>

And includes fixes for issue #3377 #3390 and #3407

@trilinos/stk 

## Related Issues

* Closes #3377 #3390 and #3407

## How Has This Been Tested?
Sierra nightly build using gcc 4.9.3 and tribits

## Checklist

- [ x ] My commit messages mention the appropriate GitHub issue numbers.
- [ x ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

