### PR TITLE
Fixed some issues with panzer not working for multi blocks

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -160,6 +160,8 @@ buildCellToNodes(panzer::ConnManager<LO,GO> & conn, Kokkos::View<GO**> & globals
   for (std::size_t which_blk=0;which_blk<block_ids.size();which_blk++) {
     // get the elem to face mapping
     const std::vector<LO> & localIDs = conn.getElementBlock(block_ids[which_blk]);
+    if ( localIDs.size() == 0 )
+      continue;
     LO thisSize = conn.getConnectivitySize(localIDs[0]);
 
     totalCells += localIDs.size();
@@ -491,6 +493,8 @@ setupLocalMeshBlockInfo(const panzer_stk::STK_Interface & mesh,
 
   }
 
+  if ( owned_block_cells.size() == 0 )
+    return;
   block_info.num_owned_cells = owned_block_cells.size();
   block_info.element_block_name = element_block_name;
   block_info.cell_topology = mesh.getCellTopology(element_block_name);


### PR DESCRIPTION
There is a bug if panzer runs on multi blocks where all the blocks are not on all the MPI ranks.  This fixes the two that I found... Not sure if they are complete, doubt they are..

@rppawlo @eric-c-cyr can one of you look this over and accept?