### PR TITLE
Panzer: improve performance of assembly evaluators on cuda

### DIFF
--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/analyze_performance.py
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/analyze_performance.py
@@ -1,0 +1,213 @@
+#! /usr/bin/env python
+
+"""
+Script for analyzing Panzer kernel performance on next-generation
+architectures.  Runs hierarchic parallelism and generates plots from
+data.
+"""
+
+__version__ = "1.0"
+__author__  = "Roger Pawlowski"
+__date__    = "Dec 2018"
+
+# Import python modules for command-line options, the operating system, regular
+# expressions, and system functions
+import commands
+import argparse
+import os
+import re
+import sys
+import datetime
+
+#############################################################################
+
+def main():
+
+    """Script for analyzing Phalanx performance on next-generation architectures."""
+
+    # Initialization
+    print '****************************************'
+    print '* Starting Panzer Analysis'
+    print '****************************************'
+
+    parser = argparse.ArgumentParser(description='Panzer hierarchic parallelism analysis script')
+    parser.add_argument('-r', '--run', action='store_true', help='Run the executable to generate data and output to files.')
+    parser.add_argument('-a', '--analyze', action='store_true', help='Analyze the data from files generated with --run.')
+    parser.add_argument('-p', '--prefix', help='Add a prefix string to all output filenames.')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Print more data to screen.')
+    parser.add_argument('-o', '--basis-order', type=int, required=True, help='FE basis order.')
+    parser.add_argument('-ts', '--team-size', type=int, required=True, help='Team size for hierarchic parallelism.')
+    parser.add_argument('-vs', '--vector-size', type=int, required=True, help='Vector size for hierarchic parallelism.')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-b', '--base-exe', action='store_true', default=False, help="Use the Base executable")
+    group.add_argument('-m', '--mixed-exe', action='store_true', default=False, help="Use the Mixed Field Type executable")
+    group.add_argument('-d', '--device-dag-exe', action='store_true', default=True, help="Use the Device DAG executable")
+    args = parser.parse_args()
+
+    nx = 20
+    ny = 20
+    nz = 20
+    order = args.basis_order
+    ts = args.team_size
+    vs = args.vector_size
+    print "basis order = %d, team size = %d, vector size = %d\n" % (order, ts, vs)
+
+    executable = "./PanzerAdaptersSTK_MixedPoissonExample.exe"
+
+    print "Starting Workset Analysis"
+
+    ws_step_size = 100
+    workset_range = range(100,2000+ws_step_size,ws_step_size)
+    print "workset range = "+str(workset_range)
+
+    timings = {}
+    if args.analyze:
+        import numpy as np
+        timings["panzer::AssemblyEngine::evaluate_volume(panzer::Traits::Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] GatherSolution (Tpetra): GRADPHI_FIELD (panzer::Traits::Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] DOFDiv: DIV_GRADPHI_FIELD (panzer::Traits::Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] Integrator_DivBasisTimesScalar (EVALUATES):  RESIDUAL_GRADPHI_FIELD"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] Sine Source"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] Integrator_DivBasisTimesScalar (CONTRIBUTES):  RESIDUAL_GRADPHI_FIELD"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] SCATTER_GRADPHI_FIELD Scatter Residual (Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] DOF: GRADPHI_FIELD accel_jac  (panzer::Traits::Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] Integrator_GradBasisDotVector (EVALUATES):  RESIDUAL_PHI_MASS_OP"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] GatherSolution (Tpetra): PHI (panzer::Traits::Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] DOFGradient: GRAD_PHI (panzer::Traits::Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] Integrator_GradBasisDotVector (EVALUATES):  RESIDUAL_PHI_DIFFUSION_OP"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] SumStatic Rank 2 Evaluator"] = np.zeros(len(workset_range),dtype=np.float64)
+        timings["[panzer::Traits::Jacobian] SCATTER_PHI Scatter Residual (Jacobian)"] = np.zeros(len(workset_range),dtype=np.float64)
+        
+
+    #print dir(np)
+        
+    for i in range(len(workset_range)):
+
+        ws = workset_range[i]
+        
+        filename = "fea_nx_%i_ny_%i_nz_%i_order_%i_ws_%i_ts_%i_vs_%i.dat" % (nx, ny, nz , order, ws, ts, vs)
+        if args.prefix:
+            filename = args.prefix+filename
+        command = executable+" --x-elements=%i --y-elements=%i --z-elements=%i --hgrad-basis-order=%i --hdiv-basis-order=%i --workset-size=%i --use-shared-mem-for-ad --no-check-order" % (nx, ny, nz, order, order, ws)  +" >& "+filename
+
+        if args.run:
+            #print 'generating data...'
+            if args.verbose:
+                print "  Running \""+command+"\" ...",
+                sys.stdout.flush()
+            os.system(command);
+            if args.verbose:
+                print "completed!"
+                sys.stdout.flush()
+
+        if args.analyze:
+            f = open(filename, mode='r')                
+            lines = f.readlines()
+            for line in lines:
+                if args.verbose:
+                    print line,
+                for key,value in timings.iteritems():
+                    if key in line:
+                        split_line = line.split()
+                        timings[key][i] += float(split_line[-4])
+                        if args.verbose:
+                            print "  found key: "+key+" = "+str(split_line[-4])
+                        break
+            f.close()
+
+    do_jac = True
+            
+    if args.analyze:
+        import matplotlib.pyplot as plt
+        fig = plt.figure()
+        plt.semilogy()
+        # maroon = #990033, light blue = #00ffff
+        #plt.plot(workset_range,timings["Jacobian Evaluation Time <<Host DAG>>"],label="Jac Total Time (Host DAG)",marker="o",color="#990033",markersize=8)
+        #plt.plot(workset_range,timings["Jacobian Evaluation Time <<Device DAG>>"],label="Jac Total Time (Device DAG)",marker="s",color="r",markersize=8)
+        #plt.plot(workset_range,timings["Residual Evaluation Time <<Host DAG>>"],label="Res Total Time (Host DAG)",marker="o",color="b",markersize=8)
+        plt.plot(workset_range,timings["panzer::AssemblyEngine::evaluate_volume(panzer::Traits::Jacobian)"],label="Jacobian Volume Assembly Total Time",marker="s",color="#00ffff",markersize=8)
+        plt.xlabel("Workset Size",fontsize=16)
+        plt.ylabel("Time (s)",fontsize=16)
+        plt.tick_params(labelsize=16)
+        title = "nel=%i,order=%i" % (nx*ny*nz,order)
+        plt.title(title)
+        #plt.legend(bbox_to_anchor=(1,1))
+        plt.legend(loc='upper center', bbox_to_anchor=(0.5,1.0),ncol=2,fancybox=True,shadow=True, prop={'size': 12})
+        plt.grid()
+        dag_timings_filename = "total_time_nx_%i_ny_%i_nz_%i_order_%i_ts_%i_vs_%i.png" % (nx, ny, nz ,order, ts, vs)
+        fig.savefig(dag_timings_filename)
+        #plt.show()
+            
+        fig = plt.figure(2)
+        #plt.clf()
+        plt.semilogy()
+        plt.plot(workset_range,timings["[panzer::Traits::Jacobian] Integrator_DivBasisTimesScalar (EVALUATES):  RESIDUAL_GRADPHI_FIELD"],label="Integrator DivBasisTimesScalar (eval)",marker='s')
+        plt.plot(workset_range,timings["[panzer::Traits::Jacobian] Integrator_DivBasisTimesScalar (CONTRIBUTES):  RESIDUAL_GRADPHI_FIELD"],label="Integrator DivBasisTimesScalar (contrib)",marker='^')
+        plt.plot(workset_range,timings["[panzer::Traits::Jacobian] Integrator_GradBasisDotVector (EVALUATES):  RESIDUAL_PHI_MASS_OP"],label="Integrator GradBasisDotVector (mass op)",marker='*')
+        plt.plot(workset_range,timings["[panzer::Traits::Jacobian] Integrator_GradBasisDotVector (EVALUATES):  RESIDUAL_PHI_DIFFUSION_OP"],label="Integrator GradBasisDotVector (diff op)",marker='D')
+        plt.plot(workset_range,timings["[panzer::Traits::Jacobian] DOF: GRADPHI_FIELD accel_jac  (panzer::Traits::Jacobian)"],label="DOF (GradPHI)",marker='+')
+        plt.plot(workset_range,timings["[panzer::Traits::Jacobian] DOFGradient: GRAD_PHI (panzer::Traits::Jacobian)"],label="DOFGradient (GradPhi)",marker='x')
+        #plt.plot(workset_range,timings["[panzer::Traits::Jacobian] DOFDiv: DIV_GRADPHI_FIELD (panzer::Traits::Jacobian)"],label="DOF Div (GradPhi)",marker='o')
+        #plt.plot(workset_range,timings[""],label="Res Scatter",marker='.',color="#ff6600")
+        plt.xlabel("Workset Size",fontsize=16)
+        plt.ylabel("Time (s)",fontsize=16)
+        plt.tick_params(labelsize=16)
+        plt.ylim(1.0e-4,1.0e1)
+        title = "nel=%i,order=%i" % (nx*ny*nz,order)
+        plt.title(title)
+        #plt.legend(bbox_to_anchor=(1,1))
+        plt.legend(loc='upper center', bbox_to_anchor=(0.5,0.25),ncol=2,fancybox=True,shadow=True, prop={'size': 10})
+        #plt.axis([0,2000,1.0e-4,0.1])
+        plt.grid()
+        res_evaluator_timings_filename = "kernel_timings_nx_%i_ny_%i_nz_%i_order_%i_ts_%i_vs_%i.png" % (nx, ny, nz, order, ts, vs)
+        fig.savefig(res_evaluator_timings_filename)
+
+        #print dir(plt)
+
+        # Plot to assess savings
+        count = 0;
+        for key,value in timings.iteritems():
+            filename_f = "raw_data_output_timer_%i_nx_%i_ny_%i_nz_%i_order_%i_ws_%i_ts_%i_vs_%i.csv" % (count, nx, ny, nz, order, ws, ts, vs)
+            write_file = open(filename_f,'w')
+            count += 1;
+            write_file.write(str(key)+"\n")
+            for i in range(len(workset_range)):
+                write_file.write(str(workset_range[i])+", "+str(timings[key][i])+"\n")
+        
+    print "Finished Workset Analysis"
+
+    if args.verbose:
+        print timings
+    
+
+        # f = open(filename, mode='r')
+        # lines = f.readlines()
+        # for line in lines:
+        #     print line,
+        #     split_line = line.split(" ")
+        #     print split_line[1]
+        # f.close()
+        
+
+    
+    #os.chdir('/Users')
+
+    # Write timestamp for backup
+    #os.chdir('/Users/rppawlo')
+    #timestamp_file = open('BACKUP_DATE', 'w')
+    #today = datetime.datetime.today()
+    #date = today.strftime("YYYY.MM.DD: %Y.%m.%d at HH.MM.SS: %H.%M.%S")
+    #timestamp_file.write(date)
+    #timestamp_file.close()
+    
+    print '****************************************'
+    print '* Finished Panzer Analysis!'
+    print '****************************************'
+    
+
+#############################################################################
+# If called from the command line, call main()
+#############################################################################
+
+if __name__ == "__main__":
+    main()

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/main.cpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/main.cpp
@@ -144,6 +144,10 @@ int main(int argc,char * argv[])
      int x_elements=10,y_elements=10,z_elements=10,hgrad_basis_order=1,hdiv_basis_order=1;
      std::string celltype = "Hex"; // or "Tet"
      std::string output_filename="output_";
