### PR TITLE
Change parallel build level on white/ride from 128 to 64 (#2464)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -65,7 +65,7 @@ fi
 echo "Using white/ride compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
 
 export ATDM_CONFIG_USE_NINJA=ON
-export ATDM_CONFIG_BUILD_COUNT=128
+export ATDM_CONFIG_BUILD_COUNT=64
 # NOTE: Above settings are used for running on a single rhel7F (Firestone,
 # Dual-Socket POWER8, 8 cores per socket, K80 GPUs) node.
 


### PR DESCRIPTION
From talking with Si Hammond, he suggests that you will not get any real
speedup going voer 64 build proceses on 'white' and 'ride' and this might help
to reduce the random 'bsub' crashes durring building on white/ride (see #2464).

I did not test this at all but this change is so simple and basic I think it would be very hard for this to break anything on white/ride.
