### PR TITLE
Update all_supported_builds.sh file to support ctest-s-local-test-driver.sh (TRIL-212)

### DIFF
--- a/cmake/std/atdm/waterman/all_supported_builds.sh
+++ b/cmake/std/atdm/waterman/all_supported_builds.sh
@@ -1,1 +1,9 @@
-export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=" gnu-release-debug-openmp-Power9-Volta70 gnu-opt-openmp-Power9-Volta70 cuda-9.2-release-debug-Power9-Volta70 cuda-9.2-debug-Power9-Volta70 cuda-9.2-opt-Power9-Volta70"
+export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-waterman-
+
+export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
+  cuda-9.2-debug
+  cuda-9.2-opt
+  cuda-9.2-release-debug
+  gnu-debug-openmp
+  gnu-release-debug-openmp
+  )


### PR DESCRIPTION
@fryeguy52 

## Description

This matches the changes that I forgot to make in commit ab6fbffd8617141792d18e8a98a12b167ae8bf0b.

## Motivation and Context

Need to be able to use [ctest-s-local-test-driver.sh](https://github.com/trilinos/Trilinos/blob/develop/cmake/std/atdm/README.md#ctest-s-local-test-driversh) on 'waterman'.

## How Has This Been Tested?

I ran both `checkin-test-atdm.sh` and `ctest-s-local-test-driver.sh` on 'waterman' (see https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-237).
