### PR TITLE
Add install of ATDM env scripts, rename JOB_NAME to ATDM_CONFIG_JOB_NAME (#2689)

### DIFF
--- a/cmake/std/atdm/ATDMDevEnvSettings.cmake
+++ b/cmake/std/atdm/ATDMDevEnvSettings.cmake
@@ -17,6 +17,8 @@ IF (NOT "$ENV{ATDM_CONFIG_COMPLETED_ENV_SETUP}" STREQUAL "TRUE")
 ENDIF()
 
 
+ASSERT_DEFINED(ENV{ATDM_CONFIG_JOB_NAME})
+
 ASSERT_DEFINED(ENV{ATDM_CONFIG_BUILD_COUNT})
 ASSERT_DEFINED(ENV{ATDM_CONFIG_CTEST_PARALLEL_LEVEL})
 
@@ -249,10 +251,52 @@ ATDM_SET_CACHE(TPL_DLlib_LIBRARIES "-ldl" CACHE FILEPATH)
 # enabled anywhere in the EM-Plasma/BuildScripts files.xsxs
 
 #
-# E) Test Disables
+# G) Test Disables
 #
 # There are some tests that have to be disabled for a braod set of builds
 # for example, if all openmp builds are failing a certain test then it 
 # makes more sense to disbale it once in this file instead of in every openmp
 # buid's tweaks file
 #
+
+
+#
+# H) ATDM env config install hooks
+#
+# Install just enough to allow loading the exact matching env and nothing
+# else!
+#
+
+IF (COMMAND INSTALL)
+
+SET(ATDM_CONFIG_SCRIPTS_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/share/atdm-trilinos)
+
+  INSTALL( FILES ${CMAKE_CURRENT_LIST_DIR}/load-env.sh
+    DESTINATION ${ATDM_CONFIG_SCRIPTS_INSTALL_DIR} )
+  
+  INSTALL( DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/utils
+    DESTINATION ${ATDM_CONFIG_SCRIPTS_INSTALL_DIR}
+    PATTERN "*.cmake" EXCLUDE )
+  
+  INSTALL( DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/$ENV{ATDM_CONFIG_KNOWN_SYSTEM_NAME}
+    DESTINATION ${ATDM_CONFIG_SCRIPTS_INSTALL_DIR}
+    PATTERN "*.cmake" EXCLUDE )
+  
+  SET( ATDM_JOB_NAME $ENV{ATDM_CONFIG_JOB_NAME} )
+  
+  SET( ATDM_INSTALLED_ENV_LOAD_SCRIPT_NAME load_matching_env.sh
+    CACHE STRING
+    "Name of script installed in <CMAKE_INSTALL_PREFIX> to source to load matching env." )
+  
+  SET( ATDM_TRILINOS_INSTALL_PREFIX_ENV_VAR_NAME  ATDM_TRILINOS_INSTALL_PREFIX
+    CACHE STRING
+    "Name of env var set to <CMAKE_INSTALL_PREFIX> set in installed script <ATDM_INSTALLED_ENV_LOAD_SCRIPT_NAME>." )
+  
+  CONFIGURE_FILE( ${CMAKE_CURRENT_LIST_DIR}/load_matching_env.sh.in
+    ${CMAKE_CURRENT_BINARY_DIR}/load_matching_env.sh @ONLY )
+  
+  INSTALL( FILES ${CMAKE_CURRENT_BINARY_DIR}/load_matching_env.sh
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    RENAME ${ATDM_INSTALLED_ENV_LOAD_SCRIPT_NAME} )
+
+ENDIF()

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -14,6 +14,7 @@ build locally as described below.
 
 **Outline:**
 * <a href="#quick-start">Quick-start</a>
+* <a href="#installation-and-usage">Installation and usage</a>
 * <a href="#checkin-test-atdmsh">checkin-test-atdm.sh</a>
 * <a href="#specific-instructions-for-each-system">Specific instructions for each system</a>
 * <a href="#troubleshooting-configuration-problems">Troubleshooting configuration problems</a>
@@ -144,7 +145,8 @@ Some examples of `<job-name>` keyword sets used on various platforms include:
 
 The script `cmake/std/atdm/load-env.sh` when sourced sets some bash
 environment variables that are prefixed with `ATDM_CONFIG_` and other standard
-variables.
+variables.  This includes setting the var `ATDM_CONFIG_JOB_NAME` which stores
+the input `<job-name>` which is used in other parts of the system.
 
 The file `ATDMDevEnv.cmake` pulls bash environment variables set by the
 sourced `atdm/load-env.sh` script and sets up a number of CMake cache
@@ -169,6 +171,43 @@ When `ATDMDevEnv.cmake` is being processed, if there is a "tweaks" file
 defined for a build, then it will be picked up in the CMake cache var <a
 href="#ATDM_TWEAKS_FILES">ATDM_TWEAKS_FILES</a> and that file will be read in
 using `INCLUDE()` to process the extra options contained within it.
+
+
+## Installation and usage
+
+When including the `ATDMDevEnv.cmake` file (or `ATDMDevEnvSettings.cmake`) at
+configure time as described above, the cmake configure automatically sets up
+to install an environment script:
+
+```
+  <install-prefix>/<load-matching-env-sh>
+```
+
+where `<install-prefix>` and `<load-matching-env-sh>` are set at
+configure-time using:
+
+```
+  -D CMAKE_INSTALL_PREFIX=<install-prefix> \
+  -D ATDM_INSTALLED_ENV_LOAD_SCRIPT_NAME=<load-matching-env-sh> \
+  -D ATDM_TRILINOS_INSTALL_PREFIX_ENV_VAR_NAME=<trilinos-install-prefix-var-name> \
+```
+
+* If `ATDM_INSTALLED_ENV_LOAD_SCRIPT_NAME` is not specified then it is given the
+name `load_matching_env.sh` by default.
+
+* If `ATDM_TRILINOS_INSTALL_PREFIX_ENV_VAR_NAME` is not specified then it is
+given the name `ATDM_TRILINOS_INSTALL_PREFIX` by default.
+
+After installation with `make install`, a client can load the environment to
+use this ATDM configuration of Trilinos by running:
+
+```
+$ source <install-prefix>/<load-matching-env-sh>
+```
+
+Sourcing this file sets all of the various `ATDM_CONG_` environment variables
+described above and also sets the environment variable
+`<trilinos-install-prefix-var-name>` to `<install-prefix>`.
 
 
 ## checkin-test-atdm.sh
@@ -403,7 +442,7 @@ $ cmake \
 
 $ make -j16
 
-$ salloc -N 1 -p standard -J $JOB_NAME ctest -j16
+$ salloc -N 1 -p standard -J $ATDM_CONFIG_JOB_NAME ctest -j16
 ```
 
 ### SEMS rhel6 environment
@@ -531,7 +570,7 @@ contents:
 
 ```
   <system-name>/
-    environment.sh  # Load env for the given system based on $JOB_NAME keys
+    environment.sh  # Load env for the given system based on $ATDM_CONFIG_JOB_NAME keys
     all_supported_builds.sh  # [Optional] List of all supported builds
     tweaks/
        <COMPILER0>-<BUILD_TYPE0>-<NODE_TYPE0>.cmake  # [Optional]

--- a/cmake/std/atdm/chama/environment.sh
+++ b/cmake/std/atdm/chama/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on chama for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 
@@ -17,7 +17,7 @@ fi
 if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "SNB" ] ; then
   echo "***"
   echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option on this system."
