### PR TITLE
Panzer: use subviews for Intrepid2 methods

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
@@ -83,7 +83,8 @@ namespace panzer {
     void evaluateValues(const PHX::MDField<Scalar,IP,Dim,void,void,void,void,void,void> & cub_points,
                         const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
                         const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
-                        const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv);
+                        const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
+                        const int in_num_cells = -1);
 
     void evaluateValues(const PHX::MDField<Scalar,IP,Dim,void,void,void,void,void,void> & cub_points,
                         const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
@@ -91,7 +92,8 @@ namespace panzer {
                         const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
                         const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
                         const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
-                        bool use_vertex_coordinates=true);
+                        bool use_vertex_coordinates=true,
+                        const int in_num_cells = -1);
 
     void evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cell_cub_points,
                           const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
@@ -104,7 +106,8 @@ namespace panzer {
                         const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
                         const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
                         const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
-                        bool use_vertex_coordinates=true);
+                        bool use_vertex_coordinates=true,
+                        const int in_num_cells = -1);
 
 
     //! Method to apply orientations to a basis values container.
@@ -112,7 +115,8 @@ namespace panzer {
     void applyOrientations(const PHX::MDField<const Scalar,Cell,BASIS> & orientations);
 
     // this is used in workset factory
-    void applyOrientations(const std::vector<Intrepid2::Orientation> & orientations);
+    void applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
+                           const int in_num_cells = -1);
 
     void setExtendedDimensions(const std::vector<PHX::index_size_type> & ddims)
     { ddims_ = ddims; }
@@ -173,31 +177,37 @@ namespace panzer {
 
     void evaluateValues_Const(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                              const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
+                              const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                              const int in_num_cells);
 
     void evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                              const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
                              const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                             const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
+                             const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                             const int in_num_cells);
 
     void evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                              const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
+                              const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                              const int in_num_cells);
 
     void evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
                               const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
                               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                              const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
+                              const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                              const int in_num_cells);
 
     void evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                              const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
                              const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
-                             const PHX::MDField<Scalar,Cell,IP> & weighted_measure);
+                             const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                             const int in_num_cells);
  
   private:
 
-    void evaluateBasisCoordinates(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates);
+    void evaluateBasisCoordinates(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
+                                  const int in_num_cells = -1);
 
     /** Evaluate the reference values for the basis functions needed
       *

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -59,12 +59,13 @@ void panzer::BasisValues2<Scalar>::
 evaluateValues(const PHX::MDField<Scalar,IP,Dim,void,void,void,void,void,void> & cub_points,
                const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
                const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
-               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv)
+               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
+               const int in_num_cells)
 {
   PHX::MDField<Scalar,Cell,IP> weighted_measure;
   PHX::MDField<Scalar,Cell,NODE,Dim> vertex_coordinates;
-  build_weighted = false; 
-  evaluateValues(cub_points,jac,jac_det,jac_inv,weighted_measure,vertex_coordinates,false);
+  build_weighted = false;
+  evaluateValues(cub_points,jac,jac_det,jac_inv,weighted_measure,vertex_coordinates,false,in_num_cells);
 }
 
 template <typename Scalar>
@@ -75,127 +76,164 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim,void,void,void,void,void,void> &
                const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
                const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
                const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
-               bool use_vertex_coordinates)
+               bool use_vertex_coordinates,
+               const int in_num_cells)
 {
   MDFieldArrayFactory af("",ddims_,true);
- 
+
   int num_dim   = basis_layout->dimension();
 
   // currently this just copies on the basis objects are converted
   // in intrepid
   evaluateReferenceValues(cub_points,compute_derivatives,use_vertex_coordinates);
 
+  const int num_cells = in_num_cells < 0 ? jac.extent(0) : in_num_cells;
+  const std::pair<int,int> cell_range(0,num_cells);
+
   PureBasis::EElementSpace elmtspace = getElementSpace();
   if(elmtspace==PureBasis::CONST ||
      elmtspace==PureBasis::HGRAD) {
+    auto s_basis_scalar = Kokkos::subview(basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HGRADtransformVALUE(basis_scalar.get_view(),
+      HGRADtransformVALUE(s_basis_scalar,
                           basis_ref_scalar.get_view());
 
     if(build_weighted) {
+      auto s_weighted_basis_scalar = Kokkos::subview(weighted_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_basis_scalar.get_view(), 
-                        weighted_measure.get_view(), 
-                        basis_scalar.get_view());
+        multiplyMeasure(s_weighted_basis_scalar,
+                        s_weighted_measure,
+                        s_basis_scalar);
     }
   }
   else if(elmtspace==PureBasis::HCURL) {
+    auto s_basis_vector = Kokkos::subview(basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_inv = Kokkos::subview(jac_inv.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HCURLtransformVALUE(basis_vector.get_view(),
-                          jac_inv.get_view(),
+      HCURLtransformVALUE(s_basis_vector,
+                          s_jac_inv,
                           basis_ref_vector.get_view());
-    
+
     if(build_weighted) {
+      auto s_weighted_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_basis_vector.get_view(), 
-                        weighted_measure.get_view(), 
-                        basis_vector.get_view());
+        multiplyMeasure(s_weighted_basis_vector,
+                        s_weighted_measure,
+                        s_basis_vector);
     }
   }
   else if(elmtspace==PureBasis::HDIV)
   {
+    auto s_basis_vector = Kokkos::subview(basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac = Kokkos::subview(jac.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_det = Kokkos::subview(jac_det.get_view(),cell_range,Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HDIVtransformVALUE(basis_vector.get_view(),
-                         jac.get_view(),
-                         jac_det.get_view(),
+      HDIVtransformVALUE(s_basis_vector,
+                         s_jac,
+                         s_jac_det,
                          basis_ref_vector.get_view());
 
     if(build_weighted) {
+      auto s_weighted_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_basis_vector.get_view(), 
-                        weighted_measure.get_view(), 
-                        basis_vector.get_view());
+        multiplyMeasure(s_weighted_basis_vector,
+                        s_weighted_measure,
+                        s_basis_vector);
     }
   }
   else if(elmtspace==PureBasis::HVOL)
   {
+    auto s_basis_scalar = Kokkos::subview(basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_det = Kokkos::subview(jac_det.get_view(),cell_range,Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HVOLtransformVALUE(basis_scalar.get_view(),
-                         jac_det.get_view(),
+      HVOLtransformVALUE(s_basis_scalar,
+                         s_jac_det,
                          basis_ref_scalar.get_view());
 
     if(build_weighted) {
+      auto s_weighted_basis_scalar = Kokkos::subview(weighted_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_basis_scalar.get_view(), 
-                        weighted_measure.get_view(), 
-                        basis_scalar.get_view());
+        multiplyMeasure(s_weighted_basis_scalar,
+                        s_weighted_measure,
+                        s_basis_scalar);
     }
   }
   else { TEUCHOS_ASSERT(false); }
 
   if(elmtspace==PureBasis::HGRAD && compute_derivatives) {
+    auto s_grad_basis = Kokkos::subview(grad_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_inv = Kokkos::subview(jac_inv.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HGRADtransformGRAD(grad_basis.get_view(),
-                         jac_inv.get_view(),
+      HGRADtransformGRAD(s_grad_basis,
+                         s_jac_inv,
                          grad_basis_ref.get_view());
 
     if(build_weighted) {
+      auto s_weighted_grad_basis = Kokkos::subview(weighted_grad_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_grad_basis.get_view(), 
-                        weighted_measure.get_view(), 
-                        grad_basis.get_view());
+        multiplyMeasure(s_weighted_grad_basis,
+                        s_weighted_measure,
+                        s_grad_basis);
     }
   }
   else if(elmtspace==PureBasis::HCURL && num_dim==2 && compute_derivatives) {
+    auto s_curl_basis_scalar = Kokkos::subview(curl_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_det = Kokkos::subview(jac_det.get_view(),cell_range,Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HDIVtransformDIV(curl_basis_scalar.get_view(),
-                       jac_det.get_view(),   // note only volume deformation is needed!
-                                             // this relates directly to this being in
-                                             // the divergence space in 2D!
+      HDIVtransformDIV(s_curl_basis_scalar,
+                       s_jac_det,   // note only volume deformation is needed!
+                                    // this relates directly to this being in
+                                    // the divergence space in 2D!
                        curl_basis_ref_scalar.get_view());
 
     if(build_weighted) {
+      auto s_weighted_curl_basis_scalar = Kokkos::subview(weighted_curl_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_curl_basis_scalar.get_view(), 
-                        weighted_measure.get_view(), 
-                        curl_basis_scalar.get_view());
+        multiplyMeasure(s_weighted_curl_basis_scalar,
+                        s_weighted_measure,
+                        s_curl_basis_scalar);
     }
   }
   else if(elmtspace==PureBasis::HCURL && num_dim==3 && compute_derivatives) {
+    auto s_curl_basis_vector = Kokkos::subview(curl_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac = Kokkos::subview(jac.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_det = Kokkos::subview(jac_det.get_view(),cell_range,Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HCURLtransformCURL(curl_basis_vector.get_view(),
-                         jac.get_view(),
-                         jac_det.get_view(),
+      HCURLtransformCURL(s_curl_basis_vector,
+                         s_jac,
+                         s_jac_det,
                          curl_basis_ref_vector.get_view());
 
     if(build_weighted) {
+      auto s_weighted_curl_basis_vector = Kokkos::subview(weighted_curl_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_curl_basis_vector.get_view(), 
-                        weighted_measure.get_view(), 
-                        curl_basis_vector.get_view());
+        multiplyMeasure(s_weighted_curl_basis_vector,
+                        s_weighted_measure,
+                        s_curl_basis_vector);
     }
   }
   else if(elmtspace==PureBasis::HDIV && compute_derivatives) {
+    auto s_div_basis = Kokkos::subview(div_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_det = Kokkos::subview(jac_det.get_view(),cell_range,Kokkos::ALL());
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-      HDIVtransformDIV(div_basis.get_view(),
-                       jac_det.get_view(),
+      HDIVtransformDIV(s_div_basis,
+                       s_jac_det,
                        div_basis_ref.get_view());
-    
+
     if(build_weighted) {
+      auto s_weighted_div_basis = Kokkos::subview(weighted_div_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+      auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
       Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-        multiplyMeasure(weighted_div_basis.get_view(), 
-                        weighted_measure.get_view(), 
-                        div_basis.get_view());
+        multiplyMeasure(s_weighted_div_basis,
+                        s_weighted_measure,
+                        s_div_basis);
     }
   }
 
@@ -212,13 +250,15 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim,void,void,void,void,void,void> &
       // fill in basis coordinates
       for (size_type i = 0; i < basis_coordinates_ref.extent(0); ++i)
         for (size_type j = 0; j < basis_coordinates_ref.extent(1); ++j)
-           basis_coordinates_ref(i,j) = dyn_basis_coordinates_ref(i,j); 
+           basis_coordinates_ref(i,j) = dyn_basis_coordinates_ref(i,j);
 */
 
