### PR TITLE
Tpetra:  Updated modules for tests on white.

### DIFF
--- a/sampleScripts/Sandia-SEMS/test_tpetra_sandia
+++ b/sampleScripts/Sandia-SEMS/test_tpetra_sandia
@@ -271,7 +271,19 @@ elif [ "$MACHINE" = "white" ]; then
   SKIP_HWLOC=True
 
   module purge
-  module load devpack/openmpi/1.10.4/gcc/5.4.0/cuda/8.0.44
+
+  #KDD 7/18  Updated devpack
+  #KDD 7/18  module load devpack/openmpi/1.10.4/gcc/5.4.0/cuda/8.0.44
+  #KDD 9/18  OpenMPI3 has problems with Tpetra_ASSUME_CUDA_AWARE_MPI=ON
+  #KDD 9/18  module load devpack/20180521/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
+  #KDD 9/18  This configuration seems to work
+  module load git/2.10.1
+  module load openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
+  module load cmake/3.9.6
+  module load openblas/0.2.20/gcc/7.2.0
+  module load boost/1.65.1/gcc/7.2.0
+  module load cuda/9.2.88
+  module load netcdf-exo/4.4.1.1/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176
 
   if [ -z "$KOKKOS_ARCH" ]; then
     KOKKOS_ARCH="Power8;Pascal60"


### PR DESCRIPTION

@trilinos/tpetra 

## Description
In Tpetra's test script, updated modules used on white.
These modules use OpenMPI 2 and Cuda 9.2 
All tests pass as of 9/18/18.

