### PR TITLE
tpetra: Fix types in MultiVector_MicroBenchmark with complex enabled

### DIFF
--- a/packages/tpetra/core/test/MultiVector/MultiVector_MicroBenchmark.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_MicroBenchmark.cpp
@@ -66,8 +66,8 @@ namespace { // (anonymous)
     typedef Tpetra::MultiVector<SC, LO, GO, NT> MV;
     typedef Teuchos::ScalarTraits<SC> STS;
     
-    SC ONE = STS::one();
-    SC ZERO = STS::zero();
+    typename MV::impl_scalar_type ONE = STS::one();
+    typename MV::impl_scalar_type ZERO = STS::zero();
 
     // Problem parameters
     size_t vector_size = 125000;


### PR DESCRIPTION
This partially addresses issue #3823 reported by @lucbv.

@crtrott provided this fix which allows Tpetra to compile in Cuda builds
with complex enabled.

In a Cuda build with complex<RealType> enabled, the lambda body in a
Kokkos::parallel_for should capture Kokkos::complex<RealType> values,
not std::complex types.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra


## How Has This Been Tested?
Built without compilation errors on White Kepler nodes with Cuda_Serial enabled.

Configuration script below:

```
export TRILINOS_DIR=/ascldap/users/ndellin/IntegrationTests/Trilinos

# Load modules
module purge
source ${TRILINOS_DIR}/cmake/std/atdm/load-env.sh cuda-9.2-opt-Kepler37
module swap cmake/3.9.6 cmake/3.12.3

# Packages
PACKAGE1=Tpetra

# Configure
cmake \
 -GNinja \
 -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
 -DTrilinos_ENABLE_TESTS:BOOL=ON \
  -DTrilinos_ENABLE_${PACKAGE1}=ON \
  -DTrilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
  -DKOKKOS_ENABLE_DEPRECATED_CODE:BOOL=ON \
$TRILINOS_DIR
```

<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