+     int workset_size = 20;
+     bool use_shared_mem_for_ad = true;
+     bool check_order_for_shared_mem = true;
+     bool stacked_timer_output = true;
 
      Teuchos::CommandLineProcessor clp;
      clp.throwExceptions(false);
@@ -158,11 +162,31 @@ int main(int argc,char * argv[])
      clp.setOption("hgrad-basis-order",&hgrad_basis_order);
      clp.setOption("hdiv-basis-order",&hdiv_basis_order);
      clp.setOption("output-filename",&output_filename);
+     clp.setOption("workset-size",&workset_size);
+     clp.setOption("use-shared-mem-for-ad","no-use-shared-mem-for-ad",&use_shared_mem_for_ad);
+     clp.setOption("check-order","no-check-order",&check_order_for_shared_mem);
+     clp.setOption("stacked-timer-output","time-monitor-output",&stacked_timer_output);
 
      // parse commandline argument
      Teuchos::CommandLineProcessor::EParseCommandLineReturn r_parse= clp.parse( argc, argv );
      if (r_parse == Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED) return  0;
      if (r_parse != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL  ) return -1;
+
+     // cuda optimizations
+     ////////////////////////////////////////////////////
+     // Always use shared memory optimization for residual
+     // evaluation. For AD with FADs, we run out of shared memory on
+     // this problem for basis order 3 or higher. Disable shared mem
+     // use in this case.
+     if (check_order_for_shared_mem) {
+       if (std::max(hdiv_basis_order,hgrad_basis_order) > 2)
+	 use_shared_mem_for_ad = false;
+     }
+     panzer::HP::inst().setUseSharedMemory(true,use_shared_mem_for_ad);
+     if (use_shared_mem_for_ad)
+       out << "Use Shared Memory for AD: ON" << std::endl;
+     else
+       out << "Use Shared Memory for AD: OFF" << std::endl;
 
      // variable declarations
      ////////////////////////////////////////////////////
@@ -177,9 +201,6 @@ int main(int argc,char * argv[])
      else if (celltype == "Tet") mesh_factory = Teuchos::rcp(new panzer_stk::CubeTetMeshFactory);
      else
        throw std::runtime_error("not supported celltype argument: try Hex or Tet");
-
-     // other declarations
-     const std::size_t workset_size = 20;
 
      // construction of uncommitted (no elements) mesh
      ////////////////////////////////////////////////////////
@@ -332,7 +353,7 @@ int main(int argc,char * argv[])
         = Teuchos::rcp(new panzer::ResponseLibrary<panzer::Traits>(wkstContainer,dofManager,linObjFactory));
 
      {
-       const int integration_order = 10;
+       const int integration_order = 2 * std::max(hgrad_basis_order,hdiv_basis_order) + 1;
 
        std::vector<std::string> eBlocks;
        mesh->getElementBlockNames(eBlocks);
@@ -493,12 +514,17 @@ int main(int argc,char * argv[])
      }
 
      stackedTimer->stop("Mixed Poisson");
-     Teuchos::StackedTimer::OutputOptions options;
-     options.output_fraction = true;
-     options.output_minmax = true;
-     options.output_histogram = true;
-     options.num_histogram = 5;
-     stackedTimer->report(std::cout, Teuchos::DefaultComm<int>::getComm(), options);
+     if (stacked_timer_output) {
+       Teuchos::StackedTimer::OutputOptions options;
+       options.output_fraction = true;
+       options.output_minmax = true;
+       options.output_histogram = true;
+       options.num_histogram = 5;
+       stackedTimer->report(std::cout, Teuchos::DefaultComm<int>::getComm(), options);
+     }
+     else {
+       Teuchos::TimeMonitor::summarize(out,false,true,false,Teuchos::Union);
+     }
 
      // all done!
      /////////////////////////////////////////////////////////////
