### PR TITLE
Decrease parallel build level on 'waterman' from 128 to 64 (ATDV-63)

### DIFF
--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -53,7 +53,7 @@ fi
 echo "Using waterman compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
 
 export ATDM_CONFIG_USE_NINJA=ON
-export ATDM_CONFIG_BUILD_COUNT=128
+export ATDM_CONFIG_BUILD_COUNT=64
 # NOTE: Above settings are used for building on a Dual-Socket POWER9 with 8
 # cores per socket.
 


### PR DESCRIPTION
## Description

The build Trilinos-atdm-waterman-cuda-9.2-release-debug has been crashing the
last several days and not submitting results to CDash.  I reduced the build
level on Jenkins for this buil to 64 and it retured build results today.
Hopefully reducing this build level to 64 for all builds will avoid these
build crashes.

## Motivation and Context

WE don't like build crashes.  We like results on CDash.

## How Has This Been Tested?

I did not directly test this commit.  The change is trivial and super safe.
