### PR TITLE
NOX: aggregate line search statistics

### DIFF
--- a/packages/nox/src-thyra/NOX_LineSearch_SafeguardedDirection.cpp
+++ b/packages/nox/src-thyra/NOX_LineSearch_SafeguardedDirection.cpp
@@ -51,6 +51,7 @@
 #include "NOX_LineSearch_SafeguardedDirection.hpp"
 
 #include "NOX_LineSearch_Utils_Printing.H"
+#include "NOX_LineSearch_Utils_Counters.H"
 #include "NOX_LineSearch_Utils_Slope.H"
 #include "NOX_Abstract_Vector.H"
 #include "NOX_Abstract_Group.H"
@@ -60,6 +61,7 @@
 #include "NOX_MeritFunction_Generic.H"
 #include "NOX_StatusTest_FiniteValue.H"
 #include "NOX_GlobalData.H"
+#include "NOX_SolverStats.hpp"
 #include "NOX_TOpEleWiseMinSwap.hpp"
 #include "NOX_Thyra_Vector.H"
 #include "Thyra_VectorBase.hpp"
@@ -70,7 +72,8 @@ SafeguardedDirection(const Teuchos::RCP<NOX::GlobalData>& gd,
              Teuchos::ParameterList& params) :
   paramsPtr_(NULL),
   globalDataPtr_(gd),
-  print_(gd->getUtils())
+  print_(gd->getUtils()),
+  counter_(&gd->getNonConstSolverStatistics()->line_search)
 {
   reset(gd, params);
 }
@@ -81,6 +84,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 {
   globalDataPtr_ = gd;
   print_.reset(gd->getUtils());
+  counter_ = &gd->getNonConstSolverStatistics()->line_search;
   paramsPtr_ = &params;
 
   Teuchos::ParameterList& p = params.sublist("Safeguarded Direction");
@@ -100,7 +104,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 
   // Set up counter
   if (useCounter_)
-    counter_.reset();
+    counter_->reset();
 
   return true;
 }
@@ -113,8 +117,8 @@ bool NOX::LineSearch::SafeguardedDirection::compute(Abstract::Group& newGrp,
   printOpeningRemarks();
 
   if (useCounter_) {
-    counter_.incrementNumLineSearches();
-    counter_.incrementNumNonTrivialLineSearches();
+    counter_->incrementNumLineSearches();
+    counter_->incrementNumNonTrivialLineSearches();
   }
 
   // Limit individual entries
@@ -157,7 +161,7 @@ bool NOX::LineSearch::SafeguardedDirection::compute(Abstract::Group& newGrp,
   }
 
   if (useCounter_)
-    counter_.setValues(*paramsPtr_);
+    counter_->setValues(*paramsPtr_);
 
   return true;
 }

--- a/packages/nox/src-thyra/NOX_LineSearch_SafeguardedDirection.hpp
+++ b/packages/nox/src-thyra/NOX_LineSearch_SafeguardedDirection.hpp
@@ -54,7 +54,6 @@
 #include "NOX_LineSearch_Generic.H" // base class
 
 #include "NOX_LineSearch_Utils_Printing.H"  // class data member
-#include "NOX_LineSearch_Utils_Counters.H"  // class data member
 #include "Teuchos_RCP.hpp"          // class data member
 
 // Forward Declarations
@@ -62,6 +61,7 @@ namespace NOX {
   namespace MeritFunction {
     class Generic;
   }
+  class LineSearchCounters;
 }
 
 namespace NOX {
@@ -104,7 +104,7 @@ private:
   bool useCounter_;
   Teuchos::RCP<NOX::GlobalData> globalDataPtr_;
   NOX::LineSearch::Utils::Printing print_;
-  NOX::LineSearch::Utils::Counters counter_;
+  NOX::LineSearchCounters* counter_;
 
 };
 } // namespace LineSearch

