### PR TITLE
Revert "Framework: Make Kokkos-Kernels build in PR testing..."

### DIFF
--- a/packages/kokkos-kernels/src/graph/KokkosGraph_graph_color_d2.hpp
+++ b/packages/kokkos-kernels/src/graph/KokkosGraph_graph_color_d2.hpp
@@ -115,6 +115,3 @@ void graph_color_d2(KernelHandle *handle,
 
 #endif //_KOKKOS_GRAPH_COLOR_HPP
 
-
-// This is a trivial edit to force the PR tester to build KokkosKernels.  
-// DO NOT MERGE THIS PR INTO TRILINOS!

--- a/packages/kokkos-kernels/unit_test/CMakeLists.txt
+++ b/packages/kokkos-kernels/unit_test/CMakeLists.txt
@@ -21,7 +21,6 @@ INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_
 #           the following relative path does not work or users should put kokkoskernels and kokkos
 #           at the same place
 SET(GTEST_SOURCE_DIR ${${PARENT_PACKAGE_NAME}_SOURCE_DIR}/../kokkos/tpls/gtest)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_PTHREAD=0")
 INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
 
 INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})


### PR DESCRIPTION
Reverts trilinos/Trilinos#3803 because people don't read.