### PR TITLE
Atdm waterman disables

### DIFF
--- a/cmake/std/atdm/waterman/tweaks/CUDA-9.2-DEBUG-CUDA-POWER9-VOLTA70.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA-9.2-DEBUG-CUDA-POWER9-VOLTA70.cmake
@@ -4,5 +4,10 @@ ATDM_SET_ENABLE(TeuchosNumerics_LAPACK_test_MPI_1_DISABLE ON)
 #disable from issue #2466
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
 
+# Disable some unit tests that run too slow in this DEBUG build (#2827)
+ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_block_gauss_seidel_double_int_size_t_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
+  CACHE STRING )
+
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ALL_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,0 +1,6 @@
+# This test fails consistently (#2751)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
+
+# This test runs out of CUDA memory all on its own (#3340)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)
+

--- a/cmake/std/atdm/waterman/tweaks/GNU-DEBUG-OPENMP-POWER9.cmake
+++ b/cmake/std/atdm/waterman/tweaks/GNU-DEBUG-OPENMP-POWER9.cmake
@@ -4,6 +4,11 @@ ATDM_SET_ENABLE(TeuchosNumerics_LAPACK_test_MPI_1_DISABLE ON)
 #disable from issue #2466
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
 
+# Disable some unit tests that run too slow in this DEBUG build (#2827)
+ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_block_gauss_seidel_double_int_size_t_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
+  CACHE STRING )
+
 #disable failing test as in #3173
 ATDM_SET_ENABLE(KokkosKernels_sparse_openmp_MPI_1_DISABLE ON)
 


### PR DESCRIPTION
@trilinos/framework @bartlettroscoe 

## Description
This disables the test `PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3` on the atdm waterman builds:

* Trilinos-atdm-waterman-cuda-9.2-debug
* Trilinos-atdm-waterman-cuda-9.2-opt

see #2751 

This also disables a unit test that is timing out in the test `KokkosKernels_sparse_serial_MPI_1` on the atdm waterman builds:

* Trilinos-atdm-waterman-cuda-9.2-debug
* Trilinos-atdm-waterman-gnu-debug-openmp

see #3438 and #2964 

`KokkosKernels_sparse_serial_MPI_1` does not timeout anymore on these builds when I tested it

Trilinos-atdm-waterman-cuda-9.2-debug
```
7/8 Test #6: KokkosKernels_sparse_serial_MPI_1 ...   Passed  230.71 sec
```
Trilinos-atdm-waterman-gnu-debug-openmp
```
6/7 Test #5: KokkosKernels_sparse_serial_MPI_1 ...   Passed  217.19 sec
```