### PR TITLE
Tempus: Add warning about workingState equal to null.

### DIFF
--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -215,7 +215,16 @@ public:
 
     /// Return the working state
     Teuchos::RCP<SolutionState<Scalar> > getWorkingState() const
-      { return workingState_; }
+    {
+      if (workingState_ == Teuchos::null) {
+        Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+        Teuchos::OSTab ostab(out,1,"SolutionHistory::getWorkingState()");
+        *out << "Warning - WorkingState is null and likely has been promoted.  "
+             << "You might want to call getCurrentState() instead.\n"
+             << std::endl;
+      }
+      return workingState_;
+    }
 
     /// Get the number of states
     int getNumStates() const {return history_->size();}


### PR DESCRIPTION
Closes #3847 

@trilinos/tempus 

## Description
Add warning if workingState is null.

## Motivation and Context
Users can request the workingState when it is not valid. This gives them a warning that it is not valid.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.

