### PR TITLE
Modify the use of LAPACK GEES/GEEV in the Belos and Anasazi solvers for Intel MKL 18.0.2

### DIFF
--- a/packages/anasazi/src/AnasaziBlockKrylovSchur.hpp
+++ b/packages/anasazi/src/AnasaziBlockKrylovSchur.hpp
@@ -1465,6 +1465,17 @@ namespace Anasazi {
           std::vector<int> bwork( curDim_ );
           int info = 0, sdim = 0; 
           char jobvs = 'V';
+
+          int opt_lwork = -1;
+          lapack.GEES( jobvs,curDim_, schurH_->values(), schurH_->stride(), &sdim, &tmp_rRitzValues[0],
+                       &tmp_iRitzValues[0], subQ.values(), subQ.stride(), &work[0], opt_lwork, 
+                       &rwork[0], &bwork[0], &info );
+          opt_lwork = std::abs (static_cast<int> (Teuchos::ScalarTraits<ScalarType>::real (work[0])));
+          if (opt_lwork > lwork)
+          {
+            lwork = opt_lwork;
+            work.resize( lwork );
+          } 
           lapack.GEES( jobvs,curDim_, schurH_->values(), schurH_->stride(), &sdim, &tmp_rRitzValues[0],
                        &tmp_iRitzValues[0], subQ.values(), subQ.stride(), &work[0], lwork, 
                        &rwork[0], &bwork[0], &info );

--- a/packages/anasazi/src/AnasaziGeneralizedDavidson.hpp
+++ b/packages/anasazi/src/AnasaziGeneralizedDavidson.hpp
@@ -1279,11 +1279,25 @@ void GeneralizedDavidson<ScalarType,MV,OP>::solveProjectedEigenproblem()
         int sdim;
         int work_size = 3*d_curDim;
         std::vector<ScalarType>  work(work_size);
+        std::vector<MagnitudeType> rwork( d_curDim );
+        std::vector<int> bwork( d_curDim );
+
         int info;
+        int opt_lwork = -1;
 
         Teuchos::LAPACK<int,ScalarType> lapack;
+
         lapack.GEES( vecs, d_curDim, d_S->values(), d_S->stride(), &sdim, &d_alphar[0], &d_alphai[0],
-                     d_Z->values(), d_Z->stride(), &work[0], work_size, 0, 0, &info);
+                     d_Z->values(), d_Z->stride(), &work[0], opt_lwork, &rwork[0], &bwork[0], &info);
+
+        opt_lwork = std::abs (static_cast<int> (Teuchos::ScalarTraits<ScalarType>::real (work[0])));
+        if (opt_lwork > work_size)
+        {
+          work_size = opt_lwork;
+          work.resize( work_size );
+        }
+        lapack.GEES( vecs, d_curDim, d_S->values(), d_S->stride(), &sdim, &d_alphar[0], &d_alphai[0],
+                     d_Z->values(), d_Z->stride(), &work[0], work_size, &rwork[0], &bwork[0], &info);
 
         std::fill( d_betar.begin(), d_betar.end(), ST::one() );
 

--- a/packages/belos/src/BelosGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosGCRODRSolMgr.hpp
@@ -2060,7 +2060,7 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
   int i, j;
   bool xtraVec = false;
   ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
-  //ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
+  MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
 
   // Real and imaginary eigenvalue components
   std::vector<MagnitudeType> wr(m), wi(m);
@@ -2073,11 +2073,6 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
 
   // Sorted order of harmonic Ritz values, also used for DGEEV
   std::vector<int> iperm(m);
-
-  // Size of workspace and workspace for DGEEV
-  int lwork = 4*m;
-  std::vector<ScalarType> work(lwork);
-  std::vector<MagnitudeType> rwork(lwork);
 
   // Output info
   int info = 0;
@@ -2094,16 +2089,27 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
 
   // Compute H_m + d*H_m^{-H}*e_m*e_m^H
   ScalarType d = HH(m, m-1) * HH(m, m-1);
-  Teuchos::SerialDenseMatrix<int, ScalarType> harmHH( Teuchos::Copy, HH, HH.numRows(), HH.numCols() );
+  Teuchos::SerialDenseMatrix<int, ScalarType> harmHH( Teuchos::Copy, HH, m, m );
   for( i=0; i<m; ++i )
     harmHH(i, m-1) += d * e_m[i];
 
   // Revise to do query for optimal workspace first
   // Create simple storage for the left eigenvectors, which we don't care about.
-  const int ldvl = m;
+  const int ldvl = 1;
   ScalarType* vl = 0;
-  //lapack.GEEV('N', 'V', m, harmHH.values(), harmHH.stride(), &wr[0], &wi[0],
-  //            vl, ldvl, vr.values(), vr.stride(), &work[0], lwork, &info);
+
+  // Size of workspace and workspace for DGEEV
+  int lwork = -1;
+  std::vector<ScalarType> work(1);
+  std::vector<MagnitudeType> rwork(2*m);
+
+  // First query GEEV for the optimal workspace size
+  lapack.GEEV('N', 'V', m, harmHH.values(), harmHH.stride(), &wr[0], &wi[0],
+              vl, ldvl, vr.values(), vr.stride(), &work[0], lwork, &rwork[0], &info);
+
+  lwork = std::abs (static_cast<int> (Teuchos::ScalarTraits<ScalarType>::real (work[0])));
+  work.resize( lwork );
+
   lapack.GEEV('N', 'V', m, harmHH.values(), harmHH.stride(), &wr[0], &wi[0],
               vl, ldvl, vr.values(), vr.stride(), &work[0], lwork, &rwork[0], &info);
   TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::solve(): LAPACK GEEV failed to compute eigensolutions.");


### PR DESCRIPTION
This commit modifies the use of LAPACK GEES/GEEV in solvers that employ this method such that they determine the optimal lwork size before allocating the work vector. This should not be necessary, but the Intel MKL 18.0.[0-3] library has a known bug that can cause this method to seg fault due to bad memory access, when the optimal size is not used. This was fixed in MKL Update 4, as documented here:

https://software.intel.com/en-us/articles/intel-math-kernel-library-intel-mkl-2018-bug-fixes-list

Since there is a concern that the MKL 18.0.2 library that is on the ATDM platforms
will be in use for the near-term, the interactions with the LAPACK calls to GEES/GEEV
in Anasazi and Belos will be modified.

This commit addresses the issues in bugs #3497 and #3499, except for the
Anasazi_MultiVecTraitsTest2_MPI_4 failure.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos @trilinos/anasazi 

## Description
<!--- Please describe your changes in detail. -->
This commit modifies the use of LAPACK GEES/GEEV in solvers that employ this method such that they determine the optimal lwork size before allocating the work vector. This should not be necessary, but the Intel MKL 18.0.[0-3] library has a known bug that can cause this method to seg fault due to bad memory access, when the optimal size is not used. 

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Should fix test failures on Mutrino

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues 

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #3497 and #3499
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
On Mutrino and Chama using offending Intel MKL library.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->