### PR TITLE
kokkos-kernels: Fix #3493 (incorrect dot product results & segfaults for complex Tpetra::MultiVector)

### DIFF
--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
@@ -73,8 +73,8 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
 
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
+//KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
+//KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
 
 
 #endif

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -51,11 +51,12 @@ extern "C" double               ddot_( const int* N, const double* x, const int*
                                        const double* y, const int* y_inc);
 extern "C" float                sdot_( const int* N, const float* x, const int* x_inc,
                                        const float* y, const int* y_inc);
+/*
 extern "C" std::complex<double> zdotu_( const int* N, const std::complex<double>* x, const int* x_inc,
                                        const std::complex<double>* y, const int* y_inc);
 extern "C" std::complex<float>  cdotu_( const int* N, const std::complex<float>* x, const int* x_inc,
                                        const std::complex<float>* y, const int* y_inc);
-
+*/				    
 namespace KokkosBlas {
 namespace Impl {
 
@@ -131,6 +132,8 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   } \
 };
 
+#if 0
+
 #define KOKKOSBLAS1_ZDOT_TPL_SPEC_DECL_BLAS( LAYOUT, MEMSPACE, ETI_SPEC_AVAIL ) \
 template<class ExecSpace> \
 struct Dot< \
@@ -195,17 +198,23 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   } \
 };
 
+#endif // 0
+
 KOKKOSBLAS1_DDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, true)
 KOKKOSBLAS1_DDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, false)
 
 KOKKOSBLAS1_SDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, true)
 KOKKOSBLAS1_SDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, false)
 
+#if 0
+
 KOKKOSBLAS1_ZDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, true)
 KOKKOSBLAS1_ZDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, false)
 
 KOKKOSBLAS1_CDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, true)
 KOKKOSBLAS1_CDOT_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, false)
+
+#endif // 0
 
 }
 }


### PR DESCRIPTION
@trilinos/tpetra @trilinos/kokkos-kernels @kddevin @kyungjoo-kim 

## Description

`KokkosBlas::dot` for 1-D Views gave incorrect complex dot product results, due to incorrect assumptions about the Fortran ABI for complex return values.  This made Tpetra tests fail with complex enabled.  I fixed this by patching kokkos-kernels not to use the BLAS for those functions.

NOTE: I have not yet patched kokkos-kernels.  https://github.com/kokkos/kokkos-kernels/issues/307 discusses various ways to fix the issue.  I would prefer to let kokkos-kernels developers decide how to do that in a more permanent way.
 
## Motivation and Context

Salinas uses Tpetra with complex arithmetic.

## Related Issues

* Closes #3493
* Related to https://github.com/kokkos/kokkos-kernels/issues/307 

## How Has This Been Tested?

Mac, Clang, OpenMPI.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.