### PR TITLE
Replace STEQR with PTEQR in Stokhos for issue #3542

### DIFF
--- a/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
@@ -61,7 +61,7 @@ namespace HermiteBasisUnitTest {
     OrdinalType p;
     Stokhos::HermiteBasis<OrdinalType,ValueType> basis;
     
-    UnitTestSetup() : rtol(1e-12), atol(1e-7), p(10), basis(p) {}
+    UnitTestSetup() : rtol(1e-12), atol(1e-5), p(10), basis(p) {}
     
   };
 

--- a/packages/stokhos/test/UnitTest/Stokhos_LanczosUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_LanczosUnitTest.cpp
@@ -89,7 +89,7 @@ struct Lanczos_PCE_Setup {
     func()
   {
     rtol = 1e-8;
-    atol = 1e-12;
+    atol = 1e-10;
     const OrdinalType d = 3;
     const OrdinalType p = 5;
     

--- a/packages/stokhos/test/UnitTest/Stokhos_NormalizedLegendreBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_NormalizedLegendreBasisUnitTest.cpp
@@ -61,7 +61,7 @@ namespace LegendreBasisUnitTest {
     OrdinalType p;
     Stokhos::LegendreBasis<OrdinalType,ValueType> basis;
     
-    UnitTestSetup() : rtol(1e-12), atol(1e-12), p(10), basis(p,true) {}
+    UnitTestSetup() : rtol(1e-12), atol(1e-10), p(10), basis(p,true) {}
     
   };
 

--- a/packages/stokhos/test/UnitTest/Stokhos_Sparse3TensorUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_Sparse3TensorUnitTest.cpp
@@ -62,8 +62,8 @@ namespace Sparse3TensorUnitTest {
     Teuchos::RCP<Cijk_type> Cijk;
     
     UnitTestSetup(): d(3), p(4), bases(d) {
-      rtol = 1e-15;
-      atol = 1e-15;
+      rtol = 1e-14;
+      atol = 1e-14;
       sparse_tol = 1e-15;
       
       // Create product basis

--- a/packages/stokhos/test/UnitTest/Stokhos_UnitTestHelpers.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_UnitTestHelpers.hpp
@@ -555,7 +555,7 @@ namespace Stokhos {
     out << "Discrete orthogonality error = " << x.normInf() << std::endl;
 
     // Compare PCE coefficients
-    bool success = Stokhos::compareSDM(x, "x", z, "zero", 1e-14, 1e-14, out);
+    bool success = Stokhos::compareSDM(x, "x", z, "zero", rel_tol, abs_tol, out);
 
     return success;
   }


### PR DESCRIPTION
The LAPACK function STEQR doesn't appear to work on IBM Power systems.  In #3658 a solution was found by replacing STEQR with PTEQR, which seems to not have problems on this platform.  This PR replaces usage of STEQR with PTEQR in Stokhos.  However this isn't completely trivial because PTEQR is for symmetric, positive-definite systems where STEQR is for symmetric, indefinite systems (and therefore is a completely different algorithm, which is probably why it works when STEQR doesn't).  So to use PTEQR I had to compute a shift to make the system positive definite.  This caused a few tests to fail due to numerical differences with very tight tolerances, so I had to loosen some of those tolerances to get things to pass.  After these changes, all of the Stokhos tests pass on white.  For issue #3542.