### PR TITLE
Tempus: Add ability to quiet warning about workingState equal to null.

### DIFF
--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -214,9 +214,9 @@ public:
     }
 
     /// Return the working state
-    Teuchos::RCP<SolutionState<Scalar> > getWorkingState() const
+    Teuchos::RCP<SolutionState<Scalar> > getWorkingState(bool warn=true) const
     {
-      if (workingState_ == Teuchos::null) {
+      if (workingState_ == Teuchos::null && warn) {
         Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
         Teuchos::OSTab ostab(out,1,"SolutionHistory::getWorkingState()");
         *out << "Warning - WorkingState is null and likely has been promoted.  "

--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -236,7 +236,7 @@ void SolutionHistory<Scalar>::initWorkingState()
 
     // If workingState_ has a valid pointer, we are still working on it,
     // i.e., step failed and trying again, so do not initialize it.
-    if (getWorkingState() != Teuchos::null) return;
+    if (getWorkingState(false) != Teuchos::null) return;
 
     Teuchos::RCP<SolutionState<Scalar> > newState;
     if (getNumStates() < storageLimit_) {


### PR DESCRIPTION
Closes #3883 

@trilinos/tempus 

## Description
New warning needs ability to turn off.

## Motivation and Context
Too much output in places.

## Checklist

- [x] My code follows the code style of the affected package(s).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
