### PR TITLE
Belos CGSingleRed: Do not bug out when system is already solved

### DIFF
--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -429,6 +429,9 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     MVT::MvTransMv( one, *S_, *Z_, sHz );
     rHz = sHz(0,0);
     delta = sHz(1,0);
+    if ((delta < Teuchos::ScalarTraits<ScalarType>::eps()) &&
+        (stest_->checkStatus(this) == Passed))
+      return;
     alpha = rHz / delta;   
 
     // Check that alpha is a positive number!


### PR DESCRIPTION
@trilinos/belos 

## Description
The single-reduction CG throws an error when trying to solve a system with the exact solution as initial guess. (This happens for my time-dependent problem. Both solution and forcing term are zero on the first time step.) 
With the proposed change, this trivial solve costs two all-reduces, one for the inner product and one for the convergence check.