### PR TITLE
Zoltan2 small mj changes

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -580,7 +580,7 @@ private:
     int check_migrate_avoid_migration_option; //whether to migrate=1, avoid migrate=2, or leave decision to MJ=0
     int migration_type; // when doing the migration, 0 will aim for perfect load-imbalance, 
     			//1 - will aim for minimized number of messages with possibly bad load-imbalance
-    mj_scalar_t minimum_migration_imbalance; //when MJ decides whether to migrate, the minimum imbalance for migration.
+    double minimum_migration_imbalance; //when MJ decides whether to migrate, the minimum imbalance for migration.
     int num_threads; //num threads
 
     mj_part_t total_num_cut ; //how many cuts will be totally
@@ -1312,7 +1312,7 @@ public:
                 bool distribute_points_on_cut_lines_,
                 int max_concurrent_part_calculation_,
                 int check_migrate_avoid_migration_option_,
-                mj_scalar_t minimum_migration_imbalance_, int migration_type_ = 0);
+                double minimum_migration_imbalance_, int migration_type_ = 0);
     /*! \brief Function call, if the part boxes are intended to be kept.
      *
      */
@@ -5914,7 +5914,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::set_partitioning_paramet
                 bool distribute_points_on_cut_lines_,
                 int max_concurrent_part_calculation_,
                 int check_migrate_avoid_migration_option_,
-                mj_scalar_t minimum_migration_imbalance_,
+                double minimum_migration_imbalance_,
 		int migration_type_ ){
         this->distribute_points_on_cut_lines = distribute_points_on_cut_lines_;
         this->max_concurrent_part_calculation = max_concurrent_part_calculation_;
@@ -6542,7 +6542,7 @@ private:
     int check_migrate_avoid_migration_option; //whether to migrate=1, avoid migrate=2, or leave decision to MJ=0
     int migration_type; // when doing the migration, 0 will aim for perfect load-imbalance, 
  			//1 for minimized messages
-    mj_scalar_t minimum_migration_imbalance; //when MJ decides whether to migrate, the minimum imbalance for migration.
+    double minimum_migration_imbalance; //when MJ decides whether to migrate, the minimum imbalance for migration.
     bool mj_keep_part_boxes; //if the boxes need to be kept.
 
     int num_threads;

--- a/packages/zoltan2/test/partition/CMakeLists.txt
+++ b/packages/zoltan2/test/partition/CMakeLists.txt
@@ -21,6 +21,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 # MultiJagged Tests
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    mj_int_coordinates
+    SOURCES mj_int_coordinates.cpp
+    COMM serial mpi
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
+# MultiJagged Tests
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
     mjTest
     SOURCES MultiJaggedTest.cpp
     NUM_MPI_PROCS 4

--- a/packages/zoltan2/test/partition/MultiJaggedTest.cpp
+++ b/packages/zoltan2/test/partition/MultiJaggedTest.cpp
@@ -565,7 +565,8 @@ int GeometricGenInterface(RCP<const Teuchos::Comm<int> > &comm,
         int migration_doMigration_type,
         bool test_boxes,
         bool rectilinear,
-        int  mj_premigration_option   
+        int  mj_premigration_option,
+        int  mj_premigration_coordinate_cutoff   
 )
 {
     int ierr = 0;
@@ -654,6 +655,10 @@ int GeometricGenInterface(RCP<const Teuchos::Comm<int> > &comm,
     if(imbalance > 1)
         params->set("imbalance_tolerance", double(imbalance));
     params->set("mj_premigration_option", mj_premigration_option);
+    if (mj_premigration_coordinate_cutoff > 0){
+        params->set("mj_premigration_coordinate_count", 
+                     mj_premigration_coordinate_cutoff);
+    }
 
     if(pqParts != "")
         params->set("mj_parts", pqParts);
@@ -783,7 +788,8 @@ int testFromDataFile(
                     double (migration_imbalance_cut_off));
     }
     if (mj_premigration_coordinate_cutoff > 0){
-        params->set("mj_premigration_coordinate_count", mj_premigration_coordinate_cutoff);
+        params->set("mj_premigration_coordinate_count",
+                     mj_premigration_coordinate_cutoff);
     }
 
     Zoltan2::PartitioningProblem<inputAdapter_t> *problem;
@@ -1333,7 +1339,8 @@ int main(int narg, char *arg[])
                     migration_processor_assignment_type,
                     migration_doMigration_type,
                     test_boxes,
-                    rectilinear, mj_premigration_option, mj_premigration_coordinate_cutoff);
+                    rectilinear,
+                    mj_premigration_option, mj_premigration_coordinate_cutoff);
         }
         catch(std::string s){
             if(tcomm->getRank() == 0){
@@ -1360,7 +1367,8 @@ int main(int narg, char *arg[])
                     migration_all_to_all_type,
                     migration_imbalance_cut_off,
                     migration_processor_assignment_type,
-                    migration_doMigration_type, test_boxes, rectilinear, mj_premigration_option, mj_premigration_coordinate_cutoff);
+                    migration_doMigration_type, test_boxes, rectilinear, 
+                    mj_premigration_option, mj_premigration_coordinate_cutoff);
             break;
 #ifdef hopper_separate_test
         case 1:
