### PR TITLE
revert disable of panzer Curl test on waterman #3340

### DIFF
--- a/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,6 +1,3 @@
 # This test fails consistently (#2751)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
 
-# This test runs out of CUDA memory all on its own (#3340)
-ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)
-


### PR DESCRIPTION
Re-enables test disabled as part of #3340.