### PR TITLE
Remove Deprecated Doxygen Options

### DIFF
--- a/packages/common/Doxyfile
+++ b/packages/common/Doxyfile
@@ -30,7 +30,6 @@ STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
 MULTILINE_CPP_IS_BRIEF = NO
-DETAILS_AT_TOP         = NO
 INHERIT_DOCS           = YES
 DISTRIBUTE_GROUP_DOC   = NO
 SEPARATE_MEMBER_PAGES  = NO
@@ -66,7 +65,6 @@ GENERATE_DEPRECATEDLIST= YES
 ENABLED_SECTIONS       = 
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = YES
-SHOW_DIRECTORIES       = YES
 FILE_VERSION_FILTER    = 
 #---------------------------------------------------------------------------
 # configuration options related to warning and progress messages
@@ -120,7 +118,6 @@ HTML_FILE_EXTENSION    = .html
 #HTML_HEADER            = ../../common/header.html
 #HTML_FOOTER            = ../../common/footer.html
 #HTML_STYLESHEET        = ../../common/styles.css
-HTML_ALIGN_MEMBERS     = YES
 GENERATE_HTMLHELP      = NO
 CHM_FILE               = 
 HHC_LOCATION           = 
@@ -167,8 +164,6 @@ MAN_LINKS              = NO
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
-XML_SCHEMA             = 
-XML_DTD                = 
 XML_PROGRAMLISTING     = YES
 #---------------------------------------------------------------------------
 # configuration options for the AutoGen Definitions output


### PR DESCRIPTION
@trilinos/framework 

## Description
This PR removes obsolete Doxyfile options so they don't show up as warnings when you build Trilinos' documentation.

## Motivation and Context
Warning-free compilation makes me happy.

## How Has This Been Tested?
I'm using `doxygen-1.8.14` (looks to be about a year old).