### PR TITLE
Framework: Add config GCC 4.9.3 SERIAL PR Build

### DIFF
--- a/cmake/std/PullRequestLinuxCommonTestingSettingsSERIAL.cmake
+++ b/cmake/std/PullRequestLinuxCommonTestingSettingsSERIAL.cmake
@@ -1,0 +1,101 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxCommonTestingSettings.cmake
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+set (Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ALLOW_NO_PACKAGES ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ENABLE_SECONDARY_TESTED_CODE ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_IGNORE_MISSING_EXTRA_REPOSITORIES ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ENABLE_TESTS ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_TEST_CATEGORIES BASIC CACHE STRING "Set by default for PR testing")
+set (Trilinos_ENABLE_CONFIGURE_TIMING ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_CTEST_USE_NEW_AAO_FEATURES ON CACHE BOOL "Set by default for PR testing")
+
+
+# Options from cmake/std/MpiReleaseDebugSharedPtSettings.cmake
+
+set (TPL_ENABLE_MPI OFF CACHE BOOL "Set by default for PR testing")
+set (CMAKE_BUILD_TYPE RELEASE CACHE STRING "Set by default for PR testing")
+set (Trilinos_ENABLE_DEBUG ON CACHE BOOL "Set by default for PR testing")
+set (BUILD_SHARED_LIBS ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ENABLE_DEBUG_SYMBOLS ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ENABLE_EXPLICIT_INSTANTIATION ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_ENABLE_SECONDARY_TESTED_CODE OFF CACHE BOOL "Set by default for PR testing")
+set (Teuchos_ENABLE_DEFAULT_STACKTRACE OFF CACHE BOOL "Set by default for PR testing")
+
+# Options from cmake/std/BasicCiTestingSettings.cmake
+
+set (Trilinos_TPL_SYSTEM_INCLUDE_DIRS TRUE CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_GLM OFF CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_Matio OFF CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_X11 OFF CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_Pthread ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_BLAS ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_LAPACK ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_Boost ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_BoostLib ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_ParMETIS ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_Zlib ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_HDF5 ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_Netcdf ON CACHE BOOL "Set by default for PR testing")
+set (TPL_ENABLE_SuperLU ON CACHE BOOL "Set by default for PR testing")
+set (Trilinos_TRACE_ADD_TEST ON CACHE BOOL "Set by default for PR testing")
+
+set (TPL_ENABLE_Scotch ON CACHE BOOL "Set by default for PR testing")
+# Disable test that was enabled when Scotch TPL was enabled (#2051, #2052)
+set (Zoltan2_orderingTestDriverExample_MPI_1_DISABLE ONCACHE BOOL "Set by default for PR testing")
+
+# Disable long-failing Piro test until it can be fixed (#826)
+set (Piro_EpetraSolver_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
+
+# Options from SEMSDevEnv.cmake
+
+SET(CMAKE_C_COMPILER "$ENV{CC}" CACHE FILEPATH "Set by default for PR testing")
+
+SET(CMAKE_CXX_COMPILER "$ENV{CXX}" CACHE FILEPATH "Set by default for PR testing")
+
+SET(CMAKE_Fortran_COMPILER "$ENV{F90}" CACHE FILEPATH "Set by default for PR testing")
+
+# SET(MPI_BASE_DIR "$ENV{SEMS_OPENMPI_ROOT}" CACHE PATH "Set by default for PR testing")
+
+#SET(Trilinos_EXTRA_LINK_FLAGS "-lgomp -lgfortran -lldl -ldl" CACHE STRING "Set by default for PR testing")
+
+SET(Trilinos_ENABLE_PyTrilinos OFF CACHE BOOL "Set by default for PR testing")
+
+# Options (still from SEMSDevEnv.cmake) specific to TPLs
+# TPL enables handled previously
+
+SET(Boost_INCLUDE_DIRS "$ENV{SEMS_BOOST_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(Boost_LIBRARY_DIRS "$ENV{SEMS_BOOST_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+SET(BoostLib_INCLUDE_DIRS "$ENV{SEMS_BOOST_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(BoostLib_LIBRARY_DIRS "$ENV{SEMS_BOOST_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+SET(ParMETIS_INCLUDE_DIRS "$ENV{SEMS_PARMETIS_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(ParMETIS_LIBRARY_DIRS "$ENV{SEMS_PARMETIS_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+SET(Zlib_INCLUDE_DIRS "$ENV{SEMS_ZLIB_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(Zlib_LIBRARY_DIRS "$ENV{SEMS_ZLIB_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+SET(HDF5_INCLUDE_DIRS "$ENV{SEMS_HDF5_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(HDF5_LIBRARY_DIRS "$ENV{SEMS_HDF5_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+SET(Netcdf_INCLUDE_DIRS "$ENV{SEMS_NETCDF_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(Netcdf_LIBRARY_DIRS "$ENV{SEMS_NETCDF_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+SET(SuperLU_INCLUDE_DIRS "$ENV{SEMS_SUPERLU_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+SET(SuperLU_LIBRARY_DIRS "$ENV{SEMS_SUPERLU_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")
+
+set (TPL_Scotch_INCLUDE_DIRS "$ENV{SEMS_SCOTCH_INCLUDE_PATH}" CACHE PATH "Set by default for PR testing")
+set (Scotch_LIBRARY_DIRS "$ENV{SEMS_SCOTCH_LIBRARY_PATH}" CACHE PATH "Set by default for PR testing")

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -178,6 +178,14 @@ elif [ "Trilinos_pullrequest_gcc_4.9.3" == "${JOB_BASE_NAME:?}" ] ; then
     echo "There was an issue loading the gcc environment. The error code was: $ierror"
     exit $ierror
   fi
+elif [ "Trilinos_pullrequest_gcc_4.9.3_SERIAL" == "${JOB_BASE_NAME:?}" ] ; then
+  # TODO: Update this to use a 4.9.3 SERIAL testing environment script.
+  source ${TRILINOS_DRIVER_SRC_DIR}/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh 
+  ierror=$?
+  if [[ $ierror != 0 ]]; then
+    echo "There was an issue loading the gcc environment. The error code was: $ierror"
+    exit $ierror
+  fi
 elif [ "Trilinos_pullrequest_intel_17.0.1" == "${JOB_BASE_NAME:?}" ] ; then
   source ${TRILINOS_DRIVER_SRC_DIR}/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
   ierror=$?
@@ -243,6 +251,9 @@ else
     CONFIG_SCRIPT=PullRequestLinuxGCC4.8.4TestingSettings.cmake
   elif [ "Trilinos_pullrequest_gcc_4.9.3" == "${JOB_BASE_NAME:?}" ]; then
     CONFIG_SCRIPT=PullRequestLinuxGCC4.9.3TestingSettings.cmake
+  elif [ "Trilinos_pullrequest_gcc_4.9.3_SERIAL" == "${JOB_BASE_NAME:?}" ]; then
+    # TODO: Update this to use a 4.9.3 SERIAL testing environment script.
+    CONFIG_SCRIPT=PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake
   fi
 fi
 

--- a/cmake/std/PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake
@@ -1,0 +1,21 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC 4.9.3 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxGCC4.9.3TestingSettings.cmake
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+
+# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettingsSERIAL.cmake")

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
@@ -1,0 +1,37 @@
+# This script can be used to load the appropriate environment for the
+# GCC 4.9.3 Pull Request testing build on a Linux machine that has access to
+# the SEMS NFS mount.
+
+# usage: $ source PullRequestGCC4.9.3TestingEnv.sh
+
+source /projects/sems/modulefiles/utils/sems-modules-init.sh
+
+module load sems-gcc/4.9.3
+# module load sems-openmpi/1.10.1
+module load sems-python/2.7.9
+module load sems-git/2.10.1
+module load sems-boost/1.63.0/base
+module load sems-zlib/1.2.8/base
+module load sems-hdf5/1.8.12/parallel
+module load sems-netcdf/4.4.1/exo_parallel
+module load sems-parmetis/4.0.3/parallel
+module load sems-scotch/6.0.3/nopthread_64bit_parallel
+module load sems-superlu/4.3/base
+
+# Load the SEMS CMake Module
+# - One of the SEMS modules will load CMake 3.4.x also,
+#   so this will pull in the SEMS cmake 3.10.3 version
+#   for Trilinos compatibility.
+module load sems-cmake/3.10.3
+
+# Using CMake and Ninja modules from the ATDM project space.
+# SEMS does not yet supply a recent enough version of CMake
+# for the single configure/build/test capability. We are also
+# using a custom version of Ninja (with Fortran support not
+# available in main-line Ninja) to significantly speed up
+# compile and link times.
+module load atdm-env
+module load atdm-cmake/3.11.1
+module load atdm-ninja_fortran/1.7.2
+
+


### PR DESCRIPTION
@trilinos/framework 

This is my initial stab at modifying the PR testing scripts to add in a GCC 4.9.3 SERIAL build.  From what I can tell, it looks like the driver scripts assume an MPI world since MPI is enabled in "common" scripts that get loaded by other scripts.  So to not worry about breaking anything I pretty much just created a SERIAL version of the configs and scripts and key them off the Jenkins job [Trilinos_pullrequest_gcc_4.9.3_SERIAL][1].  

Generally the change to the configuration is to switch the `MPI ON` settings that I found in the configuration as well as to change the compilers from the MPI* variants (i.e., MPICXX, MPICC) to use the standard compiler variations (CC=gcc, CXX=g++, F90=gfortran) etc.

I'm not 100% sure this is what we need though to have a serial build set up properly.  I had a look at the 4.9.3 SERIAL build that's run on the nightlies and that setup seems different than the PR tests use.  In those tests, I believe we use the Parameterized builds, which are driven by `cmake/ctest/drivers/parameterized`.  In those tests, the Jenkins job has the parameter `JENKINS_COMM_TYPE` which gets passed in and is used on line 63:

https://github.com/trilinos/Trilinos/blob/1d0e85eaf149870aeb6067fef8d7c832b897fc06/cmake/ctest/drivers/parameterized/ctest_linux_nightly_generic.cmake#L62-L64

I didn't see an analog to this in the scripts that drive the PR tests, so I'd like @trilinos/framework to have a look at this and let me know if I'm missing a configuration piece.

@jwillenbring 
@prwolfe 
@allevin 

[1]: https://ascic-jenkins.sandia.gov/job/trilinos-folder/job/Trilinos_pullrequest_gcc_4.9.3_SERIAL/
