### PR TITLE
 Set parallel build level based on cores on machine for 'sems-rhel6' and 'cee-rhel6' builds (TRIL-228)

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -251,8 +251,10 @@ builds on the local system can be run by using `all` instead of `<job-name-0>
 The parallel level for building and running tests are determined by the env
 vars `ATDM_CONFIG_BUILD_COUNT` and `ATDM_CONFIG_CTEST_PARALLEL_LEVEL`,
 respectfully, as set by default for the given system by the `atdm/load-env.sh`
-script.  These values can be overridden by setting the env vars
-`ATDM_CONFIG_BUILD_COUNT_OVERRIDE` and
+script for the given machine.  (On most machines, these are fixed but on
+generic systems like <a href="#sems-rhel6-environment">sems-rhel6</a>, they
+are computed from the number of cores on that machine).  These values can be
+overridden by setting the env vars `ATDM_CONFIG_BUILD_COUNT_OVERRIDE` and
 `ATDM_CONFIG_CTEST_PARALLEL_LEVEL_OVERIDE`, respectfully as, for example:
 
 ```
@@ -518,7 +520,7 @@ $ cmake \
 
 $ make NP=16
 
-$ ctest -j16 \
+$ ctest -j8
 ```
 
 NOTE: Above including `sems-rhel6` in the job build name
@@ -536,6 +538,12 @@ $ ./checkin-test-atdm.sh sems-rhel6-clang-opt-openmp \
   --enable-packages=MueLu \
   --local-do-all
 ```
+
+NOTE: The number of parallel build and test processes in this case are
+determine automatically from the number of cores on the current machine.  But
+this can be overridden by setting the env var
+`ATDM_CONFIG_NUM_CORES_ON_MACHINE_OVERRIDE` **before** sourcing the
+`atdm/load-env.sh <job-name>` script.
 
 
 ### CEE RHEL6 environment
@@ -582,6 +590,12 @@ $ env ATDM_CHT_DEFAULT_ENV=cee-rhel6-default \
 NOTE: Above one must set `ATDM_CHT_DEFAULT_ENV=cee-rhel6-default` in the env
 when passing in `all` in order for it to select the correct set of supported
 builds for the `cee-rhel6` env.
+
+NOTE: The number of parallel build and test processes in this case are
+determine automatically from the number of cores on the current machine.  But
+this can be overridden by setting the env var
+`ATDM_CONFIG_NUM_CORES_ON_MACHINE_OVERRIDE` **before** sourcing the
+`atdm/load-env.sh <job-name>` script.
 
 
 ### waterman

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -110,4 +110,6 @@ export ATDM_CONFIG_LAPACK_LIBS=${ATDM_CONFIG_BLAS_LIBS}
 # NOTE: HDF5_ROOT and NETCDF_ROOT should already be set in env from above
 # module loads!
 
+export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
+
 export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE

--- a/cmake/std/atdm/utils/get_num_cores_on_machine.sh
+++ b/cmake/std/atdm/utils/get_num_cores_on_machine.sh
@@ -1,0 +1,24 @@
+################################################################################
+#
+# Get the known system name (or error out)
+#
+################################################################################
+
+unset ATDM_CONFIG_NUM_CORES_ON_MACHINE
+
+# Assert this script is sourced, not run!
+called=$_
+if [ "$called" == "$0" ] ; then
+  echo "This script '$0' is being called.  Instead, it must be sourced!"
+  exit 1
+fi
+
+# Get num cores on rhel machines
+export ATDM_CONFIG_NUM_CORES_ON_MACHINE=`grep processor /proc/cpuinfo | wc -l`
+
+# Allow for override
+if [[ "${ATDM_CONFIG_NUM_CORES_ON_MACHINE_OVERRIDE}" != "" ]] ; then
+  export ATDM_CONFIG_NUM_CORES_ON_MACHINE=$ATDM_CONFIG_NUM_CORES_ON_MACHINE_OVERRIDE
+fi
+
+# ToDo: Add logic to find this out on other machines as well if needed!


### PR DESCRIPTION
@fryeguy52 

## Description

See commits for details but this sets the parallel build and test level based on the number of cores on the given rhel6 system.

## Motivation and Context

We don't want to overload a given rhel6 machine like what happened with the 'sems-rhel6' builds over the last two days (see https://software-sandbox.sandia.gov/jira/browse/TRIL-228).

## How Has This Been Tested?

I tested with a subset of packages for the 'sems-rhel6' and 'cee-rhel6' builds.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
