### PR TITLE
MueLu: Fix wrong method to set output stream

### DIFF
--- a/packages/muelu/test/unit_tests_kokkos/MueLu_TestHelpers_Common_kokkos.hpp
+++ b/packages/muelu/test/unit_tests_kokkos/MueLu_TestHelpers_Common_kokkos.hpp
@@ -109,7 +109,7 @@
 // Macro to set MueLu's internal oh-so FancyOStream to be the same as the one used by Teuchos' unit testing framework.
 // This prevents MueLu's output from intermingling with with the unit test pass/fail summary lines.
 #define MUELU_TESTING_SET_OSTREAM \
-   MueLu::VerboseObject::SetDefaultOStream(Teuchos::fancyOStream(out.getOStream()));
+   MueLu::VerboseObject::SetMueLuOStream(Teuchos::fancyOStream(out.getOStream()));
 
 #define MUELU_TESTING_DO_NOT_TEST(lib,packagesNotEnabled) \
   if (TestHelpers_kokkos::Parameters::getLib() == lib) { \

--- a/packages/muelu/test/unit_tests_kokkos/SaPFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/SaPFactory_kokkos.cpp
@@ -147,7 +147,7 @@ namespace MueLuTests {
   TEUCHOS_UNIT_TEST(SaPFactory_kokkos, EpetraVsTpetra)
   {
 #   include "MueLu_UseShortNames.hpp"
-    MueLu::VerboseObject::SetDefaultOStream(Teuchos::rcpFromRef(out));
+    MueLu::VerboseObject::SetMueLuOStream(Teuchos::rcpFromRef(out));
 
     out << "version: " << MueLu::Version() << std::endl;
     out << "Compare results of Epetra and Tpetra" << std::endl;


### PR DESCRIPTION
@trilinos/muelu 

## Description
Follow-up fix for PR #3419. Set the output stream correctly in MueLu's Kokkos refactor unit tests.

