### PR TITLE
Fixes condition estimate computation to address issue #3338

### DIFF
--- a/packages/belos/epetra/test/BlockCG/CMakeLists.txt
+++ b/packages/belos/epetra/test/BlockCG/CMakeLists.txt
@@ -23,6 +23,15 @@ IF (${PACKAGE_NAME}_ENABLE_Triutils)
     )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    pseudo_cg_hb
+    SOURCES test_pseudo_cg_hb.cpp 
+    COMM serial mpi
+    ARGS
+      "--verbose --filename=bcsstk14.hb"
+    STANDARD_PASS_OUTPUT 
+    )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
     resolve_cg_hb
     SOURCES test_resolve_cg_hb.cpp 
     COMM serial mpi
@@ -77,8 +86,10 @@ IF (${PACKAGE_NAME}_ENABLE_Triutils)
       SOURCES test_pseudo_pcg_hb.cpp 
       COMM serial mpi
       ARGS
+        "--verbose --filename=bcsstk14.hb --left-prec --tol=1e-8 --max-iters=110"
         "--verbose --filename=bcsstk14.hb --left-prec --tol=1e-8 --num-rhs=5 --max-iters=110"
         "--verbose --filename=bcsstk14.hb --right-prec --tol=1e-8 --num-rhs=5 --max-iters=110"
+        "--verbose --filename=bcsstk14.hb --left-prec --tol=1e-8 --num-rhs=1 --max-iters=110"
       STANDARD_PASS_OUTPUT 
       )
 

--- a/packages/belos/tpetra/test/BlockCG/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockCG/CMakeLists.txt
@@ -10,7 +10,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_PseudoBlockCG_hb_test
   SOURCES test_pseudo_bl_cg_hb.cpp
-  ARGS
+  ARGS "--verbose"
   COMM serial mpi
   )
 

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
@@ -61,26 +61,26 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
-int main (int argc, char *argv[])
-{
-  using Teuchos::Comm;
-  using Teuchos::CommandLineProcessor;
-  using Teuchos::ParameterList;
-  using Teuchos::parameterList;
-  using Teuchos::RCP;
-  using Teuchos::tuple;
-  using std::cout;
-  using std::endl;
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
 
   typedef double                           ST;
-  typedef Teuchos::ScalarTraits<ST>       SCT;
+  typedef ScalarTraits<ST>                SCT;
   typedef SCT::magnitudeType               MT;
-  typedef Tpetra::MultiVector<ST>          MV;
   typedef Tpetra::Operator<ST>             OP;
-  typedef Belos::MultiVecTraits<ST,MV>    MVT;
+  typedef Tpetra::MultiVector<ST>          MV;
   typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV>    MVT;
 
-  Teuchos::GlobalMPISession mpisess (&argc, &argv, &cout);
+  GlobalMPISession mpisess(&argc,&argv,&cout);
 
   bool success = false;
   bool verbose = false;
@@ -90,6 +90,7 @@ int main (int argc, char *argv[])
     int MyPID = 0;
 
     typedef Tpetra::Map<>::node_type Node;
+
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     RCP<Node>             node; // only for type deduction; null ok
 
@@ -102,7 +103,6 @@ int main (int argc, char *argv[])
     int numrhs = 1;      // total number of right-hand sides to solve for
     int blocksize = 1;   // blocksize used by solver
     int maxiters = -1;   // maximum number of iterations for solver to use
-    bool condest = true; // compute the condition estimate
     std::string filename("bcsstk14.hb");
     MT tol = 1.0e-5;     // relative residual tolerance
 
@@ -115,8 +115,6 @@ int main (int argc, char *argv[])
     cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
     cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
     cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
-    cmdp.setOption("condest","nocond",&condest,"Compute a condition number estimate");
-
     if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }
@@ -127,23 +125,26 @@ int main (int argc, char *argv[])
       frequency = -1;  // reset frequency if test is not verbose
     }
 
-    MyPID = comm->getRank ();
+    MyPID = rank(*comm);
     proc_verbose = ( verbose && (MyPID==0) );
 
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
     //
     // Get the data from the HB file and build the Map,Matrix
     //
-    RCP<Tpetra::CrsMatrix<ST> > A;
+    RCP<CrsMatrix<ST> > A;
     Tpetra::Utils::readHBMatrix(filename,comm,node,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors
     RCP<MV> B, X;
-    X = rcp (new MV (map, numrhs));
-    MVT::MvRandom (*X);
-    B = rcp (new MV (map, numrhs));
-    OPT::Apply (*A, *X, *B);
-    MVT::MvInit (*X, 0.0);
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
 
     //
     // ********Other information used by block solver***********
@@ -154,10 +155,11 @@ int main (int argc, char *argv[])
       maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
     }
     //
