### PR TITLE
Tpetra:  Added extra CMake logic for setting Tpetra_ASSUME_CUDA_AWARE_MPI

### DIFF
--- a/packages/tpetra/CMakeLists.txt
+++ b/packages/tpetra/CMakeLists.txt
@@ -172,6 +172,21 @@ ELSE ()
       ENDIF ()
     ENDIF ()
 
+    IF ((NOT Tpetra_FOUND_OMPI_INFO_EXECUTABLE) AND (DEFINED MPI_USE_COMPILER_WRAPPERS) AND MPI_USE_COMPILER_WRAPPERS AND (DEFINED CMAKE_CXX_COMPILER))
+      # Paths are returned with (forward) slashes, and no trailing slash:
+      # 
+      # https://cmake.org/cmake/help/v2.8.12/cmake.html#command%3aget_filename_component
+      #
+      GET_FILENAME_COMPONENT (Tpetra_MPI_CXX_COMPILER_ABS_PATH "${CMAKE_CXX_COMPILER}" ABSOLUTE)
+      # In the command below, PATH is a "legacy alias" for DIRECTORY; it
+      # works with CMake <= 2.8.11.  DIRECTORY requires CMake >= 2.8.12.
+      GET_FILENAME_COMPONENT (Tpetra_MPI_CXX_COMPILER_PARENT_DIR "${Tpetra_MPI_CXX_COMPILER_ABS_PATH}" PATH)
+      FIND_PROGRAM (Tpetra_OMPI_INFO_EXECUTABLE "ompi_info" ${Tpetra_MPI_CXX_COMPILER_PARENT_DIR} NO_DEFAULT_PATH)
+      IF (Tpetra_OMPI_INFO_EXECUTABLE)
+        SET (Tpetra_FOUND_OMPI_INFO_EXECUTABLE ON)
+      ENDIF ()
+    ENDIF ()
+
     # Next, try MPI_BIN_DIR.
     IF ((NOT Tpetra_FOUND_OMPI_INFO_EXECUTABLE) AND (DEFINED MPI_BIN_DIR))
       FIND_PROGRAM (Tpetra_OMPI_INFO_EXECUTABLE "ompi_info" ${MPI_BIN_DIR} NO_DEFAULT_PATH)

--- a/packages/tpetra/core/test/Comm/CMakeLists.txt
+++ b/packages/tpetra/core/test/Comm/CMakeLists.txt
@@ -57,3 +57,13 @@ IF (Tpetra_ENABLE_CUDA AND Tpetra_INST_CUDA)
     COMM mpi
     )
 ENDIF ()
+
+IF (Tpetra_ENABLE_CUDA AND Tpetra_INST_CUDA AND Tpetra_ASSUME_CUDA_AWARE_MPI)
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    cudaMpi_CanaryTest
+    SOURCES
+      cudaMpi_CanaryTest
+    NUM_MPI_PROCS 2
+    COMM mpi
+    )
+ENDIF ()

