### PR TITLE
Phalanx default option for multiple evaluator field registration

### DIFF
--- a/packages/phalanx/CMakeLists.txt
+++ b/packages/phalanx/CMakeLists.txt
@@ -15,7 +15,7 @@ TRIBITS_ADD_SHOW_DEPRECATED_WARNINGS_OPTION()
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ALLOW_MULTIPLE_EVALUATORS_FOR_SAME_FIELD
   PHX_ALLOW_MULTIPLE_EVALUATORS_FOR_SAME_FIELD
   "Enable to use backwards compatible mode where multiple evaluators can be registered that evalaute the same field. Phalanx will use the first evaluator it finds. Default to OFF but unless Panzer is enabled. For backwards compatibility with Panzer users, we default this to ON."
-  ${PROJECT_NAME}_ENABLE_Panzer )
+  "${${PROJECT_NAME}_ENABLE_Panzer}" )
 MESSAGE(STATUS "Allow Multiple Evaluator Registration for Same Field: ${${PACKAGE_NAME}_ALLOW_MULTIPLE_EVALUATORS_FOR_SAME_FIELD}")
 
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_EXPLICIT_TEMPLATE_INSTANTIATION

--- a/packages/phalanx/CMakeLists.txt
+++ b/packages/phalanx/CMakeLists.txt
@@ -14,12 +14,13 @@ TRIBITS_ADD_SHOW_DEPRECATED_WARNINGS_OPTION()
 
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ALLOW_MULTIPLE_EVALUATORS_FOR_SAME_FIELD
   PHX_ALLOW_MULTIPLE_EVALUATORS_FOR_SAME_FIELD
-  "Enable to use backwards compatible mode where multiple evaluators can be registered that evalaute the same field. Phalanx will use the first evaluator it finds. This should default to off but for backwards compatibility with current codes, we default this to ON."
-  ON )
+  "Enable to use backwards compatible mode where multiple evaluators can be registered that evalaute the same field. Phalanx will use the first evaluator it finds. Default to OFF but unless Panzer is enabled. For backwards compatibility with Panzer users, we default this to ON."
+  ${PROJECT_NAME}_ENABLE_Panzer )
+MESSAGE(STATUS "Allow Multiple Evaluator Registration for Same Field: ${${PACKAGE_NAME}_ALLOW_MULTIPLE_EVALUATORS_FOR_SAME_FIELD}")
 
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_EXPLICIT_TEMPLATE_INSTANTIATION
   PHX_ETI
-  "Build with explicit template instation enabled."
+  "Build with explicit template instation enabled in the examples."
   OFF )
 
 # If not explicitly defined by the user, pick a default node type that
@@ -98,6 +99,9 @@ TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_TEUCHOS_TIME_MONITOR
   "Build with Teuchos TimeMonitors wrapped around each evaluator."
   "${${PROJECT_NAME}_ENABLE_TEUCHOS_TIME_MONITOR}" )
 
+# Use only for CUDA builds
+MESSAGE(STATUS "Sacado Hierarchic DFAD support: ${Sacado_ENABLE_HIERARCHICAL_DFAD}")
+
 # Experimental device dag support
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_DEVICE_DAG
   PHX_ENABLE_DEVICE_DAG
@@ -124,8 +128,6 @@ IF(${PACKAGE_NAME}_ENABLE_KOKKOS_AMT)
   MESSAGE(FATAL_ERROR "Phalanx configure ERROR: Kokkos AMT support is enabled but is not implemented for Pthreads execution space. Please change your execution space or disable AMT support in Phalanx.")
 ENDIF()
 ENDIF(${PACKAGE_NAME}_ENABLE_KOKKOS_AMT)
-
-MESSAGE(STATUS "Sacado Hierarchic DFAD support: ${Sacado_ENABLE_HIERARCHICAL_DFAD}")
 
 # For use by Phalanx and Panzer unit tests
 GLOBAL_SET(PHALANX_UNIT_TEST_MAIN


### PR DESCRIPTION
Closes #3995 

If panzer is not enabled, phalanx by default will not allow multiple evaluators to be registered that evaluate the same field. We have to allow multiple registration when panzer is enabled due to a design issue.