### PR TITLE
Reducing subspace sizes due to biorthogonal basis construction for #3585

### DIFF
--- a/packages/anasazi/epetra/test/OrthoManager/cxx_gentest.cpp
+++ b/packages/anasazi/epetra/test/OrthoManager/cxx_gentest.cpp
@@ -107,9 +107,9 @@ int main(int argc, char *argv[])
   bool debug = false;
   bool useMass = true;
   int dim = 100;
-  int sizeS  = 5;
-  int sizeX1 = 11; // MUST: sizeS + sizeX1 + sizeX2 <= elements[0]-1
-  int sizeX2 = 13; // MUST: sizeS + sizeX1 + sizeX2 <= elements[0]-1
+  int sizeS  = 3;
+  int sizeX1 = 6; // MUST: sizeS + sizeX1 + sizeX2 <= elements[0]-1
+  int sizeX2 = 7; // MUST: sizeS + sizeX1 + sizeX2 <= elements[0]-1
 
   bool success = true;
   try {


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/anasazi 

## Description
<!--- Please describe your changes in detail. -->
This test, unlike the two other orthogonalization tests, generates a biorthogonal
basis.  When all the dimensions are summed up, the orthogonal constraints in this
test are twice the size of the other two tests.  Using random vectors, it would be
more likely that a degenerate basis could be constructed by this test.  Since the
objective of the test to make sure that the orthogonalization methods in Anasazi can
construct a biorthogonal basis, the size of the basis is not as much the point.
So, the dimension of each component of this test have been halved because of the
biorthogonality.  This seems to eliminate random failures that were observed on the
CEE, and are the subject of the bug #3585 .

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This should address the random failures in #3585.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues #3585 

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
On CEE, where the test failure was more often observed and could be studied.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->