### PR TITLE
Add support for CTS-1 machines 'eclipse' and 'ghost' (em-plasma/buildscripts#114)

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -465,7 +465,7 @@ example, skip configure, skip the build, skip running tests, etc.
 
 * <a href="#ridewhite">ride/white</a>
 * <a href="#shillerhansen">shiller/hansen</a>
-* <a href="#chamaserrano">chama/serrano</a>
+* <a href="#chamaserrano">chama/serrano/eclipse/ghost</a>
 * <a href="#mutrino">mutrino</a>
 * <a href="#sems-rhel6-environment">SEMS RHEL6 Environment</a>
 * <a href="#sems-rhel7-environment">SEMS RHEL7 Environment</a>
@@ -566,12 +566,13 @@ $ srun ./checkin-test-atdm.sh intel-opt-openmp \
 
 ### chama/serrano
 
-Once logged on to 'chama' or 'serrano', one can directly configure and build
-on the login node (being careful not to overload the node) using the `chama`
-and `serrano` envs, respectively.  But to run the tests, one must run on the
-compute nodes using the `srun` command.  For example, to configure, build and
-run the tests for say `MueLu` on 'serrano' or 'chama', (after cloning Trilinos
-on the `develop` branch) one would do:
+Once logged on to the TLCC-2 machine 'chama' or the CTS-1 'serrano', 'eclipse'
+or 'ghost' machines, one can directly configure and build on the login node
+(being careful not to overload the node) using the `chama` and `serrano` envs,
+respectively.  But to run the tests, one must run on the compute nodes using
+the `srun` command.  For example, to configure, build and run the tests for
+say `MueLu` on 'serrano', (after cloning Trilinos on the `develop` branch) one
+would do:
 
 
 ```
@@ -1238,7 +1239,7 @@ they support are:
 
 * `cee-rhel6/`: CEE LANL RHEL6 systems with a CEE environment
 
-* `chama/`: Supports SNL HPC machine `chama`.
+* `chama/`: Supports SNL HPC TLCC-2 machine `chama`.
 
 * `mutrino/`: Supports SNL HPC machine `mutrino`.
 
@@ -1249,7 +1250,8 @@ they support are:
 
 * `sems-rhel7/`: SNL COE RHEL7 systems with the SEMS NFS environment
 
-* `serrano/`: Supports SNL HPC machine `serrano`.
+* `serrano/`: Supports SNL HPC CTS-1 machines `serrano`, 'eclipse', and
+  'ghost'.
 
 * `shiller/`: Supports GNU, Intel, and CUDA builds on both the SRN machine
   `shiller` and the mirror SON machine `hansen`.

--- a/cmake/std/atdm/utils/get_known_system_name.sh
+++ b/cmake/std/atdm/utils/get_known_system_name.sh
@@ -46,8 +46,17 @@ elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "ride"* ]] ; then
 elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "chama"* ]] ; then
   ATDM_HOSTNAME=chama
   ATDM_SYSTEM_NAME=chama
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "serrano"* ]] || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ ser[0-9]+ ]] ; then
+elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "serrano"* ]] \
+  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ ser[0-9]+ ]] ; then
   ATDM_HOSTNAME=serrano
+  ATDM_SYSTEM_NAME=serrano
+elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "eclipse"* ]] \
+  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ ec[0-9]+ ]] ; then
+  ATDM_HOSTNAME=eclipse
+  ATDM_SYSTEM_NAME=serrano
+elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "ghost"* ]] \
+  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ gho[0-9]+ ]] ; then
+  ATDM_HOSTNAME=ghost
   ATDM_SYSTEM_NAME=serrano
 elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "mutrino"* ]] ; then
   ATDM_HOSTNAME=mutrino


### PR DESCRIPTION
CC: @jmgate, @fryeguy52 

## Description

These match the 'serrano' system (which needs to be renamed to 'cts1' at some
point).  This was requested by EMPIRE in the GitLab issue
em-plasma/buildscripts#114.

This should work on both the login and compute nodes on 'eclipse' and 'ghost'.

## Motivation and Context

I guess people want to build and run on other CTS-1 systems 'eclipse' and 'ghost' as per:

* https://cee-gitlab.sandia.gov/EM-Plasma/BuildScripts/issues/114

## How Has This Been Tested?

I tested on 'eclipse' with:

```
$  cat src_default_env.sh
#!/bin/bash
source cmake/std/atdm/load-env.sh default

# Test on login node

$ ./src_default_env.sh
Hostname 'eclipse-login9' matches known ATDM host 'eclipse' and system 'serrano'
Setting compiler and build options for buld name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL
...

# Test on compute node

$  salloc -N1 --time=0:20:00 --account=fy150090

$ srun -n1 ./src_default_env.sh
Hostname 'ec331' matches known ATDM host 'eclipse' and system 'serrano'
Setting compiler and build options for buld name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL
...
```

I tested on 'ghost' with:

```
$  cat src_default_env.sh
#!/bin/bash
source cmake/std/atdm/load-env.sh default

#  Test on login node

$ ./src_default_env.sh
Hostname 'ghost-login2' matches known ATDM host 'ghost' and system 'serrano'
Setting compiler and build options for buld name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL
...

# Test on compute node

$  salloc -N1 --time=0:20:00 --account=fy150090

$ srun -n1 ./src_default_env.sh
Hostname 'gho448' matches known ATDM host 'ghost' and system 'serrano'
Setting compiler and build options for buld name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL
...
```

If 'eclipse' and 'ghost' are 100% identical with 'serrano', that should be enough testing. 
