### PR TITLE
Tempus: add `abs` guard around embedded error estimator

### DIFF
--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -288,11 +288,12 @@ void StepperDIRK<Scalar>::takeStep(
        //compute: || ee / sc ||
        assign(sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
        Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *ee_, *abs_u, sc.ptr());
-       Scalar err = Thyra::norm_inf(*sc);
+       Scalar err = std::abs(Thyra::norm_inf(*sc));
        metaData->setErrorRel(err);
 
        // test if step should be rejected
-       if (err > 1.0) workingState->setSolutionStatus(Status::FAILED);
+       if (std::isinf(err) || std::isnan(err)) workingState->setSolutionStatus(Status::FAILED);
+       else if (err > Teuchos::as<Scalar>(1.0)) workingState->setSolutionStatus(Status::FAILED);
     }
 
     if (pass == true) workingState->setSolutionStatus(Status::PASSED);

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -376,11 +376,12 @@ void StepperExplicitRK<Scalar>::takeStep(
        //compute: || ee / sc ||
        assign(sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
        Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *ee_, *abs_u, sc.ptr());
-       Scalar err = Thyra::norm_inf(*sc);
+       Scalar err = std::abs(Thyra::norm_inf(*sc));
        metaData->setErrorRel(err);
 
        // test if step should be rejected
-       if (err > 1.0) workingState->setSolutionStatus(Status::FAILED);
+       if (std::isinf(err) || std::isnan(err)) workingState->setSolutionStatus(Status::FAILED);
+       else if (err > Teuchos::as<Scalar>(1.0)) workingState->setSolutionStatus(Status::FAILED);
     }
 
     workingState->setOrder(this->getOrder());


### PR DESCRIPTION
To hopefully catch an over/under-flow bug in the comparison `err > 1.0`

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus 

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
[All Tempus tests are passing](https://github.com/trilinos/Trilinos/files/2439833/Tuesday-2018-10-02-15_45-build_tempus_dev-test.log)