@@ -605,7 +631,7 @@ void testInitialization(const int hgrad_basis_order,
                         std::vector<panzer::BC>& bcs)
 {
   {
-    const int integration_order = 10;
+    const int integration_order = 2 * std::max(hgrad_basis_order,hdiv_basis_order) + 1;
     Teuchos::ParameterList& p = ipb->sublist("MixedPoisson Physics");
     p.set("Type","MixedPoisson");
     p.set("Model ID","solid");

--- a/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_HierarchicParallelism.cpp
@@ -48,7 +48,9 @@ namespace panzer {
     use_auto_team_size_(true),
     team_size_(-1),
     vector_size_(1),
-    fad_vector_size_(1)
+    fad_vector_size_(1),
+    use_shared_memory_(true),
+    fad_use_shared_memory_(false)
   {
 #if defined(SACADO_VIEW_CUDA_HIERARCHICAL_DFAD)
 #if defined(KOKKOS_ENABLE_CUDA)
@@ -71,6 +73,13 @@ namespace panzer {
     team_size_ = in_team_size;
     vector_size_ = in_vector_size;
     fad_vector_size_ = in_fad_vector_size;
+  }
+
+  void HP::setUseSharedMemory(const bool& in_use_shared_memory,
+			      const bool& in_fad_use_shared_memory)
+  {
+    use_shared_memory_ = in_use_shared_memory;
+    fad_use_shared_memory_ = in_fad_use_shared_memory;
   }
 
 }

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv.hpp
@@ -43,16 +43,16 @@
 #ifndef PANZER_EVALUATOR_DOF_DIV_DECL_HPP
 #define PANZER_EVALUATOR_DOF_DIV_DECL_HPP
 
-#include "Phalanx_Evaluator_Macros.hpp"
-#include "Phalanx_MDField.hpp"
 #include "Panzer_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_MDField.hpp"
 
 namespace panzer {
-    
+
 //! Interpolates basis DOF values to IP DOF Div values
-template<typename EvalT, typename TRAITS>                   
-class DOFDiv : public panzer::EvaluatorWithBaseImpl<TRAITS>,      
-                public PHX::EvaluatorDerived<EvalT, TRAITS>  {   
+template<typename EvalT, typename TRAITS>
+class DOFDiv : public panzer::EvaluatorWithBaseImpl<TRAITS>,
+	       public PHX::EvaluatorDerived<EvalT, TRAITS>  {
 public:
 
   DOFDiv(const Teuchos::ParameterList& p);
@@ -81,7 +81,7 @@ private:
   bool use_descriptors_;
   panzer::BasisDescriptor bd_;
   panzer::IntegrationDescriptor id_;
-  
+
   PHX::MDField<const ScalarT,Cell,Point> dof_value;
   PHX::MDField<ScalarT,Cell,IP> dof_div;
 
@@ -90,10 +90,10 @@ private:
 };
 
 // Specitialization for the Jacobian
-template<typename TRAITS>                   
-class DOFDiv<panzer::Traits::Jacobian,TRAITS> : 
-                public panzer::EvaluatorWithBaseImpl<TRAITS>,      
-                public PHX::EvaluatorDerived<panzer::Traits::Jacobian, TRAITS>  {   
+template<typename TRAITS>
+class DOFDiv<panzer::Traits::Jacobian,TRAITS> :
+                public panzer::EvaluatorWithBaseImpl<TRAITS>,
+                public PHX::EvaluatorDerived<panzer::Traits::Jacobian, TRAITS>  {
 public:
 
   DOFDiv(const Teuchos::ParameterList& p);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv_impl.hpp
@@ -46,54 +46,109 @@
 #include "Panzer_IntegrationRule.hpp"
 #include "Panzer_BasisIRLayout.hpp"
 #include "Panzer_Workset_Utilities.hpp"
-#include "Intrepid2_FunctionSpaceTools.hpp"
+#include "Panzer_HierarchicParallelism.hpp"
 
 namespace panzer {
 
-namespace {
-
 //**********************************************************************
-template<typename ScalarT,typename ArrayT>                   
-void evaluateDiv_withSens(int numCells,
-                          PHX::MDField<ScalarT,Cell,IP> & dof_div, 
-                          PHX::MDField<const ScalarT,Cell,Point> & dof_value,
-                          const ArrayT & div_basis)
-{ 
-  if(numCells>0) {
-    // evaluate at quadrature points
+template<typename ScalarT,typename ArrayT>
+class EvaluateDOFDiv_withSens {
+  PHX::MDField<ScalarT,Cell,IP> dof_div;
+  PHX::MDField<const ScalarT,Cell,Point> dof_value;
+  const ArrayT div_basis;
+  const int num_fields;
+  const int num_points;
+  const int fad_size;
+  const bool use_shared_memory;
 
-    int numFields = div_basis.extent(1);
-    int numPoints = div_basis.extent(2);
+public:
+  using scratch_view = Kokkos::View<ScalarT* ,typename PHX::exec_space::scratch_memory_space,Kokkos::MemoryUnmanaged>;
 
-    for (int cell=0; cell<numCells; cell++) {
-      for (int pt=0; pt<numPoints; pt++) {
-        // first initialize to the right thing (prevents over writing with 0)
-        // then loop over one less basis function
-        // ScalarT & div = dof_div(cell,pt);
-        dof_div(cell,pt) = dof_value(cell, 0) * div_basis(cell, 0, pt);
-        for (int bf=1; bf<numFields; bf++)
-          dof_div(cell,pt) += dof_value(cell, bf) * div_basis(cell, bf, pt);
+  EvaluateDOFDiv_withSens(PHX::MDField<ScalarT,Cell,IP> & in_dof_div,
+                          PHX::MDField<const ScalarT,Cell,Point> & in_dof_value,
+                          const ArrayT & in_div_basis,
+			  const bool in_use_shared_memory = false)
+    : dof_div(in_dof_div),
+      dof_value(in_dof_value),
+      div_basis(in_div_basis),
+      num_fields(static_cast<int>(div_basis.extent(1))),
+      num_points(static_cast<int>(div_basis.extent(2))),
+      fad_size(static_cast<int>(Kokkos::dimension_scalar(in_dof_div.get_view()))),
+      use_shared_memory(in_use_shared_memory)
+  {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
+  {
+    const int cell = team.league_rank();
+
+    if (use_shared_memory) {
+      // Copy reused data into fast scratch space
+      scratch_view dof_values(team.team_shmem(),num_fields,fad_size);
+      scratch_view point_values(team.team_shmem(),num_points,fad_size);
+
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_fields), [&] (const int& dof) {
+	dof_values(dof) = dof_value(cell,dof);
+      });
+
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points), [&] (const int& pt) {
+	point_values(pt) = 0.0;
+      });
+
+      team.team_barrier();
+
+      // Perform contraction
+      for (int dof=0; dof<num_fields; ++dof) {
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points), [&] (const int& pt) {
+	  point_values(pt) += dof_values(dof) * div_basis(cell,dof,pt);
+        });
       }
+
+      // Copy to main memory
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points), [&] (const int& pt) {
+	dof_div(cell,pt) = point_values(pt);
+      });
+    }
+    else {
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points), [&] (const int& pt) {
+	// first initialize to the right thing (prevents over writing with 0)
+	// then loop over one less basis function
+	// ScalarT & div = dof_div(cell,pt);
+	dof_div(cell,pt) = dof_value(cell, 0) * div_basis(cell, 0, pt);
+	for (int bf=1; bf<num_fields; bf++)
+	  dof_div(cell,pt) += dof_value(cell, bf) * div_basis(cell, bf, pt);
+      });
     }
   }
-}
+  size_t team_shmem_size(int team_size ) const
+  {
+    if (not use_shared_memory)
+      return 0;
 
-}
+    size_t bytes;
+    if (Sacado::IsADType<ScalarT>::value)
+      bytes = scratch_view::shmem_size(num_fields,fad_size) + scratch_view::shmem_size(num_points,fad_size);
+    else
+      bytes = scratch_view::shmem_size(num_fields) + scratch_view::shmem_size(num_points);
+    return bytes;
+  }
+
+};
 
 //**********************************************************************
 // MOST EVALUATION TYPES
 //**********************************************************************
 
 //**********************************************************************
-template<typename EvalT, typename TRAITS>                   
+template<typename EvalT, typename TRAITS>
 DOFDiv<EvalT, TRAITS>::
 DOFDiv(const Teuchos::ParameterList & p) :
   use_descriptors_(false),
-  dof_value( p.get<std::string>("Name"), 
+  dof_value( p.get<std::string>("Name"),
 	     p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
   basis_name(p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->name())
 {
-  Teuchos::RCP<const PureBasis> basis 
+  Teuchos::RCP<const PureBasis> basis
      = p.get< Teuchos::RCP<BasisIRLayout> >("Basis")->getBasis();
 
   // Verify that this basis supports the div operation
@@ -103,27 +158,27 @@ DOFDiv(const Teuchos::ParameterList & p) :
                              "DOFDiv: Basis of type \"" << basis->name() << "\" in DOF Div should require orientations. So we are throwing.");
 
   // build dof_div
-  dof_div = PHX::MDField<ScalarT,Cell,IP>(p.get<std::string>("Div Name"), 
+  dof_div = PHX::MDField<ScalarT,Cell,IP>(p.get<std::string>("Div Name"),
       	                                  p.get< Teuchos::RCP<panzer::IntegrationRule> >("IR")->dl_scalar );
 
   // add to evaluation graph
   this->addEvaluatedField(dof_div);
   this->addDependentField(dof_value);
-  
+
   std::string n = "DOFDiv: " + dof_div.fieldTag().name() + " ("+PHX::typeAsString<EvalT>()+")";
   this->setName(n);
 }
 
 //**********************************************************************
-template<typename EvalT, typename TRAITS>                   
+template<typename EvalT, typename TRAITS>
 DOFDiv<EvalT, TRAITS>::
 DOFDiv(const PHX::FieldTag & input,
        const PHX::FieldTag & output,
        const panzer::BasisDescriptor & bd,
        const panzer::IntegrationDescriptor & id)
   : use_descriptors_(true)
-  , bd_(bd) 
-  , id_(id) 
+  , bd_(bd)
+  , id_(id)
   , dof_value(input)
 {
   TEUCHOS_ASSERT(bd.getType()=="HDiv");
@@ -134,33 +189,36 @@ DOFDiv(const PHX::FieldTag & input,
   // add to evaluation graph
   this->addEvaluatedField(dof_div);
   this->addDependentField(dof_value);
-  
+
   std::string n = "DOFDiv: " + dof_div.fieldTag().name() + " ("+PHX::typeAsString<EvalT>()+")";
   this->setName(n);
 }
 
 //**********************************************************************
-template<typename EvalT, typename TRAITS>                   
+template<typename EvalT, typename TRAITS>
 void DOFDiv<EvalT, TRAITS>::
 postRegistrationSetup(typename TRAITS::SetupData sd,
                       PHX::FieldManager<TRAITS>& fm)
 {
-  this->utils.setFieldData(dof_value,fm);
-  this->utils.setFieldData(dof_div,fm);
-
   if(not use_descriptors_)
     basis_index = panzer::getBasisIndex(basis_name, (*sd.worksets_)[0], this->wda);
 }
 
 //**********************************************************************
-template<typename EvalT, typename TRAITS>                   
+template<typename EvalT, typename TRAITS>
 void DOFDiv<EvalT, TRAITS>::
 evaluateFields(typename TRAITS::EvalData workset)
-{ 
+{
+  if (workset.num_cells == 0)
+    return;
+
   const panzer::BasisValues2<double> & basisValues = use_descriptors_ ?  this->wda(workset).getBasisValues(bd_,id_)
                                                                       : *this->wda(workset).bases[basis_index];
 
-  evaluateDiv_withSens<ScalarT>(workset.num_cells,dof_div,dof_value,basisValues.div_basis);
+  const bool use_shared_memory = panzer::HP::inst().useSharedMemory<ScalarT>();
+  auto policy = panzer::HP::inst().teamPolicy<ScalarT,PHX::exec_space>(workset.num_cells);
+  auto f = EvaluateDOFDiv_withSens<ScalarT,typename panzer::BasisValues2<double>::Array_CellBasisIP>(dof_div,dof_value,basisValues.div_basis,use_shared_memory);
+  Kokkos::parallel_for(policy,f,this->getName());
 }
 
 //**********************************************************************
@@ -170,15 +228,15 @@ evaluateFields(typename TRAITS::EvalData workset)
 //**********************************************************************
 
 //**********************************************************************
-template<typename TRAITS>                   
+template<typename TRAITS>
 DOFDiv<panzer::Traits::Jacobian, TRAITS>::
 DOFDiv(const Teuchos::ParameterList & p) :
   use_descriptors_(false),
-  dof_value( p.get<std::string>("Name"), 
+  dof_value( p.get<std::string>("Name"),
 	     p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
   basis_name(p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->name())
 {
-  Teuchos::RCP<const PureBasis> basis 
+  Teuchos::RCP<const PureBasis> basis
      = p.get< Teuchos::RCP<BasisIRLayout> >("Basis")->getBasis();
 
   // do you specialize because you know where the basis functions are and can
@@ -198,27 +256,27 @@ DOFDiv(const Teuchos::ParameterList & p) :
                              "DOFDiv: Basis of type \"" << basis->name() << "\" in DOF Div should require orientations. So we are throwing.");
 
   // build dof_div
-  dof_div = PHX::MDField<ScalarT,Cell,IP>(p.get<std::string>("Div Name"), 
+  dof_div = PHX::MDField<ScalarT,Cell,IP>(p.get<std::string>("Div Name"),
       	                                  p.get< Teuchos::RCP<panzer::IntegrationRule> >("IR")->dl_scalar );
 
   // add to evaluation graph
   this->addEvaluatedField(dof_div);
   this->addDependentField(dof_value);
-  
+
   std::string n = "DOFDiv: " + dof_div.fieldTag().name() + " ("+PHX::typeAsString<panzer::Traits::Jacobian>()+")";
   this->setName(n);
 }
 
 //**********************************************************************
-template<typename TRAITS>                   
+template<typename TRAITS>
 DOFDiv<panzer::Traits::Jacobian, TRAITS>::
 DOFDiv(const PHX::FieldTag & input,
        const PHX::FieldTag & output,
        const panzer::BasisDescriptor & bd,
        const panzer::IntegrationDescriptor & id)
   : use_descriptors_(true)
-  , bd_(bd) 
-  , id_(id) 
+  , bd_(bd)
+  , id_(id)
   , dof_value(input)
 {
   TEUCHOS_ASSERT(bd.getType()=="HDiv");
@@ -231,13 +289,13 @@ DOFDiv(const PHX::FieldTag & input,
   // add to evaluation graph
   this->addEvaluatedField(dof_div);
   this->addDependentField(dof_value);
-  
+
   std::string n = "DOFDiv: " + dof_div.fieldTag().name() + " ("+PHX::typeAsString<panzer::Traits::Jacobian>()+")";
   this->setName(n);
 }
 
 //**********************************************************************
-template<typename TRAITS>                   
+template<typename TRAITS>
 void DOFDiv<panzer::Traits::Jacobian, TRAITS>::
 postRegistrationSetup(typename TRAITS::SetupData sd,
                       PHX::FieldManager<TRAITS>& fm)
@@ -249,16 +307,21 @@ postRegistrationSetup(typename TRAITS::SetupData sd,
     basis_index = panzer::getBasisIndex(basis_name, (*sd.worksets_)[0], this->wda);
 }
 
-template<typename TRAITS>                   
+template<typename TRAITS>
 void DOFDiv<panzer::Traits::Jacobian,TRAITS>::
 evaluateFields(typename TRAITS::EvalData workset)
-{ 
+{
+  if (workset.num_cells == 0)
+    return;
+
   const panzer::BasisValues2<double> & basisValues = use_descriptors_ ?  this->wda(workset).getBasisValues(bd_,id_)
                                                                       : *this->wda(workset).bases[basis_index];
 
   if(!accelerate_jacobian) {
-    // do the case where we use the AD types to determine the derivatives
-    evaluateDiv_withSens(workset.num_cells,dof_div,dof_value,basisValues.div_basis);
+    const bool use_shared_memory = panzer::HP::inst().useSharedMemory<ScalarT>();
+    auto policy = panzer::HP::inst().teamPolicy<ScalarT,PHX::exec_space>(workset.num_cells);
+    auto f = EvaluateDOFDiv_withSens<ScalarT,typename panzer::BasisValues2<double>::Array_CellBasisIP>(dof_div,dof_value,basisValues.div_basis,use_shared_memory);
+    Kokkos::parallel_for(policy,f,this->getName());
     return;
   }
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFGradient_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFGradient_impl.hpp
@@ -46,43 +46,98 @@
 #include "Panzer_IntegrationRule.hpp"
 #include "Panzer_BasisIRLayout.hpp"
 #include "Panzer_Workset_Utilities.hpp"
+#include "Panzer_HierarchicParallelism.hpp"
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
 namespace panzer {
 
 namespace {
 
-template <typename ScalarT,typename ArrayT>
-struct evaluateGrad_withSens {
-  evaluateGrad_withSens (PHX::MDField<ScalarT> dof_grad,
-      PHX::MDField<const ScalarT,Cell,Point> dof_value,
-      const ArrayT  grad_basis) :
-        dof_grad_(dof_grad),dof_value_(dof_value),grad_basis_(grad_basis)
-      {}
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const size_t &cell) const
-  {
-    // evaluate at quadrature points
-    int numFields = grad_basis_.extent(1);
-    int numPoints = grad_basis_.extent(2);
-    int spaceDim  = grad_basis_.extent(3);
-    for (int pt=0; pt<numPoints; pt++) {
-      for (int d=0; d<spaceDim; d++) {
-        // first initialize to the right thing (prevents over writing with 0)
-        // then loop over one less basis function
-        dof_grad_(cell,pt,d) = dof_value_(cell, 0) * grad_basis_(cell, 0, pt, d);
-        for (int bf=1; bf<numFields; bf++)
-          dof_grad_(cell,pt,d) += dof_value_(cell, bf) * grad_basis_(cell, bf, pt, d);
+  template <typename ScalarT,typename ArrayT>
+  struct evaluateGrad_withSens {
+    using exec_space = typename PHX::exec_space;
+    using scratch_view = Kokkos::View<ScalarT*,typename exec_space::scratch_memory_space,Kokkos::MemoryUnmanaged>;
+    using team_policy = Kokkos::TeamPolicy<exec_space>::member_type;
+
+    PHX::MDField<ScalarT>  dof_grad_;
+    PHX::MDField<const ScalarT,Cell,Point>  dof_value_;
+    const ArrayT grad_basis_;
+    const int num_fields_;
+    const int num_points_;
+    const int space_dim_;
+    const int fad_size_;
+    const bool use_shared_memory_;
+
+    evaluateGrad_withSens(PHX::MDField<ScalarT> dof_grad,
+			  PHX::MDField<const ScalarT,Cell,Point> dof_value,
+			  const ArrayT  grad_basis,
+			  const bool use_shared_memory) :
+      dof_grad_(dof_grad),
+      dof_value_(dof_value),
+      grad_basis_(grad_basis),
+      num_fields_(grad_basis.extent(1)),
+      num_points_(grad_basis.extent(2)),
+      space_dim_(grad_basis.extent(3)),
+      fad_size_(Kokkos::dimension_scalar(dof_grad.get_view())),
+      use_shared_memory_(use_shared_memory) {}
+
+    KOKKOS_INLINE_FUNCTION
+    void operator() (const team_policy& team) const
+    {
+      const int cell = team.league_rank();
+
+      if (not use_shared_memory_) {
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points_), [&] (const int& pt) {
+	  for (int d=0; d<space_dim_; ++d) {
+	    // first initialize to the right thing (prevents over writing with 0)
+	    // then loop over one less basis function
+	    dof_grad_(cell,pt,d) = dof_value_(cell, 0) * grad_basis_(cell, 0, pt, d);
+	    for (int bf=1; bf<num_fields_; ++bf)
+	      dof_grad_(cell,pt,d) += dof_value_(cell, bf) * grad_basis_(cell, bf, pt, d);
+	  }
+	});
+      } else {
+	scratch_view dof_values(team.team_shmem(),num_fields_,fad_size_);
+	scratch_view point_values(team.team_shmem(),num_points_,fad_size_);
+
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_fields_), [&] (const int& dof) {
+	  dof_values(dof) = dof_value_(cell,dof);
+	});
+	team.team_barrier();
+
+	for (int dim=0; dim < space_dim_; ++dim) {
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points_), [&] (const int& pt) {
+	    point_values(pt) = 0.0;
+	  });
+	  // Perform contraction
+	  for (int dof=0; dof<num_fields_; ++dof) {
+	    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points_), [&] (const int& pt) {
+	      point_values(pt) += dof_values(dof) * grad_basis_(cell,dof,pt,dim);
+	    });
+	  }
+	  // Copy to main memory
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_points_), [&] (const int& pt) {
+	    dof_grad_(cell,pt,dim) = point_values(pt);
+	  });
+	} // loop over dim
       }
     }
-  }
-  PHX::MDField<ScalarT>  dof_grad_;
-  PHX::MDField<const ScalarT,Cell,Point>  dof_value_;
-  const ArrayT grad_basis_;
 
-};
+    size_t team_shmem_size(int team_size ) const
+    {
+      if (not use_shared_memory_)
+	return 0;
 
-}
+      size_t bytes;
+      if (Sacado::IsADType<ScalarT>::value)
+	bytes = scratch_view::shmem_size(num_fields_,fad_size_) + scratch_view::shmem_size(num_points_,fad_size_);
+      else
+	bytes = scratch_view::shmem_size(num_fields_) + scratch_view::shmem_size(num_points_);
+      return bytes;
+    }
+  };
+
+} // anonymous namespace
 
 //**********************************************************************
 template<typename EvalT, typename Traits>
@@ -90,13 +145,13 @@ DOFGradient<EvalT, Traits>::
 DOFGradient(
   const Teuchos::ParameterList& p) :
   use_descriptors_(false),
-  dof_value( p.get<std::string>("Name"), 
+  dof_value( p.get<std::string>("Name"),
 	     p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->functional),
-  dof_gradient( p.get<std::string>("Gradient Name"), 
+  dof_gradient( p.get<std::string>("Gradient Name"),
 		p.get< Teuchos::RCP<panzer::IntegrationRule> >("IR")->dl_vector ),
   basis_name(p.get< Teuchos::RCP<panzer::BasisIRLayout> >("Basis")->name())
 {
-  Teuchos::RCP<const PureBasis> basis 
+  Teuchos::RCP<const PureBasis> basis
      = p.get< Teuchos::RCP<BasisIRLayout> >("Basis")->getBasis();
 
   // Verify that this basis supports the gradient operation
@@ -105,21 +160,21 @@ DOFGradient(
 
   this->addEvaluatedField(dof_gradient);
   this->addDependentField(dof_value);
-  
+
   std::string n = "DOFGradient: " + dof_gradient.fieldTag().name() + " ("+PHX::typeAsString<EvalT>()+")";
   this->setName(n);
 }
 
 //**********************************************************************
-template<typename EvalT, typename TRAITS>                   
+template<typename EvalT, typename TRAITS>
 DOFGradient<EvalT, TRAITS>::
 DOFGradient(const PHX::FieldTag & input,
             const PHX::FieldTag & output,
             const panzer::BasisDescriptor & bd,
             const panzer::IntegrationDescriptor & id)
   : use_descriptors_(true)
-  , bd_(bd) 
-  , id_(id) 
+  , bd_(bd)
+  , id_(id)
   , dof_value(input)
   , dof_gradient(output)
 {
@@ -129,7 +184,7 @@ DOFGradient(const PHX::FieldTag & input,
 
   this->addEvaluatedField(dof_gradient);
   this->addDependentField(dof_value);
-  
+
   std::string n = "DOFGradient: " + dof_gradient.fieldTag().name() + " ("+PHX::typeAsString<EvalT>()+")";
   this->setName(n);
 }
@@ -142,9 +197,6 @@ postRegistrationSetup(
   typename Traits::SetupData sd,
   PHX::FieldManager<Traits>& fm)
 {
-  this->utils.setFieldData(dof_value,fm);
-  this->utils.setFieldData(dof_gradient,fm);
-
   if(not use_descriptors_)
     basis_index = panzer::getBasisIndex(basis_name, (*sd.worksets_)[0], this->wda);
 }
@@ -153,19 +205,19 @@ postRegistrationSetup(
 template<typename EvalT, typename Traits>
 void
 DOFGradient<EvalT, Traits>::
-evaluateFields(
-  typename Traits::EvalData workset)
-{ 
-  if (workset.num_cells == 0 )
+evaluateFields(typename Traits::EvalData workset)
+{
+  if (workset.num_cells == 0)
     return;
 
   const panzer::BasisValues2<double> & basisValues = use_descriptors_ ?  this->wda(workset).getBasisValues(bd_,id_)
                                                                       : *this->wda(workset).bases[basis_index];
 
   typedef decltype(basisValues.grad_basis) ArrayT;
-
-  evaluateGrad_withSens<ScalarT, ArrayT> eval(dof_gradient,dof_value,basisValues.grad_basis);
-  Kokkos::parallel_for(workset.num_cells, eval);
+  bool use_shared_memory = panzer::HP::inst().useSharedMemory<ScalarT>();
+  evaluateGrad_withSens<ScalarT, ArrayT> eval(dof_gradient,dof_value,basisValues.grad_basis,use_shared_memory);
+  auto policy = panzer::HP::inst().teamPolicy<ScalarT,PHX::Device>(workset.num_cells);
+  Kokkos::parallel_for(policy, eval, "panzer::DOFGradient::evaluateFields");
 }
 
 //**********************************************************************

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_Functors.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_Functors.hpp
@@ -58,38 +58,91 @@ class EvaluateDOFWithSens_Vector {
   PHX::View<const ScalarT**> dof_basis; // <C,P>
   PHX::View<ScalarT***> dof_ip; // <C,P,D>
   Array basis;
-
-  int numFields;
-  int numPoints;
+  const int numFields;
+  const int numPoints;
+  const int fadSize;
+  const bool use_shared_memory;
 
 public:
-  typedef typename PHX::Device execution_space;
+  //using scratch_view = Kokkos::View<ScalarT* ,typename PHX::exec_space::scratch_memory_space,typename PHX::DevLayout<ScalarT>::type,Kokkos::MemoryUnmanaged>;
+  using scratch_view = Kokkos::View<ScalarT* ,typename PHX::exec_space::scratch_memory_space,Kokkos::MemoryUnmanaged>;
 
   EvaluateDOFWithSens_Vector(PHX::View<const ScalarT**> in_dof_basis,
                              PHX::View<ScalarT***> in_dof_ip,
-                             Array in_basis) 
-    : dof_basis(in_dof_basis), dof_ip(in_dof_ip), basis(in_basis)
-  {
-    numFields = static_cast<int>(basis.extent(1));
-    numPoints = static_cast<int>(basis.extent(2));
-  }
+                             Array in_basis,
+			     bool in_use_shared_memory = false)
+    : dof_basis(in_dof_basis), dof_ip(in_dof_ip), basis(in_basis),
+      numFields(static_cast<int>(basis.extent(1))),
+      numPoints(static_cast<int>(basis.extent(2))),
+      fadSize(static_cast<int>(Kokkos::dimension_scalar(dof_basis))),
+      use_shared_memory(in_use_shared_memory)
+  {}
+
   KOKKOS_INLINE_FUNCTION
   void operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
   {
     const int cell = team.league_rank();
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numPoints),KOKKOS_LAMBDA (const int& pt) {
-      for (int d=0; d<spaceDim; ++d) {
-        // first initialize to the right thing (prevents over writing with 0)
-        // then loop over one less basis function
-        dof_ip(cell,pt,d) = dof_basis(cell, 0) * basis(cell, 0, pt, d);
-	// The start index is one, not zero since we used the zero index for initialization above.
-	for (int bf=1; bf<numFields; ++bf) {
-          dof_ip(cell,pt,d) += dof_basis(cell, bf) * basis(cell, bf, pt, d);
+    if (not use_shared_memory) {
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numPoints), [&] (const int& pt) {
+	for (int d=0; d<spaceDim; ++d) {
+	  // first initialize to the right thing (prevents over writing with 0)
+	  // then loop over one less basis function
+	  dof_ip(cell,pt,d) = dof_basis(cell, 0) * basis(cell, 0, pt, d);
+	  // The start index is one, not zero since we used the zero index for initialization above.
+	  for (int bf=1; bf<numFields; ++bf) {
+	    dof_ip(cell,pt,d) += dof_basis(cell, bf) * basis(cell, bf, pt, d);
+	  }
 	}
-      }
-    });
+      });
+    }
+    else {
+
+      // Copy reused data into fast scratch space
+      scratch_view dof_values(team.team_shmem(),numFields,fadSize);
+      scratch_view point_values(team.team_shmem(),numPoints,fadSize);
+
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numFields), [&] (const int& dof) {
+	dof_values(dof) = dof_basis(cell,dof);
+      });
+
+      team.team_barrier();
+
+      for (int dim=0; dim < spaceDim; ++dim) {
+
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numPoints), [&] (const int& pt) {
+	  point_values(pt) = 0.0;
+	});
+
+	// Perform contraction
+	for (int dof=0; dof<numFields; ++dof) {
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numPoints), [&] (const int& pt) {
+	    point_values(pt) += dof_values(dof) * basis(cell,dof,pt,dim);
+          });
+	}
+
+	// Copy to main memory
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numPoints), [&] (const int& pt) {
+	  dof_ip(cell,pt,dim) = point_values(pt);
+        });
+
+      } // loop over dim
+    } // if (use_shared_memory) {
   }
