### PR TITLE
PullRequestLinuxDriver.sh: add a retry loop for the github fetch

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -106,6 +106,7 @@ do
     if i != num_retries
     then
       echo "retry $i"
+      sleep $(($i*20))
     else
       exit $ierror
     fi

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -109,6 +109,8 @@ do
     else
       exit $ierror
     fi
+  else
+    break
   fi
 done
 

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -95,12 +95,22 @@ fi
 
 git remote -v
 
-git fetch source_remote ${TRILINOS_SOURCE_BRANCH:?}
-ierror=$?
-if [[ $ierror != 0 ]]; then
-  echo "Source remote fetch failed. The error code was: $ierror"
-  exit $ierror
-fi
+num_retries=3
+
+for i in `seq ${num_retries}`
+do
+  git fetch source_remote ${TRILINOS_SOURCE_BRANCH:?}
+  ierror=$?
+  if [[ $ierror != 0 ]]; then
+    echo "Source remote fetch failed. The error code was: $ierror"
+    if i != num_retries
+    then
+      echo "retry $i"
+    else
+      exit $ierror
+    fi
+  fi
+done
 
 git fetch origin ${TRILINOS_TARGET_BRANCH:?}
 ierror=$?


### PR DESCRIPTION
We are seeing more issues when communicating to github
so I am adding a retry loop.

@trilinos/framework 

## Description
This adds a loop to retry fetching the source branch from GitHub. We see this failure infrequently.

## How Has This Been Tested?
This was tested by setting up an autotester that looked at PR's into this branch on my fork and creating a whitespace commit on a throw-away branch. The resulting PR can test the driver script as the target branch.

