### PR TITLE
Import stk development from the sierra stream

### DIFF
--- a/packages/stk/stk_unit_tests/stk_io/UnitTestWriteSTKMesh.cpp
+++ b/packages/stk/stk_unit_tests/stk_io/UnitTestWriteSTKMesh.cpp
@@ -21,6 +21,7 @@
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
 #include "stk_mesh/base/Field.hpp"
+#include <stk_unit_test_utils/MeshFixture.hpp>
 
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_util/environment/memory_util.hpp>
@@ -33,6 +34,7 @@
 #include <iostream>
 #include <unistd.h>                     // for unlink
 
+#include "stk_util/environment/Env.hpp"
 namespace
 {
 
@@ -261,4 +263,48 @@ TEST(StkIo, check_memory)
     }
 }
 
+class StkIoResultsOutput : public stk::unit_test_util::MeshFixture
+{
+protected:
+    void setup_mesh(const std::string & meshSpec, stk::mesh::BulkData::AutomaticAuraOption auraOption)
+    {
+        setup_empty_mesh(auraOption);
+
+        stk::mesh::Field<int> & field = get_meta().declare_field<stk::mesh::Field<int>>(stk::topology::NODE_RANK, "nodal_field");
+        const int initValue = 0;
+        stk::mesh::put_field_on_mesh(field, get_meta().universal_part(), &initValue);
+
+        stk::io::fill_mesh(meshSpec, get_bulk());
+    }
+};
+
+TEST_F(StkIoResultsOutput, write_nodal_face_variable_multiple_procs)
+{
+    if (stk::parallel_machine_size(MPI_COMM_WORLD) != 2) return;
+    //if (sierra::Env::parallel_size() != 2) return;
+
+    std::string meshSpec = stk::unit_test_util::get_option("--mesh-spec", "generated:1x1x2|sideset:z");
+
+    setup_mesh(meshSpec, stk::mesh::BulkData::NO_AUTO_AURA);
+
+    const std::string fileName = "nodal_field_as_face_variable.e";
+    stk::io::StkMeshIoBroker stkIo;
+    stkIo.set_bulk_data(get_bulk());
+    size_t outputFileIndex = stkIo.create_output_mesh(fileName, stk::io::WRITE_RESULTS);
+    stkIo.use_nodeset_for_sideset_nodes_fields(outputFileIndex, true);
+    stkIo.check_field_existence_when_creating_nodesets(outputFileIndex, false);
+
+    stk::mesh::FieldBase * nodalField = get_meta().get_field(stk::topology::NODE_RANK, "nodal_field");
+    ASSERT_TRUE(nodalField != nullptr);
+    stkIo.add_field(outputFileIndex, *nodalField, stk::topology::FACE_RANK, "nodal_field");
+    stkIo.write_output_mesh(outputFileIndex);
+    stkIo.begin_output_step(outputFileIndex, 0.0);
+    stkIo.write_defined_output_fields(outputFileIndex);
+    stkIo.end_output_step(outputFileIndex);
+
+    stk::mesh::MetaData meta(3);
+    stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA);
+    EXPECT_NO_THROW(stk::io::fill_mesh(fileName, bulk));
+    unlink(fileName.c_str());
+}
 }


### PR DESCRIPTION
This imports development as of the commit

commit 9803baddc8e8cdf021c51385b263d1dfcbde8e8a
Author: David Glaze <djglaze@sandia.gov>
Date:   Tue Sep 11 16:09:14 2018 -0600

    StkIo: fix issue with inconsistent number of nodeset variables

    Change-Id: If0ee587658259585a67a0e0e6cee0d1ed52eba1c
    Reviewed-on: https://sierra-git.sandia.gov:4443/349695
    Reviewed-by: Alan B Williams <william@sandia.gov>
    Tested-by: David Jason Glaze <djglaze@sandia.gov>

and is designed to fix issue #3377

@trilinos/stk 

## Related Issues

* Closes #3377 

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