+
+  size_t team_shmem_size(int team_size ) const
+  {
+    if (not use_shared_memory)
+      return 0;
+
+    size_t bytes;
+    if (Sacado::IsADType<ScalarT>::value)
+      bytes = scratch_view::shmem_size(numFields,fadSize) + scratch_view::shmem_size(numPoints,fadSize);
+    else
+      bytes = scratch_view::shmem_size(numFields) + scratch_view::shmem_size(numPoints);
+    return bytes;
+  }
+
 };
 
 template <typename ScalarT, typename Array>
@@ -106,7 +159,7 @@ public:
 
   EvaluateDOFWithSens_Scalar(PHX::MDField<const ScalarT,Cell,Point> in_dof_basis,
                              PHX::MDField<ScalarT,Cell,Point> in_dof_ip,
-                             Array in_basis) 
+                             Array in_basis)
     : dof_basis(in_dof_basis), dof_ip(in_dof_ip), basis(in_basis)
   {
     numFields = basis.extent(1);
@@ -133,8 +186,8 @@ class EvaluateDOFFastSens_Vector {
   Kokkos::View<const int*,PHX::Device> offsets;
   Array basis;
 
-  int numFields;
-  int numPoints;
+  const int numFields;
+  const int numPoints;
 
 public:
   typedef typename PHX::Device execution_space;
@@ -142,12 +195,12 @@ public:
   EvaluateDOFFastSens_Vector(PHX::MDField<const ScalarT,Cell,Point> in_dof_basis,
                              PHX::MDField<ScalarT,Cell,Point,Dim> in_dof_ip,
                              Kokkos::View<const int*,PHX::Device> in_offsets,
-                             Array in_basis) 
-    : dof_basis(in_dof_basis), dof_ip(in_dof_ip), offsets(in_offsets), basis(in_basis)
-  {
-    numFields = basis.extent(1);
-    numPoints = basis.extent(2);
-  }
+                             Array in_basis)
+    : dof_basis(in_dof_basis), dof_ip(in_dof_ip), offsets(in_offsets), basis(in_basis),
+      numFields(in_basis.extent(1)),
+      numPoints(in_basis.extent(2))
+  {}
+
   KOKKOS_INLINE_FUNCTION
   void operator()(const unsigned int cell) const
   {
@@ -188,7 +241,7 @@ public:
   EvaluateDOFFastSens_Scalar(PHX::MDField<const ScalarT,Cell,Point> in_dof_basis,
                              PHX::MDField<ScalarT,Cell,Point> in_dof_ip,
                              Kokkos::View<const int*,PHX::Device> in_offsets,
-                             Array in_basis) 
+                             Array in_basis)
     : dof_basis(in_dof_basis), dof_ip(in_dof_ip), offsets(in_offsets), basis(in_basis)
   {
     numFields = basis.extent(1);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar.hpp
@@ -213,7 +213,16 @@ namespace panzer
       }; // end of struct FieldMultTag
 
       /**
-       *  \brief Perform the integration.
+       *  \brief This empty struct allows us to optimize `operator()()`
+       *         depending on the number of field multipliers.
+       */
+      template<int NUM_FIELD_MULT>
+      struct SharedFieldMultTag
+      {
+      }; // end of struct FieldMultTag
+
+      /**
+       *  \brief Perform the integration. Main memory version.
        *
        *  Generally speaking, for a given cell in the `Workset`, this routine
        *  loops over quadrature points and bases to perform the integration,
@@ -234,6 +243,28 @@ namespace panzer
         const FieldMultTag<NUM_FIELD_MULT>& tag,
         const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;
 
+      /**
+       *  \brief Perform the integration. Shared memory version.
+       *
+       *  Generally speaking, for a given cell in the `Workset`, this routine
+       *  loops over quadrature points and bases to perform the integration,
+       *  scaling the vector field to be integrated by the multiplier (\f$ M
+       *  \f$) and any field multipliers (\f$ a(x) \f$, \f$ b(x) \f$, etc.).
+       *
+       *  \note Optimizations are made for the cases in which we have no field
+       *        multipliers or only a single one.
+       *
+       *  \param[in] tag  An indication of the number of field multipliers we
+       *                  have; either 0, 1, or something else.
+       *  \param[in] cell The cell in the `Workset` over which to integrate.
+       */
+      template<int NUM_FIELD_MULT>
+      KOKKOS_INLINE_FUNCTION
+      void
+      operator()(
+        const SharedFieldMultTag<NUM_FIELD_MULT>& tag,
+        const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;
+
     private:
 
       /**
@@ -252,6 +283,9 @@ namespace panzer
        *  \brief The scalar type.
        */
       using ScalarT = typename EvalT::ScalarT;
+
+      /// Type for shared memory
+      using scratch_view = Kokkos::View<ScalarT* ,typename PHX::exec_space::scratch_memory_space,Kokkos::MemoryUnmanaged>;
 
       /**
        *  \brief An `enum` determining the behavior of this `Evaluator`.
@@ -314,6 +348,11 @@ namespace panzer
        *  \brief The scalar basis information necessary for integration.
        */
       PHX::MDField<double, panzer::Cell, panzer::BASIS, panzer::IP> basis_;
+
+      /**
+       * \brief If set to true, device shared memory will be used.
+       */
+      bool use_shared_memory;
 
   }; // end of class Integrator_DivBasisTimesScalar
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar_impl.hpp
@@ -82,7 +82,8 @@ namespace panzer
     :
     evalStyle_(evalStyle),
     multiplier_(multiplier),
-    basisName_(basis.name())
+    basisName_(basis.name()),
+    use_shared_memory(false)
   {
     using Kokkos::View;
     using panzer::BASIS;
@@ -200,7 +201,7 @@ namespace panzer
 
   /////////////////////////////////////////////////////////////////////////////
   //
-  //  operator()()
+  //  No shared memory operator()()
   //
   /////////////////////////////////////////////////////////////////////////////
   template<typename EvalT, typename Traits>
@@ -274,6 +275,98 @@ namespace panzer
 
   /////////////////////////////////////////////////////////////////////////////
   //
+  //  Shared memory operator()()
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  template<int NUM_FIELD_MULT>
+  KOKKOS_INLINE_FUNCTION
+  void
+  Integrator_DivBasisTimesScalar<EvalT, Traits>::
+  operator()(
+    const SharedFieldMultTag<NUM_FIELD_MULT>& /* tag */,
+    const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
+  {
+    using panzer::EvaluatorStyle;
+    const int cell = team.league_rank();
+    const int numQP = scalar_.extent(1);
+    const int numBases = basis_.extent(1);
+    const int fadSize = Kokkos::dimension_scalar(field_.get_view());
+
+    scratch_view tmp(team.team_shmem(),1,fadSize);
+    scratch_view tmp_field(team.team_shmem(),numBases,fadSize);
+
+    // Initialize the evaluated field.
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+      tmp_field(basis) = 0.0;
+    });
+
+    // The following if-block is for the sake of optimization depending on the
+    // number of field multipliers.
+    if (NUM_FIELD_MULT == 0)
+    {
+      // Loop over the quadrature points, scale the integrand by the
+      // multiplier, and then perform the actual integration, looping over the
+      // bases.
+      for (int qp(0); qp < numQP; ++qp)
+      {
+	team.team_barrier();
+	tmp(0) = multiplier_ * scalar_(cell, qp);
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+	  tmp_field(basis) += basis_(cell, basis, qp) * tmp(0);
+	});
+      } // end loop over the quadrature points
+    }
+    else if (NUM_FIELD_MULT == 1)
+    {
+      // Loop over the quadrature points, scale the integrand by the multiplier
+      // and the single field multiplier, and then perform the actual
+      // integration, looping over the bases.
+      for (int qp(0); qp < numQP; ++qp)
+      {
+	team.team_barrier();
+        tmp(0) = multiplier_ * scalar_(cell, qp) * kokkosFieldMults_(0)(cell, qp);
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+	  tmp_field(basis) += basis_(cell, basis, qp) * tmp(0);
+	});
+      } // end loop over the quadrature points
+    }
+    else
+    {
+      // Loop over the quadrature points and pre-multiply all the field
+      // multipliers together, scale the integrand by the multiplier and the
+      // combination of field multipliers, and then perform the actual
+      // integration, looping over the bases.
+      const int numFieldMults = kokkosFieldMults_.extent(0);
+      for (int qp(0); qp < numQP; ++qp)
+      {
+	team.team_barrier();
+        ScalarT fieldMultsTotal(1); // need shared mem here
+        for (int fm(0); fm < numFieldMults; ++fm)
+          fieldMultsTotal *= kokkosFieldMults_(fm)(cell, qp);
+        tmp(0) = multiplier_ * scalar_(cell, qp) * fieldMultsTotal;
+	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+	  tmp_field(basis) += basis_(cell, basis, qp) * tmp(0);
+	});
+      } // end loop over the quadrature points
+    } // end if (NUM_FIELD_MULT == something)
+
+    // Put final values into target field
+    if (evalStyle_ == EvaluatorStyle::EVALUATES) {
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),[&] (const int& basis) {
+	field_(cell,basis) = tmp_field(basis);
+      });
+    }
+    else { // Contributed
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),[&] (const int& basis) {
+	field_(cell,basis) += tmp_field(basis);
+      });
+    }
+
+  } // end of operator()
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
   //  evaluateFields()
   //
   /////////////////////////////////////////////////////////////////////////////
