### PR TITLE
Chnage the ATDM build on ride/white to use different netcdf

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -96,6 +96,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] ; then
   if [[ "$ATDM_CONFIG_COMPILER" == "CUDA-9.2" ]] ; then
     module load devpack/20180521/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88   
     module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+    module swap netcdf-exo/4.6.1/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88 netcdf/4.6.1/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
   else
     echo
     echo "***"


### PR DESCRIPTION
@trilinos/framework 
@bartlettroscoe 

## Description
issue: #3288

switch the netcdf module that is loaded for the builds on ride/white
to address some failing tests on white/ride