### PR TITLE
Tpetra transferAndFillComplete: Avoid dereferencing of null-pointer

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8455,7 +8455,8 @@ namespace Classes {
       SourcePids.resize (getColMap ()->getNodeNumElements ());
       SourceCol_pids.get1dCopy (SourcePids ());
     }
-    else if (BaseDomainMap->isSameAs (*BaseRowMap) &&
+    else if ( ! MyImporter.is_null () &&
+             BaseDomainMap->isSameAs (*BaseRowMap) &&
              getDomainMap ()->isSameAs (*getRowMap ())) {
       // We can use the rowTransfer + SourceMatrix's Import to find out who owns what.
       IntVectorType TargetRow_pids (domainMap);


### PR DESCRIPTION
@trilinos/tpetra 

## Description
Small fix to `transferAndFillComplete`: Avoid dereferencing null pointer.