### PR TITLE
Remove Piro disable for #2474 and add Panzer disable for #3579

### DIFF
--- a/cmake/std/atdm/mutrino/tweaks/ALL_BUILDS.cmake
+++ b/cmake/std/atdm/mutrino/tweaks/ALL_BUILDS.cmake
@@ -1,6 +1,3 @@
-# Disable test that is randomly failing in this build (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 # Disable SEACAS tests that get messed up due to extra STDERR output on
 # 'mutrino' that does not occur on other platforms (see #3183)
 ATDM_SET_ENABLE(SEACASAprepro_aprepro_array_test_DISABLE ON)

--- a/cmake/std/atdm/ride/tweaks/CUDA-9.2-RELEASE-CUDA-POWER8-KEPLER37.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA-9.2-RELEASE-CUDA-POWER8-KEPLER37.cmake
@@ -1,9 +1,6 @@
 # Disable test that times out at 10 minutes (#2446)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_main_driver_energy-ss-loca-eigenvalue_DISABLE ON)
 
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")
 
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ALL_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/ride/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,6 +1,9 @@
 # Disable test that runs over 30 min currently (#2446)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
 
+# Disable test that consistantly times out at 10 minutes (#3579)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)
+
 # Disable randomly failing MueLu tests (#2311)
 ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON)
 ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)

--- a/cmake/std/atdm/ride/tweaks/GNU-RELEASE-OPENMP-POWER8.cmake
+++ b/cmake/std/atdm/ride/tweaks/GNU-RELEASE-OPENMP-POWER8.cmake
@@ -1,4 +1,1 @@
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ALL_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/serrano/tweaks/INTEL-DEBUG-OPENMP-BDW.cmake
+++ b/cmake/std/atdm/serrano/tweaks/INTEL-DEBUG-OPENMP-BDW.cmake
@@ -1,5 +1,2 @@
 # Disable test that is failing or timing out in this build (see #2751)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
-
-# Disable test that is randomly failing in this build (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/serrano/tweaks/INTEL-RELEASE-OPENMP-BDW.cmake
+++ b/cmake/std/atdm/serrano/tweaks/INTEL-RELEASE-OPENMP-BDW.cmake
@@ -1,5 +1,2 @@
 # Disable test that is failing or timing out in this build (see #2751)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
-
-# Disable test that is randomly failing in this build (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/shiller/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,6 +1,9 @@
 # Disable test that runs over 30 min currently (#2446)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
 
+# Disable test that consistantly times out at 10 minutes (#3579)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)
+
 # Disable test that times out after 10 minutes (#2455)
 ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
 

--- a/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-OPENMP-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-OPENMP-HSW.cmake
@@ -1,2 +1,0 @@
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-SERIAL-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU-RELEASE-SERIAL-HSW.cmake
@@ -4,9 +4,6 @@ ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
 # Disable test takes a long time to complete for some reason (#2455)
 ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
 
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 # Disable test that times out randomly for some unkown reason (#2925)
 ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)
 

--- a/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-OPENMP-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-OPENMP-HSW.cmake
@@ -2,6 +2,3 @@
 ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
   "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
   CACHE STRING )
-
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-SERIAL-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-DEBUG-SERIAL-HSW.cmake
@@ -7,8 +7,5 @@ ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS
 "--gtest_filter=-serial.sparse_block_gauss_seidel_double_int_int_TestExecSpace:serial.sparse_trsv_mv_double_int_int_LayoutLeft_TestExecSpace"
   CACHE STRING )
 
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 # Disable perpetually failing KokkosCore test (#3233)
 ATDM_SET_ENABLE(KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-OPENMP-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-OPENMP-HSW.cmake
@@ -1,2 +1,0 @@
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-SERIAL-HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/INTEL-RELEASE-SERIAL-HSW.cmake
@@ -1,2 +1,0 @@
-# This test fails consistently with a major numerical error (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/waterman/tweaks/CUDA-9.2-RELEASE-CUDA-POWER9-VOLTA70.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA-9.2-RELEASE-CUDA-POWER9-VOLTA70.cmake
@@ -1,5 +1,2 @@
-# This test fails consistently (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ALL_COMMON_TWEAKS.cmake")

--- a/cmake/std/atdm/waterman/tweaks/GNU-RELEASE-OPENMP-POWER9.cmake
+++ b/cmake/std/atdm/waterman/tweaks/GNU-RELEASE-OPENMP-POWER9.cmake
@@ -1,4 +1,1 @@
-# This test fails consistently (#2474)
-ATDM_SET_ENABLE(Piro_MatrixFreeDecorator_UnitTests_MPI_4_DISABLE ON)
-
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ALL_COMMON_TWEAKS.cmake")


### PR DESCRIPTION
@trilinos/panzer, @trilinos/piro, @fryeguy52 

## Description

Commits to remove `Piro_MatrixFreeDecorator_UnitTests_MPI_4` test disables as per #2474 and add `PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4` test disables for CUDA builds on 'white/ride' and 'hansen/shiller' as per #3579.

## Motivation and Context

We agreed to enable this Piro test everywhere (see #2474) and we agreed to disable this Panzer test for CUDA builds on 'white/ride' and 'hansen/shiller' (see #3579).

## How Has This Been Tested?

I did local configures of Panzer on 'white' using

```
$ ./checkin-test-atdm.sh cuda-9.2-opt-Power8-Kepler37 --enable-packages=Piro,Panzer --configure

$ grep _DISABLE cuda-9.2-opt-Power8-Kepler37/configure.out 
...
-- Setting default PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE=ON
...
-- PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4: NOT added test because PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE='ON'!
...
```

so the Panzer test is being disabled correctly in 'white'.  (I will just assume it will be disabled correctly on 'hansen/shiller'.)

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
