### PR TITLE
Panzer multiblock tests

### DIFF
--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/CMakeLists.txt
@@ -4,9 +4,9 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 SET(ASSEMBLY_EXAMPLE_SOURCES
   main.cpp
   )
-  
+
 TRIBITS_ADD_EXECUTABLE(
-  CurlLaplacianExample 
+  CurlLaplacianExample
   SOURCES ${ASSEMBLY_EXAMPLE_SOURCES}
   )
 
@@ -26,22 +26,22 @@ TRIBITS_ADD_ADVANCED_TEST(
 FOREACH( ORDER 1 2 3 4 )
   TRIBITS_ADD_ADVANCED_TEST(
     CurlLaplacianExample-ConvTest-Quad-Order-${ORDER}
-    TEST_0 EXEC CurlLaplacianExample 
+    TEST_0 EXEC CurlLaplacianExample
       ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER}
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-04
-    TEST_1 EXEC CurlLaplacianExample 
+    TEST_1 EXEC CurlLaplacianExample
       ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-08
-    TEST_2 EXEC CurlLaplacianExample 
+    TEST_2 EXEC CurlLaplacianExample
       ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-16
-    TEST_3 EXEC CurlLaplacianExample 
+    TEST_3 EXEC CurlLaplacianExample
       ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER}
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
@@ -57,27 +57,57 @@ FOREACH( ORDER 1 2 3 4 )
       PASS_REGULAR_EXPRESSION "Test Passed"
     COMM mpi
     )
-ENDFOREACH() 
+ENDFOREACH()
+
+FOREACH( ORDER 1 )
+  TRIBITS_ADD_ADVANCED_TEST(
+    CurlLaplacianMultiblockExample-ConvTest-Quad-Order-${ORDER}
+    TEST_0 EXEC CurlLaplacianExample
+      ARGS --use-tpetra --use-twod --x-blocks=2 --cell="Quad" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER} --output-filename="multiblock-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-08
+    TEST_1 EXEC CurlLaplacianExample
+      ARGS --use-tpetra --use-twod --x-blocks=2 --cell="Quad" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER} --output-filename="multiblock-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-16
+    TEST_2 EXEC CurlLaplacianExample
+      ARGS --use-tpetra --use-twod --x-blocks=2 --cell="Quad" --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER} --output-filename="multiblock-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-32
+    TEST_3 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+           ${ORDER}
+           MPE-Multiblock-ConvTest-Quad-${ORDER}-
+           8
+           16
+           32
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+    )
+ENDFOREACH()
 
 # FOREACH( ORDER 1 2 3 4 )
 #   TRIBITS_ADD_ADVANCED_TEST(
 #     CurlLaplacianExample-ConvTest-Tri-Order-${ORDER}
-#     TEST_0 EXEC CurlLaplacianExample 
+#     TEST_0 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-twod --cell="Tri" --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-04
-#     TEST_1 EXEC CurlLaplacianExample 
+#     TEST_1 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-twod --cell="Tri" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-08
-#     TEST_2 EXEC CurlLaplacianExample 
+#     TEST_2 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-twod --cell="Tri" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-16
-#     TEST_3 EXEC CurlLaplacianExample 
+#     TEST_3 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-twod --cell="Tri" --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
@@ -93,27 +123,27 @@ ENDFOREACH()
 #       PASS_REGULAR_EXPRESSION "Test Passed"
 #     COMM mpi
 #     )
-# ENDFOREACH() 
+# ENDFOREACH()
 
 # FOREACH( ORDER 1 2 3 4 )
 #   TRIBITS_ADD_ADVANCED_TEST(
 #     CurlLaplacianExample-ConvTest-Hex-Order-${ORDER}
-#     TEST_0 EXEC CurlLaplacianExample 
+#     TEST_0 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-threed --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER} --
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-04
-#     TEST_1 EXEC CurlLaplacianExample 
+#     TEST_1 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-threed --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-08
-#     TEST_2 EXEC CurlLaplacianExample 
+#     TEST_2 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-threed --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-16
-#     TEST_3 EXEC CurlLaplacianExample 
+#     TEST_3 EXEC CurlLaplacianExample
 #       ARGS --use-epetra --use-threed --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER}
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
@@ -129,4 +159,4 @@ ENDFOREACH()
 #       PASS_REGULAR_EXPRESSION "Test Passed"
 #     COMM mpi
 #     )