--- a/packages/tpetra/core/test/Comm/cudaMpi_CanaryTest.cpp
+++ b/packages/tpetra/core/test/Comm/cudaMpi_CanaryTest.cpp
@@ -1,0 +1,202 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+// This test exercises MPI on CUDA platforms, without any interaction 
+// with Trilinos.  If this test fails, there is likely something wrong
+// with the MPI installation on the CUDA platform.
+// See Trilinos github issue #3405 and related test cudaAwareMpi.cpp
+// in this directory.
+
+#include <iostream>
+#include <cstdio>
+#include <mpi.h>
+
+int main(int narg, char **arg)
+{
+  MPI_Init(&narg, &arg);
+
+  int lclSuccess = 1; 
+  int gblSuccess = 0; 
+
+  std::cout << "Testing CUDA-awareness of the MPI implementation" << std::endl;
+
+  int myRank;    MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+  int numProcs;  MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
+
+  if (numProcs < 2) {
+    std::cout << "This test is more meaningful if run with at least 2 MPI "
+              << "processes.  You ran with only 1 MPI process." << std::endl;
+  }
+
+  // Create Views for sending and receiving data.
+  int length = 1;
+
+  int *sendBuf, *recvBuf;
+  cudaMalloc(&sendBuf, length * sizeof(int));
+  cudaMalloc(&recvBuf, length * sizeof(int));
+
+  int *sendBuf_h = (int*)malloc(length * sizeof(int));
+  int *recvBuf_h = (int*)malloc(length * sizeof(int));
+
+  // NEIGHBOR TEST
+  if (numProcs > 1) {
+    std::cout << myRank << " NEIGHBOR TEST" << std::endl;
+
+    const int msgTag = 43;
+    const int correctValue = 1;
+    const int flagValue = -1;
+
+    //We exercise only the first two processes. 
+        
+    if (myRank == 0) { // sending process
+
+      for (int i = 0; i < length; i++) sendBuf_h[i] = correctValue;
+      cudaMemcpy(sendBuf, sendBuf_h, length*sizeof(int), cudaMemcpyHostToDevice);
+
+      const int tgtRank = 1;
+
+      std::cout << "     " << myRank << " Send " << std::endl;
+      MPI_Request sendReq;
+      MPI_Isend(sendBuf, length, MPI_INT, tgtRank, msgTag, 
+                MPI_COMM_WORLD, &sendReq);
+
+      std::cout << "     " << myRank << " Wait " << std::endl;
+      MPI_Status stat;
+      MPI_Wait(&sendReq, &stat);
+    }
+    else if (myRank == 1) { // receiving process
+
+      for (int i = 0; i < length; i++) recvBuf_h[i] = flagValue;
+      cudaMemcpy(recvBuf, recvBuf_h, length*sizeof(int), cudaMemcpyHostToDevice);
+
+      const int srcRank = 0;
+
+      std::cout << "     " << myRank << " Recv " << std::endl;
+      MPI_Request recvReq;
+      MPI_Irecv(recvBuf, length, MPI_INT, srcRank, msgTag, 
+                MPI_COMM_WORLD, &recvReq);
+
+      std::cout << "     " << myRank << " Wait " << std::endl;
+      MPI_Status stat;
+      MPI_Wait(&recvReq, &stat);
+
+      cudaMemcpy(recvBuf_h, recvBuf, length*sizeof(int), cudaMemcpyDeviceToHost);
+      if (recvBuf_h[0] == correctValue)  {
+        lclSuccess = 1;
+        std::cout << "     " << myRank << " Check Result:  OK " << std::endl;
+      }
+      else {
+        lclSuccess = 0;
+        std::cout << "     " << myRank << " Check Result:  BAD " << std::endl;
+      }
+    }
+
+    gblSuccess = 0; 
+    MPI_Allreduce(&lclSuccess, &gblSuccess, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    if (gblSuccess != 1)
+      std::cout << "Neighbor test failed on some process!" << std::endl;
+    else 
+      std::cout << "Neighbor test succeeded on all processes!" << std::endl;
+  }
+
+  
+  // Self-message test
+  {
+    std::cout << myRank << " SELF-MSG TEST" << std::endl;
+
+    const int msgTag = 42; // just some nontrivial tag for MPI messages
+
+    // Fill send buffer with some unique positive value.
+    const int correctValue = myRank + 1;
+    for (int i = 0; i < length; i++) sendBuf_h[i] = correctValue;
+    cudaMemcpy(sendBuf, sendBuf_h, length*sizeof(int), cudaMemcpyHostToDevice);
+
+    // Fill receive buffer with a flag value, always negative.
+    const int flagValue = -(myRank + 1);
+    for (int i = 0; i < length; i++) recvBuf_h[i] = flagValue;
+    cudaMemcpy(recvBuf, recvBuf_h, length*sizeof(int), cudaMemcpyHostToDevice);
+
+    const int srcRank = myRank; // self-messages
+    const int tgtRank = myRank;
+
+    std::cout << "     " << myRank << " Send/Recv " << std::endl;
+    MPI_Request recvReq, sendReq;
+    MPI_Irecv(recvBuf, 1, MPI_INT, srcRank, msgTag, 
+              MPI_COMM_WORLD, &recvReq);
+    MPI_Isend(sendBuf, 1, MPI_INT, tgtRank, msgTag, 
+              MPI_COMM_WORLD, &sendReq);
+
+    std::cout << "     " << myRank << " Wait " << std::endl;
+    MPI_Status stat;
+    MPI_Wait(&sendReq, &stat);
+    MPI_Wait(&recvReq, &stat);
+
+    cudaMemcpy(recvBuf_h, recvBuf, length*sizeof(int), cudaMemcpyDeviceToHost);
+    if (recvBuf_h[0] == correctValue)  {
+      lclSuccess = 1;
+      std::cout << "     " << myRank << " Check Result:  OK " << std::endl;
+    }
+    else {
+      lclSuccess = 0;
+      std::cout << "     " << myRank << " Check Result:  BAD " << std::endl;
+    }
+
+    // Make sure that everybody finished and got the right answer.
+    gblSuccess = 0; 
+    MPI_Allreduce(&lclSuccess, &gblSuccess, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+   
+    if (gblSuccess != 1)
+      std::cout << "Self-message test failed on some process; !" << std::endl;
+    else
+      std::cout << "Self-message test succeeded on all processes!" << std::endl;
+  }
+
+  cudaFree(sendBuf);
+  cudaFree(recvBuf);
+
+  free(sendBuf_h);
+  free(recvBuf_h);
+
+  MPI_Finalize();
+  return 0;
+}


### PR DESCRIPTION
For issue #3405 
These changes add logic to CMake's configuration, increasing the number of locations in which ompi_info is found.  The changes allow ompi_info to be found for ATDM builds on white.
ATDM builds did not set MPI_CXX_COMPILER; instead, they set CMAKE_CXX_COMPILER.  The new logic looks for ompi_info in the same directory as CMAKE_CXX_COMPILER.

I also added a test program, cudaMpi_CanaryTest.cpp.  It exercises MPI with CUDA directly, without any Kokkos or Trilinos data structures.  If this test fails with a given MPI installation (e.g., OpenMPI3 on white), the problem is likely with MPI, not with Tpetra.  Is there a better place in Trilinos for such tests, rather than in the packages?  Do we need a "stableSystemPackage" that includes tests like these, which have no dependence on Trilinos yet flag conditions that will cause Trilinos to fail?

Note that once this change is merged, ATDM tests using OpenMPI3 on white will fail unless they explicitly set Tpetra_ASSUME_CUDA_AWARE_MPI=OFF.  _**Since OpenMPI3 is known to be bad on white, users should probably use OpenMPI2.**_

@bartlettroscoe @fryeguy52  To save you headaches, I will not set AT:AUTOMERGE for this PR; feel free to merge when you are ready.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra @bartlettroscoe @fryeguy52 



## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Implemented and exercised on white.
Exercised on linux workstation.

## Checklist

- [ x] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
