### PR TITLE
PyTrilinos: Suppress Zoltan Debugging Output

### DIFF
--- a/packages/PyTrilinos/example/exIsorropia.py.in
+++ b/packages/PyTrilinos/example/exIsorropia.py.in
@@ -103,34 +103,34 @@ def main(comm):
     print(colorer.elemsWithColor(0))
 
 
-    pList = Teuchos.ParameterList()
-    pList.set("PARTITIONING METHOD", "RANDOM")
+    pList = {"partitioning method": "random",
+             "Zoltan": {"debug_level": "0"}}
 
     if iAmRoot: print("Constructing Isorropia.Epetra.Partitioner")
     partitioner = Isorropia.Epetra.Partitioner(crsg, pList)
     partitioner.partition(True)
-    print(partitioner)
+    #print(partitioner)
 
-    #pList.set("PARTITIONING METHOD", "HYPERGRAPH2D")
+    #pList["partitioning method"] = "hypergraph2d"
     #if iAmRoot: print("Constructing Isorropia.Epetra.Partitioner2D")
     #part2D = Isorropia.Epetra.Partitioner2D(crsg, pList)
     #print(part2D)
 
-    pList.set("PARTITIONING METHOD", "HYPERGRAPH2D")
+    pList["partitioning method"] = "hypergraph2d"
     if iAmRoot: print("Constructing Isorropia.Epetra.Partitioner")
     part2D = Isorropia.Epetra.Partitioner(crsg, pList)
-    print(part2D)
+    #print(part2D)
 
     if iAmRoot: print("Constructing Isorropia.Epetra.Redistributor")
     Redis = Isorropia.Epetra.Redistributor(partitioner)
     newCrsg = Redis.redistribute(crsg)
-    print(Redis)
+    #print(Redis)
 
     print(newCrsg)
 
-    print("BUILDING COSTDESCRIBER")
+    print("Building CostDescriber")
     costDesc = Isorropia.Epetra.CostDescriber()
-    print(costDesc)
+    #print(costDesc)
 
 ################################################################################
 

--- a/packages/PyTrilinos/src/Isorropia.Epetra.i
+++ b/packages/PyTrilinos/src/Isorropia.Epetra.i
@@ -80,7 +80,6 @@ from . import _IsorropiaEpetra
 
 // Local include files
 #define NO_IMPORT_ARRAY
-#define SWIG_FILE_WITH_INIT
 #include "numpy_include.hpp"
 %}
 

--- a/packages/PyTrilinos/test/testIsorropia.py.in
+++ b/packages/PyTrilinos/test/testIsorropia.py.in
@@ -64,57 +64,62 @@ class PartitionerTestCase(unittest.TestCase):
     def setUp(self):
         nRows = 10
         self.pList = Teuchos.ParameterList()
-        self.pList.set("PARTITIONING METHOD", "CYCLIC")
-        self.pDictionary = {"PARTITIONING METHOD":"CYCLIC"}
+        self.pList.set("partitioning method", "cyclic")
+        self.sublist = self.pList.sublist("Zoltan")
+        self.sublist.set("debug_level", "0")
+        self.quiet = {"debug_level": "0"}
+        self.pDictionary = {"partitioning method": "cyclic",
+                            "Zoltan": self.quiet}
         self.map = Epetra.Map(nRows, 0, comm)
         self.crsg = buildGraph(comm, comm.NumProc()*10)
-        
-        
         self.part = Isorropia.Epetra.Partitioner(self.crsg, self.pList)
         self.costs = Isorropia.Epetra.CostDescriber()
-#        self.pv = LOCA.ParameterVector()
-#        self.pv.addParameter("Zero"     )
-#        self.pv.addParameter("One", 1.0 )
-#        self.pv.addParameter("Pi" , 3.14)
-
-
 
     def testAlwaysPasses(self):
-        "Test Isorropia.alwaysPasses"
+        """
+        Test Isorropia.alwaysPasses
+        """
         self.assertEquals(0, 0.0)
 
     def testConstructor0(self):
-        """Test Partitioner(Teuchos::RCP<const Epetra_CrsGraph> input_graph,
+        """
+        Test Partitioner(Teuchos::RCP<const Epetra_CrsGraph> input_graph,
 			 const Teuchos::ParameterList& paramlist,
-			 bool compute_partitioning_now)"""
+			 bool compute_partitioning_now)
+        """
         part = Isorropia.Epetra.Partitioner(self.crsg, self.pList, True)
         self.failUnless(isinstance(part, Isorropia.Epetra.Partitioner))
         part = Isorropia.Epetra.Partitioner(self.crsg, self.pDictionary, True)
         self.failUnless(isinstance(part, Isorropia.Epetra.Partitioner))
 
     def testConstructor1(self):
