### PR TITLE
Panzer: allow HVol elements

### DIFF
--- a/packages/panzer/adapters-stk/example/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/CMakeLists.txt
@@ -1,6 +1,7 @@
 ADD_SUBDIRECTORY(square_mesh)
 ADD_SUBDIRECTORY(PoissonExample)
 ADD_SUBDIRECTORY(CurlLaplacianExample)
+ADD_SUBDIRECTORY(MixedCurlLaplacianExample)
 ADD_SUBDIRECTORY(MixedPoissonExample)
 ADD_SUBDIRECTORY(PoissonInterfaceExample)
 ADD_SUBDIRECTORY(assembly_engine)

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/CMakeLists.txt
@@ -1,0 +1,229 @@
+
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+
+SET(ASSEMBLY_EXAMPLE_SOURCES
+  main.cpp
+  )
+
+TRIBITS_ADD_EXECUTABLE(
+  MixedCurlLaplacianExample
+  SOURCES ${ASSEMBLY_EXAMPLE_SOURCES}
+  )
+
+TRIBITS_ADD_ADVANCED_TEST(
+  MixedCurlLaplacianExample
+  EXCLUDE_IF_NOT_TRUE ${${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}
+  TEST_0 EXEC MixedCurlLaplacianExample
+    ARGS --use-epetra --output-filename="base-curl-test-"
+    PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+    NUM_MPI_PROCS 4
+  TEST_1 EXEC MixedCurlLaplacianExample
+    ARGS --use-tpetra --output-filename="base-curl-test-"
+    PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+    NUM_MPI_PROCS 4
+  COMM mpi
+  )
+
+FOREACH( ORDER 1 2 )
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianExample-ConvTest-Quad-Order-${ORDER}
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-04
+    TEST_1 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-08
+    TEST_2 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-16
+    TEST_3 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-32
+    TEST_4 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+           ${ORDER}
+           MPE-ConvTest-Quad-${ORDER}-
+           4
+           8
+           16
+           32
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+    )
+ENDFOREACH()
+
+FOREACH( ORDER 3 )
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianExample-ConvTest-Quad-Order-${ORDER}
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-04
+    TEST_1 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-08
+    TEST_2 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Quad" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-16
+    TEST_4 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+           ${ORDER}
+           MPE-ConvTest-Quad-${ORDER}-
+           4
+           8
+           16
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+    )
+ENDFOREACH()
+
+FOREACH( ORDER 1 )
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianMultiblockExample-ConvTest-Quad-Order-${ORDER}
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --x-blocks=2 --cell="Quad" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER} --output-filename="multiblock-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-08
+    TEST_1 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --x-blocks=2 --cell="Quad" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER} --output-filename="multiblock-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-16
+    TEST_2 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --x-blocks=2 --cell="Quad" --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER} --output-filename="multiblock-"
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-32
+    TEST_3 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+           ${ORDER}
+           MPE-Multiblock-ConvTest-Quad-${ORDER}-
+           8
+           16
+           32
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+    )
+ENDFOREACH()
+
+FOREACH( ORDER 1 )
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianExample-ConvTest-Tri-Order-${ORDER}
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-08
+    TEST_1 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-16
+    TEST_2 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-32
+    TEST_3 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=64 --y-elements=64 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-64
+    TEST_4 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+           ${ORDER}
+           MPE-ConvTest-Tri-${ORDER}-
+           8
+           16
+           32
+           64
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+    )
+ENDFOREACH()
+
+FOREACH( ORDER 2 )
+  TRIBITS_ADD_ADVANCED_TEST(
+    MixedCurlLaplacianExample-ConvTest-Tri-Order-${ORDER}
+    EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+    TEST_0 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-04
+    TEST_1 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-08
+    TEST_2 EXEC MixedCurlLaplacianExample
+      ARGS --use-tpetra --use-twod --cell="Tri" --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
+      PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
+      NUM_MPI_PROCS 4
+      OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-16
+    TEST_3 CMND python
+      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+           ${ORDER}
+           MPE-ConvTest-Tri-${ORDER}-
+           4
+           8
+           16
+      PASS_REGULAR_EXPRESSION "Test Passed"
+    COMM mpi
+    )
+ENDFOREACH()
+
+# FOREACH( ORDER 1 2 3 4 )
+#   TRIBITS_ADD_ADVANCED_TEST(
+#     CurlLaplacianExample-ConvTest-Hex-Order-${ORDER}
+#     EXCLUDE_IF_NOT_TRUE ${PARENT_PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
+#     TEST_0 EXEC CurlLaplacianExample
+#       ARGS --use-epetra --use-threed --x-elements=4 --y-elements=4 --z-elements=4 --basis-order=${ORDER} --
+#       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+#       NUM_MPI_PROCS 4
+#       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-04
+#     TEST_1 EXEC CurlLaplacianExample
+#       ARGS --use-epetra --use-threed --x-elements=8 --y-elements=8 --z-elements=4 --basis-order=${ORDER}
+#       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+#       NUM_MPI_PROCS 4
+#       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-08
+#     TEST_2 EXEC CurlLaplacianExample
+#       ARGS --use-epetra --use-threed --x-elements=16 --y-elements=16 --z-elements=4 --basis-order=${ORDER}
+#       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+#       NUM_MPI_PROCS 4
+#       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-16
+#     TEST_3 EXEC CurlLaplacianExample
+#       ARGS --use-epetra --use-threed --x-elements=32 --y-elements=32 --z-elements=4 --basis-order=${ORDER}
+#       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
+#       NUM_MPI_PROCS 4
+#       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-32
+#     TEST_4 CMND python
+#       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
+#            ${ORDER}
+#            MPE-ConvTest-Hex-${ORDER}-
+#            4
+#            8
+#            16
+#            32
+#       PASS_REGULAR_EXPRESSION "Test Passed"
+#     COMM mpi
+#     )
+# ENDFOREACH()

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_BCStrategy_Dirichlet_Constant.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_BCStrategy_Dirichlet_Constant.hpp
@@ -1,0 +1,80 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_BC_Dirichlet_Constant_hpp__
+#define __Example_BC_Dirichlet_Constant_hpp__
+
+#include <vector>
+#include <string>
+
+#include "Teuchos_RCP.hpp"
+#include "Panzer_BCStrategy_Dirichlet_DefaultImpl.hpp"
+#include "Panzer_Traits.hpp"
+#include "Panzer_PureBasis.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+namespace Example {
+
+  template <typename EvalT>
+  class BCStrategy_Dirichlet_Constant : public panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT> {
+  public:    
+    
+    BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data);
+    
+    void setup(const panzer::PhysicsBlock& side_pb,
+	       const Teuchos::ParameterList& user_data);
+    
+    void buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+				    const panzer::PhysicsBlock& pb,
+				    const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& factory,
+				    const Teuchos::ParameterList& models,
+				    const Teuchos::ParameterList& user_data) const;
+
+    std::string residual_name;
+    Teuchos::RCP<panzer::PureBasis> basis;
+  };
+
+}
+
+#include "Example_BCStrategy_Dirichlet_Constant_impl.hpp"
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_BCStrategy_Dirichlet_Constant_impl.hpp
@@ -1,0 +1,144 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_Assert.hpp"
+#include "Phalanx_DataLayout_MDALayout.hpp"
+#include "Phalanx_FieldManager.hpp"
+#include "Panzer_PhysicsBlock.hpp"
+
+#include "Panzer_PureBasis.hpp"
+
+// Evaluators
+#include "Panzer_Constant.hpp"
+
+#include "Phalanx_MDField.hpp"
+#include "Phalanx_DataLayout.hpp"
+#include "Phalanx_DataLayout_MDALayout.hpp"
+
+// ***********************************************************************
+template <typename EvalT>
+Example::BCStrategy_Dirichlet_Constant<EvalT>::
+BCStrategy_Dirichlet_Constant(const panzer::BC& bc, const Teuchos::RCP<panzer::GlobalData>& global_data) :
+  panzer::BCStrategy_Dirichlet_DefaultImpl<EvalT>(bc,global_data)
+{
+  TEUCHOS_ASSERT(this->m_bc.strategy() == "Constant");
+}
+
+// ***********************************************************************
+template <typename EvalT>
+void Example::BCStrategy_Dirichlet_Constant<EvalT>::
+setup(const panzer::PhysicsBlock& side_pb,
+      const Teuchos::ParameterList& /* user_data */)
+{
+  using Teuchos::RCP;
+  using std::vector;
+  using std::string;
+  using std::pair;
+
+  // need the dof value to form the residual
+  this->required_dof_names.push_back(this->m_bc.equationSetName());
+
+  // unique residual name
+  this->residual_name = "Residual_" + this->m_bc.identifier();
+
+  // map residual to dof 
+  this->residual_to_dof_names_map[residual_name] = this->m_bc.equationSetName();
+
+  // map residual to target field
+  this->residual_to_target_field_map[residual_name] = "Constant_" + this->m_bc.equationSetName();
+
+  // find the basis for this dof 
+  const vector<pair<string,RCP<panzer::PureBasis> > >& dofs = side_pb.getProvidedDOFs();
+
+  for (vector<pair<string,RCP<panzer::PureBasis> > >::const_iterator dof_it = 
+	 dofs.begin(); dof_it != dofs.end(); ++dof_it) {
+    if (dof_it->first == this->m_bc.equationSetName())
+      this->basis = dof_it->second;
+  }
+
+  TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(this->basis), std::runtime_error,
+		     "Error the name \"" << this->m_bc.equationSetName()
+		     << "\" is not a valid DOF for the boundary condition:\n"
+		     << this->m_bc << "\n");
+
+}
+
+// ***********************************************************************
+template <typename EvalT>
+void Example::BCStrategy_Dirichlet_Constant<EvalT>::
+buildAndRegisterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+			   const panzer::PhysicsBlock& /* pb */,
+			   const panzer::ClosureModelFactory_TemplateManager<panzer::Traits>& /* factory */,
+			   const Teuchos::ParameterList& /* models */,
+			   const Teuchos::ParameterList& /* user_data */) const
+{
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  // provide a constant target value to map into residual
+  if(basis->isScalarBasis()) {
+    ParameterList p("BC Constant Dirichlet");
+    p.set("Name", "Constant_" + this->m_bc.equationSetName());
+    p.set("Data Layout", basis->functional);
+    p.set("Value", this->m_bc.params()->template get<double>("Value"));
+    
+    RCP< PHX::Evaluator<panzer::Traits> > op = 
+      rcp(new panzer::Constant<EvalT,panzer::Traits>(p));
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+  else if(basis->isVectorBasis()) {
+    ParameterList p("BC Constant Dirichlet");
+    p.set("Name", "Constant_" + this->m_bc.equationSetName());
+    p.set("Data Layout", basis->functional_grad);
+    p.set("Value", this->m_bc.params()->template get<double>("Value"));
+    
+    RCP< PHX::Evaluator<panzer::Traits> > op = 
+      rcp(new panzer::Constant<EvalT,panzer::Traits>(p));
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+
+}

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_BCStrategy_Factory.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_BCStrategy_Factory.hpp
@@ -1,0 +1,87 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_BCStrategyFactory_hpp__
+#define __Example_BCStrategyFactory_hpp__
+
+#include "Teuchos_RCP.hpp"
+#include "Panzer_Traits.hpp"
+#include "Panzer_BCStrategy_TemplateManager.hpp"
+#include "Panzer_BCStrategy_Factory.hpp"
+#include "Panzer_BCStrategy_Factory_Defines.hpp"
+
+// Add my bcstrategies here
+#include "Example_BCStrategy_Dirichlet_Constant.hpp"
+
+namespace Example {
+  
+PANZER_DECLARE_BCSTRATEGY_TEMPLATE_BUILDER(BCStrategy_Dirichlet_Constant,
+  BCStrategy_Dirichlet_Constant)
+
+struct BCStrategyFactory : public panzer::BCStrategyFactory {
+
+   Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> >
+   buildBCStrategy(const panzer::BC& bc,const Teuchos::RCP<panzer::GlobalData>& global_data) const
+   {
+
+      Teuchos::RCP<panzer::BCStrategy_TemplateManager<panzer::Traits> > bcs_tm = 
+	Teuchos::rcp(new panzer::BCStrategy_TemplateManager<panzer::Traits>);
+      
+      bool found = false;
+
+      PANZER_BUILD_BCSTRATEGY_OBJECTS("Constant",
+        BCStrategy_Dirichlet_Constant)
+
+      TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, 
+			 "Error - the BC Strategy called \"" << bc.strategy() <<
+			 "\" is not a valid identifier in the BCStrategyFactory.  Either add a "
+                         "valid implementation to your factory or fix your input file.  The "
+                         "relevant boundary condition is:\n\n" << bc << std::endl);
+      
+      return bcs_tm;
+   }
+
+};
+  
+}
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_ClosureModel_Factory.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_ClosureModel_Factory.hpp
@@ -1,0 +1,71 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_ClosureModelFactory_hpp__
+#define __Example_ClosureModelFactory_hpp__
+
+#include "Panzer_ClosureModel_Factory.hpp"
+
+namespace Example {
+
+template<typename EvalT>
+class ModelFactory : public panzer::ClosureModelFactory<EvalT> {
+
+public:
+
+   Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
+   buildClosureModels(const std::string& model_id,
+                      const Teuchos::ParameterList& models,
+		      const panzer::FieldLayoutLibrary& fl,
+		      const Teuchos::RCP<panzer::IntegrationRule>& ir,
+                      const Teuchos::ParameterList& default_params,
+                      const Teuchos::ParameterList& user_data,
+		      const Teuchos::RCP<panzer::GlobalData>& global_data,
+                      PHX::FieldManager<panzer::Traits>& fm) const;
+
+};
+
+}
+
+#include "Example_ClosureModel_Factory_impl.hpp"
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_ClosureModel_Factory_TemplateBuilder.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_ClosureModel_Factory_TemplateBuilder.hpp
@@ -1,0 +1,66 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_ClosureModel_Factory_TemplateBuilder_hpp__
+#define __Example_ClosureModel_Factory_TemplateBuilder_hpp__
+
+#include <string>
+#include "Sacado_mpl_apply.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Example_ClosureModel_Factory.hpp"
+
+namespace Example {
+
+class ClosureModelFactory_TemplateBuilder {
+public:
+    
+   template <typename EvalT>
+   Teuchos::RCP<panzer::ClosureModelFactoryBase> build() const 
+   {
+      return Teuchos::rcp( static_cast<panzer::ClosureModelFactoryBase*>(new Example::ModelFactory<EvalT>) );
+   }
+    
+};
+  
+}
+
+#endif 

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_ClosureModel_Factory_impl.hpp
@@ -1,0 +1,322 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_ClosureModelFactoryT_hpp__
+#define __Example_ClosureModelFactoryT_hpp__
+
+#include <iostream>
+#include <sstream>
+#include <typeinfo>
+
+#include "Panzer_IntegrationRule.hpp"
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_ScalarToVector.hpp"
+#include "Panzer_String_Utilities.hpp"
+#include "Panzer_Sum.hpp"
+#include "Panzer_DotProduct.hpp"
+#include "Panzer_Product.hpp"
+
+#include "Phalanx_FieldTag_Tag.hpp"
+#include "Teuchos_ParameterEntry.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
+
+#include "Example_SimpleSource.hpp"
+#include "Example_CurlSolution.hpp"
+
+// ********************************************************************
+// ********************************************************************
+template<typename EvalT>
+Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > > 
+Example::ModelFactory<EvalT>::
+buildClosureModels(const std::string& model_id,
+		   const Teuchos::ParameterList& models,  
+		   const panzer::FieldLayoutLibrary& fl,
+		   const Teuchos::RCP<panzer::IntegrationRule>& ir,
+		   const Teuchos::ParameterList& /* default_params */,
+		   const Teuchos::ParameterList& /* user_data */,
+		   const Teuchos::RCP<panzer::GlobalData>& /* global_data */,
+		   PHX::FieldManager<panzer::Traits>& /* fm */) const
+{
+  using std::string;
+  using std::vector;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::ParameterList;
+  using PHX::Evaluator;
+
+  RCP< vector< RCP<Evaluator<panzer::Traits> > > > evaluators = 
+    rcp(new vector< RCP<Evaluator<panzer::Traits> > > );
+
+  if (!models.isSublist(model_id)) {
+    models.print(std::cout);
+    std::stringstream msg;
+    msg << "Falied to find requested model, \"" << model_id 
+	<< "\", for equation set:\n" << std::endl;
+    TEUCHOS_TEST_FOR_EXCEPTION(!models.isSublist(model_id), std::logic_error, msg.str());
+  }
+
+  std::vector<Teuchos::RCP<const panzer::PureBasis> > bases;
+  fl.uniqueBases(bases);
+
+  const ParameterList& my_models = models.sublist(model_id);
+
+  for (ParameterList::ConstIterator model_it = my_models.begin(); 
+       model_it != my_models.end(); ++model_it) {
+    
+    bool found = false;
+    
+    const std::string key = model_it->first;
+    ParameterList input;
+    const Teuchos::ParameterEntry& entry = model_it->second;
+    const ParameterList& plist = Teuchos::getValue<Teuchos::ParameterList>(entry);
+
+    if (plist.isType<double>("Value")) {
+      // at IP
+      {
+	input.set("Name", key);
+	input.set("Value", plist.get<double>("Value"));
+	input.set("Data Layout", ir->dl_scalar);
+	RCP< Evaluator<panzer::Traits> > e = 
+	  rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
+	evaluators->push_back(e);
+      }
+      // at BASIS
+      for (std::vector<Teuchos::RCP<const panzer::PureBasis> >::const_iterator basis_itr = bases.begin();
+	   basis_itr != bases.end(); ++basis_itr) {
+	input.set("Name", key);
+	input.set("Value", plist.get<double>("Value"));
+	Teuchos::RCP<const panzer::BasisIRLayout> basis = basisIRLayout(*basis_itr,*ir);
+	input.set("Data Layout", basis->functional);
+	RCP< Evaluator<panzer::Traits> > e = 
+	  rcp(new panzer::Constant<EvalT,panzer::Traits>(input));
+	evaluators->push_back(e);
+      }
+      found = true;
+    }
+
+    if (plist.isType<std::string>("Scalar Names")) {
+      { // at IP
+        std::string value = plist.get<std::string>("Scalar Names");
+	Teuchos::RCP<std::vector<std::string> > scalarNames = Teuchos::rcp(new std::vector<std::string>);
+        panzer::StringTokenizer(*scalarNames,value,",",true);
+        
+	input.set("Vector Name", key);
+	input.set("Scalar Names", scalarNames.getConst()); // evaluator expects a <const std::vector> so make sure it is
+	input.set("Data Layout Scalar", ir->dl_scalar);
+	input.set("Data Layout Vector", ir->dl_vector);
+	RCP< Evaluator<panzer::Traits> > e = 
+	  rcp(new panzer::ScalarToVector<EvalT,panzer::Traits>(input));
+	evaluators->push_back(e);
+      }
+      found = true;
+    }
+
+    if (plist.isType<std::string>("Type")) {
+      std::string type = plist.get<std::string>("Type");
+      if(type=="SIMPLE SOURCE") {
+	RCP< Evaluator<panzer::Traits> > e = 
+	  rcp(new Example::SimpleSource<EvalT,panzer::Traits>(key,*ir));
+	evaluators->push_back(e);
+
+        found = true;
+      }
+      else if(type=="EFIELD_EXACT") {
+        RCP< Evaluator<panzer::Traits> > e = 
+          rcp(new Example::CurlSolution<EvalT,panzer::Traits>(key,*ir));
+        evaluators->push_back(e);
+
+        found = true;
+      }
+      else if(type=="L2 ERROR_CALC") {
+        {
+          std::vector<std::string> values(2);
+          values[0] = plist.get<std::string>("Field A");
+          values[1] = plist.get<std::string>("Field B");
+  
+          std::vector<double> scalars(2); 
+          scalars[0] = 1.0; 
+          scalars[1] = -1.0;
+  
+          Teuchos::ParameterList p;
+          p.set("Sum Name",key+"_DIFF"); // Name of sum
+          p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+          p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+          p.set("Data Layout",ir->dl_vector);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        {
+          Teuchos::RCP<const panzer::PointRule> pr = ir;
+  
+          Teuchos::ParameterList p;
+          p.set("Result Name",key);
+          p.set("Vector A Name",key+"_DIFF");
+          p.set("Vector B Name",key+"_DIFF");
+          p.set("Point Rule",pr);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::DotProduct<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        found = true;
+      }
+      else if(type=="HCurl ERROR_CALC") {
+        // Compute L2 contribution
+        {
+          std::vector<std::string> values(2);
+          values[0] = plist.get<std::string>("Field A");
+          values[1] = plist.get<std::string>("Field B");
+  
+          std::vector<double> scalars(2); 
+          scalars[0] = 1.0; 
+          scalars[1] = -1.0;
+  
+          Teuchos::ParameterList p;
+          p.set("Sum Name",key+"_HCurl_ValueDiff"); // Name of sum
+          p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+          p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+          p.set("Data Layout",ir->dl_vector);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        {
+          Teuchos::RCP<const panzer::PointRule> pr = ir;
+  
+          Teuchos::ParameterList p;
+          p.set("Result Name",key+"_L2");
+          p.set("Vector A Name",key+"_HCurl_ValueDiff");
+          p.set("Vector B Name",key+"_HCurl_ValueDiff");
+          p.set("Point Rule",pr);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::DotProduct<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        // Compute HCurl contribution
+        {
+          std::vector<std::string> values(2);
+          values[0] = "CURL_" + plist.get<std::string>("Field A");
+          values[1] = "CURL_" + plist.get<std::string>("Field B");
+  
+          std::vector<double> scalars(2); 
+          scalars[0] = 1.0; 
+          scalars[1] = -1.0;
+  
+          Teuchos::ParameterList p;
+          p.set("Sum Name",key+"_HCurl_CurlDiff"); // Name of sum
+          p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+          p.set<RCP<const std::vector<double> > >("Scalars",Teuchos::rcpFromRef(scalars));
+          p.set("Data Layout",ir->dl_scalar);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        {
+          Teuchos::RCP<const panzer::PointRule> pr = ir;
+          std::vector<std::string> values(2);
+          values[0] = key+"_HCurl_CurlDiff";
+          values[1] = key+"_HCurl_CurlDiff";
+  
+          Teuchos::ParameterList p;
+          p.set("Product Name",key+"_HCurlSemi");
+          p.set("Values Names",Teuchos::rcpFromRef(values));
+          p.set("Data Layout",ir->dl_scalar);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::Product<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        {
+          std::vector<std::string> values(2);
+          values[0] = key+"_L2";
+          values[1] = key+"_HCurlSemi";
+  
+          Teuchos::ParameterList p;
+          p.set("Sum Name",key); // Name of sum
+          p.set<RCP<std::vector<std::string> > >("Values Names",Teuchos::rcpFromRef(values));
+          p.set("Data Layout",ir->dl_scalar);
+  
+          RCP< Evaluator<panzer::Traits> > e = 
+                   rcp(new panzer::Sum<EvalT,panzer::Traits>(p));
+  
+          evaluators->push_back(e);
+        }
+
+        found = true;
+      }
+
+
+      // none found!
+    }
+
+
+    if (!found) {
+      std::stringstream msg;
+      msg << "ClosureModelFactory failed to build evaluator for key \"" << key 
+	  << "\"\nin model \"" << model_id 
+	  << "\".  Please correct the type or add support to the \nfactory." <<std::endl;
+      TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, msg.str());
+    }
+
+  }
+
+  return evaluators;
+}
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlLaplacianEquationSet.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlLaplacianEquationSet.hpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __CurlLaplacianExample_EquationSet_Energy_hpp__
+#define __CurlLaplacianExample_EquationSet_Energy_hpp__
+
+#include <vector>
+#include <string>
+
+#include "Teuchos_RCP.hpp"
+#include "Panzer_EquationSet_DefaultImpl.hpp"
+#include "Panzer_Traits.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+namespace Example {
+
+/** The equation set serves two roles. The first is to let the panzer library
+  * know which fields this equation set defines and their names. It registers
+  * the evaluators required for a particular equation set. The level of the
+  * granularity is largely up to a user. For instance this could be the momentum
+  * or continuity equation in Navier-Stokes, or it could simply be the Navier-Stokes
+  * equations. 
+  *
+  * Generally, this inherits from the panzer::EquationSet_DefaultImpl which takes
+  * care of adding the gather (extract basis coefficients from solution vector) and 
+  * scatter (using element matrices and vectors distribute and sum their values
+  * to a global linear system) evaluators. These use data members that must be set by
+  * the user.
+  */
+template <typename EvalT>
+class CurlLaplacianEquationSet : public panzer::EquationSet_DefaultImpl<EvalT> {
+public:    
+
+   /** In the constructor you set all the fields provided by this
+     * equation set. 
+     */
+   CurlLaplacianEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
+			    const int& default_integration_order,
+			    const panzer::CellData& cell_data,
+			    const Teuchos::RCP<panzer::GlobalData>& global_data,
+			    const bool build_transient_support);
+    
+   /** The specific evaluators are registered with the field manager argument.
+     */
+   void buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+					      const panzer::FieldLibrary& field_library,
+                                              const Teuchos::ParameterList& user_data) const;
+
+};
+
+}
+
+#include "Example_CurlLaplacianEquationSet_impl.hpp"
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlLaplacianEquationSet_impl.hpp
@@ -1,0 +1,321 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef USER_APP_EQUATIONSET_ENERGY_T_HPP
+#define USER_APP_EQUATIONSET_ENERGY_T_HPP
+
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_Assert.hpp"
+#include "Phalanx_DataLayout_MDALayout.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_IntegrationRule.hpp"
+#include "Panzer_BasisIRLayout.hpp"
+
+// include evaluators here
+#include "Panzer_Integrator_BasisTimesVector.hpp"
+#include "Panzer_Integrator_BasisTimesScalar.hpp"
+#include "Panzer_Integrator_CurlBasisDotVector.hpp"
+#include "Panzer_ScalarToVector.hpp"
+#include "Panzer_Sum.hpp"
+#include "Panzer_Constant.hpp"
+
+// ***********************************************************************
+template <typename EvalT>
+Example::CurlLaplacianEquationSet<EvalT>::
+CurlLaplacianEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
+			 const int& default_integration_order,
+			 const panzer::CellData& cell_data,
+			 const Teuchos::RCP<panzer::GlobalData>& global_data,
+			 const bool build_transient_support) :
+  panzer::EquationSet_DefaultImpl<EvalT>(params, default_integration_order, cell_data, global_data, build_transient_support )
+{
+  // ********************
+  // Validate and parse parameter list
+  // ********************
+  {    
+    Teuchos::ParameterList valid_parameters;
+    this->setDefaultValidParameters(valid_parameters);
+    
+    valid_parameters.set("Model ID","","Closure model id associated with this equaiton set");
+    valid_parameters.set("EField Basis Type","HCurl","Type of Basis to use");
+    valid_parameters.set("BField Basis Type","HDiv","Type of Basis to use");
+    valid_parameters.set("EField Basis Order",1,"Order of the basis");
+    valid_parameters.set("BField Basis Order",1,"Order of the basis");
+    valid_parameters.set("Integration Order",-1,"Order of the integration rule");
+    
+    params->validateParametersAndSetDefaults(valid_parameters);
+  }
+  
+  std::string e_basis_type = params->get<std::string>("EField Basis Type");
+  std::string b_basis_type = params->get<std::string>("BField Basis Type");
+  int e_basis_order = params->get<int>("EField Basis Order");
+  int b_basis_order = params->get<int>("BField Basis Order");
+  int integration_order = params->get<int>("Integration Order");
+  std::string model_id = params->get<std::string>("Model ID");
+
+   // ********************
+   // Panzer uses strings to match fields. In this section we define the
+   // name of the fields provided by this equation set. This is a bit strange
+   // in that this is not the fields necessarily required by this equation set.
+   // For instance for the momentum equations in Navier-Stokes only the velocity
+   // fields are added, the pressure field is added by continuity.
+   //
+   // In this case "EFIELD" is the lone field.  We also name the curl
+   // for this field. These names automatically generate evaluators for "EFIELD"
+   // and "CURL_EFIELD" gathering the basis coefficients of "EFIELD" and
+   // the values of the EFIELD and CURL_EFIELD fields at quadrature points.
+   //
+   // After all the equation set evaluators are added to a given field manager, the
+   // panzer code adds in appropriate scatter evaluators to distribute the
+   // entries into the residual and the Jacobian operator. These operators will be
+   // "required" by the field manager and will serve as roots of evaluation tree.
+   // The leaves of this tree will include the gather evaluators whose job it is to
+   // gather the solution from a vector.
+   // ********************
+
+   // ********************
+   // Assemble DOF names and Residual names
+   // ********************
+
+   this->addDOF("EFIELD",e_basis_type,e_basis_order,integration_order);
+   this->addDOFCurl("EFIELD");
+   if (this->buildTransientSupport())
+     this->addDOFTimeDerivative("EFIELD");
+
+   this->addDOF("BFIELD",b_basis_type,b_basis_order,integration_order);
+   if (this->buildTransientSupport())
+     this->addDOFTimeDerivative("BFIELD");
+
+   // ********************
+   // Build Basis Functions and Integration Rules
+   // ********************
+   
+   this->addClosureModel(model_id);
+
+   this->setupDOFs();
+}
+
+// ***********************************************************************
+template <typename EvalT>
+void Example::CurlLaplacianEquationSet<EvalT>::
+buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
+				      const panzer::FieldLibrary& /* fl */,
+				      const Teuchos::ParameterList& /* user_data */) const
+{
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+   
+  Teuchos::RCP<panzer::IntegrationRule> e_ir = this->getIntRuleForDOF("EFIELD");
+  Teuchos::RCP<panzer::IntegrationRule> b_ir = this->getIntRuleForDOF("BFIELD");
+  Teuchos::RCP<panzer::BasisIRLayout> e_basis = this->getBasisIRLayoutForDOF("EFIELD"); 
+  Teuchos::RCP<panzer::BasisIRLayout> b_basis = this->getBasisIRLayoutForDOF("BFIELD"); 
+  bool scalar_b = b_basis->dimension() < 3;  
+
+  // ********************
+  // Energy Equation
+  // ********************
+
+  // Transient Operator: Assembles \int \dot{T} v
+  if (this->buildTransientSupport()) {
+    ParameterList p("E Transient Residual");
+    p.set("Residual Name", "RESIDUAL_EFIELD_TRANSIENT_OP"); // we are defining the name of this operator
+    p.set("Value Name", "DXDT_EFIELD"); // this field is constructed by the panzer library
+//    p.set("Test Field Name", "EFIELD"); 
+    p.set("Basis", e_basis);
+    p.set("IR", e_ir);
+    p.set("Multiplier", 1.0);
+
+    RCP< PHX::Evaluator<panzer::Traits> > op = 
+      rcp(new panzer::Integrator_BasisTimesVector<EvalT,panzer::Traits>(p));
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+
+  // Transient Operator: Assembles \int \dot{T} v
+  if (this->buildTransientSupport()) {
+    ParameterList p("B Transient Residual");
+    p.set("Residual Name", "RESIDUAL_BFIELD_TRANSIENT_OP"); // we are defining the name of this operator
+    p.set("Value Name", "DXDT_BFIELD"); // this field is constructed by the panzer library
+//    p.set("Test Field Name", "EFIELD"); 
+    p.set("Basis", b_basis);
+    p.set("IR", b_ir);
+    p.set("Multiplier", 1.0);
+
+    RCP< PHX::Evaluator<panzer::Traits> > op = 
+      rcp(new panzer::Integrator_BasisTimesVector<EvalT,panzer::Traits>(p));
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+
+  // Diffusion Operator: Assembles \int \nabla T \cdot \nabla v
+  {
+    using panzer::EvaluatorStyle;
+    using panzer::Integrator_CurlBasisDotVector;
+    using panzer::Traits;
+    using PHX::Evaluator;
+    using std::string;
+    string resName("RESIDUAL_EFIELD"), valName("BFIELD");
+    double thermalConductivity(1.0), multiplier(-thermalConductivity);
+    RCP<Evaluator<Traits>> op = rcp(new
+      Integrator_CurlBasisDotVector<EvalT, Traits>(EvaluatorStyle::CONTRIBUTES,
+      resName, valName, *e_basis, *e_ir, multiplier));
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+
+  // Mass operator
+  {   
+    ParameterList p("Source Residual");
+    p.set("Residual Name", "RESIDUAL_EFIELD_MASS_OP");
+    p.set("Value Name", "EFIELD"); 
+    p.set("Basis", e_basis);
+    p.set("IR", e_ir);
+    p.set("Multiplier", -1.0);
+    
+    RCP< PHX::Evaluator<panzer::Traits> > op = 
+      rcp(new panzer::Integrator_BasisTimesVector<EvalT,panzer::Traits>(p));
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+  
+  // Source Operator
+  {   
+    ParameterList p("Source Residual");
+    p.set("Residual Name", "RESIDUAL_EFIELD_SOURCE_OP");
+    p.set("Value Name", "SOURCE_EFIELD"); // this field must be provided by the closure model factory
+                                               // and specified by the user
+    p.set("Basis", e_basis);
+    p.set("IR", e_ir);
+    p.set("Multiplier", 1.0);
+    
+    RCP< PHX::Evaluator<panzer::Traits> > op = 
+      rcp(new panzer::Integrator_BasisTimesVector<EvalT,panzer::Traits>(p));
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+
+  // Use a sum operator to form the overall residual for the equation
+  {
+    std::vector<std::string> sum_names;
+    
+    // these are the names of the residual values to sum together
+    sum_names.push_back("RESIDUAL_EFIELD_MASS_OP");
+    sum_names.push_back("RESIDUAL_EFIELD_SOURCE_OP");
+    if (this->buildTransientSupport())
+      sum_names.push_back("RESIDUAL_EFIELD_TRANSIENT_OP");
+
+    this->buildAndRegisterResidualSummationEvaluator(fm,"EFIELD",sum_names);
+  }
+
+  // Diffusion Operator: Assembles \int \nabla T \cdot \nabla v
+  {
+    using panzer::EvaluatorStyle;
+    using panzer::Integrator_BasisTimesVector;
+    using panzer::Integrator_BasisTimesScalar;
+    using panzer::Traits;
+    using PHX::Evaluator;
+    using std::string;
+    ParameterList p("B Curl Residual");
+    p.set("Residual Name", "RESIDUAL_BFIELD_CURL_OP");
+    p.set("Value Name", "CURL_EFIELD"); 
+    p.set("Basis", b_basis);
+    p.set("IR", b_ir);
+    p.set("Multiplier", 1.0);
+    RCP<Evaluator<Traits>> op;
+    if(scalar_b){
+      op  = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(p));
+    } else {
+      op  = rcp(new
+      Integrator_BasisTimesVector<EvalT, Traits>(p));
+    }
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+
+  // Mass operator
+  {   
+    using panzer::EvaluatorStyle;
+    using panzer::Integrator_BasisTimesVector;
+    using panzer::Integrator_BasisTimesScalar;
+    using panzer::Traits;
+    using PHX::Evaluator;
+    using std::string;
+    ParameterList p("Source Residual");
+    p.set("Residual Name", "RESIDUAL_BFIELD_MASS_OP");
+    p.set("Value Name", "BFIELD"); 
+    p.set("Basis", b_basis);
+    p.set("IR", b_ir);
+    p.set("Multiplier", -1.0);
+    
+    RCP< PHX::Evaluator<panzer::Traits> > op; 
+    if(scalar_b){
+      op  = rcp(new
+      Integrator_BasisTimesScalar<EvalT, Traits>(p));
+    } else {
+      op  = rcp(new
+      Integrator_BasisTimesVector<EvalT, Traits>(p));
+    }
+    
+    this->template registerEvaluator<EvalT>(fm, op);
+  }
+  
+  // Use a sum operator to form the overall residual for the equation
+  {
+    std::vector<std::string> sum_names;
+    
+    // these are the names of the residual values to sum together
+    sum_names.push_back("RESIDUAL_BFIELD_MASS_OP");
+    sum_names.push_back("RESIDUAL_BFIELD_CURL_OP");
+    if (this->buildTransientSupport())
+      sum_names.push_back("RESIDUAL_BFIELD_TRANSIENT_OP");
+
+    this->buildAndRegisterResidualSummationEvaluator(fm,"BFIELD",sum_names);
+  }
+
+}
+
+// ***********************************************************************
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlSolution.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlSolution.hpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_CurlSolution_hpp__
+#define __Example_CurlSolution_hpp__
+
+#include "PanzerAdaptersSTK_config.hpp"
+
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_Dimension.hpp"
+#include "Panzer_FieldLibrary.hpp"
+
+#include <string>
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace Example {
+    
+  using panzer::Cell;
+  using panzer::Point;
+  using panzer::Dim;
+
+/** The analytic solution to the mixed poisson equation for the sine source.
+  */
+template<typename EvalT, typename Traits>
+class CurlSolution : public panzer::EvaluatorWithBaseImpl<Traits>,
+                        public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+public:
+    CurlSolution(const std::string & name,
+                       const panzer::IntegrationRule & ir);
+                                                                        
+    void postRegistrationSetup(typename Traits::SetupData d,           
+                               PHX::FieldManager<Traits>& fm);        
+                                                                     
+    void evaluateFields(typename Traits::EvalData d);               
+
+
+private:
+  typedef typename EvalT::ScalarT ScalarT;
+
+  // Simulation solution
+  PHX::MDField<ScalarT,Cell,Point,Dim> solution;
+  PHX::MDField<ScalarT,Cell,Point>     solution_curl;
+  int ir_degree, ir_index;
+};
+
+}
+
+#include "Example_CurlSolution_impl.hpp"
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlSolution_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_CurlSolution_impl.hpp
@@ -1,0 +1,108 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in solution and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of solution code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __Example_CurlSolution_impl_hpp__
+#define __Example_CurlSolution_impl_hpp__
+
+#include <cmath>
+
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+
+namespace Example {
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+CurlSolution<EvalT,Traits>::CurlSolution(const std::string & name,
+                                         const panzer::IntegrationRule & ir)
+{
+  using Teuchos::RCP;
+
+  Teuchos::RCP<PHX::DataLayout> dl_vector = ir.dl_vector;
+  Teuchos::RCP<PHX::DataLayout> dl_scalar = ir.dl_scalar;
+  ir_degree = ir.cubature_degree;
+
+  solution      = PHX::MDField<ScalarT,Cell,Point,Dim>(name, dl_vector);
+  solution_curl = PHX::MDField<ScalarT,Cell,Point>("CURL_"+name, dl_scalar);
+
+  // only thing that works
+  TEUCHOS_ASSERT(ir.spatial_dimension==2);
+
+  this->addEvaluatedField(solution);
+  this->addEvaluatedField(solution_curl);
+  
+  std::string n = "Curl Solution";
+  this->setName(n);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void CurlSolution<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
+                                                       PHX::FieldManager<Traits>& /* fm */)
+{
+  ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void CurlSolution<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+{ 
+  using panzer::index_t;
+  for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+    for (int point = 0; point < solution.extent_int(1); ++point) {
+
+      const double & x = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,0);
+      const double & y = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,1);
+
+      solution(cell,point,0) = -(y-1.0)*y + cos(2.0*M_PI*x)*sin(2.0*M_PI*y);
+      solution(cell,point,1) = -(x-1.0)*x + sin(2.0*M_PI*x)*cos(2.0*M_PI*y);
+
+      solution_curl(cell,point) = -2.0*x+2.0*y;
+    }
+  }
+}
+
+//**********************************************************************
+}
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_EquationSetFactory.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_EquationSetFactory.hpp
@@ -1,0 +1,93 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef __CurlLaplacianExample_EquationSetFactory_hpp__
+#define __CurlLaplacianExample_EquationSetFactory_hpp__
+
+#include "Panzer_EquationSet_Factory.hpp"
+#include "Panzer_EquationSet_Factory_Defines.hpp"
+#include "Panzer_CellData.hpp"
+
+// Add my equation sets here
+#include "Example_CurlLaplacianEquationSet.hpp"
+
+namespace Example {
+
+// A macro that defines a class to make construction of the equation sets easier
+//   - The equation set is constructed over a list of automatic differention types
+PANZER_DECLARE_EQSET_TEMPLATE_BUILDER(CurlLaplacianEquationSet, CurlLaplacianEquationSet)
+
+// A user written factory that creates each equation set.  The key member here
+// is buildEquationSet
+class EquationSetFactory : public panzer::EquationSetFactory {
+public:
+
+   Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> >
+   buildEquationSet(const Teuchos::RCP<Teuchos::ParameterList>& params,
+		    const int& default_integration_order,
+                    const panzer::CellData& cell_data,
+		    const Teuchos::RCP<panzer::GlobalData>& global_data,
+                    const bool build_transient_support) const
+   {
+      Teuchos::RCP<panzer::EquationSet_TemplateManager<panzer::Traits> > eq_set= 
+         Teuchos::rcp(new panzer::EquationSet_TemplateManager<panzer::Traits>);
+         
+      bool found = false; // this is used by PANZER_BUILD_EQSET_OBJECTS
+         
+      // macro checks if(ies.name=="CurlLaplacian") then an EquationSet_Energy object is constructed
+      PANZER_BUILD_EQSET_OBJECTS("CurlLaplacian", CurlLaplacianEquationSet)
+         
+      // make sure your equation set has been found
+      if(!found) {
+	std::string msg = "Error - the \"Equation Set\" called \"" + params->get<std::string>("Type") +
+                           "\" is not a valid equation set identifier. Please supply the correct factory.\n";
+         TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, msg);
+      }
+         
+      return eq_set;
+   }
+    
+};
+
+}
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_SimpleSource.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_SimpleSource.hpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef EXAMPLE_SIMPLE_SOURCE_DECL_HPP
+#define EXAMPLE_SIMPLE_SOURCE_DECL_HPP
+
+#include "PanzerAdaptersSTK_config.hpp"
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_FieldManager.hpp"
+
+#include "Panzer_Dimension.hpp"
+#include "Panzer_FieldLibrary.hpp"
+
+#include <string>
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace Example {
+    
+  using panzer::Cell;
+  using panzer::Point;
+  using panzer::Dim;
+
+/** A source for the curl Laplacian that results in the solution
+  */
+template<typename EvalT, typename Traits>
+class SimpleSource : public panzer::EvaluatorWithBaseImpl<Traits>,
+                        public PHX::EvaluatorDerived<EvalT, Traits>  {
+
+public:
+    SimpleSource(const std::string & name,
+                       const panzer::IntegrationRule & ir);
+                                                                        
+    void postRegistrationSetup(typename Traits::SetupData d,           
+                               PHX::FieldManager<Traits>& fm);        
+                                                                     
+    void evaluateFields(typename Traits::EvalData d);               
+
+
+private:
+  typedef typename EvalT::ScalarT ScalarT;
+
+  // Simulation source
+  PHX::MDField<ScalarT,Cell,Point,Dim> source;
+  int ir_degree, ir_index;
+};
+
+}
+
+#include "Example_SimpleSource_impl.hpp"
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_SimpleSource_impl.hpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/Example_SimpleSource_impl.hpp
@@ -1,0 +1,104 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef EXAMPLE_SIMPLE_SOURCE_IMPL_HPP
+#define EXAMPLE_SIMPLE_SOURCE_IMPL_HPP
+
+#include <cmath>
+
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Workset.hpp"
+#include "Panzer_Workset_Utilities.hpp"
+
+namespace Example {
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+SimpleSource<EvalT,Traits>::SimpleSource(const std::string & name,
+                                         const panzer::IntegrationRule & ir)
+{
+  using Teuchos::RCP;
+
+  Teuchos::RCP<PHX::DataLayout> data_layout = ir.dl_vector;
+  ir_degree = ir.cubature_degree;
+
+  source = PHX::MDField<ScalarT,Cell,Point,Dim>(name, data_layout);
+
+  this->addEvaluatedField(source);
+  
+  std::string n = "Simple Source";
+  this->setName(n);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void SimpleSource<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,           
+                                                       PHX::FieldManager<Traits>& /* fm */)
+{
+  ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
+void SimpleSource<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
+{ 
+  using panzer::index_t;
+  for (index_t cell = 0; cell < workset.num_cells; ++cell) {
+    for (int point = 0; point < source.extent_int(1); ++point) {
+
+      const double & x = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,0);
+      const double & y = this->wda(workset).int_rules[ir_index]->ip_coordinates(cell,point,1);
+
+      source(cell,point,0) = 2.0+y-y*y + cos(2.0*M_PI*x)*sin(2.0*M_PI*y);
+      source(cell,point,1) = 2.0+x-x*x + sin(2.0*M_PI*x)*cos(2.0*M_PI*y);
+
+      // if three d
+      if(source.extent(2)==3)
+        source(cell,point,2) = 0.0;
+    }
+  }
+}
+
+//**********************************************************************
+}
+
+#endif

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/convergence_rate.py
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/convergence_rate.py
@@ -1,0 +1,87 @@
+import math
+import sys
+import re
+
+try:
+  if not len(sys.argv)>4:
+    print('Expected at least three solution files with the line \"Error = \%f\" in them')
+    raise Exception("Failure: Command line - <cmd> [basis-order] [filename-prefix] [coarsest mesh res] [second mesh res] [third mesh res] ...")
+
+  basis_order = float(sys.argv[1])
+  file_prefix = sys.argv[2]
+
+  mesh_res = []
+  for i in range(3,len(sys.argv)):
+    mesh_res += [int(sys.argv[i])]
+
+  max_res =  max(mesh_res)
+
+  #orderPat   = re.compile('.*Basis Order = (.*)$')  
+  l2ErrorPat = re.compile('.*L2 Error = (.*)$')
+  h1ErrorPat = re.compile('.*HCurl Error = (.*)$')
+
+  #basis_order = 0
+  l2_error_value = 0
+  hcurl_error_value = 0
+  prev_l2_error_value = 0
+  prev_hcurl_error_value = 0
+
+  l2_error_values = []
+  hcurl_error_values = []
+  rate_values = []
+
+  for cnt, res in enumerate(mesh_res):
+    if max_res>=100:
+      filename = '%s%03d' % (file_prefix,res)
+    elif max_res>=10:
+      filename = '%s%02d' % (file_prefix,res)
+    else:
+      filename = '%s%d' % (file_prefix,res)
+
+    print("opening \"" + filename +"\"")
+    f = open(filename);
+
+    # look for the "Error = ..." line
+    for line in f:
+      #orderMatch = orderPat.match(line)
+      #if orderMatch!=None:
+      #  basis_order = float(orderMatch.group(1))
+
+      errorMatch = l2ErrorPat.match(line)
+      if errorMatch!=None:
+        l2_error_value = float(errorMatch.group(1))
+        l2_error_values += [l2_error_value]
+
+      errorMatch = h1ErrorPat.match(line)
+      if errorMatch!=None:
+        hcurl_error_value = float(errorMatch.group(1))
+        hcurl_error_values += [hcurl_error_value]
+   
+    if cnt>0:
+      prev_error = prev_l2_error_value + prev_hcurl_error_value
+      error = l2_error_value + hcurl_error_value        
+      rate = math.log(prev_error/error)/math.log(2)
+      rate_values += [rate]
+      diff = rate - basis_order
+
+      if rate > 0.90*basis_order:
+        print('%s: Convergence order of %f is within 10 percent of %f: PASSED' % (filename, rate, basis_order)) 
+      else:
+        print('%s: Convergence order of %f is not within 10 percent of %f: FAILED' % (filename, rate, basis_order)) 
+        raise Exception('Exception')
+
+    prev_l2_error_value = l2_error_value
+    prev_hcurl_error_value = hcurl_error_value
+
+  # end for res
+
+  print('L2 errors   : ', l2_error_values)
+  print('Curl errors : ', hcurl_error_values)
+  print('HCurl errors   : ', [l2_error_values[i] + hcurl_error_values[i] for i in range(len(l2_error_values))])
+  print('Conv rate   : ', rate_values)
+
+except Exception as e:
+  print("Test Failed: ")
+  print(e)
+else:
+  print("Test Passed")

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/main.cpp
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/main.cpp
@@ -1,0 +1,768 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_StackedTimer.hpp>
+#include <Teuchos_FancyOStream.hpp>
+
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_GlobalData.hpp"
+#include "Panzer_Workset_Builder.hpp"
+#include "Panzer_WorksetContainer.hpp"
+#include "Panzer_AssemblyEngine.hpp"
+#include "Panzer_AssemblyEngine_TemplateManager.hpp"
+#include "Panzer_AssemblyEngine_TemplateBuilder.hpp"
+#include "Panzer_LinearObjFactory.hpp"
+#include "Panzer_BlockedEpetraLinearObjFactory.hpp"
+#include "Panzer_TpetraLinearObjFactory.hpp"
+#include "Panzer_DOFManagerFactory.hpp"
+#include "Panzer_FieldManagerBuilder.hpp"
+#include "Panzer_PureBasis.hpp"
+#include "Panzer_GlobalData.hpp"
+#include "Panzer_ResponseLibrary.hpp"
+#include "Panzer_ResponseEvaluatorFactory_Functional.hpp"
+#include "Panzer_Response_Functional.hpp"
+#include "Panzer_CheckBCConsistency.hpp"
+
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_STK_WorksetFactory.hpp"
+#include "Panzer_STKConnManager.hpp"
+#include "Panzer_STK_Version.hpp"
+#include "Panzer_STK_Interface.hpp"
+#include "Panzer_STK_SquareQuadMeshFactory.hpp"
+#include "Panzer_STK_SquareTriMeshFactory.hpp"
+#include "Panzer_STK_CubeHexMeshFactory.hpp"
+#include "Panzer_STK_SetupUtilities.hpp"
+#include "Panzer_STK_Utilities.hpp"
+#include "Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp"
+
+#include "Epetra_MpiComm.h"
+
+#include "EpetraExt_RowMatrixOut.h"
+#include "EpetraExt_VectorOut.h"
+
+#include "BelosPseudoBlockGmresSolMgr.hpp"
+#include "BelosTpetraAdapter.hpp"
+
+#include "Example_BCStrategy_Factory.hpp"
+#include "Example_ClosureModel_Factory_TemplateBuilder.hpp"
+#include "Example_EquationSetFactory.hpp"
+
+#include "AztecOO.h"
+
+#include <sstream>
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+
+
+//
+// This is the Mathematica code used to generate this example.
+// It also generates a plot of the vector field so it is clear
+// what the solution is doing.
+//
+//      Needs["VectorAnalysis`"]
+//
+//      phi0[x_,y_]=(1-x)*(1-y)
+//      phi1[x_,y_]=x*(1-y)
+//      phi2[x_,y_]=x*y
+//      phi3[x_,y_]=y*(1-x)
+//
+//      psi0[x_,y_]={1-y,0,0}
+//      psi1[x_,y_]={0,x,0}
+//      psi2[x_,y_]={y,0,0}
+//      psi3[x_,y_]={0,1-x,0}
+//
+//      u[x_,y_]=phi2[x,y]*psi0[x,y]+phi3[x,y]*psi1[x,y]+phi0[x,y]*psi2[x,y]+phi1[x,y]*psi3[x,y]
+//      f[x_,y_]=u[x,y]+Curl[Curl[u[x,y],Cartesian[x,y,z]],Cartesian[x,y,z]]
+//
+//      TwoDVec[g_]={g[[1]],g[[2]]}
+//
+//      DotProduct[u[0.5,0],{1,0,0}]
+//      DotProduct[u[1,0.5],{0,1,0}]
+//      DotProduct[u[0.5,1],{1,0,0}]
+//      DotProduct[u[0,0.5],{0,1,0}]
+//
+//      Out[118]= 0.
+//      Out[119]= 0.
+//      Out[120]= 0.
+//      Out[121]= 0.
+//
+//      VectorPlot[TwoDVec[u[x,y]],{x,0,1},{y,0,1}]
+//      Simplify[u[x,y]]
+//      Simplify[f[x,y]]
+//
+//      Out[144]= {-(-1+y) y,-(-1+x) x,0}
+//      Out[145]= {2+y-y^2,2+x-x^2,0}
+//
+
+void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
+		        std::vector<panzer::BC>& bcs,
+                        const std::vector<std::string>& eBlockNames,
+                        int basis_order,
+                        const bool threeD);
+
+void solveEpetraSystem(panzer::LinearObjContainer & container);
+void solveTpetraSystem(panzer::LinearObjContainer & container);
+
+// calls MPI_Init and MPI_Finalize
+int main(int argc,char * argv[])
+{
+   using std::endl;
+   using Teuchos::RCP;
+   using Teuchos::rcp_dynamic_cast;
+   using panzer::StrPureBasisPair;
+   using panzer::StrPureBasisComp;
+
+   Kokkos::initialize(argc,argv);
+
+   Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+   RCP<Epetra_Comm> Comm = Teuchos::rcp(new Epetra_MpiComm(MPI_COMM_WORLD));
+   Teuchos::RCP<const Teuchos::MpiComm<int> > comm = Teuchos::rcp(new Teuchos::MpiComm<int>(MPI_COMM_WORLD));
+   Teuchos::FancyOStream out(Teuchos::rcpFromRef(std::cout));
+   out.setOutputToRootOnly(0);
+   out.setShowProcRank(true);
+
+   const auto stackedTimer = Teuchos::rcp(new Teuchos::StackedTimer("Panzer MixedPoisson Test"));
+   Teuchos::TimeMonitor::setStackedTimer(stackedTimer);
+   stackedTimer->start("Curl Laplacian");
+
+   // Build command line processor
+   ////////////////////////////////////////////////////
+
+   bool useTpetra = true;
+   bool threeD = false;
+   int x_blocks = 1;
+   int x_elements=20,y_elements=20,z_elements=20;
+   std::string celltype = "Quad"; // or "Tri" (2d), Hex or Tet (3d)
+   double x_size=1.,y_size=1.,z_size=1.;
+   int basis_order = 1;
+   std::string output_filename="output_";
+
+   Teuchos::CommandLineProcessor clp;
+   clp.throwExceptions(false);
+   clp.setDocString("This example solves curl laplacian problem with Hex and Tet inline mesh with high order.\n");
+
+   clp.setOption("cell",&celltype);
+   clp.setOption("use-tpetra","use-epetra",&useTpetra);
+   clp.setOption("use-threed","use-twod",&threeD);
+   clp.setOption("x-blocks",&x_blocks);
+   clp.setOption("x-elements",&x_elements);
+   clp.setOption("y-elements",&y_elements);
+   clp.setOption("z-elements",&z_elements);
+   clp.setOption("x-size",&x_size);
+   clp.setOption("y-size",&y_size);
+   clp.setOption("z-size",&z_size);
+   clp.setOption("basis-order",&basis_order);
+   clp.setOption("output-filename",&output_filename);
+
+   // parse commandline argument
+   Teuchos::CommandLineProcessor::EParseCommandLineReturn r_parse= clp.parse( argc, argv );
+   if (r_parse == Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED) return  0;
+   if (r_parse != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL  ) return -1;
+
+   // variable declarations
+   ////////////////////////////////////////////////////
+
+   // factory definitions
+   Teuchos::RCP<Example::EquationSetFactory> eqset_factory =
+     Teuchos::rcp(new Example::EquationSetFactory); // where poison equation is defined
+   Example::BCStrategyFactory bc_factory;    // where boundary conditions are defined
+
+   // construction of uncommitted (no elements) mesh
+   ////////////////////////////////////////////////////////
+
+   RCP<panzer_stk::STK_MeshFactory> mesh_factory;
+   if(threeD) {
+     mesh_factory = rcp(new panzer_stk::CubeHexMeshFactory);
+
+     // set mesh factory parameters
+     RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+     pl->set("X Blocks",x_blocks);
+     pl->set("Y Blocks",1);
+     pl->set("Z Blocks",1);
+     pl->set("X Elements",x_elements/x_blocks);
+     pl->set("Y Elements",y_elements);
+     pl->set("Z Elements",z_elements);
+     pl->set("Xf",x_size);
+     pl->set("Yf",y_size);
+     pl->set("Zf",z_size);
+     mesh_factory->setParameterList(pl);
+   }
+   else {
+     if      (celltype == "Quad") mesh_factory = Teuchos::rcp(new panzer_stk::SquareQuadMeshFactory);
+     else if (celltype == "Tri")  mesh_factory = Teuchos::rcp(new panzer_stk::SquareTriMeshFactory);
+     else
+       throw std::runtime_error("not supported celltype argument: try Quad or Tri");
+
+     // set mesh factory parameters
+     RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+     pl->set("X Blocks",x_blocks);
+     pl->set("Y Blocks",1);
+     pl->set("X Elements",x_elements/x_blocks);
+     pl->set("Y Elements",y_elements);
+     pl->set("Xf",x_size);
+     pl->set("Yf",y_size);
+     mesh_factory->setParameterList(pl);
+   }
+
+   RCP<panzer_stk::STK_Interface> mesh = mesh_factory->buildUncommitedMesh(MPI_COMM_WORLD);
+
+   // other declarations
+   const std::size_t workset_size = 8;
+
+   // construct input physics and physics block
+   ////////////////////////////////////////////////////////
+
+   Teuchos::RCP<Teuchos::ParameterList> ipb = Teuchos::parameterList("Physics Blocks");
+   std::vector<panzer::BC> bcs;
+   std::vector<RCP<panzer::PhysicsBlock> > physicsBlocks;
+   {
+      bool build_transient_support = false;
+
+      std::vector<std::string> eBlockNames;
+      mesh->getElementBlockNames(eBlockNames);
+      testInitialization(ipb, bcs, eBlockNames, basis_order, threeD);
+
+      const panzer::CellData volume_cell_data(workset_size, mesh->getCellTopology(eBlockNames[0]));
+
+      // GobalData sets ostream and parameter interface to physics
+      Teuchos::RCP<panzer::GlobalData> gd = panzer::createGlobalData();
+
+      // Can be overridden by the equation set
+      int default_integration_order = 4;
+
+      // the physics block knows how to build and register evaluator with the field manager
+      for (const auto& block : eBlockNames) {
+        RCP<panzer::PhysicsBlock> pb
+          = rcp(new panzer::PhysicsBlock(ipb, block,
+                                         default_integration_order,
+                                         volume_cell_data,
+                                         eqset_factory,
+                                         gd,
+                                         build_transient_support));
+
+        // we can have more than one physics block, one per element block
+        physicsBlocks.push_back(pb);
+      }
+   }
+
+   // finish building mesh, set required field variables and mesh bulk data
+   ////////////////////////////////////////////////////////////////////////
+
+   for (const auto pb : physicsBlocks) {
+      const std::vector<StrPureBasisPair> & blockFields = pb->getProvidedDOFs();
+
+      // insert all fields into a set
+      std::set<StrPureBasisPair,StrPureBasisComp> fieldNames;
+      fieldNames.insert(blockFields.begin(),blockFields.end());
+
+      // build string for modifiying vectors
+      std::vector<std::string> dimenStr(3);
+      dimenStr[0] = "X"; dimenStr[1] = "Y"; dimenStr[2] = "Z";
+
+      // add basis to DOF manager: block specific
+      std::set<StrPureBasisPair,StrPureBasisComp>::const_iterator fieldItr;
+      for (fieldItr=fieldNames.begin();fieldItr!=fieldNames.end();++fieldItr) {
+         Teuchos::RCP<const panzer::PureBasis> basis = fieldItr->second;
+         if(basis->getElementSpace()==panzer::PureBasis::HGRAD)
+            mesh->addSolutionField(fieldItr->first,pb->elementBlockID());
+         else if(basis->getElementSpace()==panzer::PureBasis::HCURL) {
+            for(int i=0;i<basis->dimension();i++)
+               mesh->addCellField(fieldItr->first+dimenStr[i],pb->elementBlockID());
+         }
+         else if(basis->getElementSpace()==panzer::PureBasis::HDIV) {
+            for(int i=0;i<basis->dimension();i++)
+               mesh->addCellField(fieldItr->first+dimenStr[i],pb->elementBlockID());
+         }
+         else if(basis->getElementSpace()==panzer::PureBasis::HVOL) {
+            for(int i=0;i<basis->dimension();i++)
+               mesh->addCellField(fieldItr->first+dimenStr[i],pb->elementBlockID());
+         }
+      }
+   }
+   mesh_factory->completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+
+
+   // check that the bcs exist in the mesh
+   /////////////////////////////////////////////////////////////
+   {
+     std::vector<std::string> eBlockNames;
+     mesh->getElementBlockNames(eBlockNames);
+     std::vector<std::string> sidesetNames;
+     mesh->getSidesetNames(sidesetNames);
+     panzer::checkBCConsistency(eBlockNames,sidesetNames,bcs);
+   }
+
+   // build DOF Manager and linear object factory
+   /////////////////////////////////////////////////////////////
+
+   RCP<panzer::UniqueGlobalIndexerBase> dofManager;
+   Teuchos::RCP<panzer::LinearObjFactory<panzer::Traits> > linObjFactory;
+
+   // build the connection manager
+   if(!useTpetra) {
+     const Teuchos::RCP<panzer::ConnManager<int,int> > conn_manager = Teuchos::rcp(new panzer_stk::STKConnManager<int>(mesh));
+
+     panzer::DOFManagerFactory<int,int> globalIndexerFactory;
+     RCP<panzer::UniqueGlobalIndexer<int,int> > dofManager_int
+           = globalIndexerFactory.buildUniqueGlobalIndexer(Teuchos::opaqueWrapper(MPI_COMM_WORLD),physicsBlocks,conn_manager);
+     dofManager = dofManager_int;
+
+     // construct some linear algebra object, build object to pass to evaluators
+     linObjFactory = Teuchos::rcp(new panzer::BlockedEpetraLinearObjFactory<panzer::Traits,int>(comm.getConst(),dofManager_int));
+   }
+   else {
+     const Teuchos::RCP<panzer::ConnManager<int,panzer::Ordinal64> > conn_manager
+         = Teuchos::rcp(new panzer_stk::STKConnManager<panzer::Ordinal64>(mesh));
+
+     panzer::DOFManagerFactory<int,panzer::Ordinal64> globalIndexerFactory;
+     RCP<panzer::UniqueGlobalIndexer<int,panzer::Ordinal64> > dofManager_long
+           = globalIndexerFactory.buildUniqueGlobalIndexer(Teuchos::opaqueWrapper(MPI_COMM_WORLD),physicsBlocks,conn_manager);
+     dofManager = dofManager_long;
+
+     // construct some linear algebra object, build object to pass to evaluators
+     linObjFactory = Teuchos::rcp(new panzer::TpetraLinearObjFactory<panzer::Traits,double,int,panzer::Ordinal64>(comm,dofManager_long));
+   }
+
+   // build worksets
+   ////////////////////////////////////////////////////////
+
+   Teuchos::RCP<panzer_stk::WorksetFactory> wkstFactory
+      = Teuchos::rcp(new panzer_stk::WorksetFactory(mesh)); // build STK workset factory
+   Teuchos::RCP<panzer::WorksetContainer> wkstContainer     // attach it to a workset container (uses lazy evaluation)
+      = Teuchos::rcp(new panzer::WorksetContainer);
+   wkstContainer->setFactory(wkstFactory);
+   for(size_t i=0;i<physicsBlocks.size();i++)
+     wkstContainer->setNeeds(physicsBlocks[i]->elementBlockID(),physicsBlocks[i]->getWorksetNeeds());
+   wkstContainer->setWorksetSize(workset_size);
+   wkstContainer->setGlobalIndexer(dofManager);
+
+   // Setup STK response library for writing out the solution fields
+   ////////////////////////////////////////////////////////////////////////
+   Teuchos::RCP<panzer::ResponseLibrary<panzer::Traits> > stkIOResponseLibrary
+      = Teuchos::rcp(new panzer::ResponseLibrary<panzer::Traits>(wkstContainer,dofManager,linObjFactory));
+
+   {
+      // get a vector of all the element blocks
+      std::vector<std::string> eBlocks;
+      {
+         // get all element blocks and add them to the list
+         std::vector<std::string> eBlockNames;
+         mesh->getElementBlockNames(eBlockNames);
+         for(std::size_t i=0;i<eBlockNames.size();i++)
+            eBlocks.push_back(eBlockNames[i]);
+      }
+
+      panzer_stk::RespFactorySolnWriter_Builder builder;
+      builder.mesh = mesh;
+      stkIOResponseLibrary->addResponse("Main Field Output",eBlocks,builder);
+   }
+
+   // Setup response library for checking the error in this manufactered solution
+   ////////////////////////////////////////////////////////////////////////
+
+   Teuchos::RCP<panzer::ResponseLibrary<panzer::Traits> > errorResponseLibrary
+      = Teuchos::rcp(new panzer::ResponseLibrary<panzer::Traits>(wkstContainer,dofManager,linObjFactory));
+
+   {
+     std::vector<std::string> eBlocks;
+     mesh->getElementBlockNames(eBlocks);
+
+     panzer::FunctionalResponse_Builder<int,int> builder;
+
+     builder.comm = MPI_COMM_WORLD;
+     builder.cubatureDegree = 10;
+     builder.requiresCellIntegral = true;
+     builder.quadPointField = "EFIELD_ERROR";
+
+     errorResponseLibrary->addResponse("L2 Error",eBlocks,builder);
+
+     builder.comm = MPI_COMM_WORLD;
+     builder.cubatureDegree = 10;
+     builder.requiresCellIntegral = true;
+     builder.quadPointField = "EFIELD_HCURL_ERROR";
+
+     errorResponseLibrary->addResponse("HCurl Error",eBlocks,builder);
+   }
+
+   // setup closure model
+   /////////////////////////////////////////////////////////////
+
+   // Add in the application specific closure model factory
+   panzer::ClosureModelFactory_TemplateManager<panzer::Traits> cm_factory;
+   Example::ClosureModelFactory_TemplateBuilder cm_builder;
+   cm_factory.buildObjects(cm_builder);
+
+   Teuchos::ParameterList closure_models("Closure Models");
+   {
+     closure_models.sublist("solid").sublist("SOURCE_EFIELD").set<std::string>("Type","SIMPLE SOURCE"); // a constant source
+        // SOURCE_EFIELD field is required by the CurlLaplacianEquationSet
+
+     // required for error calculation
+     closure_models.sublist("solid").sublist("EFIELD_ERROR").set<std::string>("Type","L2 ERROR_CALC");
+     closure_models.sublist("solid").sublist("EFIELD_ERROR").set<std::string>("Field A","EFIELD");
+     closure_models.sublist("solid").sublist("EFIELD_ERROR").set<std::string>("Field B","EFIELD_EXACT");
+
+     closure_models.sublist("solid").sublist("EFIELD_HCURL_ERROR").set<std::string>("Type","HCurl ERROR_CALC");
+     closure_models.sublist("solid").sublist("EFIELD_HCURL_ERROR").set<std::string>("Field A","EFIELD");
+     closure_models.sublist("solid").sublist("EFIELD_HCURL_ERROR").set<std::string>("Field B","EFIELD_EXACT");
+
+     closure_models.sublist("solid").sublist("EFIELD_EXACT").set<std::string>("Type","EFIELD_EXACT");
+     // closure_models.sublist("solid").sublist("EFIELD_EXACT").set<std::string>("Type","SIMPLE SOURCE");
+   }
+
+   Teuchos::ParameterList user_data("User Data"); // user data can be empty here
+
+   // setup field manager builder
+   /////////////////////////////////////////////////////////////
+
+   Teuchos::RCP<panzer::FieldManagerBuilder> fmb =
+         Teuchos::rcp(new panzer::FieldManagerBuilder);
+   fmb->setWorksetContainer(wkstContainer);
+   fmb->setupVolumeFieldManagers(physicsBlocks,cm_factory,closure_models,*linObjFactory,user_data);
+   fmb->setupBCFieldManagers(bcs,physicsBlocks,*eqset_factory,cm_factory,bc_factory,closure_models,
+                             *linObjFactory,user_data);
+
+   fmb->writeVolumeGraphvizDependencyFiles("volume",physicsBlocks);
+   fmb->writeBCGraphvizDependencyFiles("saucy");
+
+   // setup assembly engine
+   /////////////////////////////////////////////////////////////
+
+   // build assembly engine: The key piece that brings together everything and
+   //                        drives and controls the assembly process. Just add
+   //                        matrices and vectors
+   panzer::AssemblyEngine_TemplateManager<panzer::Traits> ae_tm;
+   panzer::AssemblyEngine_TemplateBuilder builder(fmb,linObjFactory);
+   ae_tm.buildObjects(builder);
+
+   // Finalize construcition of STK writer response library
+   /////////////////////////////////////////////////////////////
+   {
+      user_data.set<int>("Workset Size",workset_size);
+      stkIOResponseLibrary->buildResponseEvaluators(physicsBlocks,
+                                        cm_factory,
+                                        closure_models,
+                                        user_data,true,"io");
+
+      user_data.set<int>("Workset Size",workset_size);
+      errorResponseLibrary->buildResponseEvaluators(physicsBlocks,
+                                                    cm_factory,
+                                                    closure_models,
+                                                    user_data,true,"error");
+   }
+
+   // assemble linear system
+   /////////////////////////////////////////////////////////////
+
+   // build linear algebra objects: Ghost is for parallel assembly, it contains
+   //                               local element contributions summed, the global IDs
+   //                               are not unique. The non-ghosted or "global"
+   //                               container will contain the sum over all processors
+   //                               of the ghosted objects. The global indices are unique.
+   RCP<panzer::LinearObjContainer> ghostCont = linObjFactory->buildGhostedLinearObjContainer();
+   RCP<panzer::LinearObjContainer> container = linObjFactory->buildLinearObjContainer();
+   linObjFactory->initializeGhostedContainer(panzer::LinearObjContainer::X |
+                                             panzer::LinearObjContainer::F |
+                                             panzer::LinearObjContainer::Mat,*ghostCont);
+   linObjFactory->initializeContainer(panzer::LinearObjContainer::X |
+                                      panzer::LinearObjContainer::F |
+                                      panzer::LinearObjContainer::Mat,*container);
+   ghostCont->initialize();
+   container->initialize();
+
+   // Actually evaluate
+   /////////////////////////////////////////////////////////////
+
+   panzer::AssemblyEngineInArgs input(ghostCont,container);
+   input.alpha = 0;
+   input.beta = 1;
+
+   // evaluate physics: This does both the Jacobian and residual at once
+   ae_tm.getAsObject<panzer::Traits::Jacobian>()->evaluate(input);
+
+   // solve linear system
+   /////////////////////////////////////////////////////////////
+
+   if(useTpetra)
+      solveTpetraSystem(*container);
+   else
+      solveEpetraSystem(*container);
+
+   // output data (optional)
+   /////////////////////////////////////////////////////////////
+
+   // write out solution
+   if(true) {
+      // fill STK mesh objects
+      Teuchos::RCP<panzer::ResponseBase> resp = stkIOResponseLibrary->getResponse<panzer::Traits::Residual>("Main Field Output");
+      panzer::AssemblyEngineInArgs respInput(ghostCont,container);
+      respInput.alpha = 0;
+      respInput.beta = 1;
+
+      stkIOResponseLibrary->addResponsesToInArgs<panzer::Traits::Residual>(respInput);
+      stkIOResponseLibrary->evaluate<panzer::Traits::Residual>(respInput);
+
+      // write to exodus
+      // ---------------
+      // Due to multiple instances of this test being run at the same
+      // time (one for each order), we need to differentiate output to
+      // prevent race conditions on output file. Multiple runs for the
+      // same order are ok as they are staged one after another in the
+      // ADD_ADVANCED_TEST cmake macro.
+      std::ostringstream filename;
+      filename << output_filename << basis_order << ".exo";
+      mesh->writeToExodus(filename.str());
+   }
+
+   // compute error norm
+   /////////////////////////////////////////////////////////////
+
+   if(true) {
+      Teuchos::FancyOStream lout(Teuchos::rcpFromRef(std::cout));
+      lout.setOutputToRootOnly(0);
+
+      panzer::AssemblyEngineInArgs respInput(ghostCont,container);
+      respInput.alpha = 0;
+      respInput.beta = 1;
+
+      Teuchos::RCP<panzer::ResponseBase> l2_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("L2 Error");
+      Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > l2_resp_func =
+            Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(l2_resp);
+      Teuchos::RCP<Thyra::VectorBase<double> > l2_respVec = Thyra::createMember(l2_resp_func->getVectorSpace());
+      l2_resp_func->setVector(l2_respVec);
+
+      Teuchos::RCP<panzer::ResponseBase> h1_resp = errorResponseLibrary->getResponse<panzer::Traits::Residual>("HCurl Error");
+      Teuchos::RCP<panzer::Response_Functional<panzer::Traits::Residual> > h1_resp_func =
+            Teuchos::rcp_dynamic_cast<panzer::Response_Functional<panzer::Traits::Residual> >(h1_resp);
+      Teuchos::RCP<Thyra::VectorBase<double> > h1_respVec = Thyra::createMember(h1_resp_func->getVectorSpace());
+      h1_resp_func->setVector(h1_respVec);
+
+      errorResponseLibrary->addResponsesToInArgs<panzer::Traits::Residual>(respInput);
+      errorResponseLibrary->evaluate<panzer::Traits::Residual>(respInput);
+
+      lout << "L2 Error = " << sqrt(l2_resp_func->value) << std::endl;
+      lout << "HCurl Error = " << sqrt(h1_resp_func->value) << std::endl;
+   }
+
+   stackedTimer->stop("Curl Laplacian");
+   Teuchos::StackedTimer::OutputOptions options;
+   options.output_fraction = true;
+   options.output_minmax = true;
+   options.output_histogram = true;
+   options.num_histogram = 5;
+   stackedTimer->report(std::cout, Teuchos::DefaultComm<int>::getComm(), options);
+
+   // all done!
+   /////////////////////////////////////////////////////////////
+
+   if(useTpetra)
+      out << "ALL PASSED: Tpetra" << std::endl;
+   else
+      out << "ALL PASSED: Epetra" << std::endl;
+
+   return 0;
+}
+
+void solveEpetraSystem(panzer::LinearObjContainer & container)
+{
+   // convert generic linear object container to epetra container
+   panzer::EpetraLinearObjContainer & ep_container
+         = Teuchos::dyn_cast<panzer::EpetraLinearObjContainer>(container);
+
+   ep_container.get_x()->PutScalar(0.0);
+
+   // Setup the linear solve: notice A is used directly
+   Epetra_LinearProblem problem(&*ep_container.get_A(),&*ep_container.get_x(),&*ep_container.get_f());
+
+   // build the solver
+   AztecOO solver(problem);
+   solver.SetAztecOption(AZ_solver,AZ_gmres); // we don't push out dirichlet conditions
+   solver.SetAztecOption(AZ_precond,AZ_none);
+   solver.SetAztecOption(AZ_kspace,3000);
+   solver.SetAztecOption(AZ_output,1);
+   solver.SetAztecOption(AZ_precond,AZ_Jacobi);
+
+   // solve the linear system
+   solver.Iterate(50000,1e-9);
+
+   // we have now solved for the residual correction from
+   // zero in the context of a Newton solve.
+   //     J*e = -r = -(f - J*0) where f = J*u
+   // Therefore we have  J*e=-J*u which implies e = -u
+   // thus we will scale the solution vector
+   ep_container.get_x()->Scale(-1.0);
+}
+
+void solveTpetraSystem(panzer::LinearObjContainer & container)
+{
+  typedef panzer::TpetraLinearObjContainer<double,int,panzer::Ordinal64> LOC;
+
+  LOC & tp_container = Teuchos::dyn_cast<LOC>(container);
+
+  // do stuff
+  // Wrap the linear problem to solve in a Belos::LinearProblem
+  // object.  The "X" argument of the LinearProblem constructor is
+  // only copied shallowly and will be overwritten by the solve, so we
+  // make a deep copy here.  That way we can compare the result
+  // against the original X_guess.
+  typedef Tpetra::MultiVector<double,int,panzer::Ordinal64> MV;
+  typedef Tpetra::Operator<double,int,panzer::Ordinal64> OP;
+  typedef Belos::LinearProblem<double,MV, OP> ProblemType;
+  Teuchos::RCP<ProblemType> problem(new ProblemType(tp_container.get_A(), tp_container.get_x(), tp_container.get_f()));
+  TEUCHOS_ASSERT(problem->setProblem());
+
+  typedef Belos::PseudoBlockGmresSolMgr<double,MV,OP> SolverType;
+
+  Teuchos::ParameterList belosList;
+  belosList.set( "Num Blocks", 3000 );            // Maximum number of blocks in Krylov factorization
+  belosList.set( "Block Size", 1 );              // Blocksize to be used by iterative solver
+  belosList.set( "Maximum Iterations", 50000 );       // Maximum number of iterations allowed
+  belosList.set( "Maximum Restarts", 20 );      // Maximum number of restarts allowed
+  belosList.set( "Convergence Tolerance", 1e-9 );         // Relative convergence tolerance requested
+  belosList.set( "Verbosity", Belos::Errors + Belos::Warnings + Belos::TimingDetails + Belos::StatusTestDetails );
+  belosList.set( "Output Frequency", 1 );
+  belosList.set( "Output Style", 1 );
+
+  SolverType solver(problem, Teuchos::rcpFromRef(belosList));
+
+  Belos::ReturnType result = solver.solve();
+  if (result == Belos::Converged)
+    std::cout << "Result: Converged." << std::endl;
+  else {
+    TEUCHOS_ASSERT(false); // FAILURE!
+  }
+
+  // scale by -1
+  tp_container.get_x()->scale(-1.0);
+
+  tp_container.get_A()->resumeFill(); // where does this go?
+}
+
+void testInitialization(const Teuchos::RCP<Teuchos::ParameterList>& ipb,
+		        std::vector<panzer::BC>& bcs,
+                        const std::vector<std::string>& eBlockNames,
+                        int basis_order,
+                        const bool threeD)
+{
+  {
+    std::string b_basis_type = threeD ? "HDiv" : "HVol";
+    int b_basis_order = threeD ? basis_order : basis_order-1; 
+
+    Teuchos::ParameterList& p = ipb->sublist("CurlLapacian Physics");
+    p.set("Type","CurlLaplacian");
+    p.set("Model ID","solid");
+    p.set("EField Basis Type","HCurl");
+    p.set("BField Basis Type",b_basis_type);
+    p.set("EField Basis Order",basis_order);
+    p.set("BField Basis Order",b_basis_order);
+    p.set("Integration Order",10);
+  }
+
+  std::size_t bc_id = 0;
+  for (const auto& block : eBlockNames) {
+    panzer::BCType bctype = panzer::BCT_Dirichlet;
+    std::string sideset_id = "left";
+    std::string element_block_id = block;
+    std::string dof_name = "EFIELD";
+    std::string strategy = "Constant";
+    double value = 0.0;
+    Teuchos::ParameterList p;
+    p.set("Value",value);
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
+		  strategy, p);
+    bcs.push_back(bc);
+  }
+
+  // multiblock splits on x only
+  for (const auto& block : eBlockNames) {
+    panzer::BCType bctype = panzer::BCT_Dirichlet;
+    std::string sideset_id = "top";
+    std::string element_block_id = block;
+    std::string dof_name = "EFIELD";
+    std::string strategy = "Constant";
+    double value = 0.0;
+    Teuchos::ParameterList p;
+    p.set("Value",value);
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
+		  strategy, p);
+    bcs.push_back(bc);
+  }
+
+  for (const auto& block : eBlockNames) {
+    panzer::BCType bctype = panzer::BCT_Dirichlet;
+    std::string sideset_id = "right";
+    std::string element_block_id = block;
+    std::string dof_name = "EFIELD";
+    std::string strategy = "Constant";
+    double value = 0.0;
+    Teuchos::ParameterList p;
+    p.set("Value",value);
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
+		  strategy, p);
+    bcs.push_back(bc);
+  }
+
+  // multiblock splits on x only
+  for (const auto& block : eBlockNames) {
+    panzer::BCType bctype = panzer::BCT_Dirichlet;
+    std::string sideset_id = "bottom";
+    std::string element_block_id = block;
+    std::string dof_name = "EFIELD";
+    std::string strategy = "Constant";
+    double value = 0.0;
+    Teuchos::ParameterList p;
+    p.set("Value",value);
+    panzer::BC bc(bc_id++, bctype, sideset_id, element_block_id, dof_name,
+		  strategy, p);
+    bcs.push_back(bc);
+  }
+
+}

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
@@ -175,6 +175,11 @@ namespace panzer {
                               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
                               const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
 
+    void evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
+                             const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
+                             const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
+                             const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
+
     void evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
                               const PHX::MDField<Scalar,Cell,IP> & weighted_measure);

