### PR TITLE
Fix checkin-test-sems.sh

### DIFF
--- a/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
+++ b/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
@@ -15,4 +15,5 @@ else
   return
 fi
 
-source ${_SCRIPT_DIR}/../load_sems_dev_env.sh
+source ${_SCRIPT_DIR}/../load_sems_dev_env.sh ""
+# NOTE: Above, must pass empty arg "" or bash will pass in "$@" which is bad!

--- a/cmake/std/sems/checkin-test-sems.sh
+++ b/cmake/std/sems/checkin-test-sems.sh
@@ -93,7 +93,7 @@ fi
 
 if [ "$TRILINOS_CHECKIN_TEST_SEMS_SKIP_MODULE_LOAD" == "" ] ; then
   export TRILINOS_SEMS_DEV_ENV_VERBOSE=1
-  source $TRILINOS_DIR/cmake/std/GCC-4.8.4-OpenMPI-1.10.1-MpiReleaseDebugSharedPtOpenMP_env.sh
+  source $TRILINOS_DIR/cmake/load_sems_dev_env.sh ""
   # NOTE: Above, must pass empty arg "" or bash will pass in "$@" which is
   # bad!
 else


### PR DESCRIPTION
It was passing in the arguments to checkin-test-sems.sh to the soruce script
which is not what you want.  This is a silly bash behavior.  It should be
fixed in all use cases now.
