### PR TITLE
Swap out OpenMPI 3.1.0 for OpenMPI 2.1.2 on white/ride (#3290)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -81,8 +81,10 @@ fi
 if [ "$ATDM_CONFIG_COMPILER" == "GNU" ] ; then
 
   # Load the modules and set up env
-  module load devpack/20180308/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176
+  module load devpack/20180521/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
+  module swap openmpi openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
   module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+  module swap netcdf-exo/4.6.1/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88 netcdf/4.6.1/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
   export OMPI_CXX=`which g++`
   export OMPI_CC=`which gcc`
   export OMPI_FC=`which gfortran`
@@ -95,6 +97,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] ; then
   fi
   if [[ "$ATDM_CONFIG_COMPILER" == "CUDA-9.2" ]] ; then
     module load devpack/20180521/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88   
+    module swap openmpi openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
     module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
     module swap netcdf-exo/4.6.1/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88 netcdf/4.6.1/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
   else


### PR DESCRIPTION
@trilinos/<teamName>

## Description

Here, just the MPI implementation is swapped out but the TPLs for OpenMPI
3.1.0 remain (because they have not been built for the GCC 7.2.0 + OpenMPI
2.1.2 + CUDA 9.2).  It is not clear how this can work but it is all that we
can do without the TPLs properly built for this env.

I also switched to the GCC 7.2.0 + OpenMPI 2.1.2 + CUDA 9.2 env for the GNU
non-CUDA build just to be consistent.

## Motivation and Context

We want the `Ifpack2_BlockTriDiContainerUnitAndPerfTests_MPI_4` test failure to go away described in #3290.  It looks like OpenMPI 3.1.0 is not doing the right thing with CUDA memory but OpenMPI 2.1.2 appears to be.

## How Has This Been Tested?

On 'white' I ran:

```
$ bsub -x -Is -n 20 ./checkin-test-atdm.sh  all \
  --enable-packages=Kokkos,Ifpack2,SEACAS,Panzer --local-do-all
```

and all of the builds and tests passed (including the `Ifpack2_BlockTriDiContainerUnitAndPerfTests_MPI_4` test).  I picked these package because of their usage of CUDA and TPLs.  And Panzer in some way tests most of Trilinos (at least somewhat).

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
