### PR TITLE
Piro: adding feature request for Tempus when called through Piro.

### DIFF
--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
@@ -191,6 +191,12 @@ template <typename Scalar>
 void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::observeTimeStep()
 {
+  //Don't observe solution if step failed to converge
+  if ((solutionHistory_->getWorkingState() != Teuchos::null) && 
+     (solutionHistory_->getWorkingState()->getSolutionStatus() == Tempus::Status::FAILED)) { 
+    return;
+  }
+ 
   //Get solution
   Teuchos::RCP<const Thyra::VectorBase<Scalar> > solution = solutionHistory_->getCurrentState()->getX();
   solution.assert_not_null();


### PR DESCRIPTION
It does not make sense to call the observer when a particular Tempus
step did not complete successfully. Adding logic to only call observer
upon successful completion of Tempus step.

@trilinos/piro 

## Description

## Motivation and Context
Feature request by @bartgol for Albany.

## Related Issues

## How Has This Been Tested?
Run Piro and Albany tests.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

