### PR TITLE
Disable timing-out test KokkosContainers_UnitTest_Serial_MPI_1 in 'waterman' cuda-9.2-debug build (#3336)

### DIFF
--- a/cmake/std/atdm/waterman/tweaks/CUDA-9.2-DEBUG-CUDA-POWER9-VOLTA70.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA-9.2-DEBUG-CUDA-POWER9-VOLTA70.cmake
@@ -4,6 +4,9 @@ ATDM_SET_ENABLE(TeuchosNumerics_LAPACK_test_MPI_1_DISABLE ON)
 #disable from issue #2466
 ATDM_SET_ENABLE(Belos_Tpetra_PseudoBlockCG_hb_test_MPI_4_DISABLE ON)
 
+# Disable timing out unit test in this debug build (#3336)
+ATDM_SET_ENABLE(KokkosContainers_UnitTest_Serial_MPI_1_DISABLE ON)
+
 # Disable some unit tests that run too slow in this DEBUG build (#2827)
 ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
   "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_block_gauss_seidel_double_int_size_t_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"


### PR DESCRIPTION
@trilinos/kokkos, @fryeguy52 

## Description

Now that this test is running and passing in the new build Trilinos-atdm-waterman-cuda-9.2-release-debug (see #3659 and #3633), it is fine to disable this in this full -O3 build.

## Motivation and Context

Failing timing out tests provide no value and cluster up the dashboard with red.  See #3336 and #3633 for motivation.

## How Has This Been Tested?

On 'waterman' I ran:

```
$ ./checkin-test-atdm.sh cuda-9.2-debug-Power9-Volta70 --enable-packages=Kokkos --configure
```

and the configure output showed:

```
-- KokkosContainers_UnitTest_Serial_MPI_1: NOT added test because KokkosContainers_UnitTest_Serial_MPI_1_DISABLE='ON'!
```

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