@@ -289,18 +382,45 @@ namespace panzer
     // Grab the basis information.
     basis_ = this->wda(workset).bases[basisIndex_]->weighted_div_basis;
 
-    // The following if-block is for the sake of optimization depending on the
-    // number of field multipliers.  The parallel_fors will loop over the cells
-    // in the Workset and execute operator()() above.
-    if (fieldMults_.size() == 0) {
-      auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<0>,PHX::Device>(workset.num_cells);
-      parallel_for(policy, *this);
-    } else if (fieldMults_.size() == 1) {
-      auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<1>,PHX::Device>(workset.num_cells);
-      parallel_for(policy, *this);
-    } else {
-      auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<-1>,PHX::Device>(workset.num_cells);
-      parallel_for(policy, *this);
+    use_shared_memory = panzer::HP::inst().useSharedMemory<ScalarT>();
+
+    if (use_shared_memory) {
+      int bytes;
+      if (Sacado::IsADType<ScalarT>::value) {
+	const int fadSize = Kokkos::dimension_scalar(field_.get_view());
+	bytes = scratch_view::shmem_size(1,fadSize) + scratch_view::shmem_size(basis_.extent(1),fadSize);
+      }
+      else
+	bytes = scratch_view::shmem_size(1) + scratch_view::shmem_size(basis_.extent(1));
+
+      // The following if-block is for the sake of optimization depending on the
+      // number of field multipliers.  The parallel_fors will loop over the cells
+      // in the Workset and execute operator()() above.
+      if (fieldMults_.size() == 0) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<0>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+	parallel_for(policy, *this, this->getName());
+      } else if (fieldMults_.size() == 1) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<1>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+	parallel_for(policy, *this, this->getName());
+      } else {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<-1>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+	parallel_for(policy, *this, this->getName());
+      }
+    }
+    else {
+      // The following if-block is for the sake of optimization depending on the
+      // number of field multipliers.  The parallel_fors will loop over the cells
+      // in the Workset and execute operator()() above.
+      if (fieldMults_.size() == 0) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<0>,PHX::Device>(workset.num_cells);
+	parallel_for(policy, *this, this->getName());
+      } else if (fieldMults_.size() == 1) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<1>,PHX::Device>(workset.num_cells);
+	parallel_for(policy, *this, this->getName());
+      } else {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<-1>,PHX::Device>(workset.num_cells);
+	parallel_for(policy, *this, this->getName());
+      }
     }
   } // end of evaluateFields()
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_decl.hpp
@@ -211,13 +211,21 @@ namespace panzer
         typename Traits::EvalData d);
 
       /**
-       *  \brief This empty struct allows us to optimize `operator()()`
-       *         depending on the number of field multipliers.
+       *  \brief This empty struct allows us to optimize
+       *         `operator()()` depending on the number of field
+       *         multipliers. This is the version that does not use
+       *         shared memory.
        */
       template<int NUM_FIELD_MULT>
