### PR TITLE
PUMI: add package 'lion'

### DIFF
--- a/PackagesList.cmake
+++ b/PackagesList.cmake
@@ -68,6 +68,7 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
   Sacado                packages/sacado                   PT
   MiniTensor            packages/minitensor               PT
   Epetra                packages/epetra                   PT
+  SCOREClion            SCOREC/lion                       ST
   SCORECpcu             SCOREC/pcu                        ST
   SCORECgmi             SCOREC/gmi                        ST
   SCORECgmi_sim         SCOREC/gmi_sim                    ST
@@ -146,6 +147,7 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
 # Allow builds even if some packages are missing
 
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCOREC)
+TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCOREClion)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECgmi)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECgmi_sim)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SCORECpcu)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/pumi

## Description
Fixes https://github.com/SCOREC/core/issues/187 when built against https://github.com/SCOREC/core/commit/7b56bcbaea90ad3ff81679358264c029ec0b0fcb (or later).

## Motivation and Context
The PUMI `lion` package was modified to add control over all print statements to conform with XSDK policy M11.  `lion` did not have the necessary TriBITS support files defined which resulted in the Trilinos build failing.

## Related Issues

* Closes  https://github.com/SCOREC/core/issues/187


## How Has This Been Tested?

A build with and without `LION_COMPRESS` enabled was successful on SCOREC RHEL7 workstations using the following environment and configure scripts:

envRhel7.sh
```
module load \
  cmake/3.12.1-wfk2b7e \
  gcc/7.3.0-bt47fwr \
  mpich/3.2.1-niuhmad \
  openblas/0.3.2-nro36nb \
  boost/1.68.0-6n3iupn \
  parmetis/4.0.3-int64-ssgv6kc \
  netcdf/4.6.1-7m62oeb
```

