### PR TITLE
MueLu tests: Do not run Epetra test w/ kokkos refactor

### DIFF
--- a/packages/muelu/example/ParameterList/MLParameterList.cpp
+++ b/packages/muelu/example/ParameterList/MLParameterList.cpp
@@ -281,6 +281,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
 
     } // if (muelu)
 
+    if (params->isType<bool>("use kokkos refactor"))
+      params->remove("use kokkos refactor");
 
     if ( translatedmuelu ) {
        //

--- a/packages/muelu/example/ParameterList/MLParameterList.cpp
+++ b/packages/muelu/example/ParameterList/MLParameterList.cpp
@@ -141,7 +141,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     RCP<Matrix>  A = Pr->BuildMatrix();
 
     //
-    // Preconditionner configuration
+    // Preconditioner configuration
     //
 
     // ML parameter list
@@ -179,6 +179,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       std::cout << MueLu::ML2MueLuParameterTranslator::translate(*params, "SA") << std::endl;
 
       // Multigrid Hierarchy
+      if (xpetraParameters.GetLib() == Xpetra::UseEpetra)
+        params->set("use kokkos refactor", false);
       MLParameterListInterpreter mueLuFactory(*params);
       RCP<Hierarchy> H = mueLuFactory.CreateHierarchy();
 

--- a/packages/muelu/test/maxwell/CMakeLists.txt
+++ b/packages/muelu/test/maxwell/CMakeLists.txt
@@ -40,7 +40,7 @@ IF (${PACKAGE_NAME}_ENABLE_Belos AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     ENDIF()
   ENDIF()
 
-  IF (${PACKAGE_NAME}_ENABLE_Epetra)
+  IF (${PACKAGE_NAME}_ENABLE_Epetra AND (NOT ${PACKAGE_NAME}_ENABLE_Kokkos_Refactor OR NOT ${PACKAGE_NAME}_ENABLE_Kokkos_Refactor_Use_By_Default))
     TRIBITS_ADD_TEST(
       Maxwell3D
       NAME "Maxwell3D-Epetra"


### PR DESCRIPTION
@trilinos/muelu 

## Description
- Xpetra's CRS matrix does not implement `setAllValues` using Kokkos views for Epetra, so the test shouldn't run.
- Do not run ML parameter test w/ kokkos refactor

Addresses part of #3717 