### PR TITLE
ML: Fix #3594 (Clang warning)

### DIFF
--- a/packages/ml/src/Coarsen/ml_agg_min_energy.cpp
+++ b/packages/ml/src/Coarsen/ml_agg_min_energy.cpp
@@ -45,7 +45,7 @@ static void ML_multiply_self_all(ML_Operator* Op, double* Column2Norm)
   int nnz     = (data->rowptr)[n_rows];
   int *bindx  = data->columns;
   double *val = data->values;
-  double register dtemp;
+  double dtemp;
 
   for (int i = 0; i < nnz; i++) {
        dtemp = *val++;


### PR DESCRIPTION
@trilinos/ml 

Fix #3594.  `register` is a deprecated keyword in C++.  Deleting it here should not change the meaning of the code.
