### PR TITLE
Tempus: Fixed some FPEs.

### DIFF
--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -453,7 +453,7 @@ void SolutionHistory<Scalar>::setParameterList(
     break;
   }
   case STORAGE_TYPE_UNLIMITED: {
-    storage_limit = std::numeric_limits<int>::max();
+    storage_limit = 1000000000;
     break;
   }
   }

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -105,7 +105,7 @@ Scalar StepperExplicitRK<Scalar>::getInitTimeStep(
   const Teuchos::RCP<SolutionHistory<Scalar> >& sh) const
 {
 
-   Scalar dt = std::numeric_limits<Scalar>::max();
+   Scalar dt = Scalar(1.0e+99);
    if (!stepperPL_->get<bool>("Use Embedded")) return dt;
 
    Teuchos::RCP<SolutionState<Scalar> > currentState=sh->getCurrentState();

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -84,7 +84,7 @@ public:
     virtual Scalar getOrderMax() const {return 1.0;}
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
-      {return std::numeric_limits<Scalar>::max();}
+      {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -51,8 +51,8 @@ public:
     /// Solve problem using x in-place.
     const Thyra::SolveStatus<Scalar> solveImplicitODE(
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x);
-    
-    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers)
     virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
        {initial_guess_ = initial_guess;}
 
@@ -65,7 +65,7 @@ public:
       { return stepperPL_->get<bool>("Use Embedded", false); }
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
-      {return std::numeric_limits<Scalar>::max();}
+      {return Scalar(1.0e+99);}
   //@}
 
 protected:
@@ -73,7 +73,7 @@ protected:
   Teuchos::RCP<Teuchos::ParameterList>                stepperPL_;
   Teuchos::RCP<WrapperModelEvaluator<Scalar> >        wrapperModel_;
   Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >   solver_;
-  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -117,7 +117,7 @@ public:
     virtual Scalar getOrderMax() const {return 2.0;}
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
-      {return std::numeric_limits<Scalar>::max();}
+      {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -73,7 +73,7 @@ public:
     virtual Scalar getOrderMax() const {return 2.0;}
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
-      {return std::numeric_limits<Scalar>::max();}
+      {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -90,7 +90,7 @@ public:
       {return stepperPL_->get<int>("Maximum Order");}
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
-      {return std::numeric_limits<Scalar>::max();}
+      {return Scalar(1.0e+99);}
     virtual void setOrder   (Scalar ord)
       {stepperPL_->set<int>("Order", ord);}
     virtual void setOrderMin(Scalar ord)

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -106,7 +106,7 @@ public:
     virtual Scalar getOrderMax() const {return stateStepper_->getOrderMax();}
     virtual Scalar getInitTimeStep(
         const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
-      {return std::numeric_limits<Scalar>::max();}
+      {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const
       {return stateStepper_->isExplicit() or sensitivityStepper_->isExplicit();}
@@ -119,10 +119,10 @@ public:
       {return stateStepper_->isOneStepMethod() and
               sensitivityStepper_->isOneStepMethod();}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-    
+
   //@}
-    
-  /// Pass initial guess to Newton solver (only relevant for explicit schemes)  
+
+  /// Pass initial guess to Newton solver (only relevant for explicit schemes)
   virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
      {initial_guess_ = initial_guess;}
 
@@ -164,7 +164,7 @@ private:
   Teuchos::RCP<SolutionHistory<Scalar> > sensSolutionHistory_;
   bool reuse_solver_;
   bool force_W_update_;
-  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -512,7 +512,7 @@ TimeStepControl<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
 
-  const double stdMax =         std::numeric_limits<double>::max();
+  const double stdMax = double(1.0e+99);
   pl->set<double>("Initial Time"         , 0.0    , "Initial time");
   pl->set<double>("Final Time"           , stdMax , "Final time");
   pl->set<int>   ("Initial Time Index"   , 0      , "Initial time index");

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -12,12 +12,12 @@
     </ParameterList>
     <ParameterList id="26" name="Time Step Control">
       <Parameter docString="" id="6" isDefault="true" isUsed="true" name="Initial Time" type="double" value="0.00000000000000000e+00"/>
-      <Parameter docString="" id="7" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.79769313486231571e+308"/>
+      <Parameter docString="" id="7" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.0e+99"/>
       <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
       <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
       <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
       <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
-      <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.79769313486231571e+308"/>
+      <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.0e+99"/>
       <Parameter docString="" id="15" isDefault="true" isUsed="true" name="Minimum Order" type="int" value="1"/>
       <Parameter docString="" id="16" isDefault="true" isUsed="true" name="Initial Order" type="int" value="1"/>
       <Parameter docString="" id="17" isDefault="true" isUsed="true" name="Maximum Order" type="int" value="1"/>
@@ -26,7 +26,7 @@
       <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
       <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
-      <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.79769313486231571e+308"/>
+      <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>
       <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index Interval" type="int" value="1000000"/>
       <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -14,12 +14,12 @@
     </ParameterList>
     <ParameterList id="31" name="Time Step Control">
       <Parameter docString="" id="8" isDefault="true" isUsed="true" name="Initial Time" type="double" value="0.00000000000000000e+00"/>
-      <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.79769313486231571e+308"/>
+      <Parameter docString="" id="9" isDefault="true" isUsed="true" name="Final Time" type="double" value="1.0e+99"/>
       <Parameter docString="" id="10" isDefault="true" isUsed="true" name="Initial Time Index" type="int" value="0"/>
       <Parameter docString="" id="11" isDefault="true" isUsed="true" name="Final Time Index" type="int" value="1000000"/>
       <Parameter docString="" id="12" isDefault="true" isUsed="true" name="Minimum Time Step" type="double" value="0.0"/>
       <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Initial Time Step" type="double" value="1.0"/>
-      <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.79769313486231571e+308"/>
+      <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Time Step" type="double" value="1.0e+99"/>
       <Parameter docString="" id="17" isDefault="true" isUsed="true" name="Minimum Order" type="int" value="1"/>
       <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Initial Order" type="int" value="1"/>
       <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Maximum Order" type="int" value="1"/>
@@ -28,7 +28,7 @@
       <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
       <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
-      <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.79769313486231571e+308"/>
+      <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>
       <Parameter docString="" id="24" isDefault="true" isUsed="true" name="Output Index Interval" type="int" value="1000000"/>
       <Parameter docString="" id="25" isDefault="true" isUsed="true" name="Maximum Number of Stepper Failures" type="int" value="10"/>
       <Parameter docString="" id="26" isDefault="true" isUsed="true" name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorTest.cpp
@@ -50,10 +50,13 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, PL_ME_Construction)
   RCP<ParameterList> referencePL =
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref.xml");
 
-  //std::cout << std::endl;
-  //std::cout << "testPL      -------------- \n" << *testPL << std::endl;
-  //std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
-  TEST_ASSERT(haveSameValues(*testPL,*referencePL))
+  bool pass = haveSameValues(*testPL, *referencePL, true);
+  if (!pass) {
+    std::cout << std::endl;
+    std::cout << "testPL      -------------- \n" << *testPL << std::endl;
+    std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
+  }
+  TEST_ASSERT(pass)
 }
 
 
@@ -93,10 +96,13 @@ TEUCHOS_UNIT_TEST(IntegratorBasic, Construction)
   RCP<ParameterList> referencePL =
     getParametersFromXmlFile("Tempus_IntegratorBasic_ref2.xml");
 
-  //std::cout << std::endl;
-  //std::cout << "testPL      -------------- \n" << *testPL << std::endl;
-  //std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
-  TEST_ASSERT(haveSameValues(*testPL,*referencePL))
+  bool pass = haveSameValues(*testPL, *referencePL, true);
+  if (!pass) {
+    std::cout << std::endl;
+    std::cout << "testPL      -------------- \n" << *testPL << std::endl;
+    std::cout << "referencePL -------------- \n" << *referencePL << std::endl;
+  }
+  TEST_ASSERT(pass)
 }
 
 } // namespace Tempus_Test


### PR DESCRIPTION
Replaced the usage std::numeric_limits::max() for the default values
as it can cause FPEs.  Rebaselined the Integrator tests as it checks
the default values.

All tests pass on MacOS.

#4169 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus 

## Description
<!--- Please describe your changes in detail. -->
Replaced std::numeric_limits<Scalar>::max() with 1.0e+99, and std::numeric_limits<int>::max() with 1000000000.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Avoid FPEs.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
All test pass on MacOS.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
