### PR TITLE
MueLu: reenable tests on mutrino

### DIFF
--- a/cmake/std/atdm/mutrino/tweaks/ALL_BUILDS.cmake
+++ b/cmake/std/atdm/mutrino/tweaks/ALL_BUILDS.cmake
@@ -2,12 +2,12 @@
 ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
 
 # Disable MueLu tests having file I/O problems on mutrino (#2839)
-ATDM_SET_ENABLE(MueLu_CreateOperatorTpetra_MPI_1_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_CreateOperatorTpetra_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(MueLu_CreateOperatorTpetra_MPI_1_DISABLE OFF)
+ATDM_SET_ENABLE(MueLu_CreateOperatorTpetra_MPI_4_DISABLE OFF)
+ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE OFF)
+ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_4_DISABLE OFF)
+ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE OFF)
+ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_4_DISABLE OFF)
 
 # Disable SEACAS tests that get messed up due to extra STDERR output on
 # 'mutrino' that does not occur on other platforms (see #3183)


### PR DESCRIPTION
Auto-PR for SHA 696da9d