### PR TITLE
MueLu: Fix some float build issues

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
@@ -42,7 +42,7 @@ namespace MueLu {
   Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > op,
                              const Teuchos::ParameterList& inParamList,
-                             Teuchos::RCP<Xpetra::MultiVector<double, LocalOrdinal, GlobalOrdinal, Node> > coords = Teuchos::null,
+                             Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LocalOrdinal, GlobalOrdinal, Node> > coords = Teuchos::null,
                              Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > nullspace = Teuchos::null) {
     typedef MueLu::HierarchyManager<Scalar,LocalOrdinal,GlobalOrdinal,Node> HierarchyManager;
     typedef MueLu::HierarchyUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node> HierarchyUtils;

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -145,6 +145,8 @@ namespace MueLu {
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::compute() {
 
 
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType realType;
+
 #ifdef HAVE_MUELU_CUDA
     if (parameterList_.get<bool>("refmaxwell: cuda profile setup", false)) cudaProfilerStart();
 #endif
@@ -806,7 +808,7 @@ namespace MueLu {
 #endif
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("nullspace.mat"), *Nullspace_);
       if (Coords_ != null)
-        Xpetra::IO<double, LO, GlobalOrdinal, Node>::Write(std::string("coords.mat"), *Coords_);
+        Xpetra::IO<realType, LO, GlobalOrdinal, Node>::Write(std::string("coords.mat"), *Coords_);
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("D0_nuked.mat"), *D0_Matrix_);
       Xpetra::IO<SC, LO, GlobalOrdinal, Node>::Write(std::string("A_nodal.mat"), *A_nodal_Matrix_);
       Xpetra::IO<SC, LO, GO, NO>::Write(std::string("P11.mat"), *P11_);
@@ -835,6 +837,7 @@ namespace MueLu {
 
     const SC SC_ZERO = Teuchos::ScalarTraits<SC>::zero();
     const SC SC_ONE = Teuchos::ScalarTraits<SC>::one();
+    const Scalar half = SC_ONE / (SC_ONE + SC_ONE);
     size_t dim = Nullspace_->getNumVectors();
     size_t numLocalRows = SM_Matrix_->getNodeNumRows();
 
@@ -1017,7 +1020,7 @@ namespace MueLu {
 #if defined(HAVE_MUELU_DEBUG) && !defined(HAVE_MUELU_CUDA)
                                        TEUCHOS_ASSERT_EQUALITY(P11colind(m),jNew);
 #endif
-                                       P11vals(m) += 0.5 * v * n;
+                                       P11vals(m) += half * v * n;
                                      }
                                    }
                                  }
@@ -1041,7 +1044,7 @@ namespace MueLu {
 #if defined(HAVE_MUELU_DEBUG) && !defined(HAVE_MUELU_CUDA)
                                        TEUCHOS_ASSERT_EQUALITY(P11colind(m),jNew);
 #endif
-                                       P11vals(m) += 0.5 * v * n;
+                                       P11vals(m) += half * v * n;
                                      }
                                    }
                                  }
@@ -1164,7 +1167,7 @@ namespace MueLu {
 #ifdef HAVE_MUELU_DEBUG
                 TEUCHOS_ASSERT_EQUALITY(P11colind[m],jNew);
 #endif
-                  P11vals[m] += 0.5 * v * n;
+                  P11vals[m] += half * v * n;
               }
             }
           }
@@ -1187,7 +1190,7 @@ namespace MueLu {
 #ifdef HAVE_MUELU_DEBUG
                 TEUCHOS_ASSERT_EQUALITY(P11colind[m],jNew);
 #endif
-                  P11vals[m] += 0.5 * v * n;
+                  P11vals[m] += half * v * n;
               }
             }
           }
