### PR TITLE
EXODUS: Fix so builds with NetCDF variants (no hdf5 and/or cdf5)

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_create_group.c
+++ b/packages/seacas/libraries/exodus/src/ex_create_group.c
@@ -72,7 +72,7 @@ int ex_create_group(int parent_id, const char *group_name)
   snprintf(errmsg, MAX_ERR_LENGTH,
            "ERROR: Group capabilities are not available in this netcdf "
            "version--not netcdf4");
-  ex_err_fn(exoid, __func__, errmsg, NC_ENOTNC4);
+  ex_err(__func__, errmsg, NC_ENOTNC4);
   EX_FUNC_LEAVE(EX_FATAL);
 #endif
 }

--- a/packages/seacas/libraries/exodus/src/ex_open.c
+++ b/packages/seacas/libraries/exodus/src/ex_open.c
@@ -232,7 +232,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
 #endif
       }
       else if (type == 4) {
-#if defined(NC_64BIT_DATA)
+#if NC_HAS_CDF5
         fprintf(stderr,
                 "EXODUS: ERROR: Attempting to open the CDF5 "
                 "file:\n\t'%s'\n\t failed. The netcdf library supports "

--- a/packages/seacas/libraries/exodus/src/ex_open_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_open_par.c
@@ -244,7 +244,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
 #endif
     }
     else if (type == 4) {
-#if defined(NC_64BIT_DATA)
+#if NC_HAS_CDF5
       fprintf(stderr,
               "EXODUS: ERROR: Attempting to open the CDF5 "
               "file:\n\t'%s'\n\t failed. The netcdf library supports "

--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -1473,12 +1473,10 @@ static int warning_output = 0;
 
 int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
 {
-  char errmsg[MAX_ERR_LENGTH];
-  int  nc_mode = 0;
-#if NC_HAS_HDF5
+  char       errmsg[MAX_ERR_LENGTH];
+  int        nc_mode      = 0;
   static int netcdf4_mode = -1;
-#endif /* NC_NETCDF4 */
-#if defined(NC_64BIT_DATA)
+#if NC_HAS_CDF5
   static int netcdf5_mode = -1;
 #endif
 
@@ -1518,7 +1516,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
   }
 #endif
 
-#if !defined(NC_64BIT_DATA)
+#if !NC_HAS_CDF5
   if (my_mode & EX_64BIT_DATA) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "EXODUS: ERROR: File format specified as 64bit_data, but "
@@ -1563,7 +1561,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
   int64_status = my_mode & (EX_ALL_INT64_DB | EX_ALL_INT64_API);
 
   if ((int64_status & EX_ALL_INT64_DB) != 0) {
-#if NC_HAS_HDF5 || defined(NC_64BIT_DATA)
+#if NC_HAS_HDF5 || NC_HAS_CDF5
     /* Library DOES support netcdf4 and/or cdf5 ... See if user
      * specified either of these and use that one; if not, pick
      * netcdf4, non-classic as default.
@@ -1571,7 +1569,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
     if (my_mode & EX_NETCDF4) {
       my_mode |= EX_NOCLASSIC;
     }
-#if defined(NC_64BIT_DATA)
+#if NC_HAS_CDF5
     else if (my_mode & EX_64BIT_DATA) {
       ; /* Do nothing, already set */
     }
@@ -1697,7 +1695,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
     nc_mode |= NC_CLASSIC_MODEL;
   }
 
-#if defined(NC_64BIT_DATA)
+#if NC_HAS_CDF5
   if (my_mode & EX_64BIT_DATA) {
     nc_mode |= (NC_64BIT_DATA);
   }
@@ -1727,7 +1725,7 @@ int ex_int_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
 #if NC_HAS_HDF5
       !(nc_mode & NC_NETCDF4) &&
 #endif
-#if defined(NC_64BIT_DATA)
+#if NC_HAS_CDF5
       !(nc_mode & NC_64BIT_DATA) &&
 #endif
       filesiz == 1) {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Description
<!--- Please describe your changes in detail. -->
Fix build of exodus library if some of the NetCDF variants (such as no HDF5 or no PNetCDF/CDF5 capability) are used.  Fixes #3663.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
