### PR TITLE
Atdm ride panzer disable

### DIFF
--- a/cmake/std/atdm/ATDMDevEnvSettings.cmake
+++ b/cmake/std/atdm/ATDMDevEnvSettings.cmake
@@ -343,6 +343,13 @@ ATDM_SET_CACHE(TPL_DLlib_LIBRARIES "-ldl" CACHE FILEPATH)
 # buid's tweaks file
 #
 
+IF(ATDM_USE_CUDA)
+  ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedCurlLaplacianExample_DISABLE ON)
+  ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-1_DISABLE ON)
+  ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-2_DISABLE ON)
+  ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Quad-Order-3_DISABLE ON)
+  ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-2_DISABLE ON)
+ENDIF()
 
 #
 # H) ATDM env config install hooks

--- a/cmake/std/atdm/ride/tweaks/CUDA-9.2-RELEASE-CUDA-POWER8-KEPLER37.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA-9.2-RELEASE-CUDA-POWER8-KEPLER37.cmake
@@ -1,5 +1,6 @@
 # Disable test that times out at 10 minutes (#2446)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_main_driver_energy-ss-loca-eigenvalue_DISABLE ON)
+ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-1_DISABLE ON)
 
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")
 


### PR DESCRIPTION
@trilinos/framework , @bartlettroscoe 

## Description
This pull request disables some PanzerAdaptersSTK tests for some ATDM builds.  The tests:
* PanzerAdaptersSTK_MixedCurlLaplacianExample
* PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-1
* PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-2
* PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Quad-Order-3
* PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-2

are disabled for **all cuda** builds.

The test:
* PanzerAdaptersSTK_MixedCurlLaplacianExample-ConvTest-Tri-Order-1 

is disabled on `Trilinos-atdm-white-ride-cuda-9.2-opt`

## Motivation and Context

## Related Issues

#3939 
#3950 

## How Has This Been Tested?
Local testing on ride shows that these tests are disabled for cuda builds but not the gnu builds