-        """Test Partitioner(Teuchos::RCP<const Epetra_CrsGraph> input_graph,
+        """
+        Test Partitioner(Teuchos::RCP<const Epetra_CrsGraph> input_graph,
 			 Teuchos::RCP<CostDescriber> costs,
 			 const Teuchos::ParameterList& paramlist,
-			 bool compute_partitioning_now)"""
+			 bool compute_partitioning_now)
+        """
         part = Isorropia.Epetra.Partitioner(self.crsg, self.costs, self.pList, True)
         self.failUnless(isinstance(part, Isorropia.Epetra.Partitioner))
 
     def testConstructor2(self):
-        """Test Partitioner(Teuchos::RCP<const Epetra_CrsGraph> input_graph,
+        """
+        Test Partitioner(Teuchos::RCP<const Epetra_CrsGraph> input_graph,
                          Teuchos::RCP<const Epetra_MultiVector> coords,
 			 const Teuchos::ParameterList& paramlist,
-			 bool compute_partitioning_now)"""
+			 bool compute_partitioning_now)
+        """
         coords = Epetra.MultiVector(self.map, 2, True)
         part = Isorropia.Epetra.Partitioner(self.crsg, coords, self.pList, True)
         self.failUnless(isinstance(part, Isorropia.Epetra.Partitioner))
 
-
-
     def testCreateNewMap(self):
-        """Test createNewMap()"""
+        """
+        Test createNewMap()
+        """
         ## Don't actually do any partitioning
-        part = Isorropia.Epetra.Partitioner(self.crsg, {"PARTITIONING METHOD":"BLOCK"}, False)
+        part = Isorropia.Epetra.Partitioner(self.crsg, {"partitioning method": "block",
+                                                        "Zoltan": self.quiet}, False)
         newMap = part.createNewMap()
         self.failUnless(newMap.IsOneToOne())
         myElems = newMap.MyGlobalElements()
@@ -122,7 +127,9 @@ class PartitionerTestCase(unittest.TestCase):
             self.failUnless(elem // 10 == comm.MyPID())
 
     def testCyclicPartition(self):
-        """Test Cyclic 1D Partitioning, relies on createNewMap()"""
+        """
+        Test Cyclic 1D Partitioning, relies on createNewMap()
+        """
         part = Isorropia.Epetra.Partitioner(self.crsg, self.pList, True)
         newMap = part.createNewMap()
         self.failUnless(newMap.IsOneToOne())
@@ -130,18 +137,20 @@ class PartitionerTestCase(unittest.TestCase):
         for elem in myElems:
             self.failUnless(elem % comm.NumProc() == comm.MyPID())
 
-
-    ## As written, this will fail if the random partition is cyclic. However, 
-    ## it appears that the random partitioning uses the same seed every time, in 
-    ## which case it should pass every time, or fail every time (the small cases
-    ## I've tested don't fail, and as numProc() grows the probability of randomly
-    ## partitioning as cyclic drops quickly)
+    # As written, this will fail if the random partition is cyclic. However, it
+    # appears that the random partitioning uses the same seed every time, in
+    # which case it should pass every time, or fail every time (the small cases
+    # I've tested don't fail, and as numProc() grows the probability of randomly
+    # partitioning as cyclic drops quickly)
     def testRepartitioning(self):
-        """Test compute(True) forces repartitioning, relies on createNewMap()"""
-        part = Isorropia.Epetra.Partitioner(self.crsg, {"PARTITIONING METHOD":"RANDOM"}, True)
+        """
+        Test compute(True) forces repartitioning, relies on createNewMap()
+        """
+        part = Isorropia.Epetra.Partitioner(self.crsg, {"partitioning method": "random",
+                                                        "Zoltan": self.quiet}, True)
         newMap = part.createNewMap()
         myFirstElems = newMap.MyGlobalElements()
-        part.setParameters({"PARTITIONING METHOD":"CYCLIC"})
+        part.setParameters({"partitioning method": "cyclic", "Zoltan": self.quiet})
         part.compute(True)
         newMap = part.createNewMap()
         isEqual = True

--- a/packages/PyTrilinos/test/testTeuchos_RCP.py.in
+++ b/packages/PyTrilinos/test/testTeuchos_RCP.py.in
@@ -278,7 +278,8 @@ if (${Trilinos_ENABLE_Isorropia}):
             "Test the Teuchos.RCP functions on Isorropia objects"
 
             def setUp(self):
-                self.p     = Teuchos.ParameterList({"PARTITIONING METHOD" : "CYCLIC"})
+                self.p     = Teuchos.ParameterList({"partitioning method": "cyclic",
+                                                    "Zoltan": {"debug_level": "0"}})
                 self.comm  = Epetra.PyComm()
                 self.nRows = 10 * self.comm.NumProc()
                 self.map   = Epetra.Map(self.nRows, 0, self.comm)


### PR DESCRIPTION
@trilinos/pytrilinos 

## Description
When I test `PyTrilinos.Isorropia` objects, I now use a ParameterList that sets the Zoltan `debug_level` to `0`.

## Motivation and Context
This makes testing output cleaner.

## Related Issues

* Closes #3586 

## How Has This Been Tested?
I built a PyTrilinos with all packages enabled and ran the Isorropia tests directly from the command-line (as opposed to using `ctest`).

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