-      struct FieldMultTag
-      {
-      }; // end of struct FieldMultTag
+      struct FieldMultTag {};
+
+      /**
+       *  \brief This empty struct allows us to optimize
+       *         `operator()()` depending on the number of field
+       *         multipliers. This is the shared memory version.
+       */
+      template<int NUM_FIELD_MULT>
+      struct SharedFieldMultTag {};
 
       /**
        *  \brief Perform the integration.
@@ -242,6 +250,29 @@ namespace panzer
         const FieldMultTag<NUM_FIELD_MULT>& tag,
         const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;
 
+      /**
+       *  \brief Perform the integration.
+       *
+       *  Generally speaking, for a given cell in the `Workset`, this routine
+       *  loops over quadrature points, vector dimensions, and bases to perform
+       *  the integration, scaling the vector field to be integrated by the
+       *  multiplier (\f$ M \f$) and any field multipliers (\f$ a(x) \f$, \f$
+       *  b(x) \f$, etc.). Uses Shared memory.
+       *
+       *  \note Optimizations are made for the cases in which we have no field
+       *        multipliers or only a single one.
+       *
+       *  \param[in] tag  An indication of the number of field multipliers we
+       *                  have; either 0, 1, or something else.
+       *  \param[in] cell The cell in the `Workset` over which to integrate.
+       */
+      template<int NUM_FIELD_MULT>
+      KOKKOS_INLINE_FUNCTION
+      void
+      operator()(
+        const SharedFieldMultTag<NUM_FIELD_MULT>& tag,
+        const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const;
+
     private:
 
       /**
@@ -261,6 +292,9 @@ namespace panzer
        *  \brief The scalar type.
        */
       using ScalarT = typename EvalT::ScalarT;
+
+      /// Type for shared memory
+      using scratch_view = Kokkos::View<ScalarT* ,typename PHX::exec_space::scratch_memory_space,Kokkos::MemoryUnmanaged>;
 
       /**
        *  \brief An `enum` determining the behavior of this `Evaluator`.

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
@@ -204,7 +204,7 @@ namespace panzer
 
   /////////////////////////////////////////////////////////////////////////////
   //
-  //  operator()()
+  //  operator()() NO shared memory
   //
   /////////////////////////////////////////////////////////////////////////////
   template<typename EvalT, typename Traits>
@@ -289,6 +289,110 @@ namespace panzer
 
   /////////////////////////////////////////////////////////////////////////////
   //
+  //  operator()() With shared memory
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  template<int NUM_FIELD_MULT>
+  KOKKOS_INLINE_FUNCTION
+  void
+  Integrator_GradBasisDotVector<EvalT, Traits>::
+  operator()(
+    const SharedFieldMultTag<NUM_FIELD_MULT>& /* tag */,
+    const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
+  {
+    using panzer::EvaluatorStyle;
+    const int cell = team.league_rank();
+    const int numQP = vector_.extent(1);
+    const int numDim = vector_.extent(2);
+    const int numBases = basis_.extent(1);
+    const int fadSize = Kokkos::dimension_scalar(field_.get_view());
+
+    scratch_view tmp(team.team_shmem(),1,fadSize);
+    scratch_view tmp_field(team.team_shmem(),numBases,fadSize);
+
+    // Initialize the evaluated field.
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+      tmp_field(basis) = 0.0;
+    });
+
+    // The following if-block is for the sake of optimization depending on the
+    // number of field multipliers.
+    if (NUM_FIELD_MULT == 0)
+    {
+      // Loop over the quadrature points and dimensions of our vector fields,
+      // scale the integrand by the multiplier, and then perform the
+      // integration, looping over the bases.
+      for (int qp(0); qp < numQP; ++qp)
+      {
+        for (int dim(0); dim < numDim; ++dim)
+        {
+	  team.team_barrier();
+          tmp(0) = multiplier_ * vector_(cell, qp, dim);
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+	    tmp_field(basis) += basis_(cell, basis, qp, dim) * tmp(0);
+	  });
+        } // end loop over the dimensions of the vector field
+      } // end loop over the quadrature points
+    }
+    else if (NUM_FIELD_MULT == 1)
+    {
+      // Loop over the quadrature points and dimensions of our vector fields,
+      // scale the integrand by the multiplier and the single field multiplier,
+      // and then perform the actual integration, looping over the bases.
+      for (int qp(0); qp < numQP; ++qp)
+      {
+        for (int dim(0); dim < numDim; ++dim)
+        {
+	  team.team_barrier();
+          tmp(0) = multiplier_ * vector_(cell, qp, dim) *
+            kokkosFieldMults_(0)(cell, qp);
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+	      tmp_field(basis) += basis_(cell, basis, qp, dim) * tmp(0);
+	  });
+        } // end loop over the dimensions of the vector field
+      } // end loop over the quadrature points
+    }
+    else
+    {
+      // Loop over the quadrature points and pre-multiply all the field
+      // multipliers together.  Then loop over the dimensions of our vector
+      // fields, scale the integrand by the multiplier and the combination of
+      // the field multipliers, and then perform the actual integration,
+      // looping over the bases.
+      const int numFieldMults(kokkosFieldMults_.extent(0));
+      for (int qp(0); qp < numQP; ++qp)
+      {
+        ScalarT fieldMultsTotal(1); // need shared mem here
+        for (int fm(0); fm < numFieldMults; ++fm)
+          fieldMultsTotal *= kokkosFieldMults_(fm)(cell, qp);
+        for (int dim(0); dim < numDim; ++dim)
+        {
+	  team.team_barrier();
+          tmp(0) = multiplier_ * vector_(cell, qp, dim) * fieldMultsTotal;
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {
+	    tmp_field(basis) += basis_(cell, basis, qp, dim) * tmp(0);
+	  });
+        } // end loop over the dimensions of the vector field
+      } // end loop over the quadrature points
+    } // end if (NUM_FIELD_MULT == something)
+
+    // Put final values into target field
+    if (evalStyle_ == EvaluatorStyle::EVALUATES) {
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),[&] (const int& basis) {
+	field_(cell,basis) = tmp_field(basis);
+      });
+    }
+    else { // Contributed
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),[&] (const int& basis) {
+	field_(cell,basis) += tmp_field(basis);
+      });
+    }
+
+  } // end of operator()()
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
   //  evaluateFields()
   //
   /////////////////////////////////////////////////////////////////////////////
