### PR TITLE
Issue #4154 Upgrading Windows nightly build to CMake 3.12.0

### DIFF
--- a/cmake/ctest/drivers/windows/README.md
+++ b/cmake/ctest/drivers/windows/README.md
@@ -5,7 +5,7 @@ be worthwhile to browse the scripts for these locations. Alternatively, you coul
 and install the software wherever you want - just be sure to copy and update the build scripts
 with the correct locations.
 
-**[CMake][1]** - required to setup the build configuration. (Tested using version 3.8.1)
+**[CMake][1]** - required to setup the build configuration. (Tested using version 3.8.1, later upgraded to 3.12.0)
 
 **[Ninja][2]** - required to parallelize the build on Windows. (Tested using version 1.7.2)
 

--- a/cmake/ctest/drivers/windows/create_windows_package.bat
+++ b/cmake/ctest/drivers/windows/create_windows_package.bat
@@ -12,7 +12,7 @@ setlocal
 rem Set the location of Git, Ninja, etc.
 set SEMS_DIR=C:\projects\sems\install\win-x86_64
 set NINJA_DIR=%SEMS_DIR%\utility\ninja\1.7.2
-set CMAKE_DIR=%SEMS_DIR%\utility\cmake\3.8.1\bin
+set CMAKE_DIR=%SEMS_DIR%\utility\cmake\3.12.0\bin
 set GIT_EXE=%SEMS_DIR%\utility\git\2.13.0\cmd\git.exe
 set PATH=%NINJA_DIR%;%PATH%
 

--- a/cmake/ctest/drivers/windows/task_driver_windows.bat
+++ b/cmake/ctest/drivers/windows/task_driver_windows.bat
@@ -5,7 +5,7 @@ setlocal
 rem Set the location of Git, Ninja, etc.
 set SEMS_DIR=C:\projects\sems\install\win-x86_64
 set NINJA_DIR=%SEMS_DIR%\utility\ninja\1.7.2
-set CTEST_EXE=%SEMS_DIR%\utility\cmake\3.8.1\bin\ctest.exe
+set CTEST_EXE=%SEMS_DIR%\utility\cmake\3.12.0\bin\ctest.exe
 set GIT_EXE=%SEMS_DIR%\utility\git\2.13.0\cmd\git.exe
 set PATH=%NINJA_DIR%;%PATH%
 set TRILINOS_REPOSITORY_LOCATION=https://gitlab-ex.sandia.gov/trilinos-project/Trilinos.git


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 
@csiefer2 

## Description
<!--- Please describe your changes in detail. -->

Upgrading the Trilinos nightly build on Windows to use CMake 3.12.0
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

Issue #4154 
The Windows build is currently trying to use CMake 3.8.1, which is no longer sufficient.

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

I did some sanity testing of the CMake installation in general.

I requested a review from @bmpersc because he recently fixed the system so it properly runs tests again and we discussed these further changes.