-  echo "*** '$ATDM_CONFIG_KOKKOS_ARCH' appears in $JOB_NAME which then sets the KOKKOS_ARCH"
+  echo "*** '$ATDM_CONFIG_KOKKOS_ARCH' appears in $ATDM_CONFIG_JOB_NAME which then sets the KOKKOS_ARCH"
   echo "*** on Chama 'SNB' is the only valid KOKKOS_ARCH. If no KOKKOS_ARCH is specified then"
   echo "*** 'SNB' will be used by default"
   echo "***"

--- a/cmake/std/atdm/load-env.sh
+++ b/cmake/std/atdm/load-env.sh
@@ -52,17 +52,17 @@ if [[ $ATDM_CONFIG_KNOWN_SYSTEM_NAME == "" ]] ; then
 fi
 
 #
-# C) Set JOB_NAME and Trilinos base directory
+# C) Set ATDM_CONFIG_JOB_NAME and Trilinos base directory
 #
 
-export JOB_NAME=$1
+export ATDM_CONFIG_JOB_NAME=$1
 
 # Get the Trilins base dir
 export ATDM_CONFIG_TRILNOS_DIR=`get_abs_dir_path $ATDM_SCRIPT_DIR/../../..`
 echo "ATDM_CONFIG_TRILNOS_DIR = $ATDM_CONFIG_TRILNOS_DIR"
 
 #