@@ -1370,7 +1378,8 @@ int main(int narg, char *arg[])
                     migration_all_to_all_type,
                     migration_imbalance_cut_off,
                     migration_processor_assignment_type,
-                    migration_doMigration_type, test_boxes, rectilinear, mj_premigration_option);
+                    migration_doMigration_type, test_boxes, rectilinear,
+                    mj_premigration_option);
             break;
 #endif
         default:
@@ -1380,7 +1389,8 @@ int main(int narg, char *arg[])
                     migration_all_to_all_type,
                     migration_imbalance_cut_off,
                     migration_processor_assignment_type,
-                    migration_doMigration_type, test_boxes, rectilinear, mj_premigration_option);
+                    migration_doMigration_type, test_boxes, rectilinear, 
+                    mj_premigration_option, mj_premigration_coordinate_cutoff);
             break;
         }
 

--- a/packages/zoltan2/test/partition/mj_int_coordinates.cpp
+++ b/packages/zoltan2/test/partition/mj_int_coordinates.cpp
@@ -103,7 +103,7 @@ int main(int narg, char *arg[])
   params.set("error_check_level", "debug_mode_assertions");
 
   params.set("algorithm", "multijagged");
-  params.set("num_global_parts", nprocs);
+  params.set("num_global_parts", nprocs+1);
 
   ///////////////////////////////////////////////////////////////////////
   // Test one:  No weights

