### PR TITLE
PullRequestLinuxDriver.sh: correct syntax error

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -104,7 +104,7 @@ do
   ierror=$?
   if [[ $ierror != 0 ]]; then
     echo "Source remote fetch failed. The error code was: $ierror"
-    if i != num_retries
+    if $i != $num_retries
     then
       echo "retry $i"
       sleep $(($i*20))


### PR DESCRIPTION
must dereference shell variables when used.

@trilinos/framework 

## Motivation and Context
Broke PR #3527 