-# D) Parse $JOB_NAME for consumption by the system-specific environoment.sh
+# D) Parse $ATDM_CONFIG_JOB_NAME for consumption by the system-specific environoment.sh
 # script
 #
 

--- a/cmake/std/atdm/load_matching_env.sh.in
+++ b/cmake/std/atdm/load_matching_env.sh.in
@@ -1,0 +1,6 @@
+# Source this script to load the env that was used to build this version of
+# Trilinos and also load env vars that describe what was built.
+
+source @ATDM_CONFIG_SCRIPTS_INSTALL_DIR@/load-env.sh @ATDM_JOB_NAME@
+
+export @ATDM_TRILINOS_INSTALL_PREFIX_ENV_VAR_NAME@=@CMAKE_INSTALL_PREFIX@

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on mutrino for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 
@@ -18,7 +18,7 @@ if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "HSW" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" != "K
   echo
   echo "***"
   echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option on this system."
-  echo "*** '$ATDM_CONFIG_KOKKOS_ARCH' appears in $JOB_NAME which then sets the KOKKOS_ARCH."
+  echo "*** '$ATDM_CONFIG_KOKKOS_ARCH' appears in $ATDM_CONFIG_JOB_NAME which then sets the KOKKOS_ARCH."
   echo "*** On Mutrino 'HSW' and 'KNL' are the only valid KOKKOS_ARCH settings."
   echo "*** If no KOKKOS_ARCH is specified then 'HSW' will be used by default."
   echo "***"
@@ -109,7 +109,7 @@ export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE
 # In this case, sbatch is used to run the script but it also sends ouptut to
 # STDOUT in real-time while it is running in addition to writing to the
 # <outout_file>.  The job name for the sbatch script is taken from the env var
-# 'JOB_NAME'.  This works for local builds since JOB_NAME.
+# 'ATDM_CONFIG_JOB_NAME'.  This works for local builds since ATDM_CONFIG_JOB_NAME.
 #
 # Note that you can pass in the script to run with arguments such as with
 # "<some-script> <arg1> <arg2>" and it will work.  But note that this has to
@@ -172,7 +172,7 @@ function atdm_run_script_on_compute_node {
   echo "Running '$script_to_run' using sbatch in the background ..."
   set -x
   sbatch --output=$output_file --wait -N1 ${ATDM_CONFIG_SBATCH_EXTRA_ARGS} \
-    --time=${timeout} -J $JOB_NAME ${script_to_run} &
+    --time=${timeout} -J $ATDM_CONFIG_JOB_NAME ${script_to_run} &
   SBATCH_PID=$!
   set +x
   

--- a/cmake/std/atdm/rhel6/environment.sh
+++ b/cmake/std/atdm/rhel6/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on a SEMS NFS mounted RHEL6 for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 
@@ -16,7 +16,7 @@ else
   echo
   echo "***"
   echo "*** ERROR: Specifying KOKKOS_ARCH is not supported on RHEL6 ATDM builds"
-  echo "*** remove '$ATDM_CONFIG_KOKKOS_ARCH' from JOB_NAME=$JOB_NAME"
+  echo "*** remove '$ATDM_CONFIG_KOKKOS_ARCH' from ATDM_CONFIG_JOB_NAME=$ATDM_CONFIG_JOB_NAME"
   echo "***"
   return
 fi

--- a/cmake/std/atdm/serrano/environment.sh
+++ b/cmake/std/atdm/serrano/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on serrano for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 
@@ -17,7 +17,7 @@ fi
 if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "BDW" ] ; then
   echo "***"
   echo "*** ERROR: KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH is not a valid option on this system."
