### PR TITLE
Tempus:  Split apart ERK and IMEX FSA tests to reduce timeouts.

### DIFF
--- a/packages/tempus/test/ExplicitRK/CMakeLists.txt
+++ b/packages/tempus/test/ExplicitRK/CMakeLists.txt
@@ -8,17 +8,169 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_EXECUTABLE(
   ExplicitRK_Combined_FSA
-  SOURCES Tempus_ExplicitRK_Combined_FSA.cpp Tempus_ExplicitRK_FSA.hpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  SOURCES Tempus_ExplicitRK_Combined_FSA.cpp Tempus_ExplicitRK_FSA.hpp
   TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Forward_Euler"
+  ARGS "--method=\"RK Forward Euler\""
   NUM_MPI_PROCS 1
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_RK_Explicit_4_Stage"
+  ARGS "--method=\"RK Explicit 4 Stage\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_3_8_Rule"
+  ARGS "--method=\"RK Explicit 3/8 Rule\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_4_Stage_3rd_Order_By_Runge"
+  ARGS "--method=\"RK Explicit 4 Stage 3rd order by Runge\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_5_Stage_3rd_Order_By_Kinnmark_And_Gray"
+  ARGS "--method=\"RK Explicit 5 Stage 3rd order by Kinnmark and Gray\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_3_Stage_3rd_Order"
+  ARGS "--method=\"RK Explicit 3 Stage 3rd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_3_Stage_3rd_Order_TVD"
+  ARGS "--method=\"RK Explicit 3 Stage 3rd order TVD\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_3_Stage_3rd_Order_By_Heun"
+  ARGS "--method=\"RK Explicit 3 Stage 3rd order by Heun\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_2_Stage_2nd_Order_By_Runge"
+  ARGS "--method=\"RK Explicit 2 Stage 2nd order by Runge\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_RK_Explicit_Trapezoidal"
+  ARGS "--method=\"RK Explicit Trapezoidal\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Combined_FSA
+  NAME "ExplicitRK_Combined_FSA_General_ERK"
+  ARGS "--method=\"General ERK\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE(
   ExplicitRK_Staggered_FSA
-  SOURCES Tempus_ExplicitRK_Staggered_FSA.cpp Tempus_ExplicitRK_FSA.hpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  SOURCES Tempus_ExplicitRK_Staggered_FSA.cpp Tempus_ExplicitRK_FSA.hpp
   TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Forward_Euler"
+  ARGS "--method=\"RK Forward Euler\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_RK_Explicit_4_Stage"
+  ARGS "--method=\"RK Explicit 4 Stage\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_3_8_Rule"
+  ARGS "--method=\"RK Explicit 3/8 Rule\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_4_Stage_3rd_Order_By_Runge"
+  ARGS "--method=\"RK Explicit 4 Stage 3rd order by Runge\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_5_Stage_3rd_Order_By_Kinnmark_And_Gray"
+  ARGS "--method=\"RK Explicit 5 Stage 3rd order by Kinnmark and Gray\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_3_Stage_3rd_Order"
+  ARGS "--method=\"RK Explicit 3 Stage 3rd order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_3_Stage_3rd_Order_TVD"
+  ARGS "--method=\"RK Explicit 3 Stage 3rd order TVD\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_3_Stage_3rd_Order_By_Heun"
+  ARGS "--method=\"RK Explicit 3 Stage 3rd order by Heun\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_2_Stage_2nd_Order_By_Runge"
+  ARGS "--method=\"RK Explicit 2 Stage 2nd order by Runge\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_RK_Explicit_Trapezoidal"
+  ARGS "--method=\"RK Explicit Trapezoidal\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  ExplicitRK_Staggered_FSA
+  NAME "ExplicitRK_Staggered_FSA_General_ERK"
+  ARGS "--method=\"General ERK\""
   NUM_MPI_PROCS 1
   )
 

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_Combined_FSA.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_Combined_FSA.cpp
@@ -8,16 +8,34 @@
 
 #include "Tempus_ExplicitRK_FSA.hpp"
 
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+std::string method_name;
+
 namespace Tempus_Test {
 
 TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_Combined_FSA)
 {
-  test_sincos_fsa(true, false, out, success);
+  test_sincos_fsa(method_name, true, false, out, success);
 }
 
 TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_Combined_FSA_Tangent)
 {
-  test_sincos_fsa(true, true, out, success);
+  test_sincos_fsa(method_name, true, true, out, success);
 }
 
 } // namespace Tempus_Test
