### PR TITLE
disable KokkosCore_UnitTest_Serial_MPI_1 in atdm intel-debug-serial b…

### DIFF
--- a/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-SERIAL-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-SERIAL-HSW.cmake
@@ -9,3 +9,6 @@ ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
 
 # This test fails consistently with a major numerical error (#2474)
 ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
+
+# Disable perpetually failing KokkosCore test (#3233)
+ATDM_SET_ENABLE(KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON)


### PR DESCRIPTION
@trilinos/framework, @bartlettroscoe 

## Description
This disables the test `KokkosCore_UnitTest_Serial_MPI_1` for the ATDM build `Trilinos-atdm-hansen-shiller-intel-debug-serial`.  This is test is continually failing and is being disabled to keep the dashboard clean

## Related Issues
#3233 