@@ -1243,14 +1246,14 @@ namespace MueLu {
                 if (P11_status[jNew] == ST_INVALID || P11_status[jNew] < nnz_old) {
                   P11_status[jNew] = nnz;
                   P11colind[nnz] = jNew;
-                  P11vals[nnz] = 0.5 * v * n;
+                  P11vals[nnz] = half * v * n;
                   // or should it be
-                  // P11vals[nnz] = 0.5 * n;
+                  // P11vals[nnz] = half * n;
                   nnz++;
                 } else {
-                  P11vals[P11_status[jNew]] += 0.5 * v * n;
+                  P11vals[P11_status[jNew]] += half * v * n;
                   // or should it be
-                  // P11vals[P11_status[jNew]] += 0.5 * n;
+                  // P11vals[P11_status[jNew]] += half * n;
                 }
               }
             }
@@ -1275,14 +1278,14 @@ namespace MueLu {
                 if (P11_status[jNew] == ST_INVALID || P11_status[jNew] < nnz_old) {
                   P11_status[jNew] = nnz;
                   P11colind[nnz] = jNew;
-                  P11vals[nnz] = 0.5 * v * n;
+                  P11vals[nnz] = half * v * n;
                   // or should it be
-                  // P11vals[nnz] = 0.5 * n;
+                  // P11vals[nnz] = half * n;
                   nnz++;
                 } else {
-                  P11vals[P11_status[jNew]] += 0.5 * v * n;
+                  P11vals[P11_status[jNew]] += half * v * n;
                   // or should it be
-                  // P11vals[P11_status[jNew]] += 0.5 * n;
+                  // P11vals[P11_status[jNew]] += half * n;
                 }
               }
             }