+
+int main( int argc, char* argv[] )
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  // Add "--method" command line argument
+  Teuchos::CommandLineProcessor& CLP = Teuchos::UnitTestRepository::getCLP();
+  method_name = "";
+  CLP.setOption("method", &method_name, "Stepper method");
+
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_FSA.hpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_FSA.hpp
@@ -39,7 +39,8 @@ using Tempus::SolutionState;
 
 // ************************************************************
 // ************************************************************
-void test_sincos_fsa(const bool use_combined_method,
+void test_sincos_fsa(const std::string& method_name,
+                     const bool use_combined_method,
                      const bool use_dfdp_as_tangent,
                      Teuchos::FancyOStream &out, bool &success)
 {
@@ -55,6 +56,14 @@ void test_sincos_fsa(const bool use_combined_method,
   RKMethods.push_back("RK Explicit 2 Stage 2nd order by Runge");
   RKMethods.push_back("RK Explicit Trapezoidal");
   RKMethods.push_back("General ERK");
+
+  // Check that method_name is valid
+  if (method_name != "") {
+    auto it = std::find(RKMethods.begin(), RKMethods.end(), method_name);
+    TEUCHOS_TEST_FOR_EXCEPTION(it == RKMethods.end(), std::logic_error,
+                               "Invalid RK method name " << method_name);
+  }
+
   std::vector<double> RKMethodErrors;
   if (use_combined_method) {
     RKMethodErrors.push_back(0.183799);
@@ -90,6 +99,10 @@ void test_sincos_fsa(const bool use_combined_method,
   my_out->setOutputToRootOnly(0);
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
+
+    // If we were given a method to run, skip this method if it doesn't match
+    if (method_name != "" && RKMethods[m] != method_name)
+      continue;
 
     std::string RKMethod_ = RKMethods[m];
     std::replace(RKMethod_.begin(), RKMethod_.end(), ' ', '_');

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_Staggered_FSA.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_Staggered_FSA.cpp
@@ -8,16 +8,34 @@
 
 #include "Tempus_ExplicitRK_FSA.hpp"
 
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+std::string method_name;
+
 namespace Tempus_Test {
 
 TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_Staggered_FSA)
 {
-  test_sincos_fsa(false, false, out, success);
+  test_sincos_fsa(method_name, false, false, out, success);
 }
 
 TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_Staggered_FSA_Tangent)
 {
-  test_sincos_fsa(false, true, out, success);
+  test_sincos_fsa(method_name, false, true, out, success);
 }
 
 } // namespace Tempus_Test
+
+int main( int argc, char* argv[] )
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  // Add "--method" command line argument
+  Teuchos::CommandLineProcessor& CLP = Teuchos::UnitTestRepository::getCLP();
+  method_name = "";
+  CLP.setOption("method", &method_name, "Stepper method");
+
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/tempus/test/IMEX_RK_Partitioned/CMakeLists.txt
+++ b/packages/tempus/test/IMEX_RK_Partitioned/CMakeLists.txt
@@ -8,17 +8,71 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_EXECUTABLE(
   IMEX_RK_Partitioned_Combined_FSA
-  SOURCES Tempus_IMEX_RK_Partitioned_Combined_FSA.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  SOURCES Tempus_IMEX_RK_Partitioned_Combined_FSA.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp
   TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_1st_Order"
+  ARGS "--method=\"Partitioned IMEX RK 1st order\""
   NUM_MPI_PROCS 1
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_SSP2"
+  ARGS "--method=\"Partitioned IMEX RK SSP2\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_ARS_233"
+  ARGS "--method=\"Partitioned IMEX RK ARS 233\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA
+  NAME "IMEX_RK_Partitioned_Combined_FSA_General_Partioned_IMEX_RK"
+  ARGS "--method=\"General Partitioned IMEX RK\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE(
   IMEX_RK_Partitioned_Staggered_FSA
-  SOURCES Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  SOURCES Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp
   TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order"
+  ARGS "--method=\"Partitioned IMEX RK 1st order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_SSP2"
+  ARGS "--method=\"Partitioned IMEX RK SSP2\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_ARS_233"
+  ARGS "--method=\"Partitioned IMEX RK ARS 233\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_General_Partioned_IMEX_RK"
+  ARGS "--method=\"General Partitioned IMEX RK\""
   NUM_MPI_PROCS 1
   )
 

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Combined_FSA.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Combined_FSA.cpp
@@ -8,16 +8,34 @@
 
 #include "Tempus_IMEX_RK_Partitioned_FSA.hpp"
 
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+std::string method_name;
+
 namespace Tempus_Test {
 
 TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Combined_FSA)
 {
-  test_vdp_fsa(true, false, out, success);
+  test_vdp_fsa(method_name, true, false, out, success);
 }
 
 TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Combined_FSA_Tangent)
 {
-  test_vdp_fsa(true, true, out, success);
+  test_vdp_fsa(method_name, true, true, out, success);
 }
 
 } // namespace Tempus_Test
+
+int main( int argc, char* argv[] )
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  // Add "--method" command line argument
+  Teuchos::CommandLineProcessor& CLP = Teuchos::UnitTestRepository::getCLP();
+  method_name = "";
+  CLP.setOption("method", &method_name, "Stepper method");
+
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
@@ -41,7 +41,8 @@ using Tempus::SolutionState;
 
 // ************************************************************
 // ************************************************************
-void test_vdp_fsa(const bool use_combined_method,
+void test_vdp_fsa(const std::string& method_name,
+                  const bool use_combined_method,
                   const bool use_dfdp_as_tangent,
                   Teuchos::FancyOStream &out, bool &success)
 {
@@ -50,6 +51,13 @@ void test_vdp_fsa(const bool use_combined_method,
   stepperTypes.push_back("Partitioned IMEX RK SSP2"     );
   stepperTypes.push_back("Partitioned IMEX RK ARS 233"  );
   stepperTypes.push_back("General Partitioned IMEX RK"  );
+
+  // Check that method_name is valid
+  if (method_name != "") {
+    auto it = std::find(stepperTypes.begin(), stepperTypes.end(), method_name);
+    TEUCHOS_TEST_FOR_EXCEPTION(it == stepperTypes.end(), std::logic_error,
+                               "Invalid stepper type " << method_name);
+  }
 
   std::vector<double> stepperOrders;
   std::vector<double> stepperErrors;
@@ -117,6 +125,10 @@ void test_vdp_fsa(const bool use_combined_method,
 
   std::vector<std::string>::size_type m;
   for(m = 0; m != stepperTypes.size(); m++) {
+
+    // If we were given a method to run, skip this method if it doesn't match
+    if (method_name != "" && stepperTypes[m] != method_name)
+      continue;
 
     std::string stepperType = stepperTypes[m];
     std::string stepperName = stepperTypes[m];

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp
@@ -8,16 +8,34 @@
 
 #include "Tempus_IMEX_RK_Partitioned_FSA.hpp"
 
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+std::string method_name;
+
 namespace Tempus_Test {
 
 TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Staggered_FSA)
 {
-  test_vdp_fsa(false, false, out, success);
+  test_vdp_fsa(method_name, false, false, out, success);
 }
 
 TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Staggered_FSA_Tangent)
 {
-  test_vdp_fsa(false, true, out, success);
+  test_vdp_fsa(method_name, false, true, out, success);
 }
 
 } // namespace Tempus_Test
+
+int main( int argc, char* argv[] )
+{
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  // Add "--method" command line argument
+  Teuchos::CommandLineProcessor& CLP = Teuchos::UnitTestRepository::getCLP();
+  method_name = "";
+  CLP.setOption("method", &method_name, "Stepper method");
+
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}


### PR DESCRIPTION
As was done with the DIRK tests a while ago, split apart the Explicit RK
and Partitioned-IMEX FSA tests to make them run shorter, and therefore
less likely to timeout in debug builds.