### PR TITLE
zoltan2: remove warning from unit tests

### DIFF
--- a/packages/zoltan2/test/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/helpers/UserInputForTests.hpp
@@ -2862,7 +2862,7 @@ void UserInputForTests::setPamgenAdjacencyGraph()
 //  if(rank == 0) std::cout << "\nSetting graph of connectivity..." << std::endl;
   Teuchos::ArrayView<const zgno_t> rowMapElementList = 
                                         rowMap->getNodeElementList();
-  for (size_t ii = 0; ii < rowMapElementList.size(); ii++)
+  for (Teuchos_Ordinal ii = 0; ii < rowMapElementList.size(); ii++)
   {
     zgno_t gid = rowMapElementList[ii];
     size_t numEntriesInRow = A->getNumEntriesInGlobalRow (gid);


### PR DESCRIPTION
This header caused multiple unit test compilations
to fail when warnings-as-errors was enabled as the
size() function has a parameterized retrun type. I
change to the typedef used in Teuchos to determine
the function return type.

@trilinos/zoltan2 

