### PR TITLE
Promoting 100% clean 'cee-rhel6' builds to 'ATDM' CDash group (TRIL-212)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-clang-5.0.1-openmpi-1.10.2-serial-static-opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-clang-5.0.1-openmpi-1.10.2-serial-static-opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=ATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-gnu-4.9.3-openmpi-1.10.2-serial-static-opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-gnu-4.9.3-openmpi-1.10.2-serial-static-opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=ATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-gnu-7.2.0-openmpi-1.10.2-serial-static-opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-gnu-7.2.0-openmpi-1.10.2-serial-static-opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=ATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-intel-17.0.1-intelmpi-5.1.2-serial-static-opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6-intel-17.0.1-intelmpi-5.1.2-serial-static-opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=ATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh


### PR DESCRIPTION
@trilinos/framework, @srajama1, @rppawlo, @kddevin, @jwillenbring, @mperego 

## Description

As of today, these four 'cee-rhel6' builds are 100% clean.  As these match the
SPARC CI builds, these are important builds to elevate and maintain.

NOTE: The the intel-18.0.2 build is still not clean due to the problems with
MKL GEEV() as described in issues #3499 and #3914 so we can't promote that
build yet.

NOTE: Since these builds are run by a cron job on my CEE RHEL6 machine 'ceerws1113', the promotion has to be done in the driver scripts.

## Motivation and Context

These are the only builds so far that protect SPARC's configuration of Trilinos (see [TRIL-212](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-212)) and these match SPARC's CI builds so these are critical to promote and maintain.

## How Has This Been Tested?

Not tested.  The changes are trivial.  If there a a problem, we will see it on CDash (or fail to see it on CDash).
