### PR TITLE
Stacked timer unit testing support

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -37,9 +37,9 @@ StackedTimer::LevelTimer::report(std::ostream &os) {
 
 }
 
-BaseTimer*
-StackedTimer::LevelTimer::findBaseTimer(const std::string &name) {
-  BaseTimer* t = NULL;
+const BaseTimer*
+StackedTimer::LevelTimer::findBaseTimer(const std::string &name) const {
+  const BaseTimer* t = NULL;
   if (get_full_name() == name) {
     return this;
   }

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -37,6 +37,22 @@ StackedTimer::LevelTimer::report(std::ostream &os) {
 
 }
 
+BaseTimer*
+StackedTimer::LevelTimer::findBaseTimer(const std::string &name) {
+  BaseTimer* t = NULL;
+  if (get_full_name() == name) {
+    return this;
+  }
+  else {
+    for (unsigned i=0;i<sub_timers_.size(); ++i){
+      t = sub_timers_[i].findBaseTimer(name);
+      if (t != NULL)
+        return t;
+    }
+  }
+  return t;
+}
+  
 BaseTimer::TimeInfo
 StackedTimer::LevelTimer::findTimer(const std::string &name, bool& found) {
   BaseTimer::TimeInfo t;

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -384,6 +384,13 @@ protected:
       */
      void report(std::ostream &os);
 
+    /**
+     * Return pointer to the BaseTimer corresponding to a given string
+     * @param name input string to search for
+     * @return pointer to BaseTimer (NULL if none found)
+     */
+    BaseTimer* findBaseTimer(const std::string &name);
+    
      /**
       * Return the time info for a given string
       * @param name input string to search for
@@ -512,6 +519,18 @@ public:
      else
        return timer_.accumulatedTimePerTimerCall(name);
    }
+  
+  /**
+   * Return pointer to the BaseTimer corresponding to a given string (full string name)
+   * @param name input string to search for
+   * @return BaseTimer
+   */
+  BaseTimer* findBaseTimer(const std::string &name) {
+    BaseTimer* baseTimer = timer_.findBaseTimer(name);
+    TEUCHOS_TEST_FOR_EXCEPTION(baseTimer == NULL, std::runtime_error,
+                               "StackedTimer::findBaseTimer() failed to find a timer named \"" << name << "\"!\n");
+    return baseTimer;
+  }
 
   /**
    * Return the time info for a given string (full string name)

--- a/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
+++ b/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
@@ -13,6 +13,7 @@
 #include <tuple>
 #include <regex>
 #include <iterator>
+#include <limits>
 
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
 #include "Kokkos_Core.hpp"
@@ -208,6 +209,63 @@ TEUCHOS_UNIT_TEST(StackedTimer, Basic)
   timer.report(out, comm, options);
 }
 
+TEUCHOS_UNIT_TEST(StackedTimer, UnitTestSupport)
+{
+  const Teuchos::RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
+  const int myRank = Teuchos::rank(*comm);
+
+  const auto timeMonitorDefaultStackedTimer = Teuchos::TimeMonitor::getStackedTimer();
+  const auto timer = Teuchos::rcp(new Teuchos::StackedTimer("Total Time", false));
+  timer->startBaseTimer();
+  for (int i=0; i < 10; ++i) {
+    timer-> start("Subtask");
+    timer->incrementUpdates();
+    timer->incrementUpdates(2);
+    timer-> stop("Subtask");
+  }
+  timer->stopBaseTimer();
+
+  // If users want to set timer values for unit testing, force them to
+  // const_cast the timer by returning a const Timer object.
+  auto top_timer = const_cast<Teuchos::BaseTimer*>(timer->findBaseTimer("Total Time"));
+  auto sub_timer = const_cast<Teuchos::BaseTimer*>(timer->findBaseTimer("Total Time@Subtask"));
+  TEST_ASSERT(top_timer != nullptr);
+  TEST_ASSERT(sub_timer != nullptr);
+
+  // Test for exception for bad timer name
+  TEST_THROW(timer->findBaseTimer("Testing misspelled timer name!"),std::runtime_error);
+
+  {
+    TEST_EQUALITY(top_timer->numCalls(),1);
+    TEST_EQUALITY(top_timer->numUpdates(),0);
+    TEST_EQUALITY(sub_timer->numCalls(),10);
+    TEST_EQUALITY(sub_timer->numUpdates(),30);
+  }
+
+  // Test the serial version of report
+  if (myRank == 0)
+    timer->report(out);
+
+  // Override timers for unit testing
+  top_timer->setAccumulatedTime(5000.0);
+  top_timer->overrideNumCallsForUnitTesting(2);
+  top_timer->overrideNumUpdatesForUnitTesting(3);
+  sub_timer->setAccumulatedTime(4000.0);
+  sub_timer->overrideNumCallsForUnitTesting(4);
+  sub_timer->overrideNumUpdatesForUnitTesting(5);
+  {
+    const double timerTolerance = 100.0 * std::numeric_limits<double>::epsilon();
+    TEST_FLOATING_EQUALITY(5000.0,top_timer->accumulatedTime(),timerTolerance);
+    TEST_EQUALITY(top_timer->numCalls(),2);
+    TEST_EQUALITY(top_timer->numUpdates(),3);
+    TEST_FLOATING_EQUALITY(4000.0,sub_timer->accumulatedTime(),timerTolerance);
+    TEST_EQUALITY(sub_timer->numCalls(),4);
+    TEST_EQUALITY(sub_timer->numUpdates(),5);
+  }
+
+  if (myRank == 0)
+    timer->report(out);
+}
 
 TEUCHOS_UNIT_TEST(StackedTimer, TimeMonitorInteroperability)
 {


### PR DESCRIPTION
Some applications are writing unit testing scripts that rely on StackedTimer data. This commit adds queries and overrides of Timer values to help support unit testing of the StackedTimer for both Trilinos and within the applications.

Also cleaned up some inconsistent naming conventions.