### PR TITLE
Framework: Fix Master-Merge PR script branch restriction check

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-Test.sh
+++ b/cmake/std/PullRequestLinuxDriver-Test.sh
@@ -38,11 +38,12 @@ function test_pr_constraints_master()
     then
         echo -e "NOTICE: Destination branch is trilinos/Trilnos::master"
 
-        if [[ ! "${src_repo:?}" =~ ${re_trilinos_url:?} ]] || [[ ! "${src_branch:?}" == "develop" ]]
+        re_src_branchname="master_merge_[0-9]{8}_[0-9]{6}"
+
+        if [[ ! "${src_repo:?}" =~ ${re_trilinos_url:?} ]] || [[ ! "${src_branch:?}" =~ ${re_src_branchname:?} ]]
         then
-            echo -e "ERROR : Source branch is NOT trilinos/Trilinos::develop"
-            echo -e "      : This violates Trilinos policy, pull requests into the master branch"
-            echo -e "      : are only allowed from the develop branch."
+            echo -e "ERROR : Source branch is NOT trilinos/Trilinos::master_merge_YYYYMMDD_HHMMSS"
+            echo -e "      : This violates Trilinos policy, pull requests into the master branch are restricted."
             echo -e "      : Perhaps you forgot to specify the develop branch as the target in your PR?"
             echo -e "------------------------------------------------------------------------------------------"
             echo -e ""


### PR DESCRIPTION
As discovered in #4073 the check to verify the incoming branch to Master must be trilinos/develop was wrong. We forgot that the master-merge script actually forks off develop into a branch that's named like `master_merge_20181218_020657` ... This PR updates the branch check to make sure that the branch name is correct for PR's into master.

@trilinos/framework 