### PR TITLE
Teuchos: Fix #3983 (see #1608)

### DIFF
--- a/packages/teuchos/remainder/src/CMakeLists.txt
+++ b/packages/teuchos/remainder/src/CMakeLists.txt
@@ -30,3 +30,9 @@ TRIBITS_ADD_LIBRARY(
   SOURCES ${SOURCES}
   DEFINES -DTEUCHOS_LIB_EXPORTS_MODE
   )
+
+#
+# Make a trivial change to this comment if you add / remove a file to
+# / from this directory.  That ensures that running "make" will also
+# rerun CMake in order to regenerate Makefiles.
+#

--- a/packages/teuchos/remainder/src/Trilinos_LinearSolverSetupFailure.hpp
+++ b/packages/teuchos/remainder/src/Trilinos_LinearSolverSetupFailure.hpp
@@ -1,0 +1,118 @@
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef TRILINOS_LINEAR_SOLVER_SETUP_FAILURE_HPP
+#define TRILINOS_LINEAR_SOLVER_SETUP_FAILURE_HPP
+
+/// \file Trilinos_LinearSolverSetupFailure.hpp
+/// \brief Declaration and definition of
+///   Trilinos::LinearSolverSetupFailure exception class.
+
+#include "TeuchosRemainder_config.h"
+#include <stdexcept>
+#include <string>
+
+/// \namespace Trilinos
+/// \brief Namespace of things generally useful to many Trilinos packages
+namespace Trilinos {
+
+/// \brief Exception reporting failure in setting up a linear solver.
+///
+/// This class exists so that NOX and Stratimikos can share a common
+/// exception type, without introducing a dependency between the
+/// packages.  See Trilinos GitHub Issue #1608.
+///
+/// "Failure to set up a linear solver" includes preconditioners and
+/// sparse direct solvers.  It refers to the setup phase, not the
+/// actual solve, for solvers that separate setup and solve into two
+/// separate interfaces or function calls.  Setup does <i>not</i>
+/// refer to a "failure to converge when performing an iterative
+/// linear solve."
+///
+/// Here are some examples of legitimate "failures to set up a linear
+/// solver":
+///
+/// <ul>
+/// <li> Sparse LU factorization (either complete or incomplete) found
+///      that the matrix is singular. </li>
+/// <li> When setting up a block (a.k.a. physics-based, a.k.a. Teko)
+///      preconditioner, setup found that one of the blocks is
+///      singular. </li>
+/// </ul>
+///
+/// Any code that throws this exception is responsible for ensuring
+/// consistent behavior across multiple MPI processes.  Code that
+/// catches this exception may assume that if any process in the
+/// relevant communicator throws this exception, then all processes in
+/// the relevant communicator will throw this exception, in such a way
+/// as to ensure correct, deadlock-free MPI behavior.  For example,
+/// suppose that a preconditioner implements additive Schwarz domain
+/// decomposition, with one subdomain per MPI process.  Suppose that
+/// the preconditioner uses a sparse direct solver on each subdomain.
+/// If the sparse direct solver discovers that one subdomain has a
+/// singular matrix, then the preconditioner is responsible for
+/// ensuring that all processes in the matrix's communicator make a
+/// consistent choice to throw the exception.
+///
+/// One would expect to catch and recover from this exception in a
+/// nonlinear solver or time integrator.  A nonlinear solver might
+/// recover by reducing the nonlinear step size.  A time integrator
+/// might recover by reducing the time step size.  In general,
+/// recovery from this exception would likely involve slowing down and
+/// making choices in favor of stability.
+///
+/// In general, it's suboptimal coding practice to use exceptions for
+/// control flow with nonexceptional conditions.  Better practice is
+/// to return with a useful error code.  If a solver can detect
+/// conditions like "the matrix is singular," I consider that a
+/// nonexceptional condition.  However, it looks like NOX and
+/// Stratimikos don't have a better way to communicate, so we'll do
+/// our best for now by including this exception.
+class LinearSolverSetupFailure : public std::runtime_error {
+public:
+  LinearSolverSetupFailure (const std::string& msg) :
+    std::runtime_error (msg) {}
+  virtual ~LinearSolverSetupFailure () = default;
+};
+
+} // namespace Trilinos
+
+#endif // TRILINOS_LINEAR_SOLVER_SETUP_FAILURE_HPP

--- a/packages/teuchos/remainder/test/CMakeLists.txt
+++ b/packages/teuchos/remainder/test/CMakeLists.txt
@@ -3,3 +3,7 @@
 ADD_SUBDIRECTORIES(
   SolverFactory
   )
