### PR TITLE
Sacado:  Fix various compiler warnings.

### DIFF
--- a/packages/sacado/example/template_container_example.cpp
+++ b/packages/sacado/example/template_container_example.cpp
@@ -41,6 +41,7 @@
 template <class T>
 struct MyClass {
   T x;
+  MyClass() : x() {}  // to avoid uninitialized value warning below
 };
 
 // A functor to initialize a container of objects of type MyClass<T>

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -923,18 +923,21 @@ struct compute_fad_dim_from_alloc_prop;
 template < >
 struct compute_fad_dim_from_alloc_prop<> {
   template <typename CtorProp>
+  KOKKOS_INLINE_FUNCTION
   static unsigned eval(const CtorProp&) { return 0; }
 };
 
 template < typename P >
 struct compute_fad_dim_from_alloc_prop<P> {
   template <typename CtorProp>
+  KOKKOS_INLINE_FUNCTION
   static unsigned eval(const CtorProp&) { return 0; }
 };
 
 template < typename P0, typename ... P >
 struct compute_fad_dim_from_alloc_prop<P0,P...> {
   template <typename CtorProp>
+  KOKKOS_INLINE_FUNCTION
   static unsigned eval(const CtorProp& prop) {
     unsigned d1 = compute_fad_dim_from_alloc_prop<P0>::eval(prop);
     unsigned d2 = compute_fad_dim_from_alloc_prop<P...>::eval(prop);
@@ -947,6 +950,7 @@ struct compute_fad_dim_from_alloc_prop<
   CommonViewAllocProp<ViewSpecializeSacadoFad, ValueType>
   > {
   template <typename CtorProp>
+  KOKKOS_INLINE_FUNCTION
   static unsigned eval(const CtorProp& prop) {
     using specialize = ViewSpecializeSacadoFad;
     using CVAP = CommonViewAllocProp< specialize, ValueType >;
@@ -960,6 +964,7 @@ struct compute_fad_dim_from_alloc_prop<
   CommonViewAllocProp<ViewSpecializeSacadoFadContiguous, ValueType>
   > {
   template <typename CtorProp>
+  KOKKOS_INLINE_FUNCTION
   static unsigned eval(const CtorProp& prop) {
     using specialize = ViewSpecializeSacadoFadContiguous;
     using CVAP = CommonViewAllocProp< specialize, ValueType >;
@@ -975,6 +980,7 @@ struct appendFadToLayoutViewAllocHelper
   using specialize = typename Traits::specialize;
   using CtorProp = ViewCtorProp< P... >;
 
+  KOKKOS_INLINE_FUNCTION
   static layout_type returnNewLayoutPlusFad( const CtorProp & arg_prop, const layout_type & arg_layout ) {
 
     layout_type appended_layout( arg_layout );
@@ -1257,7 +1263,7 @@ public:
 
   //----------------------------------------
 
-  KOKKOS_INLINE_FUNCTION ~ViewMapping() = default ;
+  KOKKOS_INLINE_FUNCTION ~ViewMapping() {}
   KOKKOS_INLINE_FUNCTION ViewMapping() : m_impl_handle(0) , m_impl_offset() , m_array_offset() , m_fad_size(0) , m_fad_stride(0) {}
 
   KOKKOS_INLINE_FUNCTION ViewMapping( const ViewMapping & ) = default ;

--- a/packages/sacado/src/Sacado_trad.hpp
+++ b/packages/sacado/src/Sacado_trad.hpp
@@ -284,6 +284,7 @@ Derp {          // one derivative-propagation operation
 #if RAD_REINIT > 0
         const Double a;
         inline void *operator new(size_t, Derp *x) { return x; }
+        inline void operator delete(void*, Derp *) {}
 #else
         static Derp *LastDerp;
         Derp *next;
@@ -1590,7 +1591,8 @@ ADcontext<Double>::new_ADmemblock(size_t len)
 #ifdef RAD_AUTO_AD_Const // {
                 *ADVari::Last_ADvari = 0;
                 ADVari::Last_ADvari = &ADVari::First_ADvari;
-                if ((a = ADVari::First_ADvari)) {
+                a = ADVari::First_ADvari;
+                if (a) {
                         do {
                                 anext = a->Next;
                                 if ((v = (IndepADvar<Double> *)a->padv)) {

--- a/packages/sacado/src/Sacado_trad2.hpp
+++ b/packages/sacado/src/Sacado_trad2.hpp
@@ -1203,7 +1203,8 @@ ADcontext<Double>::new_ADmemblock(size_t len)
 			ADVari::adc.rad_need_reinit &= ~2;
 			*ADVari::Last_ADvari = 0;
 			ADVari::Last_ADvari = &ADVari::First_ADvari;
-			if ((anext = ADVari::First_ADvari)) {
+                        anext = ADVari::First_ADvari;
+			if (anext) {
 				while((a = anext)) {
 					anext = a->Next;
 					if ((v = (IndepADvar<Double> *)a->padv)) {

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -56,7 +56,7 @@ namespace Sacado {
     private:
 
       // Enumerated flag so logic is evaluated at compile-time
-      enum { stride_one = 1 == static_stride };
+      static constexpr bool stride_one = (1 == static_stride);
 
     public:
 
@@ -180,7 +180,7 @@ namespace Sacado {
       //! Returns derivative component \c i with bounds checking
       KOKKOS_INLINE_FUNCTION
       T dx(int i) const {
-        return sz_.value ? dx_[ stride_one ? i : i * stride_.value ] : T(0.);
+        return unsigned(sz_.value) ? dx_[ stride_one ? i : i * stride_.value ] : T(0.);
       }
 
       //! Returns derivative component \c i without bounds checking


### PR DESCRIPTION
1.  Fix use of uninitialized variable in template container example.
2.  Fix missing KOKKOS_INLINE_FUNCTION macro in View specializations.
3.  Fix enum-in-bool-context warning in new Fad design.
4.  Fix warning about use of "=" in "==" context in Rad.
5.  Fix warning about missing operator delete in Rad.