### PR TITLE
Teuchos: stacked timer can optionally align output

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -493,12 +493,20 @@ StackedTimer::report(std::ostream &os, Teuchos::RCP<const Teuchos::Comm<int> > c
          << std::endl;
     }
     if ( (options.max_levels != INT_MAX) && options.print_warnings) {
-      os << "Teuchos::StackedTimer::report() - max_levels set to " << options.max_levels
-         << ", to print more levels, increase value of OutputOptions::max_levels." << std::endl;
+      os << "Teuchos::StackedTimer::report() - max_levels manually set to " << options.max_levels
+         << ". \nTo print more levels, increase value of OutputOptions::max_levels." << std::endl;
     }
     if (options.align_columns) {
       std::vector<bool> printed(flat_names_.size(), false);
       computeColumnWidthsForAligment("", 0, printed, 0., options);
+    }
+    if (not options.print_names_before_values and not options.align_columns) {
+      options.align_columns = true;
+      if (options.print_warnings)
+        os << "Teuchos::StackedTimer::report() - option print_names_before_values=false "
+           << "\nrequires that the option align_columns=true too. Setting the value for "
+           << "\nalign_column to true."
+           << std::endl;
     }
 
     std::vector<bool> printed(flat_names_.size(), false);

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -3,7 +3,8 @@
 
 #include "Teuchos_StackedTimer.hpp"
 #include <limits>
-
+#include <algorithm>
+#include <sstream>
 
 namespace Teuchos {
 
@@ -16,7 +17,7 @@ void error_out(const std::string& msg, const bool)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,msg);
 }
-  
+
 
 void
 StackedTimer::LevelTimer::report(std::ostream &os) {
@@ -35,7 +36,7 @@ StackedTimer::LevelTimer::report(std::ostream &os) {
   os << "Remainder: " << accumulatedTime() - t_total<<std::endl;
 
 }
-  
+
 BaseTimer::TimeInfo
 StackedTimer::LevelTimer::findTimer(const std::string &name, bool& found) {
   BaseTimer::TimeInfo t;
@@ -74,6 +75,7 @@ StackedTimer::collectRemoteData(Teuchos::RCP<const Teuchos::Comm<int> > comm, co
   int num_names = flat_names_.size();
   sum_.resize(num_names);
   count_.resize(num_names);
+  updates_.resize(num_names);
   active_.resize(num_names);
 
   if (options.output_minmax || options.output_histogram) {
@@ -162,9 +164,15 @@ std::pair<std::string, std::string> getPrefix(const std::string &name) {
   return std::pair<std::string, std::string>(std::string(""), name);
 }
 
-
 double
-StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os, std::vector<bool> &printed, double parent_time, const OutputOptions &options) {
+StackedTimer::computeColumnWidthsForAligment(std::string prefix,
+                                             int print_level,
+                                             std::vector<bool> &printed,
+                                             double parent_time,
+                                             const OutputOptions &options)
+{
+  // This replicates printLevel but counts column width instead of
+  // printing to ostream. This must be kept in sync with printLevel()
   double total_time = 0.0;
 
   for (int i=0; i<flat_names_.size(); ++i ) {
@@ -177,30 +185,68 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
     if ( prefix != split_names.first)
       continue;
 
-    // Output the data
-    for (int l=0; l<level; ++l)
-      os << "|   ";
-    os << split_names.second << ": ";
+    // Output the indentation level and timer name
+    {
+      std::ostringstream os;
+      for (int l=0; l<level; ++l)
+        os << "|   ";
+      // Output the timer name
+      os << split_names.second << ": ";
+      alignments_.timer_names_= std::max(alignments_.timer_names_,os.str().size());
+    }
+
     // output averge time
-    os << sum_[i]/active_[i];
+    {
+      std::ostringstream os;
+      os << sum_[i]/active_[i];
+      alignments_.average_time_ = std::max(alignments_.average_time_,os.str().size());
+    }
+
     // output percentage
-    if ( options.output_fraction && parent_time>0)
+    if ( options.output_fraction && parent_time>0) {
+      std::ostringstream os;
       os << " - "<<sum_[i]/active_[i]/parent_time*100<<"%";
+      alignments_.fraction_ = std::max(alignments_.fraction_,os.str().size());
+    }
+
     // output count
-    os << " ["<<count_[i]/active_[i]<<"]";
+    {
+      std::ostringstream os;
+      os << " ["<<count_[i]/active_[i]<<"]";
+      alignments_.count_ = std::max(alignments_.count_,os.str().size());
+    }
+
     // output total counts
-    if ( options.output_total_updates )
+    if ( options.output_total_updates) {
+      std::ostringstream os;
       os << " ("<<updates_[i]/active_[i]<<")";
+      alignments_.total_updates_ = std::max(alignments_.total_updates_,os.str().size());
+    }
+
     // Output min and maxs
     if ( options.output_minmax && active_[i]>1) {
-      os << " {min="<<min_[i]<<", max="<<max_[i];
-      if (active_[i]>1)
-        os<<", std dev="<<sqrt(std::max<double>(sum_sq_[i]-sum_[i]*sum_[i]/active_[i],0.0)/(active_[i]-1));
-      os << "}";
+      {
+        std::ostringstream os;
+        os << " {min=" << min_[i];
+        alignments_.min_ = std::max(alignments_.min_,os.str().size());
+      }
+      {
+        std::ostringstream os;
+        os << ", max=" << max_[i];
+        if (active_[i] <= 1)
+          os << "}";
+        alignments_.max_ = std::max(alignments_.max_,os.str().size());
+      }
+      if (active_[i]>1) {
+        std::ostringstream os;
+        os << ", std dev=" << sqrt(std::max<double>(sum_sq_[i]-sum_[i]*sum_[i]/active_[i],0.0)/(active_[i]-1));
+        os << "}";
+        alignments_.stddev_ = std::max(alignments_.stddev_,os.str().size());
+      }
     }
     // Output histogram
     if ( options.output_histogram && active_[i] >1 ) {
-      // dump the histogram
+      std::ostringstream os;
       os << " <";
       for (int h=0;h<options.num_histogram; ++h) {
         if (h)
@@ -209,17 +255,144 @@ StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os,
           os << hist_[h][i];
       }
       os << ">";
+      alignments_.histogram_ = std::max(alignments_.histogram_,os.str().size());
+    }
+
+    printed[i] = true;
+    computeColumnWidthsForAligment(flat_names_[i], level+1, printed, sum_[i]/active_[i], options);
+    total_time += sum_[i]/active_[i];
+  }
+  return total_time;
+}
+
+double
+StackedTimer::printLevel (std::string prefix, int print_level, std::ostream &os, std::vector<bool> &printed, double parent_time, const OutputOptions &options)
+{
+  // NOTE: If you change the outputting format or logic in this
+  // function, you must make a corresponding change to the function
+  // computeColumnWidthsForAlignment() or the alignments will be
+  // incorrect if the user requests aligned output!
+
+  double total_time = 0.0;
+
+  for (int i=0; i<flat_names_.size(); ++i ) {
+    if (printed[i])
+      continue;
+    int level = std::count(flat_names_[i].begin(), flat_names_[i].end(), '@');
+    if ( (level != print_level) || (level >= options.max_levels) )
+      continue;
+    auto split_names = getPrefix(flat_names_[i]);
+    if ( prefix != split_names.first)
+      continue;
+
+    // Output the indentation level
+    {
+      std::ostringstream tmp;
+      for (int l=0; l<level; ++l) {
+        tmp << "|   ";
+      }
+      // Output the timer name
+      tmp << split_names.second << ": ";
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.timer_names_);
+      os << tmp.str();
+    }
+    // output averge time
+    {
+      std::ostringstream tmp;
+      tmp << sum_[i]/active_[i];
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.average_time_);
+      os << tmp.str();
+    }
+    // output percentage
+    if ( options.output_fraction && parent_time>0) {
+      std::ostringstream tmp;
+      tmp << " - "<<sum_[i]/active_[i]/parent_time*100<<"%";
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.fraction_);
+      os << tmp.str();
+    }
+    // to keep alignment for later columns if requested
+    else if (options.output_fraction) {
+      if (options.align_columns)
+        os << std::setw(alignments_.fraction_) << " ";
+    }
+    // output count
+    {
+      std::ostringstream tmp;
+      tmp << " ["<<count_[i]/active_[i]<<"]";
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.count_);
+      os << tmp.str();
+    }
+    // output total counts
+    if ( options.output_total_updates ) {
+      std::ostringstream tmp;
+      tmp << " ("<<updates_[i]/active_[i]<<")";
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.total_updates_);
+      os << tmp.str();
+    }
+    // Output min and maxs
+    if ( options.output_minmax && active_[i]>1) {
+      {
+        std::ostringstream tmp;
+        tmp << " {min="<<min_[i];
+        if (options.align_columns)
+          os << std::left << std::setw(alignments_.min_);
+        os << tmp.str();
+      }
+      {
+        std::ostringstream tmp;
+        tmp <<", max="<<max_[i];
+        if (active_[i] <= 1)
+          tmp << "}";
+        if (options.align_columns)
+          os << std::left << std::setw(alignments_.max_);
+        os << tmp.str();
+      }
+      if (active_[i]>1) {
+        std::ostringstream tmp;
+        tmp << ", std dev="<<sqrt(std::max<double>(sum_sq_[i]-sum_[i]*sum_[i]/active_[i],0.0)/(active_[i]-1));
+        tmp << "}";
+        if (options.align_columns)
+          os << std::left << std::setw(alignments_.stddev_);
+        os << tmp.str();
+      }
+    }
+    // Output histogram
+    if ( options.output_histogram && active_[i] >1 ) {
+      std::ostringstream tmp;
+      tmp << " <";
+      for (int h=0;h<options.num_histogram; ++h) {
+        if (h)
+          tmp <<", "<<hist_[h][i];
+        else
+          tmp << hist_[h][i];
+      }
+      tmp << ">";
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.histogram_);
+      os << tmp.str();
     }
     os << std::endl;
     printed[i] = true;
     double sub_time = printLevel(flat_names_[i], level+1, os, printed, sum_[i]/active_[i], options);
     if (sub_time > 0 ) {
+      std::ostringstream tmp;
       for (int l=0; l<=level; ++l)
-        os << "|   ";
-      os << "Remainder: " <<  sum_[i]/active_[i]- sub_time;
+        tmp << "|   ";
+      tmp << "Remainder: ";
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.timer_names_);
+      os << tmp.str();
+      if (options.align_columns)
+        os << std::left << std::setw(alignments_.average_time_);
+      os << sum_[i]/active_[i]- sub_time;
       if ( options.output_fraction && (sum_[i]/active_[i] > 0.) )
         os << " - "<< (sum_[i]/active_[i]- sub_time)/(sum_[i]/active_[i])*100 << "%";
