### PR TITLE
Intrepid2: Increased tolerance of test to address Issue #3879

### DIFF
--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
@@ -1474,11 +1474,11 @@ int InterpolationProjectionHex(const bool verbose) {
                 diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
             }
 
-            if(diffErr > pow(7, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            if(diffErr > pow(8, degree)*tol) { //heuristic relation on how round-off error depends on degree
               errorFlag++;
               *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
               *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << " (tol: " << pow(8, degree)*tol << ")" << std::endl;
             }
           }
 


### PR DESCRIPTION
Increased tolerance for test InterpolationProjection_HEX to address Issue #3879

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Related to issue #3879 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
