### PR TITLE
Phalanx: add debug output support during DAG traversal

### DIFF
--- a/packages/phalanx/example/FiniteElementAssembly/FiniteElementAssembly.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly/FiniteElementAssembly.cpp
@@ -263,6 +263,9 @@ int main(int argc, char *argv[])
     fm.postRegistrationSetup(nullptr);
     fm.writeGraphvizFile("example_fem",".dot",true,true);
 
+    // In debug mode, print the evaluator start stop messages
+    fm.printEvaluatorStartStopMessage<Residual>(Teuchos::rcpFromRef(std::cout));
+
     // Set the team and vector size on the workset for Host DAG
     for (auto& w : worksets) {
       w.team_size_ = p.teamSize();

--- a/packages/phalanx/example/FiniteElementAssembly_DeviceDag/FiniteElementAssembly_DeviceDag.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly_DeviceDag/FiniteElementAssembly_DeviceDag.cpp
@@ -262,6 +262,9 @@ int main(int argc, char *argv[])
     fm.postRegistrationSetup(nullptr,build_device_dag);
     fm.writeGraphvizFile("example_fem",".dot",true,true);
 
+    // In debug mode, print the evaluator start stop messages
+    fm.printEvaluatorStartStopMessage<Residual>(Teuchos::rcpFromRef(std::cout));
+
     // Create targets to fill (residual and Jacobian)
     Kokkos::View<double*,PHX::Device> f = lof.createSolutionVector("global_residual"); // residual
     KokkosSparse::CrsMatrix<double,int,PHX::Device> J = lof.createJacobianMatrix("global_jacobian"); // Jacobian

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/FiniteElementAssembly_MixedFieldTypes.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/FiniteElementAssembly_MixedFieldTypes.cpp
@@ -291,6 +291,9 @@ int main(int argc, char *argv[])
     fm.postRegistrationSetup(nullptr);
     fm.writeGraphvizFile("example_fem",".dot",true,true);
 
+    // In debug mode, print the evaluator start stop messages
+    fm.printEvaluatorStartStopMessage<Residual>(Teuchos::rcpFromRef(std::cout));
+
     // Set the team and vector size on the workset for Host DAG
     for (auto& w : worksets) {
       w.team_size_ = p.teamSize();

--- a/packages/phalanx/src/Phalanx_DAG_Manager.hpp
+++ b/packages/phalanx/src/Phalanx_DAG_Manager.hpp
@@ -200,6 +200,14 @@ namespace PHX {
     std::vector<Teuchos::RCP<PHX::Evaluator<Traits>>>& 
     getEvaluatorsBindingField(const PHX::FieldTag& ft);
 
+    /** \brief Print to user specified ostream when each evalautor
+        starts and stops. Useful for debugging. Enabled only in debug
+        builds.
+
+        @param [in] ostr RCP to output stream. If set to null, this disables printing.
+    */
+    void printEvaluatorStartStopMessage(const Teuchos::RCP<std::ostream>& ostr);
+
   protected:
 
     /*! @brief Depth-first search algorithm. */ 
@@ -275,6 +283,9 @@ namespace PHX {
     
     //! Contians pointers to DeviceEvaluators for Device DAG support.
     Kokkos::View<PHX::DeviceEvaluatorPtr<Traits>*,PHX::Device> device_evaluators_;
+
+    //! If non-null, in debug builds, the DAG manager will print when an evalautor starts and stops.
+    Teuchos::RCP<std::ostream> start_stop_debug_ostream_;
   };
   
   template<typename Traits>

--- a/packages/phalanx/src/Phalanx_DAG_Manager_Def.hpp
+++ b/packages/phalanx/src/Phalanx_DAG_Manager_Def.hpp
@@ -435,6 +435,14 @@ evaluateFields(typename Traits::EvalData d)
 #ifdef PHX_TEUCHOS_TIME_MONITOR
     Teuchos::TimeMonitor Time(*evalTimers[topoSortEvalIndex[n]]);
 #endif
+
+#ifdef PHX_DEBUG
+    if (nonnull(start_stop_debug_ostream_)) {
+      *start_stop_debug_ostream_ << "Phalanx::DagManager: Starting node: "
+                                 << nodes_[topoSortEvalIndex[n]].getNonConst()->getName()
+                                 << std::endl;
+    }
+#endif
     
     using clock = std::chrono::steady_clock;
     std::chrono::time_point<clock> start = clock::now();
@@ -442,6 +450,15 @@ evaluateFields(typename Traits::EvalData d)
     nodes_[topoSortEvalIndex[n]].getNonConst()->evaluateFields(d);
     
     nodes_[topoSortEvalIndex[n]].sumIntoExecutionTime(clock::now()-start);
+
+#ifdef PHX_DEBUG
+    if (nonnull(start_stop_debug_ostream_)) {
+      *start_stop_debug_ostream_ << "Phalanx::DagManager: Completed node: "
+                                 << nodes_[topoSortEvalIndex[n]].getNonConst()->getName()
+                                 << std::endl;
+    }
+#endif
+
   }
 }
 
@@ -860,6 +877,15 @@ std::vector<Teuchos::RCP<PHX::Evaluator<Traits>>>&
 PHX::DagManager<Traits>::getEvaluatorsBindingField(const PHX::FieldTag& ft)
 {
   return field_to_evaluators_binding_[ft.identifier()];
+}
+
+//=======================================================================
+template<typename Traits>
+void
+PHX::DagManager<Traits>::
+printEvaluatorStartStopMessage(const Teuchos::RCP<std::ostream>& ostr)
+{
+  start_stop_debug_ostream_ = ostr;
 }
 
 //=======================================================================

--- a/packages/phalanx/src/Phalanx_EvaluationContainer.hpp
+++ b/packages/phalanx/src/Phalanx_EvaluationContainer.hpp
@@ -146,6 +146,14 @@ namespace PHX {
      */
     const std::vector<Teuchos::RCP<PHX::FieldTag>>& getFieldTags();
 
+    /** \brief Print to user specified ostream when each evalautor
+        starts and stops. Useful for debugging. Enabled only in debug
+        builds.
+
+        @param [in] ostr RCP to output stream. If set to null, this disables printing.
+    */
+    void printEvaluatorStartStopMessage(const Teuchos::RCP<std::ostream>& ostr);
+
   protected:
 
     bool post_registration_setup_called_;

--- a/packages/phalanx/src/Phalanx_EvaluationContainer_Def.hpp
+++ b/packages/phalanx/src/Phalanx_EvaluationContainer_Def.hpp
@@ -395,5 +395,14 @@ PHX::EvaluationContainer<EvalT, Traits>::getFieldTags()
 }
 
 // *************************************************************************
+template <typename EvalT, typename Traits>
+void
+PHX::EvaluationContainer<EvalT, Traits>::
+printEvaluatorStartStopMessage(const Teuchos::RCP<std::ostream>& ostr)
+{
+  this->dag_manager_.printEvaluatorStartStopMessage(ostr);
+}
+
+// *************************************************************************
 
 #endif 

--- a/packages/phalanx/src/Phalanx_FieldManager.hpp
+++ b/packages/phalanx/src/Phalanx_FieldManager.hpp
@@ -322,6 +322,15 @@ namespace PHX {
     const std::vector<Teuchos::RCP<PHX::FieldTag>>&
     getFieldTagsForSizing();
 
+    /** \brief Print to user specified ostream when each evalautor
+        starts and stops. Useful for debugging. Enabled only in debug
+        builds.
+
+        @param [in] ostr RCP to output stream. If set to null, this disables printing.
+    */
+    template<typename EvalT>
+    void printEvaluatorStartStopMessage(const Teuchos::RCP<std::ostream>& ostr);
+
   private:
 
     typedef PHX::EvaluationContainer_TemplateManager<Traits> SCTM;

--- a/packages/phalanx/src/Phalanx_FieldManager_Def.hpp
+++ b/packages/phalanx/src/Phalanx_FieldManager_Def.hpp
@@ -497,5 +497,14 @@ PHX::FieldManager<Traits>::getFieldTagsForSizing()
 }
 
 // **************************************************************
+template<typename Traits>
+template<typename EvalT>
+void PHX::FieldManager<Traits>::
+printEvaluatorStartStopMessage(const Teuchos::RCP<std::ostream>& ostr)
+{
+  m_eval_containers.template getAsObject<EvalT>()->printEvaluatorStartStopMessage(ostr);  
+}
+
+// **************************************************************
 
 #endif


### PR DESCRIPTION
Application requested option to output the start and stop of evaluators for help with debugging.