+
+ADD_SUBDIRECTORIES(
+  LinearSolverSetupFailure
+  )

--- a/packages/teuchos/remainder/test/LinearSolverSetupFailure/CMakeLists.txt
+++ b/packages/teuchos/remainder/test/LinearSolverSetupFailure/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  LinearSolverSetupFailure
+  SOURCES
+    LinearSolverSetupFailure.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/teuchos/remainder/test/LinearSolverSetupFailure/LinearSolverSetupFailure.cpp
+++ b/packages/teuchos/remainder/test/LinearSolverSetupFailure/LinearSolverSetupFailure.cpp
@@ -1,0 +1,118 @@
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ***********************************************************************
+// @HEADER
+
+#include "Trilinos_LinearSolverSetupFailure.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include <type_traits>
+
+namespace { // (anonymous)
+
+  void throws_LSSF () {
+    throw Trilinos::LinearSolverSetupFailure ("Not an std::runtime_error");
+  }
+
+  void does_not_throw () {
+  }
+
+  void throws_runtime_error () {
+    throw std::runtime_error ("Not a LinearSolverSetupFailure");
+  }
+
+  void catches_LSSF_0 (bool& success, Teuchos::FancyOStream& out) {
+    out << "Test that LinearSolverSetupFailure has a what() method that "
+      "returns something convertible to std::string, and test that the "
+      "resulting message is as expected" << std::endl;
+    Teuchos::OSTab tab1 (out);
+    bool threw = false;
+    try {
+      throws_LSSF ();
+    }
+    catch (Trilinos::LinearSolverSetupFailure& e) {
+      threw = true;
+      const std::string msg (e.what ());
+      TEST_ASSERT( msg == "Not an std::runtime_error" );
+    }
+    TEST_ASSERT( threw );
+  }
+
+  void catches_LSSF_1 (bool& success, Teuchos::FancyOStream& out) {
+    out << "Test that LinearSolverSetupFailure is a subclass of "
+      "std::runtime_error" << std::endl;
+    Teuchos::OSTab tab1 (out);
+
+    bool first_threw = false;
+    try {
+      throws_LSSF ();
+    }
+    catch (std::runtime_error& e) {
+      first_threw = true;
+      const std::string msg (e.what ());
+      TEST_ASSERT(msg == "Not an std::runtime_error");
+    }
+    TEST_ASSERT( first_threw );
+    static_assert (std::has_virtual_destructor<Trilinos::LinearSolverSetupFailure>::value,
+      "LinearSolverSetupFailure does not have a virtual destructor.  "
+      "This is bad for memory safety, because LinearSolverSetupFailure "
+      "inherits from a class with virtual methods.");
+
+    bool second_threw = false;
+    try {
+      throws_runtime_error ();
+    }
+    catch (std::runtime_error& e) {
+      second_threw = true;
+      const std::string msg (e.what ());
+      TEST_ASSERT(msg == "Not a LinearSolverSetupFailure");
+    }
+    TEST_ASSERT( second_threw );
+  }
+
+  TEUCHOS_UNIT_TEST( LinearSolverSetupFailure, Test0 )
+  {
+    using std::endl;
+
+    out << "LinearSolverSetupFailure Test0" << endl;
+    Teuchos::OSTab tab1 (out);
+    TEST_NOTHROW( does_not_throw () ); // sanity-check TEST_NOTHROW macro itself
+    TEST_NOTHROW( catches_LSSF_0 (success, out) );
+    TEST_NOTHROW( catches_LSSF_1 (success, out) );
+  }
+} // (anonymous)


### PR DESCRIPTION
@trilinos/teuchos @trilinos/nox @trilinos/stratimikos @trilinos/thyra 

@jmgate requested that I add an exception class to Teuchos, so that NOX and Stratimikos / Thyra can share a common exception class for reporting failure in setup of a linear solver.  I consulted with @jmgate on 03 Dec 2018 to scope the work.  This commit adds the requested class, Trilinos::LinearSolverSetupFailure, as well as a unit test.

This commit fixes #3983, and works towards resolving #1608.

Note that this PR does _not_ add a subpackage to Teuchos, as discussed here: https://github.com/trilinos/Trilinos/issues/1608#issuecomment-377358361 .  That is a separate issue.  Furthermore, adding subpackages has the potential to break downstream applications' builds.

## Related Issues

* Closes #3983 
* Blocks #1608 