+    auto s_basis_coordinates = Kokkos::subview(basis_coordinates.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_vertex_coordinates = Kokkos::subview(vertex_coordinates.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
     Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
-    cell_tools.mapToPhysicalFrame(basis_coordinates.get_view(), 
+    cell_tools.mapToPhysicalFrame(s_basis_coordinates,
                                   basis_coordinates_ref.get_view(),
-                                  vertex_coordinates.get_view(),
+                                  s_vertex_coordinates,
                                   intrepid_basis->getBaseCellTopology());
   }
 }
@@ -231,7 +271,8 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim,void,void,void,void,void,void> &
 
 template <typename Scalar>
 void panzer::BasisValues2<Scalar>::
-evaluateBasisCoordinates(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates)
+evaluateBasisCoordinates(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
+                         const int in_num_cells)
 {
   MDFieldArrayFactory af("",ddims_,true);
 
@@ -248,10 +289,15 @@ evaluateBasisCoordinates(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coord
     for (int j = 0; j < basis_coordinates_ref.extent_int(1); ++j)
       basis_coordinates_ref(i,j) = dyn_basis_coordinates_ref(i,j);
 
+  const int num_cells = in_num_cells < 0 ? vertex_coordinates.extent(0) : in_num_cells;
+  const std::pair<int,int> cell_range(0,num_cells);
+  const auto s_basis_coordinates = Kokkos::subview(basis_coordinates.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+  const auto s_vertex_coordinates = Kokkos::subview(vertex_coordinates.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
-  cell_tools.mapToPhysicalFrame(basis_coordinates.get_view(),
+  cell_tools.mapToPhysicalFrame(s_basis_coordinates,
                                 basis_coordinates_ref.get_view(),
-                                vertex_coordinates.get_view(),
+                                s_vertex_coordinates,
                                 intrepid_basis->getBaseCellTopology());
 }
 
@@ -267,21 +313,22 @@ evaluateValues(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> &
                const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
                const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
                const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
-               bool use_vertex_coordinates)
+               bool use_vertex_coordinates,
+               const int in_num_cells)
 {
 
   PureBasis::EElementSpace elmtspace = getElementSpace();
 
   if(elmtspace == PureBasis::CONST){
-    evaluateValues_Const(cub_points,jac_inv,weighted_measure);
+    evaluateValues_Const(cub_points,jac_inv,weighted_measure,in_num_cells);
   } else if(elmtspace == PureBasis::HVOL){
-    evaluateValues_HVol(cub_points,jac_det,jac_inv,weighted_measure);
+    evaluateValues_HVol(cub_points,jac_det,jac_inv,weighted_measure,in_num_cells);
   } else if(elmtspace == PureBasis::HGRAD){
-    evaluateValues_HGrad(cub_points,jac_inv,weighted_measure);
+    evaluateValues_HGrad(cub_points,jac_inv,weighted_measure,in_num_cells);
   } else if(elmtspace == PureBasis::HCURL){
-    evaluateValues_HCurl(cub_points,jac,jac_det,jac_inv,weighted_measure);
+    evaluateValues_HCurl(cub_points,jac,jac_det,jac_inv,weighted_measure,in_num_cells);
   } else if(elmtspace == PureBasis::HDIV){
-    evaluateValues_HDiv(cub_points,jac,jac_det,weighted_measure);
+    evaluateValues_HDiv(cub_points,jac,jac_det,weighted_measure,in_num_cells);
   } else {
     TEUCHOS_TEST_FOR_EXCEPT_MSG(true,"panzer::BasisValues2::evaluateValues : Element space not recognized.");
   }
@@ -297,7 +344,8 @@ template <typename Scalar>
 void panzer::BasisValues2<Scalar>::
 evaluateValues_Const(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                      const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                     const PHX::MDField<Scalar,Cell,IP> & weighted_measure)
+                     const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                     const int in_num_cells)
 {
 
   TEUCHOS_ASSERT(getElementSpace() == PureBasis::CONST);
@@ -310,7 +358,7 @@ evaluateValues_Const(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
   const int num_points = basis_layout->numPoints();
   const int num_basis  = basis.cardinality();
   const int num_dim    = basis_layout->dimension();
-  const int num_cells  = basis_layout->numCells();
+  const int num_cells = in_num_cells < 0 ? basis_layout->numCells() : in_num_cells;
 
   auto cell_basis_scalar = af.buildStaticArray<Scalar,Cell,BASIS,IP>("cell_basis_scalar",1,num_basis,num_points);
   auto cell_cub_points = af.buildStaticArray<Scalar,IP,Dim>("cell_cub_points",num_points,num_dim);
@@ -362,9 +410,15 @@ evaluateValues_Const(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
 
 
   if(build_weighted){
-    fst::multiplyMeasure(weighted_basis_scalar.get_view(),weighted_measure.get_view(),basis_scalar.get_view());
+    const std::pair<int,int> cell_range(0,num_cells);
+    auto s_weighted_basis_scalar = Kokkos::subview(weighted_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
+    auto s_basis_scalar = Kokkos::subview(basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    fst::multiplyMeasure(s_weighted_basis_scalar,s_weighted_measure,s_basis_scalar);
     if(compute_derivatives){
-      fst::multiplyMeasure(weighted_grad_basis.get_view(),weighted_measure.get_view(),grad_basis.get_view());
+      auto s_weighted_grad_basis = Kokkos::subview(weighted_grad_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      auto s_grad_basis = Kokkos::subview(grad_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      fst::multiplyMeasure(s_weighted_grad_basis,s_weighted_measure,s_grad_basis);
     }
   }
 
@@ -376,7 +430,8 @@ void panzer::BasisValues2<Scalar>::
 evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                     const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
                     const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                    const PHX::MDField<Scalar,Cell,IP> & weighted_measure)
+                    const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                    const int in_num_cells)
 {
 
   TEUCHOS_ASSERT(getElementSpace() == PureBasis::HVOL);
@@ -389,7 +444,7 @@ evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,vo
   const int num_points = basis_layout->numPoints();
   const int num_basis  = basis.cardinality();
   const int num_dim    = basis_layout->dimension();
-  const int num_cells  = basis_layout->numCells();
+  const int num_cells = in_num_cells < 0 ? basis_layout->numCells() : in_num_cells;
 
   auto cell_basis_scalar = af.buildStaticArray<Scalar,Cell,BASIS,IP>("cell_basis_scalar",1,num_basis,num_points);
   auto cell_cub_points = af.buildStaticArray<Scalar,IP,Dim>("cell_cub_points",num_points,num_dim);
@@ -425,9 +480,13 @@ evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,vo
   }
 
 
-  if(build_weighted)
-    fst::multiplyMeasure(weighted_basis_scalar.get_view(),weighted_measure.get_view(),basis_scalar.get_view());
-
+  if(build_weighted) {
+    const std::pair<int,int> cell_range(0,num_cells);
+    auto s_weighted_basis_scalar = Kokkos::subview(weighted_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
+    auto s_basis_scalar = Kokkos::subview(basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    fst::multiplyMeasure(s_weighted_basis_scalar,s_weighted_measure,s_basis_scalar);
+  }
 
 }
 
@@ -435,7 +494,8 @@ template <typename Scalar>
 void panzer::BasisValues2<Scalar>::
 evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
                      const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-                     const PHX::MDField<Scalar,Cell,IP> & weighted_measure)
+                     const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                     const int in_num_cells)
 {
 
   TEUCHOS_ASSERT(getElementSpace() == PureBasis::HGRAD);
@@ -448,7 +508,7 @@ evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
   const int num_points = basis_layout->numPoints();
   const int num_basis  = basis.cardinality();
   const int num_dim    = basis_layout->dimension();
-  const int num_cells  = cub_points.extent(0);
+  const int num_cells = in_num_cells < 0 ? cub_points.extent(0) : in_num_cells;
 
   auto cell_basis_scalar = af.buildStaticArray<Scalar,Cell,BASIS,IP>("cell_basis_scalar",1,num_basis,num_points);
   auto cell_cub_points = af.buildStaticArray<Scalar,IP,Dim>("cell_cub_points",num_points,num_dim);
@@ -499,9 +559,15 @@ evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
   }
 
   if(build_weighted){
-    fst::multiplyMeasure(weighted_basis_scalar.get_view(),weighted_measure.get_view(),basis_scalar.get_view());
+    const std::pair<int,int> cell_range(0,num_cells);
+    auto s_weighted_basis_scalar = Kokkos::subview(weighted_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
+    auto s_basis_scalar = Kokkos::subview(basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    fst::multiplyMeasure(s_weighted_basis_scalar,s_weighted_measure,s_basis_scalar);
     if(compute_derivatives){
-      fst::multiplyMeasure(weighted_grad_basis.get_view(),weighted_measure.get_view(),grad_basis.get_view());
+      auto s_weighted_grad_basis = Kokkos::subview(weighted_grad_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      auto s_grad_basis = Kokkos::subview(grad_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+      fst::multiplyMeasure(s_weighted_grad_basis,s_weighted_measure,s_grad_basis);
     }
   }
 
@@ -514,7 +580,8 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
                const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
                const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
                const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv,
-               const PHX::MDField<Scalar,Cell,IP> & weighted_measure)
+                     const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                     const int in_num_cells)
 {
 
   TEUCHOS_ASSERT(getElementSpace() == PureBasis::HCURL);
@@ -528,7 +595,7 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
   const int num_points = basis_layout->numPoints();
   const int num_basis  = basis.cardinality();
   const int num_dim    = basis_layout->dimension();
-  const int num_cells  = basis_layout->numCells();
+  const int num_cells = in_num_cells < 0 ? basis_layout->numCells() : in_num_cells;
 
   auto cell_cub_points = af.buildStaticArray<Scalar,IP,Dim>("cell_cub_points",num_points,num_dim);
   auto cell_jac = af.buildStaticArray<Scalar,Cell,IP,Dim,Dim>("cell_jac",1,num_points,num_dim,num_dim);
@@ -606,12 +673,20 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
   }
 
   if(build_weighted){
-    fst::multiplyMeasure(weighted_basis_vector.get_view(),weighted_measure.get_view(),basis_vector.get_view());
+    const std::pair<int,int> cell_range(0,num_cells);
+    auto s_weighted_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
+    auto s_basis_vector = Kokkos::subview(basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    fst::multiplyMeasure(s_weighted_basis_vector,s_weighted_measure,s_basis_vector);
     if(compute_derivatives){
       if(num_dim==2){
-        fst::multiplyMeasure(weighted_curl_basis_scalar.get_view(),weighted_measure.get_view(),curl_basis_scalar.get_view());
+        auto s_weighted_curl_basis_scalar = Kokkos::subview(weighted_curl_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+        auto s_curl_basis_scalar = Kokkos::subview(curl_basis_scalar.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+        fst::multiplyMeasure(s_weighted_curl_basis_scalar,s_weighted_measure,s_curl_basis_scalar);
       } else if(num_dim==3){
-        fst::multiplyMeasure(weighted_curl_basis_vector.get_view(),weighted_measure.get_view(),curl_basis_vector.get_view());
+        auto s_weighted_curl_basis_vector = Kokkos::subview(weighted_curl_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+        auto s_curl_basis_vector = Kokkos::subview(curl_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+        fst::multiplyMeasure(s_weighted_curl_basis_vector,s_weighted_measure,s_curl_basis_vector);
       }
     }
   }
@@ -621,9 +696,10 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,v
 template <typename Scalar>
 void panzer::BasisValues2<Scalar>::
 evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void> & cub_points,
-               const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
-               const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
-               const PHX::MDField<Scalar,Cell,IP> & weighted_measure)
+                    const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac,
+                    const PHX::MDField<Scalar,Cell,IP,void,void,void,void,void,void> & jac_det,
+                    const PHX::MDField<Scalar,Cell,IP> & weighted_measure,
+                    const int in_num_cells)
 {
 
   TEUCHOS_ASSERT(getElementSpace() == PureBasis::HDIV);
@@ -636,7 +712,7 @@ evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,vo
   const int num_points = basis_layout->numPoints();
   const int num_basis  = basis.cardinality();
   const int num_dim    = basis_layout->dimension();
-  const int num_cells  = basis_layout->numCells();
+  const int num_cells = in_num_cells < 0 ? basis_layout->numCells() : in_num_cells;
 
   auto cell_cub_points = af.buildStaticArray<Scalar,IP,Dim>("cell_cub_points",num_points,num_dim);
   auto cell_jac = af.buildStaticArray<Scalar,Cell,IP,Dim,Dim>("cell_jac",1,num_points,num_dim,num_dim);
@@ -689,9 +765,15 @@ evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,vo
   }
 
   if(build_weighted){
-    fst::multiplyMeasure(weighted_basis_vector.get_view(),weighted_measure.get_view(),basis_vector.get_view());
+    const std::pair<int,int> cell_range(0,num_cells);
+    auto s_weighted_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),cell_range,Kokkos::ALL());
+    auto s_basis_vector = Kokkos::subview(basis_vector.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    fst::multiplyMeasure(s_weighted_basis_vector,s_weighted_measure,s_basis_vector);
     if(compute_derivatives){
-      fst::multiplyMeasure(weighted_div_basis.get_view(),weighted_measure.get_view(),div_basis.get_view());
+      auto s_weighted_div_basis = Kokkos::subview(weighted_div_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+      auto s_div_basis = Kokkos::subview(div_basis.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+      fst::multiplyMeasure(s_weighted_div_basis,s_weighted_measure,s_div_basis);
     }
   }
 
@@ -747,7 +829,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                  const PHX::MDField<Scalar,Cell,IP,Dim,Dim,void,void,void,void> & jac_inv)
 {
   MDFieldArrayFactory af("",ddims_,true);
- 
+
   int num_ip    = basis_layout->numPoints();
   int num_card  = basis_layout->cardinality();
   int num_dim   = basis_layout->dimension();
@@ -769,12 +851,12 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
        ArrayDynamic dyn_basis_ref_scalar = af.buildArray<Scalar,BASIS,IP>("dyn_basis_ref_scalar",num_card,num_ip);
 
        intrepid_basis->getValues(dyn_basis_ref_scalar.get_view(),
-                                 dyn_cub_points.get_view(), 
+                                 dyn_cub_points.get_view(),
                                  Intrepid2::OPERATOR_VALUE);
 
        // transform values method just transfers values to array with cell index - no need to call
        for (int b = 0; b < num_card; ++b)
-         for (int ip = 0; ip < num_ip; ++ip) 
+         for (int ip = 0; ip < num_ip; ++ip)
            basis_scalar(icell,b,ip) = dyn_basis_ref_scalar(b,ip);
 
     }
@@ -782,7 +864,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
       ArrayDynamic dyn_basis_ref_scalar = af.buildArray<Scalar,BASIS,IP>("dyn_basis_ref_scalar",num_card,num_ip);
 
       intrepid_basis->getValues(dyn_basis_ref_scalar.get_view(),
-                                dyn_cub_points.get_view(), 
+                                dyn_cub_points.get_view(),
                                 Intrepid2::OPERATOR_VALUE);
 
       int one_cell= 1;
@@ -799,7 +881,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                                                                                       dyn_basis_ref_scalar.get_view());
 
        for (int b = 0; b < num_card; ++b)
-         for (int ip = 0; ip < num_ip; ++ip) 
+         for (int ip = 0; ip < num_ip; ++ip)
            basis_scalar(icell,b,ip) = dyn_basis_scalar(0,b,ip);
 
     }
@@ -807,23 +889,23 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
        ArrayDynamic dyn_basis_ref_scalar = af.buildArray<Scalar,BASIS,IP>("dyn_basis_ref_scalar",num_card,num_ip);
 
        intrepid_basis->getValues(dyn_basis_ref_scalar.get_view(),
-                                 dyn_cub_points.get_view(), 
+                                 dyn_cub_points.get_view(),
                                  Intrepid2::OPERATOR_VALUE);
-       
+
        // transform values method just transfers values to array with cell index - no need to call
        for (int b = 0; b < num_card; ++b)
-         for (int ip = 0; ip < num_ip; ++ip) 
+         for (int ip = 0; ip < num_ip; ++ip)
            basis_scalar(icell,b,ip) = dyn_basis_ref_scalar(b,ip);
-       
+
        if(compute_derivatives) {
- 
+
           int one_cell = 1;
           ArrayDynamic dyn_grad_basis_ref = af.buildArray<Scalar,BASIS,IP,Dim>("dyn_grad_basis_ref",num_card,num_ip,num_dim);
           ArrayDynamic dyn_grad_basis = af.buildArray<Scalar,Cell,BASIS,IP,Dim>("dyn_grad_basis",one_cell,num_card,num_ip,num_dim);
           ArrayDynamic dyn_jac_inv = af.buildArray<Scalar,Cell,IP,Dim,Dim>("dyn_jac_inv",one_cell,num_ip,num_dim,num_dim);
 
           intrepid_basis->getValues(dyn_grad_basis_ref.get_view(),
-                                    dyn_cub_points.get_view(), 
+                                    dyn_cub_points.get_view(),
                                     Intrepid2::OPERATOR_GRAD);
 
           int cellInd = 0;
@@ -837,7 +919,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                                                                                                   dyn_grad_basis_ref.get_view());
 
           for (int b = 0; b < num_card; ++b)
-            for (int ip = 0; ip < num_ip; ++ip) 
+            for (int ip = 0; ip < num_ip; ++ip)
               for (int d = 0; d < num_dim; ++d)
                  grad_basis(icell,b,ip,d) = dyn_grad_basis(0,b,ip,d);
 
@@ -845,11 +927,11 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
     }
     else if(elmtspace==PureBasis::HCURL) {
       ArrayDynamic dyn_basis_ref_vector = af.buildArray<Scalar,BASIS,IP,Dim>("dyn_basis_ref_vector",num_card,num_ip,num_dim);
-  
+
       intrepid_basis->getValues(dyn_basis_ref_vector.get_view(),
-                                dyn_cub_points.get_view(), 
+                                dyn_cub_points.get_view(),
                                 Intrepid2::OPERATOR_VALUE);
-  
+
       int one_cell = 1;
       ArrayDynamic dyn_basis_vector = af.buildArray<Scalar,Cell,BASIS,IP,Dim>("dyn_basis_vector",one_cell,num_card,num_ip,num_dim);
       ArrayDynamic dyn_jac_inv = af.buildArray<Scalar,Cell,IP,Dim,Dim>("dyn_jac_inv",one_cell,num_ip,num_dim,num_dim);
@@ -865,19 +947,19 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                                                                                        dyn_basis_ref_vector.get_view());
 
       for (int b = 0; b < num_card; ++b)
-        for (int ip = 0; ip < num_ip; ++ip) 
-          for (int d = 0; d < num_dim; ++d) 
+        for (int ip = 0; ip < num_ip; ++ip)
+          for (int d = 0; d < num_dim; ++d)
              basis_vector(icell,b,ip,d) = dyn_basis_vector(0,b,ip,d);
 
       if(compute_derivatives && num_dim ==2) {
- 
+
           int one_cell = 1;
           ArrayDynamic dyn_curl_basis_ref_scalar = af.buildArray<Scalar,BASIS,IP>("dyn_curl_basis_ref_scalar",num_card,num_ip);
           ArrayDynamic dyn_curl_basis_scalar = af.buildArray<Scalar,Cell,BASIS,IP>("dyn_curl_basis_scalar",one_cell,num_card,num_ip);
           ArrayDynamic dyn_jac_det = af.buildArray<Scalar,Cell,IP>("dyn_jac_det",one_cell,num_ip);
 
           intrepid_basis->getValues(dyn_curl_basis_ref_scalar.get_view(),
-                                    dyn_cub_points.get_view(), 
+                                    dyn_cub_points.get_view(),
                                     Intrepid2::OPERATOR_CURL);
 
           int cellInd = 0;
@@ -889,7 +971,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                                                                                         dyn_curl_basis_ref_scalar.get_view());
 
           for (int b = 0; b < num_card; ++b)
-            for (int ip = 0; ip < num_ip; ++ip) 
+            for (int ip = 0; ip < num_ip; ++ip)
                 curl_basis_scalar(icell,b,ip) = dyn_curl_basis_scalar(0,b,ip);
 
       }
@@ -902,7 +984,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
           ArrayDynamic dyn_jac = af.buildArray<Scalar,Cell,IP,Dim,Dim>("dyn_jac",one_cell,num_ip,num_dim,num_dim);
 
           intrepid_basis->getValues(dyn_curl_basis_ref.get_view(),
-                                    dyn_cub_points.get_view(), 
+                                    dyn_cub_points.get_view(),
                                     Intrepid2::OPERATOR_CURL);
 
           int cellInd = 0;
@@ -920,8 +1002,8 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                                                                                           dyn_curl_basis_ref.get_view());
 
           for (int b = 0; b < num_card; ++b)
-            for (int ip = 0; ip < num_ip; ++ip) 
-               for (int d = 0; d < num_dim; ++d) 
+            for (int ip = 0; ip < num_ip; ++ip)
+               for (int d = 0; d < num_dim; ++d)
                   curl_basis_vector(icell,b,ip,d) = dyn_curl_basis(0,b,ip,d);
 
       }
@@ -932,7 +1014,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
       ArrayDynamic dyn_basis_ref_vector = af.buildArray<Scalar,BASIS,IP,Dim>("dyn_basis_ref_vector",num_card,num_ip,num_dim);
 
       intrepid_basis->getValues(dyn_basis_ref_vector.get_view(),
-                                dyn_cub_points.get_view(), 
+                                dyn_cub_points.get_view(),
                                 Intrepid2::OPERATOR_VALUE);
 
       int one_cell= 1;
@@ -955,8 +1037,8 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
                                                                                       dyn_basis_ref_vector.get_view());
 
        for (int b = 0; b < num_card; ++b)
-         for (int ip = 0; ip < num_ip; ++ip) 
-           for (int d = 0; d < num_dim; ++d) 
+         for (int ip = 0; ip < num_ip; ++ip)
+           for (int d = 0; d < num_dim; ++d)
               basis_vector(icell,b,ip,d) = dyn_basis_vector(0,b,ip,d);
 
        if(compute_derivatives) {
@@ -965,17 +1047,17 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim,void,void,void,void,void>
            ArrayDynamic dyn_div_basis = af.buildArray<Scalar,Cell,BASIS,IP>("dyn_div_basis_scalar",one_cell,num_card,num_ip);
 
            intrepid_basis->getValues(dyn_div_basis_ref.get_view(),
-                                     dyn_cub_points.get_view(), 
+                                     dyn_cub_points.get_view(),
                                      Intrepid2::OPERATOR_DIV);
 
            Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::HDIVtransformDIV<Scalar>(dyn_div_basis.get_view(),
                                                                                                  dyn_jac_det.get_view(),
                                                                                                  dyn_div_basis_ref.get_view());
-           
+
            for (int b = 0; b < num_card; ++b)
-             for (int ip = 0; ip < num_ip; ++ip) 
+             for (int ip = 0; ip < num_ip; ++ip)
                  div_basis(icell,b,ip) = dyn_div_basis(0,b,ip);
-  
+
         }
 
     }
@@ -1006,23 +1088,23 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool comp
     ArrayDynamic dyn_basis_ref_scalar = af.buildArray<Scalar,BASIS,IP>("dyn_basis_ref_scalar",num_card,num_quad);
 
     intrepid_basis->getValues(dyn_basis_ref_scalar.get_view(),
-                              dyn_cub_points.get_view(), 
+                              dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_VALUE);
 
     for (int b = 0; b < num_card; ++b)
-      for (int ip = 0; ip < num_quad; ++ip) 
+      for (int ip = 0; ip < num_quad; ++ip)
         basis_ref_scalar(b,ip) = dyn_basis_ref_scalar(b,ip);
   }
   else if(elmtspace==PureBasis::HDIV || elmtspace==PureBasis::HCURL) {
     ArrayDynamic dyn_basis_ref_vector = af.buildArray<Scalar,BASIS,IP,Dim>("dyn_basis_ref_vector",num_card,num_quad,num_dim);
 
     intrepid_basis->getValues(dyn_basis_ref_vector.get_view(),
-                              dyn_cub_points.get_view(), 
+                              dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_VALUE);
 
     for (int b = 0; b < num_card; ++b)
-      for (int ip = 0; ip < num_quad; ++ip) 
-        for (int d = 0; d < num_dim; ++d) 
+      for (int ip = 0; ip < num_quad; ++ip)
+        for (int d = 0; d < num_dim; ++d)
            basis_ref_vector(b,ip,d) = dyn_basis_ref_vector(b,ip,d);
   }
   else { TEUCHOS_ASSERT(false); }
@@ -1031,12 +1113,12 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool comp
     ArrayDynamic dyn_grad_basis_ref = af.buildArray<Scalar,BASIS,IP,Dim>("dyn_basis_ref_vector",num_card,num_quad,num_dim);
 
     intrepid_basis->getValues(dyn_grad_basis_ref.get_view(),
-                              dyn_cub_points.get_view(), 
+                              dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_GRAD);
 
     for (int b = 0; b < num_card; ++b)
-      for (int ip = 0; ip < num_quad; ++ip) 
-        for (int d = 0; d < num_dim; ++d) 
+      for (int ip = 0; ip < num_quad; ++ip)
+        for (int d = 0; d < num_dim; ++d)
            grad_basis_ref(b,ip,d) = dyn_grad_basis_ref(b,ip,d);
   }
   else if(elmtspace==PureBasis::HCURL && compute_derivatives && num_dim==2) {
@@ -1047,7 +1129,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool comp
                               Intrepid2::OPERATOR_CURL);
 
     for (int b = 0; b < num_card; ++b)
-      for (int ip = 0; ip < num_quad; ++ip) 
+      for (int ip = 0; ip < num_quad; ++ip)
         curl_basis_ref_scalar(b,ip) = dyn_curl_basis_ref(b,ip);
   }
   else if(elmtspace==PureBasis::HCURL && compute_derivatives && num_dim==3) {
@@ -1058,8 +1140,8 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool comp
                               Intrepid2::OPERATOR_CURL);
 
     for (int b = 0; b < num_card; ++b)
-      for (int ip = 0; ip < num_quad; ++ip) 
-        for (int d = 0; d < num_dim; ++d) 
+      for (int ip = 0; ip < num_quad; ++ip)
+        for (int d = 0; d < num_dim; ++d)
            curl_basis_ref_vector(b,ip,d) = dyn_curl_basis_ref(b,ip,d);
   }
   else if(elmtspace==PureBasis::HDIV && compute_derivatives) {
@@ -1070,11 +1152,11 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool comp
                               Intrepid2::OPERATOR_DIV);
 
     for (int b = 0; b < num_card; ++b)
-      for (int ip = 0; ip < num_quad; ++ip) 
+      for (int ip = 0; ip < num_quad; ++ip)
         div_basis_ref(b,ip) = dyn_div_basis_ref(b,ip);
   }