-      os <<std::endl;
+      os << std::endl;
     }
     total_time += sum_[i]/active_[i];
   }
@@ -242,6 +415,11 @@ StackedTimer::report(std::ostream &os, Teuchos::RCP<const Teuchos::Comm<int> > c
       os << "Teuchos::StackedTimer::report() - max_levels set to " << options.max_levels
          << ", to print more levels, increase value of OutputOptions::max_levels." << std::endl;
     }
+    if (options.align_columns) {
+      std::vector<bool> printed(flat_names_.size(), false);
+      computeColumnWidthsForAligment("", 0, printed, 0., options);
+    }
+
     std::vector<bool> printed(flat_names_.size(), false);
     printLevel("", 0, os, printed, 0., options);
   }

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -507,7 +507,7 @@ public:
   struct OutputOptions {
     OutputOptions() : output_fraction(false), output_total_updates(false), output_histogram(false),
                       output_minmax(false), num_histogram(10), max_levels(INT_MAX),
-                      print_warnings(true), align_columns(false) {}
+                      print_warnings(true), align_columns(false), print_names_before_values(true) {}
     bool output_fraction;
     bool output_total_updates;
     bool output_histogram;
@@ -516,6 +516,7 @@ public:
     int max_levels;
     bool print_warnings;
     bool align_columns;
+    bool print_names_before_values;
   };
 
   /**

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -507,7 +507,7 @@ public:
   struct OutputOptions {
     OutputOptions() : output_fraction(false), output_total_updates(false), output_histogram(false),
                       output_minmax(false), num_histogram(10), max_levels(INT_MAX),
-                      print_warnings(true) {}
+                      print_warnings(true), align_columns(false) {}
     bool output_fraction;
     bool output_total_updates;
     bool output_histogram;
@@ -515,6 +515,7 @@ public:
     int num_histogram;
     int max_levels;
     bool print_warnings;
+    bool align_columns;
   };
 
   /**
@@ -541,6 +542,29 @@ protected:
   Array<unsigned long long> updates_;
   Array<int> active_;
 
+  /// Stores the column widths for output alignment
+  struct AlignmentWidths {
+    std::string::size_type timer_names_;
+    std::string::size_type average_time_;
+    std::string::size_type fraction_;
+    std::string::size_type count_;
+    std::string::size_type total_updates_;
+    std::string::size_type min_;
+    std::string::size_type max_;
+    std::string::size_type stddev_;
+    std::string::size_type histogram_;
+    AlignmentWidths() :
+      timer_names_(0),
+      average_time_(0),
+      fraction_(0),
+      count_(0),
+      total_updates_(0),
+      min_(0),
+      max_(0),
+      stddev_(0),
+      histogram_(0){}
+  } alignments_;
+
   /**
     * Flatten the timers into a single array
     */
@@ -556,6 +580,16 @@ protected:
     * Migrate all the timer data to rank=0 if parallel
     */
    void collectRemoteData(Teuchos::RCP<const Teuchos::Comm<int> > comm, const OutputOptions &options );
