### PR TITLE
Remove Sundance from list of extra repos (#3611, #1761)

### DIFF
--- a/cmake/ExtraRepositoriesList.cmake
+++ b/cmake/ExtraRepositoriesList.cmake
@@ -76,7 +76,6 @@ MARK_AS_ADVANCED(Trilinos_REPOS_URL_BASE)
 
 TRIBITS_PROJECT_DEFINE_EXTRA_REPOSITORIES(
   MOOCHO_repo  packages/moocho  GIT  ${Trilinos_REPOS_URL_BASE}moocho  NOPACKAGES  Nightly
-  Sundance_repo  packages/Sundance  GIT  ${Trilinos_REPOS_URL_BASE}Sundance  NOPACKAGES  Nightly
   CTrilinos_repo  packages/CTrilinos  GIT  ${Trilinos_REPOS_URL_BASE}CTrilinos  NOPACKAGES  Nightly
   ForTrilinos_repo  packages/ForTrilinos  GIT  ${Trilinos_REPOS_URL_BASE}ForTrilinos  NOPACKAGES  EX
   Optika_repo  packages/optika  GIT  ${Trilinos_REPOS_URL_BASE}optika  NOPACKAGES  Nightly


### PR DESCRIPTION
@trilinos/framework 

NOTE: There is no @trilinos/sundance team and there is no `Sundance` label to attach

## Description

It looks like the configure fo Sundance against Trilinos 'develop' has been
failing since 6/1/207 (see #3611).  Also, Sundance development appears to be
dead (the last commit to the 'master' branch was back in 6/27/205).

Therefore, it makes sense to stop including Sundance against the list extra
repos that Trilinos is tested against.

## Motivation and Context

Switching to the all-at-once mode in #1761 resulted in the Sundance configure failure bringing down building and testing of any Trilinos packages in the build `Linux-GCC-4.9.3-openmpi-1.8.7_Debug_DEV_Werror` build (see #3611).

## How Has This Been Tested?

I did not test it.  But PR testing will build and test every PT package because of the file that I modified.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
