### PR TITLE
Tpetra: Clean up CrsGraph::Swap testing

### DIFF
--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
@@ -141,7 +141,7 @@ generate_crsgraph(Teuchos::RCP<Teuchos::Comm<int> >&      comm,
 
     const bool verbose = Tpetra::Details::Behavior::verbose();
 
-    const int comm_rank = (size_t)comm->getRank();
+    const int comm_rank = comm->getRank();
 
     map_row_to_cols_type gbl_rows;
     for(auto& e: gbl_edges)

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
@@ -114,8 +114,6 @@ TEUCHOS_STATIC_SETUP()
                   " this option is ignored and a serial comm is always used.");
     clp.setOption("error-tol-slack", &errorTolSlack, "Slack off of machine epsilon used to check test results");
 }
-// todo: update options so that this test won't run in serial (it's not set up for that currently)
-
 
 
 


### PR DESCRIPTION
@trilinos/tpetra

There were some `#if 0` blocks in the test which needed to be changed to use `Tpetra::Details::Behavior::verbose()` for consistency.

This PR is convenient as well for testing changes to PR jobs on Jenkins for @trilinos/framework for #4065 =) . 