### PR TITLE
Domi: Fix config bug

### DIFF
--- a/packages/domi/src/CMakeLists.txt
+++ b/packages/domi/src/CMakeLists.txt
@@ -51,7 +51,7 @@ IF(Domi_ENABLE_Epetra)
   SET(HAVE_EPETRA ON)
 ENDIF()
 
-IF(Domi_ENABLE_Tpetra)
+IF(Domi_ENABLE_TpetraCore)
   SET(HAVE_TPETRA ON)
 ENDIF()
 


### PR DESCRIPTION
@trilinos/domi 

## Description
In `domi/src/CMakeLists.txt`, I needed to change `Domi_ENABLE_Tpetra` to `Domi_ENABLE_TpetraCore` to ensure that the `HAVE_TPETRA` macro was set properly in `Domi_config.h`.

## Motivation and Context
This manifest in PyTrilinos, where Tpetra for `PyTrilinos.Domi` was enabled, but not Tpetra for Domi.

## Related Issues

* Addresses #3618, #3687

## How Has This Been Tested?
I tested this by running the Domi tests and the PyTrilinos tests. For PyTrilinos, I had to disable ML in order to work around #3456.  The error really doesn't show up in Domi tests: Tpetra was always improperly disabled and all tests passed.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
