### PR TITLE
KokkosKernels - remove cusparse testing in spgemm.

### DIFF
--- a/packages/kokkos-kernels/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/packages/kokkos-kernels/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -287,9 +287,9 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
   crsMat_t output_mat2;
   run_spgemm<crsMat_t, device>(input_mat, input_mat, SPGEMM_DEBUG, output_mat2);
 
-  SPGEMMAlgorithm algorithms [] = {SPGEMM_KK_MEMORY, SPGEMM_KK_SPEED, SPGEMM_KK_MEMSPEED, SPGEMM_CUSPARSE,SPGEMM_MKL};
+  SPGEMMAlgorithm algorithms [] = {SPGEMM_KK_MEMORY, SPGEMM_KK_SPEED, SPGEMM_KK_MEMSPEED, /* SPGEMM_CUSPARSE, */SPGEMM_MKL};
 
-  for (int ii = 0; ii < 5; ++ii){
+  for (int ii = 0; ii < 4; ++ii){
 
     SPGEMMAlgorithm spgemm_algorithm = algorithms[ii];
 


### PR DESCRIPTION
## Description

Removes spgemm cusparse testing as it also fails from kokkoskernels and it is not tested in spotcheck. To make trilinos nightly tests running, we need to remove this from trilinos and solve the problem in kokkoskernels. 

## Related Issues

#3438 

