### PR TITLE
NOX: add observer for solution update

### DIFF
--- a/packages/nox/src/NOX_Abstract_PrePostOperator.H
+++ b/packages/nox/src/NOX_Abstract_PrePostOperator.H
@@ -58,25 +58,25 @@ namespace NOX {
   namespace Solver {
     class Generic;
   }
+  namespace Abstract {
+    class Vector;
+  }
 }
 
 namespace NOX {
 namespace Abstract {
 
-/*!
-
-  \brief %NOX's pure virtual class to allow users to insert pre and
-  post operations into nox's solvers (before and after the
+/** \brief %NOX's pure virtual class to allow users to insert user
+  defined operations into nox's solvers (before and after the
   NOX::Solver::Generic::iterate() and NOX::Solver::Generic::solve()
-  methods).
+  methods). This is an Observer from GoF design pattern book.
 
   The user should implement their own concrete implementation of this
   class and register it as a
   Teuchos::RCP<NOX::Abstract::PrePostoperator> in the "Solver
   Options" sublist.
 
-
-  To create and use a user defined pre/post operators:
+  To create and register a user defined pre/post operator:
 
   <ol>
 
@@ -98,73 +98,55 @@ namespace Abstract {
   \endcode
 
   </ol>
-
-  \author Roger Pawlowski (SNL 9233)
 */
 
 class PrePostOperator {
 
 public:
 
-  //! %Abstract %Vector constructor (does nothing)
-  PrePostOperator() {};
+  //! Constructor
+  PrePostOperator() {}
 
-  //! Copy constructor (doesnothing)
-  PrePostOperator(const NOX::Abstract::PrePostOperator& /*source*/) {};
+  //! Copy constructor
+  PrePostOperator(const NOX::Abstract::PrePostOperator& /*source*/) {}
 
-  //! %Abstract %Vector destructor (does nothing)
-  virtual ~PrePostOperator() {};
+  //! Destructor
+  virtual ~PrePostOperator() {}
 
   //! User defined method that will be executed at the start of a call to NOX::Solver::Generic::iterate().
-  virtual void runPreIterate(const NOX::Solver::Generic& solver);
+  virtual void runPreIterate(const NOX::Solver::Generic& solver) {}
 
   //! User defined method that will be executed at the end of a call to NOX::Solver::Generic::iterate().
-  virtual void runPostIterate(const NOX::Solver::Generic& solver);
+  virtual void runPostIterate(const NOX::Solver::Generic& solver) {}
 
   //! User defined method that will be executed at the start of a call to NOX::Solver::Generic::solve().
-  virtual void runPreSolve(const NOX::Solver::Generic& solver);
+  virtual void runPreSolve(const NOX::Solver::Generic& solver) {}
 
   //! User defined method that will be executed at the end of a call to NOX::Solver::Generic::solve().
-  virtual void runPostSolve(const NOX::Solver::Generic& solver);
+  virtual void runPostSolve(const NOX::Solver::Generic& solver) {}
+
+  /** \brief User defined method that will be executed prior to the
+      update of the solution vector during a call to
+      NOX::Solver::Generic::step(). This is intended to allow users to
+      adjust the direction before the solution update, typically based
+      on knowledge of the problem formulation. The direction is const
+      as we can't guarantee that changes to the direction won't
+      violate assumptions of the solution algorithm. Users can change
+      the update/direciton after a const cast, but NOX may not
+      function as expected. Use at your own risk!
+
+      \param [in] update - the direction vector that will be used to update the solution. This will not 
+      \param [in] solver - the nox solver
+   */
+  virtual void runPreSolutionUpdate(const NOX::Abstract::Vector& update, const NOX::Solver::Generic& solver) {}
 
   //! User defined method that will be executed before a call to NOX::LineSearch::Generic::compute(). Only to be used in NOX::Solver::LineSearchBased!
-  virtual void runPreLineSearch(const NOX::Solver::Generic& solver);
+  virtual void runPreLineSearch(const NOX::Solver::Generic& solver) {}
 
   //! User defined method that will be executed after a call to NOX::LineSearch::Generic::compute(). Only to be used in NOX::Solver::LineSearchBased!
-  virtual void runPostLineSearch(const NOX::Solver::Generic& solver);
-
+  virtual void runPostLineSearch(const NOX::Solver::Generic& solver) {}
 }; // class PrePostOperator
 } // namespace Abstract
 } // namespace NOX
