### PR TITLE
kokkos kernels - add complex float static assert testing

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
@@ -300,7 +300,7 @@ struct BlockCrsMatrixMaker {
         auto* const block = &values(j*bs2);
         for (Int bi = 0; bi < bs; ++bi) {
           auto& e = block[bi*bs + bi];
-          e = 1.01*std::max(rowsum[bs*r + bi], colsum(bs*c + bi, 0))*signof(e);
+          e = Magnitude(1.01)*std::max(rowsum[bs*r + bi], colsum(bs*c + bi, 0))*signof(e);
         }
       }
     }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
@@ -345,6 +345,10 @@ int main (int argc, char** argv) {
       break;
     }
     try {
+      if (comm->getRank() == 0) {
+        const bool detail = false;
+        Kokkos::print_configuration(std::cout, detail);
+      }
       if (in->teuchos_test) {
         Teuchos::UnitTestRepository::runUnitTestsFromMain(1, argv);
       }

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Util.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Util.hpp
@@ -197,6 +197,8 @@ namespace KokkosBatched {
                      std::is_same<T,size_t>::value                   ||
                      std::is_same<T,double>::value                   ||
 		     std::is_same<T,float>::value                    ||
+		     std::is_same<T,Kokkos::complex<float> >::value ||
+		     std::is_same<T,std::complex<float> >::value    ||
 		     std::is_same<T,Kokkos::complex<double> >::value ||
 		     std::is_same<T,std::complex<double> >::value,
 		     "KokkosKernels:: Invalid SIMD<> type." );


### PR DESCRIPTION
This fix allows the use of complex float #3574. It also fixes an error in unit test. FYI: the error is converting data type. 
