### PR TITLE
Kokkos,Tpetra: Fix #4094

### DIFF
--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -230,9 +230,6 @@ T atomic_fetch_oper( const Oper& op, volatile T * const dest ,
   typename Kokkos::Impl::enable_if<
                 ( sizeof(T) != 4 )
              && ( sizeof(T) != 8 )
-          #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-             && ( sizeof(T) != 16 )
-          #endif
            , const T >::type val )
 {
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -357,7 +357,6 @@ namespace Tpetra {
     fillComplete_ (false),
     frobNorm_ (-STM::one ())
   {
-    typedef typename local_matrix_type::values_type values_type;
     const char tfecfFuncName[] = "CrsMatrix(RCP<const CrsGraph>,local_matrix_type::values_type,[, "
       "RCP<ParameterList>]): ";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -378,7 +377,6 @@ namespace Tpetra {
 
     const size_t numCols = graph->getColMap ()->getNodeNumElements ();
     auto lclGraph = graph->getLocalGraph ();
-    const size_t numEnt = lclGraph.entries.extent (0);
     this->lclMatrix_ = local_matrix_type ("Tpetra::CrsMatrix::lclMatrix_",
                                           numCols, values, lclGraph);
     // FIXME (22 Jun 2016) I would very much like to get rid of

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2587,8 +2587,6 @@ namespace Tpetra {
     using ::Tpetra::Details::ProfilingRegion;
     using ::Tpetra::Details::Blas::fill;
     typedef typename dual_view_type::t_dev::memory_space DMS;
-    //typedef typename dual_view_type::t_host::memory_space HMS;
-    typedef typename dual_view_type::t_host::device_type HMS; // avoid CudaUVMSpace issues
     typedef typename dual_view_type::t_dev::execution_space DES;
     typedef typename dual_view_type::t_host::execution_space HES;
     typedef LocalOrdinal LO;


### PR DESCRIPTION
@trilinos/kokkos @trilinos/tpetra 

## Description

Fix #4094 by patching Kokkos to fix https://github.com/kokkos/kokkos/issues/1951.
Fix some Tpetra build warnings.

## Motivation and Context

Build with `Scalar=complex<double>` enabled was broken.

## Related Issues

* Closes #4094 
* Is blocked by https://github.com/kokkos/kokkos/issues/1951 

It's blocked in a sense; we need to fix Kokkos, else this is only a temporary fix that will get clobbered on the next Kokkos-to-Trilinos promotion.

## How Has This Been Tested?

Linux, GCC 4.9.3, OpenMP, OpenMPI 1.10.1.