### PR TITLE
Framework: Add sample comment for autotester script

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -223,6 +223,7 @@ cmake --version
 module list
 
 # This crashes for the serial case since MPI variables are not set
+# - See Issue #3625
 if [ "*_SERIAL" != "${JOB_BASE_NAME:?}" ]; then
   echo "MPI type = sems-${SEMS_MPI_NAME:?}/${SEMS_MPI_VERSION:?}"
 fi


### PR DESCRIPTION
@trilinos/framework 	

Sample PR to ensure that the force-merge of #3650 does not cause problems with normal PR testing since we touched the `PullRequestLinuxDriver.sh` file.

The force-merge was required due to the chicken-and-egg issue with that script referenced in #3625.  

@prwolfe @jwillenbring 	We aren't intending to merge this, but my edit was to just stick a comment into `PullRequestLinuxDriver.sh` to reference the issue #3625 so if this gets merged it won't really cause any issues... it might even be useful to merge 🤷‍♂️  