--- a/packages/panzer/disc-fe/src/Panzer_IntrepidBasisFactory.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntrepidBasisFactory.hpp
@@ -48,6 +48,8 @@
 #include <map>
 
 #include "Intrepid2_HVOL_C0_FEM.hpp"
+#include "Intrepid2_HVOL_TRI_Cn_FEM.hpp"
+#include "Intrepid2_HVOL_QUAD_Cn_FEM.hpp"
 
 #include "Teuchos_RCP.hpp"
 #include "Intrepid2_Basis.hpp"
@@ -136,6 +138,15 @@ namespace panzer {
 
     if ( (basis_type == "Const") && (basis_order == 0) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HVOL_C0_FEM<ExecutionSpace,OutputValueType,PointValueType>(cell_topology) );
+
+    else if ( (basis_type == "HVol") && (basis_order == 0) )
+      basis = Teuchos::rcp( new Intrepid2::Basis_HVOL_C0_FEM<ExecutionSpace,OutputValueType,PointValueType>(cell_topology) );
+
+    else if ( (basis_type == "HVol") && (cell_type == "Quadrilateral") && (basis_order > 0) )
+      basis = Teuchos::rcp( new Intrepid2::Basis_HVOL_QUAD_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
+
+    else if ( (basis_type == "HVol") && (cell_type == "Triangle") && (basis_order > 0) )
+      basis = Teuchos::rcp( new Intrepid2::Basis_HVOL_TRI_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>(basis_order, point_type) );
 
     else if ( (basis_type == "HGrad") && (cell_type == "Hexahedron") && (basis_order == 1) )
       basis = Teuchos::rcp( new Intrepid2::Basis_HGRAD_HEX_C1_FEM<ExecutionSpace,OutputValueType,PointValueType> );

--- a/packages/panzer/disc-fe/src/Panzer_L2Projection_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_L2Projection_impl.hpp
@@ -94,7 +94,7 @@ namespace panzer {
     auto M = ghostedMatrix->getLocalMatrix();
     const int fieldIndex = targetGlobalIndexer_->getFieldNum(targetBasisDescriptor_.getType());
 
-    const bool is_scalar = targetBasisDescriptor_.getType()=="HGrad" || targetBasisDescriptor_.getType()=="Const";
+    const bool is_scalar = targetBasisDescriptor_.getType()=="HGrad" || targetBasisDescriptor_.getType()=="Const" || targetBasisDescriptor_.getType()=="HVol";
 
     // Loop over element blocks and fill mass matrix
     if(is_scalar){
@@ -348,7 +348,7 @@ namespace panzer {
         Kokkos::View<const double***,PHX::Device> sourceUnweightedScalarBasis;
         Kokkos::View<const double****,PHX::Device> sourceUnweightedVectorBasis;
         bool useRankThreeBasis = false; // default to gradient or vector basis
-        if ( (sourceBasisDescriptor.getType() == "HGrad") || (sourceBasisDescriptor.getType() == "Const") ) {
+        if ( (sourceBasisDescriptor.getType() == "HGrad") || (sourceBasisDescriptor.getType() == "Const") || (sourceBasisDescriptor.getType() == "HVol") ) {
           if (directionIndex == -1) { // Project dof value
             sourceUnweightedScalarBasis = sourceBasisValues.basis_scalar.get_static_view();
             useRankThreeBasis = true;

--- a/packages/panzer/disc-fe/src/Panzer_PureBasis.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_PureBasis.cpp
@@ -122,12 +122,17 @@ void panzer::PureBasis::initialize(const std::string & in_basis_type,const int i
     element_space_ = HDIV;
   else if(basis_type_=="Const")
     element_space_ = CONST;
+  else if(basis_type_=="HVol")
+    element_space_ = HVOL;
   else { TEUCHOS_TEST_FOR_EXCEPTION(true,std::invalid_argument,
 				    "PureBasis::initializeIntrospection - Invalid basis name \"" 
 				    << basis_type_ << "\""); }
   
   switch(getElementSpace()) {
   case CONST:
+     basis_rank_ = 0;
+     break;
+  case HVOL:
      basis_rank_ = 0;
      break;
   case HGRAD:

--- a/packages/panzer/disc-fe/src/Panzer_PureBasis.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_PureBasis.hpp
@@ -61,7 +61,7 @@ namespace panzer {
   class PureBasis { 
 
   public:
-    typedef enum { HGRAD=0, HCURL=1, HDIV=2, CONST=3 } EElementSpace;
+    typedef enum { HGRAD=0, HCURL=1, HDIV=2, HVOL=3, CONST=4 } EElementSpace;
     
     /** Build a basis given a type, order and CellData object
       \param[in] basis_type String name that describes the type of basis
@@ -139,7 +139,7 @@ namespace panzer {
     { return getElementSpace()==HCURL || getElementSpace()==HDIV; }
 
     bool isScalarBasis() const
-    { return getElementSpace()==HGRAD || getElementSpace()==CONST; }
+    { return getElementSpace()==HGRAD || getElementSpace()==CONST || getElementSpace()==HVOL; }
 
     int getBasisRank() const
     { return basis_rank_; }


### PR DESCRIPTION
Adapted CurlLaplacianExample into a mixed version that uses both HCurl and HDiv elements in 3D or HCurl and HVol elements in 2D.

Exposed HVol basis type and defined its basis values. Modified L2Projection to allow HVol elements.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Description
<!--- Please describe your changes in detail. -->
Previously HVol elements were allowed in Panzer only through the Const basis option. This was restricted to zeroth order and did not use the HVOL basis value transformation for defining the basis. This change keeps the Const basis but adds the option to use arbitrary order HVol elements on 2D meshes.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
The z component of an HDiv DOF should use an HVol basis in 2D. This is necessary for arbitrary order electromagnetics in 2D.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Added the test example MixedCurlLaplacianExample. This is the same test as CurlLaplacianExample except it's in mixed form such that it uses both HCurl elements for the primary DOF and HVol elements for the curl of that DOF.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
Most everything in the MixedCurlLaplacianExample directory is copied directly from CurlLaplacianExample. The changes of interest there are in Example_CurlLaplacianEquationSet_impl.hpp, main.cpp, and CMakeLists.txt.
