### PR TITLE
Return 100% passing cee-hrl6-gnu-7.2.0 to 'ATDM' CDash group (TRIL-212)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Specialized
+export Trilinos_TRACK=ATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh


### PR DESCRIPTION
This build was 100% passing after the switch from static to shared libs.
Therefore, we can promote back to the 'ATDM' CDash group.
