### PR TITLE
added some timers, fixed an N^2 issue in itialization

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -237,6 +237,9 @@ buildNodeToCellMatrix(const Teuchos::RCP<const Teuchos::Comm<int> > & comm,
   typedef Tpetra::CrsMatrix<LO,LO,GO> crs_type;
   typedef Tpetra::Import<LO,GO> import_type;
 
+
+  PANZER_FUNC_TIME_MONITOR("panzer_stk::buildNodeToCellMatrix");
+
   TEUCHOS_ASSERT(owned_cells.extent(0)==owned_cells_to_nodes.extent(0));
 
   // build a unque node map to use with fill complete
@@ -254,7 +257,7 @@ buildNodeToCellMatrix(const Teuchos::RCP<const Teuchos::Comm<int> > & comm,
   // This is essentially another way to store cells_to_nodes
   RCP<crs_type> cell_to_node;
   {
-
+    PANZER_FUNC_TIME_MONITOR("Build matrix");
     // The matrix is indexed by (global cell, global node) = local node
     cell_to_node = rcp(new crs_type(cell_map,0));
     cell_to_node->resumeFill();
@@ -285,6 +288,7 @@ buildNodeToCellMatrix(const Teuchos::RCP<const Teuchos::Comm<int> > & comm,
   // Transpose the cell_to_node array to create the node_to_cell array
   RCP<crs_type> node_to_cell;
   {
+    PANZER_FUNC_TIME_MONITOR("Tranpose matrix");
     // Create an object designed to transpose the (global cell, global node) matrix to give
     // a (global node, global cell) matrix
     Tpetra::RowMatrixTransposer<LO,LO,GO> transposer(cell_to_node);
@@ -320,6 +324,8 @@ buildGhostedCellOneRing(const Teuchos::RCP<const Teuchos::Comm<int> > & comm,
                         Kokkos::View<const GO*> cells,
                         Kokkos::View<const GO**> cells_to_nodes)
 {
+
+  PANZER_FUNC_TIME_MONITOR("panzer_stk::buildGhostedCellOneRing");
   typedef Tpetra::CrsMatrix<int,int,GO> crs_type;
 
   // cells : (local cell index) -> global cell index
@@ -479,7 +485,10 @@ setupLocalMeshBlockInfo(const panzer_stk::STK_Interface & mesh,
       cell_pattern = Teuchos::rcp(new panzer::ElemFieldPattern(topology));
     }
 
-    conn.buildConnectivity(*cell_pattern);
+    {
+      PANZER_FUNC_TIME_MONITOR("Build connectivity");
+      conn.buildConnectivity(*cell_pattern);
+    }
   }
 
   std::vector<LO> owned_block_cells;
@@ -498,9 +507,10 @@ setupLocalMeshBlockInfo(const panzer_stk::STK_Interface & mesh,
   block_info.num_owned_cells = owned_block_cells.size();
   block_info.element_block_name = element_block_name;
   block_info.cell_topology = mesh.getCellTopology(element_block_name);
-
-  panzer::partitioning_utilities::setupSubLocalMeshInfo<LO,GO>(mesh_info, owned_block_cells, block_info);
-
+  {
+    PANZER_FUNC_TIME_MONITOR("panzer::partitioning_utilities::setupSubLocalMeshInfo");
+    panzer::partitioning_utilities::setupSubLocalMeshInfo<LO,GO>(mesh_info, owned_block_cells, block_info);
+  }
 }
 
 
@@ -868,6 +878,8 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
   // Note: We are assuming that virtual cells belong to ranks and are not 'shared' - this will change later on
   Kokkos::View<GO*> virtual_cells = Kokkos::View<GO*>("virtual_cells",num_virtual_cells);
   {
+    PANZER_FUNC_TIME_MONITOR("Initial global index creation");
+
     const int num_ranks = comm->getSize();
     const int rank = comm->getRank();
 
@@ -917,6 +929,8 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
 
   // Transfer information from 'faceToElement' datasets to local arrays
   {
+    PANZER_FUNC_TIME_MONITOR("Transer faceToElement to local");
+
     int virtual_cell_index = num_real_cells;
     for(size_t f=0;f<elems_by_face.extent(0);f++) {
 
@@ -982,77 +996,81 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
   // There are two of everything, an "owned" data structured corresponding to "owned"
   // cells. And a "ghstd" data structure corresponding to ghosted cells
   ////////////////////////////////////////////////////////////////////////////////////
+  {
+    PANZER_FUNC_TIME_MONITOR("Assign Indices");
+    mesh_info.cell_to_faces           = cell_to_face;
+    mesh_info.face_to_cells           = face_to_cells;      // faces
+    mesh_info.face_to_lidx            = face_to_localidx;
 
-  mesh_info.cell_to_faces           = cell_to_face;
-  mesh_info.face_to_cells           = face_to_cells;      // faces
-  mesh_info.face_to_lidx            = face_to_localidx;
+    mesh_info.num_owned_cells = owned_cells.extent(0);
+    mesh_info.num_ghstd_cells = ghstd_cells.extent(0);
+    mesh_info.num_virtual_cells = virtual_cells.extent(0);
 
-  mesh_info.num_owned_cells = owned_cells.extent(0);
-  mesh_info.num_ghstd_cells = ghstd_cells.extent(0);
-  mesh_info.num_virtual_cells = virtual_cells.extent(0);
+    mesh_info.global_cells = Kokkos::View<GO*>("global_cell_indices",num_total_cells);
+    mesh_info.local_cells = Kokkos::View<LO*>("local_cell_indices",num_total_cells);
 
-  mesh_info.global_cells = Kokkos::View<GO*>("global_cell_indices",num_total_cells);
-  mesh_info.local_cells = Kokkos::View<LO*>("local_cell_indices",num_total_cells);
+    for(int i=0;i<num_owned_cells;++i){
+      mesh_info.global_cells(i) = owned_cells(i);
+      mesh_info.local_cells(i) = i;
+    }
 
-  for(int i=0;i<num_owned_cells;++i){
-    mesh_info.global_cells(i) = owned_cells(i);
-    mesh_info.local_cells(i) = i;
-  }
+    for(int i=0;i<num_ghstd_cells;++i){
+      mesh_info.global_cells(i+num_owned_cells) = ghstd_cells(i);
+      mesh_info.local_cells(i+num_owned_cells) = i+num_owned_cells;
+    }
 
-  for(int i=0;i<num_ghstd_cells;++i){
-    mesh_info.global_cells(i+num_owned_cells) = ghstd_cells(i);
-    mesh_info.local_cells(i+num_owned_cells) = i+num_owned_cells;
-  }
+    for(int i=0;i<num_virtual_cells;++i){
+      mesh_info.global_cells(i+num_real_cells) = virtual_cells(i);
+      mesh_info.local_cells(i+num_real_cells) = i+num_real_cells;
+    }
 
-  for(int i=0;i<num_virtual_cells;++i){
-    mesh_info.global_cells(i+num_real_cells) = virtual_cells(i);
-    mesh_info.local_cells(i+num_real_cells) = i+num_real_cells;
-  }
+    mesh_info.cell_vertices = Kokkos::View<double***, PHX::Device>("cell_vertices",num_total_cells,vertices_per_cell,space_dim);
 
-  mesh_info.cell_vertices = Kokkos::View<double***, PHX::Device>("cell_vertices",num_total_cells,vertices_per_cell,space_dim);
+    // Initialize coordinates to zero
+    Kokkos::deep_copy(mesh_info.cell_vertices, 0.);
 
-  // Initialize coordinates to zero
-  Kokkos::deep_copy(mesh_info.cell_vertices, 0.);
-
-  for(int i=0;i<num_owned_cells;++i){
-    for(int j=0;j<vertices_per_cell;++j){
-      for(int k=0;k<space_dim;++k){
-        mesh_info.cell_vertices(i,j,k) = owned_vertices(i,j,k);
+    for(int i=0;i<num_owned_cells;++i){
+      for(int j=0;j<vertices_per_cell;++j){
+        for(int k=0;k<space_dim;++k){
+          mesh_info.cell_vertices(i,j,k) = owned_vertices(i,j,k);
+        }
       }
     }
-  }
 
-  for(int i=0;i<num_ghstd_cells;++i){
-    for(int j=0;j<vertices_per_cell;++j){
-      for(int k=0;k<space_dim;++k){
-        mesh_info.cell_vertices(i+num_owned_cells,j,k) = ghstd_vertices(i,j,k);
+    for(int i=0;i<num_ghstd_cells;++i){
+      for(int j=0;j<vertices_per_cell;++j){
+        for(int k=0;k<space_dim;++k){
+          mesh_info.cell_vertices(i+num_owned_cells,j,k) = ghstd_vertices(i,j,k);
+        }
       }
     }
-  }
 
-  // This will backfire at some point, but we're going to make the virtual cell have the same geometry as the cell it interfaces with
-  // This way we can define a virtual cell geometry without extruding the face outside of the domain
-  for(int i=0;i<num_virtual_cells;++i){
+    // This will backfire at some point, but we're going to make the virtual cell have the same geometry as the cell it interfaces with
+    // This way we can define a virtual cell geometry without extruding the face outside of the domain
+    {
+      PANZER_FUNC_TIME_MONITOR("Assign geometry traits");
+      for(int i=0;i<num_virtual_cells;++i){
 
-    const LO virtual_cell = i+num_real_cells;
-    bool exists = false;
-    for(int local_face=0; local_face<faces_per_cell; ++local_face){
-      const LO face = cell_to_face(virtual_cell, local_face);
-      if(face >= 0){
-        exists = true;
-        const LO other_side = (face_to_cells(face, 0) == virtual_cell) ? 1 : 0;
-        const LO real_cell = face_to_cells(face,other_side);
-        TEUCHOS_ASSERT(real_cell < num_real_cells);
-        for(int j=0;j<vertices_per_cell;++j){
-          for(int k=0;k<space_dim;++k){
-            mesh_info.cell_vertices(virtual_cell,j,k) = mesh_info.cell_vertices(real_cell,j,k);
+        const LO virtual_cell = i+num_real_cells;
+        bool exists = false;
+        for(int local_face=0; local_face<faces_per_cell; ++local_face){
+          const LO face = cell_to_face(virtual_cell, local_face);
+          if(face >= 0){
+            exists = true;
+            const LO other_side = (face_to_cells(face, 0) == virtual_cell) ? 1 : 0;
+            const LO real_cell = face_to_cells(face,other_side);
+            TEUCHOS_ASSERT(real_cell < num_real_cells);
+            for(int j=0;j<vertices_per_cell;++j){
+              for(int k=0;k<space_dim;++k){
+                mesh_info.cell_vertices(virtual_cell,j,k) = mesh_info.cell_vertices(real_cell,j,k);
+              }
+            }
+            break;
           }
         }
-        break;
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(!exists, "panzer_stk::generateLocalMeshInfo : Virtual cell is not linked to real cell");
       }
     }
-
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!exists, "panzer_stk::generateLocalMeshInfo : Virtual cell is not linked to real cell");
   }
 
   // Setup element blocks and sidesets
@@ -1060,11 +1078,13 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
   mesh.getSidesetNames(sideset_names);
 
   for(const std::string & element_block_name : element_block_names){
+    PANZER_FUNC_TIME_MONITOR("Set up setupLocalMeshBlockInfo");
     panzer::LocalMeshBlockInfo<LO,GO> & block_info = mesh_info.element_blocks[element_block_name];
     setupLocalMeshBlockInfo(mesh, conn, mesh_info, element_block_name, block_info);
 
     // Setup sidesets
     for(const std::string & sideset_name : sideset_names){
+      PANZER_FUNC_TIME_MONITOR("Setup LocalMeshSidesetInfo");
       panzer::LocalMeshSidesetInfo<LO,GO> & sideset_info = mesh_info.sidesets[element_block_name][sideset_name];
       setupLocalMeshSidesetInfo(mesh, conn, mesh_info, element_block_name, sideset_name, sideset_info);
     }

--- a/packages/panzer/disc-fe/src/Panzer_LocalPartitioningUtilities.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_LocalPartitioningUtilities.cpp
@@ -66,7 +66,7 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
                       const std::vector<LO> & owned_parent_cells,
                       panzer::LocalMeshInfoBase<LO,GO> & sub_info)
 {
-
+  PANZER_FUNC_TIME_MONITOR("panzer::partitioning_utilities::setupSubLocalMeshInfo");
   // The goal of this function is to fill a LocalMeshInfoBase (sub_info) with
   // a subset of cells from a given parent LocalMeshInfoBase (parent_info)
 
@@ -99,7 +99,7 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
   std::vector<LO> ghstd_parent_cells;
   std::vector<LO> virtual_parent_cells;
   {
-
+    PANZER_FUNC_TIME_MONITOR("Construct parent cell vector");
     // We grab all of the owned cells and put their global indexes into sub_info
     // We also put all of the owned cell indexes in the parent's indexing scheme into a set to use for lookups
     std::unordered_set<LO> owned_parent_cells_set(owned_parent_cells.begin(), owned_parent_cells.end());
@@ -163,10 +163,19 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
   const int num_real_cells = num_owned_cells + num_ghstd_cells;
   const int num_total_cells = num_real_cells + num_virtual_cells;
 
-  std::vector<LO> all_parent_cells;
-  all_parent_cells.insert(all_parent_cells.end(), owned_parent_cells.begin(), owned_parent_cells.end());
-  all_parent_cells.insert(all_parent_cells.end(), ghstd_parent_cells.begin(), ghstd_parent_cells.end());
-  all_parent_cells.insert(all_parent_cells.end(), virtual_parent_cells.begin(), virtual_parent_cells.end());
+  std::vector<std::pair<LO, LO> > all_parent_cells(num_total_cells);
+  for (std::size_t i=0; i< owned_parent_cells.size(); ++i)
+    all_parent_cells[i] = std::pair<LO, LO>(owned_parent_cells[i], i);
+
+  for (std::size_t i=0; i< ghstd_parent_cells.size(); ++i) {
+    LO insert = owned_parent_cells.size()+i;
+    all_parent_cells[insert] = std::pair<LO, LO>(ghstd_parent_cells[i], insert);
+  }
+
+  for (std::size_t i=0; i< virtual_parent_cells.size(); ++i) {
+    LO insert = owned_parent_cells.size()+ ghstd_parent_cells.size()+i;
+    all_parent_cells[insert] = std::pair<LO, LO>(virtual_parent_cells[i], insert);
+  }
 
   sub_info.num_owned_cells = owned_parent_cells.size();
   sub_info.num_ghstd_cells = ghstd_parent_cells.size();
@@ -187,7 +196,7 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
   sub_info.local_cells = Kokkos::View<LO*>("local_cells", num_total_cells);
   sub_info.cell_vertices = Kokkos::View<double***, PHX::Device>("cell_vertices", num_total_cells, num_vertices_per_cell, num_dims);
   for(int cell=0;cell<num_total_cells;++cell){
-    const LO parent_cell = all_parent_cells[cell];
+    const LO parent_cell = all_parent_cells[cell].first;
     sub_info.global_cells(cell) = parent_info.global_cells(parent_cell);
     sub_info.local_cells(cell) = parent_info.local_cells(parent_cell);
     for(int vertex=0;vertex<num_vertices_per_cell;++vertex){
@@ -221,9 +230,12 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
   // First create the faces
   std::vector<face_t> faces;
   {
-
+    PANZER_FUNC_TIME_MONITOR("Create faces");
     // faces_set: cell_0, subcell_index_0, cell_1, subcell_index_1
     std::unordered_map<LO,std::unordered_map<LO, std::pair<LO,LO> > > faces_set;
+
+    std::sort(all_parent_cells.begin(), all_parent_cells.end());
+
     for(int owned_cell=0;owned_cell<num_owned_cells;++owned_cell){
       const LO owned_parent_cell = owned_parent_cells[owned_cell];
       for(int local_face=0;local_face<num_faces_per_cell;++local_face){
@@ -240,10 +252,12 @@ setupSubLocalMeshInfo(const panzer::LocalMeshInfoBase<LO,GO> & parent_info,
         const LO neighbor_subcell_index = parent_info.face_to_lidx(parent_face, neighbor_side);
 
         // Convert parent cell index into sub cell index
-        auto itr = std::find(all_parent_cells.begin(), all_parent_cells.end(), neighbor_parent_cell);
+        std::pair<LO, LO> search_point(neighbor_parent_cell, 0);
+        auto itr = std::lower_bound(all_parent_cells.begin(), all_parent_cells.end(), search_point);
+
         TEUCHOS_TEST_FOR_EXCEPT_MSG(itr == all_parent_cells.end(), "panzer_stk::setupSubLocalMeshInfo : Neighbor cell was not found in owned, ghosted, or virtual cells");
 
-        const LO neighbor_cell = std::distance(all_parent_cells.begin(), itr);
+        const LO neighbor_cell = itr->second;
 
         LO cell_0, cell_1, subcell_index_0, subcell_index_1;
         if(owned_cell < neighbor_cell){


### PR DESCRIPTION
Added more timers in the code, found a place where you had N^2 operations, fixed that in one place, 

Timing differences
```

|   L2Projection::Build Mass Matrix: 248.589 - 30.1226% [1] {min=248.585, max=248.593, std dev=0.00586798} <1, 0, 0, 0, 0, 0, 0, 0, 0, 1>
|   |   panzer_stk::generateLocalMeshInfo: 124.846 - 50.2217% [1] {min=122.894, max=126.797, std dev=2.75999} <1, 0, 0, 0, 0, 0, 0, 0, 0, 1>

```

down to

```

|   L2Projection::Build Mass Matrix: 10.451 - 2.89238% [1] {min=10.4492, max=10.4528, std dev=0.00256631} <1, 0, 0, 0, 0, 0, 0, 0, 0, 1>

|   |   panzer_stk::generateLocalMeshInfo: 7.51236 - 71.882% [1] {min=7.47739, max=7.54733, std dev=0.0494508} <1, 0, 0, 0, 0, 0, 0, 0, 0, 1>

```