@@ -304,16 +408,45 @@ namespace panzer
     // Grab the basis information.
     basis_ = this->wda(workset).bases[basisIndex_]->weighted_grad_basis;
 
-    // The following if-block is for the sake of optimization depending on the
-    // number of field multipliers.  The parallel_fors will loop over the cells
-    // in the Workset and execute operator()() above.
-    const int vector_size = panzer::HP::inst().vectorSize<ScalarT>();
-    if (fieldMults_.size() == 0)
-      parallel_for(TeamPolicy<FieldMultTag<0>,PHX::Device>(workset.num_cells,Kokkos::AUTO(),vector_size), *this);
-    else if (fieldMults_.size() == 1)
-      parallel_for(TeamPolicy<FieldMultTag<1>,PHX::Device>(workset.num_cells,Kokkos::AUTO(),vector_size), *this);
-    else
-      parallel_for(TeamPolicy<FieldMultTag<-1>,PHX::Device>(workset.num_cells,Kokkos::AUTO(),vector_size), *this);
+    bool use_shared_memory = panzer::HP::inst().useSharedMemory<ScalarT>();
+    if (use_shared_memory) {
+      int bytes;
+      if (Sacado::IsADType<ScalarT>::value) {
+	const int fadSize = Kokkos::dimension_scalar(field_.get_view());
+	bytes = scratch_view::shmem_size(1,fadSize) + scratch_view::shmem_size(basis_.extent(1),fadSize);
+      }
+      else
+	bytes = scratch_view::shmem_size(1) + scratch_view::shmem_size(basis_.extent(1));
+
+      // The following if-block is for the sake of optimization depending on the
+      // number of field multipliers.  The parallel_fors will loop over the cells
+      // in the Workset and execute operator()() above.
+      if (fieldMults_.size() == 0) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<0>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+        parallel_for(policy, *this, this->getName());
+      } else if (fieldMults_.size() == 1) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<1>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+        parallel_for(policy, *this, this->getName());
+      } else {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<-1>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+        parallel_for(policy, *this, this->getName());
+      }
+    }
+    else {
+      // The following if-block is for the sake of optimization depending on the
+      // number of field multipliers.  The parallel_fors will loop over the cells
+      // in the Workset and execute operator()() above.
+      if (fieldMults_.size() == 0) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<0>,PHX::Device>(workset.num_cells);
+        parallel_for(policy, *this, this->getName());
+      } else if (fieldMults_.size() == 1) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<1>,PHX::Device>(workset.num_cells);
+        parallel_for(policy, *this, this->getName());
+      } else {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<-1>,PHX::Device>(workset.num_cells);
+        parallel_for(policy, *this, this->getName());
+      }
+    }
   } // end of evaluateFields()
 
   /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This converts all functors for the MixedPoisson example to use hierarchic evaluators. Additionally it adds optional kernels for using shared memory where appropriate.