### PR TITLE
KokkosKernels: Fix for spgemm unit_test mkl macro

### DIFF
--- a/packages/kokkos-kernels/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/packages/kokkos-kernels/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -301,14 +301,14 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
     case SPGEMM_CUSPARSE:
       //TODO: add these test failure cases for cusparse too.
       algo = "SPGEMM_CUSPARSE";
-#ifndef KERNELS_HAVE_CUSPARSE
+#if !defined(KERNELS_HAVE_CUSPARSE) && !defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
       is_expected_to_fail = true;
 #endif
       break;
 
     case SPGEMM_MKL:
       algo = "SPGEMM_MKL";
-#ifndef HAVE_KOKKOSKERNELS_MKL
+#if !defined(HAVE_KOKKOSKERNELS_MKL) && !defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
       is_expected_to_fail = true;
 #endif
       //MKL requires scalar to be either float or double


### PR DESCRIPTION
Address Trilinos issue #3438, incorporates part of fix from
PR kokkos/kokkos-kernels#290

@trillinos/kokkos-kernels