-# ENDFOREACH() 
+# ENDFOREACH()

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/main.cpp
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/main.cpp
@@ -144,7 +144,8 @@ using Teuchos::rcp;
 
 void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
 		        std::vector<panzer::BC>& bcs,
-                        const std::string & eBlockName,int basis_order);
+                        const std::vector<std::string>& eBlockNames,
+                        int basis_order);
 
 void solveEpetraSystem(panzer::LinearObjContainer & container);
 void solveTpetraSystem(panzer::LinearObjContainer & container);
@@ -176,12 +177,13 @@ int main(int argc,char * argv[])
 
    bool useTpetra = true;
    bool threeD = false;
+   int x_blocks = 1;
    int x_elements=20,y_elements=20,z_elements=20;
    std::string celltype = "Quad"; // or "Tri" (2d), Hex or Tet (3d)
    double x_size=1.,y_size=1.,z_size=1.;
    int basis_order = 1;
    std::string output_filename="output_";
-   
+
    Teuchos::CommandLineProcessor clp;
    clp.throwExceptions(false);
    clp.setDocString("This example solves curl laplacian problem with Hex and Tet inline mesh with high order.\n");
@@ -189,6 +191,7 @@ int main(int argc,char * argv[])
    clp.setOption("cell",&celltype);
    clp.setOption("use-tpetra","use-epetra",&useTpetra);
    clp.setOption("use-threed","use-twod",&threeD);
+   clp.setOption("x-blocks",&x_blocks);
    clp.setOption("x-elements",&x_elements);
    clp.setOption("y-elements",&y_elements);
    clp.setOption("z-elements",&z_elements);
@@ -214,25 +217,22 @@ int main(int argc,char * argv[])
    // construction of uncommitted (no elements) mesh
    ////////////////////////////////////////////////////////
 
-   std::string eBlockName = "";
    RCP<panzer_stk::STK_MeshFactory> mesh_factory;
    if(threeD) {
      mesh_factory = rcp(new panzer_stk::CubeHexMeshFactory);
 
      // set mesh factory parameters
      RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
-     pl->set("X Blocks",1);
+     pl->set("X Blocks",x_blocks);
      pl->set("Y Blocks",1);
      pl->set("Z Blocks",1);
-     pl->set("X Elements",x_elements);
+     pl->set("X Elements",x_elements/x_blocks);
      pl->set("Y Elements",y_elements);
      pl->set("Z Elements",z_elements);
      pl->set("Xf",x_size);
      pl->set("Yf",y_size);
      pl->set("Zf",z_size);
      mesh_factory->setParameterList(pl);
-
-     eBlockName = "eblock-0_0_0";
    }
    else {
      if      (celltype == "Quad") mesh_factory = Teuchos::rcp(new panzer_stk::SquareQuadMeshFactory);
@@ -242,15 +242,13 @@ int main(int argc,char * argv[])
 
      // set mesh factory parameters
      RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
-     pl->set("X Blocks",1);
+     pl->set("X Blocks",x_blocks);
      pl->set("Y Blocks",1);
-     pl->set("X Elements",x_elements);
+     pl->set("X Elements",x_elements/x_blocks);
      pl->set("Y Elements",y_elements);
      pl->set("Xf",x_size);
      pl->set("Yf",y_size);
      mesh_factory->setParameterList(pl);
-
-     eBlockName = "eblock-0_0";
    }
 
    RCP<panzer_stk::STK_Interface> mesh = mesh_factory->buildUncommitedMesh(MPI_COMM_WORLD);
