### PR TITLE
Xpetra: fix issue #3804

### DIFF
--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix.hpp
@@ -951,14 +951,12 @@ namespace Xpetra {
 #ifdef HAVE_XPETRA_TPETRA
     /// \brief Access the local Kokkos::CrsMatrix data
     local_matrix_type getLocalMatrix () const {
-      return getTpetra_CrsMatrixNonConst()->getLocalMatrix();
+      TEUCHOS_UNREACHABLE_RETURN(local_matrix_type());
     }
 
     void setAllValues (const typename local_matrix_type::row_map_type& ptr,
                        const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& ind,
-                       const typename local_matrix_type::values_type& val) {
-      getTpetra_CrsMatrixNonConst()->setAllValues(ptr,ind,val);
-    }
+                       const typename local_matrix_type::values_type& val) {    }
 #endif
 #endif
 
@@ -1338,14 +1336,12 @@ namespace Xpetra {
 #ifdef HAVE_XPETRA_TPETRA
     /// \brief Access the local Kokkos::CrsMatrix data
     local_matrix_type getLocalMatrix () const {
-      return getTpetra_CrsMatrixNonConst()->getLocalMatrix();
+      TEUCHOS_UNREACHABLE_RETURN(local_matrix_type());
     }
 
     void setAllValues (const typename local_matrix_type::row_map_type& ptr,
                        const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& ind,
-                       const typename local_matrix_type::values_type& val) {
-      getTpetra_CrsMatrixNonConst()->setAllValues(ptr,ind,val);
-    }
+                       const typename local_matrix_type::values_type& val) {    }
 #endif
 #endif
 


### PR DESCRIPTION
Removing implementation of getLocalMatrix and setAllValues from Xpetra::TpetraCrsMatrix specializations on <SC,int,int,EpetraNode> and <SC,int,long long,EpetraNode>

@trilinos/xpetra 

## Description
Fixing a specialization in Xpetra CrsMatrix

## Motivation and Context
This fixes some build errors on the dashboard...

## Related Issues

* Closes #3804 