### PR TITLE
Kokkos promotion deprecation changes

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -217,7 +217,11 @@ KOKKOS_INLINE_FUNCTION
 constexpr typename
 std::enable_if< is_view_fad< View<T,P...> >::value, unsigned >::type
 dimension_scalar(const View<T,P...>& view) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   return view.implementation_map().dimension_scalar();
+#else
+  return view.impl_map().dimension_scalar();
+#endif
 }
 
 template <typename Layout>

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -960,7 +960,11 @@ KOKKOS_INLINE_FUNCTION
 constexpr typename
 std::enable_if< is_dynrankview_fad< DynRankView<T,P...> >::value, unsigned >::type
 dimension_scalar(const DynRankView<T,P...>& view) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   return view.implementation_map().dimension_scalar();
+#else
+  return view.impl_map().dimension_scalar();
+#endif
 }
 
 
@@ -1214,7 +1218,11 @@ create_mirror( const Kokkos::DynRankView<T,P...> & src
   layout.stride[7] = src.stride_7();
 
   layout.dimension[src.rank()] = Kokkos::dimension_scalar(src);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   layout.stride[src.rank()] = src.implementation_map().stride_scalar();
+#else
+  layout.stride[src.rank()] = src.impl_map().stride_scalar();
+#endif
 
   return dst_type(std::string(src.label()).append("_mirror"),
                   Impl::reconstructLayout(layout, src.rank()+1));

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -206,7 +206,7 @@ KOKKOS_INLINE_FUNCTION
 constexpr typename
 std::enable_if< is_view_uq_pce< View<T,P...> >::value, unsigned >::type
 dimension_scalar(const View<T,P...>& view) {
-  return view.implementation_map().dimension_scalar();
+  return view.impl_map().dimension_scalar();
 }
 
 template <typename view_type>
@@ -215,7 +215,7 @@ constexpr typename
 std::enable_if< is_view_uq_pce<view_type>::value,
                 typename CijkType<view_type>::type >::type
 cijk(const view_type& view) {
-  return view.implementation_map().cijk();
+  return view.impl_map().cijk();
 }
 
 template <typename view_type>
@@ -223,7 +223,7 @@ KOKKOS_INLINE_FUNCTION
 constexpr typename
 std::enable_if< is_view_uq_pce<view_type>::value, bool >::type
 is_allocation_contiguous(const view_type& view) {
-  return view.implementation_map().is_allocation_contiguous();
+  return view.impl_map().is_allocation_contiguous();
 }
 
 template <typename ViewType>
@@ -315,7 +315,7 @@ create_mirror( const Kokkos::View<T,P...> & src
   layout.dimension[src_type::rank] = Kokkos::dimension_scalar(src);
 
   return dst_type(view_alloc(std::string(src.label()).append("_mirror"),
-                             src.implementation_map().cijk()), layout);
+                             src.impl_map().cijk()), layout);
 }
 
 template< class T , class ... P >
@@ -357,7 +357,7 @@ create_mirror( const Kokkos::View<T,P...> & src
   layout.dimension[src_type::rank] = Kokkos::dimension_scalar(src);
 
   return dst_type(view_alloc(std::string(src.label()).append("_mirror"),
-                             src.implementation_map().cijk()), layout);
+                             src.impl_map().cijk()), layout);
 }
 
 template<class Space, class T, class ... P>
@@ -371,7 +371,7 @@ create_mirror(const Space& , const Kokkos::View<T,P...> & src
   typename src_type::array_layout layout = src.layout();
   layout.dimension[src_type::rank] = Kokkos::dimension_scalar(src);
   return typename Impl::MirrorType<Space,T,P ...>::view_type(
-    view_alloc(src.label(), src.implementation_map().cijk()),layout);
+    view_alloc(src.label(), src.impl_map().cijk()),layout);
 }
 
 // Overload of deep_copy for UQ::PCE views intializing to a constant scalar

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_UQ_PCE.hpp
@@ -319,8 +319,13 @@ namespace Kokkos {
     typedef typename dual_view_type::t_dev device_type;
     typedef typename dual_view_type::t_host host_type;
     dual_view_type dual_view = mv.getDualView();
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     if (dual_view.modified_host() > dual_view.modified_device())
       return dimension_scalar(dual_view.template view<device_type>());
+#else
+    if ( dual_view.need_sync_device() )
+    { return dimension_scalar(dual_view.template view<device_type>()); }
+#endif
     return dimension_scalar(dual_view.template view<host_type>());
   }
 