@@ -267,9 +265,11 @@ int main(int argc,char * argv[])
    {
       bool build_transient_support = false;
 
-      testInitialization(ipb, bcs, eBlockName,basis_order);
+      std::vector<std::string> eBlockNames;
+      mesh->getElementBlockNames(eBlockNames);
+      testInitialization(ipb, bcs, eBlockNames, basis_order);
 
-      const panzer::CellData volume_cell_data(workset_size, mesh->getCellTopology(eBlockName));
+      const panzer::CellData volume_cell_data(workset_size, mesh->getCellTopology(eBlockNames[0]));
 
       // GobalData sets ostream and parameter interface to physics
       Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
@@ -277,25 +277,25 @@ int main(int argc,char * argv[])
       // Can be overridden by the equation set
       int default_integration_order = 4;
 
-      // the physics block nows how to build and register evaluator with the field manager
-      RCP<panzer::PhysicsBlock> pb
-	= rcp(new panzer::PhysicsBlock(ipb, eBlockName,
-				       default_integration_order,
-				       volume_cell_data,
-				       eqset_factory,
-				       gd,
-				       build_transient_support));
+      // the physics block knows how to build and register evaluator with the field manager
+      for (const auto& block : eBlockNames) {
+        RCP<panzer::PhysicsBlock> pb
+          = rcp(new panzer::PhysicsBlock(ipb, block,
+                                         default_integration_order,
+                                         volume_cell_data,
+                                         eqset_factory,
+                                         gd,
+                                         build_transient_support));
 
-      // we can have more than one physics block, one per element block
-      physicsBlocks.push_back(pb);
+        // we can have more than one physics block, one per element block
+        physicsBlocks.push_back(pb);
+      }
    }
 
    // finish building mesh, set required field variables and mesh bulk data
    ////////////////////////////////////////////////////////////////////////
 
-   {
-      RCP<panzer::PhysicsBlock> pb = physicsBlocks[0]; // we are assuming only one physics block
-
+   for (const auto pb : physicsBlocks) {
       const std::vector<StrPureBasisPair> & blockFields = pb->getProvidedDOFs();
 
       // insert all fields into a set
@@ -317,9 +317,8 @@ int main(int argc,char * argv[])
                mesh->addCellField(fieldItr->first+dimenStr[i],pb->elementBlockID());
          }
       }
-
-      mesh_factory->completeMeshConstruction(*mesh,MPI_COMM_WORLD);
    }
+   mesh_factory->completeMeshConstruction(*mesh,MPI_COMM_WORLD);
 
 
    // check that the bcs exist in the mesh
@@ -371,7 +370,7 @@ int main(int argc,char * argv[])
    Teuchos::RCP<panzer::WorksetContainer> wkstContainer     // attach it to a workset container (uses lazy evaluation)
       = Teuchos::rcp(new panzer::WorksetContainer);
    wkstContainer->setFactory(wkstFactory);
-   for(size_t i=0;i<physicsBlocks.size();i++) 
+   for(size_t i=0;i<physicsBlocks.size();i++)
      wkstContainer->setNeeds(physicsBlocks[i]->elementBlockID(),physicsBlocks[i]->getWorksetNeeds());
    wkstContainer->setWorksetSize(workset_size);
    wkstContainer->setGlobalIndexer(dofManager);
@@ -680,7 +679,8 @@ void solveTpetraSystem(panzer::LinearObjContainer & container)
 
 void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
 		        std::vector<panzer::BC>& bcs,
