### PR TITLE
Ifpack2: change ILUT level-of-fill to double, update documentation (I…

### DIFF
--- a/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
@@ -161,7 +161,7 @@ public:
   ///
   /// ILUT implements the following parameters:
   /// <ul>
-  /// <li> "fact: ilut level-of-fill" (\c int)
+  /// <li> "fact: ilut level-of-fill" (\c double)
   /// <li> "fact: drop tolerance" (\c magnitude_type)
   /// <li> "fact: absolute threshold" (\c magnitude_type)
   /// <li> "fact: relative threshold" (\c magnitude_type)
@@ -173,9 +173,12 @@ public:
   /// number of entries to keep in the strict upper triangle of the
   /// current row, and in the strict lower triangle of the current
   /// row.  It does <B>not</B> correspond to the \f$p\f$ parameter in Saad's original
-  /// description.
-  /// Each row has at most \f$level-of-fill + nnz(A(i; 1 : i))\f$
-  /// nonzero elements.
+  /// description. This parameter represents a maximum fill fraction.
+  /// In this implementation, the L and U factors always contains nonzeros corresponding
+  /// to the original sparsity pattern of A, so this value should be >= 1.0.
+  /// Letting \f$fill = \frac{(level-of-fill - 1)*nnz(A)}{2*N}\f$,
+  /// each row of the computed L and U factors contains at most \f$fill\f$
+  /// nonzero elements in addition to those from the sparsity pattern of A.
   /// ILUT always keeps the diagonal entry in the
   /// current row, regardless of the drop tolerance or fill level.
   ///
@@ -314,7 +317,7 @@ public:
   /// not including the diagonal entry in that row (which is always
   /// part of U).  This has a different meaning for ILUT than it does
   /// for ILU(k).
-  inline int getLevelOfFill() const {
+  inline double getLevelOfFill() const {
     return LevelOfFill_;
   }
 
@@ -406,7 +409,7 @@ private:
   magnitude_type Athresh_; //!< Absolute threshold
   magnitude_type Rthresh_; //!< Relative threshold
   magnitude_type RelaxValue_; //!< Relax value
-  int LevelOfFill_; //!< Max fill level
+  double LevelOfFill_; //!< Max fill level
   //! Discard all elements below this tolerance
   magnitude_type DropTolerance_;
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -1012,7 +1012,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, ILU_Overlap, Scalar, L
   params.set ("inner preconditioner name", "RILUK");
   {
     Teuchos::ParameterList innerParams;
-    innerParams.set ("fact: ilut level-of-fill", 0.0);
+    innerParams.set ("fact: iluk level-of-fill", 0.0);
     innerParams.set ("fact: drop tolerance", 0.0);
     params.set ("inner preconditioner parameters", innerParams);
   }
@@ -1079,7 +1079,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, ILU_NonOverlap, Scalar
   params.set ("inner preconditioner name", "RILUK");
   {
     Teuchos::ParameterList innerParams;
-    innerParams.set ("fact: ilut level-of-fill", 0.0);
+    innerParams.set ("fact: iluk level-of-fill", 0.0);
     innerParams.set ("fact: drop tolerance", 0.0);
     params.set ("inner preconditioner parameters", innerParams);
   }


### PR DESCRIPTION
…ssue #3782)

@trilinos/Ifpack2 @mhoemmen 

## Description
<!--- Please describe your changes in detail. -->
In ILUT changed the storage of level-of-fill from int to double, updated documentation to reflect actual behavior, and added a unit test.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Previously the documentation for this parameter given in setParameters() indicated that the parameter "fact: ilut level-of-fill" represented a max number of additional nonzero entries per row of the L and U factors, when it was actually being used as a fill fraction. As such, this is more appropriately represented by a double. The parameter was previously allowed to be provided as a double in input, but this value was cast to an int for storage and cast back to a double for computations. This truncation is unnecessary.

## Checklist

- [X] My commit messages mention the appropriate GitHub issue numbers.
- [X] My code follows the code style of the affected package(s).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

## Additional Information
Unsure if this is consider breaking backwards compatibility. This could impact results for users providing a non-integer double value for this parameter, but in this case the previous behavior wasn't doing what was expected.
