### PR TITLE
Thyra: add function to reset the ModelEvaluatorDefaultBase lazy initialization flag

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
@@ -264,6 +264,7 @@ public:
   { responseLibrary_->buildResponseEvaluators(physicsBlocks,eqset_factory,cm_factory,closure_models,user_data,write_graphviz_file,graphviz_file_prefix);
     require_in_args_refresh_ = true;
     require_out_args_refresh_ = true;
+    this->resetDefaultBase();
 
     typedef Thyra::ModelEvaluatorBase MEB;
     MEB::OutArgsSetup<Scalar> outArgs;
@@ -286,6 +287,7 @@ public:
   { responseLibrary_->buildResponseEvaluators(physicsBlocks,cm_factory,closure_models,user_data,write_graphviz_file,graphviz_file_prefix);
     require_in_args_refresh_ = true;
     require_out_args_refresh_ = true;
+    this->resetDefaultBase();
 
     typedef Thyra::ModelEvaluatorBase MEB;
     MEB::OutArgsSetup<Scalar> outArgs;
@@ -777,6 +779,7 @@ addResponse(const std::string & responseName,
 
    require_in_args_refresh_ = true;
    require_out_args_refresh_ = true;
+   this->resetDefaultBase();
 
    return responses_.size()-1;
 }

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
@@ -790,6 +790,7 @@ addParameter(const Teuchos::Array<std::string> & names,
 
   require_in_args_refresh_ = true;
   require_out_args_refresh_ = true;
+  this->resetDefaultBase();
 
   return parameter_index;
 }
@@ -810,6 +811,7 @@ addDistributedParameter(const std::string & key,
 
   require_in_args_refresh_ = true;
   require_out_args_refresh_ = true;
+  this->resetDefaultBase();
 
   return parameter_index;
 }

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDefaultBase.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDefaultBase.hpp
@@ -231,6 +231,12 @@ protected:
    */
   void initializeDefaultBase();
 
+  /** \brief Sets the the DefaultBase to an uninitialized state, forcing lazy initialization when needed.
+   *
+   *  This is used when a derived class changes state and requires lazy initialization.
+   */
+  void resetDefaultBase();
+
   //@}
 
 private:
@@ -860,6 +866,11 @@ void ModelEvaluatorDefaultBase<Scalar>::initializeDefaultBase()
 
 }
 
+template<class Scalar>
+void ModelEvaluatorDefaultBase<Scalar>::resetDefaultBase()
+{
+  isInitialized_ = false;
+}
 
 // Private functions with default implementaton to be overridden by subclasses
 

--- a/packages/thyra/core/test/nonlinear/UnitTests/CMakeLists.txt
+++ b/packages/thyra/core/test/nonlinear/UnitTests/CMakeLists.txt
@@ -10,6 +10,17 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
   
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  ModelEvaluatorDefaultBase
+  SOURCES
+    ModelEvaluatorDefaultBase_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS thyra_nonlinear_test_models
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  )
+
   
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   DefaultNonlinearSolverBuilder

