### PR TITLE
TRIBITS_CTEST_DRIVER(): Correctly pass in excluded package disables for all-at-once approach

### DIFF
--- a/cmake/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/cmake/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -553,8 +553,9 @@ INCLUDE(${CMAKE_CURRENT_LIST_DIR}/TribitsCTestDriverCoreHelpers.cmake)
 #     the specific set of packages to test.  If left at the default value of
 #     empty "", then `${PROJECT_NAME}_ENABLE_ALL_PACKAGES`_ is set to ``ON``
 #     and that enables packages as described in `<Project>_ENABLE_ALL_PACKAGES
-#     enables all PT (cond. ST) SE packages`_.  This variable can use ',' to
-#     separate package names instead of ';'.  The default value is empty "".
+#     enables all PT (and conditionally all ST) SE packages`_.  This variable
+#     can use ',' to separate package names instead of ';'.  The default value
+#     is empty "".
 #
 #   .. _${PROJECT_NAME}_ADDITIONAL_PACKAGES:
 #
@@ -591,12 +592,13 @@ INCLUDE(${CMAKE_CURRENT_LIST_DIR}/TribitsCTestDriverCoreHelpers.cmake)
 #
 #   ``${PROJECT_NAME}_EXCLUDE_PACKAGES``
 #
-#     A list of package **NOT** to enable when determining the set of packages
-#     to be tested.  NOTE: Listing packages here will *not* disable the
-#     package in the inner CMake configure.  To do that, you will have to
-#     disable them in the variable EXTRA_CONFIGURE_OPTIONS (set in your driver
-#     script). This list can be specified with semi-colons ';' or with comas
-#     ','.  The default value is empty "".
+#     A semi-colon ';' or comma ',' separated list of packages **NOT** to
+#     enable when determining the set of packages to be tested.  NOTE: Listing
+#     packages here will *not* disable the package in the inner CMake
+#     configure when using the package-by-packages approach.  To do that, you
+#     will have to disable them in the variable EXTRA_CONFIGURE_OPTIONS (set
+#     in your driver script).  But for the all-at-once approach this list of
+#     package disables **IS** pass into the inner configure.
 #
 #   ``${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES``
 #
@@ -1534,6 +1536,8 @@ FUNCTION(TRIBITS_CTEST_DRIVER)
 
   # List of packages to not directly process.  .
   SET_DEFAULT_AND_FROM_ENV( ${PROJECT_NAME}_EXCLUDE_PACKAGES "" )
+  STRING(REPLACE "," ";" ${PROJECT_NAME}_EXCLUDE_PACKAGES
+    "${${PROJECT_NAME}_EXCLUDE_PACKAGES}" )
 
   IF(${PROJECT_NAME}_REPOSITORY_BRANCH)
     SET(${PROJECT_NAME}_BRANCH_DEFAULT ${${PROJECT_NAME}_REPOSITORY_BRANCH})

--- a/cmake/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
+++ b/cmake/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
@@ -1306,14 +1306,23 @@ MACRO(TRIBITS_CTEST_ALL_AT_ONCE)
   TRIBITS_FWD_CMAKE_CONFIG_ARGS_0()
   IF (${PROJECT_NAME}_ENABLE_ALL_PACKAGES)
     LIST(APPEND CONFIGURE_OPTIONS
-      "-D${PROJECT_NAME}_ENABLE_ALL_PACKAGES=ON"
-      )
+      "-D${PROJECT_NAME}_ENABLE_ALL_PACKAGES=ON" )
+    FOREACH(TRIBITS_PACKAGE ${${PROJECT_NAME}_EXCLUDE_PACKAGES})
+      LIST(APPEND CONFIGURE_OPTIONS
+        "-D${PROJECT_NAME}_ENABLE_${TRIBITS_PACKAGE}=OFF" )
+    ENDFOREACH()
+    # NOTE: Above we have to explicitly set disables for the excluded pacakges
+    # since we are pssing in ${PROJECT_NAME}_ENABLE_ALL_PACKAGES=ON.  This is
+    # effectively the "black-listing" approach.
   ELSE()
     FOREACH(TRIBITS_PACKAGE ${${PROJECT_NAME}_PACKAGES_TO_DIRECTLY_TEST})
       LIST(APPEND CONFIGURE_OPTIONS
-         "-D${PROJECT_NAME}_ENABLE_${TRIBITS_PACKAGE}=ON"
-        )
+         "-D${PROJECT_NAME}_ENABLE_${TRIBITS_PACKAGE}=ON" )
     ENDFOREACH()
+    # NOTE: Above we don't have to consider the packages excluded in
+    # ${PROJECT_NAME}_EXCLUDE_PACKAGES because they are not enabled ad this
+    # point and therefore no in ${PROJECT_NAME}_PACKAGES_TO_DIRECTLY_TEST.
+    # This is effectively the "white-listing" approach.
   ENDIF()
   LIST(APPEND CONFIGURE_OPTIONS
     "-D${PROJECT_NAME}_ENABLE_TESTS:BOOL=ON")


### PR DESCRIPTION
@trilinos/framework 

## Description

Fixes `TRIBITS_CTEST_DRIVER()` when passing `in ${PROJECT_NAME}_EANBLE_ALL_PACKAGES=ON` and `${PROJECT_NAME}_EXCLUDE_PACKAGES=<pkg0>,<pkg1>,...`.   This is well unit tested in TriBITSPub/TriBITS#269.

Technically this does break backward compatibility for the all-at-once mode but it does not touch the packages-by-package mode.  But the impact of this behavior change should only be good.

## Motivation and Context

Without this fix, the Trilinos "Clean" builds are broken because the inner configure does not disable PyTrilinos (see https://github.com/trilinos/Trilinos/issues/1761#issuecomment-429112174).

## How Has This Been Tested?

This is well tested in TriBITS.  See TriBITSPub/TriBITS#269.  The Trilinos PR testing system currently does not use `TRIBITS_CTEST_DRIVER()` so it does not need to be tested as part of Trilinos PR testing (but it will trigger testing all Trilinos packages anyway).

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] These changes break backwards compatibility.