-    RCP<ParameterList> belosList = parameterList ("Belos");
-    belosList->set ("Block Size", blocksize); // Blocksize to be used by iterative solver
-    belosList->set ("Maximum Iterations", maxiters); // Maximum number of iterations allowed
-    belosList->set ("Convergence Tolerance", tol); // Relative convergence tolerance requested
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Estimate Condition Number", true );
     int verbLevel = Belos::Errors + Belos::Warnings;
     if (debug) {
       verbLevel += Belos::Debug;
@@ -165,25 +167,20 @@ int main (int argc, char *argv[])
     if (verbose) {
       verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
     }
-    belosList->set ("Verbosity", verbLevel);
+    belosList.set( "Verbosity", verbLevel );
     if (verbose) {
       if (frequency > 0) {
-        belosList->set ("Output Frequency", frequency);
+        belosList.set( "Output Frequency", frequency );
       }
     }
-    if (condest) {
-      belosList->set("Estimate Condition Number", true);
-    }
-
     //
     // Construct an unpreconditioned linear problem instance.
     //
-    typedef Belos::LinearProblem<ST, MV, OP> problem_type;
-    RCP<problem_type> problem = rcp (new problem_type (A, X, B));
-    bool set = problem->setProblem();
-    if (! set) {
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
       if (proc_verbose)
-        cout << endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << endl;
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
       return -1;
     }
     //
@@ -191,97 +188,57 @@ int main (int argc, char *argv[])
     // *************Start the block CG iteration***********************
     // *******************************************************************
     //
-    Belos::PseudoBlockCGSolMgr<ST,MV,OP> solver;
-    solver.setParameters (belosList);
-    solver.setProblem (problem);
-
-    if (proc_verbose) {
-      cout << "Input parameter list: " << endl;
-      belosList->print (cout);
-      cout << endl;
-
-      cout << "Belos parameter list: " << endl;
-      solver.getCurrentParameters ()->print (cout);
-      cout << endl;
-    }
+    Belos::PseudoBlockCGSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
 
     //
     // **********Print out information about problem*******************
     //
     if (proc_verbose) {
-      cout << endl << endl;
-      cout << "Dimension of matrix: " << NumGlobalElements << endl;
-      cout << "Number of right-hand sides: " << numrhs << endl;
-      cout << "Block size used by solver: " << blocksize << endl;
-      cout << "Max number of CG iterations: " << maxiters << endl;
-      cout << "Relative residual tolerance: " << tol << endl;
-      cout << endl;
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
     }
     //
     // Perform solve
     //
     Belos::ReturnType ret = solver.solve();
-
-    {
-      std::ostringstream os;
-      os << "Proc " << comm->getRank () << ": Finished solve" << endl;
-      std::cerr << os.str ();
-    }
-
-    if (proc_verbose) {
-      cout << "Input parameter list after solve: " << endl;
-      belosList->print (cout);
-      cout << endl;
-
-      cout << "Belos parameter list after solve: " << endl;
-      solver.getCurrentParameters ()->print (cout);
-      cout << endl;
-    }
-
     //
     // Compute actual residuals.
     //
     bool badRes = false;
-    std::vector<MT> actual_resids (numrhs);
-    std::vector<MT> rhs_norm (numrhs);
-    MV resid (map, numrhs);
-    OPT::Apply (*A, *X, resid);
-    MVT::MvAddMv (-one, resid, one, *B, resid);
-    MVT::MvNorm (resid, actual_resids);
-    MVT::MvNorm (*B, rhs_norm);
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
     if (proc_verbose) {
-      cout << "---------- Actual Residuals (normalized) ----------"
-           << endl << endl;
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
     }
-    for (int i = 0; i < numrhs; ++i) {
+    for ( int i=0; i<numrhs; i++) {
       MT actRes = actual_resids[i]/rhs_norm[i];
       if (proc_verbose) {
-        cout << "Problem " << i << " : \t" << actRes << endl;
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
       }
-      if (actRes > tol) {
-        badRes = true;
-      }
+      if (actRes > tol) badRes = true;
     }
 
-    success = (ret==Belos::Converged && ! badRes);
+    if (proc_verbose)
+      std::cout<<std::endl<<"Condition Estimate: " << SCT::real(solver.getConditionEstimate()) << std::endl;
 
-    // Check condition estimate
-    const ST cond = solver.getConditionEstimate ();
-    if (condest && cond < SCT::one ()) {
-      success = false;
-    }
-    if (proc_verbose) {
-      cout << "Condition Estimate = "<<cond <<endl;
-    }
+    success = (ret==Belos::Converged && !badRes);
 
     if (success) {
-      if (proc_verbose) {
-        cout << "\nEnd Result: TEST PASSED" << endl;
-      }
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
     } else {
-      if (proc_verbose) {
-        cout << "\nEnd Result: TEST FAILED" << endl;
-      }
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
     }
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);


### PR DESCRIPTION
The issue #3338 is the failure of the Tpetra pseudo-block CG test on an important test platform.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Description
<!--- Please describe your changes in detail. -->
There are two issues, one the _STEQR provided by the LAPACK libraries
on that platform is seg faulting and, two, the general condition estimate
computation performed by single-vector/pseudo-block CG is generally wrong.
The condition estimate computation is now implemented for the single-vector
CG kernel, when it wasn't before. Furthermore, it is corrected for the
pseudo-block CG kernel, where it was wrongly storing information when
there was more than one right-hand side.  The LAPACK routine being used to
perform the condition estimation computation is _PTEQR, which has no issues
on the test platform of concern to #3338.

Tests have been fixed for the Tpetra pseudo-block CG, so that they output
information, including the condition estimation.  Tests have been augmented
to perform condition estimation for Epetra and perform an unpreconditioned
pseudo-block CG solve, using Epetra.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
The condition estimation computation was wrong, in almost every circumstance.
Now it is right.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

#3338 

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Locally on OS X using GCC7.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->