### PR TITLE
Fix compiling using Sacado with a CUDA device compiler and KOKKOS_ENABLE_CUDA=OFF

### DIFF
--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -139,7 +139,7 @@ T atomic_compare_exchange( volatile T * const dest , const T & compare ,
 // GCC native CAS supports int, long, unsigned int, unsigned long.
 // Intel native CAS support int and long with the same interface as GCC.
 #if !defined(KOKKOS_ENABLE_ROCM_ATOMICS)
-#if !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 inline

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Exchange.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Exchange.hpp
@@ -193,7 +193,7 @@ void atomic_assign(
 
 //----------------------------------------------------------------------------
 
-#if !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 template< typename T >

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -173,7 +173,7 @@ T atomic_fetch_add( volatile T * const dest ,
 #endif
 //----------------------------------------------------------------------------
 #if !defined(KOKKOS_ENABLE_ROCM_ATOMICS)
-#if !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 #if defined( KOKKOS_ENABLE_ASM ) && defined ( KOKKOS_ENABLE_ISA_X86_64 )

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
@@ -75,7 +75,7 @@ unsigned long long int atomic_fetch_and( volatile unsigned long long int * const
 #endif
 #endif
 //----------------------------------------------------------------------------
-#if !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 inline

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
@@ -75,7 +75,7 @@ unsigned long long int atomic_fetch_or( volatile unsigned long long int * const 
 #endif
 #endif
 //----------------------------------------------------------------------------
-#if !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 inline

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -163,7 +163,7 @@ T atomic_fetch_sub( volatile T * const dest ,
 #endif
 //----------------------------------------------------------------------------
 #if !defined(KOKKOS_ENABLE_ROCM_ATOMICS)
-#if !definedKOKKOS_ENABLE_CUDA || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 inline

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -163,7 +163,7 @@ T atomic_fetch_sub( volatile T * const dest ,
 #endif
 //----------------------------------------------------------------------------
 #if !defined(KOKKOS_ENABLE_ROCM_ATOMICS)
-#if !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+#if !definedKOKKOS_ENABLE_CUDA || !defined(__CUDA_ARCH__) || defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 inline

--- a/packages/sacado/src/Sacado_DynamicArrayTraits.cpp
+++ b/packages/sacado/src/Sacado_DynamicArrayTraits.cpp
@@ -37,7 +37,7 @@ namespace Sacado {
 }
 #endif
 
-#if defined(HAVE_SACADO_KOKKOSCORE) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDACC__)
+#if defined(HAVE_SACADO_KOKKOSCORE) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
 namespace Sacado {
   namespace Impl {
     const Kokkos::MemoryPool<Kokkos::Cuda>* global_sacado_cuda_memory_pool_host = 0;

--- a/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
+++ b/packages/sacado/src/Sacado_DynamicArrayTraits.hpp
@@ -86,7 +86,7 @@ namespace Sacado {
   }
 #endif
 
-#if defined(HAVE_SACADO_KOKKOSCORE) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(__CUDACC__)
+#if defined(HAVE_SACADO_KOKKOSCORE) && !defined(SACADO_DISABLE_CUDA_IN_KOKKOS) && defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
 
   namespace Impl {
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos
@trilinos/sacado

## Description
If a `CUDA` device compiler and `KOKKOS_ENABLE_CUDA=OFF`, still define
- `Kokkos::atomic_compare_exchange`
- `Kokkos::atomic_exchange`
- `Kokkos::atomic_fetch_add`
- `Kokkos::atomic_fetch_and`
- `Kokkos::atomic_fetch_or`
- `Kokkos::atomic_fetch_sub`

and don't define `Sacado::createGlobalMemoryPool` and `Sacado::destroyGlobalMemoryPool` with a `Kokkos::Cuda` parameter in that case.

## Motivation and Context
Fixes https://github.com/kokkos/kokkos/issues/1607 and https://github.com/dealii/dealii/issues/6423.

## How Has This Been Tested?
Compiling `Trilinos` configured without `CUDA` support, but with `Kokkos` and `Sacado` works.
Compiling (`deal.II`)[https://github.com/dealii/dealii/] with `CUDA` support and such a `Trilinos` configuration works and passes `deal.II`s test suite.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.