-  echo "*** '$ATDM_CONFIG_KOKKOS_ARCH' appears in $JOB_NAME which then sets the KOKKOS_ARCH"
+  echo "*** '$ATDM_CONFIG_KOKKOS_ARCH' appears in $ATDM_CONFIG_JOB_NAME which then sets the KOKKOS_ARCH"
   echo "*** on Serrano 'BDW' is the only valid KOKKOS_ARCH. If no KOKKOS_ARCH is specified then"
   echo "*** 'BDW' will be used by default"
   echo "***"

--- a/cmake/std/atdm/shiller/environment.sh
+++ b/cmake/std/atdm/shiller/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on shiller/hansen for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 

--- a/cmake/std/atdm/toss3/environment.sh
+++ b/cmake/std/atdm/toss3/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on toss3 (chama and serrano) for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 
@@ -100,7 +100,7 @@ export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE
 # In this case, sbatch is used to run the script but it also sends ouptut to
 # STDOUT in real-time while it is running in addition to writing to the
 # <outout_file>.  The job name for the sbatch script is taken from the env var
-# 'JOB_NAME'.  This works for local builds since JOB_NAME.
+# 'ATDM_CONFIG_JOB_NAME'.  This works for local builds since ATDM_CONFIG_JOB_NAME.
 #
 # Note that you can pass in the script to run with arguments such as with
 # "<some-script> <arg1> <arg2>" and it will work.  But note that this has to