--- a/packages/nox/src/CMakeLists.txt
+++ b/packages/nox/src/CMakeLists.txt
@@ -126,6 +126,7 @@ APPEND_SET(HEADERS
   NOX_Solver_AndersonAcceleration.H
   NOX_Solver_PrePostOperator.H
   NOX_Solver_SingleStep.H
+  NOX_SolverStats.hpp
   )
 APPEND_SET(SOURCES
   NOX_Solver_Factory.C

--- a/packages/nox/src/NOX_GlobalData.C
+++ b/packages/nox/src/NOX_GlobalData.C
@@ -51,6 +51,7 @@
 #include "NOX_GlobalData.H"
 #include "Teuchos_ParameterList.hpp"
 #include "NOX_MeritFunction_SumOfSquares.H"
+#include "NOX_SolverStats.hpp"
 
 NOX::GlobalData::
 GlobalData(const Teuchos::RCP<Teuchos::ParameterList>& noxParams)
@@ -61,7 +62,9 @@ GlobalData(const Teuchos::RCP<NOX::Utils>& utils,
            const Teuchos::RCP<NOX::MeritFunction::Generic>& mf) :
   utilsPtr(utils),
   meritFunctionPtr(mf)
-{}
+{
+  solverStatsPtr = Teuchos::rcp(new NOX::SolverStats);
+}
 
 NOX::GlobalData::~GlobalData() {}
 
@@ -70,6 +73,8 @@ initialize(const Teuchos::RCP<Teuchos::ParameterList>& noxParams)
 {
   paramListPtr = noxParams;
   utilsPtr = Teuchos::rcp(new NOX::Utils(noxParams->sublist("Printing")));
+  if (is_null(solverStatsPtr))
+    solverStatsPtr = Teuchos::rcp(new NOX::SolverStats);
 
   Teuchos::ParameterList& so = noxParams->sublist("Solver Options");
 
@@ -93,3 +98,11 @@ NOX::GlobalData::getMeritFunction() const
 Teuchos::RCP<Teuchos::ParameterList>
 NOX::GlobalData::getNoxParameterList() const
 { return paramListPtr; }
+
+Teuchos::RCP<const NOX::SolverStats>
+NOX::GlobalData::getSolverStatistics() const
+{ return solverStatsPtr; }
+
+Teuchos::RCP<NOX::SolverStats>
+NOX::GlobalData::getNonConstSolverStatistics()
+{ return solverStatsPtr; }

--- a/packages/nox/src/NOX_GlobalData.H
+++ b/packages/nox/src/NOX_GlobalData.H
@@ -62,6 +62,7 @@ namespace NOX {
   namespace MeritFunction {
     class Generic;
   }
+  class SolverStats;
 }
 
 namespace NOX {
@@ -115,6 +116,12 @@ namespace NOX {
     */
     Teuchos::RCP<Teuchos::ParameterList> getNoxParameterList() const;
 
+    //! Returns const version of solver statistics
+    Teuchos::RCP<const NOX::SolverStats> getSolverStatistics() const;
+
+    //! Returns non-const version of solver statistics
+    Teuchos::RCP<NOX::SolverStats> getNonConstSolverStatistics();
+
   private:
 
     //! Copy constructor is private to preclude copying.
@@ -155,6 +162,9 @@ namespace NOX {
        data object.
     */
     Teuchos::RCP<Teuchos::ParameterList> paramListPtr;
+
+    /** \brief Stores solver statistics */
+    Teuchos::RCP<NOX::SolverStats> solverStatsPtr;
 
   }; // Class GlobalData
 

--- a/packages/nox/src/NOX_LineSearch_MoreThuente.C
+++ b/packages/nox/src/NOX_LineSearch_MoreThuente.C
@@ -57,12 +57,15 @@
 #include "NOX_Utils.H"
 #include "NOX_MeritFunction_Generic.H"
 #include "NOX_GlobalData.H"
+#include "NOX_SolverStats.hpp"
+#include "NOX_LineSearch_Utils_Counters.H"
 
 NOX::LineSearch::MoreThuente::
 MoreThuente(const Teuchos::RCP<NOX::GlobalData>& gd,
         Teuchos::ParameterList& params) :
   globalDataPtr(gd),
   print(gd->getUtils()),
+  counter(&gd->getNonConstSolverStatistics()->line_search),
   slope(gd),
   paramsPtr(0)
 {
@@ -79,6 +82,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 {
   globalDataPtr = gd;
   meritFuncPtr = gd->getMeritFunction();
+  counter = &gd->getNonConstSolverStatistics()->line_search;
   print.reset(gd->getUtils());
   slope.reset(gd);
 
@@ -106,7 +110,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
     throw "NOX Error";
   }
 
-  counter.reset();
+  counter->reset();
 
   std::string choice = p.get("Sufficient Decrease Condition", "Armijo-Goldstein");
   if (choice == "Ared/Pred")
@@ -141,14 +145,14 @@ bool NOX::LineSearch::MoreThuente::compute(Abstract::Group& grp, double& step,
               const Abstract::Vector& dir,
               const Solver::Generic& s)
 {
-  counter.incrementNumLineSearches();
+  counter->incrementNumLineSearches();
   const Abstract::Group& oldGrp = s.getPreviousSolutionGroup();
   int info = cvsrch(grp, step, oldGrp, dir, s);
 
   if (step != 1.0)
-    counter.incrementNumNonTrivialLineSearches();
+    counter->incrementNumNonTrivialLineSearches();
 
-  counter.setValues(*paramsPtr);
+  counter->setValues(*paramsPtr);
 
   return (info == 1);
 }
@@ -347,7 +351,7 @@ cvsrch(Abstract::Group& newgrp, double& stp, const Abstract::Group& oldgrp,
       if (info != 1)         // Line search failed
       {
     // RPP add
-    counter.incrementNumFailedLineSearches();
+    counter->incrementNumFailedLineSearches();
 
     if (recoveryStepType == Constant)
       stp = recoverystep;
@@ -377,7 +381,7 @@ cvsrch(Abstract::Group& newgrp, double& stp, const Abstract::Group& oldgrp,
     print.printStep(nfev, stp, finit, f, message);
 
     // RPP add
-    counter.incrementNumIterations();
+    counter->incrementNumIterations();
 
     // In the first stage we seek a step for which the modified
     // function has a nonpositive value and nonnegative derivative.

--- a/packages/nox/src/NOX_LineSearch_MoreThuente.H
+++ b/packages/nox/src/NOX_LineSearch_MoreThuente.H
@@ -54,15 +54,15 @@
 #include "NOX_LineSearch_Generic.H" // base class
 
 #include "NOX_LineSearch_Utils_Printing.H"  // data class member
-#include "NOX_LineSearch_Utils_Counters.H"  // data class member
 #include "NOX_LineSearch_Utils_Slope.H"     // data class member
-#include "Teuchos_RCP.hpp"          // data class member
+#include "Teuchos_RCP.hpp"                  // data class member
 
 // Forward Declarations
 namespace NOX {
   namespace MeritFunction {
     class Generic;
   }
+  class LineSearchCounters;
 }
 
 namespace NOX {
@@ -470,7 +470,7 @@ private:
   NOX::LineSearch::Utils::Printing print;
 
   //! Common common counters for line searches.
-  NOX::LineSearch::Utils::Counters counter;
+  NOX::LineSearchCounters* counter;
 
   //! Common slope calculations for line searches.
   NOX::LineSearch::Utils::Slope slope;

--- a/packages/nox/src/NOX_LineSearch_Polynomial.C
+++ b/packages/nox/src/NOX_LineSearch_Polynomial.C
@@ -51,6 +51,8 @@
 #include "NOX_LineSearch_Polynomial.H"
 
 #include "NOX_LineSearch_Utils_Printing.H"
+#include "NOX_SolverStats.hpp"
+#include "NOX_LineSearch_Utils_Counters.H"
 #include "NOX_LineSearch_Utils_Slope.H"
 #include "NOX_Abstract_Vector.H"
 #include "NOX_Abstract_Group.H"
@@ -66,6 +68,7 @@ Polynomial(const Teuchos::RCP<NOX::GlobalData>& gd,
   globalDataPtr(gd),
   paramsPtr(NULL),
   print(gd->getUtils()),
+  counter(&gd->getNonConstSolverStatistics()->line_search),
   slopeUtil(gd)
 {
   reset(gd, params);
@@ -83,6 +86,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
   globalDataPtr = gd;
   meritFuncPtr = gd->getMeritFunction();
   print.reset(gd->getUtils());
+  counter = &gd->getNonConstSolverStatistics()->line_search;
   paramsPtr = &params;
   slopeUtil.reset(gd);
 
@@ -145,7 +149,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 
   // Set up counter
   if (useCounter)
-    counter.reset();
+    counter->reset();
 
   return true;
 }
@@ -160,7 +164,7 @@ bool NOX::LineSearch::Polynomial::compute(Abstract::Group& newGrp,
   int nNonlinearIters = s.getNumIterations();
 
   if (useCounter)
-    counter.incrementNumLineSearches();
+    counter->incrementNumLineSearches();
 
   // Get the linear solve tolerance if doing ared/pred for conv criteria
   std::string direction = const_cast<Teuchos::ParameterList&>(s.getList()).
@@ -197,7 +201,7 @@ bool NOX::LineSearch::Polynomial::compute(Abstract::Group& newGrp,
 
   // Increment the number of newton steps requiring a line search
   if ((useCounter) && (!isConverged))
-    counter.incrementNumNonTrivialLineSearches();
+    counter->incrementNumNonTrivialLineSearches();
 
   double prevPhi = 0.0;        // \phi(\lambda_{k-1})
   double prevPrevPhi = 0.0;    // \phi(\lambda_{k-2})
@@ -318,7 +322,7 @@ bool NOX::LineSearch::Polynomial::compute(Abstract::Group& newGrp,
     nIters ++;
 
     if (useCounter)
-      counter.incrementNumIterations();
+      counter->incrementNumIterations();
 
     isConverged = checkConvergence(newValue, oldValue, oldSlope, step,
                    eta, nIters, nNonlinearIters);
@@ -329,7 +333,7 @@ bool NOX::LineSearch::Polynomial::compute(Abstract::Group& newGrp,
   if (isFailed)
   {
     if (useCounter)
-      counter.incrementNumFailedLineSearches();
+      counter->incrementNumFailedLineSearches();
 
     if (recoveryStepType == Constant)
       step = recoveryStep;
@@ -354,7 +358,7 @@ bool NOX::LineSearch::Polynomial::compute(Abstract::Group& newGrp,
   paramsPtr->set("Adjusted Tolerance", 1.0 - step * (1.0 - eta));
 
   if (useCounter)
-    counter.setValues(*paramsPtr);
+    counter->setValues(*paramsPtr);
 
   return (!isFailed);
 }

--- a/packages/nox/src/NOX_LineSearch_Polynomial.H
+++ b/packages/nox/src/NOX_LineSearch_Polynomial.H
@@ -54,15 +54,15 @@
 #include "NOX_LineSearch_Generic.H" // base class
 
 #include "NOX_LineSearch_Utils_Printing.H"  // class data member
-#include "NOX_LineSearch_Utils_Counters.H"  // class data member
 #include "NOX_LineSearch_Utils_Slope.H"     // class data member
-#include "Teuchos_RCP.hpp"          // class data member
+#include "Teuchos_RCP.hpp"                  // class data member
 
 // Forward Declarations
 namespace NOX {
   namespace MeritFunction {
     class Generic;
   }
+  class LineSearchCounters;
 }
 
 namespace NOX {
@@ -573,7 +573,7 @@ protected:
   NOX::LineSearch::Utils::Printing print;
 
   //! Common common counters for line searches.
-  NOX::LineSearch::Utils::Counters counter;
+  NOX::LineSearchCounters* counter;
 
   //! Common slope calculations for line searches.
   NOX::LineSearch::Utils::Slope slopeUtil;

--- a/packages/nox/src/NOX_LineSearch_SafeguardedStep.C
+++ b/packages/nox/src/NOX_LineSearch_SafeguardedStep.C
@@ -54,6 +54,7 @@
 #include "NOX_LineSearch_Utils_Slope.H"
 #include "NOX_Abstract_Vector.H"
 #include "NOX_Abstract_Group.H"
+#include "NOX_SolverStats.hpp"
 #include "NOX_Solver_Generic.H"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_Assert.hpp"
@@ -67,7 +68,8 @@ SafeguardedStep(const Teuchos::RCP<NOX::GlobalData>& gd,
         Teuchos::ParameterList& params) :
   paramsPtr_(NULL),
   globalDataPtr_(gd),
-  print_(gd->getUtils())
+  print_(gd->getUtils()),
+  counter_(&gd->getNonConstSolverStatistics()->line_search)
 {
   reset(gd, params);
 }
@@ -79,6 +81,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
   globalDataPtr_ = gd;
   print_.reset(gd->getUtils());
   paramsPtr_ = &params;
+  counter_ = &gd->getNonConstSolverStatistics()->line_search;
 
   Teuchos::ParameterList& p = params.sublist("Safeguarded Step");
   p.validateParametersAndSetDefaults(*getValidParameters());
@@ -100,7 +103,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
 
   // Set up counter
   if (useCounter_)
-    counter_.reset();
+    counter_->reset();
 
   return true;
 }
@@ -113,8 +116,8 @@ bool NOX::LineSearch::SafeguardedStep::compute(Abstract::Group& newGrp,
   printOpeningRemarks();
 
   if (useCounter_) {
-    counter_.incrementNumLineSearches();
-    counter_.incrementNumNonTrivialLineSearches();
+    counter_->incrementNumLineSearches();
+    counter_->incrementNumNonTrivialLineSearches();
   }
 
   invLimits_->reciprocal(*userLimits_);
@@ -160,7 +163,7 @@ bool NOX::LineSearch::SafeguardedStep::compute(Abstract::Group& newGrp,
   }
 
   if (useCounter_)
-    counter_.setValues(*paramsPtr_);
+    counter_->setValues(*paramsPtr_);
 
   return true;
 }

--- a/packages/nox/src/NOX_LineSearch_SafeguardedStep.H
+++ b/packages/nox/src/NOX_LineSearch_SafeguardedStep.H
@@ -54,7 +54,6 @@
 #include "NOX_LineSearch_Generic.H" // base class
 
 #include "NOX_LineSearch_Utils_Printing.H"  // class data member
-#include "NOX_LineSearch_Utils_Counters.H"  // class data member
 #include "Teuchos_RCP.hpp"          // class data member
 
 // Forward Declarations
@@ -62,6 +61,7 @@ namespace NOX {
   namespace MeritFunction {
     class Generic;
   }
+  class LineSearchCounters;
 }
 
 namespace NOX {
@@ -107,7 +107,7 @@ private:
   bool useCounter_;
   Teuchos::RCP<NOX::GlobalData> globalDataPtr_;
   NOX::LineSearch::Utils::Printing print_;
-  NOX::LineSearch::Utils::Counters counter_;
+  NOX::LineSearchCounters* counter_;
 
 };
 } // namespace LineSearch

--- a/packages/nox/src/NOX_LineSearch_Tensor.C
+++ b/packages/nox/src/NOX_LineSearch_Tensor.C
@@ -87,6 +87,8 @@
 #include "NOX_GlobalData.H"
 #include "NOX_Direction_Tensor.H"
 #include "NOX_Solver_TensorBasedTest.H"
+#include "NOX_LineSearch_Utils_Counters.H"
+#include "NOX_SolverStats.hpp"
 
 NOX::LineSearch::Tensor::
 Tensor(const Teuchos::RCP<NOX::GlobalData>& gd,
@@ -94,6 +96,7 @@ Tensor(const Teuchos::RCP<NOX::GlobalData>& gd,
   globalDataPtr(gd),
   paramsPtr(NULL),
   print(gd->getUtils()),
+  counter(&gd->getNonConstSolverStatistics()->line_search),
   slopeObj(gd)
 {
   //  reset(paramsPtr->sublist("Line Search"));
@@ -112,6 +115,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
   globalDataPtr = gd;
   utils = *(gd->getUtils());
   print.reset(gd->getUtils());
+  counter = &gd->getNonConstSolverStatistics()->line_search;
   paramsPtr = &lsParams;
   slopeObj.reset(gd);
 
@@ -255,7 +259,7 @@ reset(const Teuchos::RCP<NOX::GlobalData>& gd,
     convCriteria = ArmijoGoldstein;     // bwb - the others aren't implemented
 #endif
 
-  counter.reset();
+  counter->reset();
 
   return true;
 }
@@ -267,7 +271,7 @@ bool NOX::LineSearch::Tensor::compute(NOX::Abstract::Group& newGrp,
                       const NOX::Solver::Generic& s)
 {
   bool ok;
-  counter.incrementNumLineSearches();
+  counter->incrementNumLineSearches();
   isNewtonDirection = false;
 
   const NOX::Direction::Tensor& direction =
@@ -289,7 +293,7 @@ bool NOX::LineSearch::Tensor::compute(NOX::Abstract::Group& newGrp,
 #endif
 
 
-  if (counter.getNumLineSearches() == 1  ||  lsType == Newton)
+  if (counter->getNumLineSearches() == 1  ||  lsType == Newton)
     isNewtonDirection = true;
 
   // Do line search and compute new soln.
@@ -385,7 +389,7 @@ bool NOX::LineSearch::Tensor::performLinesearch(NOX::Abstract::Group& newsoln,
 
   // Update counter and allocate memory for dir2 if a linesearch is needed
   if (!isAccepted) {
-    counter.incrementNumNonTrivialLineSearches();
+    counter->incrementNumNonTrivialLineSearches();
     dir2 = dir.clone(ShapeCopy);
     *dir2 = dir;
   }
@@ -425,7 +429,7 @@ bool NOX::LineSearch::Tensor::performLinesearch(NOX::Abstract::Group& newsoln,
     }
 
     // Update the number of linesearch iterations
-    counter.incrementNumIterations();
+    counter->incrementNumIterations();
     lsIterations ++;
 
     // Compute new trial point and its function value
@@ -451,7 +455,7 @@ bool NOX::LineSearch::Tensor::performLinesearch(NOX::Abstract::Group& newsoln,
   }
 
   if (isFailed) {
-    counter.incrementNumFailedLineSearches();
+    counter->incrementNumFailedLineSearches();
     step = recoveryStep;
 
     if (step != 0.0) {
@@ -465,7 +469,7 @@ bool NOX::LineSearch::Tensor::performLinesearch(NOX::Abstract::Group& newsoln,
   }
 
   print.printStep(lsIterations, step, oldValue, newValue, message);
-  counter.setValues(*paramsPtr);
+  counter->setValues(*paramsPtr);
 
   dir2 = Teuchos::null;
 

--- a/packages/nox/src/NOX_LineSearch_Tensor.H
+++ b/packages/nox/src/NOX_LineSearch_Tensor.H
@@ -57,7 +57,6 @@
 
 #include "NOX_LineSearch_Generic.H" // base class
 #include "NOX_LineSearch_Utils_Printing.H"  // class data member
-#include "NOX_LineSearch_Utils_Counters.H"  // class data member
 #include "NOX_LineSearch_Utils_Slope.H"     // class data member
 
 // Forward declarations
@@ -65,6 +64,7 @@ namespace NOX {
   namespace Direction {
     class Tensor;
   }
+  class LineSearchCounters;
 }
 
 namespace NOX {
@@ -174,7 +174,7 @@ protected:
   NOX::LineSearch::Utils::Printing print;
 
   //! Common common counters for line searches.
-  NOX::LineSearch::Utils::Counters counter;
+  NOX::LineSearchCounters* counter;
 
   //! Common slope calculations for line searches.
   NOX::LineSearch::Utils::Slope slopeObj;

--- a/packages/nox/src/NOX_LineSearch_Utils_Counters.C
+++ b/packages/nox/src/NOX_LineSearch_Utils_Counters.C
@@ -52,17 +52,17 @@
 
 #include "Teuchos_ParameterList.hpp"
 
-NOX::LineSearch::Utils::Counters::Counters()
+NOX::LineSearchCounters::LineSearchCounters()
 {
   reset();
 }
 
-NOX::LineSearch::Utils::Counters::~Counters()
+NOX::LineSearchCounters::~LineSearchCounters()
 {
 
 }
 
-void NOX::LineSearch::Utils::Counters::reset()
+void NOX::LineSearchCounters::reset()
 {
   totalNumLineSearchCalls = 0;
   totalNumNonTrivialLineSearches = 0;
@@ -70,7 +70,7 @@ void NOX::LineSearch::Utils::Counters::reset()
   totalNumIterations = 0;
 }
 
-bool NOX::LineSearch::Utils::Counters::setValues(Teuchos::ParameterList& lineSearchParams)
+bool NOX::LineSearchCounters::setValues(Teuchos::ParameterList& lineSearchParams)
 {
   Teuchos::ParameterList& outputList = lineSearchParams.sublist("Output");
   outputList.set("Total Number of Line Search Calls", totalNumLineSearchCalls);
@@ -80,42 +80,42 @@ bool NOX::LineSearch::Utils::Counters::setValues(Teuchos::ParameterList& lineSea
   return true;
 }
 
-void NOX::LineSearch::Utils::Counters::incrementNumLineSearches(int numLS)
+void NOX::LineSearchCounters::incrementNumLineSearches(int numLS)
 {
   totalNumLineSearchCalls += numLS;
 }
 
-void NOX::LineSearch::Utils::Counters::incrementNumNonTrivialLineSearches(int numNonTrivialLS)
+void NOX::LineSearchCounters::incrementNumNonTrivialLineSearches(int numNonTrivialLS)
 {
   totalNumNonTrivialLineSearches += numNonTrivialLS;
 }
 
-void NOX::LineSearch::Utils::Counters::incrementNumFailedLineSearches(int numFailedLS)
+void NOX::LineSearchCounters::incrementNumFailedLineSearches(int numFailedLS)
 {
   totalNumFailedLineSearches += numFailedLS;
 }
 
-void NOX::LineSearch::Utils::Counters::incrementNumIterations(int numInnerIters)
+void NOX::LineSearchCounters::incrementNumIterations(int numInnerIters)
 {
   totalNumIterations += numInnerIters;
 }
 
-int NOX::LineSearch::Utils::Counters::getNumLineSearches() const
+int NOX::LineSearchCounters::getNumLineSearches() const
 {
   return totalNumLineSearchCalls;
 }
 
-int NOX::LineSearch::Utils::Counters::getNumNonTrivialLineSearches() const
+int NOX::LineSearchCounters::getNumNonTrivialLineSearches() const
 {
   return totalNumNonTrivialLineSearches;
 }
 
-int NOX::LineSearch::Utils::Counters::getNumFailedLineSearches() const
+int NOX::LineSearchCounters::getNumFailedLineSearches() const
 {
   return totalNumFailedLineSearches;
 }
 
-int NOX::LineSearch::Utils::Counters::getNumIterations() const
+int NOX::LineSearchCounters::getNumIterations() const
 {
   return totalNumIterations;
 }

--- a/packages/nox/src/NOX_LineSearch_Utils_Counters.H
+++ b/packages/nox/src/NOX_LineSearch_Utils_Counters.H
@@ -63,11 +63,6 @@ namespace NOX {
 
 namespace NOX {
 
-namespace LineSearch {
-
-//! %Common line search utilites
-namespace Utils {
-
 //! Common counters that all line search algorithms should report.
 /*!
 
@@ -97,15 +92,15 @@ list are:
 
 */
 
-class Counters {
+class LineSearchCounters {
 
 public:
 
   //! Default constructor.
-  Counters();
+  LineSearchCounters();
 
   //! Destructor.
-  virtual ~Counters();
+  virtual ~LineSearchCounters();
 
   //! Reset the counters .
   virtual void reset();
@@ -186,8 +181,7 @@ private:
   //@}
 
 };
-} // namespace Utils
-} // namespace LineSearch
+
 } // namespace NOX
 
 #endif

--- a/packages/nox/src/NOX_SolverStats.hpp
+++ b/packages/nox/src/NOX_SolverStats.hpp
@@ -1,0 +1,93 @@
+// @HEADER
+// @HEADER
+
+#ifndef NOX_SOLVER_STATS_HPP
+#define NOX_SOLVER_STATS_HPP
+
+#include "NOX_Common.H"
+#include "NOX_LineSearch_Utils_Counters.H"
+
+namespace NOX {
+
+  //! Container for solver statistics
+  struct SolverStats {
+
+    SolverStats() :
+      num_nonlinear_solves(0),
+      num_nonlinear_iterations(0),
+      num_total_nonlinear_iterations(0)
+    {}
+      
+    // Resets counters. Does not reset counters that aggregate across multiple nonlinear solves.
+    void resetForNewNonlinearSolve()
+    {
+      num_nonlinear_iterations = 0;
+      line_search.reset();
+      trust_region.reset();
+    }
+
+    //! Increases the number of nonlinear solves by one.
+    void incrementNumNonlinearSolves()
+    { ++num_nonlinear_solves; }
+
+    void incrementNumNonlinearIterations()
+    {
+      ++num_nonlinear_iterations;
+      ++num_total_nonlinear_iterations;
+    }
+
+    //! Total number of nonlinear solves attempted.
+    int num_nonlinear_solves;
+    
+    //! Number of nonlinear iterations in the last nonlinear solve.
+    int num_nonlinear_iterations;
+
+    //! Total number of nonlinear iterations for all nonlinear solves.
+    int num_total_nonlinear_iterations;
+
+    //! Statistics for the linear solve.
+    struct LinearSolveStats {
+      bool last_linear_solve_converged;
+      int num_iterations_last_linear_solve;
+      double linear_residual_norm_last_line_solve;
+      int num_iterations_all_linear_solves;      
+    };
+
+    //! Line search stats for the last nonlinear solve
+    NOX::LineSearchCounters line_search;
+
+    //! Container for trust region statistics
+    struct TrustRegionStats {
+      TrustRegionStats() :
+        num_cauchy_steps(0),
+        num_newton_steps(0),
+        num_dogleg_steps(0),
+        dogleg_fraction_cauchy_to_newton(0.0),
+        dogleg_fraction_newton_length(0.0)
+      {}
+
+      void reset()
+      {
+        num_cauchy_steps = 0;
+        num_newton_steps = 0;
+        num_dogleg_steps = 0;
+        dogleg_fraction_cauchy_to_newton = 0.0;
+        dogleg_fraction_newton_length = 0.0;
+      }
+      
+      int num_cauchy_steps; //! Number of pure Cauchy steps taken
+      int num_newton_steps; //! Number of pure Newton steps taken
+      int num_dogleg_steps; //! Number of dogleg steps taken
+      int num_trust_region_inner_iterations;
+      double dogleg_fraction_cauchy_to_newton;
+      double dogleg_fraction_newton_length;
+    };
+    
+    //! Trust Regions stats for the last nonlinear solve
+    TrustRegionStats trust_region;
+
+  };
+
+}
+
+#endif

--- a/packages/nox/src/NOX_Solver_TensorBased.H
+++ b/packages/nox/src/NOX_Solver_TensorBased.H
@@ -59,7 +59,6 @@
 
 #include "NOX_LineSearch_Generic.H" // base class
 #include "NOX_LineSearch_Utils_Printing.H"  // class data member
-#include "NOX_LineSearch_Utils_Counters.H"  // class data member
 #include "NOX_LineSearch_Utils_Slope.H"     // class data member
 
 
@@ -68,6 +67,8 @@ namespace NOX {
   namespace Direction {
     class Generic;
   }
+
+  class LineSearchCounters;
 
 namespace Solver {
 
@@ -538,7 +539,7 @@ protected:
   Teuchos::RCP<NOX::LineSearch::Utils::Printing> print;
 
   //! Common common counters for line searches.
-  NOX::LineSearch::Utils::Counters counter;
+  NOX::LineSearchCounters* counter;
 
   //! Common slope calculations for line searches.
   NOX::LineSearch::Utils::Slope slopeObj;


### PR DESCRIPTION
Added a statistics block to global data. Have all line searches now logging statistics to this.