--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
@@ -179,7 +179,7 @@ namespace MueLu {
       typedef Zoltan2::XpetraMultiVectorAdapter<RealValuedMultiVector>  InputAdapterType;
       typedef Zoltan2::PartitioningProblem<InputAdapterType>   ProblemType;
 
-      Array<double> weightsPerRow(numElements);
+      Array<real_type> weightsPerRow(numElements);
       for (LO i = 0; i < numElements; i++) {
         weightsPerRow[i] = 0.0;
 
@@ -189,7 +189,7 @@ namespace MueLu {
       }
 
       std::vector<int>           strides;
-      std::vector<const double*> weights(1, weightsPerRow.getRawPtr());
+      std::vector<const real_type*> weights(1, weightsPerRow.getRawPtr());
 
       RCP<const Teuchos::MpiComm<int> >            dupMpiComm = rcp_dynamic_cast<const Teuchos::MpiComm<int> >(rowMap->getComm()->duplicate());
       RCP<const Teuchos::OpaqueWrapper<MPI_Comm> > zoltanComm = dupMpiComm->getRawMpiComm();

--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -231,7 +231,7 @@ namespace MueLu {
 
     static RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > Transpose(Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, bool optimizeTranspose = false,const std::string & label = std::string(),const Teuchos::RCP<Teuchos::ParameterList> &params=Teuchos::null);
 
-    static RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > RealValuedToScalarMultiVector(RCP<Xpetra::MultiVector<double,LocalOrdinal,GlobalOrdinal,Node> > X);
+    static RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > RealValuedToScalarMultiVector(RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node> > X);
 
     static RCP<Xpetra::MultiVector<double,LocalOrdinal,GlobalOrdinal,Node> > ExtractCoordinatesFromParameterList(ParameterList& paramList);
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -520,15 +520,17 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  RealValuedToScalarMultiVector(RCP<Xpetra::MultiVector<double,LocalOrdinal,GlobalOrdinal,Node> > X) {
+  RealValuedToScalarMultiVector(RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node> > X) {
     RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> > Xscalar;
-#if defined(HAVE_XPETRA_TPETRA) && defined(HAVE_TPETRA_INST_COMPLEX_DOUBLE)
+#if defined(HAVE_XPETRA_TPETRA) && (defined(HAVE_TPETRA_INST_COMPLEX_DOUBLE) || defined(HAVE_TPETRA_INST_COMPLEX_FLOAT))
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType real_type;
       // Need to cast the real-valued multivector to Scalar=complex
-      if (typeid(Scalar).name() == typeid(std::complex<double>).name()) {
+    if ((typeid(Scalar).name() == typeid(std::complex<double>).name()) ||
+        (typeid(Scalar).name() == typeid(std::complex<float>).name())) {
         Xscalar = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(X->getMap(),X->getNumVectors());
         size_t numVecs = X->getNumVectors();
         for (size_t j=0;j<numVecs;j++) {
-          Teuchos::ArrayRCP<const double> XVec = X->getData(j);
+          Teuchos::ArrayRCP<const real_type> XVec = X->getData(j);
           Teuchos::ArrayRCP<Scalar> XVecScalar = Xscalar->getDataNonConst(j);
           for(size_t i = 0; i < static_cast<size_t>(XVec.size()); ++i)
             XVecScalar[i]=XVec[i];

--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -108,8 +108,8 @@ namespace MueLuTests {
       typedef Tpetra::CrsMatrix<SC,LO,GO,NO> tpetra_crsmatrix_type;
       typedef Tpetra::Operator<SC,LO,GO,NO> tpetra_operator_type;
       typedef Tpetra::MultiVector<SC,LO,GO,NO> tpetra_multivector_type;
-      typedef Xpetra::MultiVector<double,LO,GO,NO> dMultiVector;
-      typedef Tpetra::MultiVector<double,LO,GO,NO> dtpetra_multivector_type;
+      typedef Xpetra::MultiVector<real_type,LO,GO,NO> dMultiVector;
+      typedef Tpetra::MultiVector<real_type,LO,GO,NO> dtpetra_multivector_type;
 
       // Matrix
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
@@ -130,7 +130,7 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 
@@ -151,7 +151,7 @@ namespace MueLuTests {
 
       xmlFileName = "testWithRebalance.xml";
 
-      RCP<dtpetra_multivector_type> tpcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
+      RCP<dtpetra_multivector_type> tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
       RCP<tpetra_multivector_type>  tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
 
       out << "========== Create Preconditioner from xmlFile and coordinates ==========" << std::endl;
@@ -224,7 +224,7 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 
@@ -238,7 +238,7 @@ namespace MueLuTests {
 
       xmlFileName = "testWithRebalance.xml";
 
-      RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
+      RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
       RCP<Epetra_MultiVector> epnullspace   = Utils::MV2NonConstEpetraMV(nullspace);
 
       eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
@@ -277,8 +277,8 @@ namespace MueLuTests {
 
     using Teuchos::RCP;
     typedef MueLu::Utilities<SC,LO,GO,NO> Utils;
-    typedef Xpetra::MultiVector<double,LO,GO,NO> dMultiVector;
     typedef typename Teuchos::ScalarTraits<SC>::magnitudeType real_type;
+    typedef Xpetra::MultiVector<real_type,LO,GO,NO> dMultiVector;
     typedef Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
 
     Xpetra::UnderlyingLib          lib  = TestHelpers::Parameters::getLib();
@@ -312,7 +312,7 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,RealValuedMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 
@@ -331,7 +331,7 @@ namespace MueLuTests {
 
       mylist.set("xml parameter file","testWithRebalance.xml");
 
-      RCP<Tpetra::MultiVector<double,LO,GO,NO> > tpcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
+      RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
       RCP<Tpetra::MultiVector<SC,LO,GO,NO> > tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
 
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), mylist, tpcoordinates);
@@ -386,7 +386,7 @@ namespace MueLuTests {
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
       Teuchos::ParameterList galeriList;
       galeriList.set("nx", nx);
-      RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,dMultiVector>("1D", Op->getRowMap(), galeriList);
+      RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,dMultiVector>("1D", Op->getRowMap(), galeriList);
       RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), 1);
       nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
 
@@ -400,7 +400,7 @@ namespace MueLuTests {
 
       mylist.set("xml parameter file","testWithRebalance.xml");
 
-      RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
+      RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
       RCP<Epetra_MultiVector> epnullspace   = Utils::MV2NonConstEpetraMV(nullspace);
 
       eH = MueLu::CreateEpetraPreconditioner(epA, mylist, epcoordinates);
@@ -439,7 +439,8 @@ namespace MueLuTests {
 
     using Teuchos::RCP;
     typedef MueLu::Utilities<SC,LO,GO,NO> Utils;
-    typedef Xpetra::MultiVector<double,LO,GO,NO> dMultiVector;
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType real_type;
+    typedef Xpetra::MultiVector<real_type,LO,GO,NO> dMultiVector;
 
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
 
@@ -466,7 +467,7 @@ namespace MueLuTests {
         Teuchos::ParameterList clist;
         clist.set("nx", (nx * comm->getSize())/numPDEs);
         RCP<const Map>   cmap        = MapFactory::Build(lib, Teuchos::as<size_t>((nx * comm->getSize())/numPDEs), Teuchos::as<int>(0), comm);
-        RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,dMultiVector>("1D", cmap, clist);
+        RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,dMultiVector>("1D", cmap, clist);
         RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), numPDEs);
         if (numPDEs == 1) {
           nullspace->putScalar(Teuchos::ScalarTraits<Scalar>::one());
@@ -494,7 +495,7 @@ namespace MueLuTests {
         X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
 
         RCP<Tpetra::CrsMatrix<SC,LO,GO,NO> >   tpA           = MueLu::Utilities<SC,LO,GO,NO>::Op2NonConstTpetraCrs(Op);
-        RCP<Tpetra::MultiVector<double,LO,GO,NO> > tpcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
+        RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
         RCP<Tpetra::MultiVector<SC,LO,GO,NO> > tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
 
         RCP<MueLu::TpetraOperator<SC,LO,GO,NO> > tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates);
@@ -533,7 +534,7 @@ namespace MueLuTests {
         Teuchos::ParameterList clist;
         clist.set("nx", (nx * comm->getSize())/numPDEs);
         RCP<const Map>   cmap        = MapFactory::Build(lib, Teuchos::as<size_t>((nx * comm->getSize())/numPDEs), Teuchos::as<int>(0), comm);
-        RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,dMultiVector>("1D", cmap, clist);
+        RCP<dMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,dMultiVector>("1D", cmap, clist);
         RCP<MultiVector> nullspace   = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(Op->getDomainMap(), numPDEs);
         if (numPDEs == 1) {
           nullspace->putScalar(Teuchos::ScalarTraits<Scalar>::one());
@@ -561,7 +562,7 @@ namespace MueLuTests {
         X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
 
         RCP<Epetra_CrsMatrix>   epA           = MueLu::Utilities<SC,LO,GO,NO>::Op2NonConstEpetraCrs(Op);
-        RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<double,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
+        RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
         RCP<Epetra_MultiVector> epnullspace   = Utils::MV2NonConstEpetraMV(nullspace);
 
         RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
@@ -596,7 +597,8 @@ namespace MueLuTests {
 
     using Teuchos::RCP;
     typedef MueLu::Utilities<SC,LO,GO,NO> Utils;
-    typedef Xpetra::MultiVector<double,LO,GO,NO> dMultiVector;
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType real_type;
+    typedef Xpetra::MultiVector<real_type,LO,GO,NO> dMultiVector;
 
     Xpetra::UnderlyingLib          lib  = TestHelpers::Parameters::getLib();
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();


### PR DESCRIPTION
@trilinos/muelu 

## Description
As pointed out in issue #3946, MueLu does not build with `Scalar=float` or `Scalar=complex<float>`. 
I do not think that MueLu has supported using float in the past.
With the above changes, the build goes through as long as 
```
-D MueLu_ENABLE_TESTS=OFF 
-D MueLu_ENABLE_EXAMPLES=OFF
```
I would be surprised if MueLu actually worked though. The reason is that we have a lot of spots were coordinates are hard-coded to double. For an actual fix, we would need to go through and replace all occurrences with `ScalarTraits<Scalar>::magnitudeType`.