### PR TITLE
MueLu: modifying structured aggregation to compute graph of prolongator

### DIFF
--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_decl.hpp
@@ -106,7 +106,7 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildGraph(const GraphBase& graph, RCP<IndexManager>& geoData,
+    void BuildGraph(const GraphBase& graph, RCP<IndexManager>& geoData, const LO dofsPerNode,
                     RCP<CrsGraph>& myGraph, RCP<const Map>& coarseCoordinatesFineMap,
                     RCP<const Map>& coarseCoordinatesMap) const;
     //@}
@@ -116,12 +116,14 @@ namespace MueLu {
   private:
 
     void ComputeGraphDataConstant(const GraphBase& graph, RCP<IndexManager>& geoData,
-                                  const int numInterpolationPoints, ArrayRCP<size_t>& nnzOnRow,
-                                  Array<size_t>& rowPtr, Array<LO>& colIndex) const;
+                                  const LO dofsPerNode, const int numInterpolationPoints,
+                                  ArrayRCP<size_t>& nnzOnRow, Array<size_t>& rowPtr,
+                                  Array<LO>& colIndex) const;
 
     void ComputeGraphDataLinear(const GraphBase& graph, RCP<IndexManager>& geoData,
-                                const int numInterpolationPoints, ArrayRCP<size_t>& nnzOnRow,
-                                Array<size_t>& rowPtr, Array<LO>& colIndex) const;
+                                const LO dofsPerNode, const int numInterpolationPoints,
+                                ArrayRCP<size_t>& nnzOnRow, Array<size_t>& rowPtr,
+                                Array<LO>& colIndex) const;
 
   };
 

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
@@ -129,8 +129,9 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildGraph(const GraphBase& graph, RCP<IndexManager>& geoData, RCP<CrsGraph>& myGraph,
-             RCP<const Map>& coarseCoordinatesFineMap, RCP<const Map>& coarseCoordinatesMap) const {
+  BuildGraph(const GraphBase& graph, RCP<IndexManager>& geoData, const LO dofsPerNode,
+             RCP<CrsGraph>& myGraph, RCP<const Map>& coarseCoordinatesFineMap,
+             RCP<const Map>& coarseCoordinatesMap) const {
     Monitor m(*this, "BuildGraphP");
 
     RCP<Teuchos::FancyOStream> out;
@@ -153,20 +154,23 @@ namespace MueLu {
     }
     *out << "numInterpolationPoints=" << numInterpolationPoints << std::endl;
 
-    Array<LO> colIndex( geoData->getNumLocalCoarseNodes() + numInterpolationPoints*
-                        (geoData->getNumLocalFineNodes() - geoData->getNumLocalCoarseNodes()) );
-    Array<size_t> rowPtr(geoData->getNumLocalFineNodes()+1);
+    Array<LO> colIndex((geoData->getNumLocalCoarseNodes() + numInterpolationPoints*
+                        (geoData->getNumLocalFineNodes() - geoData->getNumLocalCoarseNodes()))*dofsPerNode);
+    Array<size_t> rowPtr(geoData->getNumLocalFineNodes()*dofsPerNode + 1);
     rowPtr[0] = 0;
-    ArrayRCP<size_t> nnzOnRow(geoData->getNumLocalFineNodes());
+    ArrayRCP<size_t> nnzOnRow(geoData->getNumLocalFineNodes()*dofsPerNode);
 
     *out << "Compute prolongatorGraph data" << std::endl;
     if(geoData->getInterpolationOrder() == 0) {
-      ComputeGraphDataConstant(graph, geoData, numInterpolationPoints, nnzOnRow, rowPtr, colIndex);
+      ComputeGraphDataConstant(graph, geoData, dofsPerNode, numInterpolationPoints,
+                               nnzOnRow, rowPtr, colIndex);
     } else if(geoData->getInterpolationOrder() == 1) {
-      ComputeGraphDataLinear(graph, geoData, numInterpolationPoints, nnzOnRow, rowPtr, colIndex);
+      ComputeGraphDataLinear(graph, geoData, dofsPerNode, numInterpolationPoints,
+                             nnzOnRow, rowPtr, colIndex);
     }
 
-    // Compute graph's colMap and domainMap
+    // Compute graph's rowMap, colMap and domainMap
+    RCP<Map> rowMap = MapFactory::Build(graph.GetDomainMap(), dofsPerNode);
     RCP<Map> colMap, domainMap;
     *out << "Compute domain and column maps of the CrsGraph" << std::endl;
     if(coupled){
@@ -215,11 +219,10 @@ namespace MueLu {
                                                    graph.GetDomainMap()->getNode());
     } else {
       // In this case the map will compute the global number of nodes on the coarse mesh
-      // since geoData->getNumGlobalCoarseNodes() == Teuchos::OrdinalTraits<GO>::invalid()
       // and it will assign GIDs to the local coarse nodes.
       colMap = MapFactory::Build(graph.GetDomainMap()->lib(),
-                                 geoData->getNumGlobalCoarseNodes(),
-                                 geoData->getNumLocalCoarseNodes(),
+                                 Teuchos::OrdinalTraits<GO>::invalid(),
+                                 geoData->getNumLocalCoarseNodes()*dofsPerNode,
                                  graph.GetDomainMap()->getIndexBase(),
                                  graph.GetDomainMap()->getComm(),
                                  graph.GetDomainMap()->getNode());
@@ -229,13 +232,13 @@ namespace MueLu {
       Array<GO> coarseNodeFineGIDs(geoData->getNumLocalCoarseNodes());
       geoData->getCoarseNodesData(graph.GetDomainMap(), coarseNodeCoarseGIDs, coarseNodeFineGIDs);
       coarseCoordinatesMap = MapFactory::Build(graph.GetDomainMap()->lib(),
-                                               geoData->getNumGlobalCoarseNodes(),
+                                               Teuchos::OrdinalTraits<GO>::invalid(),
                                                geoData->getNumLocalCoarseNodes(),
                                                graph.GetDomainMap()->getIndexBase(),
                                                graph.GetDomainMap()->getComm(),
                                                graph.GetDomainMap()->getNode());
       coarseCoordinatesFineMap = MapFactory::Build(graph.GetDomainMap()->lib(),
-                                                   geoData->getNumGlobalCoarseNodes(),
+                                                   Teuchos::OrdinalTraits<GO>::invalid(),
                                                    coarseNodeFineGIDs(),
                                                    graph.GetDomainMap()->getIndexBase(),
                                                    graph.GetDomainMap()->getComm(),
@@ -243,18 +246,22 @@ namespace MueLu {
     }
 
     *out << "Call constructor of CrsGraph" << std::endl;
-    myGraph = CrsGraphFactory::Build(graph.GetDomainMap(),
+    myGraph = CrsGraphFactory::Build(rowMap,
                                      colMap,
                                      nnzOnRow,
                                      Xpetra::DynamicProfile);
 
     *out << "Fill CrsGraph" << std::endl;
+    LO rowIdx = 0;
     for(LO nodeIdx = 0; nodeIdx < geoData->getNumLocalFineNodes(); ++nodeIdx) {
-      myGraph->insertLocalIndices(nodeIdx, colIndex(rowPtr[nodeIdx], nnzOnRow[nodeIdx]) );
+      for(LO dof = 0; dof < dofsPerNode; ++dof) {
+        rowIdx = nodeIdx*dofsPerNode + dof;
+        myGraph->insertLocalIndices(rowIdx, colIndex(rowPtr[rowIdx], nnzOnRow[rowIdx]) );
+      }
     }
 
     *out << "Call fillComplete on CrsGraph" << std::endl;
-    myGraph->fillComplete(domainMap, graph.GetDomainMap());
+    myGraph->fillComplete(domainMap, rowMap);
     *out << "Prolongator CrsGraph computed" << std::endl;
 
   } // BuildAggregates()
@@ -263,8 +270,9 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
   ComputeGraphDataConstant(const GraphBase& graph, RCP<IndexManager>& geoData,
-                           const int numInterpolationPoints, ArrayRCP<size_t>& nnzOnRow,
-                           Array<size_t>& rowPtr, Array<LO>& colIndex) const {
+                           const LO dofsPerNode, const int numInterpolationPoints,
+                           ArrayRCP<size_t>& nnzOnRow, Array<size_t>& rowPtr,
+                           Array<LO>& colIndex) const {
 
     RCP<Teuchos::FancyOStream> out;
     if(const char* dbg = std::getenv("MUELU_STRUCTUREDALGORITHM_DEBUG")) {
@@ -283,9 +291,6 @@ namespace MueLu {
     LO ghostedCoarseNodeCoarseLID, rem, rate;
     Array<LO> ghostedIdx(3), coarseIdx(3);
     for(LO nodeIdx = 0; nodeIdx < geoData->getNumLocalFineNodes(); ++nodeIdx) {
-      // For piece-wise constant interpolation we only get one nnz per row
-      nnzOnRow[nodeIdx] = Teuchos::as<size_t>(1);
-      rowPtr[nodeIdx + 1] = rowPtr[nodeIdx] + 1; // These needs to change for kokkos: rowPtr[nodeIdx + 1] = nodeIdx + 1;
 
       // Compute coarse ID associated with fine LID
       geoData->getFineNodeGhostedTuple(nodeIdx, ghostedIdx[0], ghostedIdx[1], ghostedIdx[2]);
@@ -306,7 +311,13 @@ namespace MueLu {
 
       geoData->getCoarseNodeGhostedLID(coarseIdx[0], coarseIdx[1], coarseIdx[2],
                                        ghostedCoarseNodeCoarseLID);
-      colIndex[rowPtr[nodeIdx]] = ghostedCoarseNodeCoarseLIDs[ghostedCoarseNodeCoarseLID]; // Here too, substitute nodeIdx for rowPtr[nodeIdx]
+
+      for(LO dof = 0; dof < dofsPerNode; ++dof) {
+        nnzOnRow[nodeIdx*dofsPerNode + dof]         = 1;
+        rowPtr[nodeIdx*dofsPerNode + dof + 1]       = rowPtr[nodeIdx*dofsPerNode + dof] + 1;
+        colIndex[rowPtr[nodeIdx*dofsPerNode + dof]] =
+          ghostedCoarseNodeCoarseLIDs[ghostedCoarseNodeCoarseLID]*dofsPerNode + dof;
+      }
     } // Loop over fine points
 
   } // ComputeGraphDataConstant()
@@ -315,8 +326,9 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
   ComputeGraphDataLinear(const GraphBase& graph, RCP<IndexManager>& geoData,
-                         const int numInterpolationPoints, ArrayRCP<size_t>& nnzOnRow,
-                         Array<size_t>& rowPtr, Array<LO>& colIndex) const {
+                         const LO dofsPerNode, const int numInterpolationPoints,
+                         ArrayRCP<size_t>& nnzOnRow, Array<size_t>& rowPtr,
+                         Array<LO>& colIndex) const {
 
     RCP<Teuchos::FancyOStream> out;
     if(const char* dbg = std::getenv("MUELU_STRUCTUREDALGORITHM_DEBUG")) {
@@ -332,6 +344,8 @@ namespace MueLu {
     Array<LO> coarseIdx(3,0);
     Array<LO> ijkRem(3,0);
     int rate = 0;
+    const LO coarsePointOffset[8][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0},
+                                        {0, 0, 1}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}};
 
     for(LO nodeIdx = 0; nodeIdx < geoData->getNumLocalFineNodes(); ++nodeIdx) {
 
@@ -373,35 +387,38 @@ namespace MueLu {
           allCoarse = false;
       }
 
+      LO rowIdx = 0, colIdx = 0;
       if(allCoarse) {
-        // Fine node lies on Coarse node, easy case, we only need the LID of the coarse node.
-        geoData->getCoarseNodeGhostedLID(coarseIdx[0], coarseIdx[1], coarseIdx[2],
-                                         colIndex[rowPtr[nodeIdx]]);
-        nnzOnRow[nodeIdx] = Teuchos::as<size_t>(1);
-        rowPtr[nodeIdx + 1] = rowPtr[nodeIdx] + 1;
+        for(LO dof = 0; dof < dofsPerNode; ++dof) {
+          rowIdx = nodeIdx*dofsPerNode + dof;
+          nnzOnRow[rowIdx] = 1;
+          rowPtr[rowIdx + 1] = rowPtr[rowIdx] + 1;
+
+          // Fine node lies on Coarse node, easy case, we only need the LID of the coarse node.
+          geoData->getCoarseNodeGhostedLID(coarseIdx[0], coarseIdx[1], coarseIdx[2], colIdx);
+          colIndex[rowPtr[rowIdx]] = colIdx*dofsPerNode + dof;
+        }
       } else {
         // Harder case, we need the LIDs of all the coarse nodes contributing to the interpolation
-        // at the current node.
-        nnzOnRow[nodeIdx] = Teuchos::as<size_t>( numInterpolationPoints );
-        rowPtr[nodeIdx + 1] = rowPtr[nodeIdx] + Teuchos::as<LO>( numInterpolationPoints );
-
         for(int dim = 0; dim < numDimensions; ++dim) {
           if(coarseIdx[dim] == geoData->getGhostedNodesInDir(dim) - 1)
             --coarseIdx[dim];
         }
-        // Compute Coarse Node LID
-        geoData->getCoarseNodeGhostedLID(    coarseIdx[0],   coarseIdx[1],   coarseIdx[2],   colIndex[ rowPtr[nodeIdx]+0]);
-        geoData->getCoarseNodeGhostedLID(    coarseIdx[0]+1, coarseIdx[1],   coarseIdx[2],   colIndex[ rowPtr[nodeIdx]+1]);
-        if(numDimensions > 1) {
-          geoData->getCoarseNodeGhostedLID(  coarseIdx[0],   coarseIdx[1]+1, coarseIdx[2],   colIndex[ rowPtr[nodeIdx]+2]);
-          geoData->getCoarseNodeGhostedLID(  coarseIdx[0]+1, coarseIdx[1]+1, coarseIdx[2],   colIndex[ rowPtr[nodeIdx]+3]);
-          if(numDimensions > 2) {
-            geoData->getCoarseNodeGhostedLID(coarseIdx[0],   coarseIdx[1],   coarseIdx[2]+1, colIndex[ rowPtr[nodeIdx]+4]);
-            geoData->getCoarseNodeGhostedLID(coarseIdx[0]+1, coarseIdx[1],   coarseIdx[2]+1, colIndex[ rowPtr[nodeIdx]+5]);
-            geoData->getCoarseNodeGhostedLID(coarseIdx[0],   coarseIdx[1]+1, coarseIdx[2]+1, colIndex[ rowPtr[nodeIdx]+6]);
-            geoData->getCoarseNodeGhostedLID(coarseIdx[0]+1, coarseIdx[1]+1, coarseIdx[2]+1, colIndex[ rowPtr[nodeIdx]+7]);
-          }
-        }
+
+        for(LO dof = 0; dof < dofsPerNode; ++dof) {
+          // at the current node.
+          rowIdx = nodeIdx*dofsPerNode + dof;
+          nnzOnRow[rowIdx] = Teuchos::as<size_t>( numInterpolationPoints );
+          rowPtr[rowIdx + 1] = rowPtr[rowIdx] + Teuchos::as<LO>(numInterpolationPoints);
+          // Compute Coarse Node LID
+          for(LO interpIdx = 0; interpIdx < numInterpolationPoints; ++interpIdx) {
+            geoData->getCoarseNodeGhostedLID(coarseIdx[0] + coarsePointOffset[interpIdx][0],
+                                             coarseIdx[1] + coarsePointOffset[interpIdx][1],
+                                             coarseIdx[2] + coarsePointOffset[interpIdx][2],
+                                             colIdx);
+            colIndex[rowPtr[rowIdx] + interpIdx] = colIdx*dofsPerNode + dof;
+          } // Loop over numInterpolationPoints
+        } // Loop over dofsPerNode
       }
     } // Loop over fine points
   } // ComputeGraphDataLinear()

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
@@ -98,8 +98,8 @@ namespace MueLu{
     //@}
 
   private:
-    void BuildConstantP(RCP<Matrix>& P, RCP<CrsGraph>& prolongatorGraph, RCP<Matrix>& A) const;
-    void BuildLinearP(RCP<Matrix>& A, RCP<CrsGraph>& prolongatorGraph,
+    void BuildConstantP(RCP<Matrix>& P, RCP<const CrsGraph>& prolongatorGraph, RCP<Matrix>& A) const;
+    void BuildLinearP(RCP<Matrix>& A, RCP<const CrsGraph>& prolongatorGraph,
                       RCP<realvaluedmultivector_type>& fineCoordinates,
                       RCP<realvaluedmultivector_type>& ghostCoordinates,
                       const int numDimensions, RCP<Matrix>& P) const;

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -138,7 +138,7 @@ namespace MueLu {
 
     // Declared main input/outputs to be retrieved and placed on the fine resp. coarse level
     RCP<Matrix> A = Get<RCP<Matrix> >(fineLevel, "A");
-    RCP<CrsGraph> prolongatorGraph = Get<RCP<CrsGraph> >(fineLevel, "prolongatorGraph");
+    RCP<const CrsGraph> prolongatorGraph = Get<RCP<CrsGraph> >(fineLevel, "prolongatorGraph");
     RCP<realvaluedmultivector_type> fineCoordinates, coarseCoordinates;
     RCP<Matrix> P;
     const int interpolationOrder = pL.get<int>("gmg: interpolation order");
@@ -178,7 +178,7 @@ namespace MueLu {
       BuildLinearP(A, prolongatorGraph, fineCoordinates, ghostCoordinates, numDimensions, P);
     }
 
-    *out << "The prolongator matrix has been build." << std::endl;
+    *out << "The prolongator matrix has been built." << std::endl;
 
     // Build the coarse nullspace
     RCP<MultiVector> fineNullspace   = Get< RCP<MultiVector> > (fineLevel, "Nullspace");
@@ -201,7 +201,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  BuildConstantP(RCP<Matrix>& P, RCP<CrsGraph>& prolongatorGraph, RCP<Matrix>& A) const {
+  BuildConstantP(RCP<Matrix>& P, RCP<const CrsGraph>& prolongatorGraph, RCP<Matrix>& A) const {
 
     // Set debug outputs based on environment variable
     RCP<Teuchos::FancyOStream> out;
@@ -214,90 +214,19 @@ namespace MueLu {
 
     *out << "BuildConstantP" << std::endl;
 
-    // Get the number of dofs per nodes from A and use that number to manually unamalgamate
-    // the maps of the prolongator graph. Eventually this operation will no longer be needed
-    // after the structured aggregation is refactored to handle this.
-    int dofsPerNode = A->GetFixedBlockSize();
-    ArrayView<const GO> initialDomainMapLIDs =
-      prolongatorGraph->getDomainMap()->getNodeElementList();
-    Array<GO> domainMapLIDs(initialDomainMapLIDs.size()*dofsPerNode);
-    for(LO elementIdx = 0; elementIdx < as<LO>(initialDomainMapLIDs.size()); ++elementIdx) {
-      for(int dof = 0; dof < dofsPerNode; ++dof) {
-        domainMapLIDs[elementIdx*dofsPerNode + dof] =
-          initialDomainMapLIDs[elementIdx]*dofsPerNode + dof;
-      }
-    }
-
-    *out << "Call domain map constructor" << std::endl;
-
-    RCP<Map> domainMap = MapFactory::Build(prolongatorGraph->getRowMap()->lib(),
-                                           prolongatorGraph->getGlobalNumCols()*dofsPerNode,
-                                           domainMapLIDs(),
-                                           prolongatorGraph->getIndexBase(),
-                                           prolongatorGraph->getComm(),
-                                           prolongatorGraph->getRowMap()->getNode());
-
-    ArrayView<const GO> initialColMapLIDs =
-      prolongatorGraph->getColMap()->getNodeElementList();
-    Array<GO> colMapLIDs(initialColMapLIDs.size()*dofsPerNode);
-    for(LO elementIdx = 0; elementIdx < as<LO>(initialColMapLIDs.size()); ++elementIdx) {
-      for(int dof = 0; dof < dofsPerNode; ++dof) {
-        colMapLIDs[elementIdx*dofsPerNode + dof] =
-          initialColMapLIDs[elementIdx]*dofsPerNode + dof;
-      }
-    }
-
-    *out << "Call column map constructor" << std::endl;
-
-    RCP<Map> colMap = MapFactory::Build(prolongatorGraph->getColMap()->lib(),
-                                        prolongatorGraph->getGlobalNumCols()*dofsPerNode,
-                                        colMapLIDs(),
-                                        prolongatorGraph->getIndexBase(),
-                                        prolongatorGraph->getComm(),
-                                        prolongatorGraph->getColMap()->getNode());
-
     std::vector<size_t> strideInfo(1);
-    strideInfo[0]    = dofsPerNode;
-    RCP<const StridedMap> stridedDomainMap = StridedMapFactory::Build(domainMap, strideInfo);
+    strideInfo[0]    = A->GetFixedBlockSize();
+    RCP<const StridedMap> stridedDomainMap =
+      StridedMapFactory::Build(prolongatorGraph->getDomainMap(), strideInfo);
 
     *out << "Call prolongator constructor" << std::endl;
 
     // Create the prolongator matrix and its associated objects
-    P = rcp(new CrsMatrixWrap(A->getDomainMap(), colMap, 0, Xpetra::StaticProfile));
-    // P = rcp(new CrsMatrixWrap(graph));
+    RCP<ParameterList> dummyList = rcp(new ParameterList());
+    P = rcp(new CrsMatrixWrap(prolongatorGraph, dummyList));
     RCP<CrsMatrix> PCrs = rcp_dynamic_cast<CrsMatrixWrap>(P)->getCrsMatrix();
-
-    ArrayRCP<size_t>  iaP;
-    ArrayRCP<LO>      jaP;
-    ArrayRCP<SC>     valP;
-
-    PCrs->allocateAllValues(A->getDomainMap()->getNodeNumElements(), iaP, jaP, valP);
-
-    ArrayView<size_t> ia  = iaP();
-    ArrayView<LO>     ja  = jaP();
-    ArrayView<SC>     val = valP();
-    ia[0] = 0;
-
-    *out << "Fill prolongator" << std::endl;
-
-    // Actually fill up the matrix, in this case all values are one, pretty easy!
-    int dofIdx;
-    ArrayView<const LO> colIdx;
-    for(LO rowIdx = 0; rowIdx < static_cast<LO>(prolongatorGraph->getNodeNumRows()); ++rowIdx) {
-      prolongatorGraph->getLocalRowView(rowIdx, colIdx);
-      for(int dof = 0; dof < dofsPerNode; ++dof) {
-        dofIdx = rowIdx*dofsPerNode + dof;
-        ia[dofIdx + 1] = dofIdx + 1;
-        ja[dofIdx]     = colIdx[0]*dofsPerNode + dof;
-        val[dofIdx]    = 1.0;
-      }
-    }
-
-    *out << "Set values and call fillComplete on prolongator" << std::endl;
-
-    // call fill complete on the prolongator
-    PCrs->setAllValues(iaP, jaP, valP);
-    PCrs->expertStaticFillComplete(domainMap, A->getDomainMap());
+    PCrs->setAllToScalar(1.0);
+    PCrs->fillComplete();
 
     // set StridingInformation of P
     if (A->IsView("stridedMaps") == true) {
@@ -310,7 +239,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  BuildLinearP(RCP<Matrix>& A, RCP<CrsGraph>& prolongatorGraph,
+  BuildLinearP(RCP<Matrix>& A, RCP<const CrsGraph>& prolongatorGraph,
                RCP<realvaluedmultivector_type>& fineCoordinates,
                RCP<realvaluedmultivector_type>& ghostCoordinates,
                const int numDimensions, RCP<Matrix>& P) const {
@@ -327,11 +256,13 @@ namespace MueLu {
     *out << "Entering BuildLinearP" << std::endl;
 
     // Extract coordinates for interpolation stencil calculations
+    const LO numFineNodes  = fineCoordinates->getLocalLength();
+    const LO numGhostNodes = ghostCoordinates->getLocalLength();
     Array<ArrayRCP<const real_type> > fineCoords(3);
     Array<ArrayRCP<const real_type> > ghostCoords(3);
     const real_type realZero = Teuchos::as<real_type>(0.0);
-    ArrayRCP<real_type> fineZero(fineCoordinates->getLocalLength(), realZero);
-    ArrayRCP<real_type> ghostZero(ghostCoordinates->getLocalLength(), realZero);
+    ArrayRCP<real_type> fineZero(numFineNodes, realZero);
+    ArrayRCP<real_type> ghostZero(numGhostNodes, realZero);
     for(int dim = 0; dim < 3; ++dim) {
       if(dim < numDimensions) {
         fineCoords[dim]  = fineCoordinates->getData(dim);
@@ -347,117 +278,66 @@ namespace MueLu {
     // Compute 2^numDimensions using bit logic to avoid round-off errors
     const int numInterpolationPoints = 1 << numDimensions;
     const int dofsPerNode = A->GetFixedBlockSize();
-    ArrayView<const GO> initialDomainMapLIDs =
-      prolongatorGraph->getDomainMap()->getNodeElementList();
-    Array<GO> domainMapLIDs(initialDomainMapLIDs.size()*dofsPerNode);
-    for(LO elementIdx = 0; elementIdx < as<LO>(initialDomainMapLIDs.size()); ++elementIdx) {
-      for(int dof = 0; dof < dofsPerNode; ++dof) {
-        domainMapLIDs[elementIdx*dofsPerNode + dof] =
-          initialDomainMapLIDs[elementIdx]*dofsPerNode + dof;
-      }
-    }
-    RCP<Map> domainMap = MapFactory::Build(prolongatorGraph->getRowMap()->lib(),
-                                           prolongatorGraph->getGlobalNumCols()*dofsPerNode,
-                                           domainMapLIDs(),
-                                           prolongatorGraph->getIndexBase(),
-                                           prolongatorGraph->getComm(),
-                                           prolongatorGraph->getRowMap()->getNode());
-
-    ArrayView<const GO> initialColMapLIDs =
-      prolongatorGraph->getColMap()->getNodeElementList();
-    Array<GO> colMapLIDs(initialColMapLIDs.size()*dofsPerNode);
-    for(LO elementIdx = 0; elementIdx < as<LO>(initialColMapLIDs.size()); ++elementIdx) {
-      for(int dof = 0; dof < dofsPerNode; ++dof) {
-        colMapLIDs[elementIdx*dofsPerNode + dof] =
-          initialColMapLIDs[elementIdx]*dofsPerNode + dof;
-      }
-    }
-    RCP<Map> colMap = MapFactory::Build(prolongatorGraph->getColMap()->lib(),
-                                        prolongatorGraph->getGlobalNumCols()*dofsPerNode,
-                                        colMapLIDs(),
-                                        prolongatorGraph->getIndexBase(),
-                                        prolongatorGraph->getComm(),
-                                        prolongatorGraph->getColMap()->getNode());
 
     std::vector<size_t> strideInfo(1);
-    strideInfo[0]    = dofsPerNode;
-    RCP<const StridedMap> stridedDomainMap = StridedMapFactory::Build(domainMap, strideInfo);
+    strideInfo[0] = dofsPerNode;
+    RCP<const StridedMap> stridedDomainMap =
+      StridedMapFactory::Build(prolongatorGraph->getDomainMap(), strideInfo);
 
     *out << "The maps of P have been computed" << std::endl;
 
-    P = rcp(new CrsMatrixWrap(A->getDomainMap(), colMap, 0, Xpetra::StaticProfile));
-    // P = rcp(new CrsMatrixWrap(graph));
+    RCP<ParameterList> dummyList = rcp(new ParameterList());
+    P = rcp(new CrsMatrixWrap(prolongatorGraph, dummyList));
     RCP<CrsMatrix> PCrs = rcp_dynamic_cast<CrsMatrixWrap>(P)->getCrsMatrix();
+    PCrs->resumeFill(); // The Epetra matrix is considered filled at this point.
 
-    ArrayRCP<size_t>  iaP;
-    ArrayRCP<LO>      jaP;
-    ArrayRCP<SC>     valP;
-
-    LO numNonZeroP = prolongatorGraph->getNodeNumEntries()*dofsPerNode;
-    PCrs->allocateAllValues(numNonZeroP, iaP, jaP, valP);
-
-    *out << "dofsPerNode=" << dofsPerNode << std::endl;
-    *out << "number of non-zeroes in P: " << numNonZeroP << std::endl;
-
-    ArrayView<size_t> ia  = iaP();
-    ArrayView<LO>     ja  = jaP();
-    ArrayView<SC>     val = valP();
-    ia[0] = 0;
-
-    LO rowDofIdx, colDofIdx;
+    LO interpolationNodeIdx = 0, rowIdx = 0;
     ArrayView<const LO> colIndices;
+    Array<SC> values;
     Array<Array<real_type> > coords(numInterpolationPoints + 1);
     Array<real_type> stencil(numInterpolationPoints);
-    for(LO rowIdx = 0; rowIdx < static_cast<LO>(prolongatorGraph->getNodeNumRows()); ++rowIdx) {
-      prolongatorGraph->getLocalRowView(rowIdx, colIndices);
-
-      // rowIdx and colIdx correspond to single ids of nodes on the fine resp. coarse mesh
-      // rowDofIdx and colDofIdx correspond to single ids of dofs on the fine resp. coarse mesh
-      if(colIndices.size() == 1) {
-        // If colIndices.size() == 1, we are handling a coarse node
-        // we only need to stick a one in the correct location!
-        for(int dof = 0; dof < dofsPerNode; ++dof) {
-          rowDofIdx = rowIdx*dofsPerNode + dof;
-          ia[rowDofIdx + 1]  = ia[rowDofIdx] + 1;
-
-          colDofIdx      = ia[rowDofIdx];
-          ja[colDofIdx]  = colIndices[0]*dofsPerNode + dof;
-          val[colDofIdx] = 1.0;
+    for(LO nodeIdx = 0; nodeIdx < numFineNodes; ++nodeIdx) {
+      if(PCrs->getNumEntriesInLocalRow(nodeIdx*dofsPerNode) == 1) {
+        values.resize(1);
+        values[0] = 1.0;
+        for(LO dof = 0; dof < dofsPerNode; ++dof) {
+          rowIdx = nodeIdx*dofsPerNode + dof;
+          prolongatorGraph->getLocalRowView(rowIdx, colIndices);
+          PCrs->replaceLocalValues(rowIdx, colIndices, values());
         }
       } else {
-        // If colIndices.size() > 1, we need to compute the linear interpolation coefficients
-        for(int dof = 0; dof < dofsPerNode; ++dof) {
-          rowDofIdx         = rowIdx*dofsPerNode + dof;
-          ia[rowDofIdx + 1] = ia[rowDofIdx] + colIndices.size();
-
-          // Extract the coordinates associated with the current node
-          // and the neighboring coarse nodes
-          coords[0].resize(3);
+        // Extract the coordinates associated with the current node
+        // and the neighboring coarse nodes
+        coords[0].resize(3);
+        for(int dim = 0; dim < 3; ++dim) {
+          coords[0][dim] = fineCoords[dim][nodeIdx];
+        }
+        prolongatorGraph->getLocalRowView(nodeIdx*dofsPerNode, colIndices);
+        for(int interpolationIdx=0; interpolationIdx < numInterpolationPoints; ++interpolationIdx) {
+          coords[interpolationIdx + 1].resize(3);
+          interpolationNodeIdx = colIndices[interpolationIdx] / dofsPerNode;
           for(int dim = 0; dim < 3; ++dim) {
-            coords[0][dim] = fineCoords[dim][rowIdx];
+            coords[interpolationIdx + 1][dim] = ghostCoords[dim][interpolationNodeIdx];
           }
-          for(int interpolationIdx = 0; interpolationIdx < numInterpolationPoints; ++interpolationIdx) {
-            coords[interpolationIdx + 1].resize(3);
-            for(int dim = 0; dim < 3; ++dim) {
-              coords[interpolationIdx + 1][dim] = ghostCoords[dim][colIndices[interpolationIdx]];
-            }
-          }
-          ComputeLinearInterpolationStencil(numDimensions, numInterpolationPoints, coords, stencil);
+        }
+        ComputeLinearInterpolationStencil(numDimensions, numInterpolationPoints, coords, stencil);
+        values.resize(numInterpolationPoints);
+        for(LO valueIdx = 0; valueIdx < numInterpolationPoints; ++valueIdx) {
+          values[valueIdx] = stencil[valueIdx];
+        }
 
-          for(int colIdx = 0; colIdx < colIndices.size(); ++colIdx) {
-            colDofIdx      = ia[rowDofIdx] + colIdx;
-            ja[colDofIdx]  = colIndices[colIdx]*dofsPerNode + dof;
-            val[colDofIdx] = stencil[colIdx];
-          }
+        // Set values in all the rows corresponding to nodeIdx
+        for(LO dof = 0; dof < dofsPerNode; ++dof) {
+          rowIdx = nodeIdx*dofsPerNode + dof;
+          prolongatorGraph->getLocalRowView(rowIdx, colIndices);
+          PCrs->replaceLocalValues(rowIdx, colIndices, values());
         }
       }
     }
 
     *out << "The calculation of the interpolation stencils has completed." << std::endl;
 
-    Xpetra::CrsMatrixUtils<SC,LO,GO,NO>::sortCrsEntries(ia, ja, val, A->getDomainMap()->lib());
-    PCrs->setAllValues(iaP, jaP, valP);
-    PCrs->expertStaticFillComplete(domainMap, A->getDomainMap());
+    PCrs->fillComplete();
 
     *out << "All values in P have been set and expertStaticFillComplete has been performed." << std::endl;
 

--- a/packages/muelu/test/structured/structured_2dof.xml
+++ b/packages/muelu/test/structured/structured_2dof.xml
@@ -18,9 +18,10 @@
       <Parameter name="factory"                                   type="string" value="StructuredAggregationFactory"/>
       <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
       <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
-      <Parameter name="aggregation: coarsening order"             type="int"    value="0"/>
+      <Parameter name="aggregation: coarsening order"             type="int"    value="1"/>
       <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
       <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
+      <Parameter name="DofsPerNope"                               type="string" value="myCoalesceDropFact"/>
     </ParameterList>
 
     <ParameterList name="myCoarseMapFact">
@@ -32,7 +33,7 @@
     <ParameterList name="myProlongatorFact">
       <Parameter name="factory"                             type="string" value="GeometricInterpolationPFactory"/>
       <Parameter name="gmg: build coarse coordinates"       type="bool"   value="true"/>
-      <Parameter name="gmg: interpolation order"            type="int"    value="0"/>
+      <Parameter name="gmg: interpolation order"            type="int"    value="1"/>
       <Parameter name="prolongatorGraph"                    type="string" value="myAggregationFact"/>
       <Parameter name="coarseCoordinatesFineMap"            type="string" value="myAggregationFact"/>
       <Parameter name="coarseCoordinatesMap"                type="string" value="myAggregationFact"/>

--- a/packages/muelu/test/structured/structured_3dof.xml
+++ b/packages/muelu/test/structured/structured_3dof.xml
@@ -21,6 +21,7 @@
       <Parameter name="aggregation: coarsening order"             type="int"    value="0"/>
       <Parameter name="aggregation: coarsening rate"              type="string" value="{3}"/>
       <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
+      <Parameter name="DofsPerNode"                               type="string" value="myCoalesceDropFact"/>
     </ParameterList>
 
     <ParameterList name="myCoarseMapFact">

--- a/packages/muelu/test/unit_tests/StructuredAggregationFactory.cpp
+++ b/packages/muelu/test/unit_tests/StructuredAggregationFactory.cpp
@@ -128,6 +128,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: number of spatial dimensions",
@@ -232,6 +233,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: number of spatial dimensions",
@@ -336,6 +338,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: number of spatial dimensions",
@@ -442,6 +445,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: number of spatial dimensions",
@@ -548,6 +552,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: number of spatial dimensions",
@@ -655,6 +660,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: number of spatial dimensions",
@@ -767,6 +773,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: coupling",
@@ -881,6 +888,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: coupling",
@@ -996,6 +1004,7 @@ namespace MueLuTests {
     dropFact->SetFactory("UnAmalgamationInfo", amalgFact);
     RCP<StructuredAggregationFactory> StructuredAggFact = rcp(new StructuredAggregationFactory());
     StructuredAggFact->SetFactory("Graph", dropFact);
+    StructuredAggFact->SetFactory("DofsPerNode", dropFact);
     StructuredAggFact->SetParameter("aggregation: mesh layout",
                                     Teuchos::ParameterEntry(meshLayout));
     StructuredAggFact->SetParameter("aggregation: coupling",
@@ -1126,6 +1135,7 @@ namespace MueLuTests {
     // Set interfactory dependencies
     CDropfact->SetFactory("UnAmalgamationInfo", AmalgFact);
     Aggfact->SetFactory("Graph", CDropfact);
+    Aggfact->SetFactory("DofsPerNode", CDropfact);
     coarseMapFact->SetFactory("Aggregates", Aggfact);
     Pfact->SetFactory("Aggregates", Aggfact);
     Pfact->SetFactory("CoarseMap", coarseMapFact);


### PR DESCRIPTION
@trilinos/muelu 

## Description
This PR modifies the prolongatorGraph output from structured aggregation.
Instead of getting a node based graph it now returns a dofs based graph.
This means that in the new format, the prolongator graph can be used to call the constructor of the prolongator matrix directly.

## Motivation and Context
This has the advantage of reducing some overhead and it also simplifies the implementation of the geometric interpolation factory.

## Related Issues

* Closes #4173 

## How Has This Been Tested?
All the tests in MueLu have been run and passed


## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.