--- a/packages/zoltan2/test/partition/mj_int_coordinates.cpp
+++ b/packages/zoltan2/test/partition/mj_int_coordinates.cpp
@@ -1,0 +1,194 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//   Zoltan2: A package of combinatorial algorithms for scientific computing
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Karen Devine      (kddevin@sandia.gov)
+//                    Erik Boman        (egboman@sandia.gov)
+//                    Siva Rajamanickam (srajama@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+
+/*! \file mj_int_coordinates.cpp
+    \brief Generate a test to partition integer coordinates
+    See definition of int_scalar_t
+*/
+
+#include <Zoltan2_PartitioningSolution.hpp>
+#include <Zoltan2_PartitioningProblem.hpp>
+#include <Zoltan2_BasicVectorAdapter.hpp>
+#include <Zoltan2_InputTraits.hpp>
+#include <Tpetra_Map.hpp>
+#include <vector>
+#include <cstdlib>
+
+int main(int narg, char *arg[])
+{
+  Tpetra::ScopeGuard scope(&narg, &arg);
+  const Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+  int rank = comm->getRank(); 
+  int nprocs = comm->getSize();
+  int nFail = 0;
+
+  typedef Tpetra::Map<> Map_t;
+  typedef Map_t::local_ordinal_type localId_t;
+  typedef Map_t::global_ordinal_type globalId_t;
+  typedef int int_scalar_t;  // This is the case we are testing here.
+
+  typedef Zoltan2::BasicUserTypes<int_scalar_t, localId_t, globalId_t> myTypes;
+  typedef Zoltan2::BasicVectorAdapter<myTypes> inputAdapter_t;
+
+  typedef Zoltan2::EvaluatePartition<inputAdapter_t> quality_t;
+
+  ///////////////////////////////////////////////////////////////////////
+  // Create input data.
+
+  size_t localCount = 40;
+  int dim = 3;
+
+  // Create coordinates that range from 0 to 9
+  int_scalar_t *coords = new int_scalar_t [dim * localCount];
+  int_scalar_t *x = coords; 
+  int_scalar_t *y = x + localCount; 
+  int_scalar_t *z = y + localCount; 
+
+  srand(rank);
+  for (size_t i=0; i < localCount*dim; i++)
+    coords[i] = int_scalar_t(rand() / (double)RAND_MAX) % 10;
+
+  // Create global ids for the coordinates.
+  globalId_t *globalIds = new globalId_t [localCount];
+  globalId_t offset = rank * localCount;
+  for (size_t i=0; i < localCount; i++) globalIds[i] = offset++;
+   
+  ///////////////////////////////////////////////////////////////////////
+  // Create parameters for an MJ problem
+
+  Teuchos::ParameterList params("test params");
+  params.set("debug_level", "basic_status");
+  params.set("error_check_level", "debug_mode_assertions");
+
+  params.set("algorithm", "multijagged");
+  params.set("num_global_parts", nprocs);
+
+  ///////////////////////////////////////////////////////////////////////
+  // Test one:  No weights
+
+  inputAdapter_t *ia1 = new inputAdapter_t(localCount,globalIds,x,y,z,1,1,1);
+
+  Zoltan2::PartitioningProblem<inputAdapter_t> *problem1 =
+           new Zoltan2::PartitioningProblem<inputAdapter_t>(ia1, &params);
+   
+  problem1->solve();
+
+  quality_t *metricObject1 = new quality_t(ia1, &params, comm,
+					   &problem1->getSolution());
+  if (rank == 0){
+
+    metricObject1->printMetrics(std::cout);
+
+    double imb = metricObject1->getObjectCountImbalance();
+    if (imb <= 1.01)  // Should get perfect balance
+      std::cout << "no weights -- balance satisfied: " << imb << std::endl;
+    else {
+      std::cout << "no weights -- balance failure: " << imb << std::endl;
+      nFail++;
+    }
+    std::cout << std::endl;
+  }
+  delete metricObject1;
+  delete problem1;
+  delete ia1;
+   
+  ///////////////////////////////////////////////////////////////////////
+  // Test two:  weighted
+  // Create a Zoltan2 input adapter that includes weights.
+
+  int_scalar_t *weights = new int_scalar_t [localCount];
+  for (size_t i=0; i < localCount; i++) weights[i] = 1 + int_scalar_t(rank);
+
+  std::vector<const int_scalar_t *>coordVec(3);
+  std::vector<int> coordStrides(3);
+
+  coordVec[0] = x; coordStrides[0] = 1;
+  coordVec[1] = y; coordStrides[1] = 1;
+  coordVec[2] = z; coordStrides[2] = 1;
+
+  std::vector<const int_scalar_t *>weightVec(1);
+  std::vector<int> weightStrides(1);
+
+  weightVec[0] = weights; weightStrides[0] = 1;
+
+  inputAdapter_t *ia2=new inputAdapter_t(localCount, globalIds, coordVec, 
+                                         coordStrides,weightVec,weightStrides);
+
+  Zoltan2::PartitioningProblem<inputAdapter_t> *problem2 =
+           new Zoltan2::PartitioningProblem<inputAdapter_t>(ia2, &params);
+
+  problem2->solve();
+
+  quality_t *metricObject2 = new quality_t(ia2, &params, comm,
+					   &problem2->getSolution());
+  if (rank == 0){
+
+    metricObject2->printMetrics(std::cout);
+
+    double imb = metricObject2->getWeightImbalance(0);
+    if (imb <= 1.01)
+      std::cout << "weighted -- balance satisfied " << imb << std::endl;
+    else {
+      std::cout << "weighted -- balance failed " << imb << std::endl;
+      nFail++;
+    }
+    std::cout << std::endl;
+  }
+  delete metricObject2;
+
+  if (weights) delete [] weights;
+  if (coords) delete [] coords;
+  if (globalIds) delete [] globalIds;
+  delete problem2;
+  delete ia2;
+
+  if (rank == 0) { 
+    if (nFail == 0) std::cout << "PASS" << std::endl;
+    else  std::cout << "FAIL:  " << nFail << " tests failed" << std::endl;
+  }
+
+  return 0;
+}
+


### PR DESCRIPTION
@trilinos/zoltan2 

Changed variable minimum_migration_imbalance to be double (which it always should be) rather than mj_scalar_t (which is provided by the user).    This fix removes compiler warnings when mj_scalar_t is int.

Also, this branch includes an unrelated change to the MJ test program, allowing another option to be set on the command line.  This option might help debug some odd MJ behavior on large problems.


## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

Tested on mac with clang.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
