### PR TITLE
Fixes randomization issue with Teuchos::SerialDenseMatrix in parallel

### DIFF
--- a/packages/anasazi/epetra/test/OrthoManager/cxx_main.cpp
+++ b/packages/anasazi/epetra/test/OrthoManager/cxx_main.cpp
@@ -845,33 +845,6 @@ int testProject(RCP<OrthoManager<ST,MV> > OM,
         C_outs.back().push_back( rcp( new SerialDenseMatrix<int,ST>(*C[1]) ) );
       }
 
-      // do we run the reversed input?
-      /*
-      if ( (t & 3) == 3 ) {
-        // copies of S,MS
-        Scopy = MVT::CloneCopy(*S);
-        // randomize this data, it should be overwritten
-        for (unsigned int i=0; i<C.size(); i++) {
-          C[i]->random();
-        }
-        // flip the inputs
-        theX = tuple( theX[1], theX[0] );
-        // run test
-        OM->project(*Scopy,theX,C);
-        // we allocate S and MS for each test, so we can save these as views
-        // however, save copies of the C
-        S_outs.push_back( Scopy );
-        // we are in a special case: P_X1 and P_X2, so we know we applied 
-        // two projectors, and therefore have two C[i]
-        C_outs.push_back( Array<RCP<SerialDenseMatrix<int,ST> > >() );
-        // reverse the Cs to compensate for the reverse projectors
-        C_outs.back().push_back( rcp( new SerialDenseMatrix<int,ST>(*C[1]) ) );
-        C_outs.back().push_back( rcp( new SerialDenseMatrix<int,ST>(*C[0]) ) );
-        // flip the inputs back
-        theX = tuple( theX[1], theX[0] );
-      }
-      */
-
       // test all outputs for correctness
       for (unsigned int o=0; o<S_outs.size(); o++) {
         // S_in = X1*C1 + X2*C2 + S_out

--- a/packages/anasazi/test/MVOPTester/MyMultiVec.hpp
+++ b/packages/anasazi/test/MVOPTester/MyMultiVec.hpp
@@ -44,6 +44,9 @@
 #include "AnasaziConfigDefs.hpp"
 #include "AnasaziMultiVec.hpp"
 
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialDenseHelpers.hpp"
+
 //! Simple example of a user's defined Anasazi::MultiVec class.
 /*! 
  * This is a simple, single processor example of user's defined
@@ -417,15 +420,17 @@ public:
   }
 
   // Fill the vectors in *this with random numbers.
-  void  MvRandom ()
+  void MvRandom ()
   {
+    Teuchos::SerialDenseMatrix<int,ScalarType> R( Length_, NumberVecs_ );
+    Teuchos::randomSyncedMatrix( R );
     for (int v = 0 ; v < NumberVecs_ ; ++v) {
       for (int i = 0 ; i < Length_ ; ++i) {
-        (*this)(i, v) = Teuchos::ScalarTraits<ScalarType>::random();
+        (*this)(i, v) = R(i, v);
       }
     }
   }
-  
+
   // Replace each element of the vectors in *this with alpha.
   void  MvInit (ScalarType alpha)
   {

--- a/packages/anasazi/test/MVOPTester/MySDMHelpers.hpp
+++ b/packages/anasazi/test/MVOPTester/MySDMHelpers.hpp
@@ -43,9 +43,7 @@
 
 #include "AnasaziConfigDefs.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_CommHelpers.hpp"
-#include "Teuchos_DefaultComm.hpp"
-#include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_SerialDenseHelpers.hpp"
 
 namespace Anasazi{
 
@@ -53,23 +51,7 @@ namespace Anasazi{
 template <class ScalarType>
 void randomSDM( Teuchos::SerialDenseMatrix<int, ScalarType>& matrix )
 {
-  Teuchos::RCP<const Teuchos::Comm<int> >
-    comm = Teuchos::DefaultComm<int>::getComm();
-
-  const int procRank = rank(*comm);
-
-  // Construct a separate serial dense matrix and synchronize it to get around
-  // input matrices that are subviews of a larger matrix.
-  Teuchos::SerialDenseMatrix<int, ScalarType> newMatrix( matrix.numRows(), matrix.numCols() );
-  if (procRank == 0)
-    newMatrix.random();
-  else
-    newMatrix.putScalar( Teuchos::ScalarTraits<ScalarType>::zero() );
-
-  broadcast(*comm, 0, matrix.numRows()*matrix.numCols(), newMatrix.values());
-
-  // Assign the synchronized matrix to the input.
-  matrix.assign( newMatrix );
+  Teuchos::randomSyncedMatrix( matrix );
 } 
 
 }

--- a/packages/belos/src/BelosMVOPTester.hpp
+++ b/packages/belos/src/BelosMVOPTester.hpp
@@ -61,6 +61,7 @@
 
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_SetScientific.hpp"
+#include "Teuchos_SerialDenseHelpers.hpp"
 
 namespace Belos {
 
@@ -965,8 +966,12 @@ namespace Belos {
       std::vector<MagType> normsB1(p), normsB2(p),
                            normsC1(p), normsC2(p),
                            normsD1(p), normsD2(p);
-      ScalarType alpha = STS::random(),
-                  beta = STS::random();
+
+      Teuchos::SerialDenseMatrix<int,ScalarType> Alpha(1,1), Beta(1,1);
+      Teuchos::randomSyncedMatrix( Alpha );
+      Teuchos::randomSyncedMatrix( Beta );
+      ScalarType alpha = Alpha(0,0),
+                  beta = Beta(0,0);
 
       B = MVT::Clone(*A,p);
       C = MVT::Clone(*A,p);
@@ -1166,7 +1171,7 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.random();
+      Teuchos::randomSyncedMatrix(SDM);
       MVT::MvTimesMatAddMv(zero,*B,SDM,one,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
@@ -1192,7 +1197,7 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.random();
+      Teuchos::randomSyncedMatrix(SDM);
       MVT::MvTimesMatAddMv(zero,*B,SDM,zero,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
@@ -1302,7 +1307,7 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.random();
+      Teuchos::randomSyncedMatrix(SDM);
       MVT::MvTimesMatAddMv(zero,*B,SDM,one,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
@@ -1328,7 +1333,7 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.random();
+      Teuchos::randomSyncedMatrix(SDM);
       MVT::MvTimesMatAddMv(zero,*B,SDM,zero,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);

--- a/packages/belos/test/MVOPTester/MyMultiVec.hpp
+++ b/packages/belos/test/MVOPTester/MyMultiVec.hpp
@@ -47,6 +47,9 @@
 #include "BelosConfigDefs.hpp"
 #include "BelosMultiVec.hpp"
 
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialDenseHelpers.hpp"
+
 //! Simple example of a user's defined Belos::MultiVec class.
 /*!
  * This is a simple, single processor example of user's defined
@@ -382,9 +385,11 @@ public:
   // Fill the vectors in *this with random numbers.
   void MvRandom ()
   {
+    Teuchos::SerialDenseMatrix<int,ScalarType> R( Length_, NumberVecs_ );
+    Teuchos::randomSyncedMatrix( R ); 
     for (int v = 0 ; v < NumberVecs_ ; ++v) {
       for (int i = 0 ; i < Length_ ; ++i) {
-        (*this)(i, v) = Teuchos::ScalarTraits<ScalarType>::random();
+        (*this)(i, v) = R(i, v);
       }
     }
   }


### PR DESCRIPTION
While addressing issue #2473, I found other places where a random serial dense
matrix was used and expected to be the same in parallel.  The synchronization
method that was used to address the issue in Anasazi has been moved to the
Teuchos serial dense helpers file so that other packages can use this utility
in the generation of tests.  In particular, this utility needed to be integrated
into the MVOP testers for Belos and Anasazi, as well as the Belos orthogonalization
tester.

The assumption that a call to generate a random variable will return the same
value on all processors is false and could have unknown consequences for testing.

While it is unknown if any random failures can be tracked to these changes at this
time, previous issues with Anasazi have been caused by this bad assumption.  So, it
is better to fix it.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/anasazi @trilinos/belos 

## Description
<!--- Please describe your changes in detail. -->
Moved the utility for generating a synchronized Teuchos::SerialDenseMatrix from Anasazi to the serial dense helpers in Teuchos.  This utility is also necessary for fixing the behavior of the MVOPTester and OrthoTester in Belos.  Other uses of random serial dense matrices, where they were expected to be the same on all processor, have been removed from Anasazi and Belos.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
It is a bad assumption that a random number generator will return the same number in parallel on all processors.  This was the reason for bug number #2473, so it should be removed from testing so that it does not result in further failures.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

#2473 

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
OS X with GNU 7.x compilers.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->