### PR TITLE
PyTrilinos: Fix wrappers for Tpetra classes moved to Classes namespace

### DIFF
--- a/packages/PyTrilinos/src/Tpetra.i
+++ b/packages/PyTrilinos/src/Tpetra.i
@@ -81,6 +81,9 @@ using Teuchos::ArrayRCP;
 
 // Tpetra include files
 #include "PyTrilinos_Tpetra_Headers.hpp"
+using Tpetra::Map;
+using Tpetra::Export;
+using Tpetra::Import;
 
 #ifdef HAVE_DOMI
 // Domi include files
@@ -639,7 +642,7 @@ __version__ = version()
 // Tpetra Map support //
 ////////////////////////
 
-%extend Tpetra::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >
+%extend Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >
 {
   Map()
   {
@@ -788,11 +791,11 @@ __version__ = version()
   }
 }
 
-%ignore Tpetra::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::Map;
-%ignore Tpetra::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getLocalElement;
-%ignore Tpetra::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getGlobalElement;
-%ignore Tpetra::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getRemoteIndexList;
-%ignore Tpetra::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getMyGlobalIndices;
+%ignore Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::Map;
+%ignore Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getLocalElement;
+%ignore Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getGlobalElement;
+%ignore Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getRemoteIndexList;
+%ignore Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD, PYTRILINOS_GLOBAL_ORD, DefaultNodeType >::getMyGlobalIndices;
 
 %include "Tpetra_Map_decl.hpp"
 
@@ -800,21 +803,21 @@ __version__ = version()
 // directives below are redundant, because it is the same as the
 // default template argument.  But SWIG is much more acurate when
 // comparing types when all template arguments are specified.
-%teuchos_rcp(Tpetra::Map< PYTRILINOS_LOCAL_ORD,
-                          PYTRILINOS_GLOBAL_ORD,
-                          DefaultNodeType >)
-%template(Map_default) Tpetra::Map< PYTRILINOS_LOCAL_ORD,
-                                    PYTRILINOS_GLOBAL_ORD,
-                                    DefaultNodeType >;
+%teuchos_rcp(Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD,
+                                   PYTRILINOS_GLOBAL_ORD,
+                                   DefaultNodeType >)
+%template(Map_default) Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD,
+                                             PYTRILINOS_GLOBAL_ORD,
+                                             DefaultNodeType >;
 %pythoncode
 {
 Map = Map_default
 }
 %inline
 %{
-  typedef Tpetra::Map< PYTRILINOS_LOCAL_ORD,
-                       PYTRILINOS_GLOBAL_ORD,
-                       DefaultNodeType > DefaultMapType;
+  typedef Tpetra::Classes::Map< PYTRILINOS_LOCAL_ORD,
+                                PYTRILINOS_GLOBAL_ORD,
+                                DefaultNodeType > DefaultMapType;
 %}
 
 /////////////////////////////
@@ -866,12 +869,12 @@ public:
 // Tpetra Export support //
 ///////////////////////////
 %include "Tpetra_Export_decl.hpp"
-%teuchos_rcp(Tpetra::Export< PYTRILINOS_LOCAL_ORD,
-                             PYTRILINOS_GLOBAL_ORD,
-                             DefaultNodeType >)
-%template(Export_default) Tpetra::Export< PYTRILINOS_LOCAL_ORD,
-                                          PYTRILINOS_GLOBAL_ORD,
-                                          DefaultNodeType >;
+%teuchos_rcp(Tpetra::Classes::Export< PYTRILINOS_LOCAL_ORD,
+                                      PYTRILINOS_GLOBAL_ORD,
+                                      DefaultNodeType >)
+%template(Export_default) Tpetra::Classes::Export< PYTRILINOS_LOCAL_ORD,
+                                                   PYTRILINOS_GLOBAL_ORD,
+                                                   DefaultNodeType >;
 %pythoncode
 {
 Export = Export_default
@@ -881,12 +884,12 @@ Export = Export_default
 // Tpetra Import support //
 ///////////////////////////
 %include "Tpetra_Import_decl.hpp"
-%teuchos_rcp(Tpetra::Import< PYTRILINOS_LOCAL_ORD,
-                             PYTRILINOS_GLOBAL_ORD,
-                             DefaultNodeType >)
-%template(Import_default) Tpetra::Import< PYTRILINOS_LOCAL_ORD,
-                                          PYTRILINOS_GLOBAL_ORD,
-                                          DefaultNodeType >;
+%teuchos_rcp(Tpetra::Classes::Import< PYTRILINOS_LOCAL_ORD,
+                                      PYTRILINOS_GLOBAL_ORD,
+                                      DefaultNodeType >)
+%template(Import_default) Tpetra::Classes::Import< PYTRILINOS_LOCAL_ORD,
+                                                   PYTRILINOS_GLOBAL_ORD,
+                                                   DefaultNodeType >;
 %pythoncode
 {
 Import = Import_default

--- a/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
+++ b/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
@@ -61,7 +61,8 @@ def get_input_files():
     os.chdir("${CMAKE_CURRENT_SOURCE_DIR}")
     result = glob.glob("Teuchos*.i")
     if (WITH_EPETRA):
-        result.extend(glob.glob("Epetra*.i"))
+        result.append("Epetra.i")
+        result.extend(glob.glob("Epetra_*.i"))
     if (WITH_TRIUTILS):
         result.extend(glob.glob("TriUtils*.i"))
     if (WITH_TPETRA):

--- a/packages/PyTrilinos/test/testTeuchos.py.in
+++ b/packages/PyTrilinos/test/testTeuchos.py.in
@@ -52,15 +52,15 @@ import unittest
 
 #
 # Parse the command-line arguments
-#from optparse import *
-#parser = OptionParser()
-#parser.add_option("-t", "--testharness", action="store_true",
-#                  dest="testharness", default=False,
-#                  help="test local build modules; prevent loading system-installed modules")
-#parser.add_option("-v", "--verbosity", type="int", dest="verbosity", default=2,
-#                  help="set the verbosity level [default 2]")
-#options,args = parser.parse_args()
-options = type("Options", (object,), {"testharness":True, "verbosity":2})
+from optparse import *
+parser = OptionParser()
+parser.add_option("-t", "--testharness", action="store_true",
+                  dest="testharness", default=False,
+                  help="test local build modules; prevent loading system-installed modules")
+parser.add_option("-v", "--verbosity", type="int", dest="verbosity", default=2,
+                  help="set the verbosity level [default 2]")
+options,args = parser.parse_args()
+
 #
 # Under normal usage, simply use 'from PyTrilinos import Teuchos'.  For testing,
 # we want to be able to control whether we import from the build directory or


### PR DESCRIPTION
@trilinos/pytrilinos 

## Description
Tpetra classes that were moved to the `Tpetra::Classes` namespace broke the PyTrilinos wrappers for Tpetra. This update fixes those wrappers

## Motivation and Context
`PyTrilinos.Tpetra` now builds and its tests pass.

## Related Issues

* Closes #3450 

## How Has This Been Tested?
Automatic testing for PyTrilinos has not been set up yet, but the tests pass on my MacBook Pro.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