@@ -331,8 +336,13 @@ namespace Kokkos {
     typedef typename dual_view_type::t_dev device_type;
     typedef typename dual_view_type::t_host host_type;
     dual_view_type dual_view = v.getDualView();
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     if (dual_view.modified_host() > dual_view.modified_device())
       return dimension_scalar(dual_view.template view<device_type>());
+#else
+    if ( dual_view.need_sync_device() )
+    { return dimension_scalar(dual_view.template view<device_type>()); }
+#endif
     return dimension_scalar(dual_view.template view<host_type>());
   }
 }

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -104,7 +104,7 @@ KOKKOS_INLINE_FUNCTION
 constexpr typename
 std::enable_if< is_view_mp_vector< View<T,P...> >::value, unsigned >::type
 dimension_scalar(const View<T,P...>& view) {
-  return view.implementation_map().dimension_scalar();
+  return view.impl_map().dimension_scalar();
 }
 
 // Declare overloads of create_mirror() so they are in scope

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
@@ -225,7 +225,11 @@ int executeInsertGlobalIndicesDP_(const comm_ptr_t& comm, const struct CmdLineOp
     rcp (new fe_multivector_t(domain_map, crs_graph->getImporter(), 1));
 
   scalar_2d_array_t element_matrix;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::resize(element_matrix, 4, 4);
+#else
+  Kokkos::resize(element_matrix, 4);
+#endif
   Teuchos::Array<Scalar> element_rhs(4);
 
   Teuchos::Array<global_ordinal_t> column_global_ids(4);     // global column ids list

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
@@ -262,7 +262,11 @@ int executeLocalElementLoopDP_(const comm_ptr_t& comm, const struct CmdLineOpts&
   RCP<multivector_t> rhs_overlapping   = rcp(new multivector_t(crs_graph_overlapping->getRowMap(), 1));
 
   scalar_2d_array_t element_matrix;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::resize(element_matrix, 4, 4);
+#else
+  Kokkos::resize(element_matrix, 4);
+#endif
   Teuchos::Array<Scalar> element_rhs(4);
 
   Teuchos::Array<global_ordinal_t> column_global_ids(4);     // global column ids list

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_MeshDatabase.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_MeshDatabase.hpp
@@ -230,7 +230,11 @@ MeshDatabase::MeshDatabase(Teuchos::RCP<const Teuchos::Comm<int> > comm,
 
   // Generate the element-to-node map
   // NOTE: Hardwired to QUAD4's.  Nodes are ordered exodus-style (counter-clockwise) within an element
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::resize(ownedElementToNode_,num_my_elements,4);
+#else
+  Kokkos::resize(ownedElementToNode_,num_my_elements);
+#endif
   int cct=0;
   for(global_ordinal_t j=myElementStart_[1]; j<myElementStop_[1]; j++) {
     for(global_ordinal_t i=myElementStart_[0]; i<myElementStop_[0]; i++) {
@@ -265,7 +269,11 @@ MeshDatabase::MeshDatabase(Teuchos::RCP<const Teuchos::Comm<int> > comm,
 
   // NOTE: This are not recorded in Aztec/Ifpack/ML ordering.  Because most apps don't do that.
   Kokkos::resize(ghostElementGlobalIDs_,my_ghost_elements.size());
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::resize(ghostElementToNode_,my_ghost_elements.size(),4);
+#else
+  Kokkos::resize(ghostElementToNode_,my_ghost_elements.size());
+#endif
   for(size_t k=0; k<my_ghost_elements.size(); k++) {
     global_ordinal_t i,j, eidx= my_ghost_elements[k];
     ghostElementGlobalIDs_(k) = eidx;

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
@@ -248,7 +248,11 @@ int executeTotalElementLoopDP_(const comm_ptr_t& comm, const struct CmdLineOpts&
   RCP<multivector_t> rhs = rcp(new multivector_t(crs_graph->getRowMap(), 1));
 
   scalar_2d_array_t element_matrix;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::resize(element_matrix, 4, 4);
+#else
+  Kokkos::resize(element_matrix, 4);
+#endif
   Teuchos::Array<Scalar> element_rhs(4);
 
   Teuchos::Array<global_ordinal_t> column_global_ids(4);     // global column ids list

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
@@ -251,7 +251,11 @@ int executeTotalElementLoopSP_(const comm_ptr_t& comm, const struct CmdLineOpts&
   RCP<multivector_t> rhs = rcp(new multivector_t(crs_graph->getRowMap(), 1));
 
   scalar_2d_array_t element_matrix;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::resize(element_matrix, 4, 4);
+#else
+  Kokkos::resize(element_matrix, 4);
+#endif
   Teuchos::Array<Scalar> element_rhs(4);
 
   Teuchos::Array<global_ordinal_t> column_global_ids(4);     // global column ids list

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_read_modify_vec_kokkos.cpp
@@ -165,8 +165,8 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // We want a _host_ View.  Vector implements "dual view"
     // semantics.  This is really only relevant for architectures with
     // two memory spaces.
-    x.sync<Kokkos::HostSpace> ();
-    auto x_2d = x.getLocalView<Kokkos::HostSpace> ();
+    x.sync_host ();
+    auto x_2d = x.getLocalViewHost ();
     // getLocalView returns a 2-D View by default.  We want a 1-D
     // View, so we take a subview.
     auto x_1d = Kokkos::subview (x_2d, Kokkos::ALL (), 0);
@@ -214,11 +214,11 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     // away.  If you create two nonconst persisting views of the same
     // Vector, and modify the entries of one view during the lifetime
     // of the other view, the entries of the other view are undefined.
-    x.sync<Kokkos::HostSpace> ();
-    auto x_2d = x.getLocalView<Kokkos::HostSpace> ();
+    x.sync_host ();
+    auto x_2d = x.getLocalViewHost ();
     auto x_1d = Kokkos::subview (x_2d, Kokkos::ALL (), 0);
     // We're going to modify the data on host.
-    x.modify<Kokkos::HostSpace> ();
+    x.modify_host ();
 
     // Use local indices to access the entries of x_data.
     // x_data.extent (0) may be longer than the number of local

--- a/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
@@ -99,14 +99,14 @@ localApplyBlockNoTrans (Tpetra::Experimental::BlockCrsMatrix<Scalar, LO, GO, Nod
   // NOTE (mfh 01 Jun 2016) This is a host code, so we have to sync
   // all the objects to host.  We sync them back to device after we're
   // done.  That's why all objects come in by nonconst reference.
-  A.template sync<Kokkos::HostSpace> ();
-  X.template sync<Kokkos::HostSpace> ();
-  Y.template sync<Kokkos::HostSpace> ();
-  Y.template modify<Kokkos::HostSpace> (); // only Y gets modified here
+  A.sync_host ();
+  X.sync_host ();
+  Y.sync_host ();
+  Y.modify_host (); // only Y gets modified here
 
   // Get the matrix values.  Blocks are stored contiguously, each
   // block in row-major order (Kokkos::LayoutRight).
-  auto val = A.template getValues<Kokkos::HostSpace> ();
+  auto val = A.getValuesHost ();
 
   auto gblGraph = A.getCrsGraph ();
   auto lclGraph = G.getLocalGraph ();
@@ -537,8 +537,8 @@ getTpetraBlockCrsMatrix (Teuchos::FancyOStream& out,
   RCP<matrix_type> A = rcp (new matrix_type (*graph, blkSize));
 
   // We're filling on the host.
-  A->sync<Kokkos::HostSpace> ();
-  A->modify<Kokkos::HostSpace> ();
+  A->sync_host ();
+  A->modify_host ();
 
   // This only matters if filling with random values.  We only do that
   // if opts.runTest is true (that is, if we're testing correctness of

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -6701,7 +6701,7 @@ namespace Tpetra {
 
     {
       // packAndPrepare* methods modify numExportPacketsPerLID_.
-      destGraph->numExportPacketsPerLID_.template modify<Kokkos::HostSpace>();
+      destGraph->numExportPacketsPerLID_.modify_host();
       Teuchos::ArrayView<size_t> numExportPacketsPerLID =
         getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
 
@@ -6722,10 +6722,10 @@ namespace Tpetra {
           // Make sure that host has the latest version, since we're
           // using the version on host.  If host has the latest
           // version, syncing to host does nothing.
-          destGraph->numExportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          destGraph->numExportPacketsPerLID_.sync_host();
           Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
             getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
-          destGraph->numImportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          destGraph->numImportPacketsPerLID_.sync_host();
           Teuchos::ArrayView<size_t> numImportPacketsPerLID =
             getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
           Distor.doReversePostsAndWaits(numExportPacketsPerLID, 1,
@@ -6738,12 +6738,12 @@ namespace Tpetra {
           // Reallocation MUST go before setting the modified flag,
           // because it may clear out the flags.
           destGraph->reallocImportsIfNeeded(totalImportPackets);
-          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          destGraph->imports_.modify_host();
           Teuchos::ArrayView<packet_type> hostImports =
             getArrayViewFromDualView(destGraph->imports_);
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
-          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          destGraph->exports_.sync_host();
           Teuchos::ArrayView<const packet_type> hostExports =
             getArrayViewFromDualView(destGraph->exports_);
           Distor.doReversePostsAndWaits(hostExports,
@@ -6752,12 +6752,12 @@ namespace Tpetra {
                                          numImportPacketsPerLID);
         }
         else { // constant number of packets per LI
-          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          destGraph->imports_.modify_host();
           Teuchos::ArrayView<packet_type> hostImports =
             getArrayViewFromDualView(destGraph->imports_);
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
-          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          destGraph->exports_.sync_host();
           Teuchos::ArrayView<const packet_type> hostExports =
             getArrayViewFromDualView(destGraph->exports_);
           Distor.doReversePostsAndWaits(hostExports,
@@ -6770,10 +6770,10 @@ namespace Tpetra {
           // Make sure that host has the latest version, since we're
           // using the version on host.  If host has the latest
           // version, syncing to host does nothing.
-          destGraph->numExportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          destGraph->numExportPacketsPerLID_.sync_host();
           Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
             getArrayViewFromDualView(destGraph->numExportPacketsPerLID_);
-          destGraph->numImportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+          destGraph->numImportPacketsPerLID_.sync_host();
           Teuchos::ArrayView<size_t> numImportPacketsPerLID =
             getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
           Distor.doPostsAndWaits(numExportPacketsPerLID, 1,
@@ -6786,12 +6786,12 @@ namespace Tpetra {
           // Reallocation MUST go before setting the modified flag,
           // because it may clear out the flags.
           destGraph->reallocImportsIfNeeded(totalImportPackets);
-          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          destGraph->imports_.modify_host();
           Teuchos::ArrayView<packet_type> hostImports =
             getArrayViewFromDualView(destGraph->imports_);
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
-          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          destGraph->exports_.sync_host();
           Teuchos::ArrayView<const packet_type> hostExports =
             getArrayViewFromDualView(destGraph->exports_);
           Distor.doPostsAndWaits(hostExports,
@@ -6800,12 +6800,12 @@ namespace Tpetra {
                                   numImportPacketsPerLID);
         }
         else { // constant number of packets per LID
-          destGraph->imports_.template modify<Kokkos::HostSpace>();
+          destGraph->imports_.modify_host();
           Teuchos::ArrayView<packet_type> hostImports =
             getArrayViewFromDualView(destGraph->imports_);
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
-          destGraph->exports_.template sync<Kokkos::HostSpace>();
+          destGraph->exports_.sync_host();
           Teuchos::ArrayView<const packet_type> hostExports =
             getArrayViewFromDualView(destGraph->exports_);
           Distor.doPostsAndWaits(hostExports,
@@ -6824,10 +6824,10 @@ namespace Tpetra {
 #endif
 
     // Backwards compatibility measure.  We'll use this again below.
-    destGraph->numImportPacketsPerLID_.template sync<Kokkos::HostSpace>();
+    destGraph->numImportPacketsPerLID_.sync_host();
     Teuchos::ArrayView<const size_t> numImportPacketsPerLID =
       getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
-    destGraph->imports_.template sync<Kokkos::HostSpace>();
+    destGraph->imports_.sync_host();
     Teuchos::ArrayView<const packet_type> hostImports =
       getArrayViewFromDualView(destGraph->imports_);
     size_t mynnz =

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3273,7 +3273,7 @@ namespace Tpetra {
       typedef Tpetra::MultiVector<DomainScalar, LO, GO, Node> DMV;
       typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MMV;
       typedef typename Node::device_type::memory_space dev_mem_space;
-      typedef Kokkos::HostSpace host_mem_space;
+      typedef typename MMV::dual_view_type::t_host::device_type host_mem_space;
       typedef typename Graph::local_graph_type k_local_graph_type;
       typedef typename k_local_graph_type::size_type offset_type;
       const char prefix[] = "Tpetra::CrsMatrix::localGaussSeidel: ";
@@ -3295,10 +3295,10 @@ namespace Tpetra {
       // mfh 28 Aug 2017: The current local Gauss-Seidel kernel only
       // runs on host.  (See comments below.)  Thus, we need to access
       // the host versions of these data.
-      const_cast<DMV&> (B).template sync<host_mem_space> ();
-      X.template sync<host_mem_space> ();
-      X.template modify<host_mem_space> ();
-      const_cast<MMV&> (D).template sync<host_mem_space> ();
+      const_cast<DMV&> (B).sync_host ();
+      X.sync_host ();
+      X.modify_host ();
+      const_cast<MMV&> (D).sync_host ();
 
       auto B_lcl = B.template getLocalView<host_mem_space> ();
       auto X_lcl = X.template getLocalView<host_mem_space> ();
@@ -3377,7 +3377,7 @@ namespace Tpetra {
       typedef Tpetra::MultiVector<DomainScalar, LO, GO, Node> DMV;
       typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MMV;
       typedef typename Node::device_type::memory_space dev_mem_space;
-      typedef Kokkos::HostSpace host_mem_space;
+      typedef typename MMV::dual_view_type::t_host::device_type host_mem_space;
       typedef typename Graph::local_graph_type k_local_graph_type;
       typedef typename k_local_graph_type::size_type offset_type;
       const char prefix[] = "Tpetra::CrsMatrix::reorderedLocalGaussSeidel: ";
@@ -3404,10 +3404,10 @@ namespace Tpetra {
       // mfh 28 Aug 2017: The current local Gauss-Seidel kernel only
       // runs on host.  (See comments below.)  Thus, we need to access
       // the host versions of these data.
-      const_cast<DMV&> (B).template sync<host_mem_space> ();
-      X.template sync<host_mem_space> ();
-      X.template modify<host_mem_space> ();
-      const_cast<MMV&> (D).template sync<host_mem_space> ();
+      const_cast<DMV&> (B).sync_host ();
+      X.sync_host ();
+      X.modify_host ();
+      const_cast<MMV&> (D).sync_host ();
 
       auto B_lcl = B.template getLocalView<host_mem_space> ();
       auto X_lcl = X.template getLocalView<host_mem_space> ();

--- a/packages/tpetra/core/src/Tpetra_Details_castAwayConstDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_castAwayConstDualView.hpp
@@ -74,11 +74,9 @@ castAwayConstDualView (const Kokkos::DualView<const ValueType*, DeviceType>& inp
     (const_cast<ValueType*> (input_dv.h_view.data ()),
      input_dv.h_view.extent (0));
 
-  Kokkos::DualView<ValueType*, DeviceType> output_dv;
-  output_dv.d_view = output_view_dev;
-  output_dv.h_view = output_view_host;
-  output_dv.modified_device = input_dv.modified_device;
-  output_dv.modified_host = input_dv.modified_host;
+  Kokkos::DualView<ValueType*, DeviceType> output_dv(output_view_dev,output_view_host);
+  if(input_dv.need_sync_host()) output_dv.modify_device();
+  if(input_dv.need_sync_device()) output_dv.modify_host();
   return output_dv;
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_getDiagCopyWithoutOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getDiagCopyWithoutOffsets_def.hpp
@@ -130,8 +130,8 @@ public:
 
     // Side effects start below this point.
 
-    diag.template modify<Kokkos::HostSpace> ();
-    D_lcl_ = diag.template getLocalView<Kokkos::HostSpace> ();
+    diag.modify_host ();
+    D_lcl_ = diag.getDualView().view_host ();
     D_lcl_1d_ = Kokkos::subview (D_lcl_, Kokkos::ALL (), 0);
 
     Kokkos::RangePolicy<host_execution_space, LO> range (0, lclNumRows);

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -894,8 +894,8 @@ packCrsGraphNew(const CrsGraph<LO, GO, NT>& sourceGraph,
 
   // Write-only device access
   auto numPacketsPerLID_nc = numPacketsPerLID; // const DV& -> DV
-  numPacketsPerLID_nc.modified_host() = 0;
-  numPacketsPerLID_nc.modified_device() = 1;
+  numPacketsPerLID_nc.clear_sync_state();
+  numPacketsPerLID_nc.modify_device();
   auto numPacketsPerLID_d = numPacketsPerLID.template view<buffer_memory_space> ();
 
   // Read-only device access

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -1012,8 +1012,8 @@ packCrsMatrixNew (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 
   // Write-only device access
   auto numPacketsPerLID_nc = numPacketsPerLID; // const DV& -> DV
-  numPacketsPerLID_nc.modified_host() = 0;
-  numPacketsPerLID_nc.modified_device() = 1;
+  numPacketsPerLID_nc.clear_sync_state();
+  numPacketsPerLID_nc.modify_device();
   auto numPacketsPerLID_d = numPacketsPerLID.template view<buffer_memory_space> ();
 
   // Read-only device access

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -788,7 +788,7 @@ namespace Tpetra {
         // an output argument).  If there are, constantNumPackets will
         // come back nonzero.  Otherwise, the source will fill the
         // numExportPacketsPerLID_ array.
-        numExportPacketsPerLID_.template modify<Kokkos::HostSpace> ();
+        numExportPacketsPerLID_.modify_host ();
         Teuchos::ArrayView<size_t> numExportPacketsPerLID =
           getArrayViewFromDualView (numExportPacketsPerLID_);
 
@@ -805,8 +805,8 @@ namespace Tpetra {
         Kokkos::View<const packet_type*, Kokkos::HostSpace,
           Kokkos::MemoryUnmanaged> exportsOldK (exportsOld.getRawPtr (),
                                                 exportsLen);
-        exports_.template modify<Kokkos::HostSpace> ();
-        Kokkos::deep_copy (exports_.template view<Kokkos::HostSpace> (),
+        exports_.modify_host ();
+        Kokkos::deep_copy (exports_.view_host (),
                            exportsOldK);
       }
     }
@@ -865,15 +865,15 @@ namespace Tpetra {
             // Make sure that host has the latest version, since we're
             // using the version on host.  If host has the latest
             // version already, syncing to host does nothing.
-            numExportPacketsPerLID_.template sync<Kokkos::HostSpace> ();
+            numExportPacketsPerLID_.sync_host ();
             Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
               getArrayViewFromDualView (numExportPacketsPerLID_);
 
             // numImportPacketsPerLID_ is the output array here, so
             // mark it as modified.  It's strictly output, so we don't
             // have to sync from device.
-            //numImportPacketsPerLID_.template sync<Kokkos::HostSpace> ();
-            numImportPacketsPerLID_.template modify<Kokkos::HostSpace> ();
+            //numImportPacketsPerLID_.sync_host ();
+            numImportPacketsPerLID_.modify_host ();
             Teuchos::ArrayView<size_t> numImportPacketsPerLID =
               getArrayViewFromDualView (numImportPacketsPerLID_);
             distor.doReversePostsAndWaits (numExportPacketsPerLID, 1,
@@ -897,10 +897,10 @@ namespace Tpetra {
             // output here.  Similarly, we don't need to mark exports_
             // as modified, since it is read only here. This legacy
             // version of doTransfer only uses host arrays.
-            imports_.template modify<Kokkos::HostSpace> ();
+            imports_.modify_host ();
             Teuchos::ArrayView<packet_type> hostImports =
               getArrayViewFromDualView (imports_);
-            exports_.template sync<Kokkos::HostSpace> ();
+            exports_.sync_host ();
             Teuchos::ArrayView<const packet_type> hostExports =
               getArrayViewFromDualView (exports_);
             distor.doReversePostsAndWaits (hostExports,
@@ -913,10 +913,10 @@ namespace Tpetra {
             // output here.  Similarly, we don't need to mark exports_
             // as modified, since it is read only here. This legacy
             // version of doTransfer only uses host arrays.
-            imports_.template modify<Kokkos::HostSpace> ();
+            imports_.modify_host ();
             Teuchos::ArrayView<packet_type> hostImports =
               getArrayViewFromDualView (imports_);
-            exports_.template sync<Kokkos::HostSpace> ();
+            exports_.sync_host ();
             Teuchos::ArrayView<const packet_type> hostExports =
               getArrayViewFromDualView (exports_);
             distor.doReversePostsAndWaits (hostExports,
@@ -934,15 +934,15 @@ namespace Tpetra {
             // Make sure that host has the latest version, since we're
             // using the version on host.  If host has the latest
             // version already, syncing to host does nothing.
-            numExportPacketsPerLID_.template sync<Kokkos::HostSpace> ();
+            numExportPacketsPerLID_.sync_host ();
             Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
               getArrayViewFromDualView (numExportPacketsPerLID_);
 
             // numImportPacketsPerLID_ is the output array here, so
             // mark it as modified.  It's strictly output, so we don't
             // have to sync from device.
-            //numImportPacketsPerLID_.template sync<Kokkos::HostSpace> ();
-            numImportPacketsPerLID_.template modify<Kokkos::HostSpace> ();
+            //numImportPacketsPerLID_.sync_host ();
+            numImportPacketsPerLID_.modify_host ();
             Teuchos::ArrayView<size_t> numImportPacketsPerLID =
               getArrayViewFromDualView (numImportPacketsPerLID_);
             distor.doPostsAndWaits (numExportPacketsPerLID, 1,
@@ -966,10 +966,10 @@ namespace Tpetra {
             // output here.  Similarly, we don't need to mark exports_
             // as modified, since it is read only here. This legacy
             // version of doTransfer only uses host arrays.
-            imports_.template modify<Kokkos::HostSpace> ();
+            imports_.modify_host ();
             Teuchos::ArrayView<packet_type> hostImports =
               getArrayViewFromDualView (imports_);
-            exports_.template sync<Kokkos::HostSpace> ();
+            exports_.sync_host ();
             Teuchos::ArrayView<const packet_type> hostExports =
               getArrayViewFromDualView (exports_);
             distor.doPostsAndWaits (hostExports,
@@ -982,10 +982,10 @@ namespace Tpetra {
             // output here.  Similarly, we don't need to mark exports_
             // as modified, since it is read only here. This legacy
             // version of doTransfer only uses host arrays.
-            imports_.template modify<Kokkos::HostSpace> ();
+            imports_.modify_host ();
             Teuchos::ArrayView<packet_type> hostImports =
               getArrayViewFromDualView (imports_);
-            exports_.template sync<Kokkos::HostSpace> ();
+            exports_.sync_host ();
             Teuchos::ArrayView<const packet_type> hostExports =
               getArrayViewFromDualView (exports_);
             distor.doPostsAndWaits (hostExports,
@@ -1001,13 +1001,13 @@ namespace Tpetra {
           // We don't need to sync imports_, because it is only for
           // output here.  This legacy version of doTransfer only uses
           // host arrays.
-          imports_.template modify<Kokkos::HostSpace> ();
+          imports_.modify_host ();
           Teuchos::ArrayView<packet_type> hostImports =
             getArrayViewFromDualView (imports_);
           // NOTE (mfh 25 Apr 2016) unpackAndCombine doesn't actually
           // change its numImportPacketsPerLID argument, so we don't
           // have to mark it modified here.
-          numImportPacketsPerLID_.template sync<Kokkos::HostSpace> ();
+          numImportPacketsPerLID_.sync_host ();
           // FIXME (mfh 25 Apr 2016) unpackAndCombine doesn't actually
           // change its numImportPacketsPerLID argument, so we should
           // be able to use a const Teuchos::ArrayView here.
@@ -1239,7 +1239,7 @@ namespace Tpetra {
             buffer_host_device_type;
           typedef typename buffer_host_device_type::memory_space
             buffer_host_memory_space;
-          this->exports_.template sync<buffer_host_memory_space> ();
+          this->exports_.sync_host ();
         }
         else { // ! commOnHost
           typedef typename buffer_device_type::memory_space buffer_dev_memory_space;
@@ -1327,11 +1327,11 @@ namespace Tpetra {
             }
             size_t totalImportPackets = 0;
             if (commOnHost) {
-              this->numExportPacketsPerLID_.template sync<CHMS> ();
-              this->numImportPacketsPerLID_.template sync<CHMS> ();
-              this->numImportPacketsPerLID_.template modify<CHMS> (); // output argument
-              auto numExp_h = create_const_view (this->numExportPacketsPerLID_.template view<CHMS> ());
-              auto numImp_h = this->numImportPacketsPerLID_.template view<CHMS> ();
+              this->numExportPacketsPerLID_.sync_host ();
+              this->numImportPacketsPerLID_.sync_host ();
+              this->numImportPacketsPerLID_.modify_host (); // output argument
+              auto numExp_h = create_const_view (this->numExportPacketsPerLID_.view_host ());
+              auto numImp_h = this->numImportPacketsPerLID_.view_host ();
 
               // MPI communication happens here.
               distor.doReversePostsAndWaits (numExp_h, 1, numImp_h);
@@ -1372,8 +1372,8 @@ namespace Tpetra {
             // launch MPI communication on host, we will need
             // numExportPacketsPerLID and numImportPacketsPerLID on
             // host.
-            this->numExportPacketsPerLID_.template sync<CHMS> ();
-            this->numImportPacketsPerLID_.template sync<CHMS> ();
+            this->numExportPacketsPerLID_.sync_host ();
+            this->numImportPacketsPerLID_.sync_host ();
 
             // NOTE (mfh 25 Apr 2016, 01 Aug 2017) doPostsAndWaits and
             // doReversePostsAndWaits currently want
@@ -1389,14 +1389,13 @@ namespace Tpetra {
             // prevent spurious debug-mode errors (e.g., "modified on
             // both device and host"), we first need to clear its
             // "modified" flags.
-            this->imports_.modified_device() = 0;
-            this->imports_.modified_host() = 0;
-
+            this->imports_.clear_sync_state();
+           
             if (commOnHost) {
-              this->imports_.template modify<CHMS> ();
-              distor.doReversePostsAndWaits (create_const_view (this->exports_.template view<CHMS> ()),
+              this->imports_.modify_host ();
+              distor.doReversePostsAndWaits (create_const_view (this->exports_.view_host ()),
                                              numExportPacketsPerLID_av,
-                                             this->imports_.template view<CHMS> (),
+                                             this->imports_.view_host (),
                                              numImportPacketsPerLID_av);
             }
             else {
@@ -1425,14 +1424,13 @@ namespace Tpetra {
             // prevent spurious debug-mode errors (e.g., "modified on
             // both device and host"), we first need to clear its
             // "modified" flags.
-            this->imports_.modified_device() = 0;
-            this->imports_.modified_host() = 0;
+            this->imports_.clear_sync_state();
 
             if (commOnHost) {
-              this->imports_.template modify<CHMS> ();
-              distor.doReversePostsAndWaits (create_const_view (this->exports_.template view<CHMS> ()),
+              this->imports_.modify_host ();
+              distor.doReversePostsAndWaits (create_const_view (this->exports_.view_host ()),
                                              constantNumPackets,
-                                             this->imports_.template view<CHMS> ());
+                                             this->imports_.view_host ());
             }
             else { // pack on device
               this->imports_.template modify<CDMS> ();
@@ -1457,11 +1455,11 @@ namespace Tpetra {
 
             size_t totalImportPackets = 0;
             if (commOnHost) {
-              this->numExportPacketsPerLID_.template sync<CHMS> ();
-              this->numImportPacketsPerLID_.template sync<CHMS> ();
-              this->numImportPacketsPerLID_.template modify<CHMS> (); // output argument
-              auto numExp_h = create_const_view (this->numExportPacketsPerLID_.template view<CHMS> ());
-              auto numImp_h = this->numImportPacketsPerLID_.template view<CHMS> ();
+              this->numExportPacketsPerLID_.sync_host ();
+              this->numImportPacketsPerLID_.sync_host ();
+              this->numImportPacketsPerLID_.modify_host (); // output argument
+              auto numExp_h = create_const_view (this->numExportPacketsPerLID_.view_host ());
+              auto numImp_h = this->numImportPacketsPerLID_.view_host ();
 
               // MPI communication happens here.
               distor.doPostsAndWaits (numExp_h, 1, numImp_h);
@@ -1495,8 +1493,8 @@ namespace Tpetra {
             // launch MPI communication on host, we will need
             // numExportPacketsPerLID and numImportPacketsPerLID on
             // host.
-            this->numExportPacketsPerLID_.template sync<CHMS> ();
-            this->numImportPacketsPerLID_.template sync<CHMS> ();
+            this->numExportPacketsPerLID_.sync_host ();
+            this->numImportPacketsPerLID_.sync_host ();
 
             // NOTE (mfh 25 Apr 2016, 01 Aug 2017) doPostsAndWaits and
             // doReversePostsAndWaits currently want
@@ -1512,14 +1510,13 @@ namespace Tpetra {
             // prevent spurious debug-mode errors (e.g., "modified on
             // both device and host"), we first need to clear its
             // "modified" flags.
-            this->imports_.modified_device() = 0;
-            this->imports_.modified_host() = 0;
+            this->imports_.clear_sync_state();
 
             if (commOnHost) {
-              this->imports_.template modify<CHMS> ();
-              distor.doPostsAndWaits (create_const_view (this->exports_.template view<CHMS> ()),
+              this->imports_.modify_host ();
+              distor.doPostsAndWaits (create_const_view (this->exports_.view_host ()),
                                       numExportPacketsPerLID_av,
-                                      this->imports_.template view<CHMS> (),
+                                      this->imports_.view_host (),
                                       numImportPacketsPerLID_av);
             }
             else { // pack on device
@@ -1544,8 +1541,7 @@ namespace Tpetra {
             // prevent spurious debug-mode errors (e.g., "modified on
             // both device and host"), we first need to clear its
             // "modified" flags.
-            this->imports_.modified_device() = 0;
-            this->imports_.modified_host() = 0;
+            this->imports_.clear_sync_state();
 
             if (commOnHost) {
               if (verbose) {
@@ -1553,10 +1549,10 @@ namespace Tpetra {
                 os << *prefix << "7.2. Comm buffers on host" << endl;
                 std::cerr << os.str ();
               }
-              this->imports_.template modify<CHMS> ();
-              distor.doPostsAndWaits (create_const_view (this->exports_.template view<CHMS> ()),
+              this->imports_.modify_host ();
+              distor.doPostsAndWaits (create_const_view (this->exports_.view_host ()),
                                       constantNumPackets,
-                                      this->imports_.template view<CHMS> ());
+                                      this->imports_.view_host ());
             }
             else { // pack on device
               if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -903,6 +903,18 @@ public:
     val_.template modify<typename MemorySpace::memory_space> ();
   }
 
+  //! Mark the matrix's valueas as modified in host space
+  inline void modify_host()
+  {
+    val_.modify_host();
+  }
+
+  //! Mark the matrix's valueas as modified in device space
+  inline void modify_device()
+  {
+    val_.modify_device();
+  }
+
   //! Whether the matrix's values need sync'ing to the given memory space.
   template<class MemorySpace>
   bool need_sync () const
@@ -916,6 +928,18 @@ public:
     return val_.template need_sync<typename MemorySpace::memory_space> ();
   }
 
+  //! Whether the matrix's values need sync'ing to host space
+  inline bool need_sync_host() const
+  {
+    return val_.need_sync_host();
+  }
+
+  //! Whether the matrix's values need sync'ing to device space
+  inline bool need_sync_device() const
+  {
+    return val_.need_sync_device();
+  }
+
   //! Sync the matrix's values <i>to</i> the given memory space.
   template<class MemorySpace>
   void sync ()
@@ -927,6 +951,18 @@ public:
     // However, insisting on a memory space avoids unnecessary
     // instantiations.
     val_.template sync<typename MemorySpace::memory_space> ();
+  }
+
+  //! Sync the matrix's values to host space
+  inline void sync_host()
+  {
+    val_.sync_host();
+  }
+
+  //! Sync the matrix's values to device space
+  inline void sync_device()
+  {
+    val_.sync_device();
   }
 
   /// \brief Get the host or device View of the matrix's values (\c val_).
@@ -944,9 +980,19 @@ public:
   /// interface always works in a thread-parallel context without
   /// needing to synchronize on the allocation.
   template<class MemorySpace>
-  auto getValues () -> decltype (val_.template view<typename MemorySpace::memory_space> ())
+  auto getValues () -> decltype (val_.template view<typename MemorySpace::memory_space> ()) const
   {
     return val_.template view<typename MemorySpace::memory_space> ();
+  }
+
+  // \brief Get the host view of the matrix's values
+  inline typename Kokkos::DualView<impl_scalar_type*, device_type>::t_host getValuesHost () const {
+    return val_.view_host();
+  }
+
+  // \brief Get the device view of the matrix's values
+  inline typename Kokkos::DualView<impl_scalar_type*, device_type>::t_dev getValuesDevice () const {
+    return val_.view_device();
   }
 
   //@}

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -950,13 +950,13 @@ public:
       // on host.
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+        (this->need_sync_host (), std::runtime_error,
          prefix << "The matrix's values need sync on both device and host.");
 #endif // HAVE_TPETRA_DEBUG
-      this->template modify<Kokkos::HostSpace> ();
-      Kokkos::deep_copy (this->template getValues<Kokkos::HostSpace> (), alpha);
+      this->modify_host ();
+      Kokkos::deep_copy (getValuesHost (), alpha);
     }
-    else if (this->template need_sync<Kokkos::HostSpace> ()) {
+    else if (this->need_sync_host ()) {
       // If we need to sync to host, then the data were last modified
       // on device.  In that case, we should again modify them on
       // device.
@@ -1005,7 +1005,7 @@ public:
 
 #ifdef HAVE_TPETRA_DEBUG
     TEUCHOS_TEST_FOR_EXCEPTION
-      (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+      (this->need_sync_host (), std::runtime_error,
        prefix << "The matrix's data were last modified on device, but have "
        "not been sync'd to host.  Please sync to host (by calling "
        "sync<Kokkos::HostSpace>() on this matrix) before calling this "
@@ -1017,7 +1017,7 @@ public:
     // data).
     typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
     auto vals_host_out =
-      const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
+      getValuesHost ();
     impl_scalar_type* vals_host_out_raw = vals_host_out.data ();
 
     for (LO k = 0; k < numColInds; ++k, pointOffset += perBlockSize) {
@@ -1439,7 +1439,7 @@ public:
 
 #ifdef HAVE_TPETRA_DEBUG
     TEUCHOS_TEST_FOR_EXCEPTION
-      (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+      (this->need_sync_host (), std::runtime_error,
        prefix << "The matrix's data were last modified on device, but have not "
        "been sync'd to host.  Please sync to host (by calling "
        "sync<Kokkos::HostSpace>() on this matrix) before calling this method.");
@@ -1450,7 +1450,7 @@ public:
     // data).
     typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
     auto vals_host_out =
-      const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
+      getValuesHost ();
     impl_scalar_type* vals_host_out_raw = vals_host_out.data ();
 
     for (LO k = 0; k < numColInds; ++k, pointOffset += perBlockSize) {
@@ -1509,7 +1509,7 @@ public:
 
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+        (this->need_sync_host (), std::runtime_error,
          prefix << "The matrix's data were last modified on device, but have "
          "not been sync'd to host.  Please sync to host (by calling "
          "sync<Kokkos::HostSpace>() on this matrix) before calling this "
@@ -1521,7 +1521,7 @@ public:
       // data).
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
       auto vals_host_out =
-        const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
+        getValuesHost ();
       impl_scalar_type* vals_host_out_raw = vals_host_out.data ();
       impl_scalar_type* const vOut = vals_host_out_raw +
         absBlockOffsetStart * offsetPerBlock ();
@@ -1990,7 +1990,7 @@ public:
     else {
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+        (this->need_sync_host (), std::runtime_error,
          prefix << "The matrix's data were last modified on device, but have "
          "not been sync'd to host.  Please sync to host (by calling "
          "sync<Kokkos::HostSpace>() on this matrix) before calling this "
@@ -2003,7 +2003,7 @@ public:
       // data).
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
       auto vals_host =
-        const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
+        getValuesHost();
       const impl_scalar_type* vals_host_raw = vals_host.data ();
 
       return getConstLocalBlockFromInput (vals_host_raw, absPointOffset);
@@ -2057,7 +2057,7 @@ public:
       const size_t absPointOffset = absBlockOffset * offsetPerBlock ();
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+        (this->need_sync_host (), std::runtime_error,
          prefix << "The matrix's data were last modified on device, but have "
          "not been sync'd to host.  Please sync to host (by calling "
          "sync<Kokkos::HostSpace>() on this matrix) before calling this "
@@ -2067,8 +2067,7 @@ public:
       // version of the data always exists (no lazy allocation for host
       // data).
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
-      auto vals_host =
-        const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
+      auto vals_host = getValuesHost();
       impl_scalar_type* vals_host_raw = vals_host.data ();
       return getNonConstLocalBlockFromInput (vals_host_raw, absPointOffset);
     }
@@ -3401,11 +3400,11 @@ public:
       // the easiest and least memory-intensive way to implement this
       // method.
       typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
-      const_cast<this_type*> (this)->template sync<Kokkos::HostSpace> ();
+      const_cast<this_type*> (this)->sync_host ();
 
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION
-        (this->template need_sync<Kokkos::HostSpace> (), std::logic_error,
+        (this->need_sync_host (), std::logic_error,
          prefix << "Right after sync to host, the matrix claims that it needs "
          "sync to host.  Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
@@ -3743,7 +3742,7 @@ public:
 
 #ifdef HAVE_TPETRA_DEBUG
     TEUCHOS_TEST_FOR_EXCEPTION
-      (this->template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+      (this->need_sync_host (), std::runtime_error,
        prefix << "The matrix's data were last modified on device, but have "
        "not been sync'd to host.  Please sync to host (by calling "
        "sync<Kokkos::HostSpace>() on this matrix) before calling this "
@@ -3754,8 +3753,7 @@ public:
     // version of the data always exists (no lazy allocation for host
     // data).
     typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
-    auto vals_host_out =
-      const_cast<this_type*> (this)->template getValues<Kokkos::HostSpace> ();
+    auto vals_host_out = getValuesHost ();
     Scalar* vals_host_out_raw =
       reinterpret_cast<Scalar*> (vals_host_out.data ());
 

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
@@ -449,10 +449,30 @@ public:
     mv_.template sync<typename TargetMemorySpace::memory_space> ();
   }
 
+  /// \brief Update data to the host
+  void sync_host() {
+    mv_.sync_host();
+  }
+ 
+  /// \brief Update data to the device
+  void sync_device() {
+    mv_.sync_device();
+  }
+
   //! Whether this object needs synchronization to the given memory space.
   template<class TargetMemorySpace>
   bool need_sync () const {
     return mv_.template need_sync<typename TargetMemorySpace::memory_space> ();
+  }
+
+  //! Whether this object needs synchronization to the host
+  bool need_sync_host() const {
+    return mv_.need_sync_host();
+  }
+ 
+  //! Whether this object needs synchronization to the device
+  bool need_sync_device() const {
+    return mv_.need_sync_device();
   }
 
   /// \brief Mark data as modified on the given memory space.
@@ -465,6 +485,15 @@ public:
     mv_.template modify<typename TargetMemorySpace::memory_space> ();
   }
 
+  /// \brief Mark data as modified on the host
+  void modify_host() {
+    mv_.modify_host();
+  }
+ 
+  /// \brief Mark data as modified on the device
+  void modify_device() {
+    mv_.modify_device();
+  }
   //@}
   //! \name Fine-grained data access
   //@{

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
@@ -67,7 +67,7 @@ namespace { // anonymous
       // the BlockMultiVector sync'd to host unnecessarily.
       // Otherwise, all the MultiVector and BlockMultiVector kernels
       // would run on host instead of device.  See Github Issue #428.
-      auto X_view_host = X.template getLocalView<Kokkos::HostSpace> ();
+      auto X_view_host = X.template getLocalView<typename MultiVectorType::dual_view_type::t_host::device_type> ();
       impl_scalar_type* X_raw = X_view_host.data ();
       return X_raw;
     }
@@ -431,7 +431,7 @@ getLocalBlock (const LO localRowIndex,
 
 // #ifdef HAVE_TPETRA_DEBUG
 //   TEUCHOS_TEST_FOR_EXCEPTION
-//     (mv_.template need_sync<Kokkos::HostSpace> (), std::runtime_error,
+//     (mv_.need_sync_host (), std::runtime_error,
 //      "Tpetra::Experimental::BlockMultiVector::getLocalBlock: This method "
 //      "accesses host data, but the object is not in sync on host." );
 // #endif // HAVE_TPETRA_DEBUG

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -1432,10 +1432,30 @@ namespace Tpetra {
       getDualView ().template sync<TargetDeviceType> ();
     }
 
+    //! Synchronize to Host
+    inline void sync_host () {
+      getDualView().sync_host();
+    }
+
+    //! Synchronize to Device
+    inline void sync_device () {
+      getDualView().sync_device();
+    }
+
     //! Whether this MultiVector needs synchronization to the given space.
     template<class TargetDeviceType>
     bool need_sync () const {
       return getDualView ().template need_sync<TargetDeviceType> ();
+    }
+
+    //! Whether this MultiVector needs synchronization to the host.
+    inline bool need_sync_host () const {
+      return getDualView().need_sync_host();
+    }
+
+    //! Whether this MultiVector needs synchronization to the device.
+    inline bool need_sync_device () const {
+      return getDualView().need_sync_device();
     }
 
     /// \brief Mark data as modified on the given device \c TargetDeviceType.
@@ -1448,6 +1468,15 @@ namespace Tpetra {
       getDualView ().template modify<TargetDeviceType> ();
     }
 
+    /// \brief Mark data as modified on the device
+    inline void modify_device () {
+      getDualView().modify_device();
+    }
+
+    /// \brief Mark data as modified on the host
+    inline void modify_host () {
+      getDualView().modify_host();
+    }
     /// \brief Return a view of the local data on a specific device.
     /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
     ///
@@ -1488,6 +1517,16 @@ namespace Tpetra {
       typename dual_view_type::t_host>::type
     getLocalView () const {
       return getDualView ().template view<TargetDeviceType> ();
+    }
+
+    /// Return a local view on the host
+    typename dual_view_type::t_host getLocalViewHost () const {
+      return getDualView().view_host();
+    }
+
+    /// Return a local view on the device
+    typename dual_view_type::t_dev getLocalViewDevice () const {
+      return getDualView().view_device();
     }
 
     //@}
@@ -2481,15 +2520,15 @@ namespace Tpetra {
         // Device memory has the most recent version of src.
         dst.template modify<DES> (); // We are about to modify dst on device.
         // Copy from src to dst on device.
-        Details::localDeepCopyConstStride (dst.template getLocalView<DES> (),
-                                           src.template getLocalView<typename SN::device_type> ());
-        dst.template sync<HES> (); // Sync dst from device to host.
+        Details::localDeepCopyConstStride (dst.getLocalViewDevice (),
+                                           src.getLocalViewDevice ());
+        dst.sync_host (); // Sync dst from device to host.
       }
       else { // Host memory has the most recent version of src.
         dst.template modify<HES> (); // We are about to modify dst on host.
         // Copy from src to dst on host.
-        Details::localDeepCopyConstStride (dst.template getLocalView<Kokkos::HostSpace> (),
-                                           src.template getLocalView<Kokkos::HostSpace> ());
+        Details::localDeepCopyConstStride (dst.getLocalViewHost (),
+                                           src.getLocalViewHost ());
         dst.template sync<DES> (); // Sync dst from host to device.
       }
     }
@@ -2514,7 +2553,7 @@ namespace Tpetra {
           // whichVecs tells the kernel which vectors (columns) of src
           // to copy.  Fill whichVecs on the host, and sync to device.
           whichvecs_type whichVecs (whichVecsLabel, numWhichVecs);
-          whichVecs.template modify<HES> ();
+          whichVecs.modify_host ();
 
           Teuchos::ArrayView<const size_t> src_whichVectors =
             getMultiVectorWhichVectors (src);
@@ -2527,15 +2566,15 @@ namespace Tpetra {
           // Mark the device version of dst's DualView as modified.
           dst.template modify<DES> ();
           // Copy from the selected vectors of src to dst, on the device.
-          Details::localDeepCopy (dst.template getLocalView<typename DN::device_type> (),
-                                  src.template getLocalView<typename SN::device_type> (),
+          Details::localDeepCopy (dst.getLocalViewDevice (),
+                                  src.getLocalViewDevice (),
                                   dst.isConstantStride (),
                                   src.isConstantStride (),
                                   whichVecs.d_view,
                                   whichVecs.d_view);
           // Sync dst's DualView to the host.  This is cheaper than
           // repeating the above copy from src to dst on the host.
-          dst.template sync<HES> ();
+          dst.sync_host ();
         }
         else { // host version of src was the most recently modified
           // Copy from the host version of src.
@@ -2552,8 +2591,8 @@ namespace Tpetra {
           // Copy from the selected vectors of src to dst, on the
           // host.  The function ignores the first instance of
           // 'whichVecs' in this case.
-          Details::localDeepCopy (dst.template getLocalView<Kokkos::HostSpace> (),
-                                  src.template getLocalView<Kokkos::HostSpace> (),
+          Details::localDeepCopy (dst.getLocalViewHost (),
+                                  src.getLocalViewHost (),
                                   dst.isConstantStride (),
                                   src.isConstantStride (),
                                   whichVecs, whichVecs);
@@ -2595,7 +2634,7 @@ namespace Tpetra {
             //
             // FIXME (mfh 29 Jul 2014) This may overwrite columns that
             // don't actually belong to dst's view.
-            dst.template sync<HES> ();
+            dst.sync_host ();
           }
           else { // host version of src was the most recently modified
             // Copy from the host version of src.
@@ -2612,8 +2651,8 @@ namespace Tpetra {
               whichVecs(i) = static_cast<DL> (dst_whichVectors[i]);
             }
             // Copy from src to the selected vectors of dst, on the host.
-            Details::localDeepCopy (dst.template getLocalView<Kokkos::HostSpace> (),
-                                    src.template getLocalView<Kokkos::HostSpace> (),
+            Details::localDeepCopy (dst.getLocalViewHost (),
+                                    src.getLocalViewHost (),
                                     dst.isConstantStride (),
                                     src.isConstantStride (),
                                     whichVecs, whichVecs);
@@ -2695,8 +2734,8 @@ namespace Tpetra {
 
             // Copy from the selected vectors of src to the selected
             // vectors of dst, on the host.
-            Details::localDeepCopy (dst.template getLocalView<Kokkos::HostSpace> (),
-                                    src.template getLocalView<Kokkos::HostSpace> (),
+            Details::localDeepCopy (dst.getLocalViewHost (),
+                                    src.getLocalViewHost (),
                                     dst.isConstantStride (),
                                     src.isConstantStride (),
                                     whichVectorsDst, whichVectorsSrc);
@@ -2705,7 +2744,7 @@ namespace Tpetra {
             //
             // FIXME (mfh 29 Jul 2014) This may overwrite columns that
             // don't actually belong to dst's view.
-            dst.template sync<HES> ();
+            dst.sync_host ();
           }
         }
       }

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -871,8 +871,8 @@ namespace Tpetra {
     }
 
     if (copyOnHost) {
-      if(this->template need_sync<HMS> ()) this->template sync<HMS> ();
-      this->template modify<HMS> ();
+      if(this->need_sync_host ()) this->sync_host ();
+      this->modify_host ();
     }
     else {
       if(this->template need_sync<DMS> ()) this->template sync<DMS> ();
@@ -908,8 +908,8 @@ namespace Tpetra {
     if (numSameIDs > 0) {
       const std::pair<size_t, size_t> rows (0, numSameIDs);
       if (copyOnHost) {
-        auto tgt_h = this->template getLocalView<HMS> ();
-        auto src_h = create_const_view (sourceMV.template getLocalView<HMS> ());
+        auto tgt_h = getDualView().view_host();
+        auto src_h = create_const_view (sourceMV.getDualView().view_host());
 
         for (size_t j = 0; j < numCols; ++j) {
           const size_t tgtCol = isConstantStride () ? j : whichVectors_[j];
@@ -995,7 +995,7 @@ namespace Tpetra {
     if (nonConstStride) {
       if (this->whichVectors_.size () == 0) {
         Kokkos::DualView<size_t*, device_type> tmpTgt ("tgtWhichVecs", numCols);
-        tmpTgt.template modify<HMS> ();
+        tmpTgt.modify_host ();
         for (size_t j = 0; j < numCols; ++j) {
           tmpTgt.h_view(j) = j;
         }
@@ -1020,7 +1020,7 @@ namespace Tpetra {
 
       if (sourceMV.whichVectors_.size () == 0) {
         Kokkos::DualView<size_t*, device_type> tmpSrc ("srcWhichVecs", numCols);
-        tmpSrc.template modify<HMS> ();
+        tmpSrc.modify_host ();
         for (size_t j = 0; j < numCols; ++j) {
           tmpSrc.h_view(j) = j;
         }
@@ -1052,14 +1052,14 @@ namespace Tpetra {
           "Set up permutation arrays on host" << std::endl;
         std::cerr << os.str ();
       }
-      auto tgt_h = this->template getLocalView<HMS> ();
-      auto src_h = create_const_view (sourceMV.template getLocalView<HMS> ());
-      permuteToLIDs_nc.template sync<HMS> ();
+      auto tgt_h = getDualView().view_host();
+      auto src_h = create_const_view (sourceMV.getDualView().view_host());
+      permuteToLIDs_nc.sync_host ();
       auto permuteToLIDs_h =
-        create_const_view (permuteToLIDs_nc.template view<HMS> ());
-      permuteFromLIDs_nc.template sync<HMS> ();
+        create_const_view (permuteToLIDs_nc.view_host ());
+      permuteFromLIDs_nc.sync_host ();
       auto permuteFromLIDs_h =
-        create_const_view (permuteFromLIDs_nc.template view<HMS> ());
+        create_const_view (permuteFromLIDs_nc.view_host ());
 
       if (debug) {
         std::ostringstream os;
@@ -1071,9 +1071,9 @@ namespace Tpetra {
         // No need to sync first, because copyOnHost argument to
         // getDualViewCopyFromArrayView puts them in the right place.
         auto tgtWhichVecs_h =
-          create_const_view (tgtWhichVecs.template view<HMS> ());
+          create_const_view (tgtWhichVecs.view_host ());
         auto srcWhichVecs_h =
-          create_const_view (srcWhichVecs.template view<HMS> ());
+          create_const_view (srcWhichVecs.view_host ());
         permute_array_multi_column_variable_stride (tgt_h, src_h,
                                                     permuteToLIDs_h,
                                                     permuteFromLIDs_h,
@@ -1199,11 +1199,11 @@ namespace Tpetra {
     // modified on host, we have to allocate a temporary device
     // version and copy back to device before we can pack.
     const bool packOnHost =
-      exportLIDs.modified_host () > exportLIDs.modified_device ();
+      exportLIDs.need_sync_device();
     auto src_dev = sourceMV.template getLocalView<dev_memory_space> ();
-    auto src_host = sourceMV.template getLocalView<host_memory_space> ();
+    auto src_host = sourceMV.getDualView().view_host();
     if (packOnHost) {
-      if (sourceMV.template need_sync<Kokkos::HostSpace> ()) {
+      if (sourceMV.need_sync_host()) {
         if (printDebugOutput) {
           std::ostringstream os;
           os << "Proc " << myRank << ": MV::packAndPrepareNew: "
@@ -1291,7 +1291,7 @@ namespace Tpetra {
     // Resizing currently requires calling the constructor, which
     // clears out the 'modified' flags.
     if (packOnHost) {
-      exports.template modify<EHMS> ();
+      exports.modify_host ();
     }
     else {
       exports.template modify<EDMS> ();
@@ -1319,9 +1319,9 @@ namespace Tpetra {
           std::cerr << os.str ();
         }
         if (packOnHost) {
-          pack_array_single_column (exports.template view<EHMS> (),
+          pack_array_single_column (exports.view_host (),
                                     create_const_view (src_host),
-                                    exportLIDs.template view<host_memory_space> (),
+                                    exportLIDs.view_host (),
                                     0,
                                     debugCheckIndices);
         }
@@ -1342,9 +1342,9 @@ namespace Tpetra {
           std::cerr << os.str ();
         }
         if (packOnHost) {
-          pack_array_single_column (exports.template view<EHMS> (),
+          pack_array_single_column (exports.view_host (),
                                     create_const_view (src_host),
-                                    exportLIDs.template view<host_memory_space> (),
+                                    exportLIDs.view_host (),
                                     sourceMV.whichVectors_[0],
                                     debugCheckIndices);
         }
@@ -1367,9 +1367,9 @@ namespace Tpetra {
           std::cerr << os.str ();
         }
         if (packOnHost) {
-          pack_array_multi_column (exports.template view<EHMS> (),
+          pack_array_multi_column (exports.view_host (),
                                    create_const_view (src_host),
-                                   exportLIDs.template view<host_memory_space> (),
+                                   exportLIDs.view_host (),
                                    numCols,
                                    debugCheckIndices);
         }
@@ -1390,9 +1390,9 @@ namespace Tpetra {
           std::cerr << os.str ();
         }
         if (packOnHost) {
-          pack_array_multi_column_variable_stride (exports.template view<EHMS> (),
+          pack_array_multi_column_variable_stride (exports.view_host (),
                                                    create_const_view (src_host),
-                                                   exportLIDs.template view<host_memory_space> (),
+                                                   exportLIDs.view_host (),
                                                    getKokkosViewDeepCopy<host_execution_space> (sourceMV.whichVectors_ ()),
                                                    numCols,
                                                    debugCheckIndices);
@@ -1494,8 +1494,7 @@ namespace Tpetra {
     // require importLIDs to match (its most recent version must be in
     // the same memory space as imports' most recent version).
     const bool unpackOnHost =
-      imports.modified_host () != 0 &&
-      imports.modified_host () > imports.modified_device ();
+      imports.need_sync_device();
 
     if (printDebugOutput) {
       std::ostringstream os;
@@ -1509,7 +1508,7 @@ namespace Tpetra {
     // because this method does not _modify_ them.  We just need them
     // to be in the right place.
     auto theImportLIDs = castAwayConstDualView (importLIDs);
-    if (unpackOnHost && importLIDs.modified_host () < importLIDs.modified_device ()) {
+    if (unpackOnHost && importLIDs.need_sync_host ()) {
       if (printDebugOutput) {
         std::ostringstream os;
         os << "(Proc " << myRank << ") MV::unpackAndCombine: sync importLIDs "
@@ -1520,9 +1519,9 @@ namespace Tpetra {
       // modified on device.  Sync importLIDs to host and do the work
       // there, since imports usually at least as much data (and often
       // has more) than importLIDs.
-      theImportLIDs.template sync<HMS> ();
+      theImportLIDs.sync_host ();
     }
-    else if (! unpackOnHost && importLIDs.modified_host () > importLIDs.modified_device ()) {
+    else if (! unpackOnHost && importLIDs.need_sync_device ()) {
       if (printDebugOutput) {
         std::ostringstream os;
         os << "(Proc " << myRank << ") MV::unpackAndCombine: sync importLIDs "
@@ -1547,21 +1546,21 @@ namespace Tpetra {
     // because copyAndPermute may have modified *this in the other
     // memory space.
     if (unpackOnHost) {
-      if(this->template need_sync<HMS> ()) this->template sync<HMS> ();
-      this->template modify<HMS> ();
+      if(this->need_sync_host ()) this->sync_host ();
+      this->modify_host ();
     }
     else { // unpack on device
       if(this->template need_sync<DMS> ()) this->template sync<DMS> ();
       this->template modify<DMS> ();
     }
     auto X_d = this->template getLocalView<DMS> ();
-    auto X_h = this->template getLocalView<HMS> ();
+    auto X_h = getDualView().view_host();
     // 'imports' may have a different device memory space (see #1088).
     auto imports_d =
       imports.template view<typename buffer_device_type::memory_space> ();
-    auto imports_h = imports.template view<Kokkos::HostSpace> ();
+    auto imports_h = imports.view_host ();
     auto importLIDs_d = importLIDs.template view<DMS> ();
-    auto importLIDs_h = importLIDs.template view<HMS> ();
+    auto importLIDs_h = importLIDs.view_host ();
 
     Kokkos::DualView<size_t*, device_type> whichVecs;
     if (! isConstantStride ()) {
@@ -1570,8 +1569,8 @@ namespace Tpetra {
                                               numVecs);
       whichVecs = Kokkos::DualView<size_t*, device_type> ("whichVecs", numVecs);
       if (unpackOnHost) {
-        whichVecs.template modify<HMS> ();
-        Kokkos::deep_copy (whichVecs.template view<HMS> (), whichVecsIn);
+        whichVecs.modify_host ();
+        Kokkos::deep_copy (whichVecs.view_host (), whichVecsIn);
       }
       else {
         whichVecs.template modify<DMS> ();
@@ -1579,7 +1578,7 @@ namespace Tpetra {
       }
     }
     auto whichVecs_d = whichVecs.template view<DMS> ();
-    auto whichVecs_h = whichVecs.template view<HMS> ();
+    auto whichVecs_h = whichVecs.view_host ();
 
     /* The layout in the export for MultiVectors is as follows:
        imports = { all of the data from row exportLIDs.front() ;
@@ -2458,7 +2457,7 @@ namespace Tpetra {
     const bool useHostVersion = this->template need_sync<device_type> ();
     if (useHostVersion) {
       // DualView was last modified on host, so run the local kernel there.
-      auto X_lcl = subview (this->template getLocalView<Kokkos::HostSpace> (),
+      auto X_lcl = subview (getDualView().view_host (),
                             rowRng, Kokkos::ALL ());
       // Compute the local sum of each column.
       Kokkos::View<impl_scalar_type*, Kokkos::HostSpace> lclSums ("MV::meanValue tmp", numVecs);
@@ -2570,8 +2569,7 @@ namespace Tpetra {
     // See #1510.  In case diag has already been marked modified on
     // host or device, we need to clear those flags, since the code
     // below works on device.
-    this->view_.modified_device () = 0;
-    this->view_.modified_host () = 0;
+    this->view_.clear_sync_state();
 
     this->template modify<device_type> ();
     auto thisView = this->getLocalView<device_type> ();
@@ -2598,7 +2596,7 @@ namespace Tpetra {
     using ::Tpetra::Details::Blas::fill;
     typedef typename dual_view_type::t_dev::memory_space DMS;
     //typedef typename dual_view_type::t_host::memory_space HMS;
-    typedef Kokkos::HostSpace HMS; // avoid CudaUVMSpace issues
+    typedef typename dual_view_type::t_host::device_type HMS; // avoid CudaUVMSpace issues
     typedef typename dual_view_type::t_dev::execution_space DES;
     typedef typename dual_view_type::t_host::execution_space HES;
     typedef LocalOrdinal LO;
@@ -2628,8 +2626,8 @@ namespace Tpetra {
       }
     }
     else { // last modified in host memory, so modify data there.
-      this->template modify<HMS> (); // we are about to modify on the host
-      auto X = this->template getLocalView<HMS> ();
+      this->modify_host (); // we are about to modify on the host
+      auto X = getDualView().view_host();
       if (this->isConstantStride ()) {
         fill (HES (), X, theAlpha, lclNumRows, numVecs);
       }
@@ -2758,7 +2756,7 @@ namespace Tpetra {
     const bool useHostVersion = this->template need_sync<device_type> ();
     if (useHostVersion) {
       auto Y_lcl =
-        Kokkos::subview (this->template getLocalView<Kokkos::HostSpace> (),
+        Kokkos::subview (getDualView().view_host (),
                          rowRng, Kokkos::ALL ());
       if (isConstantStride ()) {
         KokkosBlas::scal (Y_lcl, theAlpha, Y_lcl);
@@ -3190,10 +3188,10 @@ namespace Tpetra {
     // viewBuffer or viewBufferNonConst methods always implied a
     // device->host synchronization.  Thus, we synchronize here as
     // well.
-    const_cast<MV*> (this)->template sync<Kokkos::HostSpace> ();
+    const_cast<MV*> (this)->sync_host ();
 
     // Get a host view of the entire MultiVector's data.
-    auto hostView = this->template getLocalView<Kokkos::HostSpace> ();
+    auto hostView = getDualView().view_host ();
 
     // Get a subview of column j.
     const size_t col = isConstantStride () ? j : whichVectors_[j];
@@ -3227,14 +3225,14 @@ namespace Tpetra {
     // viewBuffer or viewBufferNonConst methods always implied a
     // device->host synchronization.  Thus, we synchronize here as
     // well.
-    const_cast<MV*> (this)->template sync<Kokkos::HostSpace> ();
+    const_cast<MV*> (this)->sync_host ();
 
     // Calling getDataNonConst() implies that the user plans to modify
     // the values in the MultiVector, so we mark the host data as modified.
-    this->template modify<Kokkos::HostSpace> ();
+    this->modify_host ();
 
     // Get a host view of the entire MultiVector's data.
-    auto hostView = this->template getLocalView<Kokkos::HostSpace> ();
+    auto hostView = getDualView().view_host ();
 
     // Get a subview of column j.
     const size_t col = isConstantStride () ? j : whichVectors_[j];
@@ -3374,7 +3372,7 @@ namespace Tpetra {
     const size_t lclNumRowsBefore = X.getLocalLength ();
     const size_t numColsBefore = X.getNumVectors ();
     const impl_scalar_type* hostPtrBefore =
-      X.template getLocalView<Kokkos::HostSpace> ().data ();
+      X.getDualView().view_host().data ();
 #endif // HAVE_TPETRA_DEBUG
 
     const std::pair<size_t, size_t> origRowRng (offset, X.origView_.extent (0));
@@ -3420,7 +3418,7 @@ namespace Tpetra {
     const size_t lclNumRowsAfter = X.getLocalLength ();
     const size_t numColsAfter = X.getNumVectors ();
     const impl_scalar_type* hostPtrAfter =
-      X.template getLocalView<Kokkos::HostSpace> ().data ();
+      X.getDualView().view_host().data ();
 
     const size_t strideRet = subViewMV.isConstantStride () ?
       subViewMV.getStride () :
@@ -3737,7 +3735,7 @@ namespace Tpetra {
   {
     typedef decltype (this->template getLocalView<device_type> ())
       dev_view_type;
-    typedef decltype (this->template getLocalView<Kokkos::HostSpace> ())
+    typedef decltype (getDualView().view_host ())
       host_view_type;
     typedef impl_scalar_type IST;
     typedef Kokkos::View<IST*, typename host_view_type::array_layout,
@@ -3777,7 +3775,7 @@ namespace Tpetra {
     dev_view_type srcView_dev;
     host_view_type srcView_host;
     if (useHostVersion) {
-      srcView_host = this->template getLocalView<Kokkos::HostSpace> ();
+      srcView_host = getDualView().view_host ();
     }
     else {
       srcView_dev = this->template getLocalView<device_type> ();
@@ -3857,16 +3855,15 @@ namespace Tpetra {
       // (replace ? with 1 or 2) have always been device->host
       // synchronization points, since <= 2012.  We retain this
       // behavior for backwards compatibility.
-      using host_memory_space = Kokkos::HostSpace;
-      if (X.template need_sync<host_memory_space> ()) {
-        X.template sync<host_memory_space> ();
+      if (X.need_sync_host ()) {
+        X.sync_host ();
       }
       if (markModified) {
-        X.template modify<host_memory_space> ();
+        X.modify_host ();
       }
       // get{1,2}dView() and get{1,2}dViewNonConst() all return a host
       // view of the data.
-      return X.template getLocalView<host_memory_space> ();
+      return X.getDualView().view_host();
     }
   } // namespace (anonymous)
 
@@ -4285,7 +4282,7 @@ namespace Tpetra {
     using Teuchos::REDUCE_SUM;
     typedef decltype (this->template getLocalView<device_type> ())
       dev_view_type;
-    typedef decltype (this->template getLocalView<Kokkos::HostSpace> ())
+    typedef decltype (getDualView().view_host ())
       host_view_type;
 
     ::Tpetra::Details::ProfilingRegion region ("Tpetra::MV::reduce");
@@ -4326,7 +4323,7 @@ namespace Tpetra {
     dev_view_type srcView_dev;
     host_view_type srcView_host;
     if (useHostVersion) {
-      srcView_host = this->template getLocalView<Kokkos::HostSpace> ();
+      srcView_host = getDualView ().view_host ();
       if (lclNumRows != static_cast<size_t> (srcView_host.extent (0))) {
         // Make sure the number of rows is correct.  If not, take a subview.
         const Kokkos::pair<size_t, size_t> rowRng (0, lclNumRows);
@@ -4421,7 +4418,7 @@ namespace Tpetra {
 
     // Write back the results to *this.
     if (useHostVersion) {
-      this->template modify<Kokkos::HostSpace> ();
+      this->modify_host ();
       if (contig || isConstantStride ()) {
         Kokkos::deep_copy (srcView_host, tgtBuf_host);
       }
@@ -4670,7 +4667,7 @@ namespace Tpetra {
         // that we can access device data directly in host code.)
         auto X_dual = this->getDualView ();
         typename dual_view_type::t_host X_host;
-        if (X_dual.template need_sync<Kokkos::HostSpace> ()) {
+        if (X_dual.need_sync_host ()) {
           // Device memory has the latest version.  Don't actually
           // sync to host; that changes the Vector's state, and may
           // change future computations (that use the data's current
@@ -4685,7 +4682,7 @@ namespace Tpetra {
           // Either host and device are in sync, or host has the
           // latest version of the Vector's data.  Thus, we can use
           // the host version directly.
-          X_host = this->template getLocalView<Kokkos::HostSpace> ();
+          X_host = getDualView ().view_host ();
         }
         // The square braces [] and their contents are in Matlab
         // format, so users may copy and paste directly into Matlab.
@@ -4842,8 +4839,7 @@ namespace Tpetra {
     // contents in either memory space, and we don't want
     // DualView::modify to complain about "concurrent modification" of
     // host and device Views.
-    this->view_.modified_device () = 0;
-    this->view_.modified_host () = 0;
+    this->view_.clear_sync_state();
 
     if (debug && this->getMap ()->getComm ()->getRank () == 0) {
       std::cout << "*** MultiVector::assign: ";
@@ -4859,7 +4855,7 @@ namespace Tpetra {
 
       if (useHostVersion) { // Host memory has the most recent version of src.
         // Copy from src to dst on host.
-        this->template modify<HMDT> ();
+        this->modify_host ();
         localDeepCopyConstStride (this->template getLocalView<HMDT> (),
                                   src.template getLocalView<HMDT> ());
       }
@@ -4901,7 +4897,7 @@ namespace Tpetra {
           // Copy from the selected vectors of src to dst, on the
           // host.  The function ignores its dstWhichVecs argument in
           // this case.
-          this->template modify<HMDT> ();
+          this->modify_host ();
           localDeepCopy (this->template getLocalView<HMDT> (),
                          src.template getLocalView<HMDT> (),
                          true, false, srcWhichVecs, srcWhichVecs);
@@ -4916,7 +4912,7 @@ namespace Tpetra {
           // to copy.  Fill whichVecs on the host, and sync to device.
           typedef Kokkos::DualView<LO*, DT> whichvecs_type;
           whichvecs_type srcWhichVecs (whichVecsLabel, numWhichVecs);
-          srcWhichVecs.template modify<HMDT> ();
+          srcWhichVecs.modify_host ();
           for (LO i = 0; i < numWhichVecs; ++i) {
             srcWhichVecs.h_view(i) = static_cast<LO> (src.whichVectors_[i]);
           }
@@ -4955,7 +4951,7 @@ namespace Tpetra {
             }
             // Copy from src to the selected vectors of dst, on the
             // host.  The functor ignores its 4th arg in this case.
-            this->template modify<HMDT> ();
+            this->modify_host ();
             localDeepCopy (this->template getLocalView<HMDT> (),
                            src.template getLocalView<HMDT> (),
                            this->isConstantStride (),
@@ -4969,7 +4965,7 @@ namespace Tpetra {
             const std::string whichVecsLabel ("MV::deep_copy::whichVecs");
             const LO numWhichVecs = static_cast<LO> (this->whichVectors_.size ());
             whichvecs_type whichVecs (whichVecsLabel, numWhichVecs);
-            whichVecs.template modify<HMDT> ();
+            whichVecs.modify_host ();
             for (LO i = 0; i < numWhichVecs; ++i) {
               whichVecs.h_view(i) = this->whichVectors_[i];
             }
@@ -5009,7 +5005,7 @@ namespace Tpetra {
 
             // Copy from the selected vectors of src to the selected
             // vectors of dst, on the host.
-            this->template modify<HMDT> ();
+            this->modify_host ();
             localDeepCopy (this->template getLocalView<HMDT> (),
                            src.template getLocalView<HMDT> (),
                            this->isConstantStride (),
@@ -5023,7 +5019,7 @@ namespace Tpetra {
             const LO dstNumWhichVecs = static_cast<LO> (this->whichVectors_.size ());
             Kokkos::DualView<LO*, DT> whichVecsDst ("MV::deep_copy::whichVecsDst",
                                                     dstNumWhichVecs);
-            whichVecsDst.template modify<HMDT> ();
+            whichVecsDst.modify_host ();
             for (LO i = 0; i < dstNumWhichVecs; ++i) {
               whichVecsDst.h_view(i) = static_cast<LO> (this->whichVectors_[i]);
             }
@@ -5037,7 +5033,7 @@ namespace Tpetra {
             const LO srcNumWhichVecs = static_cast<LO> (src.whichVectors_.size ());
             Kokkos::DualView<LO*, DT> whichVecsSrc ("MV::deep_copy::whichVecsSrc",
                                                     srcNumWhichVecs);
-            whichVecsSrc.template modify<HMDT> ();
+            whichVecsSrc.modify_host ();
             for (LO i = 0; i < srcNumWhichVecs; ++i) {
               whichVecsSrc.h_view(i) = static_cast<LO> (src.whichVectors_[i]);
             }

--- a/packages/tpetra/core/src/Tpetra_TsqrAdaptor.hpp
+++ b/packages/tpetra/core/src/Tpetra_TsqrAdaptor.hpp
@@ -222,10 +222,10 @@ namespace Tpetra {
 
       // FIXME (mfh 16 Jan 2016) Currently, TSQR is a host-only
       // implementation.
-      A.template sync<Kokkos::HostSpace> ();
-      A.template modify<Kokkos::HostSpace> ();
-      Q.template sync<Kokkos::HostSpace> ();
-      Q.template modify<Kokkos::HostSpace> ();
+      A.sync_host ();
+      A.modify_host ();
+      Q.sync_host ();
+      Q.modify_host ();
       auto A_view = A.template getLocalView<Kokkos::HostSpace> ();
       auto Q_view = Q.template getLocalView<Kokkos::HostSpace> ();
       scalar_type* const A_ptr =
@@ -285,8 +285,8 @@ namespace Tpetra {
       // to make sure it is the same communicator as the one we are
       // using in our dist_tsqr_type implementation.
 
-      Q.template sync<Kokkos::HostSpace> ();
-      Q.template modify<Kokkos::HostSpace> ();
+      Q.sync_host ();
+      Q.modify_host ();
       auto Q_view = Q.template getLocalView<Kokkos::HostSpace> ();
       scalar_type* const Q_ptr =
         reinterpret_cast<scalar_type*> (Q_view.data ());

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -880,12 +880,12 @@ namespace Tpetra {
       static_assert (static_cast<int> (DualViewType::t_dev::rank) == 1,
                      "The input DualView must have rank 1.");
       TEUCHOS_TEST_FOR_EXCEPTION
-        (x.template need_sync<Kokkos::HostSpace> (), std::logic_error, "The "
+        (x.need_sync_host (), std::logic_error, "The "
          "input Kokkos::DualView was most recently modified on device, but this "
          "function needs the host view of the data to be the most recently "
          "modified.");
 
-      auto x_host = x.template view<Kokkos::HostSpace> ();
+      auto x_host = x.view_host ();
       typedef typename DualViewType::t_dev::value_type value_type;
       return Teuchos::ArrayView<value_type> (x_host.data (),
                                              x_host.extent (0));
@@ -921,8 +921,8 @@ namespace Tpetra {
       Kokkos::View<const T*, HMS, MemoryUnmanaged> x_in (x_av.getRawPtr (), len);
       Kokkos::DualView<T*, DT> x_out (label, len);
       if (leaveOnHost) {
-        x_out.template modify<HMS> ();
-        Kokkos::deep_copy (x_out.template view<HMS> (), x_in);
+        x_out.modify_host ();
+        Kokkos::deep_copy (x_out.view_host (), x_in);
       }
       else {
         x_out.template modify<DMS> ();
@@ -941,8 +941,8 @@ namespace Tpetra {
     template<class DualViewType>
     std::string dualViewStatusToString (const DualViewType& dv, const char name[])
     {
-      const auto host = dv.modified_host ();
-      const auto dev = dv.modified_host ();
+      const auto host = dv.need_sync_device();
+      const auto dev = dv.need_sync_host();
 
       std::ostringstream os;
       os << name << ": {size: " << dv.extent (0)

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -217,7 +217,7 @@ namespace {
           B_norm = (curAbs > B_norm) ? curAbs : B_norm;
         }
       }
-      Kokkos::deep_copy (C2, A_orig);
+      Kokkos::deep_copy (C2, C_orig);
       for (LO i = 0; i < static_cast<LO> (C2.extent (0)); ++i) {
         for (LO j = 0; j < static_cast<LO> (C2.extent (1)); ++j) {
           const mag_type curAbs =

--- a/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
@@ -277,8 +277,8 @@ namespace {
     X.putScalar (one);
     Y.putScalar (zero);
     {
-      X.template sync<Kokkos::HostSpace> ();
-      X.template modify<Kokkos::HostSpace> ();
+      X.sync_host ();
+      X.modify_host();
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
@@ -303,8 +303,8 @@ namespace {
     myOut << "maxVecNorm = " << maxVecNorm << endl;
 
     {
-      Y.template sync<Kokkos::HostSpace> ();
-      Y.template modify<Kokkos::HostSpace> ();
+      Y.sync_host ();
+      Y.modify_host ();
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
@@ -337,7 +337,7 @@ namespace {
     myOut << "Check results of Y.blockWiseMultiply(alpha, D, X)" << endl;
 
     {
-      Y.template sync<Kokkos::HostSpace> ();
+      Y.sync_host ();
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {
@@ -500,8 +500,8 @@ namespace {
     X.putScalar (one);
     Y.putScalar (zero);
     {
-      X.template sync<Kokkos::HostSpace> ();
-      X.template modify<Kokkos::HostSpace> ();
+      X.sync_host ();
+      X.modify_host ();
       curScalingFactor = one;
       for (LO whichBlk = 0; whichBlk < numLocalMeshPoints; ++whichBlk) {
         for (LO whichVec = 0; whichVec < numVecs; ++whichVec) {

--- a/packages/tpetra/core/test/Block/BlockView.cpp
+++ b/packages/tpetra/core/test/Block/BlockView.cpp
@@ -167,7 +167,7 @@ namespace {
     rhs(1) = 200.0;
     rhs(2) = 300.0;
 
-    scalar_vec_type true_rhs("truerhs",3,1);
+    scalar_vec_type true_rhs("truerhs",3);
     for(int i=0; i<3; i++)
       true_rhs(i) = rhs(i);
 
@@ -266,7 +266,7 @@ namespace {
     rhs(1) = 200.0;
     rhs(2) = 300.0;
 
-    scalar_vec_type true_rhs("truerhs",3,1);
+    scalar_vec_type true_rhs("truerhs",3);
     for(int i=0; i<3; i++)
       true_rhs(i) = rhs(i);
 

--- a/packages/tpetra/core/test/FEMultiVector/FEMultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/FEMultiVector/FEMultiVector_UnitTests.cpp
@@ -563,9 +563,9 @@ namespace {
       // MV allocation favors host space for initial allocations and
       // defers device allocations.
 
-      auto X_local = X->template getLocalView<Kokkos::HostSpace> ();
-      auto X1_local = X1->template getLocalView<Kokkos::HostSpace> ();
-      auto X2_local = X2->template getLocalView<Kokkos::HostSpace> ();
+      auto X_local = X->getLocalViewHost ();
+      auto X1_local = X1->getLocalViewHost ();
+      auto X2_local = X2->getLocalViewHost ();
 
       // Make sure the pointers match.  It doesn't really matter to
       // what X2_local points, as long as it has zero rows.

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -79,7 +79,7 @@ namespace {
        "function needs the host view of the data to be the most recently "
        "modified.");
 
-    auto x_host = x.template view<Kokkos::HostSpace> ();
+    auto x_host = x.view_host ();
     typedef typename DualViewType::t_dev::value_type value_type;
     return Teuchos::ArrayView<value_type> (x_host.data (),
                                            x_host.extent (0));
@@ -2094,7 +2094,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
         SourcePids(), constantNumPackets, distor);
 
     // This test reads exports on the host, so sync there.
-    exports.template sync<Kokkos::HostSpace> ();
+    exports.sync_host ();
     Teuchos::ArrayView<char> exports_av = getArrayViewFromDualView (exports);
 
     // Do the moral equivalent of doTransfer

--- a/packages/tpetra/core/test/MultiVector/Issue364.cpp
+++ b/packages/tpetra/core/test/MultiVector/Issue364.cpp
@@ -196,9 +196,9 @@ namespace { // (anonymous)
 
     out << "Fill the master MultiVector X" << endl;
     {
-      X.template sync<host_memory_space> ();
-      X.template modify<host_memory_space> ();
-      auto X_lcl = X.template getLocalView<host_memory_space> ();
+      X.sync_host ();
+      X.modify_host ();
+      auto X_lcl = X.getLocalViewHost ();
 
       TEST_EQUALITY( static_cast<LO> (X_lcl.extent (0)), lclNumRows );
       TEST_EQUALITY( static_cast<LO> (X_lcl.extent (1)), numVecs );
@@ -216,7 +216,7 @@ namespace { // (anonymous)
           curVal = curVal + Kokkos::Details::ArithTraits<IST>::one ();
         }
       }
-      X.template sync<dev_memory_space> ();
+      X.sync_device ();
     }
 
     // Make a "backup" of X, for later comparison.
@@ -232,8 +232,8 @@ namespace { // (anonymous)
 
     out << "Modify the entries of that view, on host" << endl;
     {
-      X_sub->template sync<host_memory_space> ();
-      X_sub->template modify<host_memory_space> ();
+      X_sub->sync_host ();
+      X_sub->modify_host ();
 
       // Use negative values to distinguish changes to the subview.
       for (LO k = 0; k < static_cast<LO> (cols.size ()); ++k) {
@@ -248,7 +248,7 @@ namespace { // (anonymous)
 
         auto X_sub_j = X_sub->getVector (k);
         auto X_sub_lcl_j_2d =
-          X_sub_j->template getLocalView<host_memory_space> ();
+          X_sub_j->getLocalViewHost ();
         auto X_sub_lcl_j_1d =
           Kokkos::subview (X_sub_lcl_j_2d, Kokkos::ALL (), 0);
 
@@ -283,7 +283,7 @@ namespace { // (anonymous)
           continue;
         }
         auto X_sub_lcl_j_2d =
-          X_sub_j->template getLocalView<host_memory_space> ();
+          X_sub_j->getLocalViewHost ();
         auto X_sub_lcl_j_1d =
           Kokkos::subview (X_sub_lcl_j_2d, Kokkos::ALL (), 0);
 
@@ -292,7 +292,7 @@ namespace { // (anonymous)
         if (X_j.is_null ()) {
           continue;
         }
-        auto X_lcl_j_2d = X_j->template getLocalView<host_memory_space> ();
+        auto X_lcl_j_2d = X_j->getLocalViewHost ();
         auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
 
         auto X_copy_j = X_copy.getVector (j);
@@ -301,7 +301,7 @@ namespace { // (anonymous)
           continue;
         }
         auto X_copy_lcl_j_2d =
-          X_copy_j->template getLocalView<host_memory_space> ();
+          X_copy_j->getLocalViewHost ();
         auto X_copy_lcl_j_1d =
           Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
 
@@ -329,12 +329,12 @@ namespace { // (anonymous)
         auto iter = std::find (cols.begin (), cols.end (), j);
         if (iter == cols.end ()) { // not in the sequence
           auto X_j = X.getVector (j);
-          auto X_lcl_j_2d = X_j->template getLocalView<host_memory_space> ();
+          auto X_lcl_j_2d = X_j->getLocalViewHost ();
           auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
 
           auto X_copy_j = X_copy.getVector (j);
           auto X_copy_lcl_j_2d =
-            X_copy_j->template getLocalView<host_memory_space> ();
+            X_copy_j->getLocalViewHost ();
           auto X_copy_lcl_j_1d =
             Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
 
@@ -346,7 +346,7 @@ namespace { // (anonymous)
     }
 
     out << "Sync X_sub to device" << endl;
-    X_sub->template sync<dev_memory_space> ();
+    X_sub->sync_device ();
 
     // At this point, the device version of X_sub and the device
     // version of the corresponding columns of X should be the same.
@@ -355,11 +355,11 @@ namespace { // (anonymous)
       for (LO k = 0; k < static_cast<LO> (cols.size ()); ++k) {
         const LO j = cols[k];
         auto X_sub_j = X_sub->getVector (k);
-        auto X_sub_lcl_j_2d = X_sub_j->template getLocalView<dev_memory_space> ();
+        auto X_sub_lcl_j_2d = X_sub_j->getLocalViewDevice ();
         auto X_sub_lcl_j_1d = Kokkos::subview (X_sub_lcl_j_2d, Kokkos::ALL (), 0);
 
         auto X_j = X.getVector (j);
-        auto X_lcl_j_2d = X_j->template getLocalView<dev_memory_space> ();
+        auto X_lcl_j_2d = X_j->getLocalViewDevice ();
         auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
 
         // auto X_copy_j = X_copy.getVector (j);
@@ -379,11 +379,11 @@ namespace { // (anonymous)
         auto iter = std::find (cols.begin (), cols.end (), j);
         if (iter == cols.end ()) { // not in the sequence
           auto X_j = X.getVector (j);
-          auto X_lcl_j_2d = X_j->template getLocalView<dev_memory_space> ();
+          auto X_lcl_j_2d = X_j->getLocalViewDevice ();
           auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
 
           auto X_copy_j = X_copy.getVector (j);
-          auto X_copy_lcl_j_2d = X_copy_j->template getLocalView<dev_memory_space> ();
+          auto X_copy_lcl_j_2d = X_copy_j->getLocalViewDevice ();
           auto X_copy_lcl_j_1d = Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
 
           const bool eq = vectorsEqual (X_lcl_j_1d, X_copy_lcl_j_1d);
@@ -448,9 +448,9 @@ namespace { // (anonymous)
 
       out << "Fill the master MultiVector X" << endl;
       {
-        X.template sync<host_memory_space> ();
-        X.template modify<host_memory_space> ();
-        auto X_lcl = X.template getLocalView<host_memory_space> ();
+        X.sync_host ();
+        X.modify_host ();
+        auto X_lcl = X.getLocalViewHost ();
 
         TEST_EQUALITY( static_cast<LO> (X_lcl.extent (0)), lclNumRows );
         TEST_EQUALITY( static_cast<LO> (X_lcl.extent (1)), numVecs );
@@ -468,12 +468,12 @@ namespace { // (anonymous)
             curVal = curVal + Kokkos::Details::ArithTraits<IST>::one ();
           }
         }
-        X.template sync<dev_memory_space> ();
+        X.sync_device ();
       }
 
       // Make a "backup" of X, for later comparison.
       MV X_copy (X, Teuchos::Copy);
-      X_copy.template sync<dev_memory_space> (); // just to make sure
+      X_copy.sync_device (); // just to make sure
 
       out << "Create first view Y of a noncontiguous subset of columns of X" << endl;
       Teuchos::Array<size_t> Y_cols (4);
@@ -496,8 +496,8 @@ namespace { // (anonymous)
       out << "Sync Y to host, and modify it there.  "
         "Don't sync it back to device." << endl;
       {
-        Y->template sync<host_memory_space> ();
-        Y->template modify<host_memory_space> ();
+        Y->sync_host ();
+        Y->modify_host ();
 
         // Multiply all entries by 2.
         for (LO k = 0; k < static_cast<LO> (Y_cols.size ()); ++k) {
@@ -509,7 +509,7 @@ namespace { // (anonymous)
             continue;
           }
           auto Y_j = Y->getVector (k);
-          auto Y_lcl_j_2d = Y_j->template getLocalView<host_memory_space> ();
+          auto Y_lcl_j_2d = Y_j->getLocalViewHost ();
           auto Y_lcl_j_1d = Kokkos::subview (Y_lcl_j_2d, Kokkos::ALL (), 0);
           TEST_EQUALITY( static_cast<LO> (Y_lcl_j_1d.extent (0)), lclNumRows );
           if (! success) {
@@ -523,8 +523,8 @@ namespace { // (anonymous)
 
       out << "Modify Z on device, and sync it to host." << endl;
       {
-        Z->template sync<dev_memory_space> ();
-        Z->template modify<dev_memory_space> ();
+        Z->sync_device ();
+        Z->modify_device ();
 
         for (LO k = 0; k < static_cast<LO> (Z_cols.size ()); ++k) {
           const LO j = Z_cols[k];
@@ -535,7 +535,7 @@ namespace { // (anonymous)
             continue;
           }
           auto Z_j = Z->getVector (k);
-          auto Z_lcl_j_2d = Z_j->template getLocalView<dev_memory_space> ();
+          auto Z_lcl_j_2d = Z_j->getLocalViewDevice ();
           auto Z_lcl_j_1d = Kokkos::subview (Z_lcl_j_2d, Kokkos::ALL (), 0);
           TEST_EQUALITY( static_cast<LO> (Z_lcl_j_1d.extent (0)), lclNumRows );
           if (! success) {
@@ -545,7 +545,7 @@ namespace { // (anonymous)
         }
 
         // THIS is the thing that tests for Issue #364.
-        Z->template sync<host_memory_space> ();
+        Z->sync_host ();
       }
 
       // Check that Z's sync to host did not cause all of X to get
@@ -571,7 +571,7 @@ namespace { // (anonymous)
           if (X_j.is_null ()) {
             continue;
           }
-          auto X_lcl_j_2d = X_j->template getLocalView<host_memory_space> ();
+          auto X_lcl_j_2d = X_j->getLocalViewHost ();
           auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
           TEST_EQUALITY( static_cast<LO> (X_lcl_j_1d.extent (0)),
                          lclNumRows );
@@ -580,7 +580,7 @@ namespace { // (anonymous)
           if (X_copy_j.is_null ()) {
             continue;
           }
-          auto X_copy_lcl_j_2d = X_copy_j->template getLocalView<host_memory_space> ();
+          auto X_copy_lcl_j_2d = X_copy_j->getLocalViewHost ();
           auto X_copy_lcl_j_1d = Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
           TEST_EQUALITY( static_cast<LO> (X_copy_lcl_j_1d.extent (0)),
                          lclNumRows );
@@ -589,7 +589,7 @@ namespace { // (anonymous)
           if (Y_j.is_null ()) {
             continue;
           }
-          auto Y_lcl_j_2d = Y_j->template getLocalView<host_memory_space> ();
+          auto Y_lcl_j_2d = Y_j->getLocalViewHost ();
           auto Y_lcl_j_1d = Kokkos::subview (Y_lcl_j_2d, Kokkos::ALL (), 0);
           TEST_EQUALITY( static_cast<LO> (Y_lcl_j_1d.extent (0)),
                          lclNumRows );

--- a/packages/tpetra/core/test/MultiVector/MultiVector_TwoArgRandomize.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_TwoArgRandomize.cpp
@@ -97,8 +97,8 @@ namespace { // (anonymous)
 
     bool allInRange = true;
     if (! STS::isComplex) {
-      X.template sync<Kokkos::HostSpace> ();
-      auto X_lcl = X.template getLocalView<Kokkos::HostSpace> ();
+      X.sync_host ();
+      auto X_lcl = X.getLocalViewHost ();
 
       for (LO j = 0; j < numVecs; ++j) {
         auto X_lcl_j = Kokkos::subview (X_lcl, Kokkos::ALL (), j);

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -3917,7 +3917,11 @@ namespace {
     }
 
     Kokkos::deep_copy (X_host, THREE);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     X_gbl.template sync<device_type> ();
+#else
+    X_gbl.sync_device ();
+#endif
 
     {
       lclSuccess = success ? 1 : 0;

--- a/packages/tpetra/core/test/MultiVector/MultiVector_get2dView.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_get2dView.cpp
@@ -251,21 +251,21 @@ namespace { // (anonymous)
 
       Teuchos::ArrayRCP<Teuchos::ArrayRCP<const Scalar> > viewsConst =
         X_noncontig->get2dView ();
-      TEST_ASSERT( ! X_noncontig->template need_sync<Kokkos::HostSpace> () );
+      TEST_ASSERT( ! X_noncontig->need_sync_host () );
     }
 
     out << "Test X_noncontig->get2dViewNonConst()" << endl;
     {
       Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar> > viewsNonConst =
         X_noncontig->get2dViewNonConst ();
-      TEST_ASSERT( ! X_noncontig->template need_sync<Kokkos::HostSpace> () );
+      TEST_ASSERT( ! X_noncontig->need_sync_host () );
 
       // get2dViewNonConst is supposed to mark the host data as
       // modified.  Thus, the device data need a sync, if host and
       // device are actually different data.
       if (! std::is_same<typename MV::dual_view_type::t_dev::memory_space,
                          typename MV::dual_view_type::t_host::memory_space>::value) {
-        TEST_ASSERT( X_noncontig->template need_sync<device_type> () );
+        TEST_ASSERT( X_noncontig->need_sync_device () );
       }
 
       TEST_EQUALITY( static_cast<size_t> (viewsNonConst.size ()), numColsSubset );

--- a/sampleScripts/Sandia-SEMS/test_tpetra_sandia
+++ b/sampleScripts/Sandia-SEMS/test_tpetra_sandia
@@ -277,13 +277,19 @@ elif [ "$MACHINE" = "white" ]; then
   #KDD 9/18  OpenMPI3 has problems with Tpetra_ASSUME_CUDA_AWARE_MPI=ON
   #KDD 9/18  module load devpack/20180521/openmpi/3.1.0/gcc/7.2.0/cuda/9.2.88
   #KDD 9/18  This configuration seems to work
-  module load git/2.10.1
-  module load openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
-  module load cmake/3.9.6
-  module load openblas/0.2.20/gcc/7.2.0
-  module load boost/1.65.1/gcc/7.2.0
-  module load cuda/9.2.88
-  module load netcdf-exo/4.4.1.1/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176
+  #module load git/2.10.1
+  #module load openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
+  #module load cmake/3.9.6
+  #module load openblas/0.2.20/gcc/7.2.0
+  #module load boost/1.65.1/gcc/7.2.0
+  #module load cuda/9.2.88
+  #module load netcdf-exo/4.4.1.1/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176
+
+  module load devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
+  module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+  # Trilinos now requires cmake version >= 3.10.0
+  module swap cmake/3.9.6 cmake/3.12.3
+
 
   if [ -z "$KOKKOS_ARCH" ]; then
     KOKKOS_ARCH="Power8;Pascal60"


### PR DESCRIPTION
Don't merge this in yet. We go test failures

```
76% tests passed, 46 tests failed out of 194

Label Time Summary:
Tpetra    = 1076.23 sec*proc (194 tests)

Total Test time (real) = 334.75 sec

The following tests FAILED:
	 11 - TpetraCore_gemm_m_eq_1_MPI_1 (Failed)
	 12 - TpetraCore_gemm_m_eq_2_MPI_1 (Failed)
	 13 - TpetraCore_gemm_m_eq_5_MPI_1 (Failed)
	 14 - TpetraCore_gemm_m_eq_13_MPI_1 (Failed)
	 15 - TpetraCore_BlockMultiVector_MPI_4 (Failed)
	 17 - TpetraCore_BlockCrsMatrix_MPI_4 (Failed)
	 19 - TpetraCore_BlockView_MPI_1 (Failed)
	 23 - TpetraCore_BlankRowBugTest_MPI_2 (Failed)
	 31 - TpetraCore_Core_initialize_where_user_initializes_mpi_MPI_4 (Failed)
	 32 - TpetraCore_Core_ScopeGuard_where_user_initializes_mpi_MPI_4 (Failed)
	 35 - TpetraCore_Core_initialize_where_tpetra_initializes_kokkos_MPI_1 (Failed)
	 36 - TpetraCore_Core_ScopeGuard_where_tpetra_initializes_kokkos_MPI_1 (Failed)
	 37 - TpetraCore_Core_initialize_where_user_initializes_kokkos_MPI_1 (Failed)
	 38 - TpetraCore_Core_ScopeGuard_where_user_initializes_kokkos_MPI_1 (Failed)
	 39 - TpetraCore_Core_initialize_where_tpetra_initializes_mpi_and_user_initializes_kokkos_MPI_2 (Failed)
	 40 - TpetraCore_Core_ScopeGuard_where_tpetra_initializes_mpi_and_user_initializes_kokkos_MPI_2 (Failed)
	 48 - TpetraCore_Issue601_MPI_4 (Failed)
	 53 - TpetraCore_CrsMatrix_UnitTests_MPI_4 (Failed)
	 54 - TpetraCore_CrsMatrix_UnitTests2_MPI_4 (Failed)
	 56 - TpetraCore_CrsMatrix_UnitTests4_MPI_4 (Failed)
	 57 - TpetraCore_CrsMatrix_NonlocalAfterResume_MPI_4 (Failed)
	 61 - TpetraCore_CrsMatrix_WithGraph_Serial_MPI_4 (Failed)
	 62 - TpetraCore_CrsMatrix_ReplaceDomainMapAndImporter_MPI_4 (Failed)
	 64 - TpetraCore_CrsMatrix_NonlocalSumInto_Ignore_MPI_4 (Failed)
	 70 - TpetraCore_CrsMatrix_ReplaceLocalValues_MPI_4 (Failed)
	 78 - TpetraCore_Albany182_MPI_4 (Failed)
	 83 - TpetraCore_Issue1752_MPI_2 (Failed)
	 95 - TpetraCore_ExportToStaticGraphCrsMatrix_MPI_4 (Failed)
	101 - TpetraCore_ImportExport2_UnitTests_MPI_4 (Failed)
	103 - TpetraCore_MatrixMarket_Tpetra_CrsMatrix_InOutTest_MPI_4 (Failed)
	104 - TpetraCore_MatrixMarket_Tpetra_CrsGraph_InOutTest_MPI_4 (Failed)
	105 - TpetraCore_MatrixMarket_Operator_Test_MPI_4 (Failed)
	112 - TpetraCore_CooMatrix_MPI_2 (Failed)
	136 - TpetraCore_MatrixMatrix_UnitTests_MPI_4 (Failed)
	137 - TpetraCore_AddProfiling_UnitTests_MPI_4 (Failed)
	139 - TpetraCore_MultiVector_UnitTests_MPI_4 (Failed)
	144 - TpetraCore_MultiVector_get2dView_MPI_1 (Failed)
	162 - TpetraCore_RowMatrixTransposer_test_MPI_4 (Failed)
	163 - TpetraCore_RowMatrixTransposer_UnitTests_MPI_4 (Failed)
	173 - TpetraCore_lesson05_redistribution_MPI_4 (Failed)
	176 - TpetraCore_FEMAssembly_InsertGlobalIndicesDP_MPI_4 (Failed)
	177 - TpetraCore_FEMAssembly_LocalElementLoopDP_MPI_4 (Failed)
	178 - TpetraCore_FEMAssembly_TotalElementLoopDP_MPI_4 (Failed)
	179 - TpetraCore_FEMAssembly_TotalElementLoopSP_MPI_4 (Failed)
	180 - TpetraCore_AdditiveSchwarzHalo_MPI_4 (Failed)
	194 - TpetraCore_guide_data_redist_1_MPI_4 (Failed)
```