### PR TITLE
Remove inserted package Sundance (#3611)

### DIFF
--- a/PackagesList.cmake
+++ b/PackagesList.cmake
@@ -131,7 +131,6 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
   ROL                   packages/rol                      PT
   Piro                  packages/piro                     PT
   Panzer                packages/panzer                   PT
-  Sundance              packages/Sundance                 ST # Could be PT based on deps (BUG: 4669)
   CTrilinos             packages/CTrilinos                ST # Switched to ST to speed up checkin testing
 #  ForTrilinos           packages/ForTrilinos              EX
   PyTrilinos            packages/PyTrilinos               ST


### PR DESCRIPTION
@trilinos/framework 

## Description

Since Sundance has not configured correctly against Trilinos 'develop' in 16
months and has not had a commit in about 3 years (see #3611), it seems
reasonble to remove Sundance an an offically supported Trilinos "inserted
package".

But if someone wants to get Sundance working against Trilinos 'develop', they
can always add Sundance as an extra repo and extra package.  Since there are
no down-stream dependencies on Sundance in Trilinos, nothing would be lost.
This would be a trivial thing to set up.

The current motiviation for making this change is to clean up a nightly
Trilinos build that has an existing clone of Sundance and is failing to
configure (see #3611).

## Motivation and Context

Having Sundance still defined as an inserted package is breaking the WError build (see #3611).

## How Has This Been Tested?

I did not test it.  The PR testing will test this.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
