### PR TITLE
Tpetra:  Broke one test into four to avoid timeouts in ATDM environment #3417

### DIFF
--- a/packages/tpetra/core/test/Blas/CMakeLists.txt
+++ b/packages/tpetra/core/test/Blas/CMakeLists.txt
@@ -8,12 +8,46 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_EXECUTABLE(
   gemm
   SOURCES
     gemm
     ${TEUCHOS_STD_UNIT_TEST_MAIN}
   COMM serial mpi
+  )
+
+TRIBITS_ADD_TEST(
+  gemm
+  NAME gemm_m_eq_1
+  ARGS "--M=1"
+  COMM serial mpi
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT
-  )
+)
+
+TRIBITS_ADD_TEST(
+  gemm
+  NAME gemm_m_eq_2
+  ARGS "--M=2"
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)
+
+TRIBITS_ADD_TEST(
+  gemm
+  NAME gemm_m_eq_5
+  ARGS "--M=5"
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)
+
+TRIBITS_ADD_TEST(
+  gemm
+  NAME gemm_m_eq_13
+  ARGS "--M=13"
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+)

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -57,6 +57,15 @@ namespace {
   using std::endl;
   typedef int LO;
 
+  LO M = 13;
+
+  TEUCHOS_STATIC_SETUP()
+  {
+    Teuchos::CommandLineProcessor& clp = Teuchos::UnitTestRepository::getCLP ();
+    clp.setOption ("M", &M, "First matrix dimension M");
+  }
+
+
   template<class ValueType,
            const bool isInteger = std::is_integral<ValueType>::value>
   struct MachinePrecision
@@ -397,12 +406,17 @@ namespace {
     Tpetra::Map<> map (comm->getSize (), 1, 0, comm);
 
     auto randPool = preparePseudorandomNumberGenerator<device_type> ();
-    const LO m_vals[] = {1, 2, 5, 13};
     const LO n_vals[] = {1, 2, 5, 13};
     const LO k_vals[] = {1, 2, 5, 13};
-    for (LO m : m_vals) {
+
+    if (comm->getRank() == 0) std::cout << std::endl;
+    LO m = M;
+    {
       for (LO n : n_vals) {
         for (LO k : k_vals) {
+          if (comm->getRank() == 0) 
+            std::cout << "Testing m,n,k = " << m << "," << n << "," << k 
+                      << std::endl;
           testGemmVsTeuchosBlas<entry_type, coeff_type, device_type> (out,
                                                                       success,
                                                                       randPool,


### PR DESCRIPTION

@trilinos/tpetra @trilinos/framework 

## Description
One Tpetra test was timing out in the ATDM gcc-debug-openmp environment.  I split that test into four tests.

I do not understand why the original test took twice as long to run in the ATDM environment on white than in my environment using the ATDM scripts (see times in #3417) .  But I don't have time or interest to investigate right now.  This change allows the ATDM team to make progress.


#3417 

## How Has This Been Tested?
mac osx clang

