### PR TITLE
Disable four exodus SEACAS tests failing with Not Run on mutrino (#3496)

### DIFF
--- a/cmake/std/atdm/mutrino/tweaks/ALL_BUILDS.cmake
+++ b/cmake/std/atdm/mutrino/tweaks/ALL_BUILDS.cmake
@@ -19,3 +19,10 @@ ATDM_SET_ENABLE(SEACASAprepro_aprepro_unit_test_DISABLE ON)
 ATDM_SET_ENABLE(SEACASAprepro_lib_aprepro_lib_array_test_DISABLE ON)
 ATDM_SET_ENABLE(SEACASAprepro_lib_aprepro_lib_unit_test_DISABLE ON)
 ATDM_SET_ENABLE(SEACASExodus_exodus_unit_tests_nc5_env_DISABLE ON)
+
+# Disable seaas tests with strange Not Run with a not found for a command (see
+# #3496)
+ATDM_SET_ENABLE(SEACASAprepro_aprepro_test_exodus_DISABLE ON)
+ATDM_SET_ENABLE(SEACASIoss_exodus32_to_exodus32_DISABLE ON)
+ATDM_SET_ENABLE(SEACASIoss_exodus32_to_exodus32_pnetcdf_DISABLE ON)
+ATDM_SET_ENABLE(SEACASIoss_exodus32_to_exodus64_DISABLE ON)


### PR DESCRIPTION
@trilinos/seacas, @gsjaardema 

## Description

The commands run fine when run manually but for some reason ctest refuses to
run these and reports a:

```
  Unable to find required file: CMND_PATH-NOTFOUND
```

error.

It was requested to disable these tests.

## Motivation and Context

Tests have been failing for some time and it is desired to disable them (see https://github.com/trilinos/Trilinos/issues/3496#issuecomment-425243790).

## How Has This Been Tested?

I tested this on 'mutrino' by running:

```
$ cd ~/Trilinos.base/BUILDS/MUTRINO/CHECKIN/

$ ./checkin-test-atdm.sh intel-opt-openmp-HSW intel-opt-openmp-KNL \
  --enable-packages=SEACAS --configure
```

The showed the correct disables:

```
$ find . -maxdepth 2 -name "configure.out" -exec grep -nH "NOT added" {} \; | grep "_DISABLE" | grep exodus | grep -v "unit_tests"
./intel-opt-openmp-KNL/configure.out:409:-- SEACASIoss_exodus32_to_exodus32: NOT added test because SEACASIoss_exodus32_to_exodus32_DISABLE='ON'!
./intel-opt-openmp-KNL/configure.out:410:-- SEACASIoss_exodus32_to_exodus64: NOT added test because SEACASIoss_exodus32_to_exodus64_DISABLE='ON'!
./intel-opt-openmp-KNL/configure.out:411:-- SEACASIoss_exodus32_to_exodus32_pnetcdf: NOT added test because SEACASIoss_exodus32_to_exodus32_pnetcdf_DISABLE='ON'!
./intel-opt-openmp-KNL/configure.out:423:-- SEACASAprepro_aprepro_test_exodus: NOT added test because SEACASAprepro_aprepro_test_exodus_DISABLE='ON'!
./intel-opt-openmp-HSW/configure.out:409:-- SEACASIoss_exodus32_to_exodus32: NOT added test because SEACASIoss_exodus32_to_exodus32_DISABLE='ON'!
./intel-opt-openmp-HSW/configure.out:410:-- SEACASIoss_exodus32_to_exodus64: NOT added test because SEACASIoss_exodus32_to_exodus64_DISABLE='ON'!
./intel-opt-openmp-HSW/configure.out:411:-- SEACASIoss_exodus32_to_exodus32_pnetcdf: NOT added test because SEACASIoss_exodus32_to_exodus32_pnetcdf_DISABLE='ON'!
./intel-opt-openmp-HSW/configure.out:423:-- SEACASAprepro_aprepro_test_exodus: NOT added test because SEACASAprepro_aprepro_test_exodus_DISABLE='ON'!

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
