### PR TITLE
NOX: Fix single step parsing

### DIFF
--- a/packages/nox/src/NOX_Solver_SingleStep.C
+++ b/packages/nox/src/NOX_Solver_SingleStep.C
@@ -72,6 +72,7 @@ SingleStep(const Teuchos::RCP<NOX::Abstract::Group>& xGrp,
   validParams.set("Update Jacobian",true,"Recompute the Jacobian at each Newton iteration.");
   validParams.set("Print Norms",false,"Print the norms at each iteration.");
   validParams.set("Compute Relative Norm",false, "Computes relative norm, print only if \"Print Norms\" is enabled.");
+  validParams.sublist("Linear Solver"); // Allows for arbitrary/user defined linear solve parameters to be set
   p->sublist("Single Step Solver").validateParametersAndSetDefaults(validParams,0);
   NOX::Solver::validateSolverOptionsSublist(p->sublist("Solver Options"));
   globalDataPtr = Teuchos::rcp(new NOX::GlobalData(p));
@@ -158,7 +159,7 @@ bool NOX::Solver::SingleStep::try_step()
 
   // Reuse memory in group instead of new allocation for dir
   NOX::Abstract::Vector& dir = const_cast<NOX::Abstract::Vector&>(solnPtr->getNewton());
-  const auto ls_status = jacobian->applyJacobianInverse(paramsPtr->sublist("Linear Solver"),
+  const auto ls_status = jacobian->applyJacobianInverse(paramsPtr->sublist("Single Step Solver").sublist("Linear Solver"),
                                                         solnPtr->getF(),
                                                         dir);
 

--- a/packages/nox/test/epetra/Thyra/Thyra_SingleStepSolver_1D.C
+++ b/packages/nox/test/epetra/Thyra/Thyra_SingleStepSolver_1D.C
@@ -139,6 +139,8 @@ TEUCHOS_UNIT_TEST(SingleStepSolver, WithResetModel)
   TEST_EQUALITY(solve_status.extraParameters->get<int>("Number of Iterations"), 1);
   TEST_EQUALITY(solve_status.solveStatus, ::Thyra::SOLVE_STATUS_CONVERGED);
 
+  nl_params->print(std::cout);
+
   Teuchos::TimeMonitor::summarize();
 }
 
@@ -266,6 +268,7 @@ TEUCHOS_UNIT_TEST(SingleStepSolver, reuseJacobian)
   nl_params->sublist("Single Step Solver").set("Update Jacobian", false);
   nl_params->sublist("Single Step Solver").set("Print Norms", true);
   nl_params->sublist("Single Step Solver").set("Compute Relative Norm", true);
+  nl_params->sublist("Single Step Solver").sublist("Linear Solver").set("Tolerance", 1.0e-7);
 
   // Create a Thyra nonlinear solver
   Teuchos::RCP< ::Thyra::NOXNonlinearSolver> solver =


### PR DESCRIPTION
Minor fix to SingleStep solver so that the ls tolerance can be set from main solver plist. It was passing  the wrong sublist to stratimikos resulting in the default tolerance was always being used.