### PR TITLE
Sacado:  Fix calculation of fad size in common_view_alloc_prop for mixed view specs

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -884,7 +884,7 @@ struct CommonViewAllocProp< Kokkos::Impl::ViewSpecializeSacadoFadContiguous, Val
 };
 
 // Detect if a ViewCtorProp contains a CommonViewAllocProp
-template < typename ... >
+template < typename ... P >
 struct has_common_view_alloc_prop : public std::false_type {};
 
 template < class Specialize, class ValueType >
@@ -913,22 +913,73 @@ struct check_has_common_view_alloc_prop<P0, P...>
   enum { value = ( (has_common_view_alloc_prop<P0>::value == true) ? true : check_has_common_view_alloc_prop<P...>::value ) };
 };
 
-template <typename Traits, typename CtorProp >
-struct appendFadToLayoutViewAllocHelper 
+template < typename ... >
+struct compute_fad_dim_from_alloc_prop;
+
+template < >
+struct compute_fad_dim_from_alloc_prop<> {
+  template <typename CtorProp>
+  static unsigned eval(const CtorProp&) { return 0; }
+};
+
+template < typename P >
+struct compute_fad_dim_from_alloc_prop<P> {
+  template <typename CtorProp>
+  static unsigned eval(const CtorProp&) { return 0; }
+};
+
+template < typename P0, typename ... P >
+struct compute_fad_dim_from_alloc_prop<P0,P...> {
+  template <typename CtorProp>
+  static unsigned eval(const CtorProp& prop) {
+    unsigned d1 = compute_fad_dim_from_alloc_prop<P0>::eval(prop);
+    unsigned d2 = compute_fad_dim_from_alloc_prop<P...>::eval(prop);
+    return d1 > d2 ? d1 : d2;
+  }
+};
+
+template < class ValueType >
+struct compute_fad_dim_from_alloc_prop<
+  CommonViewAllocProp<ViewSpecializeSacadoFad, ValueType>
+  > {
+  template <typename CtorProp>
+  static unsigned eval(const CtorProp& prop) {
+    using specialize = ViewSpecializeSacadoFad;
+    using CVAP = CommonViewAllocProp< specialize, ValueType >;
+    auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVAP> const &)prop).value;
+    return cast_prop.fad_dim;
+  }
+};
+
+template < class ValueType >
+struct compute_fad_dim_from_alloc_prop<
+  CommonViewAllocProp<ViewSpecializeSacadoFadContiguous, ValueType>
+  > {
+  template <typename CtorProp>
+  static unsigned eval(const CtorProp& prop) {
+    using specialize = ViewSpecializeSacadoFadContiguous;
+    using CVAP = CommonViewAllocProp< specialize, ValueType >;
+    auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVAP> const &)prop).value;
+    return cast_prop.fad_dim;
+  }
+};
+
+template <typename Traits, typename ... P >
+struct appendFadToLayoutViewAllocHelper
 {
   using layout_type = typename Traits::array_layout;
   using specialize = typename Traits::specialize;
-  
+  using CtorProp = ViewCtorProp< P... >;
+
   static layout_type returnNewLayoutPlusFad( const CtorProp & arg_prop, const layout_type & arg_layout ) {
-
-    using CVAP_type = CommonViewAllocProp< specialize, typename Traits::value_type >;
-
-    auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVAP_type> const &)arg_prop).value;
 
     layout_type appended_layout( arg_layout );
 
     // Static View case - DynRankView layout handled within createLayout calls
-    appended_layout.dimension[ Traits::rank ] = (cast_prop.fad_dim > 0) ? cast_prop.fad_dim : 1;
+
+    const unsigned fad_dim =
+      compute_fad_dim_from_alloc_prop<P...>::eval(arg_prop);
+    appended_layout.dimension[ Traits::rank ] = (fad_dim > 0) ? fad_dim : 1;
 
     return appended_layout;
   }
