### PR TITLE
MueLu: Fix export data

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
@@ -66,6 +66,7 @@
 #include "MueLu_UncoupledAggregationFactory_kokkos_fwd.hpp"
 #endif
 
+#include "MueLu_ZoltanInterface_fwd.hpp"
 #include "MueLu_Zoltan2Interface_fwd.hpp"
 #include "MueLu_RepartitionHeuristicFactory_fwd.hpp"
 #include "MueLu_RepartitionFactory_fwd.hpp"

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -82,6 +82,7 @@
 #include <KokkosSparse_CrsMatrix.hpp>
 #endif
 
+#include "MueLu_ZoltanInterface.hpp"
 #include "MueLu_Zoltan2Interface.hpp"
 #include "MueLu_RepartitionHeuristicFactory.hpp"
 #include "MueLu_RepartitionFactory.hpp"

--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -339,9 +339,9 @@ namespace MueLu {
 
         if (data[i] < H.GetNumLevels()) {
           RCP<Level> L = H.GetLevel(data[i]);
-          if (data[i] < levelManagers_.size() && L->IsAvailable(name,&*levelManagers_[i]->GetFactory(name))) {
+          if (data[i] < levelManagers_.size() && L->IsAvailable(name,&*levelManagers_[data[i]]->GetFactory(name))) {
 	    // Try generating factory
-            RCP<T> M = L->template Get< RCP<T> >(name,&*levelManagers_[i]->GetFactory(name));
+            RCP<T> M = L->template Get< RCP<T> >(name,&*levelManagers_[data[i]]->GetFactory(name));
             if (!M.is_null()) {
               Xpetra::IO<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Write(fileName,* M);
             }

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
@@ -263,6 +263,9 @@ namespace MueLu {
         if (pL.isParameter("repartition: use subcommunicators") == true && pL.get<bool>("repartition: use subcommunicators") == true)
           permutedCoords->replaceMap(permutedCoords->getMap()->removeEmptyProcesses());
 
+        if (permutedCoords->getMap() == Teuchos::null)
+          permutedCoords = Teuchos::null;
+
         Set(coarseLevel, "Coordinates", permutedCoords);
 
         std::string fileName = "rebalanced_coordinates_level_" + toString(coarseLevel.GetLevelID()) + ".m";
@@ -281,6 +284,9 @@ namespace MueLu {
 
         if (pL.get<bool>("repartition: use subcommunicators") == true)
           permutedNullspace->replaceMap(permutedNullspace->getMap()->removeEmptyProcesses());
+
+        if (permutedNullspace->getMap() == Teuchos::null)
+          permutedNullspace = Teuchos::null;
 
         Set(coarseLevel, "Nullspace", permutedNullspace);
       }


### PR DESCRIPTION
@trilinos/muelu @pwxy 

## Description
Fix for issue #3991: The problem was that dumping did not work if either
- coordinates or nullspace were dumped after rebalancing,
- level sequences other than {0,1,2,..} were used, e.g. {2}.

Also fix missing Zoltan headers in RefMaxwell.