### PR TITLE
RefMaxwell & MiniEM updates

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
@@ -50,10 +50,6 @@ namespace MueLu {
     typedef MueLu::MLParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> MLParameterListInterpreter;
     typedef MueLu::ParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> ParameterListInterpreter;
 
-    std::string timerName = "MueLu setup time";
-    RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);
-    tm->start();
-
     bool hasParamList = inParamList.numParams();
 
     RCP<HierarchyManager> mueLuFactory;
@@ -61,6 +57,21 @@ namespace MueLu {
     // Rip off non-serializable data before validation
     Teuchos::ParameterList nonSerialList,paramList;
     MueLu::ExtractNonSerializableData(inParamList, paramList, nonSerialList);
+
+    std::string label;
+    if (hasParamList && paramList.isParameter("hierarchy label")) {
+      label = paramList.get<std::string>("hierarchy label");
+      paramList.remove("hierarchy label");
+    } else
+      label = op->getObjectLabel();
+
+    std::string timerName;
+    if (label != "")
+      timerName = "MueLu setup time (" + label + ")";
+    else
+      timerName = "MueLu setup time";
+    RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);
+    tm->start();
 
     std::string syntaxStr = "parameterlist: syntax";
     if (hasParamList && paramList.isParameter(syntaxStr) && paramList.get<std::string>(syntaxStr) == "ml") {
@@ -71,12 +82,6 @@ namespace MueLu {
     }
 
     // Create Hierarchy
-    std::string label;
-    if (hasParamList && paramList.isParameter("hierarchy label")) {
-      label = paramList.get<std::string>("hierarchy label");
-      paramList.remove("hierarchy label");
-    } else
-      label = op->getObjectLabel();
     RCP<Hierarchy> H = mueLuFactory->CreateHierarchy(label);
     H->setlib(op->getDomainMap()->lib());
 
@@ -85,6 +90,7 @@ namespace MueLu {
 
     // Set fine level operator
     H->GetLevel(0)->Set("A", op);
+    H->SetProcRankVerbose(op->getDomainMap()->getComm()->getRank());
 
     // Set coordinates if available
     if (coords != Teuchos::null)
@@ -125,10 +131,6 @@ namespace MueLu {
     typedef MueLu::MLParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> MLParameterListInterpreter;
     typedef MueLu::ParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> ParameterListInterpreter;
 
-    std::string timerName = "MueLu setup time";
-    RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);
-    tm->start();
-
     bool hasParamList = inParamList.numParams();
 
     RCP<HierarchyManager> mueLuFactory;
@@ -136,6 +138,21 @@ namespace MueLu {
     // Rip off non-serializable data before validation
     Teuchos::ParameterList nonSerialList,paramList;
     MueLu::ExtractNonSerializableData(inParamList, paramList, nonSerialList);
+
+    std::string label;
+    if (hasParamList && paramList.isParameter("hierarchy label")) {
+      label = paramList.get<std::string>("hierarchy label");
+      paramList.remove("hierarchy label");
+    } else
+      label = op->getObjectLabel();
+
+    std::string timerName;
+    if (label != "")
+      timerName = "MueLu setup time (" + label + ")";
+    else
+      timerName = "MueLu setup time";
+    RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);
+    tm->start();
 
     std::string syntaxStr = "parameterlist: syntax";
     if (hasParamList && paramList.isParameter(syntaxStr) && paramList.get<std::string>(syntaxStr) == "ml") {
@@ -146,7 +163,7 @@ namespace MueLu {
     }
 
     // Create Hierarchy
-    RCP<Hierarchy> H = mueLuFactory->CreateHierarchy();
+    RCP<Hierarchy> H = mueLuFactory->CreateHierarchy(label);
     H->setlib(op->getDomainMap()->lib());
 
     // Stick the non-serializible data on the hierarchy.
@@ -154,6 +171,7 @@ namespace MueLu {
 
     // Set fine level operator
     H->GetLevel(0)->Set("A", op);
+    H->SetProcRankVerbose(op->getDomainMap()->getComm()->getRank());
 
     mueLuFactory->SetupHierarchy(*H);
 
@@ -185,7 +203,13 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ReuseXpetraPreconditioner(const Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& A,
                                  Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node>>& H) {
-    std::string timerName = "MueLu setup time";
+    std::string label = H->GetLevel(0)->getObjectLabel();
+
+    std::string timerName;
+    if (label != "")
+      timerName = "MueLu setup time (" + label + ")";
+    else
+      timerName = "MueLu setup time";
     RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);
     tm->start();
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -46,6 +46,8 @@
 #ifndef MUELU_REFMAXWELL_DEF_HPP
 #define MUELU_REFMAXWELL_DEF_HPP
 
+#include <sstream>
+
 #include "MueLu_ConfigDefs.hpp"
 
 #include "Xpetra_Map.hpp"
@@ -80,10 +82,12 @@
 #include <KokkosSparse_CrsMatrix.hpp>
 #endif
 
+#include "MueLu_Zoltan2Interface.hpp"
+#include "MueLu_RepartitionHeuristicFactory.hpp"
+#include "MueLu_RepartitionFactory.hpp"
+#include "MueLu_RebalanceAcFactory.hpp"
+#include "MueLu_RebalanceTransferFactory.hpp"
 
-#include "MueLu_Monitor.hpp"
-#include "MueLu_MLParameterListInterpreter.hpp"
-#include "MueLu_ParameterListInterpreter.hpp"
 #include "MueLu_VerbosityLevel.hpp"
 
 #include <MueLu_CreateXpetraPreconditioner.hpp>
@@ -147,22 +151,21 @@ namespace MueLu {
 
     Teuchos::TimeMonitor tmCompute(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: compute"));
 
+    std::map<std::string, MsgType> verbMap;
+    verbMap["none"]    = None;
+    verbMap["low"]     = Low;
+    verbMap["medium"]  = Medium;
+    verbMap["high"]    = High;
+    verbMap["extreme"] = Extreme;
+    verbMap["test"]    = Test;
+
     VerbLevel oldVerbLevel = VerboseObject::GetDefaultVerbLevel();
-    {
-      std::map<std::string, MsgType> verbMap;
-      verbMap["none"]    = None;
-      verbMap["low"]     = Low;
-      verbMap["medium"]  = Medium;
-      verbMap["high"]    = High;
-      verbMap["extreme"] = Extreme;
-      verbMap["test"]    = Test;
+    std::string verbosityLevel = parameterList_.get<std::string>("verbosity", "medium");
 
-      std::string verbosityLevel = parameterList_.get<std::string>("verbosity", "medium");
+    TEUCHOS_TEST_FOR_EXCEPTION(verbMap.count(verbosityLevel) == 0, Exceptions::RuntimeError,
+                               "Invalid verbosity level: \"" << verbosityLevel << "\"");
+    VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);
 
-      TEUCHOS_TEST_FOR_EXCEPTION(verbMap.count(verbosityLevel) == 0, Exceptions::RuntimeError,
-                                 "Invalid verbosity level: \"" << verbosityLevel << "\"");
-      VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);
-    }
 
     bool defaultFilter = false;
 
@@ -171,7 +174,7 @@ namespace MueLu {
     // matrix, so zero entries mess it up.
     if (parameterList_.get<bool>("refmaxwell: filter D0", true) && D0_Matrix_->getNodeMaxNumRowEntries()>2) {
       Level fineLevel;
-      fineLevel.SetFactoryManager(Teuchos::null);
+      fineLevel.SetFactoryManager(null);
       fineLevel.SetLevelID(0);
       fineLevel.Set("A",D0_Matrix_);
       fineLevel.setlib(D0_Matrix_->getDomainMap()->lib());
@@ -192,7 +195,7 @@ namespace MueLu {
       magnitudeType threshold = 1.0e-8 * diag->normInf();
 
       Level fineLevel;
-      fineLevel.SetFactoryManager(Teuchos::null);
+      fineLevel.SetFactoryManager(null);
       fineLevel.SetLevelID(0);
       fineLevel.Set("A",SM_Matrix_);
       fineLevel.setlib(SM_Matrix_->getDomainMap()->lib());
@@ -209,7 +212,7 @@ namespace MueLu {
       magnitudeType threshold = 1.0e-8 * diag->normInf();
 
       Level fineLevel;
-      fineLevel.SetFactoryManager(Teuchos::null);
+      fineLevel.SetFactoryManager(null);
       fineLevel.SetLevelID(0);
       fineLevel.Set("A",M1_Matrix_);
       fineLevel.setlib(M1_Matrix_->getDomainMap()->lib());
@@ -237,14 +240,14 @@ namespace MueLu {
 #endif
 
     // build nullspace if necessary
-    if(Nullspace_ != Teuchos::null) {
+    if(Nullspace_ != null) {
       // no need to do anything - nullspace is built
     }
-    else if(Nullspace_ == Teuchos::null && Coords_ != Teuchos::null) {
+    else if(Nullspace_ == null && Coords_ != null) {
       // normalize coordinates
       typedef typename RealValuedMultiVector::scalar_type realScalarType;
       typedef typename Teuchos::ScalarTraits<realScalarType>::magnitudeType realMagnitudeType;
-      Teuchos::Array<realMagnitudeType> norms(Coords_->getNumVectors());
+      Array<realMagnitudeType> norms(Coords_->getNumVectors());
       Coords_->norm2(norms);
       for (size_t i=0;i<Coords_->getNumVectors();i++)
         norms[i] = ((realMagnitudeType)1.0)/norms[i];
@@ -281,11 +284,11 @@ namespace MueLu {
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("D0_clean.mat"), *D0_Matrix_);
 
     // build special prolongator for (1,1)-block
-    if(P11_==Teuchos::null) {
+    if(P11_==null) {
       // Form A_nodal = D0* M1 D0  (aka TMT_agg)
       Level fineLevel, coarseLevel;
-      fineLevel.SetFactoryManager(Teuchos::null);
-      coarseLevel.SetFactoryManager(Teuchos::null);
+      fineLevel.SetFactoryManager(null);
+      coarseLevel.SetFactoryManager(null);
       coarseLevel.SetPreviousLevel(rcpFromRef(fineLevel));
       fineLevel.SetLevelID(0);
       coarseLevel.SetLevelID(1);
@@ -297,7 +300,7 @@ namespace MueLu {
       fineLevel.setObjectLabel("RefMaxwell (1,1) A_nodal");
 
       RCP<RAPFactory> rapFact = rcp(new RAPFactory());
-      Teuchos::ParameterList rapList = *(rapFact->GetValidParameterList());
+      ParameterList rapList = *(rapFact->GetValidParameterList());
       rapList.set("transpose: use implicit", parameterList_.get<bool>("transpose: use implicit", false));
       rapList.set("rap: fix zero diagonals", parameterList_.get<bool>("rap: fix zero diagonals", true));
       rapList.set("rap: triple product", parameterList_.get<bool>("rap: triple product", false));
@@ -327,9 +330,130 @@ namespace MueLu {
 #endif
     }
 
+    bool doRebalancing = parameterList_.get<bool>("refmaxwell: subsolves on subcommunicators", false);
+    int numProcsAH, numProcsA22;
     {
       // build coarse grid operator for (1,1)-block
       formCoarseMatrix();
+
+#ifdef HAVE_MPI
+      int numProcs = SM_Matrix_->getDomainMap()->getComm()->getSize();
+      if (doRebalancing && numProcs > 1) {
+        GlobalOrdinal globalNumRowsAH = AH_->getRowMap()->getGlobalNumElements();
+        GlobalOrdinal globalNumRowsA22 = D0_Matrix_->getDomainMap()->getGlobalNumElements();
+        double ratio = parameterList_.get<double>("refmaxwell: ratio AH / A22 subcommunicators", 1.0);
+        numProcsAH = numProcs * globalNumRowsAH / (globalNumRowsAH + ratio*globalNumRowsA22);
+        numProcsA22 = numProcs * ratio * globalNumRowsA22 / (globalNumRowsAH + ratio*globalNumRowsA22);
+        if (numProcsAH + numProcsA22 < numProcs)
+          ++numProcsAH;
+        if (numProcsAH + numProcsA22 < numProcs)
+          ++numProcsA22;
+        numProcsAH = std::max(numProcsAH, 1);
+        numProcsA22 = std::max(numProcsA22, 1);
+      } else
+        doRebalancing = false;
+
+      if (doRebalancing) { // rebalance AH
+        Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Rebalance AH"));
+
+        Level fineLevel, coarseLevel;
+        fineLevel.SetFactoryManager(null);
+        coarseLevel.SetFactoryManager(null);
+        coarseLevel.SetPreviousLevel(rcpFromRef(fineLevel));
+        fineLevel.SetLevelID(0);
+        coarseLevel.SetLevelID(1);
+        coarseLevel.Set("A",AH_);
+        coarseLevel.Set("P",P11_);
+        coarseLevel.Set("R",R11_);
+        coarseLevel.Set("Coordinates",CoordsH_);
+        coarseLevel.Set("number of partitions", numProcsAH);
+
+        coarseLevel.setlib(AH_->getDomainMap()->lib());
+        fineLevel.setlib(AH_->getDomainMap()->lib());
+        coarseLevel.setObjectLabel("RefMaxwell (1,1)");
+        fineLevel.setObjectLabel("RefMaxwell (1,1)");
+
+        // auto repartheurFactory = rcp(new RepartitionHeuristicFactory());
+        // ParameterList repartheurParams;
+        // repartheurParams.set("repartition: start level",0);
+        // repartheurParams.set("repartition: min rows per proc", precList11_.get<int>("repartition: min rows per proc", 1024));
+        // repartheurParams.set("repartition: target rows per proc", precList11_.get<int>("repartition: target rows per proc", 0));
+        // repartheurParams.set("repartition: max imbalance", precList11_.get<double>("repartition: max imbalance", 1.1));
+        // repartheurFactory->SetParameterList(repartheurParams);
+
+        std::string partName = precList11_.get<std::string>("repartition: partitioner", "zoltan2");
+        RCP<Factory> partitioner;
+        if (partName == "zoltan") {
+#ifdef HAVE_MUELU_ZOLTAN
+          partitioner = rcp(new ZoltanInterface());
+          // NOTE: ZoltanInteface ("zoltan") does not support external parameters through ParameterList
+          // partitioner->SetFactory("number of partitions", repartheurFactory);
+#else
+          throw Exceptions::RuntimeError("Zoltan interface is not available");
+#endif
+        } else if (partName == "zoltan2") {
+#ifdef HAVE_MUELU_ZOLTAN2
+          partitioner = rcp(new Zoltan2Interface());
+          ParameterList partParams;
+          RCP<const ParameterList> partpartParams = rcp(new ParameterList(precList11_.sublist("repartition: params", false)));
+          partParams.set("ParameterList", partpartParams);
+          partitioner->SetParameterList(partParams);
+          // partitioner->SetFactory("number of partitions", repartheurFactory);
+#else
+          throw Exceptions::RuntimeError("Zoltan2 interface is not available");
+#endif
+        }
+
+        auto repartFactory = rcp(new RepartitionFactory());
+        ParameterList repartParams;
+        repartParams.set("repartition: print partition distribution", precList11_.get<bool>("repartition: print partition distribution", false));
+        repartParams.set("repartition: remap parts", precList11_.get<bool>("repartition: remap parts", true));
+        repartFactory->SetParameterList(repartParams);
+        // repartFactory->SetFactory("number of partitions", repartheurFactory);
+        repartFactory->SetFactory("Partition", partitioner);
+
+        auto newP = rcp(new RebalanceTransferFactory());
+        ParameterList newPparams;
+        newPparams.set("type", "Interpolation");
+        newPparams.set("repartition: rebalance P and R", precList11_.get<bool>("repartition: rebalance P and R", false));
+        newPparams.set("repartition: use subcommunicators", true);
+        newPparams.set("repartition: rebalance Nullspace", false);
+        newP->SetFactory("Coordinates", NoFactory::getRCP());
+        newP->SetParameterList(newPparams);
+        newP->SetFactory("Importer", repartFactory);
+
+        // Rebalanced R
+        auto newR = rcp(new RebalanceTransferFactory());
+        ParameterList newRparams;
+        newRparams.set("type", "Restriction");
+        newRparams.set("repartition: rebalance P and R", precList11_.get<bool>("repartition: rebalance P and R", false));
+        newRparams.set("repartition: use subcommunicators", true);
+        newR->SetParameterList(newRparams);
+        newR->SetFactory("Importer", repartFactory);
+
+        auto newA = rcp(new RebalanceAcFactory());
+        ParameterList rebAcParams;
+        rebAcParams.set("repartition: use subcommunicators", true);
+        newA->SetParameterList(rebAcParams);
+        newA->SetFactory("Importer", repartFactory);
+
+        coarseLevel.Request("R", newR.get());
+        coarseLevel.Request("P", newP.get());
+        coarseLevel.Request("Importer", repartFactory.get());
+        coarseLevel.Request("A", newA.get());
+        coarseLevel.Request("Coordinates", newP.get());
+        repartFactory->Build(coarseLevel);
+
+        if (!precList11_.get<bool>("repartition: rebalance P and R", false))
+          ImporterH_ = coarseLevel.Get< RCP<const Import> >("Importer", repartFactory.get());
+        P11_ = coarseLevel.Get< RCP<Matrix> >("P", newP.get());
+        R11_ = coarseLevel.Get< RCP<Matrix> >("R", newR.get());
+        AH_ = coarseLevel.Get< RCP<Matrix> >("A", newA.get());
+        if (!AH_.is_null())
+          AH_->setObjectLabel("RefMaxwell (1,1)");
+        CoordsH_ = coarseLevel.Get< RCP<RealValuedMultiVector> >("Coordinates", newP.get());
+      }
+#endif // HAVE_MPI
 
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
       // This should be taken out again as soon as
@@ -341,7 +465,13 @@ namespace MueLu {
         precList11_.set("aggregation: drop tol", 0.0);
       }
 #endif
-      HierarchyH_ = MueLu::CreateXpetraPreconditioner(AH_, precList11_, CoordsH_);
+      if (!AH_.is_null()) {
+        int oldRank = SetProcRankVerbose(AH_->getDomainMap()->getComm()->getRank());
+        HierarchyH_ = MueLu::CreateXpetraPreconditioner(AH_, precList11_, CoordsH_);
+        SetProcRankVerbose(oldRank);
+      }
+      VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);
+
     }
 
     {
@@ -372,20 +502,23 @@ namespace MueLu {
         Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build A22"));
 
         Level fineLevel, coarseLevel;
-        fineLevel.SetFactoryManager(Teuchos::null);
-        coarseLevel.SetFactoryManager(Teuchos::null);
+        fineLevel.SetFactoryManager(null);
+        coarseLevel.SetFactoryManager(null);
         coarseLevel.SetPreviousLevel(rcpFromRef(fineLevel));
         fineLevel.SetLevelID(0);
         coarseLevel.SetLevelID(1);
         fineLevel.Set("A",SM_Matrix_);
         coarseLevel.Set("P",D0_Matrix_);
+        coarseLevel.Set("Coordinates",Coords_);
+        coarseLevel.Set("number of partitions", numProcsA22);
+
         coarseLevel.setlib(SM_Matrix_->getDomainMap()->lib());
         fineLevel.setlib(SM_Matrix_->getDomainMap()->lib());
         coarseLevel.setObjectLabel("RefMaxwell (2,2)");
         fineLevel.setObjectLabel("RefMaxwell (2,2)");
 
         RCP<RAPFactory> rapFact = rcp(new RAPFactory());
-        Teuchos::ParameterList rapList = *(rapFact->GetValidParameterList());
+        ParameterList rapList = *(rapFact->GetValidParameterList());
         rapList.set("transpose: use implicit", false);
         rapList.set("rap: fix zero diagonals", parameterList_.get<bool>("rap: fix zero diagonals", true));
         rapList.set("rap: triple product", parameterList_.get<bool>("rap: triple product", false));
@@ -395,14 +528,115 @@ namespace MueLu {
         transPFactory = rcp(new TransPFactory());
         rapFact->SetFactory("R", transPFactory);
 
-        coarseLevel.Request("R", transPFactory.get());
-        coarseLevel.Request("A", rapFact.get());
-        A22_ = coarseLevel.Get< RCP<Matrix> >("A", rapFact.get());
-        A22_->setObjectLabel("RefMaxwell (2,2)");
-        D0_T_Matrix_ = coarseLevel.Get< RCP<Matrix> >("R", transPFactory.get());
+#ifdef HAVE_MPI
+        if (doRebalancing) {
+
+          // auto repartheurFactory = rcp(new RepartitionHeuristicFactory());
+          // ParameterList repartheurParams;
+          // repartheurParams.set("repartition: start level",0);
+          // repartheurParams.set("repartition: min rows per proc", precList22_.get<int>("repartition: min rows per proc", 1024));
+          // repartheurParams.set("repartition: target rows per proc", precList22_.get<int>("repartition: target rows per proc", 0));
+          // repartheurParams.set("repartition: max imbalance", precList22_.get<double>("repartition: max imbalance", 1.1));
+          // repartheurFactory->SetParameterList(repartheurParams);
+          // repartheurFactory->SetFactory("A", rapFact);
+
+          std::string partName = precList22_.get<std::string>("repartition: partitioner", "zoltan2");
+          RCP<Factory> partitioner;
+          if (partName == "zoltan") {
+#ifdef HAVE_MUELU_ZOLTAN
+            partitioner = rcp(new ZoltanInterface());
+            partitioner->SetFactory("A", rapFact);
+            // partitioner->SetFactory("number of partitions", repartheurFactory);
+            // NOTE: ZoltanInteface ("zoltan") does not support external parameters through ParameterList
+#else
+            throw Exceptions::RuntimeError("Zoltan interface is not available");
+#endif
+          } else if (partName == "zoltan2") {
+#ifdef HAVE_MUELU_ZOLTAN2
+            partitioner = rcp(new Zoltan2Interface());
+            ParameterList partParams;
+            RCP<const ParameterList> partpartParams = rcp(new ParameterList(precList22_.sublist("repartition: params", false)));
+            partParams.set("ParameterList", partpartParams);
+            partitioner->SetParameterList(partParams);
+            partitioner->SetFactory("A", rapFact);
+            // partitioner->SetFactory("number of partitions", repartheurFactory);
+#else
+            throw Exceptions::RuntimeError("Zoltan2 interface is not available");
+#endif
+          }
+
+          auto repartFactory = rcp(new RepartitionFactory());
+          ParameterList repartParams;
+          repartParams.set("repartition: print partition distribution", precList22_.get<bool>("repartition: print partition distribution", false));
+          repartParams.set("repartition: remap parts", precList22_.get<bool>("repartition: remap parts", true));
+          repartParams.set("repartition: remap accept partition", AH_.is_null());
+          repartFactory->SetParameterList(repartParams);
+          repartFactory->SetFactory("A", rapFact);
+          // repartFactory->SetFactory("number of partitions", repartheurFactory);
+          repartFactory->SetFactory("Partition", partitioner);
+
+          auto newP = rcp(new RebalanceTransferFactory());
+          ParameterList newPparams;
+          newPparams.set("type", "Interpolation");
+          newPparams.set("repartition: rebalance P and R", precList22_.get<bool>("repartition: rebalance P and R", false));
+          newPparams.set("repartition: use subcommunicators", true);
+          newPparams.set("repartition: rebalance Nullspace", false);
+          newP->SetFactory("Coordinates", NoFactory::getRCP());
+          newP->SetParameterList(newPparams);
+          newP->SetFactory("Importer", repartFactory);
+
+          // Rebalanced R
+          auto newR = rcp(new RebalanceTransferFactory());
+          ParameterList newRparams;
+          newRparams.set("type", "Restriction");
+          newRparams.set("repartition: rebalance P and R", precList22_.get<bool>("repartition: rebalance P and R", false));
+          newRparams.set("repartition: use subcommunicators", true);
+          newR->SetParameterList(newRparams);
+          newR->SetFactory("Importer", repartFactory);
+          newR->SetFactory("R", transPFactory);
+
+          auto newA = rcp(new RebalanceAcFactory());
+          ParameterList rebAcParams;
+          rebAcParams.set("repartition: use subcommunicators", true);
+          newA->SetParameterList(rebAcParams);
+          newA->SetFactory("A", rapFact);
+          newA->SetFactory("Importer", repartFactory);
+
+          coarseLevel.Request("R", newR.get());
+          coarseLevel.Request("P", newP.get());
+          coarseLevel.Request("Importer", repartFactory.get());
+          coarseLevel.Request("A", newA.get());
+          coarseLevel.Request("Coordinates", newP.get());
+          rapFact->Build(fineLevel,coarseLevel);
+          repartFactory->Build(coarseLevel);
+
+          if (!precList22_.get<bool>("repartition: rebalance P and R", false))
+            Importer22_ = coarseLevel.Get< RCP<const Import> >("Importer", repartFactory.get());
+          D0_Matrix_ = coarseLevel.Get< RCP<Matrix> >("P", newP.get());
+          D0_T_Matrix_ = coarseLevel.Get< RCP<Matrix> >("R", newR.get());
+          A22_ = coarseLevel.Get< RCP<Matrix> >("A", newA.get());
+          if (!A22_.is_null())
+            A22_->setObjectLabel("RefMaxwell (2,2)");
+          Coords_ = coarseLevel.Get< RCP<RealValuedMultiVector> >("Coordinates", newP.get());
+        } else
+#endif // HAVE_MPI
+        {
+          coarseLevel.Request("A", rapFact.get());
+          coarseLevel.Request("R", transPFactory.get());
+
+          A22_ = coarseLevel.Get< RCP<Matrix> >("A", rapFact.get());
+          A22_->setObjectLabel("RefMaxwell (2,2)");
+          D0_T_Matrix_ = coarseLevel.Get< RCP<Matrix> >("R", transPFactory.get());
+        }
       }
 
-      Hierarchy22_ = MueLu::CreateXpetraPreconditioner(A22_, precList22_, Coords_);
+      if (!A22_.is_null()) {
+        int oldRank = SetProcRankVerbose(A22_->getDomainMap()->getComm()->getRank());
+        Hierarchy22_ = MueLu::CreateXpetraPreconditioner(A22_, precList22_, Coords_);
+        SetProcRankVerbose(oldRank);
+      }
+      VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);
+
     }
 
     {
@@ -412,7 +646,7 @@ namespace MueLu {
           A22_->getDomainMap()->lib() == Xpetra::UseTpetra &&
           D0_Matrix_->getDomainMap()->lib() == Xpetra::UseTpetra) {
 #if defined(HAVE_MUELU_IFPACK2) && (!defined(HAVE_MUELU_EPETRA) || (defined(HAVE_MUELU_INST_DOUBLE_INT_INT)))
-        Teuchos::ParameterList hiptmairPreList, hiptmairPostList, smootherPreList, smootherPostList;
+        ParameterList hiptmairPreList, hiptmairPostList, smootherPreList, smootherPostList;
 
         if (smootherList_.isSublist("smoother: pre params"))
           smootherPreList = smootherList_.sublist("smoother: pre params");
@@ -449,15 +683,15 @@ namespace MueLu {
                              smootherPostList.get<bool>("hiptmair: zero starting solution", false));
 
         typedef Tpetra::RowMatrix<SC, LO, GO, NO> TROW;
-        Teuchos::RCP<const TROW > EdgeMatrix = Utilities::Op2NonConstTpetraRow(SM_Matrix_);
-        Teuchos::RCP<const TROW > NodeMatrix = Utilities::Op2NonConstTpetraRow(A22_);
-        Teuchos::RCP<const TROW > PMatrix = Utilities::Op2NonConstTpetraRow(D0_Matrix_);
+        RCP<const TROW > EdgeMatrix = Utilities::Op2NonConstTpetraRow(SM_Matrix_);
+        RCP<const TROW > NodeMatrix = Utilities::Op2NonConstTpetraRow(A22_);
+        RCP<const TROW > PMatrix = Utilities::Op2NonConstTpetraRow(D0_Matrix_);
 
-        hiptmairPreSmoother_  = Teuchos::rcp( new Ifpack2::Hiptmair<TROW>(EdgeMatrix,NodeMatrix,PMatrix) );
+        hiptmairPreSmoother_  = rcp( new Ifpack2::Hiptmair<TROW>(EdgeMatrix,NodeMatrix,PMatrix) );
         hiptmairPreSmoother_ -> setParameters(hiptmairPreList);
         hiptmairPreSmoother_ -> initialize();
         hiptmairPreSmoother_ -> compute();
-        hiptmairPostSmoother_ = Teuchos::rcp( new Ifpack2::Hiptmair<TROW>(EdgeMatrix,NodeMatrix,PMatrix) );
+        hiptmairPostSmoother_ = rcp( new Ifpack2::Hiptmair<TROW>(EdgeMatrix,NodeMatrix,PMatrix) );
         hiptmairPostSmoother_ -> setParameters(hiptmairPostList);
         hiptmairPostSmoother_ -> initialize();
         hiptmairPostSmoother_ -> compute();
@@ -470,7 +704,7 @@ namespace MueLu {
           std::string preSmootherType = parameterList_.get<std::string>("smoother: pre type");
           std::string postSmootherType = parameterList_.get<std::string>("smoother: post type");
 
-          Teuchos::ParameterList preSmootherList, postSmootherList;
+          ParameterList preSmootherList, postSmootherList;
           if (parameterList_.isSublist("smoother: pre params"))
             preSmootherList = parameterList_.sublist("smoother: pre params");
           if (parameterList_.isSublist("smoother: post params"))
@@ -518,11 +752,21 @@ namespace MueLu {
     }
 
     // Allocate temporary MultiVectors for solve
-    P11res_ = MultiVectorFactory::Build(P11_->getDomainMap(),1);
-    P11x_   = MultiVectorFactory::Build(P11_->getDomainMap(),1);
-    D0res_  = MultiVectorFactory::Build(D0_Matrix_->getDomainMap(),1);
-    D0x_    = MultiVectorFactory::Build(D0_Matrix_->getDomainMap(),1);
-    residual_ = MultiVectorFactory::Build(SM_Matrix_->getDomainMap(),1);
+    P11res_    = MultiVectorFactory::Build(R11_->getRangeMap(), 1);
+    if (!ImporterH_.is_null()) {
+      P11resTmp_ = MultiVectorFactory::Build(ImporterH_->getTargetMap(), 1);
+      P11xTmp_   = MultiVectorFactory::Build(ImporterH_->getSourceMap(), 1);
+      P11x_      = MultiVectorFactory::Build(ImporterH_->getTargetMap(), 1);
+    } else
+      P11x_      = MultiVectorFactory::Build(P11_->getDomainMap(), 1);
+    D0res_     = MultiVectorFactory::Build(D0_T_Matrix_->getRangeMap(), 1);
+    if (!Importer22_.is_null()) {
+      D0resTmp_ = MultiVectorFactory::Build(Importer22_->getTargetMap(), 1);
+      D0xTmp_   = MultiVectorFactory::Build(Importer22_->getSourceMap(), 1);
+      D0x_      = MultiVectorFactory::Build(Importer22_->getTargetMap(), 1);
+    } else
+      D0x_      = MultiVectorFactory::Build(D0_Matrix_->getDomainMap(), 1);
+    residual_  = MultiVectorFactory::Build(SM_Matrix_->getDomainMap(), 1);
 
 #ifdef HAVE_MUELU_CUDA
     if (parameterList_.get<bool>("refmaxwell: cuda profile setup", false)) cudaProfilerStop();
@@ -561,13 +805,15 @@ namespace MueLu {
       }
 #endif
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("nullspace.mat"), *Nullspace_);
-      if (Coords_ != Teuchos::null)
+      if (Coords_ != null)
         Xpetra::IO<double, LO, GlobalOrdinal, Node>::Write(std::string("coords.mat"), *Coords_);
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("D0_nuked.mat"), *D0_Matrix_);
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("A_nodal.mat"), *A_nodal_Matrix_);
       Xpetra::IO<SC, LO, GO, NO>::Write(std::string("P11.mat"), *P11_);
-      Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("AH.mat"), *AH_);
-      Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("A22.mat"), *A22_);
+      if (!AH_.is_null())
+        Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("AH.mat"), *AH_);
+      if (!A22_.is_null())
+        Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("A22.mat"), *A22_);
     }
 
     VerboseObject::SetDefaultVerbLevel(oldVerbLevel);
@@ -603,8 +849,8 @@ namespace MueLu {
       P_nodal = Xpetra::IO<SC, LO, GO, NO>::Read(P_filename, A_nodal_Matrix_->getDomainMap());
     } else {
       Level fineLevel, coarseLevel;
-      fineLevel.SetFactoryManager(Teuchos::null);
-      coarseLevel.SetFactoryManager(Teuchos::null);
+      fineLevel.SetFactoryManager(null);
+      coarseLevel.SetFactoryManager(null);
       coarseLevel.SetPreviousLevel(rcpFromRef(fineLevel));
       fineLevel.SetLevelID(0);
       coarseLevel.SetLevelID(1);
@@ -676,7 +922,7 @@ namespace MueLu {
     if (numProcs > 1) {
       RCP<CrsMatrixWrap> P_nodal_temp;
       RCP<const Map> targetMap = D0Crs->getColMap();
-      P_nodal_temp = Teuchos::rcp(new CrsMatrixWrap(targetMap, 0));
+      P_nodal_temp = rcp(new CrsMatrixWrap(targetMap, 0));
       RCP<const Import> importer = D0Crs->getCrsGraph()->getImporter();
       P_nodal_temp->doImport(*P_nodal, *importer, Xpetra::INSERT);
       P_nodal_temp->fillComplete(rcp_dynamic_cast<CrsMatrixWrap>(P_nodal)->getCrsMatrix()->getDomainMap(),
@@ -711,7 +957,7 @@ namespace MueLu {
       std::string algo = parameterList_.get("refmaxwell: prolongator compute algorithm",defaultAlgo);
 
       if (algo == "mat-mat") {
-        Teuchos::RCP<Matrix> D0_P_nodal = MatrixFactory::Build(SM_Matrix_->getRowMap(),0);
+        RCP<Matrix> D0_P_nodal = MatrixFactory::Build(SM_Matrix_->getRowMap(),0);
         Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*D0_Matrix_,false,*P_nodal,false,*D0_P_nodal,true,true);
 
         // Get data out of D0*P.
@@ -802,7 +1048,7 @@ namespace MueLu {
                                });
         }
 
-        P11_ = Teuchos::rcp(new CrsMatrixWrap(SM_Matrix_->getRowMap(), blockColMap, 0, Xpetra::StaticProfile));
+        P11_ = rcp(new CrsMatrixWrap(SM_Matrix_->getRowMap(), blockColMap, 0, Xpetra::StaticProfile));
         RCP<CrsMatrix> P11Crs = rcp_dynamic_cast<CrsMatrixWrap>(P11_)->getCrsMatrix();
         P11Crs->setAllValues(P11rowptr, P11colind, P11vals);
         P11Crs->expertStaticFillComplete(blockDomainMap, SM_Matrix_->getRangeMap());
@@ -850,7 +1096,7 @@ namespace MueLu {
     std::string algo = parameterList_.get("refmaxwell: prolongator compute algorithm",defaultAlgo);
 
     if (algo == "mat-mat") {
-      Teuchos::RCP<Matrix> D0_P_nodal = MatrixFactory::Build(SM_Matrix_->getRowMap(),0);
+      RCP<Matrix> D0_P_nodal = MatrixFactory::Build(SM_Matrix_->getRowMap(),0);
       Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*D0_Matrix_,false,*P_nodal,false,*D0_P_nodal,true,true);
 
       // Get data out of D0*P.
@@ -869,7 +1115,7 @@ namespace MueLu {
       // Create the matrix object
       RCP<Map> blockColMap    = Xpetra::MapFactory<LO,GO,NO>::Build(P_nodal_imported->getColMap(), dim);
       RCP<Map> blockDomainMap = Xpetra::MapFactory<LO,GO,NO>::Build(P_nodal->getDomainMap(), dim);
-      P11_ = Teuchos::rcp(new CrsMatrixWrap(SM_Matrix_->getRowMap(), blockColMap, 0, Xpetra::StaticProfile));
+      P11_ = rcp(new CrsMatrixWrap(SM_Matrix_->getRowMap(), blockColMap, 0, Xpetra::StaticProfile));
       RCP<CrsMatrix> P11Crs = rcp_dynamic_cast<CrsMatrixWrap>(P11_)->getCrsMatrix();
       P11Crs->allocateAllValues(dim*D0Pcolind.size(), P11rowptr_RCP, P11colind_RCP, P11vals_RCP);
 
@@ -962,7 +1208,7 @@ namespace MueLu {
       // Create the matrix object
       RCP<Map> blockColMap    = Xpetra::MapFactory<LO,GO,NO>::Build(P_nodal_imported->getColMap(), dim);
       RCP<Map> blockDomainMap = Xpetra::MapFactory<LO,GO,NO>::Build(P_nodal->getDomainMap(), dim);
-      P11_ = Teuchos::rcp(new CrsMatrixWrap(SM_Matrix_->getRowMap(), blockColMap, 0, Xpetra::StaticProfile));
+      P11_ = rcp(new CrsMatrixWrap(SM_Matrix_->getRowMap(), blockColMap, 0, Xpetra::StaticProfile));
       RCP<CrsMatrix> P11Crs = rcp_dynamic_cast<CrsMatrixWrap>(P11_)->getCrsMatrix();
       P11Crs->allocateAllValues(nnz_alloc, P11rowptr_RCP, P11colind_RCP, P11vals_RCP);
 
@@ -1068,9 +1314,9 @@ namespace MueLu {
     Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: Build coarse (1,1) matrix"));
     
     // coarse matrix for P11* (M1 + D1* M2 D1) P11
-    Teuchos::RCP<Matrix> Matrix1 = MatrixFactory::Build(P11_->getDomainMap(),0);
+    RCP<Matrix> Matrix1 = MatrixFactory::Build(P11_->getDomainMap(),0);
     if (parameterList_.get<bool>("rap: triple product", false) == false) {
-      Teuchos::RCP<Matrix> C = MatrixFactory::Build(SM_Matrix_->getRowMap(),0);
+      RCP<Matrix> C = MatrixFactory::Build(SM_Matrix_->getRowMap(),0);
       // construct (M1 + D1* M2 D1) P11
       Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*SM_Matrix_,false,*P11_,false,*C,true,true);
       // construct P11* (M1 + D1* M2 D1) P11
@@ -1096,8 +1342,8 @@ namespace MueLu {
                                  "lumped mass matrix required for add-on (i.e. M0inv_Matrix is null)");
 
       // coarse matrix for add-on, i.e P11* (M1 D0 M0inv D0* M1) P11
-      Teuchos::RCP<Matrix> Zaux = MatrixFactory::Build(M1_Matrix_->getRowMap(),0);
-      Teuchos::RCP<Matrix> Z = MatrixFactory::Build(D0_Matrix_->getDomainMap(),0);
+      RCP<Matrix> Zaux = MatrixFactory::Build(M1_Matrix_->getRowMap(),0);
+      RCP<Matrix> Z = MatrixFactory::Build(D0_Matrix_->getDomainMap(),0);
 
       // construct Zaux = M1 P11
       Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*M1_Matrix_,false,*P11_,false,*Zaux,true,true);
@@ -1105,7 +1351,7 @@ namespace MueLu {
       Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*D0_Matrix_,true,*Zaux,false,*Z,true,true);
 
       // construct Z* M0inv Z
-      Teuchos::RCP<Matrix> Matrix2 = MatrixFactory::Build(Z->getDomainMap(),0);
+      RCP<Matrix> Matrix2 = MatrixFactory::Build(Z->getDomainMap(),0);
       if (M0inv_Matrix_->getGlobalMaxNumRowEntries()<=1) {
         // We assume that if M0inv has at most one entry per row then
         // these are all diagonal entries.
@@ -1130,7 +1376,7 @@ namespace MueLu {
         }
         Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*ZT,false,*Z,false,*Matrix2,true,true);
       } else if (parameterList_.get<bool>("rap: triple product", false) == false) {
-        Teuchos::RCP<Matrix> C2 = MatrixFactory::Build(M0inv_Matrix_->getRowMap(),0);
+        RCP<Matrix> C2 = MatrixFactory::Build(M0inv_Matrix_->getRowMap(),0);
         // construct C2 = M0inv Z
         Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Multiply(*M0inv_Matrix_,false,*Z,false,*C2,true,true);
         // construct Matrix2 = Z* M0inv Z = Z* C2
@@ -1154,8 +1400,59 @@ namespace MueLu {
 
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::resetMatrix(Teuchos::RCP<Matrix> SM_Matrix_new) {
+  void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::resetMatrix(RCP<Matrix> SM_Matrix_new) {
     SM_Matrix_ = SM_Matrix_new;
+  }
+
+
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::solveH() const {
+
+    // iterate on coarse (1, 1) block
+    if (!ImporterH_.is_null()) {
+      P11resTmp_->doImport(*P11res_, *ImporterH_, Xpetra::INSERT);
+      P11res_.swap(P11resTmp_);
+    }
+    if (!AH_.is_null()) {
+      RCP<const Map> origXMap = P11x_->getMap();
+      RCP<const Map> origRhsMap = P11res_->getMap();
+
+      // Replace maps with maps with a subcommunicator
+      P11res_->replaceMap(AH_->getRangeMap());
+      P11x_  ->replaceMap(AH_->getDomainMap());
+      HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
+      P11x_  ->replaceMap(origXMap);
+      P11res_->replaceMap(origRhsMap);
+    }
+    if (!ImporterH_.is_null()) {
+      P11xTmp_->doExport(*P11x_, *ImporterH_, Xpetra::INSERT);
+      P11x_.swap(P11xTmp_);
+    }
+  }
+
+
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::solve22() const {
+    // iterate on (2, 2) block
+    if (!Importer22_.is_null()) {
+      D0resTmp_->doImport(*D0res_, *Importer22_, Xpetra::INSERT);
+      D0res_.swap(D0resTmp_);
+    }
+    if (!A22_.is_null()) {
+      RCP<const Map> origXMap = D0x_->getMap();
+      RCP<const Map> origRhsMap = D0res_->getMap();
+
+      // Replace maps with maps with a subcommunicator
+      D0res_->replaceMap(A22_->getRangeMap());
+      D0x_  ->replaceMap(A22_->getDomainMap());
+      Hierarchy22_->Iterate(*D0res_, *D0x_, 1, true);
+      D0x_  ->replaceMap(origXMap);
+      D0res_->replaceMap(origRhsMap);
+    }
+    if (!Importer22_.is_null()) {
+      D0xTmp_->doExport(*D0x_, *Importer22_, Xpetra::INSERT);
+      D0x_.swap(D0xTmp_);
+    }
   }
 
 
@@ -1170,13 +1467,64 @@ namespace MueLu {
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
 
     // block diagonal preconditioner on 2x2 (V-cycle for diagonal blocks)
-    HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
-    Hierarchy22_->Iterate(*D0res_,  *D0x_,  1, true);
+
+    if (!ImporterH_.is_null()) {
+      P11resTmp_->doImport(*P11res_, *ImporterH_, Xpetra::INSERT);
+      P11res_.swap(P11resTmp_);
+    }
+    if (!Importer22_.is_null()) {
+      D0resTmp_->doImport(*D0res_, *Importer22_, Xpetra::INSERT);
+      D0res_.swap(D0resTmp_);
+    }
+
+    // iterate on coarse (1, 1) block
+    if (!AH_.is_null()) {
+      RCP<const Map> origXMap = P11x_->getMap();
+      RCP<const Map> origRhsMap = P11res_->getMap();
+
+      // Replace maps with maps with a subcommunicator
+      P11res_->replaceMap(AH_->getRangeMap());
+      P11x_  ->replaceMap(AH_->getDomainMap());
+      HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
+      P11x_  ->replaceMap(origXMap);
+      P11res_->replaceMap(origRhsMap);
+    }
+
+    // iterate on (2, 2) block
+    if (!A22_.is_null()) {
+      RCP<const Map> origXMap = D0x_->getMap();
+      RCP<const Map> origRhsMap = D0res_->getMap();
+
+      // Replace maps with maps with a subcommunicator
+      D0res_->replaceMap(A22_->getRangeMap());
+      D0x_  ->replaceMap(A22_->getDomainMap());
+      Hierarchy22_->Iterate(*D0res_, *D0x_, 1, true);
+      D0x_  ->replaceMap(origXMap);
+      D0res_->replaceMap(origRhsMap);
+    }
+
+    if (!ImporterH_.is_null()) {
+      P11xTmp_->doExport(*P11x_, *ImporterH_, Xpetra::INSERT);
+      P11x_.swap(P11xTmp_);
+    }
+    if (!Importer22_.is_null()) {
+      D0xTmp_->doExport(*D0x_, *Importer22_, Xpetra::INSERT);
+      D0x_.swap(D0xTmp_);
+    }
 
     // update current solution
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS,one,one);
     X.update(one, *residual_, one);
+
+    if (!ImporterH_.is_null()) {
+      P11res_.swap(P11resTmp_);
+      P11x_.swap(P11xTmp_);
+    }
+    if (!Importer22_.is_null()) {
+      D0res_.swap(D0resTmp_);
+      D0x_.swap(D0xTmp_);
+    }
 
   }
 
@@ -1189,25 +1537,37 @@ namespace MueLu {
     SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
     residual_->update(one, RHS, negone);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
-    HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
+    solveH();
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+    if (!ImporterH_.is_null()) {
+      P11res_.swap(P11resTmp_);
+      P11x_.swap(P11xTmp_);
+    }
 
     // precondition (2,2)-block
     SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
     residual_->update(one, RHS, negone);
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
-    Hierarchy22_->Iterate(*D0res_,  *D0x_,  1, true);
+    solve22();
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+    if (!Importer22_.is_null()) {
+      D0res_.swap(D0resTmp_);
+      D0x_.swap(D0xTmp_);
+    }
 
     // precondition (1,1)-block
     SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
     residual_->update(one, RHS, negone);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
-    HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
+    solveH();
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+    if (!ImporterH_.is_null()) {
+      P11res_.swap(P11resTmp_);
+      P11x_.swap(P11xTmp_);
+    }
 
   }
 
@@ -1220,25 +1580,37 @@ namespace MueLu {
     SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
     residual_->update(one, RHS, negone);
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
-    Hierarchy22_->Iterate(*D0res_,  *D0x_,  1, true);
+    solve22();
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+    if (!Importer22_.is_null()) {
+      D0res_.swap(D0resTmp_);
+      D0x_.swap(D0xTmp_);
+    }
 
     // precondition (1,1)-block
     SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
     residual_->update(one, RHS, negone);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
-    HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
+    solveH();
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+    if (!ImporterH_.is_null()) {
+      P11res_.swap(P11resTmp_);
+      P11x_.swap(P11xTmp_);
+    }
 
     // precondition (2,2)-block
     SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
     residual_->update(one, RHS, negone);
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
-    Hierarchy22_->Iterate(*D0res_,  *D0x_,  1, true);
+    solve22();
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+    if (!Importer22_.is_null()) {
+      D0res_.swap(D0resTmp_);
+      D0x_.swap(D0xTmp_);
+    }
 
   }
 
@@ -1251,12 +1623,16 @@ namespace MueLu {
     residual_->update(one, RHS, negone);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
 
-    // block diagonal preconditioner on 2x2 (V-cycle for diagonal blocks)
-    HierarchyH_->Iterate(*P11res_, *P11x_, 1, true);
+    solveH();
 
     // update current solution
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
     X.update(one, *residual_, one);
+
+    if (!ImporterH_.is_null()) {
+      P11res_.swap(P11resTmp_);
+      P11x_.swap(P11xTmp_);
+    }
 
   }
 
@@ -1271,11 +1647,21 @@ namespace MueLu {
 
     // make sure that we have enough temporary memory
     if (X.getNumVectors() != P11res_->getNumVectors()) {
-      P11res_    = MultiVectorFactory::Build(P11_->getDomainMap(),X.getNumVectors());
-      P11x_      = MultiVectorFactory::Build(P11_->getDomainMap(),X.getNumVectors());
-      D0res_     = MultiVectorFactory::Build(D0_Matrix_->getDomainMap(),X.getNumVectors());
-      D0x_       = MultiVectorFactory::Build(D0_Matrix_->getDomainMap(),X.getNumVectors());
-      residual_  = MultiVectorFactory::Build(SM_Matrix_->getDomainMap(),1);
+      P11res_    = MultiVectorFactory::Build(R11_->getRangeMap(), X.getNumVectors());
+      if (!ImporterH_.is_null()) {
+        P11resTmp_ = MultiVectorFactory::Build(ImporterH_->getTargetMap(), X.getNumVectors());
+        P11xTmp_   = MultiVectorFactory::Build(ImporterH_->getSourceMap(), X.getNumVectors());
+        P11x_      = MultiVectorFactory::Build(ImporterH_->getTargetMap(), X.getNumVectors());
+      } else
+        P11x_      = MultiVectorFactory::Build(P11_->getDomainMap(), X.getNumVectors());
+      if (!Importer22_.is_null()) {
+        D0resTmp_ = MultiVectorFactory::Build(Importer22_->getTargetMap(), X.getNumVectors());
+        D0xTmp_   = MultiVectorFactory::Build(Importer22_->getSourceMap(), X.getNumVectors());
+        D0x_      = MultiVectorFactory::Build(Importer22_->getTargetMap(), X.getNumVectors());
+      } else
+        D0x_      = MultiVectorFactory::Build(D0_Matrix_->getDomainMap(), X.getNumVectors());
+      residual_  = MultiVectorFactory::Build(SM_Matrix_->getDomainMap(), X.getNumVectors());
+
     }
 
     // apply pre-smoothing
@@ -1358,10 +1744,28 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
   describe(Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel verbLevel) const {
-    out << "\n--------------------------------------------------------------------------------\n" <<
+
+    std::ostringstream oss;
+
+    RCP<const Teuchos::Comm<int> > comm = SM_Matrix_->getDomainMap()->getComm();
+
+    int root;
+    if (!A22_.is_null())
+      root = comm->getRank();
+    else
+      root = -1;
+
+#ifdef HAVE_MPI
+    int actualRoot;
+    reduceAll(*comm, Teuchos::REDUCE_MAX, root, Teuchos::ptr(&actualRoot));
+    root = actualRoot;
+#endif
+
+
+    oss << "\n--------------------------------------------------------------------------------\n" <<
       "---                            RefMaxwell Summary                            ---\n"
       "--------------------------------------------------------------------------------" << std::endl;
-    out << std::endl;
+    oss << std::endl;
 
     GlobalOrdinal numRows;
     GlobalOrdinal nnz;
@@ -1374,15 +1778,81 @@ namespace MueLu {
     tt = nnz;
     int nnzspacer = 2; while (tt != 0) { tt /= 10; nnzspacer++; }
 
-    out  << "block " << std::setw(rowspacer) << " rows " << std::setw(nnzspacer) << " nnz " << std::setw(9) << " nnz/row" << std::endl;
-    out << "(1, 1)" << std::setw(rowspacer) << numRows << std::setw(nnzspacer) << nnz << std::setw(9) << as<double>(nnz) / numRows << std::endl;
+    oss  << "block " << std::setw(rowspacer) << " rows " << std::setw(nnzspacer) << " nnz " << std::setw(9) << " nnz/row" << std::endl;
+    oss << "(1, 1)" << std::setw(rowspacer) << numRows << std::setw(nnzspacer) << nnz << std::setw(9) << as<double>(nnz) / numRows << std::endl;
 
-    numRows = A22_->getGlobalNumRows();
-    nnz = A22_->getGlobalNumEntries();
+    if (!A22_.is_null()) {
+      // ToDo: make sure that this is printed correctly
+      numRows = A22_->getGlobalNumRows();
+      nnz = A22_->getGlobalNumEntries();
 
-    out << "(2, 2)" << std::setw(rowspacer) << numRows << std::setw(nnzspacer) << nnz << std::setw(9) << as<double>(nnz) / numRows << std::endl;
+      oss << "(2, 2)" << std::setw(rowspacer) << numRows << std::setw(nnzspacer) << nnz << std::setw(9) << as<double>(nnz) / numRows << std::endl;
+    }
 
-    out << std::endl;
+    oss << std::endl;
+
+    std::string outstr = oss.str();
+
+#ifdef HAVE_MPI
+    RCP<const Teuchos::MpiComm<int> > mpiComm = rcp_dynamic_cast<const Teuchos::MpiComm<int> >(comm);
+    MPI_Comm rawComm = (*mpiComm->getRawMpiComm())();
+
+    int strLength = outstr.size();
+    MPI_Bcast(&strLength, 1, MPI_INT, root, rawComm);
+    if (comm->getRank() != root)
+      outstr.resize(strLength);
+    MPI_Bcast(&outstr[0], strLength, MPI_CHAR, root, rawComm);
+#endif
+
+    out << outstr;
+
+    if (IsPrint(Statistics2)) {
+      // Print the grid of processors
+      std::ostringstream oss2;
+
+      oss2 << "Sub-solver distribution over ranks" << std::endl;
+      oss2 << "( (1,1) block only is indicated by '1', (2,2) block only by '2', and both blocks by 'B' and none by '.')" << std::endl;
+
+      int numProcs = comm->getSize();
+#ifdef HAVE_MPI
+      RCP<const Teuchos::MpiComm<int> > tmpic = rcp_dynamic_cast<const Teuchos::MpiComm<int> >(comm);
+      TEUCHOS_TEST_FOR_EXCEPTION(tmpic == Teuchos::null, Exceptions::RuntimeError, "Cannot cast base Teuchos::Comm to Teuchos::MpiComm object.");
+      RCP<const Teuchos::OpaqueWrapper<MPI_Comm> > rawMpiComm = tmpic->getRawMpiComm();
+#endif
+
+      char status = 0;
+      if (!AH_.is_null())
+        status += 1;
+      if (!A22_.is_null())
+        status += 2;
+      std::vector<char> states(numProcs, 0);
+#ifdef HAVE_MPI
+      MPI_Gather(&status, 1, MPI_CHAR, &states[0], 1, MPI_CHAR, 0, *rawMpiComm);
+#else
+      states.push_back(status);
+#endif
+
+      int rowWidth = std::min(Teuchos::as<int>(ceil(sqrt(numProcs))), 100);
+      for (int proc = 0; proc < numProcs; proc += rowWidth) {
+        for (int j = 0; j < rowWidth; j++)
+          if (proc + j < numProcs)
+            if (states[proc+j] == 0)
+              oss2 << ".";
+            else if (states[proc+j] == 1)
+              oss2 << "1";
+            else if (states[proc+j] == 2)
+              oss2 << "2";
+            else
+              oss2 << "B";
+          else
+            oss2 << " ";
+
+        oss2 << "      " << proc << ":" << std::min(proc + rowWidth, numProcs) - 1 << std::endl;
+      }
+      oss2 << std::endl;
+      GetOStream(Statistics2) << oss2.str();
+    }
+
 
   }
 

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1058,6 +1058,15 @@
     </parameter>
 
     <parameter>
+      <name>repartition: rebalance Nullspace</name>
+      <type>bool</type>
+      <default>true</default>
+      <description>Rebalancing of Nullspace during the setup.</description>
+      <visible>false</visible>
+      <comment-ML>not supported by ML</comment-ML>
+    </parameter>
+
+    <parameter>
       <name>repartition: use subcommunicators</name>
       <type>bool</type>
       <default>true</default>

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1032,6 +1032,15 @@
     </parameter>
 
     <parameter>
+      <name>repartition: remap accept partition</name>
+      <type>bool</type>
+      <default>true</default>
+      <description>Whether the local rank should accept a partition.</description>
+      <visible>false</visible>
+      <comment-ML>not supported by ML</comment-ML>
+    </parameter>
+
+    <parameter>
       <name>repartition: print partition distribution</name>
       <type>bool</type>
       <default>false</default>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -213,6 +213,8 @@
         
 \cbb{repartition: remap num values}{int}{4}{Number of maximum components from each processor used to construct partial bipartite graph.}
         
+\cbb{repartition: remap accept partition}{bool}{true}{Whether the local rank should accept a partition.}
+        
 \cbb{repartition: print partition distribution}{bool}{false}{Partition distribution printout.}
         
 \cbb{repartition: rebalance P and R}{bool}{false}{Explicit rebalancing of R and P during the setup. This speeds up the solve, but slows down the setup phases.}

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -219,6 +219,8 @@
         
 \cbb{repartition: rebalance P and R}{bool}{false}{Explicit rebalancing of R and P during the setup. This speeds up the solve, but slows down the setup phases.}
         
+\cbb{repartition: rebalance Nullspace}{bool}{true}{Rebalancing of Nullspace during the setup.}
+        
 \cbb{repartition: use subcommunicators}{bool}{true}{Use subcommunicators on coarser levels.}
         
 \cbb{rap: fix zero diagonals}{bool}{false}{Set zero diagonals on coarse grids to one.}

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -247,6 +247,7 @@ namespace MueLu {
   "<Parameter name=\"repartition: max imbalance\" type=\"double\" value=\"1.2\"/>"
   "<Parameter name=\"repartition: remap parts\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"repartition: remap num values\" type=\"int\" value=\"4\"/>"
+  "<Parameter name=\"repartition: remap accept partition\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"repartition: print partition distribution\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"repartition: rebalance P and R\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"repartition: use subcommunicators\" type=\"bool\" value=\"true\"/>"
@@ -641,6 +642,8 @@ namespace MueLu {
          ("repartition: remap parts","repartition: remap parts")
       
          ("repartition: remap num values","repartition: remap num values")
+      
+         ("repartition: remap accept partition","repartition: remap accept partition")
       
          ("repartition: print partition distribution","repartition: print partition distribution")
       

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -250,6 +250,7 @@ namespace MueLu {
   "<Parameter name=\"repartition: remap accept partition\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"repartition: print partition distribution\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"repartition: rebalance P and R\" type=\"bool\" value=\"false\"/>"
+  "<Parameter name=\"repartition: rebalance Nullspace\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"repartition: use subcommunicators\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"rap: fix zero diagonals\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"rap: fix zero diagonals threshold\" type=\"double\" value=\"0.\"/>"
@@ -648,6 +649,8 @@ namespace MueLu {
          ("repartition: print partition distribution","repartition: print partition distribution")
       
          ("repartition: rebalance P and R","repartition: rebalance P and R")
+      
+         ("repartition: rebalance Nullspace","repartition: rebalance Nullspace")
       
          ("repartition: use subcommunicators","repartition: use subcommunicators")
       

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
@@ -74,6 +74,7 @@ namespace MueLu {
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))
     SET_VALID_ENTRY("repartition: rebalance P and R");
+    SET_VALID_ENTRY("repartition: rebalance Nullspace");
     SET_VALID_ENTRY("transpose: use implicit");
     SET_VALID_ENTRY("repartition: use subcommunicators");
 #undef  SET_VALID_ENTRY
@@ -105,7 +106,8 @@ namespace MueLu {
 
     if (pL.get<std::string>("type") == "Interpolation") {
       Input(coarseLevel, "P");
-      Input(coarseLevel, "Nullspace");
+      if (pL.get<bool>("repartition: rebalance Nullspace"))
+        Input(coarseLevel, "Nullspace");
       if (pL.get< RCP<const FactoryBase> >("Coordinates") != Teuchos::null)
         Input(coarseLevel, "Coordinates");
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_decl.hpp
@@ -154,9 +154,11 @@ namespace MueLu {
       @brief Determine which process should own each partition.
 
       Partitions are assigned to processes in order to minimize data movement.  The basic idea is that a good choice for partition
-      owner is to choose the pid that already has the greatest number of nonzeros for a particular partition.
+      owner is to choose the pid that already has the greatest number of nonzeros for a particular partition. If willAcceptPartition=false
+      is set on a rank, no partition will be placed there.
+
     */
-    void DeterminePartitionPlacement(const Matrix& A, GOVector& decomposition, GO numPartitions) const;
+    void DeterminePartitionPlacement(const Matrix& A, GOVector& decomposition, GO numPartitions, bool willAcceptPartition=true, bool allSubdomainsAcceptPartitions=true) const;
 
   }; // class RepartitionFactory
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_decl.hpp
@@ -65,6 +65,7 @@
 #include "MueLu_RepartitionFactory_fwd.hpp"
 #include "MueLu_CloneRepartitionInterface_fwd.hpp"
 #include "MueLu_Utilities_fwd.hpp"
+#include "MueLu_PerfUtils_fwd.hpp"
 
 namespace MueLu {
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
@@ -86,6 +86,7 @@ namespace MueLu {
     SET_VALID_ENTRY("repartition: print partition distribution");
     SET_VALID_ENTRY("repartition: remap parts");
     SET_VALID_ENTRY("repartition: remap num values");
+    SET_VALID_ENTRY("repartition: remap accept partition");
 #undef  SET_VALID_ENTRY
 
     validParamList->set< RCP<const FactoryBase> >("A",                    Teuchos::null, "Factory of the matrix A");
@@ -197,7 +198,24 @@ namespace MueLu {
     if (remapPartitions) {
       SubFactoryMonitor m1(*this, "DeterminePartitionPlacement", currentLevel);
 
-      DeterminePartitionPlacement(*A, *decomposition, numPartitions);
+      bool acceptPartition = pL.get<bool>("repartition: remap accept partition");
+      bool allSubdomainsAcceptPartitions;
+      int localNumAcceptPartition = acceptPartition;
+      int globalNumAcceptPartition;
+      MueLu_sumAll(comm, localNumAcceptPartition, globalNumAcceptPartition);
+      GetOStream(Statistics2) << "Number of ranks that accept partitions: " << globalNumAcceptPartition << std::endl;
+      if (globalNumAcceptPartition < numPartitions) {
+        GetOStream(Warnings0) << "Not enough ranks are willing to accept a partition, allowing partitions on all ranks." << std::endl;
+        acceptPartition = true;
+        allSubdomainsAcceptPartitions = true;
+      } else if (numPartitions > numProcs) {
+        // We are trying to repartition to a larger communicator.
+        allSubdomainsAcceptPartitions = true;
+      } else {
+        allSubdomainsAcceptPartitions = false;
+      }
+
+      DeterminePartitionPlacement(*A, *decomposition, numPartitions, acceptPartition, allSubdomainsAcceptPartitions);
     }
 
     // ======================================================================================================
@@ -399,7 +417,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RepartitionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  DeterminePartitionPlacement(const Matrix& A, GOVector& decomposition, GO numPartitions) const {
+  DeterminePartitionPlacement(const Matrix& A, GOVector& decomposition, GO numPartitions, bool willAcceptPartition, bool allSubdomainsAcceptPartitions) const {
     RCP<const Map> rowMap = A.getRowMap();
 
     RCP<const Teuchos::Comm<int> > comm = rowMap->getComm()->duplicate();
@@ -433,8 +451,9 @@ namespace MueLu {
     // We use two maps, original which maps a partition id of an edge to the corresponding weight,
     // and a reverse one, which is necessary to sort by edges.
     std::map<GO,GO> lEdges;
-    for (LO i = 0; i < decompEntries.size(); i++)
-      lEdges[decompEntries[i]] += A.getNumEntriesInLocalRow(i);
+    if (willAcceptPartition)
+      for (LO i = 0; i < decompEntries.size(); i++)
+        lEdges[decompEntries[i]] += A.getNumEntriesInLocalRow(i);
 
     // Reverse map, so that edges are sorted by weight.
     // This results in multimap, as we may have edges with the same weight
@@ -462,14 +481,17 @@ namespace MueLu {
 
     // Construct the set of triplets
     std::vector<Triplet<int,int> > gEdges(numProcs * maxLocal);
+    std::vector<bool> procWillAcceptPartition(numProcs, allSubdomainsAcceptPartitions);
     size_t k = 0;
     for (LO i = 0; i < gData.size(); i += 2) {
+      int procNo = i/dataSize;              // determine the processor by its offset (since every processor sends the same amount)
       GO part   = gData[i+0];
       GO weight = gData[i+1];
       if (part != -1) {                     // skip nonexistent edges
-        gEdges[k].i = i/dataSize;           // determine the processor by its offset (since every processor sends the same amount)
+        gEdges[k].i = procNo;
         gEdges[k].j = part;
         gEdges[k].v = weight;
+        procWillAcceptPartition[procNo] = true;
         k++;
       }
     }
@@ -503,8 +525,8 @@ namespace MueLu {
     if (numPartitions - numMatched > 0) {
       for (int part = 0, matcher = 0; part < numProcs; part++) {
         if (match.count(part) == 0) {
-          // Find first non-matched rank
-          while (matchedRanks[matcher])
+          // Find first non-matched rank that accepts partitions
+          while (matchedRanks[matcher] || !procWillAcceptPartition[matcher])
             matcher++;
 
           match[part] = matcher++;

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
@@ -75,6 +75,7 @@
 #include "MueLu_Level.hpp"
 #include "MueLu_MasterList.hpp"
 #include "MueLu_Monitor.hpp"
+#include "MueLu_PerfUtils.hpp"
 
 namespace MueLu {
 
@@ -382,6 +383,11 @@ namespace MueLu {
     // ======================================================================================================
     // Print some data
     // ======================================================================================================
+    if (!rowMapImporter.is_null() && IsPrint(Statistics2)) {
+      // int oldRank = SetProcRankVerbose(rebalancedAc->getRowMap()->getComm()->getRank());
+      GetOStream(Statistics2) << PerfUtils::PrintImporterInfo(rowMapImporter, "Importer for rebalancing");
+      // SetProcRankVerbose(oldRank);
+    }
     if (pL.get<bool>("repartition: print partition distribution") && IsPrint(Statistics2)) {
       // Print the grid of processors
       GetOStream(Statistics2) << "Partition distribution over cores (ownership is indicated by '+')" << std::endl;

--- a/packages/muelu/src/Utils/MueLu_PerfUtils_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_PerfUtils_decl.hpp
@@ -76,6 +76,8 @@ namespace MueLu {
   public:
     static std::string PrintMatrixInfo(const Matrix& A, const std::string& msgTag, RCP<const Teuchos::ParameterList> params = Teuchos::null);
 
+    static std::string PrintImporterInfo(RCP<const Import> importer, const std::string& msgTag);
+
     static std::string CommPattern(const Matrix& A, const std::string& msgTag, RCP<const Teuchos::ParameterList> params = Teuchos::null);
 
   private:

--- a/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
@@ -96,9 +96,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -108,6 +110,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
@@ -106,9 +106,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -118,6 +120,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
@@ -96,9 +96,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -108,6 +110,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -213,9 +216,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -225,6 +230,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -331,9 +337,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -343,6 +351,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -449,9 +458,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -461,6 +472,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -567,9 +579,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -579,6 +593,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -106,9 +106,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -118,6 +120,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -233,9 +236,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -245,6 +250,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -361,9 +367,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -373,6 +381,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -489,9 +498,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -501,6 +512,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -617,9 +629,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -629,6 +643,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
@@ -96,9 +96,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -108,6 +110,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -213,9 +216,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -225,6 +230,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -331,9 +337,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -343,6 +351,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -449,9 +458,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -461,6 +472,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -106,9 +106,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -118,6 +120,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -233,9 +236,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -245,6 +250,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -361,9 +367,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -373,6 +381,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -489,9 +498,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -501,6 +512,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
@@ -96,9 +96,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -108,6 +110,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -213,9 +216,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -225,6 +230,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -331,9 +337,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -343,6 +351,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -449,9 +458,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -461,6 +472,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -106,9 +106,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -118,6 +120,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -233,9 +236,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -245,6 +250,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -361,9 +367,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -373,6 +381,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -489,9 +498,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -501,6 +512,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
@@ -110,9 +110,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -122,6 +124,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -242,9 +245,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -254,6 +259,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -374,9 +380,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -386,6 +394,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
@@ -110,9 +110,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -122,6 +124,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -113,9 +113,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -125,6 +127,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -113,9 +113,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -125,6 +127,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -248,9 +251,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -260,6 +265,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -383,9 +389,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -395,6 +403,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
@@ -110,9 +110,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -122,6 +124,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -242,9 +245,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -254,6 +259,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -374,9 +380,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -386,6 +394,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
@@ -110,9 +110,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -122,6 +124,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -113,9 +113,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -125,6 +127,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -113,9 +113,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -125,6 +127,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -248,9 +251,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -260,6 +265,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -383,9 +389,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -395,6 +403,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,8 +240,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -247,6 +252,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,8 +240,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -247,6 +252,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,8 +260,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -267,6 +272,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,8 +260,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -267,6 +272,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -277,6 +281,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -321,6 +326,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +273,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -313,6 +318,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -299,6 +303,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -353,6 +358,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -307,6 +311,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -361,6 +366,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,8 +240,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -247,6 +252,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -396,9 +402,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -408,6 +416,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -525,8 +534,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -535,6 +546,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,8 +240,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -247,6 +252,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -388,9 +394,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -400,6 +408,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -517,8 +526,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -527,6 +538,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,8 +260,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -267,6 +272,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -418,9 +424,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -430,6 +438,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -557,8 +566,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -567,6 +578,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,8 +260,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -267,6 +272,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -426,9 +432,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -438,6 +446,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -565,8 +574,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -575,6 +586,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,8 +240,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -247,6 +252,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,8 +240,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -247,6 +252,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,8 +260,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -267,6 +272,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,8 +260,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -267,6 +272,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -398,9 +404,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -410,6 +418,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -527,9 +536,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -539,6 +550,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -390,9 +396,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -402,6 +410,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -519,9 +528,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -531,6 +542,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -420,9 +426,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -432,6 +440,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -559,9 +568,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -571,6 +582,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -428,9 +434,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -440,6 +448,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -567,9 +576,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -579,6 +590,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -327,6 +333,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -340,6 +347,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -408,6 +416,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -421,6 +430,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -319,6 +325,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -332,6 +339,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -400,6 +408,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -413,6 +422,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -349,6 +355,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -362,6 +369,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -440,6 +448,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -453,6 +462,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -357,6 +363,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -370,6 +377,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -448,6 +456,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -461,6 +470,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -326,6 +332,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -339,6 +346,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -476,9 +484,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -488,6 +498,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
@@ -108,9 +108,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -120,6 +122,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -237,9 +240,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -249,6 +254,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -318,6 +324,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -331,6 +338,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -468,9 +476,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -480,6 +490,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -348,6 +354,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -361,6 +368,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -508,9 +516,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -520,6 +530,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -118,9 +118,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -130,6 +132,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -257,9 +260,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -269,6 +274,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -356,6 +362,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -369,6 +376,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -516,9 +524,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -528,6 +538,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -277,6 +283,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -290,6 +297,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -416,9 +424,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -428,6 +438,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -269,6 +275,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -282,6 +289,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -408,9 +416,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -420,6 +430,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -299,6 +305,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -312,6 +319,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -448,9 +456,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -460,6 +470,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -307,6 +313,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -320,6 +327,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -456,9 +464,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -468,6 +478,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
@@ -104,9 +104,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -220,9 +222,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -114,9 +114,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -240,9 +242,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
@@ -94,9 +94,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -106,6 +108,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -104,9 +104,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -116,6 +118,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
@@ -93,9 +93,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -105,6 +107,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -207,9 +210,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -219,6 +224,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -322,9 +328,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -334,6 +342,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -437,9 +446,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -449,6 +460,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -552,9 +564,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -564,6 +578,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -103,9 +103,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -115,6 +117,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -227,9 +230,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -239,6 +244,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -352,9 +358,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -364,6 +372,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -477,9 +486,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -489,6 +500,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -602,9 +614,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -614,6 +628,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
@@ -93,9 +93,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -105,6 +107,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -207,9 +210,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -219,6 +224,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -322,9 +328,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -334,6 +342,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -437,9 +446,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -449,6 +460,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -103,9 +103,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -115,6 +117,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -227,9 +230,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -239,6 +244,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -352,9 +358,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -364,6 +372,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -477,9 +486,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -489,6 +500,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
@@ -93,9 +93,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -105,6 +107,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -207,9 +210,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -219,6 +224,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -322,9 +328,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -334,6 +342,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -437,9 +446,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -449,6 +460,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -103,9 +103,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -115,6 +117,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -227,9 +230,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -239,6 +244,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -352,9 +358,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -364,6 +372,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -477,9 +486,11 @@ Build (MueLu::AmalgamationFactory)
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -489,6 +500,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -97,9 +97,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -109,6 +111,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -216,9 +219,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -228,6 +233,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -335,9 +341,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -347,6 +355,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
@@ -97,9 +97,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -109,6 +111,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -100,9 +100,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -112,6 +114,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -100,9 +100,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -112,6 +114,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -222,9 +225,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -234,6 +239,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -344,9 +350,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -356,6 +364,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -98,9 +98,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -110,6 +112,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -218,9 +221,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -230,6 +235,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -338,9 +344,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -350,6 +358,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
@@ -98,9 +98,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -110,6 +112,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -113,6 +115,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -113,6 +115,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -224,9 +227,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -236,6 +241,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -347,9 +353,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -359,6 +367,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 0   [unused]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,8 +214,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -221,6 +226,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,8 +214,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -221,6 +226,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,8 +234,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -241,6 +246,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,8 +234,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -241,6 +246,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -251,6 +255,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -291,6 +296,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +247,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -283,6 +288,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -273,6 +277,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -323,6 +328,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -281,6 +285,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -331,6 +336,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,8 +214,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -221,6 +226,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -357,9 +363,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -369,6 +377,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -473,8 +482,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -483,6 +494,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,8 +214,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -221,6 +226,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -349,9 +355,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -361,6 +369,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -465,8 +474,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -475,6 +486,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,8 +234,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -241,6 +246,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -379,9 +385,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -391,6 +399,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -505,8 +514,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -515,6 +526,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,8 +234,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -241,6 +246,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -387,9 +393,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -399,6 +407,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -513,8 +522,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -523,6 +534,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,8 +214,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -221,6 +226,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,8 +214,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -221,6 +226,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,8 +234,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -241,6 +246,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,8 +234,10 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -241,6 +246,7 @@ write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
 repartition: rebalance P and R = 1
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -359,9 +365,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -371,6 +379,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -475,9 +484,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -487,6 +498,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -351,9 +357,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -363,6 +371,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -467,9 +476,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -479,6 +490,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -381,9 +387,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -393,6 +401,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -507,9 +516,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -519,6 +530,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -389,9 +395,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -401,6 +409,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -515,9 +524,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -527,6 +538,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -297,6 +303,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -310,6 +317,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -370,6 +378,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -383,6 +392,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
@@ -95,9 +95,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -107,6 +109,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -211,9 +214,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -223,6 +228,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -289,6 +295,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -302,6 +309,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -362,6 +370,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -375,6 +384,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -319,6 +325,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -332,6 +339,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -402,6 +410,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -415,6 +424,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -105,9 +105,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -117,6 +119,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -231,9 +234,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -243,6 +248,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -327,6 +333,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -340,6 +347,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -410,6 +418,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -423,6 +432,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -96,9 +96,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -108,6 +110,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -213,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -225,6 +230,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -300,6 +306,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -313,6 +320,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -434,9 +442,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -446,6 +456,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
@@ -96,9 +96,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -108,6 +110,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -213,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -225,6 +230,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -292,6 +298,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -305,6 +312,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -426,9 +434,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -438,6 +448,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -106,9 +106,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -118,6 +120,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -233,9 +236,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -245,6 +250,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -322,6 +328,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -335,6 +342,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -466,9 +474,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -478,6 +488,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -106,9 +106,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -118,6 +120,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -233,9 +236,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -245,6 +250,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -330,6 +336,7 @@ matrixmatrix: kernel params ->
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -343,6 +350,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -474,9 +482,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -486,6 +496,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -88,9 +88,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -100,6 +102,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -197,9 +200,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -209,6 +214,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -263,6 +269,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -276,6 +283,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -391,9 +399,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -403,6 +413,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
@@ -88,9 +88,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -100,6 +102,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -197,9 +200,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -209,6 +214,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -255,6 +261,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -268,6 +275,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -383,9 +391,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -395,6 +405,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -98,9 +98,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -110,6 +112,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -217,9 +220,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -229,6 +234,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -285,6 +291,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -298,6 +305,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -423,9 +431,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -435,6 +445,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -98,9 +98,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -110,6 +112,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -217,9 +220,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -229,6 +234,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -293,6 +299,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -306,6 +313,7 @@ matrixmatrix: kernel params ->
 
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction
@@ -431,9 +439,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -443,6 +453,7 @@ write end = -1   [default]
 Build (MueLu::RebalanceTransferFactory)
 Using original restrictor
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Restriction

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
@@ -91,9 +91,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -194,9 +196,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -101,9 +101,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation
@@ -214,9 +216,11 @@ ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
 repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
+repartition: remap accept partition = 1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
+repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
 repartition: use subcommunicators = 1   [default]
 type = Interpolation

--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -13,6 +13,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyBlockPrecFiles
   SOURCE_FILES
   maxwell.xml maxwell2D.xml
   solverAugmentation.xml solverAugmentationEpetra.xml
+  solverCG.xml
   solverMueLuRefMaxwell.xml solverMueLuRefMaxwell2D.xml solverMueLuRefMaxwellEpetra.xml
   solverMueLuRefMaxwellOpenMP.xml solverMueLuRefMaxwellCuda.xml
   solverAugmentationUseILU.xml

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -139,6 +139,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     bool exodus_output = false;
     bool matrix_output = false;
     std::string input_file = "maxwell.xml";
+    std::string xml = "";
     solverType solverValues[4] = {AUGMENTATION, MUELU_REFMAXWELL, ML_REFMAXWELL, CG};
     const char * solverNames[4] = {"Augmentation", "MueLu-RefMaxwell", "ML-RefMaxwell", "CG"};
     solverType solver = MUELU_REFMAXWELL;
@@ -159,6 +160,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     clp.setOption("exodus-output","no-exodus-output",&exodus_output);
     clp.setOption("matrix-output","no-matrix-output",&matrix_output);
     clp.setOption("inputFile",&input_file,"XML file with the problem definitions");
+    clp.setOption("solverFile",&xml,"XML file with the solver params");
     clp.setOption<solverType>("solver",&solver,4,solverValues,solverNames,"Solver that is used");
     clp.setOption("numTimeSteps",&numTimeSteps);
     clp.setOption("doSolveTimings","no-doSolveTimings",&doSolveTimings,"repeat the first solve \"numTimeSteps\" times");
@@ -297,57 +299,58 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     if (dt <= 0.0)
       return EXIT_FAILURE;
 
-    // Load a solver configuration
-    // This input deck choice depends on
-    // * chosen solver
-    // * linear algebra library
-    // * spatial dimension
-    // * node type
-    std::string xml;
-    if (solver == AUGMENTATION)
-      if (linAlgebra == linAlgTpetra)
-        xml = "solverAugmentation.xml";
-      else
-        xml = "solverAugmentationEpetra.xml";
-    else if (solver == CG)
-      if (linAlgebra == linAlgTpetra)
-        xml = "solverCG.xml";
-      else
-        return EXIT_FAILURE;
-    else if (solver == MUELU_REFMAXWELL) {
-      if (linAlgebra == linAlgTpetra) {
-        if (dim == 3)
-          xml = "solverMueLuRefMaxwell.xml";
-        else
-          xml = "solverMueLuRefMaxwell2D.xml";
-#ifdef KOKKOS_ENABLE_OPENMP
-      if (typeid(panzer::TpetraNodeType).name() == typeid(Kokkos::Compat::KokkosOpenMPWrapperNode).name()) {
+    if (xml == "") {
+      // Load a solver configuration
+      // This input deck choice depends on
+      // * chosen solver
+      // * linear algebra library
+      // * spatial dimension
+      // * node type
+      if (solver == AUGMENTATION)
         if (linAlgebra == linAlgTpetra)
-          xml = "solverMueLuRefMaxwellOpenMP.xml";
-        else {
-          std::cout << std::endl
-                    << "WARNING" << std::endl
-                    << "MueLu RefMaxwell + Epetra + OpenMP does currently not work." << std::endl
-                    << "The Xpetra-Epetra interface is missing \"setAllValues\" with kokkos views." << std::endl << std::endl;
+          xml = "solverAugmentation.xml";
+        else
+          xml = "solverAugmentationEpetra.xml";
+      else if (solver == CG)
+        if (linAlgebra == linAlgTpetra)
+          xml = "solverCG.xml";
+        else
           return EXIT_FAILURE;
-          xml = "solverMueLuRefMaxwellEpetra.xml";
-        }
-      }
+      else if (solver == MUELU_REFMAXWELL) {
+        if (linAlgebra == linAlgTpetra) {
+          if (dim == 3)
+            xml = "solverMueLuRefMaxwell.xml";
+          else
+            xml = "solverMueLuRefMaxwell2D.xml";
+#ifdef KOKKOS_ENABLE_OPENMP
+          if (typeid(panzer::TpetraNodeType).name() == typeid(Kokkos::Compat::KokkosOpenMPWrapperNode).name()) {
+            if (linAlgebra == linAlgTpetra)
+              xml = "solverMueLuRefMaxwellOpenMP.xml";
+            else {
+              std::cout << std::endl
+                        << "WARNING" << std::endl
+                        << "MueLu RefMaxwell + Epetra + OpenMP does currently not work." << std::endl
+                        << "The Xpetra-Epetra interface is missing \"setAllValues\" with kokkos views." << std::endl << std::endl;
+              return EXIT_FAILURE;
+              xml = "solverMueLuRefMaxwellEpetra.xml";
+            }
+          }
 #endif
 #ifdef KOKKOS_ENABLE_CUDA
-      if (typeid(panzer::TpetraNodeType).name() == typeid(Kokkos::Compat::KokkosCudaWrapperNode).name())
-        xml = "solverMueLuRefMaxwellCuda.xml";
+          if (typeid(panzer::TpetraNodeType).name() == typeid(Kokkos::Compat::KokkosCudaWrapperNode).name())
+            xml = "solverMueLuRefMaxwellCuda.xml";
 #endif
-      } else
-        if (dim == 3) {
-          xml = "solverMueLuRefMaxwellEpetra.xml";
-        } else {
-          std::cout << std::endl
-                    << "No configuration available for 2D + Epetra." << std::endl;
-          return EXIT_FAILURE;
-        }
-    } else if (solver == ML_REFMAXWELL) {
-      xml = "solverMLRefMaxwell.xml";
+        } else
+          if (dim == 3) {
+            xml = "solverMueLuRefMaxwellEpetra.xml";
+          } else {
+            std::cout << std::endl
+                      << "No configuration available for 2D + Epetra." << std::endl;
+            return EXIT_FAILURE;
+          }
+      } else if (solver == ML_REFMAXWELL) {
+        xml = "solverMLRefMaxwell.xml";
+      }
     }
     *out << "Loading solver config from " << xml << std::endl;
     RCP<Teuchos::ParameterList> lin_solver_pl = Teuchos::rcp(new Teuchos::ParameterList("Linear Solver"));

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
@@ -158,6 +158,9 @@
       <ParameterList name="sigma">
         <Parameter name="Type" type="string" value="TENSOR CONDUCTIVITY"/>
         <Parameter name="sigma" type="double" value="0.0"/>
+        <Parameter name="betax" type="double" value="0.0"/>
+        <Parameter name="betay" type="double" value="0.0"/>
+        <Parameter name="betaz" type="double" value="0.0"/>
         <Parameter name="DoF Name" type="string" value="E_edge"/>
       </ParameterList>
       <!-- Inverse of the permeability -->

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell2D.xml
@@ -112,6 +112,9 @@
       <ParameterList name="sigma">
         <Parameter name="Type" type="string" value="TENSOR CONDUCTIVITY"/>
         <Parameter name="sigma" type="double" value="0.0"/>
+        <Parameter name="betax" type="double" value="0.0"/>
+        <Parameter name="betay" type="double" value="0.0"/>
+        <Parameter name="betaz" type="double" value="0.0"/>
         <Parameter name="DoF Name" type="string" value="E_edge"/>
       </ParameterList>
       <!-- Inverse of the permeability -->

--- a/packages/panzer/mini-em/example/BlockPrec/solverCG.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverCG.xml
@@ -1,0 +1,111 @@
+<ParameterList name="Linear Solver">
+  <Parameter name="Linear Solver Type" type="string" value="Belos"/>
+  <ParameterList name="Linear Solver Types">
+    <ParameterList name="Belos">
+      <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+      <ParameterList name="Solver Types">
+        <ParameterList name="Block GMRES">
+          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
+          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+          <Parameter name="Output Frequency" type="int" value="1"/>
+          <Parameter name="Output Style" type="int" value="1"/>
+          <Parameter name="Verbosity" type="int" value="1"/>
+          <Parameter name="Maximum Iterations" type="int" value="10"/>
+          <Parameter name="Block Size" type="int" value="1"/>
+          <Parameter name="Num Blocks" type="int" value="10"/>
+          <Parameter name="Flexible Gmres" type="bool" value="true"/>
+          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
+          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="VerboseObject">
+        <Parameter name="Verbosity Level" type="string" value="medium"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+
+  <Parameter name="Preconditioner Type" type="string" value="Teko"/>
+  <ParameterList name="Preconditioner Types">
+    <ParameterList name="Teko">
+      <Parameter name="Inverse Type" type="string" value="Maxwell"/>
+      <ParameterList name="Inverse Factory Library">
+        <ParameterList name="Maxwell">
+          <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
+          <Parameter name="Use refMaxwell" type="bool" value="true"/>
+          <Parameter name="Use as preconditioner" type="bool" value="false"/>
+          <Parameter name="Debug" type="bool" value="false"/>
+          <Parameter name="Dump" type="bool" value="false"/>
+          <Parameter name="Use discrete gradient" type="bool" value="true"/>
+          <Parameter name="Solve lower triangular" type="bool" value="true"/>
+
+          <ParameterList name="Q_B Solve">
+            <Parameter name="Type" type="string" value="Belos"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <ParameterList name="Solver Types">
+              <ParameterList name="Pseudo Block CG">
+                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Maximum Iterations" type="int" value="100"/>
+                <Parameter name="Timer Label" type="string" value="CG Q_B"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
+                <Parameter name="Output Style" type="int" value="1"/>
+                <Parameter name="Verbosity" type="int" value="1"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="VerboseObject">
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
+            </ParameterList>
+          </ParameterList>
+
+          <ParameterList name="Q_B Preconditioner">
+            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
+            <ParameterList name="Prec Types">
+              <ParameterList name="Ifpack2">
+                <Parameter name="Prec Type" type="string" value="relaxation"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+
+          <ParameterList name="S_E Solve">
+            <Parameter name="Type" type="string" value="Belos"/>
+            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <ParameterList name="Solver Types">
+              <ParameterList name="Pseudo Block CG">
+                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Maximum Iterations" type="int" value="500"/>
+                <Parameter name="Timer Label" type="string" value="CG S_E"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
+                <Parameter name="Output Style" type="int" value="1"/>
+                <Parameter name="Verbosity" type="int" value="1"/>
+                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="VerboseObject">
+              <Parameter name="Verbosity Level" type="string" value="medium"/>
+            </ParameterList>
+          </ParameterList>
+
+          <ParameterList name="S_E Preconditioner">
+            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
+            <ParameterList name="Prec Types">
+              <ParameterList name="Ifpack2">
+                <Parameter name="Prec Type" type="string" value="relaxation"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
@@ -40,11 +40,11 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
@@ -64,8 +64,8 @@
               <ParameterList name="Ifpack2">
                 <Parameter name="Prec Type" type="string" value="relaxation"/>
                 <ParameterList name="Ifpack2 Settings">
-                  <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -124,11 +124,11 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
@@ -147,11 +147,13 @@
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell-Tpetra">
                 <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
+                <Parameter name="verbosity" type="string" value="extreme"/>
                 <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
                 <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
                 <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
+                <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
 
                 <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
                 <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
@@ -184,7 +186,9 @@
 
                 <ParameterList name="refmaxwell: 11list">
                   <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="number of equations" type="int" value="3"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
 
@@ -214,17 +218,20 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 22list">
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
 
@@ -254,10 +261,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
@@ -3,31 +3,19 @@
   <ParameterList name="Linear Solver Types">
     <ParameterList name="Belos">
       <Parameter name="Solver Type" type="string" value="Block GMRES"/>
-      <!-- <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/> -->
       <ParameterList name="Solver Types">
         <ParameterList name="Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
           <Parameter name="Orthogonalization" type="string" value="ICGS"/>
           <Parameter name="Output Frequency" type="int" value="1"/>
           <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="33"/>
-          <Parameter name="Maximum Iterations" type="int" value="100"/>
+          <Parameter name="Verbosity" type="int" value="1"/>
+          <Parameter name="Maximum Iterations" type="int" value="10"/>
           <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="40"/>
+          <Parameter name="Num Blocks" type="int" value="10"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
           <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
-        </ParameterList>
-        <ParameterList name="Pseudo Block GMRES">
-          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
-          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-          <Parameter name="Output Frequency" type="int" value="1"/>
-          <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="33"/>
-          <Parameter name="Maximum Iterations" type="int" value="100"/>
-          <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="40"/>
-          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="VerboseObject">
@@ -52,15 +40,16 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Verbosity" type="int" value="1"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
@@ -133,15 +122,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Verbosity" type="int" value="1"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
@@ -155,11 +145,17 @@
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell-Tpetra">
                 <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
+                <Parameter name="verbosity" type="string" value="extreme"/>
+                <Parameter name="use kokkos refactor" type="bool" value="true"/>
                 <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
                 <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
                 <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
+                <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
+
+                <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
+                <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
 
                 <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                 <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
@@ -167,7 +163,7 @@
                 <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
                 <!-- <ParameterList name="smoother: params"> -->
                 <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
+                <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
                 <!-- </ParameterList> -->
 
                 <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
@@ -189,8 +185,10 @@
 
                 <ParameterList name="refmaxwell: 11list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="3"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
 
@@ -199,7 +197,7 @@
                   <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
                   <!-- <ParameterList name="smoother: params"> -->
                   <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
+                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
                   <!-- </ParameterList> -->
 
                   <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
@@ -222,10 +220,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>
@@ -233,14 +232,16 @@
 
                 <ParameterList name="refmaxwell: 22list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
 
                   <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
                   <!-- <ParameterList name="smoother: params"> -->
                   <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="30.0"/> -->
+                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
                   <!-- </ParameterList> -->
 
                   <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
@@ -263,10 +264,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
@@ -64,8 +64,8 @@
               <ParameterList name="Ifpack">
                 <Parameter name="Prec Type" type="string" value="point relaxation"/>
                 <ParameterList name="Ifpack Settings">
-                  <Parameter name="relaxation: type" type="string" value="symmetric Gauss-Seidel"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -126,7 +126,6 @@
             <ParameterList name="Solver Types">
               <ParameterList name="Pseudo Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
@@ -145,12 +144,14 @@
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell">
                 <Parameter name="use kokkos refactor" type="bool" value="false"/>
+                <Parameter name="verbosity" type="string" value="extreme"/>
                 <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
                 <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
                 <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
                 <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
+                <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
 
                 <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
                 <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
@@ -185,6 +186,7 @@
                   <Parameter name="use kokkos refactor" type="bool" value="false"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="3"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
 
@@ -214,10 +216,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>
@@ -225,7 +228,9 @@
 
                 <ParameterList name="refmaxwell: 22list">
                   <Parameter name="use kokkos refactor" type="bool" value="false"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
 
@@ -255,10 +260,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
@@ -40,11 +40,11 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
@@ -64,8 +64,8 @@
               <ParameterList name="Ifpack2">
                 <Parameter name="Prec Type" type="string" value="relaxation"/>
                 <ParameterList name="Ifpack2 Settings">
-                  <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -125,11 +125,11 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
@@ -148,12 +148,14 @@
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell-Tpetra">
                 <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
+                <Parameter name="verbosity" type="string" value="extreme"/>
                 <Parameter name="use kokkos refactor" type="bool" value="true"/>
                 <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
                 <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
                 <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
+                <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
 
                 <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
                 <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
@@ -186,8 +188,10 @@
 
                 <ParameterList name="refmaxwell: 11list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="3"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
 
@@ -217,10 +221,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>
@@ -228,7 +233,9 @@
 
                 <ParameterList name="refmaxwell: 22list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
+                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>
                   <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
 
@@ -258,10 +265,11 @@
                   <Parameter name="repartition: enable" type="bool" value="true"/>
                   <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
                   <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
+                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
                   <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
                   <Parameter name="repartition: remap parts" type="bool" value="true"/>
                   <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
                   <ParameterList name="repartition: params">
                     <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
@@ -20,6 +20,7 @@
 #include "MiniEM_Permittivity.hpp"
 #include "MiniEM_Conductivity.hpp"
 #include "MiniEM_TensorConductivity.hpp"
+#include "MiniEM_VariableTensorConductivity.hpp"
 
 // ********************************************************************
 // ********************************************************************
@@ -138,9 +139,36 @@ buildClosureModels(const std::string& model_id,
       }
       if(type=="TENSOR CONDUCTIVITY") {
         double sigma = plist.get<double>("sigma");
+        double betax = plist.get<double>("betax");
+        double betay = plist.get<double>("betay");
+        double betaz = plist.get<double>("betaz");
         std::string DoF = plist.get<std::string>("DoF Name");
 	RCP< Evaluator<panzer::Traits> > e =
-	  rcp(new mini_em::TensorConductivity<EvalT,panzer::Traits>(key,*ir,fl,sigma,DoF));
+	  rcp(new mini_em::TensorConductivity<EvalT,panzer::Traits>(key,*ir,fl,sigma,betax,betay,betaz,DoF));
+	evaluators->push_back(e);
+
+        found = true;
+      }
+      if(type=="VARIABLE TENSOR CONDUCTIVITY") {
+        double sigma0 = plist.get<double>("sigma0");
+        double betax0 = plist.get<double>("betax0");
+        double betay0 = plist.get<double>("betay0");
+        double betaz0 = plist.get<double>("betaz0");
+        double sigma1 = plist.get<double>("sigma1");
+        double betax1 = plist.get<double>("betax1");
+        double betay1 = plist.get<double>("betay1");
+        double betaz1 = plist.get<double>("betaz1");
+        double sigma2 = plist.get<double>("sigma2");
+        double betax2 = plist.get<double>("betax2");
+        double betay2 = plist.get<double>("betay2");
+        double betaz2 = plist.get<double>("betaz2");
+        std::string DoF = plist.get<std::string>("DoF Name");
+	RCP< Evaluator<panzer::Traits> > e =
+	  rcp(new mini_em::VariableTensorConductivity<EvalT,panzer::Traits>(key,*ir,fl,sigma0,sigma1,sigma2,
+                                                                            betax0,betay0,betaz0,
+                                                                            betax1,betay1,betaz1,
+                                                                            betax2,betay2,betaz2,
+                                                                            DoF));
 	evaluators->push_back(e);
 
         found = true;

--- a/packages/panzer/mini-em/src/closures/MiniEM_TensorConductivity.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_TensorConductivity.hpp
@@ -28,6 +28,9 @@ namespace mini_em {
                  const panzer::IntegrationRule & ir,
                  const panzer::FieldLayoutLibrary & fl,
                  const double & sigma_,
+                 const double & betax_,
+                 const double & betay_,
+                 const double & betaz_,
                  const std::string& DoF_);
 
     void evaluateFields(typename Traits::EvalData d);
@@ -39,7 +42,7 @@ namespace mini_em {
     PHX::MDField<ScalarT,Cell,Point,Dim,Dim> conductivity;
     PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
     int ir_degree, ir_dim;
-    double sigma;
+    double sigma, betax, betay, betaz;
   };
 
 }

--- a/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity.hpp
@@ -1,0 +1,62 @@
+#ifndef MINIEM_VARIABLETENSORCONDUCTIVITY_DECL_HPP
+#define MINIEM_VARIABLETENSORCONDUCTIVITY_DECL_HPP
+
+#include "PanzerAdaptersSTK_config.hpp"
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_FieldLibrary.hpp"
+
+#include <string>
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace mini_em {
+
+  using panzer::Cell;
+  using panzer::Point;
+
+  template<typename EvalT, typename Traits>
+  class VariableTensorConductivity : public panzer::EvaluatorWithBaseImpl<Traits>,
+                       public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+  public:
+    VariableTensorConductivity(const std::string & name,
+                               const panzer::IntegrationRule & ir,
+                               const panzer::FieldLayoutLibrary & fl,
+                               const double & sigma0_,
+                               const double & sigma1_,
+                               const double & sigma2_,
+                               const double & betax0_,
+                               const double & betay0_,
+                               const double & betaz0_,
+                               const double & betax1_,
+                               const double & betay1_,
+                               const double & betaz1_,
+                               const double & betax2_,
+                               const double & betay2_,
+                               const double & betaz2_,
+                               const std::string& DoF_);
+
+    void evaluateFields(typename Traits::EvalData d);
+
+
+  private:
+    typedef typename EvalT::ScalarT ScalarT;
+
+    PHX::MDField<ScalarT,Cell,Point,Dim,Dim> conductivity;
+    PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
+    int ir_degree, ir_dim;
+    double sigma0, betax0, betay0, betaz0;
+    double sigma1, betax1, betay1, betaz1;
+    double sigma2, betax2, betay2, betaz2;
+  };
+
+}
+
+#include "MiniEM_VariableTensorConductivity_impl.hpp"
+
+#endif

--- a/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity_impl.hpp
@@ -1,0 +1,184 @@
+#ifndef MINIEM_VARIABLETENSORCONDUCTIVITY_IMPL_HPP
+#define MINIEM_VARIABLETENSORCONDUCTIVITY_IMPL_HPP
+
+#include <cmath>
+
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+#include "Panzer_GatherBasisCoordinates.hpp"
+
+namespace mini_em {
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+VariableTensorConductivity<EvalT,Traits>::VariableTensorConductivity(const std::string & name,
+                                                                     const panzer::IntegrationRule & ir,
+                                                                     const panzer::FieldLayoutLibrary & fl,
+                                                                     const double & sigma0_,
+                                                                     const double & sigma1_,
+                                                                     const double & sigma2_,
+                                                                     const double & betax0_,
+                                                                     const double & betay0_,
+                                                                     const double & betaz0_,
+                                                                     const double & betax1_,
+                                                                     const double & betay1_,
+                                                                     const double & betaz1_,
+                                                                     const double & betax2_,
+                                                                     const double & betay2_,
+                                                                     const double & betaz2_,
+                                                                     const std::string& DoF_)
+{
+  using Teuchos::RCP;
+
+  Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_tensor;
+  ir_degree = ir.cubature_degree;
+  ir_dim = ir.spatial_dimension;
+
+  conductivity = PHX::MDField<ScalarT,Cell,Point,Dim,Dim>(name, data_layout);
+  this->addEvaluatedField(conductivity);
+
+  betax0 = betax0_;
+  betay0 = betay0_;
+  betaz0 = betaz0_;
+  sigma0 = sigma0_ / (1.0 + betax0*betax0 + betay0*betay0 + betaz0*betaz0);
+
+  betax1 = betax1_;
+  betay1 = betay1_;
+  betaz1 = betaz1_;
+  sigma1 = sigma1_ / (1.0 + betax1*betax1 + betay1*betay1 + betaz1*betaz1);
+
+  betax2 = betax2_;
+  betay2 = betay2_;
+  betaz2 = betaz2_;
+  sigma2 = sigma2_ / (1.0 + betax2*betax2 + betay2*betay2 + betaz2*betaz2);
+
+  Teuchos::RCP<const panzer::PureBasis> basis = fl.lookupBasis(DoF_);
+  const std::string coordName = panzer::GatherBasisCoordinates<EvalT,Traits>::fieldName(basis->name());
+  coords = PHX::MDField<const ScalarT,Cell,Point,Dim>(coordName, basis->coordinates);
+  this->addDependentField(coords);
+
+  std::string n = "VariableTensorConductivity";
+  this->setName(n);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void VariableTensorConductivity<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+{
+  using panzer::index_t;
+
+  const double xl0 = 0.4;
+  const double xr0 = 0.6;
+  const double yl0 = 0.4;
+  const double yr0 = 0.6;
+  const double zl0 = 0.4;
+  const double zr0 = 0.6;
+
+  const double xl1 = 0.2;
+  const double xr1 = 0.8;
+  const double yl1 = 0.2;
+  const double yr1 = 0.8;
+  const double zl1 = 0.2;
+  const double zr1 = 0.8;
+
+  if (ir_dim == 3) {
+    for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+      for (int point = 0; point < conductivity.extent_int(1); ++point) {
+
+        const ScalarT& x = coords(cell,point,0);
+        const ScalarT& y = coords(cell,point,1);
+        const ScalarT& z = coords(cell,point,2);
+
+        if ((xl0<=x) && (x<=xr0) &&
+            (yl0<=y) && (y<=yr0) &&
+            (zl0<=z) && (z<=zr0)) {
+
+          conductivity(cell,point,0,0) = sigma0 * (1.0 + betax0*betax0);
+          conductivity(cell,point,0,1) = sigma0 * (      betax0*betay0 - betaz0);
+          conductivity(cell,point,0,2) = sigma0 * (      betax0*betaz0 + betay0);
+
+          conductivity(cell,point,1,0) = sigma0 * (      betay0*betax0 + betaz0);
+          conductivity(cell,point,1,1) = sigma0 * (1.0 + betay0*betay0);
+          conductivity(cell,point,1,2) = sigma0 * (      betay0*betaz0 - betax0);
+
+          conductivity(cell,point,2,0) = sigma0 * (      betaz0*betax0 - betay0);
+          conductivity(cell,point,2,1) = sigma0 * (      betaz0*betay0 + betax0);
+          conductivity(cell,point,2,2) = sigma0 * (1.0 + betaz0*betaz0);
+
+        } else if ((xl1<=x) && (x<=xr1) &&
+                   (yl1<=y) && (y<=yr1) &&
+                   (zl1<=z) && (z<=zr1)) {
+
+          conductivity(cell,point,0,0) = sigma1 * (1.0 + betax1*betax1);
+          conductivity(cell,point,0,1) = sigma1 * (      betax1*betay1 - betaz1);
+          conductivity(cell,point,0,2) = sigma1 * (      betax1*betaz1 + betay1);
+
+          conductivity(cell,point,1,0) = sigma1 * (      betay1*betax1 + betaz1);
+          conductivity(cell,point,1,1) = sigma1 * (1.0 + betay1*betay1);
+          conductivity(cell,point,1,2) = sigma1 * (      betay1*betaz1 - betax1);
+
+          conductivity(cell,point,2,0) = sigma1 * (      betaz1*betax1 - betay1);
+          conductivity(cell,point,2,1) = sigma1 * (      betaz1*betay1 + betax1);
+          conductivity(cell,point,2,2) = sigma1 * (1.0 + betaz1*betaz1);
+
+        } else {
+
+          conductivity(cell,point,0,0) = sigma2 * (1.0 + betax2*betax2);
+          conductivity(cell,point,0,1) = sigma2 * (      betax2*betay2 - betaz2);
+          conductivity(cell,point,0,2) = sigma2 * (      betax2*betaz2 + betay2);
+
+          conductivity(cell,point,1,0) = sigma2 * (      betay2*betax2 + betaz2);
+          conductivity(cell,point,1,1) = sigma2 * (1.0 + betay2*betay2);
+          conductivity(cell,point,1,2) = sigma2 * (      betay2*betaz2 - betax2);
+
+          conductivity(cell,point,2,0) = sigma2 * (      betaz2*betax2 - betay2);
+          conductivity(cell,point,2,1) = sigma2 * (      betaz2*betay2 + betax2);
+          conductivity(cell,point,2,2) = sigma2 * (1.0 + betaz2*betaz2);
+
+        }
+      }
+    }
+  } else {
+    for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+      for (int point = 0; point < conductivity.extent_int(1); ++point) {
+
+        const ScalarT& x = coords(cell,point,0);
+        const ScalarT& y = coords(cell,point,1);
+
+        if ((xl0<=x) && (x<=xr0) &&
+            (yl0<=y) && (y<=yr0)) {
+
+          conductivity(cell,point,0,0) = sigma0;
+          conductivity(cell,point,0,1) = 0.;
+
+          conductivity(cell,point,1,0) = 0.;
+          conductivity(cell,point,1,1) = sigma0;
+
+        } else if ((xl1<=x) && (x<=xr1) &&
+                   (yl1<=y) && (y<=yr1)) {
+
+          conductivity(cell,point,0,0) = sigma1;
+          conductivity(cell,point,0,1) = 0.;
+
+          conductivity(cell,point,1,0) = 0.;
+          conductivity(cell,point,1,1) = sigma1;
+
+        } else {
+
+          conductivity(cell,point,0,0) = sigma2;
+          conductivity(cell,point,0,1) = 0.;
+
+          conductivity(cell,point,1,0) = 0.;
+          conductivity(cell,point,1,1) = sigma2;
+
+        }
+      }
+    }
+  }
+}
+
+//**********************************************************************
+}
+
+#endif

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -261,7 +261,7 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
          // Approximate inverse of S_E
          invS_E = Teko::multiply(invQ_E,Z_E,invT_E);
        }
-     else {// refMaxwell
+     else if (S_E_prec_type_ == "MueLuRefMaxwell-Tpetra" || S_E_prec_type_ == "MueLuRefMaxwell" || S_E_prec_type_ == "ML") {// refMaxwell
 
        // Teko::LinearOp T = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Discrete Gradient"));
        // Teko::LinearOp KT = Teko::explicitMultiply(K,T);
@@ -356,6 +356,13 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
            invS_E = Teko::buildInverse(*invLib.getInverseFactory("S_E Solve"),S_E,S_E_prec);
          }
        } 
+     } else {
+       if (useAsPreconditioner)
+         invS_E = Teko::buildInverse(*invLib.getInverseFactory("S_E Preconditioner"),S_E);
+       else {
+         Teko::LinearOp S_E_prec = Teko::buildInverse(*invLib.getInverseFactory("S_E Preconditioner"),S_E);
+         invS_E = Teko::buildInverse(*invLib.getInverseFactory("S_E Solve"),S_E,S_E_prec);
+       }
      }
    }
 
@@ -412,6 +419,11 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
    if(pl.isParameter("Use refMaxwell"))
      use_refmaxwell = pl.get<bool>("Use refMaxwell");
 
+   if(pl.isSublist("S_E Preconditioner") && pl.sublist("S_E Preconditioner").isParameter("Type"))
+     S_E_prec_type_ = pl.sublist("S_E Preconditioner").get<std::string>("Type");
+   else
+     S_E_prec_type_ = "";
+
    // Output stream for debug information
    Teuchos::RCP<Teuchos::FancyOStream> debug;
    // print debug information
@@ -452,7 +464,7 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
      Teuchos::ParameterList T_E_pl = pl.sublist("T_E Solve");
      invLib.addInverse("T_E Solve",T_E_pl);
 
-   } else { // RefMaxwell based solve
+   } else if (S_E_prec_type_ == "MueLuRefMaxwell-Tpetra" || S_E_prec_type_ == "MueLuRefMaxwell" || S_E_prec_type_ == "ML") { // RefMaxwell based solve
      // S_E solve
      Teuchos::ParameterList ml_pl = pl.sublist("S_E Solve");
      invLib.addInverse("S_E Solve",ml_pl);
@@ -462,7 +474,6 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
 
      // add discrete gradient
      Teko::LinearOp T = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Discrete Gradient"));
-     S_E_prec_type_ = S_E_prec_pl.get<std::string>("Type");
      if (S_E_prec_type_ == "ML") {
        RCP<const Epetra_CrsMatrix> eT = get_Epetra_CrsMatrix(*T);
        S_E_prec_pl.sublist("ML Settings").set("D0",eT);
@@ -480,6 +491,18 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
      // S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("M1",Q_E);
 
      invLib.addInverse("S_E Preconditioner",S_E_prec_pl);
+   } else {
+     // S_E solve
+     if (pl.isParameter("S_E Solve")) {
+       Teuchos::ParameterList cg_pl = pl.sublist("S_E Solve");
+       invLib.addInverse("S_E Solve",cg_pl);
+     }
+
+     // S_E preconditioner
+     Teuchos::ParameterList S_E_prec_pl = pl.sublist("S_E Preconditioner");
+     invLib.addStratPrecond("S_E Preconditioner",
+                            S_E_prec_pl.get<std::string>("Prec Type"),
+                            S_E_prec_pl.sublist("Prec Types"));
    }
 }
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
This PR adds the option to perform the two sub-solves of RefMaxwell on disjoint sub-communicators, i.e. in parallel. I added to MueLu:
- Changes to MueLu's partition placement to set up the disjoint sub-communicators.
- Option to skip rebalancing a nullspace. (We rebalance coordinates and then use `CreateXpetraPreconditioner`)
- Fixes to `CreateXpetraPreconditioner` for when it is called on a sub-communicator.
- Finer solve timers in RefMaxwell.

Changes to MiniEM:
- Add 'Krylov only' option for the Schur complement solve. This is for comparisons at low CFL.
- Different conductivities

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/3886)
<!-- Reviewable:end -->