@@ -938,7 +989,7 @@ template <typename Layout>
 struct prependFadToLayout
 {
   using layout_type = Layout;
-  
+
   template < typename FadSizeType >
   KOKKOS_INLINE_FUNCTION
   static layout_type returnNewLayoutPlusFad( const layout_type & arg_layout, const FadSizeType fad_dim ) {
@@ -1278,15 +1329,15 @@ public:
 
     // Check if ViewCtorProp has CommonViewAllocProp - if so, retrieve the fad_size and append to layout
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
-    using CVTR = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFad
-                                                           , typename Traits::value_type >;
+
     m_offset = offset_type( padding(), local_layout );
 
-    m_array_offset = array_offset_type( padding(),
-                            ( test_traits_check == true
-                             && ((Kokkos::Impl::ViewCtorProp<void, CVTR> const &)prop).value.is_view_type)
-                            ? Kokkos::Impl::appendFadToLayoutViewAllocHelper< Traits, ctor_prop >::returnNewLayoutPlusFad(prop, local_layout)
-                            : local_layout );
+    typename Traits::array_layout internal_layout =
+      (test_traits_check == true)
+      ? Kokkos::Impl::appendFadToLayoutViewAllocHelper< Traits, P... >::returnNewLayoutPlusFad(prop, local_layout)
+      : local_layout;
+
+    m_array_offset = array_offset_type( padding(), internal_layout );
 
     const unsigned fad_dim =
       ( Rank == 0 ? m_array_offset.dimension_0() :

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -1077,16 +1077,12 @@ public:
     typedef std::integral_constant< unsigned , 0 > padding ;
 
     // Check if ViewCtorProp has CommonViewAllocProp - if so, retrieve the fad_size and append to layout
-    using CVTR = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFadContiguous 
-                                                           , typename Traits::value_type>;
-
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
 
-    typename Traits::array_layout internal_layout = 
-                            (test_traits_check == true
-                             && ((Kokkos::Impl::ViewCtorProp<void, CVTR> const &)prop).value.is_view_type) 
-                            ? Kokkos::Impl::appendFadToLayoutViewAllocHelper< Traits, ctor_prop >::returnNewLayoutPlusFad(prop, local_layout) 
-                            : local_layout;
+    typename Traits::array_layout internal_layout =
+      (test_traits_check == true)
+      ? Kokkos::Impl::appendFadToLayoutViewAllocHelper< Traits, P... >::returnNewLayoutPlusFad(prop, local_layout)
+      : local_layout;
 
     m_offset = offset_type( padding(), internal_layout );
 

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -252,9 +252,7 @@ struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFad> {
 
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
     if (test_traits_check == true) {
-      using CVTR_type = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFad, typename Traits::value_type >;
-      auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVTR_type> const &)arg_prop).value;
-      l.dimension[7] = cast_prop.fad_dim;
+      l.dimension[7] = compute_fad_dim_from_alloc_prop<P...>::eval(arg_prop);
     }
     else {
       const unsigned fad_dim = computeRank(layout);
@@ -295,10 +293,8 @@ struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFad> {
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
     const unsigned fad_dim = computeRank(layout);
     if (test_traits_check == true) {
-      using CVTR_type = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFad, typename Traits::value_type >;
-      auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVTR_type> const &)arg_prop).value;
       l.dimension[fad_dim] = 1;
-      l.dimension[7] = cast_prop.fad_dim;
+      l.dimension[7] = compute_fad_dim_from_alloc_prop<P...>::eval(arg_prop);
     }
     else {
       const size_t fad_size = layout.dimension[fad_dim];

--- a/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad_Contiguous.hpp
@@ -181,9 +181,7 @@ struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFadContiguous> {
 
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
     if (test_traits_check == true) {
-      using CVTR_type = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFadContiguous, typename Traits::value_type >;
-      auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVTR_type> const &)arg_prop).value;
-      l.dimension[7] = cast_prop.fad_dim;
+      l.dimension[7] = compute_fad_dim_from_alloc_prop<P...>::eval(arg_prop);
     }
     else {
       const unsigned fad_dim = computeRank(layout);
@@ -223,9 +221,7 @@ struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFadContiguous> {
 
     enum { test_traits_check = Kokkos::Impl::check_has_common_view_alloc_prop< P... >::value };
     if (test_traits_check == true) {
-      using CVTR_type = typename Kokkos::Impl::CommonViewAllocProp< typename Kokkos::Impl::ViewSpecializeSacadoFadContiguous, typename Traits::value_type >;
-      auto cast_prop = ((Kokkos::Impl::ViewCtorProp<void, CVTR_type> const &)arg_prop).value;
-      l.dimension[7] = cast_prop.fad_dim;
+      l.dimension[7] = compute_fad_dim_from_alloc_prop<P...>::eval(arg_prop);
     }
     else {
       const unsigned fad_dim = computeRank(layout);

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -2049,6 +2049,36 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   }
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, CommonViewAllocMixedSpec, FadType, Layout, Device )
+{
+  typedef Kokkos::View<FadType**,Kokkos::LayoutContiguous<Layout>,Device> ContViewType;
+  typedef Kokkos::View<FadType**,Layout,Device> ViewType;
+  typedef typename ContViewType::size_type size_type;
+
+  const size_type num_rows = global_num_rows;
+  const size_type num_cols = global_num_cols;
+  const size_type fad_size = global_fad_size;
+
+  // Create contiguous view
+  ContViewType v1;
+#if defined (SACADO_DISABLE_FAD_VIEW_SPEC)
+  v1 = ContViewType ("view", num_rows, num_cols);
+#else
+  v1 = ContViewType ("view", num_rows, num_cols, fad_size+1);
+#endif
+
+  // Create non-contiguous view using commen_view_alloc_prop
+  auto cprop = Kokkos::common_view_alloc_prop(v1);
+  ViewType v2(Kokkos::view_alloc("v2",cprop), num_rows, num_cols);
+
+  // Check dimensions are correct for v2
+  success = true;
+  TEUCHOS_TEST_EQUALITY(v2.extent(0), num_rows, out, success);
+  TEUCHOS_TEST_EQUALITY(v2.extent(1), num_cols, out, success);
+  TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
+}
+
 #else
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
@@ -2092,6 +2122,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos_View_Fad, AssignLayoutContiguousToLayoutStride, FadType, Layout, Device ) {}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, CommonViewAllocMixedSpec, FadType, Layout, Device ) {}
 
 #endif
 
@@ -2137,7 +2170,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   VIEW_FAD_TESTS_FLD( F, LayoutLeft, D )                                \
   VIEW_FAD_TESTS_FLD( F, LayoutRight, D )                               \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AssignLayoutContiguousToLayoutStride, F, LayoutLeft, D ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AssignLayoutContiguousToLayoutStride, F, LayoutRight, D )
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AssignLayoutContiguousToLayoutStride, F, LayoutRight, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, CommonViewAllocMixedSpec, F, LayoutLeft, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, CommonViewAllocMixedSpec, F, LayoutRight, D )
+
 #define VIEW_FAD_TESTS_SFDI( F, D )                                     \
   using Kokkos::LayoutLeft;                                             \
   using Kokkos::LayoutRight;                                            \


### PR DESCRIPTION
For issue #3679.  While converting Panzer to use hierarchical-dfad, @rppawlo 
ran into an issue with Intrepid2 that was using common_view_alloc_prop
to create a non-contiguous view using contiguous view arguments.  The
logic used within common_view_alloc_prop didn't allow for this.  I fixed
this by allowing the code that pulls out the fad dimension to work with
any specialization tag, not just the one the constructed view has.  I
also added a unit test to test this behavior.