config-trilinos-core-rhel7.sh
```
# Modify these paths for your system.
TRILINSTALLDIR=../install
TRILSRCDIR=../src
HAVE_LL=ON

cmake \
\
 -D Trilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON \
 -D CMAKE_INSTALL_PREFIX:PATH=$TRILINSTALLDIR \
 -D CMAKE_BUILD_TYPE:STRING=NONE \
 -D TPL_ENABLE_MPI:BOOL=ON \
 -D MPI_BASE_DIR:PATH=${MPICH_ROOT}/bin \
 -D CMAKE_C_FLAGS:STRING="-O2 -g" \
 -D CMAKE_CXX_FLAGS:STRING="-O2 -g -Wno-deprecated-declarations -Wno-sign-compare" \
 -D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
 -D BUILD_SHARED_LIBS:BOOL=ON \
 -D Trilinos_EXTRA_LINK_FLAGS:STRING="-ldl" \
\
 -D Trilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF \
\
 -D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
 -D Trilinos_WARNINGS_AS_ERRORS_FLAGS:STRING="" \
 -D Trilinos_ENABLE_Teuchos:BOOL=ON \
 -D Trilinos_ENABLE_Shards:BOOL=ON \
 -D Trilinos_ENABLE_Sacado:BOOL=ON \
 -D Trilinos_ENABLE_Epetra:BOOL=ON \
 -D Trilinos_ENABLE_EpetraExt:BOOL=ON \
 -D Trilinos_ENABLE_Ifpack:BOOL=ON \
 -D Trilinos_ENABLE_AztecOO:BOOL=ON \
 -D Trilinos_ENABLE_Amesos:BOOL=ON \
 -D Trilinos_ENABLE_Anasazi:BOOL=ON \
 -D Trilinos_ENABLE_Belos:BOOL=ON \
 -D Trilinos_ENABLE_ML:BOOL=ON \
 -D Trilinos_ENABLE_Intrepid:BOOL=ON \
 -D Trilinos_ENABLE_Intrepid2:BOOL=ON \
 -D Trilinos_ENABLE_NOX:BOOL=ON \
 -D Trilinos_ENABLE_Stratimikos:BOOL=ON \
 -D Trilinos_ENABLE_Thyra:BOOL=ON \
 -D Trilinos_ENABLE_Rythmos:BOOL=ON \
 -D Trilinos_ENABLE_Stokhos:BOOL=ON \
 -D Trilinos_ENABLE_Piro:BOOL=ON \
 -D Trilinos_ENABLE_Teko:BOOL=ON \
 -D Trilinos_ENABLE_STKIO:BOOL=ON \
 -D Trilinos_ENABLE_STKMesh:BOOL=ON \
 -D Trilinos_ENABLE_SEACAS:BOOL=ON \
 -D Trilinos_ENABLE_SEACASIoss:BOOL=ON \
 -D Trilinos_ENABLE_SEACASExodus:BOOL=ON \
 -D Trilinos_ENABLE_Tpetra:BOOL=ON \
 -D Trilinos_ENABLE_Ifpack2:BOOL=ON \
 -D Trilinos_ENABLE_Zoltan2:BOOL=ON \
 -D Trilinos_ENABLE_MueLu:BOOL=ON \
\
 -D Trilinos_ENABLE_Amesos2:BOOL=ON \
 -D Amesos2_ENABLE_KLU2:BOOL=ON \
\
 -D Trilinos_ENABLE_Kokkos:BOOL=ON \
 -D Trilinos_ENABLE_KokkosCore:BOOL=ON \
 -D Kokkos_ENABLE_Serial:BOOL=ON \
 -D Kokkos_ENABLE_OpenMP:BOOL=OFF \
 -D Kokkos_ENABLE_Pthread:BOOL=OFF \
\
 -D Trilinos_ENABLE_Phalanx:BOOL=ON \
 -D Phalanx_INDEX_SIZE_TYPE:STRING="INT" \
 -D Phalanx_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
 -D Phalanx_KOKKOS_DEVICE_TYPE:STRING="SERIAL" \
\
 -D TPL_ENABLE_Boost:BOOL=ON \
 -D Boost_INCLUDE_DIRS:FILEPATH="${BOOST_ROOT}/include" \
 -D Boost_LIBRARY_DIRS:FILEPATH="${BOOST_ROOT}/lib" \
 -D TPL_ENABLE_BoostLib:BOOL=ON \
 -D BoostLib_INCLUDE_DIRS:FILEPATH="${BOOST_ROOT}/include" \
 -D BoostLib_LIBRARY_DIRS:FILEPATH="${BOOST_ROOT}/lib" \
\
 -D TPL_ENABLE_Netcdf:BOOL=ON \
 -D Netcdf_INCLUDE_DIRS:PATH="${NETCDF_ROOT}/include" \
 -D Netcdf_LIBRARY_DIRS:PATH="${NETCDF_ROOT}/lib" \
\
 -D TPL_ENABLE_HDF5:BOOL=ON \
 -D HDF5_INCLUDE_DIRS:PATH="${HDF5_ROOT}/include" \
 -D HDF5_LIBRARY_DIRS:PATH="${HDF5_ROOT}/lib" \
\
 -D TPL_ENABLE_SuperLU:BOOL=OFF \
\
 -D TPL_ENABLE_X11:BOOL=OFF \
 -D TPL_ENABLE_Matio:BOOL=OFF \
\
 -D Trilinos_ENABLE_SCOREC:BOOL=ON \
 -D PCU_COMPRESS:BOOL=ON \
 -D SCOREC_DISABLE_STRONG_WARNINGS:BOOL=ON \
 -D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=OFF \
 -D Trilinos_ASSERT_MISSING_PACKAGES:BOOL=OFF \
\
 -D TPL_ENABLE_ParMETIS:STRING=ON \
 -D ParMETIS_INCLUDE_DIRS:PATH="${PARMETIS_ROOT}/include" \
 -D ParMETIS_LIBRARY_DIRS:PATH="${PARMETIS_ROOT}/lib" \
 -D TPL_ENABLE_METIS:STRING=ON \
 -D METIS_INCLUDE_DIRS:PATH="${METIS_ROOT}/include" \
 -D METIS_LIBRARY_DIRS:PATH="${METIS_ROOT}/lib" \
 -D Zoltan_ENABLE_ULLONG_IDS:BOOL=ON \
 -D Teuchos_ENABLE_LONG_LONG_INT:BOOL=$HAVE_LL \
\
 -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
 -D Tpetra_INST_FLOAT=OFF \
 -D Tpetra_INST_INT_INT=ON \
 -D Tpetra_INST_DOUBLE=ON \
 -D Tpetra_INST_COMPLEX_FLOAT=OFF \
 -D Tpetra_INST_COMPLEX_DOUBLE=OFF \
 -D Tpetra_INST_INT_LONG=OFF \
 -D Tpetra_INST_INT_UNSIGNED=OFF \
 -D Tpetra_INST_INT_LONG_LONG=$HAVE_LL \
\
 -D TPL_ENABLE_BLAS=ON \
 -D BLAS_LIBRARY_NAMES:STRING="openblas" \
 -D BLAS_LIBRARY_DIRS:PATH=${OPENBLAS_ROOT} \
 -D BLAS_INCLUDE_DIRS:PATH=${OPENBLAS_ROOT} \
\
 -D TPL_ENABLE_LAPACK=ON \
 -D LAPACK_LIBRARY_NAMES:STRING="openblas" \
 -D LAPACK_LIBRARY_DIRS:PATH=${OPENBLAS_ROOT} \
 -D LAPACK_INCLUDE_DIRS:PATH=${OPENBLAS_ROOT} \
$TRILSRCDIR
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