-  
-  
+
+
   if(use_vertex_coordinates) {
     // Intrepid removes fad types from the coordinate scalar type. We
     // pull the actual field scalar type from the basis object to be
@@ -1085,23 +1167,24 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool comp
                                                                                  basis_coordinates_ref.extent(0),
                                                                                  basis_coordinates_ref.extent(1));
       intrepid_basis->getDofCoords(dyn_basis_coordinates_ref.get_view());
-      
+
       // fill in basis coordinates
       for (int i = 0; i < basis_coordinates_ref.extent_int(0); ++i)
         for (int j = 0; j < basis_coordinates_ref.extent_int(1); ++j)
-          basis_coordinates_ref(i,j) = dyn_basis_coordinates_ref(i,j); 
+          basis_coordinates_ref(i,j) = dyn_basis_coordinates_ref(i,j);
     }
   }
-  
+
   references_evaluated = true;
 }
 
 // method for applying orientations
 template <typename Scalar>
 void BasisValues2<Scalar>::
-applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
+applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
+                  const int in_num_cells)
 {
-  if (!intrepid_basis->requireOrientation()) 
+  if (!intrepid_basis->requireOrientation())
     return;
 
   typedef Intrepid2::OrientationTools<PHX::Device> ots;
@@ -1111,12 +1194,13 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
   // thus, its size is the actual number of elements to be applied.
   // on the other hand, basis_layout num cell indicates workset size.
   // to get right size of cells, use minimum of them.
-  const int num_cell_basis_layout = basis_layout->numCells(), num_cell_orientation = orientations.size();
+  const int num_cell_basis_layout = in_num_cells < 0 ? basis_layout->numCells() : in_num_cells;
+  const int num_cell_orientation = orientations.size();
   const int num_cell  = num_cell_basis_layout < num_cell_orientation ? num_cell_basis_layout : num_cell_orientation;
   const int num_dim   = basis_layout->dimension();
   const Kokkos::pair<int,int> range_cell(0, num_cell);
 
-  // Kokkos::DynRankView<Intrepid2::Orientation,PHX::Device> 
+  // Kokkos::DynRankView<Intrepid2::Orientation,PHX::Device>
   //   drv_orts((Intrepid2::Orientation*)orientations.data(), num_cell);
   Kokkos::DynRankView<Intrepid2::Orientation,PHX::Device> drv_orts("drv_orts", num_cell);
   auto host_drv_orts = Kokkos::create_mirror_view(drv_orts);
@@ -1133,58 +1217,58 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       {
         auto drv_basis_scalar = Kokkos::subview(basis_scalar.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_scalar_tmp = Kokkos::createDynRankView(basis_scalar.get_view(),
-                                                              "drv_basis_scalar_tmp", 
+                                                              "drv_basis_scalar_tmp",
                                                               drv_basis_scalar.extent(0),  // C
                                                               drv_basis_scalar.extent(1),  // F
                                                               drv_basis_scalar.extent(2)); // P
         Kokkos::deep_copy(drv_basis_scalar_tmp, drv_basis_scalar);
-        ots::modifyBasisByOrientation(drv_basis_scalar, 
-                                      drv_basis_scalar_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_scalar,
+                                      drv_basis_scalar_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
       if(build_weighted) {
         auto drv_basis_scalar = Kokkos::subview(weighted_basis_scalar.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_scalar_tmp = Kokkos::createDynRankView(weighted_basis_scalar.get_view(),
-                                                              "drv_basis_scalar_tmp", 
+                                                              "drv_basis_scalar_tmp",
                                                               drv_basis_scalar.extent(0),  // C
                                                               drv_basis_scalar.extent(1),  // F
                                                               drv_basis_scalar.extent(2)); // P
         Kokkos::deep_copy(drv_basis_scalar_tmp, drv_basis_scalar);
-        ots::modifyBasisByOrientation(drv_basis_scalar, 
-                                      drv_basis_scalar_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_scalar,
+                                      drv_basis_scalar_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
 
-    } 
+    }
 
     if (compute_derivatives) {
       {
         auto drv_grad_basis = Kokkos::subview(grad_basis.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_grad_basis_tmp = Kokkos::createDynRankView(grad_basis.get_view(),
-                                                            "drv_grad_basis_tmp", 
+                                                            "drv_grad_basis_tmp",
                                                             drv_grad_basis.extent(0),  // C
                                                             drv_grad_basis.extent(1),  // F
                                                             drv_grad_basis.extent(2),  // P
                                                             drv_grad_basis.extent(3)); // D
         Kokkos::deep_copy(drv_grad_basis_tmp, drv_grad_basis);
-        ots::modifyBasisByOrientation(drv_grad_basis, 
-                                      drv_grad_basis_tmp, 
+        ots::modifyBasisByOrientation(drv_grad_basis,
+                                      drv_grad_basis_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
       if(build_weighted) {
         auto drv_grad_basis = Kokkos::subview(weighted_grad_basis.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_grad_basis_tmp = Kokkos::createDynRankView(weighted_grad_basis.get_view(),
-                                                            "drv_grad_basis_tmp", 
+                                                            "drv_grad_basis_tmp",
                                                             drv_grad_basis.extent(0),  // C
                                                             drv_grad_basis.extent(1),  // F
                                                             drv_grad_basis.extent(2),  // P
                                                             drv_grad_basis.extent(3)); // D
         Kokkos::deep_copy(drv_grad_basis_tmp, drv_grad_basis);
-        ots::modifyBasisByOrientation(drv_grad_basis, 
-                                      drv_grad_basis_tmp, 
+        ots::modifyBasisByOrientation(drv_grad_basis,
+                                      drv_grad_basis_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
@@ -1199,28 +1283,28 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       {
         auto drv_basis_vector = Kokkos::subview(basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_vector_tmp = Kokkos::createDynRankView(basis_vector.get_view(),
-                                                              "drv_basis_vector_tmp", 
+                                                              "drv_basis_vector_tmp",
                                                               drv_basis_vector.extent(0),  // C
                                                               drv_basis_vector.extent(1),  // F
                                                               drv_basis_vector.extent(2),  // P
                                                               drv_basis_vector.extent(3)); // D
         Kokkos::deep_copy(drv_basis_vector_tmp, drv_basis_vector);
-        ots::modifyBasisByOrientation(drv_basis_vector, 
-                                      drv_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_vector,
+                                      drv_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
       if(build_weighted) {
         auto drv_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_vector_tmp = Kokkos::createDynRankView(weighted_basis_vector.get_view(),
-                                                              "drv_basis_vector_tmp", 
+                                                              "drv_basis_vector_tmp",
                                                               drv_basis_vector.extent(0),  // C
                                                               drv_basis_vector.extent(1),  // F
                                                               drv_basis_vector.extent(2),  // P
                                                               drv_basis_vector.extent(3)); // D
         Kokkos::deep_copy(drv_basis_vector_tmp, drv_basis_vector);
-        ots::modifyBasisByOrientation(drv_basis_vector, 
-                                      drv_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_vector,
+                                      drv_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
@@ -1230,13 +1314,13 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       {
         auto drv_curl_basis_scalar = Kokkos::subview(curl_basis_scalar.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
         auto drv_curl_basis_scalar_tmp = Kokkos::createDynRankView(curl_basis_scalar.get_view(),
-                                                                   "drv_curl_basis_scalar_tmp", 
+                                                                   "drv_curl_basis_scalar_tmp",
                                                                    drv_curl_basis_scalar.extent(0),  // C
                                                                    drv_curl_basis_scalar.extent(1),  // F
-                                                                   drv_curl_basis_scalar.extent(2));  // P        
+                                                                   drv_curl_basis_scalar.extent(2));  // P
         Kokkos::deep_copy(drv_curl_basis_scalar_tmp, drv_curl_basis_scalar);
-        ots::modifyBasisByOrientation(drv_curl_basis_scalar, 
-                                      drv_curl_basis_scalar_tmp, 
+        ots::modifyBasisByOrientation(drv_curl_basis_scalar,
+                                      drv_curl_basis_scalar_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
@@ -1244,19 +1328,19 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       if(build_weighted) {
         auto drv_curl_basis_scalar = Kokkos::subview(weighted_curl_basis_scalar.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
         auto drv_curl_basis_scalar_tmp = Kokkos::createDynRankView(weighted_curl_basis_scalar.get_view(),
-                                                                   "drv_curl_basis_scalar_tmp", 
+                                                                   "drv_curl_basis_scalar_tmp",
                                                                    drv_curl_basis_scalar.extent(0),  // C
                                                                    drv_curl_basis_scalar.extent(1),  // F
-                                                                   drv_curl_basis_scalar.extent(2));  // P        
+                                                                   drv_curl_basis_scalar.extent(2));  // P
         Kokkos::deep_copy(drv_curl_basis_scalar_tmp, drv_curl_basis_scalar);
-        ots::modifyBasisByOrientation(drv_curl_basis_scalar, 
-                                      drv_curl_basis_scalar_tmp, 
+        ots::modifyBasisByOrientation(drv_curl_basis_scalar,
+                                      drv_curl_basis_scalar_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
     }
   }
-  
+
   ///
   /// hcurl 3d elements
   ///
@@ -1265,62 +1349,62 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       {
         auto drv_basis_vector = Kokkos::subview(basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_vector_tmp = Kokkos::createDynRankView(basis_vector.get_view(),
-                                                              "drv_basis_vector_tmp", 
+                                                              "drv_basis_vector_tmp",
                                                               drv_basis_vector.extent(0),  // C
                                                               drv_basis_vector.extent(1),  // F
                                                               drv_basis_vector.extent(2),  // P
                                                               drv_basis_vector.extent(3)); // D
         Kokkos::deep_copy(drv_basis_vector_tmp, drv_basis_vector);
-        ots::modifyBasisByOrientation(drv_basis_vector, 
-                                      drv_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_vector,
+                                      drv_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
       if(build_weighted) {
         auto drv_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_vector_tmp = Kokkos::createDynRankView(weighted_basis_vector.get_view(),
-                                                              "drv_basis_vector_tmp", 
+                                                              "drv_basis_vector_tmp",
                                                               drv_basis_vector.extent(0),  // C
                                                               drv_basis_vector.extent(1),  // F
                                                               drv_basis_vector.extent(2),  // P
                                                               drv_basis_vector.extent(3)); // D
         Kokkos::deep_copy(drv_basis_vector_tmp, drv_basis_vector);
-        ots::modifyBasisByOrientation(drv_basis_vector, 
-                                      drv_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_vector,
+                                      drv_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
-    } 
-    
+    }
+
     if (compute_derivatives) {
       {
         auto drv_curl_basis_vector = Kokkos::subview(curl_basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_curl_basis_vector_tmp = Kokkos::createDynRankView(curl_basis_vector.get_view(),
-                                                                   "drv_curl_basis_vector_tmp", 
+                                                                   "drv_curl_basis_vector_tmp",
                                                                    drv_curl_basis_vector.extent(0),  // C
                                                                    drv_curl_basis_vector.extent(1),  // F
                                                                    drv_curl_basis_vector.extent(2),  // P
-                                                                   drv_curl_basis_vector.extent(3));  // D        
+                                                                   drv_curl_basis_vector.extent(3));  // D
         Kokkos::deep_copy(drv_curl_basis_vector_tmp, drv_curl_basis_vector);
-        ots::modifyBasisByOrientation(drv_curl_basis_vector, 
-                                      drv_curl_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_curl_basis_vector,
+                                      drv_curl_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
       if(build_weighted) {
         auto drv_curl_basis_vector = Kokkos::subview(weighted_curl_basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_curl_basis_vector_tmp = Kokkos::createDynRankView(weighted_curl_basis_vector.get_view(),
-                                                                   "drv_curl_basis_vector_tmp", 
+                                                                   "drv_curl_basis_vector_tmp",
                                                                    drv_curl_basis_vector.extent(0),  // C
                                                                    drv_curl_basis_vector.extent(1),  // F
                                                                    drv_curl_basis_vector.extent(2),  // P
-                                                                   drv_curl_basis_vector.extent(3));  // D        
+                                                                   drv_curl_basis_vector.extent(3));  // D
         Kokkos::deep_copy(drv_curl_basis_vector_tmp, drv_curl_basis_vector);
-        ots::modifyBasisByOrientation(drv_curl_basis_vector, 
-                                      drv_curl_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_curl_basis_vector,
+                                      drv_curl_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
-      }      
+      }
     }
   }
   ///
@@ -1331,28 +1415,28 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       {
         auto drv_basis_vector = Kokkos::subview(basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_vector_tmp = Kokkos::createDynRankView(basis_vector.get_view(),
-                                                              "drv_basis_vector_tmp", 
+                                                              "drv_basis_vector_tmp",
                                                               drv_basis_vector.extent(0),  // C
                                                               drv_basis_vector.extent(1),  // F
                                                               drv_basis_vector.extent(2),  // P
                                                               drv_basis_vector.extent(3)); // D
         Kokkos::deep_copy(drv_basis_vector_tmp, drv_basis_vector);
-        ots::modifyBasisByOrientation(drv_basis_vector, 
-                                      drv_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_vector,
+                                      drv_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
-      } 
-      if(build_weighted) {      
+      }
+      if(build_weighted) {
         auto drv_basis_vector = Kokkos::subview(weighted_basis_vector.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
         auto drv_basis_vector_tmp = Kokkos::createDynRankView(weighted_basis_vector.get_view(),
-                                                              "drv_basis_vector_tmp", 
+                                                              "drv_basis_vector_tmp",
                                                               drv_basis_vector.extent(0),  // C
                                                               drv_basis_vector.extent(1),  // F
                                                               drv_basis_vector.extent(2),  // P
                                                               drv_basis_vector.extent(3)); // D
         Kokkos::deep_copy(drv_basis_vector_tmp, drv_basis_vector);
-        ots::modifyBasisByOrientation(drv_basis_vector, 
-                                      drv_basis_vector_tmp, 
+        ots::modifyBasisByOrientation(drv_basis_vector,
+                                      drv_basis_vector_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
@@ -1361,26 +1445,26 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations)
       {
         auto drv_div_basis = Kokkos::subview(div_basis.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
         auto drv_div_basis_tmp = Kokkos::createDynRankView(div_basis.get_view(),
-                                                           "drv_div_basis_tmp", 
-                                                           drv_div_basis.extent(0),  // C
-                                                           drv_div_basis.extent(1),  // F
-                                                           drv_div_basis.extent(2));  // P        
-        Kokkos::deep_copy(drv_div_basis_tmp, drv_div_basis);
-        ots::modifyBasisByOrientation(drv_div_basis, 
-                                      drv_div_basis_tmp, 
-                                      drv_orts,
-                                      intrepid_basis);
-      }
-      if(build_weighted) {      
-        auto drv_div_basis = Kokkos::subview(weighted_div_basis.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
-        auto drv_div_basis_tmp = Kokkos::createDynRankView(weighted_div_basis.get_view(),
-                                                           "drv_div_basis_tmp", 
+                                                           "drv_div_basis_tmp",
                                                            drv_div_basis.extent(0),  // C
                                                            drv_div_basis.extent(1),  // F
                                                            drv_div_basis.extent(2));  // P
         Kokkos::deep_copy(drv_div_basis_tmp, drv_div_basis);
-        ots::modifyBasisByOrientation(drv_div_basis, 
-                                      drv_div_basis_tmp, 
+        ots::modifyBasisByOrientation(drv_div_basis,
+                                      drv_div_basis_tmp,
+                                      drv_orts,
+                                      intrepid_basis);
+      }
+      if(build_weighted) {
+        auto drv_div_basis = Kokkos::subview(weighted_div_basis.get_view(), range_cell, Kokkos::ALL(), Kokkos::ALL());
+        auto drv_div_basis_tmp = Kokkos::createDynRankView(weighted_div_basis.get_view(),
+                                                           "drv_div_basis_tmp",
+                                                           drv_div_basis.extent(0),  // C
+                                                           drv_div_basis.extent(1),  // F
+                                                           drv_div_basis.extent(2));  // P
+        Kokkos::deep_copy(drv_div_basis_tmp, drv_div_basis);
+        ots::modifyBasisByOrientation(drv_div_basis,
+                                      drv_div_basis_tmp,
                                       drv_orts,
                                       intrepid_basis);
       }
@@ -1508,9 +1592,9 @@ setupArrays(const Teuchos::RCP<const panzer::BasisIRLayout>& layout,
   int numcells = basisDesc->numCells();
   panzer::PureBasis::EElementSpace elmtspace = basisDesc->getElementSpace();
   Teuchos::RCP<const shards::CellTopology> cellTopo = basisDesc->getCellTopology();
-  
+
   intrepid_basis = basisDesc->getIntrepid2Basis<PHX::Device::execution_space,Scalar,Scalar>();
-  
+
   // allocate field containers
   // field sizes defined by http://trilinos.sandia.gov/packages/docs/dev/packages/intrepid/doc/html/basis_page.html#basis_md_array_sec
 
@@ -1567,14 +1651,14 @@ setupArrays(const Teuchos::RCP<const panzer::BasisIRLayout>& layout,
           // curl of HCURL basis is not dimension dependent
           curl_basis_ref_scalar = af.buildStaticArray<Scalar,BASIS,IP>("curl_basis_ref",card,num_quad); // F, P
           curl_basis_scalar = af.buildStaticArray<Scalar,Cell,BASIS,IP>("curl_basis",numcells,card,num_quad);
-  
+
           if(build_weighted)
             weighted_curl_basis_scalar = af.buildStaticArray<Scalar,Cell,BASIS,IP>("weighted_curl_basis",numcells,card,num_quad);
        }
        else if(dim==3){
           curl_basis_ref_vector = af.buildStaticArray<Scalar,BASIS,IP,Dim>("curl_basis_ref",card,num_quad,dim); // F, P, D
           curl_basis_vector = af.buildStaticArray<Scalar,Cell,BASIS,IP,Dim>("curl_basis",numcells,card,num_quad,dim);
-  
+
           if(build_weighted)
             weighted_curl_basis_vector = af.buildStaticArray<Scalar,Cell,BASIS,IP,Dim>("weighted_curl_basis",numcells,card,num_quad,dim);
        }
@@ -1609,7 +1693,7 @@ setupArrays(const Teuchos::RCP<const panzer::BasisIRLayout>& layout,
      if(compute_derivatives) {
        div_basis_ref = af.buildStaticArray<Scalar,BASIS,IP>("div_basis_ref",card,num_quad); // F, P
        div_basis = af.buildStaticArray<Scalar,Cell,BASIS,IP>("div_basis",numcells,card,num_quad);
-  
+
        if(build_weighted)
          weighted_div_basis = af.buildStaticArray<Scalar,Cell,BASIS,IP>("weighted_div_basis",numcells,card,num_quad);
      }
@@ -1635,7 +1719,7 @@ setupArrays(const Teuchos::RCP<const panzer::BasisIRLayout>& layout,
 
      // nothing - CONST does not support CURL operation
 
-     // build div 
+     // build div
      ///////////////////////////////////////////////
 
      // nothing - CONST does not support DIV operation

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -260,7 +260,8 @@ getIntrepidCubature(const panzer::IntegrationRule & ir) const
 // ***********************************************************
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates)
+evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates,
+               const int in_num_cells)
 {
   typedef panzer::IntegrationDescriptor ID;
   const bool is_surface = int_rule->getType() == ID::SURFACE;
@@ -269,19 +270,20 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates)
   TEUCHOS_ASSERT(not (is_surface and is_cv));
 
   if(is_surface){
-    generateSurfaceCubatureValues(in_node_coordinates);
+    generateSurfaceCubatureValues(in_node_coordinates,in_num_cells);
   } else if (is_cv) {
-    getCubatureCV(in_node_coordinates);
-    evaluateValuesCV(in_node_coordinates);
+    getCubatureCV(in_node_coordinates, in_num_cells);
+    evaluateValuesCV(in_node_coordinates, in_num_cells);
   } else {
-    getCubature(in_node_coordinates);
-    evaluateRemainingValues(in_node_coordinates);
+    getCubature(in_node_coordinates, in_num_cells);
+    evaluateRemainingValues(in_node_coordinates, in_num_cells);
   }
 }
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
+getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
+            const int in_num_cells)
 {
 
   int num_space_dim = int_rule->topology->getDimension();
@@ -306,9 +308,12 @@ getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
   }
 
   // IP coordinates
-  cell_tools.mapToPhysicalFrame(ip_coordinates.get_view(),
+  const int num_cells = in_num_cells < 0 ? in_node_coordinates.extent(0) : in_num_cells;
+  auto s_ip_coordinates = Kokkos::subview(ip_coordinates.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL());
+  auto s_in_node_coordinates = Kokkos::subview(in_node_coordinates.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL());
+  cell_tools.mapToPhysicalFrame(s_ip_coordinates,
                                 dyn_cub_points.get_view(),
-                                in_node_coordinates.get_view(),
+                                s_in_node_coordinates,
                                 *(int_rule->topology));
 }
 
@@ -565,7 +570,8 @@ uniqueCoordOrdering(Array_CellIPDim & coords,
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
+generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
+                              const int in_num_cells)
 {
 
   TEUCHOS_ASSERT(int_rule->getType() == IntegrationDescriptor::SURFACE);
@@ -575,9 +581,10 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
   const shards::CellTopology & cell_topology = *(int_rule->topology);
   const panzer::IntegrationRule & ir = *int_rule;
 
+  const int num_cells = in_num_cells < 0 ? in_node_coordinates.extent(0) : in_num_cells;
+
   // Copy over coordinates
   {
-    const int num_cells = in_node_coordinates.extent(0);
     const int num_nodes = in_node_coordinates.extent(1);
     const int num_dims = in_node_coordinates.extent(2);
 
@@ -593,7 +600,6 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
   // NOTE: We are assuming that each face can have a different number of points.
   // Not sure if this is necessary, but it requires a lot of additional allocations
 
-  const int num_cells = in_node_coordinates.extent(0);
   const int cell_dim = cell_topology.getDimension();
   const int subcell_dim = cell_topology.getDimension()-1;
   const int num_subcells = cell_topology.getSubcellCount(subcell_dim);
@@ -650,16 +656,17 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
 
     // Map from side points to physical points
     auto side_ip_coordinates = Kokkos::DynRankView<Scalar,PHX::Device>("side_ip_coordinates",num_cells,num_points_on_face,cell_dim);
+    auto s_node_coordinates = Kokkos::subview(node_coordinates.get_view(),std::make_pair(0,num_cells),Kokkos::ALL,Kokkos::ALL);
     cell_tools.mapToPhysicalFrame(side_ip_coordinates,
                                   side_cub_points,
-                                  node_coordinates.get_view(),
+                                  s_node_coordinates,
                                   cell_topology);
 
     // Create a jacobian and his friends for this side
     auto side_jacobian = Kokkos::DynRankView<Scalar,PHX::Device>("side_jac",num_cells,num_points_on_face,cell_dim,cell_dim);
     cell_tools.setJacobian(side_jacobian,
                            side_cub_points,
-                           node_coordinates.get_view(),
+                           s_node_coordinates,
                            cell_topology);
 
     auto side_inverse_jacobian = Kokkos::DynRankView<Scalar,PHX::Device>("side_inv_jac",num_cells,num_points_on_face,cell_dim,cell_dim);
@@ -794,7 +801,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
   // I'm not sure if these should exist for surface integrals, but here we go!
 
   // Shakib contravarient metric tensor
-  for (size_type cell = 0; cell < contravarient.extent(0); ++cell) {
+  for (int cell = 0; cell < num_cells; ++cell) {
     for (size_type ip = 0; ip < contravarient.extent(1); ++ip) {
 
       // zero out matrix
@@ -814,10 +821,12 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
     }
   }
 
-  Intrepid2::RealSpaceTools<PHX::Device::execution_space>::inverse(contravarient.get_view(), covarient.get_view());
+  auto s_contravarient = Kokkos::subview(contravarient.get_view(), std::make_pair(0,num_cells),Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
+  auto s_covarient = Kokkos::subview(covarient.get_view(), std::make_pair(0,num_cells),Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
+  Intrepid2::RealSpaceTools<PHX::Device::execution_space>::inverse(s_contravarient, s_covarient);
 
   // norm of g_ij
-  for (size_type cell = 0; cell < contravarient.extent(0); ++cell) {
+  for (int cell = 0; cell < num_cells; ++cell) {
     for (size_type ip = 0; ip < contravarient.extent(1); ++ip) {
       norm_contravarient(cell,ip) = 0.0;
       for (size_type i = 0; i < contravarient.extent(2); ++i) {
@@ -834,7 +843,8 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
+evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
+                        const int in_num_cells)
 {
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
 
@@ -857,12 +867,13 @@ evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordi
         side_cub_points(ip,dim) = dyn_side_cub_points(ip,dim);
   }
 
+  const int num_cells = in_num_cells < 0 ? in_node_coordinates.extent(0) : in_num_cells;
+
   {
-    size_type num_cells = in_node_coordinates.extent(0);
     size_type num_nodes = in_node_coordinates.extent(1);
     size_type num_dims = in_node_coordinates.extent(2);
 
-    for (size_type cell = 0; cell < num_cells;  ++cell) {
+    for (int cell = 0; cell < num_cells;  ++cell) {
       for (size_type node = 0; node < num_nodes; ++node) {
         for (size_type dim = 0; dim < num_dims; ++dim) {
           node_coordinates(cell,node,dim) =
@@ -872,35 +883,40 @@ evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordi
     }
   }
 
+  auto s_in_node_coordinates = Kokkos::subview(in_node_coordinates.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL());
+  auto s_jac = Kokkos::subview(jac.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
   cell_tools.setJacobian(jac.get_view(),
                          cub_points.get_view(),
                          node_coordinates.get_view(),
                          *(int_rule->topology));
 
-  cell_tools.setJacobianInv(jac_inv.get_view(), jac.get_view());
+  auto s_jac_inv = Kokkos::subview(jac_inv.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  cell_tools.setJacobianInv(s_jac_inv, s_jac);
 
-  cell_tools.setJacobianDet(jac_det.get_view(), jac.get_view());
+  auto s_jac_det = Kokkos::subview(jac_det.get_view(),std::make_pair(0,num_cells),Kokkos::ALL());
+  cell_tools.setJacobianDet(s_jac_det, s_jac);
 
+  auto s_weighted_measure = Kokkos::subview(weighted_measure.get_view(),std::make_pair(0,num_cells),Kokkos::ALL());
   if (!int_rule->isSide()) {
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-    computeCellMeasure(weighted_measure.get_view(), jac_det.get_view(), cub_weights.get_view());
+    computeCellMeasure(s_weighted_measure, s_jac_det, cub_weights.get_view());
   }
   else if(int_rule->spatial_dimension==3) {
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-    computeFaceMeasure(weighted_measure.get_view(), jac.get_view(), cub_weights.get_view(),
+    computeFaceMeasure(s_weighted_measure, s_jac, cub_weights.get_view(),
                        int_rule->side, *int_rule->topology,
                        scratch_for_compute_side_measure.get_view());
   }
   else if(int_rule->spatial_dimension==2) {
     Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::
-    computeEdgeMeasure(weighted_measure.get_view(), jac.get_view(), cub_weights.get_view(),
+    computeEdgeMeasure(s_weighted_measure, s_jac, cub_weights.get_view(),
                        int_rule->side,*int_rule->topology,
                        scratch_for_compute_side_measure.get_view());
   }
   else TEUCHOS_ASSERT(false);
 
   // Shakib contravarient metric tensor
-  for (size_type cell = 0; cell < contravarient.extent(0); ++cell) {
+  for (int cell = 0; cell < num_cells; ++cell) {
     for (size_type ip = 0; ip < contravarient.extent(1); ++ip) {
 
       // zero out matrix
@@ -920,10 +936,12 @@ evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordi
     }
   }
 
-  Intrepid2::RealSpaceTools<PHX::Device::execution_space>::inverse(contravarient.get_view(), covarient.get_view());
+  auto s_covarient = Kokkos::subview(covarient.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  auto s_contravarient = Kokkos::subview(contravarient.get_view(),std::make_pair(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  Intrepid2::RealSpaceTools<PHX::Device::execution_space>::inverse(s_contravarient, s_covarient);
 
   // norm of g_ij
-  for (size_type cell = 0; cell < contravarient.extent(0); ++cell) {
+  for (int cell = 0; cell < num_cells; ++cell) {
     for (size_type ip = 0; ip < contravarient.extent(1); ++ip) {
       norm_contravarient(cell,ip) = 0.0;
       for (size_type i = 0; i < contravarient.extent(2); ++i) {
@@ -981,11 +999,14 @@ permuteToOther(const PHX::MDField<Scalar,Cell,IP,Dim>& coords,
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
 evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
-               const PHX::MDField<Scalar,Cell,IP,Dim>& other_ip_coordinates)
-               {
+               const PHX::MDField<Scalar,Cell,IP,Dim>& other_ip_coordinates,
+               const int in_num_cells)
+{
+  const int num_cells = in_num_cells < 0 ? in_node_coordinates.extent(0) : in_num_cells;
+
   if (int_rule->cv_type == "none") {
 
-    getCubature(in_node_coordinates);
+    getCubature(in_node_coordinates, in_num_cells);
 
     {
       // Determine the permutation.
@@ -1023,12 +1044,12 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
             dyn_cub_weights(ip) = old_dyn_cub_weights(permutation[ip]);
       }
       {
-        const size_type num_cells = ip_coordinates.extent(0), num_ip = ip_coordinates.extent(1),
-            num_dim = ip_coordinates.extent(2);
+        const size_type num_ip = ip_coordinates.extent(1);
+        const size_type num_dim = ip_coordinates.extent(2);
         Array_CellIPDim old_ip_coordinates = af.template buildStaticArray<Scalar,Cell,IP,Dim>(
-            "old_ip_coordinates", num_cells, num_ip, num_dim);
+            "old_ip_coordinates", ip_coordinates.extent(0), num_ip, num_dim);
         Kokkos::deep_copy(old_ip_coordinates.get_static_view(), ip_coordinates.get_static_view());
-        for (size_type cell = 0; cell < num_cells; ++cell)
+        for (int cell = 0; cell < num_cells; ++cell)
           for (size_type ip = 0; ip < num_ip; ++ip)
             if (ip != permutation[ip])
               for (size_type dim = 0; dim < num_dim; ++dim)
@@ -1037,12 +1058,12 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
       // All subsequent calculations inherit the permutation.
     }
 
-    evaluateRemainingValues(in_node_coordinates);
+    evaluateRemainingValues(in_node_coordinates, in_num_cells);
   }
 
   else {
 
-    getCubatureCV(in_node_coordinates);
+    getCubatureCV(in_node_coordinates, in_num_cells);
 
     // Determine the permutation.
     std::vector<size_type> permutation(other_ip_coordinates.extent(1));
@@ -1051,15 +1072,15 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
     // Apply the permutation to the cubature arrays.
     MDFieldArrayFactory af(prefix, alloc_arrays);
     {
-      const size_type num_cells = ip_coordinates.extent(0), num_ip = ip_coordinates.extent(1),
+      const size_type workset_size = ip_coordinates.extent(0), num_ip = ip_coordinates.extent(1),
           num_dim = ip_coordinates.extent(2);
       Array_CellIPDim old_ip_coordinates = af.template buildStaticArray<Scalar,Cell,IP,Dim>(
-          "old_ip_coordinates", num_cells, num_ip, num_dim);
+          "old_ip_coordinates", workset_size, num_ip, num_dim);
       Kokkos::deep_copy(old_ip_coordinates.get_static_view(), ip_coordinates.get_static_view());
       Array_CellIPDim old_weighted_normals = af.template buildStaticArray<Scalar,Cell,IP,Dim>(
-          "old_weighted_normals", num_cells, num_ip, num_dim);
+          "old_weighted_normals", workset_size, num_ip, num_dim);
       Array_CellIP old_weighted_measure = af.template buildStaticArray<Scalar,Cell,IP>(
-          "old_weighted_measure", num_cells, num_ip);
+          "old_weighted_measure", workset_size, num_ip);
       if (int_rule->cv_type == "side")
         Kokkos::deep_copy(old_weighted_normals.get_static_view(), weighted_normals.get_static_view());
       else
@@ -1083,13 +1104,14 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
       }
     }
 
-    evaluateValuesCV(in_node_coordinates);
+    evaluateValuesCV(in_node_coordinates, in_num_cells);
   }
 }
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
+getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
+              const int in_num_cells)
 {
   int num_space_dim = int_rule->topology->getDimension();
   if (int_rule->isSide() && num_space_dim==1) {
@@ -1097,8 +1119,9 @@ getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
         << "non-natural integration rules.";
     return;
   }
+
+  size_type num_cells = in_num_cells < 0 ? in_node_coordinates.extent(0) : (size_type) in_num_cells;
   {
-    size_type num_cells = in_node_coordinates.extent(0);
     size_type num_nodes = in_node_coordinates.extent(1);
     size_type num_dims = in_node_coordinates.extent(2);
 
@@ -1114,12 +1137,18 @@ getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
     }
   }
 
-  if (int_rule->cv_type == "side")
-    intrepid_cubature->getCubature(dyn_phys_cub_points.get_view(),dyn_phys_cub_norms.get_view(),dyn_node_coordinates.get_view());
-  else
-    intrepid_cubature->getCubature(dyn_phys_cub_points.get_view(),dyn_phys_cub_weights.get_view(),dyn_node_coordinates.get_view());
+  auto s_dyn_phys_cub_points = Kokkos::subdynrankview(dyn_phys_cub_points.get_view(),std::make_pair<unsigned,unsigned>(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  auto s_dyn_node_coordinates = Kokkos::subdynrankview(dyn_node_coordinates.get_view(),std::make_pair<unsigned,unsigned>(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  if (int_rule->cv_type == "side") {
+    auto s_dyn_phys_cub_norms = Kokkos::subdynrankview(dyn_phys_cub_norms.get_view(),std::make_pair<unsigned,unsigned>(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    intrepid_cubature->getCubature(s_dyn_phys_cub_points,s_dyn_phys_cub_norms,s_dyn_node_coordinates);
+  }
+  else {
+    auto s_dyn_phys_cub_weights = Kokkos::subdynrankview(dyn_phys_cub_weights.get_view(),std::make_pair<unsigned,unsigned>(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    intrepid_cubature->getCubature(s_dyn_phys_cub_points,s_dyn_phys_cub_weights,s_dyn_node_coordinates);
+  }
 
-  size_type num_cells = dyn_phys_cub_points.extent(0);
+  // size_type num_cells = dyn_phys_cub_points.extent(0);
   size_type num_ip =dyn_phys_cub_points.extent(1);
   size_type num_dims = dyn_phys_cub_points.extent(2);
 
@@ -1139,25 +1168,37 @@ getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates)
 
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
-evaluateValuesCV(const PHX::MDField<Scalar, Cell, NODE, Dim>& /* in_node_coordinates */)
+evaluateValuesCV(const PHX::MDField<Scalar, Cell, NODE, Dim>& in_node_coordinates,
+                 const int in_num_cells)
 {
 
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
 
-  cell_tools.mapToReferenceFrame(ref_ip_coordinates.get_view(),
-                                 ip_coordinates.get_view(),
-                                 node_coordinates.get_view(),
+  size_type num_cells = in_num_cells < 0 ? in_node_coordinates.extent(0) : (size_type) in_num_cells;
+
+  auto s_ref_ip_coordinates = Kokkos::subview(ref_ip_coordinates.get_view(),std::make_pair(0,(int)num_cells),Kokkos::ALL(),Kokkos::ALL());
+  auto s_ip_coordinates = Kokkos::subview(ip_coordinates.get_view(),std::make_pair<int,int>(0,num_cells),Kokkos::ALL(),Kokkos::ALL());
+  auto s_node_coordinates = Kokkos::subview(node_coordinates.get_view(),std::make_pair<int,int>(0,num_cells),Kokkos::ALL(),Kokkos::ALL());
+
+  cell_tools.mapToReferenceFrame(s_ref_ip_coordinates,
+                                 s_ip_coordinates,
+                                 s_node_coordinates,
                                  *(int_rule->topology));
 
-  cell_tools.setJacobian(jac.get_view(),
-                         ref_ip_coordinates.get_view(),
-                         node_coordinates.get_view(),
+  auto s_jac = Kokkos::subview(jac.get_view(),std::make_pair<int,int>(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+
+  cell_tools.setJacobian(s_jac,
+                         s_ref_ip_coordinates,
+                         s_node_coordinates,
                          *(int_rule->topology));
 
-  cell_tools.setJacobianInv(jac_inv.get_view(), jac.get_view());
+  auto s_jac_inv = Kokkos::subview(jac_inv.get_view(),std::make_pair<int,int>(0,num_cells),Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
 
-  cell_tools.setJacobianDet(jac_det.get_view(), jac.get_view());
+  cell_tools.setJacobianInv(s_jac_inv, s_jac);
 
+  auto s_jac_det = Kokkos::subview(jac_det.get_view(),std::make_pair<int,int>(0,num_cells),Kokkos::ALL());
+
+  cell_tools.setJacobianDet(s_jac_det, s_jac);
 }
 
 #define INTEGRATION_VALUES2_INSTANTIATION(SCALAR) \

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -73,26 +73,43 @@ namespace panzer {
 
     typedef PHX::MDField<Scalar,Cell,BASIS,Dim> Array_CellBASISDim;
 
-    IntegrationValues2(const std::string & pre="",bool allocArrays=false) 
+    IntegrationValues2(const std::string & pre="",bool allocArrays=false)
         : alloc_arrays(allocArrays), prefix(pre), ddims_(1,0) {}
-    
+
     //! Sizes/allocates memory for arrays
     void setupArrays(const Teuchos::RCP<const panzer::IntegrationRule>& ir);
 
     void setupArraysForNodeRule(const Teuchos::RCP<const panzer::IntegrationRule>& ir);
 
-    //! Cell vertex coordinates, not basis coordinates.
-    void evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates);
+    /** \brief Evaluate basis values.
 
-    //! \brief Match IP.
-    //
-    // Optionally provide IP coordinates for an element 'other' that shares the
-    // same side. If provided, a permutation of the cubature points is
-    // calculated so that the integration values are ordered according to the
-    // other element's. This permutation is then applied so that all fields are
-    // ordered accordingly in their IP dimension.
+        @param vertex_coordinates [in] Cell vertex coordinates, not
+        basis coordinates.
+        @param num_cells [in] (optional) number of cells in the
+        workset. This can be less than the workset size. If set to
+        zero, extent(0) of the evaluated array is used which equates
+        to the workset size.
+     */
     void evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
-                        const PHX::MDField<Scalar,Cell,IP,Dim> & other_ip_coordinates);
+                        const int num_cells = -1);
+
+    /** \brief Match IP.
+
+       Optionally provide IP coordinates for an element 'other' that
+       shares the same side. If provided, a permutation of the
+       cubature points is calculated so that the integration values
+       are ordered according to the other element's. This permutation
+       is then applied so that all fields are ordered accordingly in
+       their IP dimension.
+
+        @param num_cells [in] (optional) number of cells in the
+        workset. This can be less than the workset size. If set to
+        zero, extent(0) of the evaluated array is used which equates
+        to the workset size.
+    */
+    void evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,
+                        const PHX::MDField<Scalar,Cell,IP,Dim> & other_ip_coordinates,
+                        const int num_cells = -1);
 
     Array_IPDim cub_points;              // <IP,Dim>
     Array_IPDim side_cub_points;         // <IP,Dim> points on face topology (dim-1)
@@ -114,9 +131,9 @@ namespace panzer {
     Teuchos::RCP<Intrepid2::Cubature<PHX::Device::execution_space,double,double>> intrepid_cubature;
 
     // for Shakib stabilization <Cell,IP,Dim,Dim>
-    Array_CellIPDimDim covarient; 
-    Array_CellIPDimDim contravarient; 
-    Array_CellIP norm_contravarient; 
+    Array_CellIPDimDim covarient;
+    Array_CellIPDimDim contravarient;
+    Array_CellIP norm_contravarient;
 
     // integration points
     Array_CellIPDim ip_coordinates;      // <Cell,IP,Dim>
@@ -167,11 +184,11 @@ namespace panzer {
     std::string prefix;
     std::vector<PHX::index_size_type> ddims_;
 
-    void generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates);
-    void getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates);
-    void getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates);
-    void evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates);
-    void evaluateValuesCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates);
+    void generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+    void getCubature(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+    void getCubatureCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+    void evaluateRemainingValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates, const int in_num_cells);
+    void evaluateValuesCV(const PHX::MDField<Scalar,Cell,NODE,Dim> & vertex_coordinates,const int in_num_cells);
   };
 
 } // namespace panzer

--- a/packages/panzer/disc-fe/src/Panzer_PointValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_PointValues2.hpp
@@ -82,10 +82,11 @@ namespace panzer {
       */
     template <typename CoordinateArray,typename PointArray>
     void evaluateValues(const CoordinateArray & node_coords,
-                        const PointArray & in_point_coords)
+                        const PointArray & in_point_coords,
+                        const int in_num_cells = -1)
     { copyNodeCoords(node_coords);
       copyPointCoords(in_point_coords);
-      evaluateValues(); }
+      evaluateValues(in_num_cells); }
 
     /** Evaluate teh jacobian and derivative information at the requested reference
       * points. This version allows a shallow copy of the vertex coordinates. 
@@ -97,13 +98,14 @@ namespace panzer {
     template <typename PointArray>
     void evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & node_coords,
                         const PointArray & in_point_coords, 
-                        bool shallow_copy_nodes)
+                        bool shallow_copy_nodes,
+                        const int in_num_cells = -1)
     { if(shallow_copy_nodes)
         node_coordinates = node_coords;
       else
         copyNodeCoords(node_coords);
       copyPointCoords(in_point_coords);
-      evaluateValues(); }
+      evaluateValues(in_num_cells); }
 
     //! Return reference cell coordinates this class uses (IP,Dim) sized
     PHX::MDField<Scalar,IP,Dim> & getRefCoordinates() const 
@@ -127,7 +129,7 @@ namespace panzer {
     Teuchos::RCP<const panzer::PointRule> point_rule;
 
   private:
-    void evaluateValues();
+    void evaluateValues(const int in_num_cells);
 
     template <typename CoordinateArray>
     void copyNodeCoords(const CoordinateArray& in_node_coords);

--- a/packages/panzer/disc-fe/src/Panzer_PointValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_PointValues2_impl.hpp
@@ -84,20 +84,27 @@ namespace panzer {
 
   template <typename Scalar>
   void PointValues2<Scalar>::
-  evaluateValues()
+  evaluateValues(const int in_num_cells)
   {
     if (point_rule->isSide()) {
        TEUCHOS_ASSERT(false); // not implemented!!!!
     }
     
+    const int num_cells = in_num_cells < 0 ? (int) jac.extent(0) : in_num_cells;
+    const auto cell_range = std::pair<int,int>(0,num_cells);
+    auto s_jac = Kokkos::subview(jac.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_jac_det = Kokkos::subview(jac_det.get_view(),cell_range,Kokkos::ALL());
+    auto s_jac_inv = Kokkos::subview(jac_inv.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+    auto s_node_coordinates = Kokkos::subview(node_coordinates.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
+    auto s_point_coords = Kokkos::subview(point_coords.get_view(),cell_range,Kokkos::ALL(),Kokkos::ALL());
     Intrepid2::CellTools<PHX::exec_space> cell_tools;
     
-    cell_tools.setJacobian(jac.get_view(), coords_ref.get_view(), node_coordinates.get_view(), *(point_rule->topology));
-    cell_tools.setJacobianInv(jac_inv.get_view(), jac.get_view());
-    cell_tools.setJacobianDet(jac_det.get_view(), jac.get_view());
+    cell_tools.setJacobian(s_jac, coords_ref.get_view(), s_node_coordinates, *(point_rule->topology));
+    cell_tools.setJacobianInv(s_jac_inv, s_jac);
+    cell_tools.setJacobianDet(s_jac_det, s_jac);
     
     // IP coordinates
-    cell_tools.mapToPhysicalFrame(point_coords.get_view(), coords_ref.get_view(), node_coordinates.get_view(), *(point_rule->topology));
+    cell_tools.mapToPhysicalFrame(s_point_coords, coords_ref.get_view(), s_node_coordinates, *(point_rule->topology));
   }
 
   template <typename Scalar>

--- a/packages/panzer/disc-fe/src/Panzer_Workset.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.cpp
@@ -143,7 +143,7 @@ void WorksetDetails::setupNeeds(Teuchos::RCP<const shards::CellTopology> cell_to
     // Create and store integration values
     Teuchos::RCP<panzer::IntegrationValues2<double> > iv = Teuchos::rcp(new panzer::IntegrationValues2<double>("",true));
     iv->setupArrays(ir);
-    iv->evaluateValues(cell_vertex_coordinates);
+    iv->evaluateValues(cell_vertex_coordinates,num_cells);
     _integrator_map[integration_description.getKey()] = iv;
 
     // We need to generate a integration rule - basis pair for each basis
@@ -164,7 +164,9 @@ void WorksetDetails::setupNeeds(Teuchos::RCP<const shards::CellTopology> cell_to
                            iv->jac_det,
                            iv->jac_inv,
                            iv->weighted_measure,
-                           cell_vertex_coordinates);
+                           cell_vertex_coordinates,
+                           true,
+                           num_cells);
       } else if((ir->getType() == panzer::IntegrationDescriptor::CV_VOLUME)
           or (ir->getType() == panzer::IntegrationDescriptor::CV_SIDE)
           or (ir->getType() == panzer::IntegrationDescriptor::CV_BOUNDARY)){
@@ -178,7 +180,9 @@ void WorksetDetails::setupNeeds(Teuchos::RCP<const shards::CellTopology> cell_to
                            iv->jac_det,
                            iv->jac_inv,
                            iv->weighted_measure,
-                           cell_vertex_coordinates);
+                           cell_vertex_coordinates,
+                           true,
+                           num_cells);
       }
       _basis_map[basis_description.getKey()][integration_description.getKey()] = bv;
     }

--- a/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
@@ -309,7 +309,7 @@ applyOrientations(const std::string & eBlock, std::vector<Workset> & worksets) c
             TEUCHOS_ASSERT(layout->getBasis()!=Teuchos::null);
             if(layout->getBasis()->requiresOrientations()) {
               // apply orientations for this basis
-              details.bases[basis_index]->applyOrientations(ortsPerBlock);
+              details.bases[basis_index]->applyOrientations(ortsPerBlock,(int) worksets[i].num_cells);
             }
           }
         }
@@ -343,7 +343,7 @@ applyOrientations(const std::string & eBlock, std::vector<Workset> & worksets) c
   
           for(const auto & id : needs.getIntegrators()) {
             // apply orientations for this basis
-            details.getBasisValues(bd,id).applyOrientations(ortsPerBlock);
+            details.getBasisValues(bd,id).applyOrientations(ortsPerBlock,(int) worksets[i].num_cells);
           }
         }
       }
@@ -416,7 +416,7 @@ applyOrientations(const WorksetDescriptor & desc,std::map<unsigned,Workset> & wo
             TEUCHOS_ASSERT(layout->getBasis()!=Teuchos::null);
             if(layout->getBasis()->requiresOrientations()) {
               // apply orientations for this basis
-              details.bases[basis_index]->applyOrientations(ortsPerBlock);
+              details.bases[basis_index]->applyOrientations(ortsPerBlock,(int) itr->second.num_cells);
             }
           }
         }
@@ -451,7 +451,7 @@ applyOrientations(const WorksetDescriptor & desc,std::map<unsigned,Workset> & wo
   
           for(const auto & id : needs.getIntegrators()) {
             // apply orientations for this basis
-            details.getBasisValues(bd,id).applyOrientations(ortsPerBlock);
+            details.getBasisValues(bd,id).applyOrientations(ortsPerBlock,(int) itr->second.num_cells);
           }
         }
       }

--- a/packages/panzer/disc-fe/src/Panzer_Workset_Builder.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset_Builder.cpp
@@ -138,9 +138,9 @@ void populateValueArrays(std::size_t num_cells,bool isSide,const WorksetNeeds & 
         rcp(new panzer::IntegrationValues2<double>("",true));
     iv2->setupArrays(int_rules[i]);
     if (Teuchos::nonnull(other_details))
-      iv2->evaluateValues(details.cell_vertex_coordinates, other_details->int_rules[i]->ip_coordinates);
+      iv2->evaluateValues(details.cell_vertex_coordinates, other_details->int_rules[i]->ip_coordinates,num_cells);
     else
-      iv2->evaluateValues(details.cell_vertex_coordinates);
+      iv2->evaluateValues(details.cell_vertex_coordinates,num_cells);
       
     details.int_rules.push_back(iv2);
       
@@ -157,11 +157,13 @@ void populateValueArrays(std::size_t num_cells,bool isSide,const WorksetNeeds & 
           rcp(new panzer::BasisValues2<double>("",true,true));
       bv2->setupArrays(b_layout);
       bv2->evaluateValues(details.int_rules[int_degree_index]->cub_points,
-                         details.int_rules[int_degree_index]->jac,
-                         details.int_rules[int_degree_index]->jac_det,
-                         details.int_rules[int_degree_index]->jac_inv,
-                         details.int_rules[int_degree_index]->weighted_measure,
-                         details.cell_vertex_coordinates);
+                          details.int_rules[int_degree_index]->jac,
+                          details.int_rules[int_degree_index]->jac_det,
+                          details.int_rules[int_degree_index]->jac_inv,
+                          details.int_rules[int_degree_index]->weighted_measure,
+                          details.cell_vertex_coordinates,
+                          true,
+                          num_cells);
 
       details.bases.push_back(bv2);
     }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_BasisValues_Evaluator_impl.hpp
@@ -226,7 +226,8 @@ evaluateFields(
   basisValues->evaluateValues(pointValues.coords_ref,
                               pointValues.jac,
                               pointValues.jac_det,
-                              pointValues.jac_inv);
+                              pointValues.jac_inv,
+                              (int) workset.num_cells);
 
   // this can be over-ridden in basisValues e.g., DG element setting
   if(basis->requiresOrientations()) {
@@ -236,7 +237,7 @@ evaluateFields(
     for (index_t c=0;c<workset.num_cells;++c)
       ortPerWorkset.push_back((*orientations)[details.cell_local_ids[c]]);
     
-    basisValues->applyOrientations(ortPerWorkset);
+    basisValues->applyOrientations(ortPerWorkset, (int) workset.num_cells);
   }
 }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_PointValues_Evaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_PointValues_Evaluator_impl.hpp
@@ -180,11 +180,13 @@ evaluateFields(
 
     // evaluate the point values (construct jacobians etc...)
     pointValues.evaluateValues(this->wda(workset).cell_vertex_coordinates,
-                               basisValues.basis_coordinates_ref);
+                               basisValues.basis_coordinates_ref,
+                               workset.num_cells);
   }
   else {
     // evaluate the point values (construct jacobians etc...)
-    pointValues.evaluateValues(this->wda(workset).cell_vertex_coordinates,refPointArray);
+    pointValues.evaluateValues(this->wda(workset).cell_vertex_coordinates,refPointArray,
+                               workset.num_cells);
   }
 }
 


### PR DESCRIPTION
This PR converts all calls to Intrepid2 to use subviews. The workset concept is used to control memory usage. The last workset may not be full. That means the actual number of cells is not always equal to workset size. Intrepid2 always uses the extent (workset size) for their loops leading to extra operations on dummy cells. In the past, we just iterated on the full extent, but some applications now enable FPE trapping by default. Switching to subviews fixes the extent correctly.