### PR TITLE
PyTrilinos: Ifpack capitalization fix

### DIFF
--- a/packages/PyTrilinos/src/PyTrilinos_IFPACK_Headers.hpp
+++ b/packages/PyTrilinos/src/PyTrilinos_IFPACK_Headers.hpp
@@ -45,7 +45,7 @@
 
 // Configuration
 #include "PyTrilinos_config.h"
-#include "IFPACK_ConfigDefs.h"
+#include "Ifpack_ConfigDefs.h"
 
 // IFPACK include files
 #include "Ifpack.h"


### PR DESCRIPTION
@trilinos/pytrilinos 

## Description
As per #3245 and #3441, the file `PyTrilinos_IFPACK_Headers.hpp` includes a mis-capitalized `IFPACK_ConfigDefs.h`.

## Motivation and Context
Builds correctly on Mac OS X because the file system is case-insensitive, but fails to build on other platforms.

## Related Issues

* Closes #3245, #3441 

## How Has This Been Tested?
Unfortunately, only on my MacBook Pro, so the test is incomplete.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
