### PR TITLE
Amesos2: Compile error with MUMPS

### DIFF
--- a/packages/amesos2/src/Amesos2_MUMPS_def.hpp
+++ b/packages/amesos2/src/Amesos2_MUMPS_def.hpp
@@ -275,7 +275,7 @@ namespace Amesos2
     
     
     #ifdef HAVE_AMESOS2_TIMERS
-    Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
+    Teuchos::TimeMonitor redistTimer2(this->timers_.vecRedistTime_);
     #endif
 
     if ( is_contiguous_ == true ) {


### PR DESCRIPTION
Error message:
```
trilinos/src/packages/amesos2/src/Amesos2_MUMPS_def.hpp:278:37: error: redeclaration of 'Teuchos::TimeMonitor redistTimer'
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
                                     ^
trilinos/src/packages/amesos2/src/Amesos2_MUMPS_def.hpp:246:26: note: 'Teuchos::TimeMonitor redistTimer' previously declared here
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
```

Necessary condition for cmake configure is to enable explicitly Amesos2_ENABLE_MUMPS=ON. Using the combination TPL_ENABLE_MUMPS=ON and Trilinos_ENABLE_Amesos2=ON will show a message that Amesos2_ENABLE_MUMPS is set to ON, when in reality it will not be set to ON (didn't dig into that issue though).