### PR TITLE
Zoltan fortran example classicMakefile for use with autotools

### DIFF
--- a/packages/zoltan/example/Fortran/classicMakefile
+++ b/packages/zoltan/example/Fortran/classicMakefile
@@ -1,0 +1,31 @@
+##
+## a basic makefile to build examples 
+##
+
+BLD=../../Obj_autotools/
+
+ZOLTAN_INCLUDE=-I. -I$(BLD)/src
+
+FC=mpif90
+
+FCFLAGS =$(ID_TYPE_FLAG)
+
+EXAMPLE_NAMES= simpleRCB 
+
+all:   $(EXAMPLE_NAMES)
+
+mpi_h.mod:
+	$(FC) $(FCFLAGS) -c  mpi_h.f
+
+zoltanRCBex.mod:  mpi_h.mod
+	$(FC) $(FCFLAGS) \
+        $(TPL_INCLUDE) $(ZOLTAN_INCLUDE) \
+	-c zoltanRCBmod.f90
+
+simpleRCB:  mpi_h.mod zoltanRCBex.mod
+	$(FC) $(FCFLAGS) $(TPL_LIB_DIR) \
+        $(TPL_INCLUDE) $(ZOLTAN_INCLUDE) \
+        -o $@ simpleRCB.f90 zoltanRCBmod.o mpi_h.o $(BLD)/src/libzoltan.a $(TPL_LIBS) -lm
+
+clean:
+	@rm -rf  $(EXAMPLE_NAMES) *.mod


### PR DESCRIPTION
@trilinos/zoltan 
An external user asked how to build the F90 example provided in zoltan/example/Fortran, using a standard makefile.
This PR adds classicMakefile similar to that in the C examples.
The new file archives the makefile that I was able to make work correctly, so I won't have to rediscover it someday for someone else.
I tested this makefile on vesper (linux) with an autotools build; all good.
This change does not impact any internal users, as they build zoltan without Fortran and with Cmake.
In fact, the autotester has nothing to do for this PR.
No backward compatibility changes.

