### PR TITLE
1761 change to cmake 3.10

### DIFF
--- a/cmake/ctest/drivers/apollo/cron_driver.sh
+++ b/cmake/ctest/drivers/apollo/cron_driver.sh
@@ -27,7 +27,7 @@ module load sems-env
 module load kokkos-env
 
 module load sems-python/2.7.9
-module load sems-cmake/2.8.12
+module load sems-cmake/3.10.3
 module load sems-git/2.1.3
 module load sems-${COMPILER_SUFFIX}
 

--- a/cmake/ctest/drivers/artemis/cron_driver.sh
+++ b/cmake/ctest/drivers/artemis/cron_driver.sh
@@ -26,7 +26,7 @@ module load sems-env
 module load kokkos-env
 
 module load sems-python/2.7.9
-module load sems-cmake/2.8.12
+module load sems-cmake/3.10.3
 module load sems-git/2.1.3
 module load sems-${COMPILER_SUFFIX}
 

--- a/cmake/ctest/drivers/enigma/cron_driver.sh
+++ b/cmake/ctest/drivers/enigma/cron_driver.sh
@@ -53,7 +53,7 @@ export OMP_NUM_THREADS=2
 # load OpenMPI 1.6.4 (standard in RHEL 7)
 #module load mpi/openmpi-x86_64
 module load sems-env
-module load sems-cmake/3.5.2
+module load sems-cmake/3.10.3
 module load sems-gcc/5.3.0
 module load sems-openmpi/1.10.1
 module load sems-superlu/4.3

--- a/cmake/ctest/drivers/geminga/cron_driver.sh
+++ b/cmake/ctest/drivers/geminga/cron_driver.sh
@@ -41,7 +41,7 @@ export https_proxy="https://sonproxy.sandia.gov:80"
 
 # ===========================================================================
 export CTEST_CONFIGURATION="default"
-module load sems-cmake/3.5.2
+module load sems-cmake/3.10.3
 module load sems-gcc/5.3.0
 module load sems-openmpi/1.10.1
 module load sems-superlu/4.3/base
@@ -63,7 +63,7 @@ $SCRIPT_DIR/../cron_driver.py
 module unload sems-superlu/4.3/base
 module unload sems-openmpi/1.10.1
 module unload sems-gcc/5.3.0
-module unload sems-cmake/3.5.2
+module unload sems-cmake/3.10.3
 # ===========================================================================
 export CTEST_CONFIGURATION="nvcc_wrapper"
 #module load openmpi/1.10.0
@@ -73,7 +73,7 @@ export CTEST_CONFIGURATION="nvcc_wrapper"
 
 module load sems-env
 module load kokkos-env
-module load sems-cmake/3.5.2
+module load sems-cmake/3.10.3
 module load sems-gcc/5.3.0
 module load sems-boost/1.58.0/base
 module load sems-python/2.7.9
@@ -118,7 +118,7 @@ module unload sems-zlib/1.2.8/base
 module unload sems-python/2.7.9
 module unload sems-boost/1.58.0/base
 module unload sems-gcc/5.3.0
-module unload sems-cmake/3.5.2
+module unload sems-cmake/3.10.3
 module unload kokkos-env
 module unload sems-env
 # ===========================================================================

--- a/cmake/ctest/drivers/perseus/cron_driver.sh
+++ b/cmake/ctest/drivers/perseus/cron_driver.sh
@@ -27,7 +27,7 @@ module load sems-env
 module load kokkos-env
 
 module load sems-python/2.7.9
-module load sems-cmake/2.8.12
+module load sems-cmake/3.10.3
 module load sems-git/2.1.3
 module load sems-${COMPILER_SUFFIX}
 

--- a/cmake/ctest/drivers/ride/cron_driver.sh
+++ b/cmake/ctest/drivers/ride/cron_driver.sh
@@ -22,7 +22,7 @@ export TDD_CTEST_TEST_TYPE=${JENKINS_JOB_TYPE}
 # Machine specific environment
 #
 module load python/2.7.12
-module load cmake/3.6.2
+export PATH=/home/rabartl/install/white-ride/cmake-3.11.2/bin:$PATH
 module load git/2.10.1
 
 export TRIBITS_TDD_USE_SYSTEM_CTEST=1

--- a/cmake/ctest/drivers/rocketman/cron_driver.sh
+++ b/cmake/ctest/drivers/rocketman/cron_driver.sh
@@ -42,7 +42,7 @@ export https_proxy="https://sonproxy.sandia.gov:80"
 # ===========================================================================
 export CTEST_CONFIGURATION="default"
 module load sems-env
