### PR TITLE
Tpetra: adding a new nightly build to avoid problems reported in issue #3823

### DIFF
--- a/cmake/ctest/drivers/trappist/CMakeLists.txt
+++ b/cmake/ctest/drivers/trappist/CMakeLists.txt
@@ -5,6 +5,14 @@ execute_process(COMMAND date +%A OUTPUT_VARIABLE DAYOFWEEK)
 
 if($ENV{CTEST_CONFIGURATION} MATCHES "default")
 
+  TRILINOS_DRIVER_ADD_DASHBORAD(
+    OPENMPI_1.10.0_RELEASE_Tpetra
+    ctest_linux_nightly_mpi_release_tpetra_trappist.gcc.cmake
+    CTEST_INSTALLER_TYPE release
+    RUN_SERIAL
+    TIMEOUT_MINUTES 330
+    )
+
   TRILINOS_DRIVER_ADD_DASHBOARD(
     OPENMPI_1.10.0_RELEASE_MueLu
     ctest_linux_nightly_mpi_release_muelu_trappist.gcc.cmake

--- a/cmake/ctest/drivers/trappist/ctest_linux_nightly_mpi_release_tpetra_trappist.gcc.cmake
+++ b/cmake/ctest/drivers/trappist/ctest_linux_nightly_mpi_release_tpetra_trappist.gcc.cmake
@@ -1,0 +1,85 @@
+# @HEADER
+# ************************************************************************
+#
+#            Trilinos: An Object-Oriented Solver Framework
+#                 Copyright (2001) Sandia Corporation
+#
+#
+# Copyright (2001) Sandia Corporation. Under the terms of Contract
+# DE-AC04-94AL85000, there is a non-exclusive license for use of this
+# work by or on behalf of the U.S. Government.  Export of this program
+# may require a license from the United States Government.
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the Corporation nor the names of the
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# NOTICE:  The United States Government is granted for itself and others
+# acting on its behalf a paid-up, nonexclusive, irrevocable worldwide
+# license in this data to reproduce, prepare derivative works, and
+# perform publicly and display publicly.  Beginning five (5) years from
+# July 25, 2001, the United States Government is granted for itself and
+# others acting on its behalf a paid-up, nonexclusive, irrevocable
+# worldwide license in this data to reproduce, prepare derivative works,
+# distribute copies to the public, perform publicly and display
+# publicly, and to permit others to do so.
+#
+# NEITHER THE UNITED STATES GOVERNMENT, NOR THE UNITED STATES DEPARTMENT
+# OF ENERGY, NOR SANDIA CORPORATION, NOR ANY OF THEIR EMPLOYEES, MAKES
+# ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LEGAL LIABILITY OR
+# RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY
+# INFORMATION, APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS
+# THAT ITS USE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
+#
+# ************************************************************************
+# @HEADER
+
+
+INCLUDE("${CTEST_SCRIPT_DIRECTORY}/TrilinosCTestDriverCore.trappist.gcc.cmake")
+
+#
+# Set the options specific to this build case
+#
+
+SET(COMM_TYPE MPI)
+SET(BUILD_TYPE RELEASE)
+SET(BUILD_DIR_NAME OPENMPI_1.10.1_RELEASE_DEV_Tpetra_gcc)
+SET(CTEST_PARALLEL_LEVEL 8)
+SET(CTEST_TEST_TYPE Nightly)
+SET(Trilinos_TRACK  Nightly)      # Set CDash board to Nightly
+SET(CTEST_TEST_TIMEOUT 900)
+
+SET(Trilinos_PACKAGES Tpetra)
+
+SET(EXTRA_CONFIGURE_OPTIONS
+  "-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON"
+  "-DTrilinos_ENABLE_DEPENDENCY_UNIT_TESTS=ON"
+  "-DTrilinos_ENABLE_COMPLEX_DOUBLE=ON"
+  "-DTPL_ENABLE_SuperLU=OFF"
+  "-DTeuchos_GLOBALLY_REDUCE_UNITTEST_RESULTS=ON"
+)
+
+#
+# Set the rest of the system-specific options and run the dashboard build/test
+#
+
+TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER()


### PR DESCRIPTION
@trilinos/<teamName>

## Description
Adding a nightly build that enables complex in Tpetra.

## Motivation and Context
I am seeing some tests failures in MueLu today and I am guessing that they are being introduced by upstream packages. So to make sure of that I want to test Tpetra.
Plus it seems to me that a complex build of Tpetra wouldn't be a bad idea.

## Related Issues

* Related to #3823 