### PR TITLE
Modify logic in block Gmres solver to address bug #4128

### DIFF
--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
@@ -157,6 +157,8 @@ int main(int argc, char *argv[]) {
     belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Flexible Gmres", true );               // DON'T DO THIS IN PRACTICE, it is not true.  
+                                                           // Just make sure the solver doesn't error out.
     int verbLevel = Belos::Errors + Belos::Warnings;
     if (debug) {
       verbLevel += Belos::Debug;
@@ -174,6 +176,7 @@ int main(int argc, char *argv[]) {
     // Construct an unpreconditioned linear problem instance.
     //
     Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    problem.setInitResVec( B );
     bool set = problem.setProblem();
     if (set == false) {
       if (proc_verbose)


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Description
The flexible Gmres variant is accessed through the block Gmres solver manager.
The current logic in that solver will throw an error if there is no right
preconditioner specified in the linear problem.  If the right preconditioner is not specified, then this
solver manager could just employ an unpreconditioned block Gmres iteration.
Furthermore, the solver manager did not effectively handle the situation when the linear
problem has a left preconditioner.  That is being addressed in this commit.  A modified Tpetra test covers the change from flexible to unpreconditioned Gmres when a right preconditioned is not supplied.

## Motivation and Context
A user experience with this solver found it unhelpful that the solver threw an error and there is a natural resolution that the solver can take to address the issue.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues #4128 

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
OSX, Serial, GCC 7.x with a modified Tpetra test that is also being included in the pull request.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->