-
-inline void NOX::Abstract::PrePostOperator::
-runPreIterate(const NOX::Solver::Generic& /*solver*/) {
-  return;
-}
-
-inline void NOX::Abstract::PrePostOperator::
-runPostIterate(const NOX::Solver::Generic& /*solver*/) {
-  return;
-}
-
-inline void NOX::Abstract::PrePostOperator::
-runPreSolve(const NOX::Solver::Generic& /*solver*/) {
-  return;
-}
-
-inline void NOX::Abstract::PrePostOperator::
-runPostSolve(const NOX::Solver::Generic& /*solver*/) {
-  return;
-}
-
-inline void NOX::Abstract::PrePostOperator::
-runPreLineSearch(const NOX::Solver::Generic& /*solver*/) {
-  return;
-}
-
-inline void NOX::Abstract::PrePostOperator::
-runPostLineSearch(const NOX::Solver::Generic& /*solver*/) {
-  return;
-}
 
 #endif

--- a/packages/nox/src/NOX_PrePostOperator_Vector.C
+++ b/packages/nox/src/NOX_PrePostOperator_Vector.C
@@ -72,6 +72,13 @@ void NOX::PrePostOperatorVector::runPostSolve(const NOX::Solver::Generic& solver
     (*i)->runPostSolve(solver);
 }
 
