### PR TITLE
Replace bind1st and bind2nd by lambdas

### DIFF
--- a/packages/anasazi/src-rbgen/RBGen_Filter.hpp
+++ b/packages/anasazi/src-rbgen/RBGen_Filter.hpp
@@ -200,14 +200,20 @@ namespace RBGen {
 
       std::vector<int> ret;
       if (LARGEST == which_) {
-        int num = find(svals.begin(),svals.end(),bind2nd(std::less<ScalarType>(),tval)) - svals.begin();
+        const int num = find(svals.begin(),svals.end(),
+                             [] (const ScalarType sval) {
+                               return sval < tval;
+                             }) - svals.begin();
         ret.resize(num);
         for (int i=0; i<num; ++i) {
           ret.push_back(i);
         }
       }
       else if (SMALLEST == which_) {
-        int num = svals.end() - find(svals.begin(),svals.end(),bind2nd(std::less<ScalarType>(),tval)) + 1;
+        const int num = svals.end() - find(svals.begin(),svals.end(),
+                                           [] (const ScalarType sval) {
+                                             return sval < tval;
+                                           }) + 1;
         ret.resize(num);
         for (int i=last-num+1; i<last; ++i) {
           ret.push_back(i);

--- a/packages/tpetra/core/inout/Tpetra_MatrixIO.cpp
+++ b/packages/tpetra/core/inout/Tpetra_MatrixIO.cpp
@@ -293,7 +293,7 @@ void Tpetra::Utils::readHBMatDouble(const std::string &filename, int &numRows, i
         fin.getline(lineBuf, MAXSIZE);
         TEUCHOS_TEST_FOR_EXCEPTION(std::sscanf(lineBuf,"%*s") < 0, std::runtime_error, errStr);
         // if valFlag == 'D', then we need to convert [dD] in fp vals into [eE] that scanf can parse
-        if (valFlag == 'D') std::replace_if(lineBuf, lineBuf+MAXSIZE, std::bind2nd(std::equal_to<char>(), 'D'), 'E'); 
+        if (valFlag == 'D') std::replace_if(lineBuf, lineBuf+MAXSIZE, [] (const char c) { return c == 'D'; }, 'E');
         char *linePtr = lineBuf;
         for (int valcntr=0; valcntr < valsPerLine; ++valcntr) {
           if (valsRead == totalNumVals) break;

--- a/packages/tpetra/core/src/Tpetra_Export_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Export_def.hpp
@@ -545,7 +545,9 @@ namespace Classes {
         const size_type numInvalidExports =
           std::count_if (ExportData_->exportPIDs_().begin(),
                          ExportData_->exportPIDs_().end(),
-                         std::bind1st (std::equal_to<int>(), -1));
+                         [] (const int processor_id) {
+                           return processor_id == -1;
+                         });
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (numInvalidExports == 0, std::logic_error, "Calling getRemoteIndexList "
            "on the target Map returned IDNotPresent, but none of the returned "

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -1163,7 +1163,9 @@ namespace Classes {
 
       const size_type numInvalidRemote =
         std::count_if (remoteProcIDs.begin (), remoteProcIDs.end (),
-                       std::bind1st (std::equal_to<int> (), -1));
+                       [] (const int processor_id) {
+                         return processor_id == -1;
+                       });
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (numInvalidRemote == 0, std::logic_error, "Calling getRemoteIndexList "
          "on the source Map returned IDNotPresent, but none of the returned "


### PR DESCRIPTION
@trilinos/anasazi
@trilinos/tpetra

## Description
Replace bind1st and bind2nd by lambda functions.

## Motivation and Context
As of C++11 `std::bind1st` and `std::bind2nd` are deprecated and removed in the C++17 standard.
In particular, `libc++` doesn't contain them anymore if compiling with `std=c++17`. They can be replaced by simple lambdas.

## How Has This Been Tested?
I compiled Trilinos.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

## Additional Information
This PR requires C++11