@@ -146,7 +146,7 @@ function atdm_run_script_on_compute_node {
   echo "Running '$script_to_run' using sbatch in the background ..."
   set -x
   sbatch --output=$output_file --wait -N1 --time=${timeout} \
-    -J $JOB_NAME --account=${account} ${script_to_run} &
+    -J $ATDM_CONFIG_JOB_NAME --account=${account} ${script_to_run} &
   SBATCH_PID=$!
   set +x
   

--- a/cmake/std/atdm/utils/set_build_options.sh
+++ b/cmake/std/atdm/utils/set_build_options.sh
@@ -5,13 +5,13 @@ if [ "$called" == "$0" ] ; then
   exit 1
 fi
 
-# Assert that JOB_NAME is set!
-if [ -z "$JOB_NAME" ] ; then
-  echo "Error, must set JOB_NAME in env!"
+# Assert that ATDM_CONFIG_JOB_NAME is set!
+if [ -z "$ATDM_CONFIG_JOB_NAME" ] ; then
+  echo "Error, must set ATDM_CONFIG_JOB_NAME in env!"
   return
 fi
 
-echo "Setting default compiler and build options for JOB_NAME='${JOB_NAME}'"
+echo "Setting default compiler and build options for ATDM_CONFIG_JOB_NAME='${ATDM_CONFIG_JOB_NAME}'"
 
 # Set the defaults
 export ATDM_CONFIG_COMPILER=DEFAULT
@@ -22,81 +22,81 @@ export ATDM_CONFIG_USE_CUDA=OFF
 export ATDM_CONFIG_USE_PTHREADS=OFF
 
 # Set the compiler
-if [[ $JOB_NAME == "default" ]]; then
+if [[ $ATDM_CONFIG_JOB_NAME == "default" ]]; then
   ATDM_CONFIG_COMPILER=DEFAULT
-elif [[ $JOB_NAME == *"gnu"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"gnu"* ]]; then
   ATDM_CONFIG_COMPILER=GNU
-elif [[ $JOB_NAME == *"intel"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"intel"* ]]; then
  ATDM_CONFIG_COMPILER=INTEL
-elif [[ $JOB_NAME == *"cuda-8.0"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"cuda-8.0"* ]]; then
   ATDM_CONFIG_COMPILER=CUDA-8.0
-elif [[ $JOB_NAME == *"cuda-9.0"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"cuda-9.0"* ]]; then
   ATDM_CONFIG_COMPILER=CUDA-9.0
-elif [[ $JOB_NAME == *"cuda-9.2"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"cuda-9.2"* ]]; then
   ATDM_CONFIG_COMPILER=CUDA-9.2
-elif [[ $JOB_NAME == *"cuda"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"cuda"* ]]; then
   ATDM_CONFIG_COMPILER=CUDA
-elif [[ $JOB_NAME == *"clang"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"clang"* ]]; then
   ATDM_CONFIG_COMPILER=CLANG
 else
   echo
   echo "***"
-  echo "*** ERROR: A compiler was not specified in '$JOB_NAME'!"
+  echo "*** ERROR: A compiler was not specified in '$ATDM_CONFIG_JOB_NAME'!"
   echo "***"
 fi
 
 # Set the KOKKOS_ARCH
-if [[ $JOB_NAME == *"-AMDAVX"* ]]; then
+if [[ $ATDM_CONFIG_JOB_NAME == *"-AMDAVX"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=AMDAVX
-elif [[ $JOB_NAME == *"-ARMv8-ThunderX"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-ARMv8-ThunderX"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=ARMv8-ThunderX
-elif [[ $JOB_NAME == *"-ARMv80"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-ARMv80"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=ARMv80
-elif [[ $JOB_NAME == *"-ARMv81"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-ARMv81"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=ARMv81
-elif [[ $JOB_NAME == *"-BDW"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-BDW"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=BDW
-elif [[ $JOB_NAME == *"-BGQ"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-BGQ"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=BGQ
-elif [[ $JOB_NAME == *"-HSW"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-HSW"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=HSW
-elif [[ $JOB_NAME == *"-Kepler30"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Kepler30"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Kepler30
-elif [[ $JOB_NAME == *"-Kepler32"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Kepler32"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Kepler32
-elif [[ $JOB_NAME == *"-Kepler35"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Kepler35"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Kepler35
-elif [[ $JOB_NAME == *"-Kepler37"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Kepler37"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Kepler37
-elif [[ $JOB_NAME == *"-KNC"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-KNC"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=KNC
-elif [[ $JOB_NAME == *"-KNL"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-KNL"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=KNL
-elif [[ $JOB_NAME == *"-Maxwell50"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Maxwell50"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Maxwell50
-elif [[ $JOB_NAME == *"-Maxwell52"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Maxwell52"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Maxwell52
-elif [[ $JOB_NAME == *"-Maxwell53"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Maxwell53"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Maxwell53
-elif [[ $JOB_NAME == *"-Pascal60"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Pascal60"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Pascal60
-elif [[ $JOB_NAME == *"-Pascal61"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Pascal61"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Pascal61
-elif [[ $JOB_NAME == *"-Power7"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Power7"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Power7
-elif [[ $JOB_NAME == *"-Power8"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Power8"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Power8
-elif [[ $JOB_NAME == *"-Power9"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Power9"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Power9
-elif [[ $JOB_NAME == *"-SKX"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-SKX"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=SKX
-elif [[ $JOB_NAME == *"-SNB"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-SNB"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=SNB
-elif [[ $JOB_NAME == *"-Volta70"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Volta70"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Volta70
-elif [[ $JOB_NAME == *"-Volta72"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-Volta72"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=Volta72
-elif [[ $JOB_NAME == *"-WSM"* ]]; then
+elif [[ $ATDM_CONFIG_JOB_NAME == *"-WSM"* ]]; then
   ATDM_CONFIG_KOKKOS_ARCH=WSM
 else
   ATDM_CONFIG_KOKKOS_ARCH=DEFAULT
@@ -107,14 +107,14 @@ fi
 
 # Set the optimization level
 # Defaults to debug
-if [[ $JOB_NAME == *"opt"* ]]; then export ATDM_CONFIG_BUILD_TYPE=RELEASE; fi
+if [[ $ATDM_CONFIG_JOB_NAME == *"opt"* ]]; then export ATDM_CONFIG_BUILD_TYPE=RELEASE; fi
 
 # Set the node types default to serial
 ATDM_CONFIG_NODE_TYPE=SERIAL
-if [[ $JOB_NAME == *"openmp"* ]]; then export ATDM_CONFIG_USE_OPENMP=ON;   ATDM_CONFIG_NODE_TYPE=OPENMP; fi
-if [[ $JOB_NAME == *"cuda"* ]];   then export ATDM_CONFIG_USE_CUDA=ON;     ATDM_CONFIG_NODE_TYPE=CUDA;   fi
-if [[ $JOB_NAME == *"pthread"* ]];then export ATDM_CONFIG_USE_PTHREADS=ON; ATDM_CONFIG_NODE_TYPE=THREAD; fi
-if [[ $JOB_NAME == *"serial"* ]];then  ATDM_CONFIG_NODE_TYPE=SERIAL; fi
+if [[ $ATDM_CONFIG_JOB_NAME == *"openmp"* ]]; then export ATDM_CONFIG_USE_OPENMP=ON;   ATDM_CONFIG_NODE_TYPE=OPENMP; fi
+if [[ $ATDM_CONFIG_JOB_NAME == *"cuda"* ]];   then export ATDM_CONFIG_USE_CUDA=ON;     ATDM_CONFIG_NODE_TYPE=CUDA;   fi
+if [[ $ATDM_CONFIG_JOB_NAME == *"pthread"* ]];then export ATDM_CONFIG_USE_PTHREADS=ON; ATDM_CONFIG_NODE_TYPE=THREAD; fi
+if [[ $ATDM_CONFIG_JOB_NAME == *"serial"* ]];then  ATDM_CONFIG_NODE_TYPE=SERIAL; fi
 
 # Assert a consistent set of options
 if [[ $ATDM_CONFIG_USE_OPENMP == "ON" && $ATDM_CONFIG_USE_CUDA == "ON" ]]; then echo "Can't set more than one backend"; return 1; fi

--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -2,7 +2,7 @@
 #
 # Set up env on waterman for ATMD builds of Trilinos
 #
-# This source script gets the settings from the JOB_NAME var.
+# This source script gets the settings from the ATDM_CONFIG_JOB_NAME var.
 #
 ################################################################################
 


### PR DESCRIPTION
@bathmatt, @jmgate, @fryeguy52 

## Description

Install the ATDM configuration scripts to allow loading it from and installation of Trilinos. See the updated README.md file for details.

I also renamed the env var set in atdm/load-env.sh from JOB_NAME to
ATDM_CONFIG_JOB_NAME.  This is to avoid confusing and other problems with the
unnamespaced var JOB_NAME which is set by Jenkins.  This does not change the
behavior of the CTest -S jenkins drivers that directly read from JOB_NAME.

## Motivation and Context

EMPIRE requires that the Trilinos install base directory have a file called `configure.sh` that can be sourced in order to load the env needed to use that installation of Trilinos.   This allows that by configuring with:

```
  -D CMAKE_INSTALL_PREFIX=<install-prefix> \
  -D ATDM_INSTALLED_ENV_LOAD_SCRIPT_NAME=configure.sh \
```

This is part of the larger story #3689.

## How Has This Been Tested?

I did the configure, build, and install of Teuchos locally to test this and tested sourcing the loaded module.

However, before this gets merged, I want to do a little more manual testing with the CTest -S drivers to make sure they still work since I renamed the var `JOB_NAME` as `ATDM_CONFIG_JOB_NAME` that are used internally.  This should not break anything but I just want o make sure.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
