### PR TITLE
Piro: adding feature request for Tempus when called through Piro.

### DIFF
--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
@@ -191,8 +191,9 @@ template <typename Scalar>
 void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::observeTimeStep()
 {
-  //Don't observe solution if step failed to converge 
-  if (solutionHistory_->getWorkingState()->getSolutionStatus() == Tempus::Status::FAILED) { 
+  //Don't observe solution if step failed to converge
+  if ((solutionHistory_->getWorkingState() != Teuchos::null) && 
+     (solutionHistory_->getWorkingState()->getSolutionStatus() == Tempus::Status::FAILED)) { 
     return;
   }
  

--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
@@ -191,6 +191,11 @@ template <typename Scalar>
 void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::observeTimeStep()
 {
+  //Don't observe solution if step failed to converge 
+  if (solutionHistory_->getWorkingState()->getSolutionStatus() == Tempus::Status::FAILED) { 
+    return;
+  }
+ 
   //Get solution
   Teuchos::RCP<const Thyra::VectorBase<Scalar> > solution = solutionHistory_->getCurrentState()->getX();
   solution.assert_not_null();


### PR DESCRIPTION
It does not make sense to call the observer when a particular Tempus
step did not complete successfully.  Adding logic to only call observer
upon successful completion of Tempus step.

@trilinos/piro 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.


## Description

## Motivation and Context
Feature request by @bartgol for some Albany problems.

## Related Issues

## How Has This Been Tested?
Tested on Fedora 28 workstation by running Piro as well as Albany tests. 

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

