### PR TITLE
Disable PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4 on waterman CUDA (#3340)

### DIFF
--- a/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,0 +1,2 @@
+# This test runs out of CUDA memory all on its own (#3340)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)


### PR DESCRIPTION
@trilinos/panzer 

## Description

This test runs out of CUDA memory even when runs all on its own on 'waterman'.
We disabling this for now and the Panzer developers can then debug this
offline.

## Motivation and Context

There is little value in running tests every day that we know are going to fail (see #3340).  This test can be fixed offline.

I was given the okay to disable this test in https://github.com/trilinos/Trilinos/issues/3340#issuecomment-424699362.

## How Has This Been Tested?

On 'waterman' I ran:

```
$ ./checkin-test-atdm.sh all --enable-packages=Panzer --configure
```

which returned:

```
PASSED (NOT READY TO PUSH): Trilinos: waterman11

Wed Sep 26 13:02:59 MDT 2018

Enabled Packages: Panzer

Build test results:
-------------------
0) MPI_RELEASE_DEBUG_SHARED_PT_OPENMP => Test case MPI_RELEASE_DEBUG_SHARED_PT_OPENMP was not run! => Does not affect push readiness! (-1.00 min)
1) gnu-debug-openmp-Power9-Volta70 => passed: configure-only passed => Not ready to push! (1.05 min)
2) gnu-opt-openmp-Power9-Volta70 => passed: configure-only passed => Not ready to push! (1.04 min)
3) cuda-debug-Power9-Volta70 => passed: configure-only passed => Not ready to push! (1.79 min)
4) cuda-opt-Power9-Volta70 => passed: configure-only passed => Not ready to push! (1.83 min)
```

I then verified that this test was correctly disabled in the correct builds with:

```
$ find . -maxdepth 2 -name configure.out \
  -exec grep -nH PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE {} \; \
  | grep "NOT added"

./cuda-debug-Power9-Volta70/configure.out:851:-- PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4: NOT added test because PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE='ON'!
./cuda-opt-Power9-Volta70/configure.out:849:-- PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4: NOT added test because PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE='ON'!
```

The fact that it did not find this in the two GNU builds shows that the test is not disabled in those.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
