### PR TITLE
PyTrilinos: Remove includes of NOX_Version.h

### DIFF
--- a/packages/PyTrilinos/src/NOX.__init__.i
+++ b/packages/PyTrilinos/src/NOX.__init__.i
@@ -124,15 +124,6 @@ from . import ___init__
 %constant bool Have_Epetra = false;
 #endif
 
-/////////////////////////
-// NOX Version support //
-/////////////////////////
-%include "NOX_Version.H"
-%pythoncode
-%{
-__version__ = version().split()[2]
-%}
-
 ///////////////////////
 // NOX Utils support //
 ///////////////////////


### PR DESCRIPTION
@trilinos/pytrilinos 

## Description
Removes includes of non-existent `NOX_Version.h`

## Related Issues
* Closes #3548 

## How Has This Been Tested?
On my MacBook Pro with PyTrilinos, NOX, and NOX prerequisites enabled, with the exception of Tpetra (see #3456)

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
