### PR TITLE
MiniEM: Input file simplifications

### DIFF
--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -12,6 +12,7 @@ TRIBITS_ADD_EXECUTABLE(
 TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyBlockPrecFiles
   SOURCE_FILES
   maxwell.xml maxwell2D.xml
+  maxwell-blob-R0.xml maxwell-blob-R1.xml maxwell-blob-R2.xml maxwell-blob-R3.xml maxwell-blob-R4.xml
   solverAugmentation.xml solverAugmentationEpetra.xml
   solverCG.xml
   solverMueLuRefMaxwell.xml solverMueLuRefMaxwell2D.xml solverMueLuRefMaxwellEpetra.xml

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R0.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R0.xml
@@ -1,34 +1,12 @@
 <ParameterList>
 
   <ParameterList name="Mesh">
-    <Parameter name="Source" type="string" value="Inline Mesh" />
-    <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
+    <Parameter name="Source" type="string" value="Exodus File" />
 
     <ParameterList name="Exodus File">
       <Parameter name="dt" type="double" value="6.0e-12"/>
       <ParameterList name="Exodus Parameters">
-        <Parameter name="File Name" type="string" value="blob/blob.g" />
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
-      <Parameter name="CFL" type="double" value="4.0"/>
-      <ParameterList name="Mesh Factory Parameter List">
-        <Parameter name="X Blocks" type="int" value="1" />
-        <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
-        <Parameter name="Z Elements" type="int" value="10" />
-        <!-- <ParameterList name="Periodic BCs"> -->
-        <!--   <Parameter name="Count" type="int" value="3"/> -->
-        <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
-        <!--   <Parameter name="Periodic Condition 2" type="string" value="yz-all 1e-8: left;right"/> -->
-        <!--   <Parameter name="Periodic Condition 3" type="string" value="xy-all 1e-8: front;back"/> -->
-        <!-- </ParameterList> -->
+        <Parameter name="File Name" type="string" value="blob-R0.g" />
       </ParameterList>
     </ParameterList>
 
@@ -36,11 +14,11 @@
 
 
   <ParameterList name="Block ID to Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Maxwell Physics"/>
+    <Parameter name="block_1" type="string" value="Maxwell Physics"/>
   </ParameterList>
 
   <ParameterList name="Block ID to Auxiliary Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Auxiliary Physics Block"/>
+    <Parameter name="block_1" type="string" value="Auxiliary Physics Block"/>
   </ParameterList>
 
    <ParameterList name="Assembly">
@@ -160,108 +138,21 @@
     <ParameterList name="Electromagnetic Energy">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
     <ParameterList name="Electromagnetic Energy/dt^2">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">
-    <!-- Conditions on E-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
-    <!-- Conditions on B-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
+    <!-- None -->
   </ParameterList>
 
   <ParameterList name="Auxiliary Boundary Conditions">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R1.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R1.xml
@@ -1,34 +1,12 @@
 <ParameterList>
 
   <ParameterList name="Mesh">
-    <Parameter name="Source" type="string" value="Inline Mesh" />
-    <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
+    <Parameter name="Source" type="string" value="Exodus File" />
 
     <ParameterList name="Exodus File">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="3.0e-12"/>
       <ParameterList name="Exodus Parameters">
-        <Parameter name="File Name" type="string" value="blob/blob.g" />
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
-      <Parameter name="CFL" type="double" value="4.0"/>
-      <ParameterList name="Mesh Factory Parameter List">
-        <Parameter name="X Blocks" type="int" value="1" />
-        <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
-        <Parameter name="Z Elements" type="int" value="10" />
-        <!-- <ParameterList name="Periodic BCs"> -->
-        <!--   <Parameter name="Count" type="int" value="3"/> -->
-        <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
-        <!--   <Parameter name="Periodic Condition 2" type="string" value="yz-all 1e-8: left;right"/> -->
-        <!--   <Parameter name="Periodic Condition 3" type="string" value="xy-all 1e-8: front;back"/> -->
-        <!-- </ParameterList> -->
+        <Parameter name="File Name" type="string" value="blob-R1.g" />
       </ParameterList>
     </ParameterList>
 
@@ -36,11 +14,11 @@
 
 
   <ParameterList name="Block ID to Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Maxwell Physics"/>
+    <Parameter name="block_1" type="string" value="Maxwell Physics"/>
   </ParameterList>
 
   <ParameterList name="Block ID to Auxiliary Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Auxiliary Physics Block"/>
+    <Parameter name="block_1" type="string" value="Auxiliary Physics Block"/>
   </ParameterList>
 
    <ParameterList name="Assembly">
@@ -160,108 +138,21 @@
     <ParameterList name="Electromagnetic Energy">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
     <ParameterList name="Electromagnetic Energy/dt^2">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">
-    <!-- Conditions on E-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
-    <!-- Conditions on B-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
+    <!-- None -->
   </ParameterList>
 
   <ParameterList name="Auxiliary Boundary Conditions">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R2.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R2.xml
@@ -1,34 +1,12 @@
 <ParameterList>
 
   <ParameterList name="Mesh">
-    <Parameter name="Source" type="string" value="Inline Mesh" />
-    <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
+    <Parameter name="Source" type="string" value="Exodus File" />
 
     <ParameterList name="Exodus File">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="1.5e-12"/>
       <ParameterList name="Exodus Parameters">
-        <Parameter name="File Name" type="string" value="blob/blob.g" />
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
-      <Parameter name="CFL" type="double" value="4.0"/>
-      <ParameterList name="Mesh Factory Parameter List">
-        <Parameter name="X Blocks" type="int" value="1" />
-        <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
-        <Parameter name="Z Elements" type="int" value="10" />
-        <!-- <ParameterList name="Periodic BCs"> -->
-        <!--   <Parameter name="Count" type="int" value="3"/> -->
-        <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
-        <!--   <Parameter name="Periodic Condition 2" type="string" value="yz-all 1e-8: left;right"/> -->
-        <!--   <Parameter name="Periodic Condition 3" type="string" value="xy-all 1e-8: front;back"/> -->
-        <!-- </ParameterList> -->
+        <Parameter name="File Name" type="string" value="blob-R2.g" />
       </ParameterList>
     </ParameterList>
 
@@ -36,11 +14,11 @@
 
 
   <ParameterList name="Block ID to Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Maxwell Physics"/>
+    <Parameter name="block_1" type="string" value="Maxwell Physics"/>
   </ParameterList>
 
   <ParameterList name="Block ID to Auxiliary Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Auxiliary Physics Block"/>
+    <Parameter name="block_1" type="string" value="Auxiliary Physics Block"/>
   </ParameterList>
 
    <ParameterList name="Assembly">
@@ -160,108 +138,21 @@
     <ParameterList name="Electromagnetic Energy">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
     <ParameterList name="Electromagnetic Energy/dt^2">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">
-    <!-- Conditions on E-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
-    <!-- Conditions on B-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
+    <!-- None -->
   </ParameterList>
 
   <ParameterList name="Auxiliary Boundary Conditions">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R3.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R3.xml
@@ -1,34 +1,12 @@
 <ParameterList>
 
   <ParameterList name="Mesh">
-    <Parameter name="Source" type="string" value="Inline Mesh" />
-    <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
+    <Parameter name="Source" type="string" value="Exodus File" />
 
     <ParameterList name="Exodus File">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="0.75e-12"/>
       <ParameterList name="Exodus Parameters">
-        <Parameter name="File Name" type="string" value="blob/blob.g" />
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
-      <Parameter name="CFL" type="double" value="4.0"/>
-      <ParameterList name="Mesh Factory Parameter List">
-        <Parameter name="X Blocks" type="int" value="1" />
-        <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
-        <Parameter name="Z Elements" type="int" value="10" />
-        <!-- <ParameterList name="Periodic BCs"> -->
-        <!--   <Parameter name="Count" type="int" value="3"/> -->
-        <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
-        <!--   <Parameter name="Periodic Condition 2" type="string" value="yz-all 1e-8: left;right"/> -->
-        <!--   <Parameter name="Periodic Condition 3" type="string" value="xy-all 1e-8: front;back"/> -->
-        <!-- </ParameterList> -->
+        <Parameter name="File Name" type="string" value="blob-R3.g" />
       </ParameterList>
     </ParameterList>
 
@@ -36,11 +14,11 @@
 
 
   <ParameterList name="Block ID to Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Maxwell Physics"/>
+    <Parameter name="block_1" type="string" value="Maxwell Physics"/>
   </ParameterList>
 
   <ParameterList name="Block ID to Auxiliary Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Auxiliary Physics Block"/>
+    <Parameter name="block_1" type="string" value="Auxiliary Physics Block"/>
   </ParameterList>
 
    <ParameterList name="Assembly">
@@ -160,108 +138,21 @@
     <ParameterList name="Electromagnetic Energy">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
     <ParameterList name="Electromagnetic Energy/dt^2">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">
-    <!-- Conditions on E-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
-    <!-- Conditions on B-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
+    <!-- None -->
   </ParameterList>
 
   <ParameterList name="Auxiliary Boundary Conditions">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R4.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R4.xml
@@ -1,34 +1,12 @@
 <ParameterList>
 
   <ParameterList name="Mesh">
-    <Parameter name="Source" type="string" value="Inline Mesh" />
-    <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
+    <Parameter name="Source" type="string" value="Exodus File" />
 
     <ParameterList name="Exodus File">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="0.375e-12"/>
       <ParameterList name="Exodus Parameters">
-        <Parameter name="File Name" type="string" value="blob/blob.g" />
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
-      <Parameter name="CFL" type="double" value="4.0"/>
-      <ParameterList name="Mesh Factory Parameter List">
-        <Parameter name="X Blocks" type="int" value="1" />
-        <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
-        <Parameter name="Z Elements" type="int" value="10" />
-        <!-- <ParameterList name="Periodic BCs"> -->
-        <!--   <Parameter name="Count" type="int" value="3"/> -->
-        <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
-        <!--   <Parameter name="Periodic Condition 2" type="string" value="yz-all 1e-8: left;right"/> -->
-        <!--   <Parameter name="Periodic Condition 3" type="string" value="xy-all 1e-8: front;back"/> -->
-        <!-- </ParameterList> -->
+        <Parameter name="File Name" type="string" value="blob-R4.g" />
       </ParameterList>
     </ParameterList>
 
@@ -36,11 +14,11 @@
 
 
   <ParameterList name="Block ID to Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Maxwell Physics"/>
+    <Parameter name="block_1" type="string" value="Maxwell Physics"/>
   </ParameterList>
 
   <ParameterList name="Block ID to Auxiliary Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Auxiliary Physics Block"/>
+    <Parameter name="block_1" type="string" value="Auxiliary Physics Block"/>
   </ParameterList>
 
    <ParameterList name="Assembly">
@@ -160,108 +138,21 @@
     <ParameterList name="Electromagnetic Energy">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
     <ParameterList name="Electromagnetic Energy/dt^2">
       <Parameter name="Type" type="string" value="Functional"/>
       <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/>
-      <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/>
+      <Parameter name="Element Blocks" type="string" value="block_1"/>
       <Parameter name="Evaluation Types" type="string" value="Residual"/>
       <Parameter name="Requires Cell Integral" type="bool" value="true"/>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">
-    <!-- Conditions on E-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
-    <!-- Conditions on B-field -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList> -->
-    <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
-    <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
-    <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
-    <!-- </ParameterList> -->
-
+    <!-- None -->
   </ParameterList>
 
   <ParameterList name="Auxiliary Boundary Conditions">

--- a/packages/panzer/mini-em/example/BlockPrec/solverCG.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverCG.xml
@@ -64,8 +64,8 @@
               <ParameterList name="Ifpack2">
                 <Parameter name="Prec Type" type="string" value="relaxation"/>
                 <ParameterList name="Ifpack2 Settings">
-                  <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="2"/>
+                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
+                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell.xml
@@ -185,8 +185,8 @@
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 11list">
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="verbosity" type="string" value="extreme"/>
+                  <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="3"/>
                   <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
                   <Parameter name="aggregation: type" type="string" value="uncoupled"/>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwell2D.xml
@@ -1,220 +1,26 @@
 <ParameterList name="Linear Solver">
-  <Parameter name="Linear Solver Type" type="string" value="Belos"/>
-  <ParameterList name="Linear Solver Types">
-    <ParameterList name="Belos">
-      <Parameter name="Solver Type" type="string" value="Block GMRES"/>
-      <ParameterList name="Solver Types">
-        <ParameterList name="Block GMRES">
-          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
-          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-          <Parameter name="Output Frequency" type="int" value="1"/>
-          <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="1"/>
-          <Parameter name="Maximum Iterations" type="int" value="10"/>
-          <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="10"/>
-          <Parameter name="Flexible Gmres" type="bool" value="true"/>
-          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
-          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="VerboseObject">
-        <Parameter name="Verbosity Level" type="string" value="medium"/>
-      </ParameterList>
-    </ParameterList>
-  </ParameterList>
-
-  <Parameter name="Preconditioner Type" type="string" value="Teko"/>
   <ParameterList name="Preconditioner Types">
     <ParameterList name="Teko">
-      <Parameter name="Inverse Type" type="string" value="Maxwell"/>
       <ParameterList name="Inverse Factory Library">
         <ParameterList name="Maxwell">
-          <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
-          <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="false"/>
-          <Parameter name="Debug" type="bool" value="false"/>
-          <Parameter name="Dump" type="bool" value="false"/>
-          <Parameter name="Use discrete gradient" type="bool" value="true"/>
-          <Parameter name="Solve lower triangular" type="bool" value="true"/>
-
-          <ParameterList name="Q_B Solve">
-            <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
-            <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
-                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-                <Parameter name="Maximum Iterations" type="int" value="100"/>
-                <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="10"/>
-                <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="1"/>
-              </ParameterList>
-            </ParameterList>
-            <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="medium"/>
-            </ParameterList>
-          </ParameterList>
-
-          <!-- In 2D Q_B is block-diagonal, for lowest order elements even diagonal. -->
-          <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
-            <ParameterList name="Prec Types">
-              <ParameterList name="Ifpack2">
-                <Parameter name="Prec Type" type="string" value="relaxation"/>
-                <ParameterList name="Ifpack2 Settings">
-                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-
-          <ParameterList name="S_E Solve">
-            <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
-            <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
-                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-                <Parameter name="Maximum Iterations" type="int" value="100"/>
-                <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="10"/>
-                <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="1"/>
-                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-              </ParameterList>
-            </ParameterList>
-            <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="medium"/>
-            </ParameterList>
-          </ParameterList>
 
           <ParameterList name="S_E Preconditioner">
-            <Parameter name="Type" type="string" value="MueLuRefMaxwell-Tpetra"/>
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell-Tpetra">
-                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
-                <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
-                <Parameter name="refmaxwell: mode" type="string" value="additive"/>
-                <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
-                <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
-                <Parameter name="refmaxwell: max coarse size" type="int" value="1000"/>
-
-                <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
-                <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
-
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
-
-                <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
-
-                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                  </ParameterList>
-                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                  </ParameterList>
 
                 <ParameterList name="refmaxwell: 11list">
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="2"/>
-                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                  <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
-
-                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
-
-                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                  </ParameterList>
-                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                  </ParameterList>
-
-                  <Parameter name="repartition: enable" type="bool" value="true"/>
-                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                  <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
-                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                  <ParameterList name="repartition: params">
-                    <Parameter name="algorithm" type="string" value="multijagged"/>
-                  </ParameterList>
                 </ParameterList>
 
-                <ParameterList name="refmaxwell: 22list">
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
-                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                  <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
-
-                  <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                    <Parameter name="relaxation: backward mode" type="bool" value="false"/>
-                  </ParameterList>
-                  <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
-                  <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
-                    <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
-                    <Parameter name="relaxation: sweeps" type="int" value="2"/>
-                    <Parameter name="relaxation: use l1" type="bool" value="true"/>
-                    <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                  </ParameterList>
-
-                  <Parameter name="repartition: enable" type="bool" value="true"/>
-                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                  <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="800"/>
-                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                  <ParameterList name="repartition: params">
-                    <Parameter name="algorithm" type="string" value="multijagged"/>
-                  </ParameterList>
-                </ParameterList>
               </ParameterList>
-            </ParameterList>
-            <ParameterList name="Required Parameters">
-              <Parameter name="Coordinates" type="string" value="AUXILIARY_NODE"/>
+
+              <ParameterList name="MueLuRefMaxwell">
+
+                <ParameterList name="refmaxwell: 11list">
+                  <Parameter name="number of equations" type="int" value="2"/>
+                </ParameterList>
+
+              </ParameterList>
             </ParameterList>
           </ParameterList>
 

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellCuda.xml
@@ -1,174 +1,20 @@
 <ParameterList name="Linear Solver">
-  <Parameter name="Linear Solver Type" type="string" value="Belos"/>
-  <ParameterList name="Linear Solver Types">
-    <ParameterList name="Belos">
-      <Parameter name="Solver Type" type="string" value="Block GMRES"/>
-      <ParameterList name="Solver Types">
-        <ParameterList name="Block GMRES">
-          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
-          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-          <Parameter name="Output Frequency" type="int" value="1"/>
-          <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="1"/>
-          <Parameter name="Maximum Iterations" type="int" value="10"/>
-          <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="10"/>
-          <Parameter name="Flexible Gmres" type="bool" value="true"/>
-          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
-          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="VerboseObject">
-        <Parameter name="Verbosity Level" type="string" value="medium"/>
-      </ParameterList>
-    </ParameterList>
-  </ParameterList>
 
-  <Parameter name="Preconditioner Type" type="string" value="Teko"/>
   <ParameterList name="Preconditioner Types">
     <ParameterList name="Teko">
-      <Parameter name="Inverse Type" type="string" value="Maxwell"/>
       <ParameterList name="Inverse Factory Library">
         <ParameterList name="Maxwell">
-          <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
-          <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="false"/>
-          <Parameter name="Debug" type="bool" value="false"/>
-          <Parameter name="Dump" type="bool" value="false"/>
-          <Parameter name="Use discrete gradient" type="bool" value="true"/>
-          <Parameter name="Solve lower triangular" type="bool" value="true"/>
-
-          <ParameterList name="Q_B Solve">
-            <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
-            <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
-                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Use Single Reduction" type="bool" value="true"/>
-                <Parameter name="Maximum Iterations" type="int" value="100"/>
-                <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="10"/>
-                <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="1"/>
-                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-              </ParameterList>
-            </ParameterList>
-            <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="medium"/>
-            </ParameterList>
-          </ParameterList>
-
-          <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
-            <ParameterList name="Prec Types">
-              <ParameterList name="Ifpack2">
-                <Parameter name="Prec Type" type="string" value="relaxation"/>
-                <ParameterList name="Ifpack2 Settings">
-                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-
-          <!-- <ParameterList name="Q_B Preconditioner"> -->
-          <!--   <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/> -->
-          <!--   <ParameterList name="Prec Types"> -->
-          <!--     <ParameterList name="MueLu-Tpetra"> -->
-          <!--       <Parameter name="use kokkos refactor" type="bool" value="true"/> -->
-          <!--       <Parameter name="verbosity" type="string" value="high"/> -->
-          <!--       <Parameter name="hierarchy label" type="string" value="Q_B"/> -->
-          <!--       <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/> -->
-          <!--       <Parameter name="coarse: type" type="string" value="KLU2"/> -->
-          <!--       <Parameter name="coarse: max size" type="int" value="2500"/> -->
-          <!--       <Parameter name="aggregation: type" type="string" value="uncoupled"/> -->
-          <!--       <Parameter name="aggregation: drop scheme" type="string" value="classical"/> -->
-          <!--       <Parameter name="aggregation: drop tol" type="double" value="0.0"/> -->
-
-          <!--       <Parameter name="smoother: pre type" type="string" value="RELAXATION"/> -->
-          <!--       <ParameterList name="smoother: pre params"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
-          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
-          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: backward mode" type="bool" value="false"/> -->
-          <!--       </ParameterList> -->
-          <!--       <Parameter name="smoother: post type" type="string" value="RELAXATION"/> -->
-          <!--       <ParameterList name="smoother: post params"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
-          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
-          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: backward mode" type="bool" value="true"/> -->
-          <!--       </ParameterList> -->
-
-          <!--       <Parameter name="repartition: enable" type="bool" value="true"/> -->
-          <!--       <Parameter name="repartition: partitioner" type="string" value="zoltan2"/> -->
-          <!--       <Parameter name="repartition: start level" type="int" value="2"/> -->
-          <!--       <Parameter name="repartition: min rows per proc" type="int" value="800"/> -->
-          <!--       <Parameter name="repartition: max imbalance" type="double" value="1.1"/> -->
-          <!--       <Parameter name="repartition: remap parts" type="bool" value="true"/> -->
-          <!--       <Parameter name="repartition: rebalance P and R" type="bool" value="false"/> -->
-          <!--       <ParameterList name="repartition: params"> -->
-          <!--         <Parameter name="algorithm" type="string" value="multijagged"/> -->
-          <!--       </ParameterList> -->
-
-          <!--       <ParameterList name="Required Parameters"> -->
-          <!--         <Parameter name="Coordinates" type="string" value="B_face"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-
-          <ParameterList name="S_E Solve">
-            <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
-            <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
-                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Use Single Reduction" type="bool" value="true"/>
-                <Parameter name="Maximum Iterations" type="int" value="100"/>
-                <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="10"/>
-                <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="1"/>
-                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-              </ParameterList>
-            </ParameterList>
-            <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="medium"/>
-            </ParameterList>
-          </ParameterList>
 
           <ParameterList name="S_E Preconditioner">
-            <Parameter name="Type" type="string" value="MueLuRefMaxwell-Tpetra"/>
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell-Tpetra">
-                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
-                <Parameter name="verbosity" type="string" value="extreme"/>
                 <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
-                <Parameter name="refmaxwell: mode" type="string" value="additive"/>
-                <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
-                <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
-                <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
-                <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
-
-                <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
+                <Parameter name="rap: triple product" type="bool" value="false"/>
                 <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
-
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
-
-                <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                <!-- <ParameterList name="smoother: params"> -->
-                <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                <!-- </ParameterList> -->
 
                 <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
                 <ParameterList name="smoother: pre params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -176,7 +22,7 @@
                 </ParameterList>
                 <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
                 <ParameterList name="smoother: post params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -185,24 +31,12 @@
 
                 <ParameterList name="refmaxwell: 11list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                  <Parameter name="verbosity" type="string" value="extreme"/>
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
-                  <Parameter name="number of equations" type="int" value="3"/>
-                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                  <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
-
                   <Parameter name="tentative: calculate qr" type="bool" value="false"/>
-
-                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
+                  <Parameter name="rap: triple product" type="bool" value="false"/>
 
                   <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -210,43 +44,21 @@
                   </ParameterList>
                   <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
                     <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                  </ParameterList>
-
-                  <Parameter name="repartition: enable" type="bool" value="true"/>
-                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                  <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
-                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
-                  <ParameterList name="repartition: params">
-                    <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 22list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                  <Parameter name="verbosity" type="string" value="extreme"/>
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
-                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                  <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
+                  <Parameter name="rap: triple product" type="bool" value="false"/>
 
                   <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -254,29 +66,15 @@
                   </ParameterList>
                   <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
                     <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
-
-                  <Parameter name="repartition: enable" type="bool" value="true"/>
-                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                  <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
-                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
-                  <ParameterList name="repartition: params">
-                    <Parameter name="algorithm" type="string" value="multijagged"/>
-                  </ParameterList>
                 </ParameterList>
+
               </ParameterList>
-            </ParameterList>
-            <ParameterList name="Required Parameters">
-              <Parameter name="Coordinates" type="string" value="AUXILIARY_NODE"/>
             </ParameterList>
           </ParameterList>
 

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellOpenMP.xml
@@ -1,177 +1,21 @@
 <ParameterList name="Linear Solver">
-  <Parameter name="Linear Solver Type" type="string" value="Belos"/>
-  <ParameterList name="Linear Solver Types">
-    <ParameterList name="Belos">
-      <Parameter name="Solver Type" type="string" value="Block GMRES"/>
-      <ParameterList name="Solver Types">
-        <ParameterList name="Block GMRES">
-          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
-          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-          <Parameter name="Output Frequency" type="int" value="1"/>
-          <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="1"/>
-          <Parameter name="Maximum Iterations" type="int" value="10"/>
-          <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="10"/>
-          <Parameter name="Flexible Gmres" type="bool" value="true"/>
-          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
-          <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="VerboseObject">
-        <Parameter name="Verbosity Level" type="string" value="medium"/>
-      </ParameterList>
-    </ParameterList>
-  </ParameterList>
 
-  <Parameter name="Preconditioner Type" type="string" value="Teko"/>
   <ParameterList name="Preconditioner Types">
     <ParameterList name="Teko">
-      <Parameter name="Inverse Type" type="string" value="Maxwell"/>
       <ParameterList name="Inverse Factory Library">
         <ParameterList name="Maxwell">
-          <Parameter name="Type" type="string" value="Full Maxwell Preconditioner"/>
-          <Parameter name="Use refMaxwell" type="bool" value="true"/>
-          <Parameter name="Use as preconditioner" type="bool" value="false"/>
-          <Parameter name="Debug" type="bool" value="false"/>
-          <Parameter name="Dump" type="bool" value="false"/>
-          <Parameter name="Use discrete gradient" type="bool" value="true"/>
-          <Parameter name="Solve lower triangular" type="bool" value="true"/>
-
-          <ParameterList name="Q_B Solve">
-            <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
-            <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
-                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Use Single Reduction" type="bool" value="true"/>
-                <Parameter name="Maximum Iterations" type="int" value="100"/>
-                <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="10"/>
-                <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="1"/>
-                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-              </ParameterList>
-            </ParameterList>
-            <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="medium"/>
-            </ParameterList>
-          </ParameterList>
-
-          <ParameterList name="Q_B Preconditioner">
-            <Parameter name="Prec Type" type="string" value="Ifpack2"/>
-            <ParameterList name="Prec Types">
-              <ParameterList name="Ifpack2">
-                <Parameter name="Prec Type" type="string" value="relaxation"/>
-                <ParameterList name="Ifpack2 Settings">
-                  <Parameter name="relaxation: type" type="string" value="Jacobi"/>
-                  <Parameter name="relaxation: sweeps" type="int" value="1"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-
-          <!-- <ParameterList name="Q_B Preconditioner"> -->
-          <!--   <Parameter name="Prec Type" type="string" value="MueLu-Tpetra"/> -->
-          <!--   <ParameterList name="Prec Types"> -->
-          <!--     <ParameterList name="MueLu-Tpetra"> -->
-          <!--       <Parameter name="use kokkos refactor" type="bool" value="true"/> -->
-          <!--       <Parameter name="verbosity" type="string" value="high"/> -->
-          <!--       <Parameter name="hierarchy label" type="string" value="Q_B"/> -->
-          <!--       <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/> -->
-          <!--       <Parameter name="coarse: type" type="string" value="KLU2"/> -->
-          <!--       <Parameter name="coarse: max size" type="int" value="2500"/> -->
-          <!--       <Parameter name="aggregation: type" type="string" value="uncoupled"/> -->
-          <!--       <Parameter name="aggregation: drop scheme" type="string" value="classical"/> -->
-          <!--       <Parameter name="aggregation: drop tol" type="double" value="0.0"/> -->
-
-          <!--       <Parameter name="rap: triple product" type="bool" value="true"/> -->
-          <!--       <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
-
-          <!--       <Parameter name="smoother: pre type" type="string" value="RELAXATION"/> -->
-          <!--       <ParameterList name="smoother: pre params"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
-          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
-          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: backward mode" type="bool" value="false"/> -->
-          <!--       </ParameterList> -->
-          <!--       <Parameter name="smoother: post type" type="string" value="RELAXATION"/> -->
-          <!--       <ParameterList name="smoother: post params"> -->
-          <!--         <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/> -->
-          <!--         <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: sweeps" type="int" value="2"/> -->
-          <!--         <Parameter name="relaxation: use l1" type="bool" value="true"/> -->
-          <!--         <Parameter name="relaxation: backward mode" type="bool" value="true"/> -->
-          <!--       </ParameterList> -->
-
-          <!--       <Parameter name="repartition: enable" type="bool" value="true"/> -->
-          <!--       <Parameter name="repartition: partitioner" type="string" value="zoltan2"/> -->
-          <!--       <Parameter name="repartition: start level" type="int" value="2"/> -->
-          <!--       <Parameter name="repartition: min rows per proc" type="int" value="800"/> -->
-          <!--       <Parameter name="repartition: max imbalance" type="double" value="1.1"/> -->
-          <!--       <Parameter name="repartition: remap parts" type="bool" value="true"/> -->
-          <!--       <Parameter name="repartition: rebalance P and R" type="bool" value="false"/> -->
-          <!--       <ParameterList name="repartition: params"> -->
-          <!--         <Parameter name="algorithm" type="string" value="multijagged"/> -->
-          <!--       </ParameterList> -->
-
-          <!--       <ParameterList name="Required Parameters"> -->
-          <!--         <Parameter name="Coordinates" type="string" value="B_face"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-
-          <ParameterList name="S_E Solve">
-            <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Block CG"/>
-            <ParameterList name="Solver Types">
-              <ParameterList name="Block CG">
-                <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
-                <Parameter name="Use Single Reduction" type="bool" value="true"/>
-                <Parameter name="Maximum Iterations" type="int" value="100"/>
-                <Parameter name="Timer Label" type="string" value="CG S_E"/>
-                <Parameter name="Output Frequency" type="int" value="10"/>
-                <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="1"/>
-                <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
-              </ParameterList>
-            </ParameterList>
-            <ParameterList name="VerboseObject">
-              <Parameter name="Verbosity Level" type="string" value="medium"/>
-            </ParameterList>
-          </ParameterList>
 
           <ParameterList name="S_E Preconditioner">
-            <Parameter name="Type" type="string" value="MueLuRefMaxwell-Tpetra"/>
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell-Tpetra">
-                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
-                <Parameter name="verbosity" type="string" value="extreme"/>
                 <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
-                <Parameter name="refmaxwell: mode" type="string" value="additive"/>
-                <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
-                <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
-                <Parameter name="refmaxwell: max coarse size" type="int" value="2500"/>
-                <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
 
                 <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
                 <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
 
-                <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
-
-                <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                <!-- <ParameterList name="smoother: params"> -->
-                <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                <!-- </ParameterList> -->
-
                 <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
                 <ParameterList name="smoother: pre params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -179,7 +23,7 @@
                 </ParameterList>
                 <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
                 <ParameterList name="smoother: post params">
-                  <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                  <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                   <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                   <Parameter name="relaxation: sweeps" type="int" value="2"/>
                   <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -188,22 +32,10 @@
 
                 <ParameterList name="refmaxwell: 11list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                  <Parameter name="verbosity" type="string" value="extreme"/>
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
-                  <Parameter name="number of equations" type="int" value="3"/>
-                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                  <Parameter name="aggregation: drop tol" type="double" value="0.02"/>
-
-                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
 
                   <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -211,43 +43,20 @@
                   </ParameterList>
                   <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
                     <Parameter name="relaxation: backward mode" type="bool" value="true"/>
-                  </ParameterList>
-
-                  <Parameter name="repartition: enable" type="bool" value="true"/>
-                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                  <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
-                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
-                  <ParameterList name="repartition: params">
-                    <Parameter name="algorithm" type="string" value="multijagged"/>
                   </ParameterList>
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 22list">
                   <Parameter name="use kokkos refactor" type="bool" value="true"/>
-                  <Parameter name="verbosity" type="string" value="extreme"/>
-                  <Parameter name="coarse: max size" type="int" value="2500"/>
-                  <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
-                  <Parameter name="aggregation: type" type="string" value="uncoupled"/>
-                  <Parameter name="aggregation: drop tol" type="double" value="0.0"/>
-
-                  <!-- <Parameter name="smoother: type" type="string" value="CHEBYSHEV"/> -->
-                  <!-- <ParameterList name="smoother: params"> -->
-                  <!--   <Parameter name="chebyshev: degree" type="int" value="2"/> -->
-                  <!--   <Parameter name="chebyshev: ratio eigenvalue" type="double" value="3.0"/> -->
-                  <!-- </ParameterList> -->
 
                   <Parameter name="smoother: pre type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: pre params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
@@ -255,29 +64,15 @@
                   </ParameterList>
                   <Parameter name="smoother: post type" type="string" value="RELAXATION"/>
                   <ParameterList name="smoother: post params">
-                    <Parameter name="relaxation: type" type="string" value="Gauss-Seidel"/>
+                    <Parameter name="relaxation: type" type="string" value="MT Gauss-Seidel"/>
                     <Parameter name="relaxation: symmetric matrix structure" type="bool" value="true"/>
                     <Parameter name="relaxation: sweeps" type="int" value="2"/>
                     <Parameter name="relaxation: use l1" type="bool" value="true"/>
                     <Parameter name="relaxation: backward mode" type="bool" value="true"/>
                   </ParameterList>
-
-                  <Parameter name="repartition: enable" type="bool" value="true"/>
-                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-                  <Parameter name="repartition: start level" type="int" value="1"/>
-                  <Parameter name="repartition: min rows per proc" type="int" value="1000"/>
-                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
-                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
-                  <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
-                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
-                  <ParameterList name="repartition: params">
-                    <Parameter name="algorithm" type="string" value="multijagged"/>
-                  </ParameterList>
                 </ParameterList>
+
               </ParameterList>
-            </ParameterList>
-            <ParameterList name="Required Parameters">
-              <Parameter name="Coordinates" type="string" value="AUXILIARY_NODE"/>
             </ParameterList>
           </ParameterList>
 


### PR DESCRIPTION
@trilinos/panzer @jjellio 

## Description
This PR adds separate input files for the different blob meshes, and deduplicates the RefMaxwell solver input files. Instead of maintaining redundant solver files for all combinations of linear algebra, spatial dimension and node type, we keep one complete solver file and only apply the changes that are necessary for different combinations. This should make it easier to maintain the solver..