### PR TITLE
PyTrilinos: Parse MPI version properly

### DIFF
--- a/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
+++ b/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
@@ -46,7 +46,7 @@ def get_mpi_version():
     version = ""
     for line in open(header, 'r').readlines():
         if "MPI_VERSION" in line:
-            version = line.split(" ")[2]
+            version = line.split()[2]
             break
     return version
 
@@ -238,23 +238,12 @@ def form_class_filename(parsed_class):
     """
 
     # Determine the extension
-    if parsed_class["name"].startswith("Epetra_"):
-        ext = ".h"
-    elif parsed_class["name"].startswith("Amesos_"):
-        ext = ".h"
-    elif parsed_class["name"].startswith("AztecOO_"):
-        ext = ".h"
-    elif parsed_class["name"].startswith("Ifpack_"):
-        ext = ".h"
-    elif parsed_class["name"].startswith("Komplex_"):
+    if parsed_class["name"].startswith(("Epetra_", "Amesos_" , "AztecOO_",
+                                        "Ifpack_", "Komplex_", "Trilinos_Util_")):
         ext = ".h"
     elif parsed_class["name"] == "Pliris":
         ext = ".h"
-    elif parsed_class["name"].startswith("Trilinos_Util_"):
-        ext = ".h"
-    elif parsed_class["namespaces"][0] == "EpetraExt":
-        ext = ".h"
-    elif parsed_class["namespaces"][0] == "MLAPI":
+    elif parsed_class["namespaces"][0] in ("EpetraExt", "MLAPI"):
         ext = ".h"
     elif parsed_class["namespaces"][0] in ("NOX", "LOCA"):
         ext = ".H"
@@ -428,6 +417,9 @@ def reorder_classnames(classnames):
 ################################################################################
 
 def get_import_directives(teuchos_rcps):
+    """
+
+    """
     result = []
     for classname in teuchos_rcps:
         filename = form_class_filename(parse_class(classname))

--- a/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
+++ b/packages/PyTrilinos/src/gen_teuchos_rcp.py.in
@@ -39,6 +39,13 @@ WITH_LOCA      = cmake_bool("${NOX_ENABLE_LOCA}"            )
 WITH_MPI       = cmake_bool("${TPL_ENABLE_MPI}"             )
 WITH_PETSC     = cmake_bool("${TPL_ENABLE_PETSC}"           )
 
+# Find the MPI base directory
+MPI_BASE_DIR   = "${MPI_BASE_DIR}"
+if WITH_MPI:
+    if MPI_BASE_DIR == "":
+        MPI_BIN_DIR  = os.path.split("${MPI_CXX_COMPILER}")[0]
+        MPI_BASE_DIR = os.path.split(MPI_BIN_DIR)[0]
+
 ################################################################################
 
 def get_mpi_version():


### PR DESCRIPTION
@trilinos/pytrilinos 

## Description
A build script `get_teuchos_rcp.py` was not parsing the location of the `mpi.h` header accurately on all systems. These changes make that parsing exercise more robust.

## Motivation and Context
Reported in #3215 

## Related Issues

* Closes #3215

## How Has This Been Tested?
This has only been tested in an environment where it was already working. So it did not introduce any build errors, but it should help fix what it was intended to fix.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