+void NOX::PrePostOperatorVector::runPreSolutionUpdate(const NOX::Abstract::Vector& update,
+                                                      const NOX::Solver::Generic& solver)
+{
+  for (it i=ppop_vec_.begin(); i != ppop_vec_.end(); ++i)
+    (*i)->runPreSolutionUpdate(update,solver);
+}
+
 void NOX::PrePostOperatorVector::runPreLineSearch(const NOX::Solver::Generic& solver)
 {
   for (it i=ppop_vec_.begin(); i != ppop_vec_.end(); ++i)

--- a/packages/nox/src/NOX_PrePostOperator_Vector.H
+++ b/packages/nox/src/NOX_PrePostOperator_Vector.H
@@ -79,6 +79,8 @@ public:
 
   void runPostSolve(const NOX::Solver::Generic& solver);
 
+  void runPreSolutionUpdate(const NOX::Abstract::Vector& update, const NOX::Solver::Generic& solver);
+
   void runPreLineSearch(const NOX::Solver::Generic& solver);
 
   void runPostLineSearch(const NOX::Solver::Generic& solver);

--- a/packages/nox/src/NOX_Solver_AndersonAcceleration.C
+++ b/packages/nox/src/NOX_Solver_AndersonAcceleration.C
@@ -367,6 +367,7 @@ NOX::StatusTest::StatusType NOX::Solver::AndersonAcceleration::step()
   workVec->update(mixParam,*precF);
   for (int ii=0; ii<nStore; ii++)
     workVec->update(-gamma(ii,0), *(xMat[ii]), -Rgamma(ii,0),*(qMat[ii]),1.0);
+  prePostOperator.runPreSolutionUpdate(*workVec,*this);
   bool ok = lineSearchPtr->compute(*solnPtr, stepSize, *workVec, *this);
   if (!ok)
   {

--- a/packages/nox/src/NOX_Solver_InexactTrustRegionBased.C
+++ b/packages/nox/src/NOX_Solver_InexactTrustRegionBased.C
@@ -494,11 +494,12 @@ NOX::Solver::InexactTrustRegionBased::iterateStandard()
     // Local reference to use in the remaining computation
     const NOX::Abstract::Vector& dir = *dirPtr;
 
+    // Compute new X
+    prePostOperator.runPreSolutionUpdate(dir,*this);
+    soln.computeX(*oldSolnPtr, dir, step);
+
     // Calculate true step length
     dx = step * (computeNorm(dir));
-
-    // Compute new X
-    soln.computeX(*oldSolnPtr, dir, step);
 
     // Compute F for new current solution.
     NOX::Abstract::Group::ReturnType rtype = soln.computeF();
@@ -830,6 +831,7 @@ NOX::Solver::InexactTrustRegionBased::iterateInexact()
     NOX::Abstract::Vector& dir = *dirPtr;
 
     // Update X and compute new F
+    prePostOperator.runPreSolutionUpdate(dir,*this);
     soln.computeX(oldSoln, dir, step);
     NOX::Abstract::Group::ReturnType rtype = soln.computeF();
     if (rtype != NOX::Abstract::Group::Ok)

--- a/packages/nox/src/NOX_Solver_LineSearchBased.C
+++ b/packages/nox/src/NOX_Solver_LineSearchBased.C
@@ -189,6 +189,7 @@ NOX::StatusTest::StatusType NOX::Solver::LineSearchBased::step()
   *oldSolnPtr = *solnPtr;
 
   // Do line search and compute new soln.
+  prePostOperator.runPreSolutionUpdate(*dirPtr,*this);
   prePostOperator.runPreLineSearch(*this);
   ok = lineSearchPtr->compute(soln, stepSize, *dirPtr, *this);
   prePostOperator.runPostLineSearch(*this);

--- a/packages/nox/src/NOX_Solver_PrePostOperator.H
+++ b/packages/nox/src/NOX_Solver_PrePostOperator.H
@@ -73,8 +73,8 @@ namespace NOX {
 
 namespace Solver {
 
-/*!
-  @brief Functor to process the pre/post operator object in the parameter list.
+/**  @brief Wrapper class to hide boilerplate from solvers that
+     process the pre/post operator object from the parameter list.
 
   This is a wrapper class for a user derived
   NOX::Abstract::PrePostOperator (ppo) object.  All solvers use this
@@ -85,7 +85,6 @@ namespace Solver {
 
   For instructions on how to implement a PrePostOperator, see
   NOX::Abstract::PrePostOperator.
-
 */
 class PrePostOperator {
 
@@ -125,6 +124,9 @@ public:
 
   //! User defined method that will be executed at the end of a call to NOX::Solver::Generic::solve().
   virtual void runPostSolve(const NOX::Solver::Generic& solver);
+
+  //! User defined method that will be executed during a call to NOX::Solver::GEneric::step().
+  virtual void runPreSolutionUpdate(const NOX::Abstract::Vector& update, const NOX::Solver::Generic& solver);
 
   //! User defined method that will be executed before a call to NOX::LineSearch::Generic::compute(). Only to be used in NOX::Solver::LineSearchBased!
   virtual void runPreLineSearch(const NOX::Solver::Generic& solver);
@@ -170,6 +172,14 @@ runPostSolve(const NOX::Solver::Generic& solver)
 {
   if (havePrePostOperator)
     prePostOperatorPtr->runPostSolve(solver);
+}
+
+inline void NOX::Solver::PrePostOperator::
+runPreSolutionUpdate(const NOX::Abstract::Vector& update,
+                     const NOX::Solver::Generic& solver)
+{
+  if (havePrePostOperator)
+    prePostOperatorPtr->runPreSolutionUpdate(update,solver);
 }
 
 inline void NOX::Solver::PrePostOperator::

--- a/packages/nox/src/NOX_Solver_SingleStep.C
+++ b/packages/nox/src/NOX_Solver_SingleStep.C
@@ -168,6 +168,7 @@ bool NOX::Solver::SingleStep::try_step()
       return false;
   }
 
+  prePostOperator.runPreSolutionUpdate(dir,*this);
   solnPtr->computeX(*oldSolnPtr, dir, -1.0);
 
   return true;

--- a/packages/nox/src/NOX_Solver_TrustRegionBased.C
+++ b/packages/nox/src/NOX_Solver_TrustRegionBased.C
@@ -356,11 +356,12 @@ NOX::StatusTest::StatusType TrustRegionBased::step()
     // Local reference to use in the remaining computation
     const Abstract::Vector& dir = *dirPtr;
 
+    // Compute new X
+    prePostOperator.runPreSolutionUpdate(dir,*this);
+    soln.computeX(*oldSolnPtr, dir, step);
+
     // Calculate true step length
     dx = step * dir.norm();
-
-    // Compute new X
-    soln.computeX(*oldSolnPtr, dir, step);
 
     // Compute F for new current solution.
     NOX::Abstract::Group::ReturnType rtype = soln.computeF();


### PR DESCRIPTION
Add an observer that triggers in the solver->step() method just before the solution is updated. Required by an application that needs to modify the update.