### PR TITLE
PyTrilinos: Fix Teuchos MpiComm constructor when MPI4PY enabled

### DIFF
--- a/packages/PyTrilinos/src/Teuchos_Comm.i
+++ b/packages/PyTrilinos/src/Teuchos_Comm.i
@@ -578,23 +578,21 @@ else:
 //////////////////////////////
 // Teuchos::MpiComm support //
 //////////////////////////////
+#ifdef HAVE_MPI4PY
+// Here, we DO NOT %ignore Teuchos::MpiComm::MpiComm(MPI_Comm), and we
+// let the MPI4PY typemap for MPI_Comm handle that constructor
+#else
 %extend Teuchos::MpiComm
 {
-#ifdef HAVE_MPI4PY
-  MpiComm(MPI_Comm mpiComm = MPI_COMM_WORLD)
-  {
-    return new Teuchos::MpiComm< Ordinal >
-      (Teuchos::opaqueWrapper(mpiComm));
-  }
-#else
   MpiComm(PyObject * dummy = NULL)
   {
     return new Teuchos::MpiComm< Ordinal >
       (Teuchos::opaqueWrapper(MPI_COMM_WORLD));
   }
-#endif
 }
 %ignore Teuchos::MpiComm::MpiComm(MPI_Comm rawMpiComm);
+#endif
+
 %ignore Teuchos::MpiComm::MpiComm(const RCP<const OpaqueWrapper<MPI_Comm> >& rawMpiComm);
 %ignore Teuchos::MpiComm::MpiComm(const RCP<const OpaqueWrapper<MPI_Comm> >& rawMpiComm,
                                   const int defaultTag);
@@ -606,7 +604,7 @@ else:
 %ignore Teuchos::MpiComm::scan;
 %teuchos_rcp(Teuchos::MpiComm< int >)
 %include "Teuchos_DefaultMpiComm.hpp"
-%template(MpiComm_int) Teuchos::MpiComm<int>;
+%template(MpiComm_int) Teuchos::MpiComm< int >;
 %pythoncode
 %{
 MpiComm = MpiComm_int

--- a/packages/PyTrilinos/test/testTeuchos_Comm.py.in
+++ b/packages/PyTrilinos/test/testTeuchos_Comm.py.in
@@ -77,11 +77,10 @@ class TeuchosDefaultCommTestCase(unittest.TestCase):
         self.comm  = Teuchos.DefaultComm.getComm()
         if ('MpiComm' in dir(Teuchos)):
             self.commType = "MPI"
-            self.output   = "Teuchos::MpiComm<int>{size=%d,rank=%d" % \
-                            (self.comm.getSize(), self.comm.getRank())
+            self.output   = "MpiComm"
         else:
             self.commType = "Serial"
-            self.output   = "Teuchos::SerialComm<int>"
+            self.output   = "SerialComm"
         self.comm.barrier()
 
     def tearDown(self):
@@ -106,8 +105,9 @@ class TeuchosDefaultCommTestCase(unittest.TestCase):
 
     def testStr(self):
         "Test Teuchos.DefaultComm __str__ method"
-        n = len(self.output)
-        self.assertEqual(str(self.comm)[:n], self.output)
+        output = str(self.comm)
+        self.assertTrue("Teuchos"   in output)
+        self.assertTrue(self.output in output)
 
     def testBroadcastBadArg(self):
         "Test Teuchos.DefaultComm broadcast method with bad argument"


### PR DESCRIPTION
@trilinos/pytrilinos 

## Description
When `MPI4PY` was enabled, the `Teuchos.MpiComm`was built without a constructor. This was due to some subtle interplay between extensions to the `Teuchos.MpiComm` constructors and the `%ignore`-ing of others. This branch fixes that problem.

## Motivation and Context
PyTrilinos was not working with `MPI4PY` enabled. Now it does. This allows users to pass an `mpi4py` `MPI_Comm` object to a `PyTrilinos.Teuchos.MpiComm` constructor, which in turn allows for sub-communicators.

Closes #3461 

## How Has This Been Tested?
Automated testing has not been set up for PyTrilinos, but I have tested it on my MacBook Pro.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
