### PR TITLE
EXODUS: Fix compile error due to bad cut/paste

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -1513,7 +1513,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
              "EXODUS: ERROR: File format specified as netcdf-4, but the "
              "NetCDF library being used was not configured to enable "
              "this format\n");
-    ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+    ex_err(__func__, errmsg, EX_BADPARAM);
     EX_FUNC_LEAVE(EX_FATAL);
   }
 #endif
@@ -1524,7 +1524,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
              "EXODUS: ERROR: File format specified as 64bit_data, but "
              "the NetCDF library being used does not support this "
              "format\n");
-    ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+    ex_err(__func__, errmsg, EX_BADPARAM);
     EX_FUNC_LEAVE(EX_FATAL);
   }
 #endif
@@ -1595,7 +1595,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
              "EXODUS: ERROR: 64-bit integer storage requested, but the "
              "netcdf library does not support the required netcdf-4 or "
              "64BIT_DATA extensions.\n");
-    ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+    ex_err(__func__, errmsg, EX_BADPARAM);
     EX_FUNC_LEAVE(EX_FATAL);
 #endif
   }
@@ -1619,7 +1619,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
                "EXODUS: ERROR: EX_MPIPOSIX parallel output requested "
                "which requires NetCDF-4 support, but the library does "
                "not have that option enabled.\n");
-      ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+      ex_err(__func__, errmsg, EX_BADPARAM);
       EX_FUNC_LEAVE(EX_FATAL);
 #endif
     }
@@ -1631,7 +1631,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
                "EXODUS: ERROR: EX_MPIIO parallel output requested which "
                "requires NetCDF-4 support, but the library does not "
                "have that option enabled.\n");
-      ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+      ex_err(__func__, errmsg, EX_BADPARAM);
       EX_FUNC_LEAVE(EX_FATAL);
 #endif
     }
@@ -1643,7 +1643,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
                "EXODUS: ERROR: EX_NETCDF4 parallel output requested which "
                "requires NetCDF-4 support, but the library does not "
                "have that option enabled.\n");
-      ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+      ex_err(__func__, errmsg, EX_BADPARAM);
       EX_FUNC_LEAVE(EX_FATAL);
 #endif
     }
@@ -1661,7 +1661,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
                "EXODUS: ERROR: EX_PNETCDF parallel output requested "
                "which requires PNetCDF support, but the library does "
                "not have that option enabled.\n");
-      ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
+      ex_err(__func__, errmsg, EX_BADPARAM);
       EX_FUNC_LEAVE(EX_FATAL);
 #endif
     }


### PR DESCRIPTION
@trilinos/seacas 

Recent changes did not fully test all possible #ifdef combinations.  This patch fixes some bad cut/paste inside an #ifdef for non-netcdf-4 builds.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
