### PR TITLE
Sacado:  Fix build errors reported in issue #3845.

### DIFF
--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -58,6 +58,12 @@ struct MirrorDRVType;
 
 }
 
+template <typename view_type>
+struct is_dynrankview_fad { static const bool value = false; };
+
+template <typename view_type>
+struct is_dynrankview_fad_contiguous { static const bool value = false; };
+
 }
 
 #if defined(HAVE_SACADO_VIEW_SPEC) && !defined(SACADO_DISABLE_FAD_VIEW_SPEC)
@@ -926,12 +932,6 @@ public:
 }} //end Kokkos::Impl
 
 namespace Kokkos {
-
-template <typename view_type>
-struct is_dynrankview_fad { static const bool value = false; };
-
-template <typename view_type>
-struct is_dynrankview_fad_contiguous { static const bool value = false; };
 
 template <typename T, typename ... P>
 struct is_dynrankview_fad< DynRankView<T,P...> > {


### PR DESCRIPTION
With Sacado_ENABLE_HIERARCHICAL_DFAD=ON, as was turned on in PR #3800 in
ATDM builds, a build error (#3845) was seen in the unit tests that disable the
View specializations for Fad, since `is_dynrankview_fad_contiguous<>` is
used without being defined.  I moved the default definition of this
trait class so that it is always defined, which fixed the build errors in my
CUDA build.
