### PR TITLE
Fix view example with Intel compiler for issue #3639

### DIFF
--- a/packages/sacado/example/view_example.cpp
+++ b/packages/sacado/example/view_example.cpp
@@ -76,8 +76,10 @@ public:
     typedef typename ViewTypeC::value_type scalar_type;
 
     scalar_type t = 0.0;
-    for (size_t j=0; j<n; ++j)
-      t += A(i,j)*b(j);
+    for (size_t j=0; j<n; ++j) {
+      scalar_type bb = b(j); // fix for Intel 17.0.1 with optimization
+      t += A(i,j)*bb;
+    }
     c(i) = t;
   }
 };


### PR DESCRIPTION
This test is failing for Intel builds for some reason (see #3639).  It only fails
with Intel, and only with high optimization.  Trivial changes to the
kernel make it pass, like adding a print statement or the temporary I
added here.  Smells like an optimization bug.

@fryeguy52 @bartlettroscoe 