### PR TITLE
Framework: Removing dummy comment for Kokkos-Kernels Testing

### DIFF
--- a/packages/kokkos-kernels/src/graph/KokkosGraph_graph_color_d2.hpp
+++ b/packages/kokkos-kernels/src/graph/KokkosGraph_graph_color_d2.hpp
@@ -115,6 +115,3 @@ void graph_color_d2(KernelHandle *handle,
 
 #endif //_KOKKOS_GRAPH_COLOR_HPP
 
-
-// This is a trivial edit to force the PR tester to build KokkosKernels.  
-// DO NOT MERGE THIS PR INTO TRILINOS!


### PR DESCRIPTION
Removing a dummy comment added in that got merged in by mistake.

I will merge this to remove the dummy comment that shouldn't have been merged in.  
Before I merge it in, I want to look at the testing results in the auto-tester system before I merge it, so do not set AT:AUTOMERGE on this.

@trilinos/framework