+
+  /**
+   * Compute the column widths to align the output from report() in
+   * columns.
+   *
+   * \returns total time for this level
+   */
+  double computeColumnWidthsForAligment(std::string prefix, int print_level,
+                                        std::vector<bool> &printed, double parent_time,
+                                        const OutputOptions &options);
 
    /**
     * Recursive call to print a level of timer data.

--- a/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
+++ b/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
@@ -182,15 +182,24 @@ TEUCHOS_UNIT_TEST(StackedTimer, Basic)
 #endif
 
   // Print to screen
-  timer.report(out, comm, options);
+  out << "\n### Printing default report ###" << std::endl;
+  Teuchos::StackedTimer::OutputOptions defaultOptions;
+  timer.report(out, comm, defaultOptions);
 
-  // Enable all optional printing options
+  // Test some options
+  out << "\n### Printing aligned_column with timers names on left ###" << std::endl;
   options.output_fraction = true;
   options.output_total_updates = true;
   options.output_minmax = true;
   options.output_histogram = true;
   options.num_histogram = 3;
   options.align_columns = true;
+  timer.report(out, comm, options);
+
+  // Toggle names before values
+  TEST_EQUALITY(options.print_names_before_values,true);
+  out << "\n### Printing aligned_column with timers names on right ###" << std::endl;
+  options.print_names_before_values = false;
   timer.report(out, comm, options);
 }
 
@@ -262,13 +271,18 @@ TEUCHOS_UNIT_TEST(StackedTimer, TimeMonitorInteroperability)
 #endif
 
   Teuchos::StackedTimer::OutputOptions options;
+  out << "\n### Printing default report ###" << std::endl;
   options.output_histogram=true;
   options.num_histogram=3;
   options.output_fraction=true;
   timer->report(out, comm, options);
 
-  // Enable aligned output
+  out << "\n### Printing aligned_column with timers names on left ###" << std::endl;
   options.align_columns = true;
+  timer->report(out, comm, options);
+
+  out << "\n### Printing aligned_column with timers names on right ###" << std::endl;
+  options.print_names_before_values = false;
   timer->report(out, comm, options);
 }
 

--- a/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
+++ b/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
@@ -282,7 +282,19 @@ TEUCHOS_UNIT_TEST(StackedTimer, TimeMonitorInteroperability)
   timer->report(out, comm, options);
 
   out << "\n### Printing aligned_column with timers names on right ###" << std::endl;
+  // options.print_names_before_values=false requires that
+  // options.align_output=true. The code will automatically fix this
+  // and print a warning if warnings are enabled. Testing this here by
+  // specifying the incorrect logic.
+  options.align_columns = false;
   options.print_names_before_values = false;
+  timer->report(out, comm, options);
+
+  //Testing limited number of levels in printing
+  out << "\n### Printing with max_levels=2 ###" << std::endl;
+  options.max_levels=2;
+  options.align_columns = true;
+  options.print_names_before_values = true;
   timer->report(out, comm, options);
 }
 

--- a/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
+++ b/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
@@ -12,7 +12,6 @@
 #include <regex>
 #include <iterator>
 
-
 TEUCHOS_UNIT_TEST(PerformanceMonitorBase, UnsortedMergeUnion) {
 
   const Teuchos::RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
@@ -184,6 +183,15 @@ TEUCHOS_UNIT_TEST(StackedTimer, Basic)
 
   // Print to screen
   timer.report(out, comm, options);
+
+  // Enable all optional printing options
+  options.output_fraction = true;
+  options.output_total_updates = true;
+  options.output_minmax = true;
+  options.output_histogram = true;
+  options.num_histogram = 3;
+  options.align_columns = true;
+  timer.report(out, comm, options);
 }
 
 
@@ -198,7 +206,7 @@ TEUCHOS_UNIT_TEST(StackedTimer, TimeMonitorInteroperability)
 
   // Test the set and get stacked timer methods on TimeMonitor
   const auto timeMonitorDefaultStackedTimer = Teuchos::TimeMonitor::getStackedTimer();
-  const auto timer = Teuchos::rcp(new Teuchos::StackedTimer("StackedTimerTest::TimeMonitorInteroperability"));
+  const auto timer = Teuchos::rcp(new Teuchos::StackedTimer("TM:Interoperability"));
   TEST_ASSERT(nonnull(timeMonitorDefaultStackedTimer));
   TEST_ASSERT(nonnull(timer));
   TEST_ASSERT(timeMonitorDefaultStackedTimer != timer);
@@ -258,6 +266,10 @@ TEUCHOS_UNIT_TEST(StackedTimer, TimeMonitorInteroperability)
   options.num_histogram=3;
   options.output_fraction=true;
   timer->report(out, comm, options);
+
+  // Enable aligned output
+  options.align_columns = true;
+  timer->report(out, comm, options);
 }
 
 // Overlapping timers are not allowed in a StackedTimer, but are in
@@ -265,7 +277,7 @@ TEUCHOS_UNIT_TEST(StackedTimer, TimeMonitorInteroperability)
 // TimeMonitor by default, we have seen this error - a throw from the
 // stacked timer. In every instance so far, the intention was not to
 // actually overlap but a constructor/destructor ordering issue
-// (suually involving RCPs). To prevent tests from failing,
+// (usually involving RCPs). To prevent tests from failing,
 // StackedTimer now automatically shuts itself off if it detects
 // overlaped timers in a TimeMonitor instance, reports a warning on
 // how to fix and allows the code to continue runnning. Where this has


### PR DESCRIPTION
This PR adds the capability to align the stacked timer output into columns. Currently this aligns the columns against all timers. We might also add the ability to align only within a level.

Example from drekar:
```
Drekar: Total Time:                                                                                                                                         0.246002                 [1]  {min=0.245948   , max=0.246097   , std dev=6.58034e-05} <2, 1, 0, 0, 1>
|   panzer::SquareQuadMeshFactory::buildUncomittedMesh():                                                                                                   0.00153242  - 0.62293%   [1]  {min=0.00150515 , max=0.00156354 , std dev=3.01706e-05} <2, 0, 0, 0, 2>
|   panzer::SquareQuadMeshFactory::completeMeshConstruction():                                                                                              0.0179688   - 7.30433%   [1]  {min=0.0158245  , max=0.0186924  , std dev=0.00142957}  <1, 0, 0, 0, 3>
|   STK_Interface::setupExodusFile(filename):                                                                                                               0.00536928  - 2.18261%   [1]  {min=0.00536088 , max=0.00537834 , std dev=8.42612e-06} <2, 0, 0, 1, 1>
|   panzer::DOFManagerFactory::buildUnqueGlobalIndexer:                                                                                                     0.0134037   - 5.44862%   [1]  {min=0.0133892  , max=0.0134194  , std dev=1.37106e-05} <1, 1, 0, 1, 1>
|   |   panzer::DOFManagerFactory::buildUnqueGlobalIndexer:buildGlobalUnknowns:                                                                             0.0130995   - 97.7304%   [1]  {min=0.0130911  , max=0.0131167  , std dev=1.20271e-05} <2, 1, 0, 0, 1>
|   |   |   panzer::DOFManager::buildGlobalUnknowns:                                                                                                        0.0124465   - 95.0148%   [1]  {min=0.0124303  , max=0.0124555  , std dev=1.18849e-05} <1, 0, 1, 0, 2>
|   |   |   |   panzer::DOFManager::buildTaggedMultiVector:                                                                                                 0.00390287  - 31.3572%   [1]  {min=0.00388534 , max=0.00394477 , std dev=2.80562e-05} <3, 0, 0, 0, 1>
|   |   |   |   |   panzer::DOFManager::builderOverlapMapFromElements:                                                                                      0.0027662   - 70.8761%   [1]  {min=0.00276278 , max=0.00276984 , std dev=3.01517e-06} <1, 1, 0, 1, 1>
|   |   |   |   |   panzer::DOFManager::buildTaggedMultiVector::allocate_tagged_multivector:                                                                0.000689857 - 17.6756%   [1]  {min=0.000683257, max=0.000706584, std dev=1.11754e-05} <3, 0, 0, 0, 1>
|   |   |   |   |   panzer::DOFManager::buildTaggedMultiVector::fill_tagged_multivector:                                                                    0.000281722 - 7.21833%   [1]  {min=0.000270495, max=0.000305974, std dev=1.63356e-05} <3, 0, 0, 0, 1>
|   |   |   |   |   Remainder:                                                                                                                              0.000165087 - 4.22989%
|   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN:                                                                                                0.00769007  - 61.7851%   [1]  {min=0.00766152 , max=0.00770705 , std dev=1.98281e-05} <1, 0, 0, 1, 2>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_04 createOneToOne:                                                                    0.00410819  - 53.422%    [1]  {min=0.00405813 , max=0.00412678 , std dev=3.34233e-05} <1, 0, 0, 0, 3>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_05 alloc_unique_mv:                                                                   4.4995e-05  - 0.585105%  [1]  {min=4.4628e-05 , max=4.5956e-05 , std dev=6.44057e-07} <3, 0, 0, 0, 1>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_06 export:                                                                            0.00231272  - 30.0742%   [1]  {min=0.00222319 , max=0.00237104 , std dev=6.42599e-05} <1, 0, 0, 1, 2>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_07-09 local_count:                                                                    0.000145357 - 1.89019%   [1]  {min=0.000139542, max=0.000154699, std dev=6.86537e-06} <2, 0, 1, 0, 1>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_10 prefix_sum:                                                                        0.000400261 - 5.2049%    [1]  {min=0.000273708, max=0.000549721, std dev=0.000113662} <1, 1, 1, 0, 1>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_13-21 gid_assignment:                                                                 3.981e-05   - 0.517681%  [1]  {min=3.8413e-05 , max=4.2743e-05 , std dev=1.97769e-06} <3, 0, 0, 0, 1>
|   |   |   |   |   panzer::DOFManager::buildGlobalUnknowns_GUN::line_23 final_import:                                                                      0.000480857 - 6.25296%   [1]  {min=0.000455644, max=0.000502787, std dev=1.93402e-05} <1, 0, 2, 0, 1>
|   |   |   |   |   Remainder:                                                                                                                              0.000157876 - 2.05299%
|   |   |   |   panzer::DOFManager::buildGlobalUnknowns::build_owned_vector:                                                                                0.000211637 - 1.70037%   [1]  {min=0.000202889, max=0.000227543, std dev=1.0914e-05}  <2, 1, 0, 0, 1>
|   |   |   |   panzer::DOFManager::buildGlobalUnknowns::build_ghosted_array:                                                                               3.63e-05    - 0.291649%  [1]  {min=3.3733e-05 , max=3.8204e-05 , std dev=2.17158e-06} <1, 1, 0, 0, 2>
|   |   |   |   panzer::DOFManager::buildGlobalUnknowns::build_local_ids:                                                                                   0.000155886 - 1.25245%   [1]  {min=0.000147645, max=0.000160496, std dev=6.09277e-06} <1, 0, 1, 0, 2>
|   |   |   |   Remainder:                                                                                                                                  0.000449724 - 3.61326%
|   |   |   Remainder:                                                                                                                                      0.000653034 - 4.98518%
|   |   Remainder:                                                                                                                                          0.000304211 - 2.2696%
|   Phalanx::SortAndOrderEvaluators:                                                                                                                        3.87962e-05 - 0.0157707% [7]  {min=3.6317e-05 , max=4.0507e-05 , std dev=1.98845e-06} <1, 0, 1, 0, 2>
|   Drekar::Driver: Setup Initial Conditions:                                                                                                               0.0093738   - 3.81045%   [1]  {min=0.00595921 , max=0.0127312  , std dev=0.00387535}  <2, 0, 0, 0, 2>
|   |   Phalanx::SortAndOrderEvaluators:                                                                                                                    5.97125e-06 - 0.0637015% [3]  {min=5.657e-06  , max=6.286e-06  , std dev=2.58374e-07} <1, 0, 2, 0, 1>
|   |   Phalanx: Evaluator 111: [panzer::Traits::Residual] Constant: TF_TEMPERATURE:                                                                        3.8622e-05  - 0.412021%  [1]  {min=0          , max=3.939e-05  , std dev=1.08612e-06} <2, 0, 0, 0, 2>
|   |   Phalanx: Evaluator 109: [panzer::Traits::Residual] SCATTER_TF_TEMPERATURE Scatter Residual:                                                         5.83525e-05 - 0.622506%  [1]  {min=0          , max=5.8946e-05 , std dev=8.39336e-07} <2, 0, 0, 0, 2>
|   |   Phalanx: Evaluator 96: [panzer::Traits::Residual] Constant: TF_TEMPERATURE:                                                                         3.67365e-05 - 0.391906%  [1]  {min=0          , max=3.7854e-05 , std dev=1.58038e-06} <2, 0, 0, 0, 2>
|   |   Phalanx: Evaluator 94: [panzer::Traits::Residual] SCATTER_TF_TEMPERATURE Scatter Residual:                                                          5.8492e-05  - 0.623995%  [1]  {min=0          , max=5.9225e-05 , std dev=1.03662e-06} <2, 0, 0, 0, 2>
|   |   Remainder:                                                                                                                                          0.00917563  - 97.8859%
|   Drekar::Driver: Write Initial Conditions to file:                                                                                                       0.00930839  - 3.78386%   [1]  {min=0.00930446 , max=0.00931047 , std dev=2.7838e-06}  <1, 0, 0, 1, 2>
|   |   Phalanx::SortAndOrderEvaluators:                                                                                                                    5.9885e-06  - 0.0643344% [3]  {min=5.866e-06  , max=6.146e-06  , std dev=1.44309e-07} <2, 0, 0, 1, 1>
|   |   panzer::AssemblyEngine::evaluate_gather(panzer::Traits::Residual):                                                                                  2.09e-05    - 0.224529%  [1]  {min=1.9765e-05 , max=2.193e-05  , std dev=9.96407e-07} <1, 1, 0, 0, 2>
|   |   panzer::AssemblyEngine::evaluate_volume(panzer::Traits::Residual):                                                                                  0.000108236 - 1.16278%   [1]  {min=0.000106368, max=0.000109511, std dev=1.32816e-06} <1, 0, 0, 2, 1>
|   |   |   Phalanx: Evaluator 145: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):                          3.052e-05   - 28.1975%   [1]  {min=0          , max=3.1288e-05 , std dev=1.08612e-06} <2, 0, 0, 0, 2>
|   |   |   Phalanx: Evaluator 202: [panzer::Traits::Residual] STK HGRAD Scatter Basis HGrad:1: TF_TEMPERATURE: STK-Scatter Fields:                         2.7168e-05  - 25.1006%   [1]  {min=0          , max=2.8355e-05 , std dev=1.67867e-06} <2, 0, 0, 0, 2>
|   |   |   Phalanx: Evaluator 130: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):                          2.9333e-05  - 27.1008%   [1]  {min=0          , max=2.9473e-05 , std dev=1.9799e-07}  <2, 0, 0, 0, 2>
|   |   |   Phalanx: Evaluator 187: [panzer::Traits::Residual] STK HGRAD Scatter Basis HGrad:1: TF_TEMPERATURE: STK-Scatter Fields:                         3.101e-05   - 28.6502%   [1]  {min=0          , max=3.2407e-05 , std dev=1.97566e-06} <2, 0, 0, 0, 2>
|   |   |   Remainder:                                                                                                                                      -9.7945e-06 - -9.04917%
|   |   panzer::AssemblyEngine::evaluate_neumannbcs(panzer::Traits::Residual):                                                                              1.77573e-05 - 0.190766%  [1]  {min=1.5924e-05 , max=2.0324e-05 , std dev=1.94929e-06} <2, 0, 1, 0, 1>
|   |   panzer::AssemblyEngine::evaluate_interfacebcs(panzer::Traits::Residual):                                                                            8.80025e-06 - 0.094541%  [1]  {min=8.311e-06  , max=9.429e-06  , std dev=4.63473e-07} <1, 2, 0, 0, 1>
|   |   panzer::AssemblyEngine::evaluate_dirichletbcs(panzer::Traits::Residual):                                                                            0.00113946  - 12.2412%   [1]  {min=0.00113772 , max=0.00114218 , std dev=1.91023e-06} <1, 2, 0, 0, 1>
|   |   panzer::AssemblyEngine::evaluate_scatter(panzer::Traits::Residual):                                                                                 7.68275e-06 - 0.0825357% [1]  {min=7.054e-06  , max=8.87e-06   , std dev=8.08466e-07} <3, 0, 0, 0, 1>
|   |   Remainder:                                                                                                                                          0.00799957  - 85.9393%
|   Drekar::Driver::solve():                                                                                                                                0.0506503   - 20.5893%   [1]  {min=0.0506461  , max=0.050659   , std dev=5.96923e-06} <2, 1, 0, 0, 1>
|   |   Drekar::Driver::solve(): Main ME Solve:                                                                                                             0.0506406   - 99.9809%   [1]  {min=0.0506354  , max=0.0506499  , std dev=6.4102e-06}  <2, 1, 0, 0, 1>
|   |   |   Thyra::NOXNonlinearSolver::solve:                                                                                                               0.0470486   - 92.9069%   [1]  {min=0.0470468  , max=0.047051   , std dev=1.85804e-06} <2, 0, 1, 0, 1>
|   |   |   |   panzer::ModelEvaluator::evalModel(f):                                                                                                       0.00537353  - 11.4212%   [2]  {min=0.00536954 , max=0.00537841 , std dev=3.65967e-06} <1, 1, 1, 0, 1>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_gather(panzer::Traits::Residual):                                                                      0.000297367 - 5.53391%   [2]  {min=0.000296057, max=0.000300247, std dev=1.93805e-06} <3, 0, 0, 0, 1>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_volume(panzer::Traits::Residual):                                                                      0.0015715   - 29.2451%   [2]  {min=0.0015495  , max=0.00158903 , std dev=1.6351e-05}  <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 56: [panzer::Traits::Residual] Constant: TF_HEAT_CAPACITY:                                                       1.24838e-05 - 0.794386%  [2]  {min=1.0756e-05 , max=1.4107e-05 , std dev=1.69431e-06} <2, 0, 0, 0, 2>
|   |   |   |   |   |   Phalanx: Evaluator 64: [panzer::Traits::Residual] Constant: TF_UY:                                                                  1.26237e-05 - 0.803294%  [2]  {min=1.1104e-05 , max=1.4038e-05 , std dev=1.63531e-06} <2, 0, 0, 0, 2>
|   |   |   |   |   |   Phalanx: Evaluator 62: [panzer::Traits::Residual] Parameter Evaluator:                                                              2.48283e-05 - 1.57991%   [2]  {min=2.2559e-05 , max=2.7028e-05 , std dev=1.84702e-06} <1, 0, 2, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 1: [panzer::Traits::Residual] ScalarToVector: TF_VELOCITIES:                                                     4.66362e-05 - 2.96763%   [2]  {min=4.2533e-05 , max=4.9448e-05 , std dev=3.02686e-06} <1, 0, 1, 0, 2>
|   |   |   |   |   |   Phalanx: Evaluator 33: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):               5.5052e-05  - 3.50316%   [2]  {min=5.0355e-05 , max=5.8317e-05 , std dev=3.40695e-06} <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 46: [panzer::Traits::Residual] DOFGradient: GRAD_TF_TEMPERATURE (panzer::Traits::Residual):                      0.0001067   - 6.78972%   [2]  {min=0.000102178, max=0.00011042 , std dev=3.41666e-06} <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 54: [panzer::Traits::Residual] Constant: TF_DENSITY:                                                             9.00975e-06 - 0.573323%  [2]  {min=5.936e-06  , max=1.1734e-05 , std dev=2.87881e-06} <1, 1, 0, 0, 2>
|   |   |   |   |   |   Phalanx: Evaluator 6: [panzer::Traits::Residual] StabilizedResidualEnergy:                                                          7.0278e-05  - 4.47204%   [2]  {min=6.5931e-05 , max=7.5847e-05 , std dev=4.74179e-06} <2, 0, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 45: [panzer::Traits::Residual] DOF: TF_TEMPERATURE (panzer::Traits::Residual):                                   7.54982e-05 - 4.80422%   [2]  {min=6.5022e-05 , max=8.0317e-05 , std dev=7.07732e-06} <1, 0, 0, 0, 3>
|   |   |   |   |   |   Phalanx: Evaluator 58: [panzer::Traits::Residual] Constant: TF_THERMAL_CONDUCTIVITY:                                                7.857e-06   - 0.499969%  [2]  {min=5.797e-06  , max=9.149e-06  , std dev=1.59293e-06} <1, 0, 1, 0, 2>
|   |   |   |   |   |   Phalanx: Evaluator 7: [panzer::Traits::Residual] TauE_Shakib:                                                                       0.000120633 - 7.67629%   [2]  {min=0.000117542, max=0.000124107, std dev=2.73252e-06} <1, 1, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 8: [panzer::Traits::Residual] Temperature Fluctuations:                                                          2.55095e-05 - 1.62326%   [2]  {min=2.4794e-05 , max=2.5981e-05 , std dev=5.04652e-07} <1, 0, 0, 2, 1>
|   |   |   |   |   |   Phalanx: Evaluator 9: [panzer::Traits::Residual] SUPG Residual: RESIDUAL_TF_TEMPERATURE_VMS_SUPG:                                   0.00028476  - 18.1203%   [2]  {min=0.000277479, max=0.000291309, std dev=5.89053e-06} <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 60: [panzer::Traits::Residual] Constant: SOURCE_TF_TEMPERATURE:                                                  9.00925e-06 - 0.573291%  [2]  {min=7.473e-06  , max=1.1454e-05 , std dev=1.80962e-06} <2, 0, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 4: [panzer::Traits::Residual] Integrator_BasisTimesScalar (EVALUATES):  RESIDUAL_TF_TEMPERATURE_SOURCE_OP:       6.26477e-05 - 3.9865%    [2]  {min=5.5524e-05 , max=7.3054e-05 , std dev=7.75513e-06} <2, 0, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 66: [panzer::Traits::Residual] EnergyFluxFourier:                                                                4.59028e-05 - 2.92096%   [2]  {min=4.351e-05  , max=4.7771e-05 , std dev=1.78034e-06} <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 0: [panzer::Traits::Residual] Integrator_GradBasisDotVector (EVALUATES):  RESIDUAL_TF_TEMPERATURE_DIFFUSION_OP:  0.000159325 - 10.1384%   [2]  {min=0.000156096, max=0.000165943, std dev=4.58707e-06} <2, 1, 0, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 2: [panzer::Traits::Residual] Convection: TF_TEMPERATURE_CONVECTION_OP:                                          5.06875e-05 - 3.22543%   [2]  {min=5.0146e-05 , max=5.0984e-05 , std dev=3.79999e-07} <1, 0, 0, 1, 2>
|   |   |   |   |   |   Phalanx: Evaluator 3: [panzer::Traits::Residual] Integrator_BasisTimesScalar (EVALUATES):  RESIDUAL_TF_TEMPERATURE_CONVECTION_OP:   6.3416e-05  - 4.03539%   [2]  {min=5.9574e-05 , max=6.7398e-05 , std dev=3.47587e-06} <1, 1, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 10: [panzer::Traits::Residual] SumStatic Rank 2 Evaluator:                                                       0.000117176 - 7.45636%   [2]  {min=0.000112515, max=0.000122781, std dev=4.28132e-06} <1, 1, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 51: [panzer::Traits::Residual] SCATTER_TF_TEMPERATURE Scatter Residual:                                          4.27083e-05 - 2.71768%   [2]  {min=4.1626e-05 , max=4.393e-05  , std dev=1.25485e-06} <2, 0, 0, 0, 2>
|   |   |   |   |   |   Remainder:                                                                                                                          0.000168754 - 10.7384%
|   |   |   |   |   panzer::AssemblyEngine::evaluate_neumannbcs(panzer::Traits::Residual):                                                                  3.28077e-05 - 0.610543%  [2]  {min=2.4374e-05 , max=4.1416e-05 , std dev=9.46387e-06} <2, 0, 0, 0, 2>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_interfacebcs(panzer::Traits::Residual):                                                                1.08428e-05 - 0.201781%  [2]  {min=9.498e-06  , max=1.292e-05  , std dev=1.61222e-06} <2, 0, 1, 0, 1>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_dirichletbcs(panzer::Traits::Residual):                                                                0.00307052  - 57.1415%   [2]  {min=0.00304222 , max=0.00311485 , std dev=3.48623e-05} <2, 0, 1, 0, 1>
|   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(0):                                                                                         0.000183682 - 5.98211%   [2] 
|   |   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(0), side=3:                                                                             0.000167618 - 91.2545%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 93: [panzer::Traits::Residual] Constant: Constant_TF_TEMPERATURE:                                        6.984e-06   - 4.16662%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 95: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):       1.9067e-05  - 11.3753%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 96: [panzer::Traits::Residual] Dirichlet Residual Evaluator:                                             1.6971e-05  - 10.1248%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 97: [panzer::Traits::Residual] Dummy Scatter: BC(0)Residual_BC(0) Scatter Residual:                      9.24e-05    - 55.1253%   [2] 
|   |   |   |   |   |   |   |   Remainder:                                                                                                                  3.2196e-05  - 19.208%
|   |   |   |   |   |   |   Remainder:                                                                                                                      1.6064e-05  - 8.74555%
|   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(1):                                                                                         0.000178234 - 5.80468%   [2] 
|   |   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(1), side=1:                                                                             0.00016252  - 91.1835%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 93: [panzer::Traits::Residual] Constant: Constant_TF_TEMPERATURE:                                        7.194e-06   - 4.42653%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 95: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):       1.8368e-05  - 11.302%    [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 96: [panzer::Traits::Residual] Dirichlet Residual Evaluator:                                             2.0115e-05  - 12.3769%   [2] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 97: [panzer::Traits::Residual] Dummy Scatter: BC(1)Residual_BC(1) Scatter Residual:                      8.5067e-05  - 52.3425%   [2] 
|   |   |   |   |   |   |   |   Remainder:                                                                                                                  3.1776e-05  - 19.5521%
|   |   |   |   |   |   |   Remainder:                                                                                                                      1.5714e-05  - 8.8165%
|   |   |   |   |   |   Remainder:                                                                                                                          0.0027086   - 88.2132%
|   |   |   |   |   panzer::AssemblyEngine::evaluate_scatter(panzer::Traits::Residual):                                                                     7.35085e-05 - 1.36797%   [2]  {min=3.0241e-05 , max=0.000110979, std dev=4.33405e-05} <2, 0, 0, 0, 2>
|   |   |   |   |   Remainder:                                                                                                                              0.000316992 - 5.89914%
|   |   |   |   panzer::ModelEvaluator::evalModel(J):                                                                                                       0.00430636  - 9.153%     [1]  {min=0.00429056 , max=0.00431256 , std dev=1.05577e-05} <1, 0, 0, 0, 3>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_gather(panzer::Traits::Jacobian):                                                                      0.000146702 - 3.40663%   [1]  {min=0.000144153, max=0.000148832, std dev=2.07366e-06} <1, 1, 0, 1, 1>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_volume(panzer::Traits::Jacobian):                                                                      0.00162996  - 37.85%     [1]  {min=0.0016141  , max=0.0016405  , std dev=1.14019e-05} <1, 0, 0, 2, 1>
|   |   |   |   |   |   Phalanx: Evaluator 69: [panzer::Traits::Jacobian] Constant: TF_HEAT_CAPACITY:                                                       6.47825e-06 - 0.397449%  [1]  {min=5.099e-06  , max=7.194e-06  , std dev=9.71586e-07} <1, 0, 0, 1, 2>
|   |   |   |   |   |   Phalanx: Evaluator 77: [panzer::Traits::Jacobian] Constant: TF_UY:                                                                  6.84425e-06 - 0.419904%  [1]  {min=6.007e-06  , max=7.124e-06  , std dev=5.58167e-07} <1, 0, 0, 0, 3>
|   |   |   |   |   |   Phalanx: Evaluator 75: [panzer::Traits::Jacobian] Parameter Evaluator:                                                              1.51557e-05 - 0.929826%  [1]  {min=1.5016e-05 , max=1.5365e-05 , std dev=1.50754e-07} <1, 1, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 12: [panzer::Traits::Jacobian] ScalarToVector: TF_VELOCITIES:                                                    4.27425e-05 - 2.62231%   [1]  {min=3.5689e-05 , max=5.0425e-05 , std dev=6.7809e-06}  <2, 0, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 37: [panzer::Traits::Jacobian] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Jacobian):               2.97695e-05 - 1.8264%    [1]  {min=2.8704e-05 , max=3.1079e-05 , std dev=1.09306e-06} <2, 0, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 48: [panzer::Traits::Jacobian] DOFGradient: GRAD_TF_TEMPERATURE (panzer::Traits::Jacobian):                      5.95225e-05 - 3.65179%   [1]  {min=5.294e-05  , max=7.4242e-05 , std dev=9.94351e-06} <3, 0, 0, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 67: [panzer::Traits::Jacobian] Constant: TF_DENSITY:                                                             3.40475e-06 - 0.208886%  [1]  {min=3.073e-06  , max=3.632e-06  , std dev=2.37775e-07} <1, 0, 0, 2, 1>
|   |   |   |   |   |   Phalanx: Evaluator 17: [panzer::Traits::Jacobian] StabilizedResidualEnergy:                                                         8.6604e-05  - 5.31327%   [1]  {min=7.8502e-05 , max=9.7639e-05 , std dev=8.16334e-06} <1, 1, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 47: [panzer::Traits::Jacobian] DOF: TF_TEMPERATURE accel_jac  (panzer::Traits::Jacobian):                        5.32537e-05 - 3.26719%   [1]  {min=4.847e-05  , max=5.6501e-05 , std dev=3.39665e-06} <1, 0, 0, 2, 1>
|   |   |   |   |   |   Phalanx: Evaluator 71: [panzer::Traits::Jacobian] Constant: TF_THERMAL_CONDUCTIVITY:                                                4.90625e-06 - 0.301005%  [1]  {min=4.749e-06  , max=5.098e-06  , std dev=1.43864e-07} <1, 0, 2, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 18: [panzer::Traits::Jacobian] TauE_Shakib:                                                                      0.00026751  - 16.4121%   [1]  {min=0.000262743, max=0.000273359, std dev=5.06103e-06} <2, 0, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 19: [panzer::Traits::Jacobian] Temperature Fluctuations:                                                         2.86522e-05 - 1.75785%   [1]  {min=2.7727e-05 , max=2.9543e-05 , std dev=7.55208e-07} <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 20: [panzer::Traits::Jacobian] SUPG Residual: RESIDUAL_TF_TEMPERATURE_VMS_SUPG:                                  0.000293718 - 18.02%     [1]  {min=0.000284394, max=0.000304019, std dev=8.61212e-06} <1, 1, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 73: [panzer::Traits::Jacobian] Constant: SOURCE_TF_TEMPERATURE:                                                  5.605e-06   - 0.343874%  [1]  {min=5.029e-06  , max=6.216e-06  , std dev=5.36019e-07} <1, 1, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 15: [panzer::Traits::Jacobian] Integrator_BasisTimesScalar (EVALUATES):  RESIDUAL_TF_TEMPERATURE_SOURCE_OP:      5.1368e-05  - 3.1515%    [1]  {min=4.6305e-05 , max=5.7409e-05 , std dev=5.3699e-06}  <2, 0, 0, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 79: [panzer::Traits::Jacobian] EnergyFluxFourier:                                                                5.33413e-05 - 3.27256%   [1]  {min=4.9448e-05 , max=5.8387e-05 , std dev=3.72797e-06} <1, 1, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 11: [panzer::Traits::Jacobian] Integrator_GradBasisDotVector (EVALUATES):  RESIDUAL_TF_TEMPERATURE_DIFFUSION_OP: 9.7533e-05  - 5.98378%   [1]  {min=9.2469e-05 , max=0.000103714, std dev=4.64645e-06} <1, 1, 1, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 13: [panzer::Traits::Jacobian] Convection: TF_TEMPERATURE_CONVECTION_OP:                                         4.28128e-05 - 2.62662%   [1]  {min=3.932e-05  , max=4.868e-05  , std dev=4.09199e-06} <2, 1, 0, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 14: [panzer::Traits::Jacobian] Integrator_BasisTimesScalar (EVALUATES):  RESIDUAL_TF_TEMPERATURE_CONVECTION_OP:  7.4556e-05  - 4.57411%   [1]  {min=7.047e-05  , max=8.1715e-05 , std dev=5.05855e-06} <2, 1, 0, 0, 1>
|   |   |   |   |   |   Phalanx: Evaluator 21: [panzer::Traits::Jacobian] SumStatic Rank 2 Evaluator:                                                       0.000101183 - 6.2077%    [1]  {min=9.268e-05  , max=0.000107975, std dev=6.66454e-06} <1, 0, 1, 1, 1>
|   |   |   |   |   |   Phalanx: Evaluator 52: [panzer::Traits::Jacobian] SCATTER_TF_TEMPERATURE Scatter Residual Epetra (Jacobian):                        0.000213033 - 13.0699%   [1]  {min=0.000200304, max=0.000227263, std dev=1.17688e-05} <1, 1, 0, 1, 1>
|   |   |   |   |   |   Remainder:                                                                                                                          9.19635e-05 - 5.64208%
|   |   |   |   |   panzer::AssemblyEngine::evaluate_neumannbcs(panzer::Traits::Jacobian):                                                                  2.36585e-05 - 0.549385%  [1]  {min=2.2139e-05 , max=2.5003e-05 , std dev=1.4868e-06}  <2, 0, 0, 0, 2>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_interfacebcs(panzer::Traits::Jacobian):                                                                8.154e-06   - 0.189348%  [1]  {min=7.892e-06  , max=8.52e-06   , std dev=2.63317e-07} <1, 2, 0, 0, 1>
|   |   |   |   |   panzer::AssemblyEngine::evaluate_dirichletbcs(panzer::Traits::Jacobian):                                                                0.00186433  - 43.2924%   [1]  {min=0.00185526 , max=0.00187824 , std dev=9.84404e-06} <1, 2, 0, 0, 1>
|   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(0):                                                                                         0.000156794 - 8.41023%   [1] 
|   |   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(0), side=3:                                                                             0.000147854 - 94.2983%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 98: [panzer::Traits::Jacobian] Constant: Constant_TF_TEMPERATURE:                                        4.331e-06   - 2.92924%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 100: [panzer::Traits::Jacobian] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Jacobian):      1.0756e-05  - 7.27474%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 101: [panzer::Traits::Jacobian] Dirichlet Residual Evaluator:                                            1.5365e-05  - 10.392%    [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 102: [panzer::Traits::Jacobian] Dummy Scatter: BC(0)Residual_BC(0) Scatter Residual (Jacobian):          9.3308e-05  - 63.1082%   [1] 
|   |   |   |   |   |   |   |   Remainder:                                                                                                                  2.4094e-05  - 16.2958%
|   |   |   |   |   |   |   Remainder:                                                                                                                      8.94e-06    - 5.70175%
|   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(1):                                                                                         0.000150158 - 8.05428%   [1] 
|   |   |   |   |   |   |   panzer::AssemblyEngine::evaluateBCs: BC(1), side=1:                                                                             0.000141009 - 93.9071%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 98: [panzer::Traits::Jacobian] Constant: Constant_TF_TEMPERATURE:                                        4.051e-06   - 2.87287%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 100: [panzer::Traits::Jacobian] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Jacobian):      1.0756e-05  - 7.62788%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 101: [panzer::Traits::Jacobian] Dirichlet Residual Evaluator:                                            1.2013e-05  - 8.51931%   [1] 
|   |   |   |   |   |   |   |   Phalanx: Evaluator 102: [panzer::Traits::Jacobian] Dummy Scatter: BC(1)Residual_BC(1) Scatter Residual (Jacobian):          9.0654e-05  - 64.2895%   [1] 
|   |   |   |   |   |   |   |   Remainder:                                                                                                                  2.3535e-05  - 16.6904%
|   |   |   |   |   |   |   Remainder:                                                                                                                      9.149e-06   - 6.09292%
|   |   |   |   |   |   Remainder:                                                                                                                          0.00155737  - 83.5355%
|   |   |   |   |   panzer::AssemblyEngine::evaluate_scatter(panzer::Traits::Jacobian):                                                                     0.000352279 - 8.18044%   [1]  {min=0.000340266, max=0.000360102, std dev=8.8326e-06}  <1, 0, 1, 0, 2>
|   |   |   |   |   Remainder:                                                                                                                              0.000281285 - 6.53186%
|   |   |   |   NOX Total Preconditioner Construction:                                                                                                      0.0068794   - 14.6219%   [1]  {min=0.00687476 , max=0.00688663 , std dev=5.76336e-06} <2, 0, 1, 0, 1>
|   |   |   |   |   Ifpack_ILU::Initialize:                                                                                                                 0.000954696 - 13.8776%   [1]  {min=0.00090682 , max=0.000974566, std dev=3.22847e-05} <1, 0, 0, 0, 3>
|   |   |   |   |   Ifpack_ILU::Compute:                                                                                                                    0.000394359 - 5.73246%   [1]  {min=0.000339777, max=0.000434134, std dev=4.61732e-05} <1, 1, 0, 0, 2>
|   |   |   |   |   |   Ifpack_ILU::ComputeSetup:                                                                                                           0.000209454 - 53.1124%   [1]  {min=0.000191993, max=0.000219022, std dev=1.23079e-05} <1, 0, 0, 1, 2>
|   |   |   |   |   |   Remainder:                                                                                                                          0.000184905 - 46.8876%
|   |   |   |   |   Ifpack_ILU::ApplyInverse:                                                                                                               0.000328743 - 4.77866%   [1]  {min=0.000324483, max=0.000331467, std dev=2.98594e-06} <1, 0, 0, 2, 1>
|   |   |   |   |   |   Ifpack_ILU::ApplyInverse - Solve:                                                                                                   0.000283259 - 86.1642%   [1]  {min=0.000279086, max=0.00029047 , std dev=5.09675e-06} <2, 1, 0, 0, 1>
|   |   |   |   |   |   |   Epetra_CrsMatrix::Solve(Upper,Trans,UnitDiag,X,Y):                                                                              5.1508e-05  - 18.1841%   [2]  {min=4.9727e-05 , max=5.3429e-05 , std dev=1.75288e-06} <2, 0, 0, 1, 1>
|   |   |   |   |   |   |   Remainder:                                                                                                                      0.000231751 - 81.8159%
|   |   |   |   |   |   Remainder:                                                                                                                          4.54843e-05 - 13.8358%
|   |   |   |   |   Remainder:                                                                                                                              0.0052016   - 75.6113%
|   |   |   |   NOX Total Linear Solve:                                                                                                                     0.00449345  - 9.55065%   [1]  {min=0.00448779 , max=0.00450693 , std dev=9.05849e-06} <3, 0, 0, 0, 1>
|   |   |   |   |   Stratimikos: AztecOOLOWS:                                                                                                               0.00444702  - 98.9668%   [1]  {min=0.00444016 , max=0.00446111 , std dev=9.55855e-06} <2, 1, 0, 0, 1>
|   |   |   |   |   |   Stratimikos: AztecOOLOWS:SingleSolve:                                                                                               0.00385742  - 86.7417%   [1]  {min=0.00385091 , max=0.00386313 , std dev=5.43749e-06} <1, 1, 0, 1, 1>
|   |   |   |   |   |   |   Epetra_CrsMatrix::Multiply(TransA,X,Y):                                                                                         0.000458927 - 11.8972%   [25] {min=0.00045271 , max=0.00046577 , std dev=5.73481e-06} <1, 1, 0, 1, 1>
|   |   |   |   |   |   |   Ifpack_ILU::ApplyInverse:                                                                                                       0.000779739 - 20.214%    [24] {min=0.000746879, max=0.000822168, std dev=3.32662e-05} <2, 0, 1, 0, 1>
|   |   |   |   |   |   |   |   Ifpack_ILU::ApplyInverse - Solve:                                                                                           0.000518485 - 66.4947%   [24] {min=0.000490148, max=0.000557616, std dev=3.06627e-05} <2, 0, 1, 0, 1>
|   |   |   |   |   |   |   |   |   Epetra_CrsMatrix::Solve(Upper,Trans,UnitDiag,X,Y):                                                                      0.00027121  - 52.3083%   [48] {min=0.000247026, max=0.000300456, std dev=2.55021e-05} <2, 0, 0, 1, 1>
|   |   |   |   |   |   |   |   |   Remainder:                                                                                                              0.000247275 - 47.6917%
|   |   |   |   |   |   |   |   Remainder:                                                                                                                  0.000261254 - 33.5053%
|   |   |   |   |   |   |   Remainder:                                                                                                                      0.00261875  - 67.8888%
|   |   |   |   |   |   Remainder:                                                                                                                          0.000589601 - 13.2583%
|   |   |   |   |   Remainder:                                                                                                                              4.6427e-05  - 1.03322%
|   |   |   |   panzer::AssemblyEngine::evaluate_gather(panzer::Traits::Residual):                                                                          0.000121925 - 0.259147%  [1]  {min=0.000117473, max=0.000124736, std dev=3.11301e-06} <1, 0, 0, 2, 1>
|   |   |   |   panzer::AssemblyEngine::evaluate_volume(panzer::Traits::Residual):                                                                          6.34517e-05 - 0.134864%  [1]  {min=5.783e-05  , max=6.9353e-05 , std dev=5.90408e-06} <2, 0, 0, 0, 2>
|   |   |   |   |   Phalanx: Evaluator 236: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):                  2.54225e-05 - 40.0659%   [1]  {min=0          , max=2.5702e-05 , std dev=3.95273e-07} <2, 0, 0, 0, 2>
|   |   |   |   |   Phalanx: Evaluator 293: [panzer::Traits::Residual] STK HGRAD Scatter Basis HGrad:1: TF_TEMPERATURE: STK-Scatter Fields:                 1.23975e-05 - 19.5385%   [1]  {min=0          , max=1.2712e-05 , std dev=4.4477e-07}  <2, 0, 0, 0, 2>
|   |   |   |   |   Phalanx: Evaluator 221: [panzer::Traits::Residual] GatherSolution (Epetra): TF_TEMPERATURE (panzer::Traits::Residual):                  2.59465e-05 - 40.8917%   [1]  {min=0          , max=2.6191e-05 , std dev=3.45775e-07} <2, 0, 0, 0, 2>
|   |   |   |   |   Phalanx: Evaluator 278: [panzer::Traits::Residual] STK HGRAD Scatter Basis HGrad:1: TF_TEMPERATURE: STK-Scatter Fields:                 1.27115e-05 - 20.0333%   [1]  {min=0          , max=1.334e-05  , std dev=8.88833e-07} <2, 0, 0, 0, 2>
|   |   |   |   |   Remainder:                                                                                                                              -1.30262e-05 - -20.5294%
|   |   |   |   panzer::AssemblyEngine::evaluate_neumannbcs(panzer::Traits::Residual):                                                                      7.75225e-06 - 0.0164771% [1]  {min=7.123e-06  , max=8.87e-06   , std dev=7.67482e-07} <1, 2, 0, 0, 1>
|   |   |   |   panzer::AssemblyEngine::evaluate_interfacebcs(panzer::Traits::Residual):                                                                    7.76975e-06 - 0.0165143% [1]  {min=4.749e-06  , max=1.4527e-05 , std dev=4.54187e-06} <3, 0, 0, 0, 1>
|   |   |   |   panzer::AssemblyEngine::evaluate_dirichletbcs(panzer::Traits::Residual):                                                                    0.0015771   - 3.35207%   [1]  {min=0.00156919 , max=0.00158393 , std dev=6.81308e-06} <1, 1, 0, 0, 2>
|   |   |   |   panzer::AssemblyEngine::evaluate_scatter(panzer::Traits::Residual):                                                                         5.395e-06   - 0.0114669% [1]  {min=4.679e-06  , max=6.006e-06  , std dev=5.90968e-07} <1, 1, 0, 1, 1>
|   |   |   |   STK_Interface::writeToExodus(timestep):                                                                                                     0.0112562   - 23.9246%   [1]  {min=0.0112542  , max=0.0112579  , std dev=1.55711e-06} <1, 0, 1, 1, 1>
|   |   |   |   Remainder:                                                                                                                                  0.0129563   - 27.5381%
|   |   |   Remainder:                                                                                                                                      0.00359197  - 7.09307%
|   |   Remainder:                                                                                                                                          9.68975e-06 - 0.0191307%
|   Remainder:                                                                                                                                              0.138357    - 56.2421%
```