### PR TITLE
Skipping MPI output for serial case in Pull Request Linux Driver.

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -217,7 +217,10 @@ cmake --version
 
 module list
 
-echo "MPI type = sems-${SEMS_MPI_NAME:?}/${SEMS_MPI_VERSION:?}"
+#This crashes for the serial case since the MPI variables are not set
+if [ "Trilinos_pullrequest_gcc_4.9.3_SERIAL" != "${JOB_BASE_NAME:?}" ] ; then
+  echo "MPI type = sems-${SEMS_MPI_NAME:?}/${SEMS_MPI_VERSION:?}"
+fi
 
 CDASH_TRACK="Pull Request"
 echo "CDash Track = ${CDASH_TRACK:?}"


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Description
<!--- Please describe your changes in detail. -->

We are adding a serial dev->master build. The PR driver was outputting some MPI variable info, and this caused the serial case to crash. I ifdef'ed the output to exclude the serial case.
