### PR TITLE
EpetraExt: Add guards around the HDF5 tests

### DIFF
--- a/packages/epetraext/test/inout/CMakeLists.txt
+++ b/packages/epetraext/test/inout/CMakeLists.txt
@@ -9,9 +9,11 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  inout_hdf5_test
-  SOURCES
+IF(${PACKAGE_NAME}_USING_HDF5)
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    inout_hdf5_test
+    SOURCES
     EpetraExt_HDF5_UnitTest.cpp
-  COMM serial mpi
-  )
+    COMM serial mpi
+    )
+ENDIF()


### PR DESCRIPTION
@trilinos/EpetraExt

## Description
Add guards around the HDF5 tests to hopefully fix #3484 

## Related Issues

Closes #3484

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.