-                        const std::string & eBlockName,int basis_order)
+                        const std::vector<std::string>& eBlockNames,
+                        int basis_order)
 {
   {
     Teuchos::ParameterList& p = ipb->sublist("CurlLapacian Physics");
@@ -691,62 +691,61 @@ void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
     p.set("Integration Order",10);
   }
 
-  {
-    std::size_t bc_id = 0;
+  std::size_t bc_id = 0;
+  for (const auto& block : eBlockNames) {
     panzer::BCType bctype = panzer::BCT_Dirichlet;
     std::string sideset_id = "left";
-    std::string element_block_id = eBlockName;
+    std::string element_block_id = block;
     std::string dof_name = "EFIELD";
     std::string strategy = "Constant";
     double value = 0.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name,
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
 		  strategy, p);
     bcs.push_back(bc);
   }
 
-  {
-    std::size_t bc_id = 1;
+  // multiblock splits on x only
+  for (const auto& block : eBlockNames) {
     panzer::BCType bctype = panzer::BCT_Dirichlet;
     std::string sideset_id = "top";
-    std::string element_block_id = eBlockName;
+    std::string element_block_id = block;
     std::string dof_name = "EFIELD";
     std::string strategy = "Constant";
     double value = 0.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name,
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
 		  strategy, p);
     bcs.push_back(bc);
   }
 
-  {
-    std::size_t bc_id = 2;
+  for (const auto& block : eBlockNames) {
     panzer::BCType bctype = panzer::BCT_Dirichlet;
     std::string sideset_id = "right";
-    std::string element_block_id = eBlockName;
+    std::string element_block_id = block;
     std::string dof_name = "EFIELD";
     std::string strategy = "Constant";
     double value = 0.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name,
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
 		  strategy, p);
     bcs.push_back(bc);
   }
 
-  {
-    std::size_t bc_id = 3;
+  // multiblock splits on x only
+  for (const auto& block : eBlockNames) {
     panzer::BCType bctype = panzer::BCT_Dirichlet;
     std::string sideset_id = "bottom";
-    std::string element_block_id = eBlockName;
+    std::string element_block_id = block;
     std::string dof_name = "EFIELD";
     std::string strategy = "Constant";
     double value = 0.0;
     Teuchos::ParameterList p;
     p.set("Value",value);
-    panzer::BC bc(bc_id, bctype, sideset_id, element_block_id, dof_name,
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
 		  strategy, p);
     bcs.push_back(bc);
   }

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
@@ -13,11 +13,11 @@ TRIBITS_ADD_EXECUTABLE(
 TRIBITS_ADD_ADVANCED_TEST(
   MixedPoissonExample
   TEST_0 EXEC MixedPoissonExample
-    ARGS --use-epetra --x-elements=5 --y-elements=5 --z-elements=5
+    ARGS --use-epetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_epetra_"
     PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
     NUM_MPI_PROCS 4
   TEST_1 EXEC MixedPoissonExample
-    ARGS --use-tpetra --x-elements=5 --y-elements=5 --z-elements=5
+    ARGS --use-tpetra --x-elements=5 --y-elements=5 --z-elements=5 --output-filename="base_mixed_poisson_tpetra_"
     PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
     NUM_MPI_PROCS 4
   COMM mpi
@@ -63,3 +63,30 @@ FOREACH( ORDER 1 2 3)
 
 ENDFOREACH()
 
+## Multiblock basis order 1
+FOREACH( ORDER 1)
+  SET(HDIV_ORDER ${ORDER})
+  MATH(EXPR HGRAD_ORDER "${ORDER}")
+
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedPoissonMultiblockExample-ConvTest-Hex-Order-${ORDER}
+    TEST_0 EXEC MixedPoissonExample
+      ARGS --x-blocks=2 --x-elements=6 --y-elements=6 --z-elements=6 --hgrad-basis-order=${HGRAD_ORDER} --hdiv-basis-order=${HDIV_ORDER} --output-filename="multiblock-${ORDER}-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 3
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Hex-p${ORDER}-06
+    TEST_1 EXEC MixedPoissonExample
+      ARGS --x-blocks=2 --x-elements=12 --y-elements=12 --z-elements=12 --hgrad-basis-order=${HGRAD_ORDER} --hdiv-basis-order=${HDIV_ORDER} --output-filename="multiblock-${ORDER}-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Hex-p${ORDER}-12
+    TEST_2 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+         ${ORDER}
+         MPE-ConvTest-Hex-p${ORDER}-
+         6
+         12
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+  )
+ENDFOREACH()


### PR DESCRIPTION
This PR adds multiblock support and corresponding tests for the CurlLaplacian and MixedPoisson example problems. This is to make sure we are testing orientation tools for edge/face bases when multiple element blocks are present. See #3785 for details. 