### PR TITLE
Fix path to cmake on 'shiller' (TRIL-222)

### DIFF
--- a/cmake/std/atdm/shiller/environment.sh
+++ b/cmake/std/atdm/shiller/environment.sh
@@ -103,7 +103,7 @@ export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;-lhdf5_hl;-lhdf5;-lz;-ldl"
 export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${ATDM_CONFIG_HDF5_LIBS}"
 
 # Use manually installed cmake and ninja (see TRIL-209)
-export PATH=/ascldap/users/rabartl/install/hansen-shiller/cmake-3.11.2/bin:/ascldap/users/rabartl/install/hansen-shiller/ninja-1.8.2/bin:$PATH
+export PATH=/home/rabartl/install/hansen-shiller/cmake-3.11.2/bin:/home/rabartl/install/hansen-shiller/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
 export MPICC=`which mpicc`


### PR DESCRIPTION
CC: @jmgate, @fryeguy52 

## Description

Looks like 'shiller' does not mount /home at /ascldap/users/ while 'hansen'
does (where we run ATDM Trilinos builds).  This is fixed by switching to
/home/rabartl/ which works on both 'hanen' and 'shiller'.

## Motivation and Context

Builds on 'shiller' can't find CMake 3.11.2 without this change.  Needed for EMPIRE adoption as per https://software-sandbox.sandia.gov/jira/browse/TRIL-222.

## How Has This Been Tested?

On this branch I on 'shiller' I did:

```
$ . cmake/std/atdm/load-env.sh gnu-opt-openmp
Hostname 'shiller01' matches known ATDM host 'shiller' and system 'shiller'
ATDM_CONFIG_TRILNOS_DIR = /home/rabartl/Trilinos.base/Trilinos
Setting default compiler and build options for ATDM_CONFIG_JOB_NAME='gnu-opt-openmp'
No KOKKOS_ARCH specified so using system default
Using hansen/shiller compiler stack GNU to build RELEASE code with Kokkos node type OPENMP and KOKKOS_ARCH=HSW

$ which cmake
~/install/hansen-shiller/cmake-3.11.2/bin/cmake

$ cmake --version
cmake version 3.11.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

and on 'hansen' I did:

```
$ . cmake/std/atdm/load-env.sh gnu-opt-openmp
Hostname 'hansen01' matches known ATDM host 'hansen' and system 'shiller'
ATDM_CONFIG_TRILNOS_DIR = /home/rabartl/Trilinos.base/Trilinos
Setting default compiler and build options for ATDM_CONFIG_JOB_NAME='gnu-opt-openmp'
No KOKKOS_ARCH specified so using system default
Using hansen/shiller compiler stack GNU to build RELEASE code with Kokkos node type OPENMP and KOKKOS_ARCH=HSW

$ which cmake
/home/rabartl/install/hansen-shiller/cmake-3.11.2/bin/cmake

$ cmake --version
cmake version 3.11.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

Looks good.