--- a/packages/thyra/core/test/nonlinear/UnitTests/ModelEvaluatorDefaultBase_UnitTests.cpp
+++ b/packages/thyra/core/test/nonlinear/UnitTests/ModelEvaluatorDefaultBase_UnitTests.cpp
@@ -1,0 +1,89 @@
+/*
+// @HEADER
+// ***********************************************************************
+// 
+//    Thyra: Interfaces and Support for Abstract Numerical Algorithms
+//                 Copyright (2004) Sandia Corporation
+// 
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roscoe A. Bartlett (bartlettra@ornl.gov) 
+// 
+// ***********************************************************************
+// @HEADER
+*/
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Thyra_ModelEvaluatorBase.hpp"
+#include "Thyra_DummyTestModelEvaluator.hpp"
+
+namespace Thyra {
+
+  // In TEUCHOS_DEBUG builds, an exception is thrown in
+  // ModelEvaluatorDefaultBase runtime checking if Np() on the inArgs
+  // and outArgs is not the same. Lazy instantiation normally sets
+  // Np() on the model evaluator and underlying inArgs and outArgs. If
+  // this parameter changes in the model evaluator, the code is
+  // expected to manually call a new initialization. In some cases we
+  // want the derived ME to allow for lazy instatiaion since
+  // initialization could be costly. So the function resetDefaultBase
+  // resets the lazyInitializaion flag such that DefaultBase will
+  // automatically re-initialize at the right time and only once.
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(ModelEvaluatorDefaultBase,resetDefaultBase,Scalar)
+  {
+    const Ordinal x_size = 4;
+    const Ordinal p_size = 2;
+    const RCP<Thyra::DummyTestModelEvaluator<Scalar> > model = 
+      Thyra::dummyTestModelEvaluator<Scalar>(x_size,Teuchos::tuple<Ordinal>(p_size,p_size));
+
+    TEST_EQUALITY(model->createInArgs().Np(),2);
+    TEST_EQUALITY(model->createOutArgs().Np(),2);
+    TEST_EQUALITY(model->Np(),2);
+
+    // Lazy instantiation is already called so would normally not
+    // reset the ModelEvaluatorDefaultBase to Np() == 3 and doesn't
+    // seem to resize the outArgs structures correctly.  This tests
+    // that by adding resetDefaultBase() in set_p() function of the
+    // model evaluator results in a new lazyInstantion that makes Np
+    // consistent across all objects.
+    model->change_p_size_incorrectly(3);
+    TEST_EQUALITY(model->createInArgs().Np(),3);
+    TEST_EQUALITY(model->createOutArgs().Np(),2);
+    TEST_EQUALITY(model->Np(),2);
+
+    model->change_p_size_correctly(3);
+    TEST_EQUALITY(model->createInArgs().Np(),3);
+    TEST_EQUALITY(model->createOutArgs().Np(),3);
+    TEST_EQUALITY(model->Np(),3);
+  }
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT_REAL_SCALAR_TYPES(ModelEvaluatorDefaultBase,resetDefaultBase)
+
+}

--- a/packages/thyra/core/test/nonlinear/models/Thyra_DummyTestModelEvaluator_decl.hpp
+++ b/packages/thyra/core/test/nonlinear/models/Thyra_DummyTestModelEvaluator_decl.hpp
@@ -151,6 +151,10 @@ public:
 
   //@}
 
+  // For unit testing
+  void change_p_size_incorrectly(const Ordinal new_size);
+  void change_p_size_correctly(const Ordinal new_size);
+
 private: // functions
 
   /** \name Private functions overridden from ModelEvaulatorDefaultBase. */

--- a/packages/thyra/core/test/nonlinear/models/Thyra_DummyTestModelEvaluator_def.hpp
+++ b/packages/thyra/core/test/nonlinear/models/Thyra_DummyTestModelEvaluator_def.hpp
@@ -270,6 +270,33 @@ void DummyTestModelEvaluator<Scalar>::reportFinalPoint(
   // ToDo: Capture the final point and then provide in interface.
 }
 
+template<class Scalar>
+void
+DummyTestModelEvaluator<Scalar>::
+change_p_size_incorrectly(const Ordinal new_size)
+{
+  using MEB = ModelEvaluatorBase;
+  {
+    MEB::InArgsSetup<Scalar> inArgs(prototypeInArgs_);
+    inArgs.set_Np(new_size);
+    prototypeInArgs_ = inArgs;
+  }
+  {
+    MEB::OutArgsSetup<Scalar> outArgs(prototypeOutArgs_);
+    outArgs.set_Np_Ng(new_size,g_space_.size());
+    prototypeOutArgs_ = outArgs;
+  }
+  // forgot to call initializeDefaultBase() or resetDefaultBase()
+}
+
+template<class Scalar>
+void
+DummyTestModelEvaluator<Scalar>::
+change_p_size_correctly(const Ordinal new_size)
+{
+  this->change_p_size_incorrectly(new_size);
+  this->resetDefaultBase();
+}
 
 // Private functions overridden from ModelEvaulatorDefaultBase
 


### PR DESCRIPTION
This change allows Drekar to run correctly with Trilinos_ENABLE_DEBUG=ON (in particular IMEX and adjoint problems).

Details on why this is needed are in the new unit test.