-module load sems-cmake/3.5.2
+module load sems-cmake/3.10.3
 module load sems-gcc/5.3.0
 module load sems-openmpi/1.10.1
 module load sems-superlu/4.3/base
@@ -64,7 +64,7 @@ $SCRIPT_DIR/../cron_driver.py
 module unload sems-superlu/4.3/base
 module unload sems-openmpi/1.10.1
 module unload sems-gcc/5.3.0
-module unload sems-cmake/3.5.2
+module unload sems-cmake/3.10.3
 # ===========================================================================
 
 echo

--- a/cmake/ctest/drivers/shiller/cron_driver.sh
+++ b/cmake/ctest/drivers/shiller/cron_driver.sh
@@ -22,7 +22,7 @@ export TDD_CTEST_TEST_TYPE=${JENKINS_JOB_TYPE}
 # Machine specific environment
 #
 module load python/2.7.9
-module load cmake/3.3.2
+export PATH=/home/rabartl/install/hansen-shiller/cmake-3.11.2/bin:$PATH
 module load git/20150310
 
 export TRIBITS_TDD_USE_SYSTEM_CTEST=1

--- a/cmake/ctest/drivers/trappist/cron_driver.sh
+++ b/cmake/ctest/drivers/trappist/cron_driver.sh
@@ -39,7 +39,7 @@ export https_proxy="https://sonproxy.sandia.gov:80"
 
 # ===========================================================================
 export CTEST_CONFIGURATION="default"
-module load sems-cmake/3.5.2
+module load sems-cmake/3.10.3
 module load sems-gcc/5.3.0
 module load sems-openmpi/1.10.1
 module load sems-superlu/4.3/base
@@ -61,10 +61,10 @@ $SCRIPT_DIR/../cron_driver.py
 module unload sems-superlu/4.3/base
 module unload sems-openmpi/1.10.1
 module unload sems-gcc/5.3.0
-module unload sems-cmake/5.3.2
+module unload sems-cmake/3.10.3
 # ===========================================================================
 export CTEST_CONFIGURATION="clang"
-module load sems-cmake/3.5.2
+module load sems-cmake/3.10.3
 module load sems-clang/3.8.1
 module load sems-openmpi/1.10.1
 module load sems-superlu/4.3/base
@@ -86,7 +86,7 @@ $SCRIPT_DIR/../cron_driver.py
 module unload sems-superlu/4.3/base
 module unload sems-openmpi/1.10.1
 module unload sems-clang/3.8.1
-module unload sems-cmake/5.3.2
+module unload sems-cmake/3.10.3
 # ===========================================================================
 
 echo


### PR DESCRIPTION
@trilinos/framework 

## Description

Changes over to CMake 3.10+ on all CTest/CDash drivers (see the individual commits for more details).

The only references that I can find to CMake versions that using SEMS are:

```
$ cd Trilinos/

$ find cmake/ctest/ -type f -exec grep -nH cmake {} \; \
    grep -v "[.]cmake" | grep "\(2[.]8\|3[.]\)" | grep -v "3[.]10[.]3" | grep -v "3[.]11[.]" | sort

cmake/ctest/drivers/apollo/jenkins_driver.sh:39:module load cmake/2.8.11
cmake/ctest/drivers/artemis/jenkins_driver.sh:39:module load cmake/2.8.11
cmake/ctest/drivers/ictinus/cron_driver.sh:29:export PATH=/Users/jmwille/install/git/bin:/Users/jmwille/install/cmake-2.8.4/bin:/Users/jmwille/install/gcc-4.4.6/openmpi-1.4.3/bin:/
cmake/ctest/drivers/perseus/jenkins_driver.sh:39:module load cmake/2.8.11
cmake/ctest/drivers/windows/create_windows_package.bat:15:set CMAKE_DIR=%SEMS_DIR%\utility\cmake\3.8.1\bin
cmake/ctest/drivers/windows/task_driver_windows.bat:8:set CTEST_EXE=%SEMS_DIR%\utility\cmake\3.8.1\bin\ctest.exe
```

I don't know if any of these remaining builds are still active or not but if they are, we need to find out who owns these builds and tell them how to install an upgraded version of CMake.

## Motivation and Context

We want to switch Trilinos and TriBITS to require CMake 3.10+.  That will allow for some simplification of TriBITS and to use some nice new CMake features (see #1761).

## How Has This Been Tested?

I did not test this.  But the changes are so basic that you should be able to validate them by inspection.  And if there is a problem we will see it on CDash and then we can fix it the next day.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
