### PR TITLE
MueLu & MiniEM changes

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -1885,8 +1885,8 @@ MTGaussSeidel (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_o
       // Just use the cached column Map multivector for that.
       // force=true means fill with zeros, so no need to fill
       // remote entries (not in domain Map) with zeros.
-      //X_colMap = crsMat->getColumnMapMultiVector (X, true);
-      X_colMap = rcp (new MV (colMap, X.getNumVectors ()));
+      updateCachedMultiVector(colMap,as<size_t>(X.getNumVectors()));
+      X_colMap = cachedMV_;
       // X_domainMap is always a domain Map view of the column Map
       // multivector.  In this case, the domain and column Maps are
       // the same, so X_domainMap _is_ X_colMap.
@@ -1916,8 +1916,8 @@ MTGaussSeidel (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_o
     }
   }
   else { // Column Map and domain Map are _not_ the same.
-    //X_colMap = crsMat->getColumnMapMultiVector (X);
-    X_colMap = rcp (new MV (colMap, X.getNumVectors ()));
+    updateCachedMultiVector(colMap,as<size_t>(X.getNumVectors()));
+    X_colMap = cachedMV_;
 
     X_domainMap = X_colMap->offsetViewNonConst (domainMap, 0);
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -1474,13 +1474,12 @@ namespace MueLu {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyInverseAdditive(const MultiVector& RHS, MultiVector& X) const {
 
-    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one, zero = Teuchos::ScalarTraits<Scalar>::zero();
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one();
 
     { // compute residuals
 
       Teuchos::TimeMonitor tmRes(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: residual calculation"));
-      SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-      residual_->update(one, RHS, negone);
+      Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
       R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
       D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
     }
@@ -1563,9 +1562,8 @@ namespace MueLu {
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyInverse121(const MultiVector& RHS, MultiVector& X) const {
 
     // precondition (1,1)-block
-    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one, zero = Teuchos::ScalarTraits<Scalar>::zero();
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one();
+    Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
     solveH();
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
@@ -1576,8 +1574,7 @@ namespace MueLu {
     }
 
     // precondition (2,2)-block
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
     solve22();
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS);
@@ -1588,8 +1585,7 @@ namespace MueLu {
     }
 
     // precondition (1,1)-block
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
     solveH();
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
@@ -1606,9 +1602,8 @@ namespace MueLu {
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyInverse212(const MultiVector& RHS, MultiVector& X) const {
 
     // precondition (2,2)-block
-    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one, zero = Teuchos::ScalarTraits<Scalar>::zero();
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one();
+    Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
     solve22();
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS);
@@ -1619,8 +1614,7 @@ namespace MueLu {
     }
 
     // precondition (1,1)-block
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
     solveH();
     P11_->apply(*P11x_,*residual_,Teuchos::NO_TRANS);
@@ -1631,8 +1625,7 @@ namespace MueLu {
     }
 
     // precondition (2,2)-block
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Utilities::Residual(*SM_Matrix_, X, RHS, *residual_);
     D0_T_Matrix_->apply(*residual_,*D0res_,Teuchos::NO_TRANS);
     solve22();
     D0_Matrix_->apply(*D0x_,*residual_,Teuchos::NO_TRANS);
@@ -1648,9 +1641,8 @@ namespace MueLu {
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyInverse11only(const MultiVector& RHS, MultiVector& X) const {
 
     // compute residuals
-    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one, zero = Teuchos::ScalarTraits<Scalar>::zero();
-    SM_Matrix_->apply(X, *residual_, Teuchos::NO_TRANS, one, zero);
-    residual_->update(one, RHS, negone);
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one();
+    Utilities::Residual(*SM_Matrix_, X, RHS,*residual_);
     R11_->apply(*residual_,*P11res_,Teuchos::NO_TRANS);
 
     solveH();

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -333,8 +333,10 @@ namespace MueLu {
 #endif
     }
 
+#ifdef HAVE_MPI
     bool doRebalancing = parameterList_.get<bool>("refmaxwell: subsolves on subcommunicators", false);
     int numProcsAH, numProcsA22;
+#endif
     {
       // build coarse grid operator for (1,1)-block
       formCoarseMatrix();
@@ -513,7 +515,6 @@ namespace MueLu {
         fineLevel.Set("A",SM_Matrix_);
         coarseLevel.Set("P",D0_Matrix_);
         coarseLevel.Set("Coordinates",Coords_);
-        coarseLevel.Set("number of partitions", numProcsA22);
 
         coarseLevel.setlib(SM_Matrix_->getDomainMap()->lib());
         fineLevel.setlib(SM_Matrix_->getDomainMap()->lib());
@@ -533,6 +534,8 @@ namespace MueLu {
 
 #ifdef HAVE_MPI
         if (doRebalancing) {
+
+          coarseLevel.Set("number of partitions", numProcsA22);
 
           // auto repartheurFactory = rcp(new RepartitionHeuristicFactory());
           // ParameterList repartheurParams;

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -836,11 +836,13 @@ namespace MueLu {
     std::string levelSuffix  = " (level=" + toString(startLevel) + ")";
     std::string levelSuffix1 = " (level=" + toString(startLevel+1) + ")";
 
+    bool useStackedTimer = !Teuchos::TimeMonitor::getStackedTimer().is_null();
+
     RCP<Monitor>     iterateTime;
     RCP<TimeMonitor> iterateTime1;
     if (startLevel == 0)
       iterateTime  = rcp(new Monitor(*this, "Solve", label, (nIts == 1) ? None : Runtime0, Timings0));
-    else
+    else if (!useStackedTimer)
       iterateTime1 = rcp(new TimeMonitor(*this, prefix + "Solve (total, level=" + toString(startLevel) + ")", Timings0));
 
     std::string iterateLevelTimeLabel = prefix + "Solve" + levelSuffix;
@@ -952,7 +954,9 @@ namespace MueLu {
         RCP<Level> Coarse = Levels_[startLevel+1];
         {
           // ============== PRESMOOTHING ==============
-          RCP<TimeMonitor> STime      = rcp(new TimeMonitor(*this, prefix + "Solve : smoothing (total)"      , Timings0));
+          RCP<TimeMonitor> STime;
+          if (!useStackedTimer)
+            STime                     = rcp(new TimeMonitor(*this, prefix + "Solve : smoothing (total)"      , Timings0));
           RCP<TimeMonitor> SLevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : smoothing" + levelSuffix, Timings0));
 
           if (Fine->IsAvailable("PreSmoother")) {
@@ -963,7 +967,9 @@ namespace MueLu {
 
         RCP<MultiVector> residual;
         {
-          RCP<TimeMonitor> ATime      = rcp(new TimeMonitor(*this, prefix + "Solve : residual calculation (total)"      , Timings0));
+          RCP<TimeMonitor> ATime;
+          if (!useStackedTimer)
+          ATime                       = rcp(new TimeMonitor(*this, prefix + "Solve : residual calculation (total)"      , Timings0));
           RCP<TimeMonitor> ALevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : residual calculation" + levelSuffix, Timings0));
           Utilities::Residual(*A, X, B,*residual_[startLevel]);
           residual = residual_[startLevel];
@@ -977,7 +983,9 @@ namespace MueLu {
         //        const bool initializeWithZeros = true;
         {
           // ============== RESTRICTION ==============
-          RCP<TimeMonitor> RTime      = rcp(new TimeMonitor(*this, prefix + "Solve : restriction (total)"      , Timings0));
+          RCP<TimeMonitor> RTime;
+          if (!useStackedTimer)
+            RTime                     = rcp(new TimeMonitor(*this, prefix + "Solve : restriction (total)"      , Timings0));
           RCP<TimeMonitor> RLevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : restriction" + levelSuffix, Timings0));
           coarseRhs = coarseRhs_[startLevel];
 
@@ -996,7 +1004,9 @@ namespace MueLu {
 
         coarseX = coarseX_[startLevel]; coarseX->putScalar(SC_ZERO);
         if (!doPRrebalance_ && !importer.is_null()) {
-          RCP<TimeMonitor> ITime      = rcp(new TimeMonitor(*this, prefix + "Solve : import (total)"       , Timings0));
+          RCP<TimeMonitor> ITime;
+          if (!useStackedTimer)
+            ITime                     = rcp(new TimeMonitor(*this, prefix + "Solve : import (total)"       , Timings0));
           RCP<TimeMonitor> ILevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : import" + levelSuffix1, Timings0));
 
           // Import: range map of R --> domain map of rebalanced Ac (before subcomm replacement)
@@ -1030,7 +1040,9 @@ namespace MueLu {
         }
 
         if (!doPRrebalance_ && !importer.is_null()) {
-          RCP<TimeMonitor> ITime      = rcp(new TimeMonitor(*this, prefix + "Solve : export (total)"      ,  Timings0));
+          RCP<TimeMonitor> ITime;
+          if (!useStackedTimer)
+            ITime                     = rcp(new TimeMonitor(*this, prefix + "Solve : export (total)"      ,  Timings0));
           RCP<TimeMonitor> ILevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : export" + levelSuffix1, Timings0));
 
           // Import: range map of rebalanced Ac (before subcomm replacement) --> domain map of P
@@ -1046,7 +1058,9 @@ namespace MueLu {
         RCP<MultiVector> correction = correction_[startLevel];
         {
           // ============== PROLONGATION ==============
-          RCP<TimeMonitor> PTime      = rcp(new TimeMonitor(*this, prefix + "Solve : prolongation (total)"      , Timings0));
+          RCP<TimeMonitor> PTime;
+          if (!useStackedTimer)
+            PTime                     = rcp(new TimeMonitor(*this, prefix + "Solve : prolongation (total)"      , Timings0));
           RCP<TimeMonitor> PLevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : prolongation" + levelSuffix, Timings0));
           P->apply(*coarseX, *correction, Teuchos::NO_TRANS, one, zero);
         }
@@ -1054,7 +1068,9 @@ namespace MueLu {
 
         {
           // ============== POSTSMOOTHING ==============
-          RCP<TimeMonitor> STime      = rcp(new TimeMonitor(*this, prefix + "Solve : smoothing (total)"      , Timings0));
+          RCP<TimeMonitor> STime;
+          if (!useStackedTimer)
+            STime                     = rcp(new TimeMonitor(*this, prefix + "Solve : smoothing (total)"      , Timings0));
           RCP<TimeMonitor> SLevelTime = rcp(new TimeMonitor(*this, prefix + "Solve : smoothing" + levelSuffix, Timings0));
 
           if (Fine->IsAvailable("PostSmoother")) {

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -1002,7 +1002,7 @@ namespace MueLu {
         if (Coarse->IsAvailable("Importer"))
           importer = Coarse->Get< RCP<const Import> >("Importer");
 
-        coarseX = coarseX_[startLevel]; coarseX->putScalar(SC_ZERO);
+        coarseX = coarseX_[startLevel];
         if (!doPRrebalance_ && !importer.is_null()) {
           RCP<TimeMonitor> ITime;
           if (!useStackedTimer)

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
@@ -148,7 +148,17 @@ namespace MueLu {
     // Test 2: check whether A is actually distributed, i.e. more than one processor owns part of A
     // TODO: this global communication can be avoided if we store the information with the matrix (it is known when matrix is created)
     // TODO: further improvements could be achieved when we use subcommunicator for the active set. Then we only need to check its size
+
+    // TODO: The block transfer factories do not check correctly whether or not repartitioning actually took place.
     {
+      if (comm->getSize() == 1 && Teuchos::rcp_dynamic_cast<const RAPFactory>(Afact) != Teuchos::null) {
+        GetOStream(Statistics1) << "Repartitioning?  NO:" <<
+            "\n  comm size = 1" << std::endl;
+
+        Set(currentLevel, "number of partitions", -1);
+        return;
+      }
+
       int numActiveProcesses = 0;
       MueLu_sumAll(comm, Teuchos::as<int>((A->getNodeNumRows() > 0) ? 1 : 0), numActiveProcesses);
 

--- a/packages/muelu/src/Utils/MueLu_Monitor.hpp
+++ b/packages/muelu/src/Utils/MueLu_Monitor.hpp
@@ -243,8 +243,9 @@ namespace MueLu {
         timerMonitorExclusive_(object, object.ShortClassName() + ": " + msg, timerLevel)
     {
       if (object.IsPrint(TimingsByLevel)) {
-        levelTimeMonitor_ = rcp(new TimeMonitor(object, object.ShortClassName() + ": " + msg +
-            " (total, level=" + Teuchos::Utils::toString(levelID) + ")", timerLevel));
+        if (Teuchos::TimeMonitor::getStackedTimer().is_null())
+          levelTimeMonitor_ = rcp(new TimeMonitor(object, object.ShortClassName() + ": " + msg +
+              " (total, level=" + Teuchos::Utils::toString(levelID) + ")", timerLevel));
         levelTimeMonitorExclusive_ = rcp(new MutuallyExclusiveTimeMonitor<Level>(object, object.ShortClassName() +
             MUELU_TIMER_AS_STRING + ": " + msg + " (level=" + Teuchos::Utils::toString(levelID) + ")", timerLevel));
       }
@@ -266,8 +267,9 @@ namespace MueLu {
     {
       if (object.IsPrint(TimingsByLevel)) {
         std::string label = FormattingHelper::getColonLabel(level.getObjectLabel());
-        levelTimeMonitor_ = rcp(new TimeMonitor(object, label+object.ShortClassName() + ": " +  msg +
-            " (total, level=" + Teuchos::Utils::toString(level.GetLevelID()) + ")", timerLevel));
+        if (Teuchos::TimeMonitor::getStackedTimer().is_null())
+          levelTimeMonitor_ = rcp(new TimeMonitor(object, label+object.ShortClassName() + ": " +  msg +
+              " (total, level=" + Teuchos::Utils::toString(level.GetLevelID()) + ")", timerLevel));
         levelTimeMonitorExclusive_ = rcp(new MutuallyExclusiveTimeMonitor<Level>(object, label+object.ShortClassName() +
             MUELU_TIMER_AS_STRING + ": " + msg + " (level=" + Teuchos::Utils::toString(level.GetLevelID()) + ")", timerLevel));
       }
@@ -312,7 +314,7 @@ namespace MueLu {
     SubFactoryMonitor(const BaseClass& object, const std::string & msg, int levelID, MsgType msgLevel = Runtime1, MsgType timerLevel = Timings1)
       : SubMonitor(object, msg, msgLevel, timerLevel)
     {
-      if (object.IsPrint(TimingsByLevel))
+      if (object.IsPrint(TimingsByLevel) && Teuchos::TimeMonitor::getStackedTimer().is_null())
         levelTimeMonitor_ = rcp(new TimeMonitor(object, object.ShortClassName() + ": " + msg +
                                                 " (sub, total, level=" + Teuchos::Utils::toString(levelID) + ")", timerLevel));
     }
@@ -328,7 +330,7 @@ namespace MueLu {
     SubFactoryMonitor(const BaseClass& object, const std::string & msg, const Level & level, MsgType msgLevel = Runtime1, MsgType timerLevel = Timings1)
       : SubMonitor(object, msg, FormattingHelper::getColonLabel(level.getObjectLabel()), msgLevel, timerLevel)
     {
-      if (object.IsPrint(TimingsByLevel)) {
+      if (object.IsPrint(TimingsByLevel) && Teuchos::TimeMonitor::getStackedTimer().is_null()) {
         std::string label = FormattingHelper::getColonLabel(level.getObjectLabel());
         levelTimeMonitor_ = rcp(new TimeMonitor(object, label+object.ShortClassName() + ": " +  msg +
                                                 " (sub, total, level=" + Teuchos::Utils::toString(level.GetLevelID()) + ")", timerLevel));

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
@@ -238,7 +238,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -359,7 +358,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -480,7 +478,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -601,7 +598,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 100) achieved

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -258,7 +258,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -389,7 +388,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -520,7 +518,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -651,7 +648,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 100) achieved

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
@@ -238,7 +238,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -359,7 +358,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -480,7 +478,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -258,7 +258,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -389,7 +388,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -520,7 +518,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
@@ -238,7 +238,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -359,7 +358,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -480,7 +478,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -258,7 +258,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -389,7 +388,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -520,7 +518,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
@@ -132,7 +132,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -267,7 +266,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -402,7 +400,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -135,7 +135,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -273,7 +272,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -411,7 +409,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
@@ -132,7 +132,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -267,7 +266,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -402,7 +400,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -135,7 +135,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -273,7 +272,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -411,7 +409,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
@@ -262,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -282,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
@@ -262,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -282,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
@@ -246,7 +246,7 @@ Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 type = Interpolation
 write start = -1   [default]
 write end = -1   [default]
@@ -262,7 +262,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -266,7 +266,7 @@ Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 type = Interpolation
 write start = -1   [default]
 write end = -1   [default]
@@ -282,7 +282,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
@@ -242,6 +242,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -251,6 +252,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -260,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -262,6 +262,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -271,6 +272,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -280,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
@@ -234,7 +234,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -254,7 +254,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
@@ -234,7 +234,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -356,7 +355,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -254,7 +254,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -396,7 +395,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (<Direct> solver interface)

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
@@ -242,6 +242,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -251,6 +252,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -260,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -536,6 +537,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -545,6 +547,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -554,7 +557,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -262,6 +262,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -271,6 +272,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -280,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -576,6 +577,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -585,6 +587,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -594,7 +597,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (<Direct> solver interface)

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
@@ -242,6 +242,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -251,6 +252,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -260,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -262,6 +262,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -271,6 +272,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -280,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
@@ -262,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -558,7 +557,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -282,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -598,7 +597,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
@@ -262,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -460,7 +459,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -282,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -500,7 +499,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (<Direct> solver interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
@@ -262,7 +262,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -506,7 +505,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -282,7 +282,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -546,7 +545,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
@@ -236,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -446,7 +445,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -256,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -486,7 +485,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
@@ -234,7 +234,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -254,7 +254,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
@@ -234,7 +234,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -254,7 +254,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
@@ -232,7 +232,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -350,7 +349,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -468,7 +466,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -586,7 +583,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 100) achieved

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -252,7 +252,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -380,7 +379,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -508,7 +506,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -636,7 +633,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 100) achieved

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
@@ -232,7 +232,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -350,7 +349,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -468,7 +466,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -252,7 +252,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -380,7 +379,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -508,7 +506,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
@@ -232,7 +232,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -350,7 +349,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
@@ -468,7 +466,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -252,7 +252,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -380,7 +379,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
@@ -508,7 +506,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -119,7 +119,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -241,7 +240,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -363,7 +361,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -122,7 +122,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -247,7 +246,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -372,7 +370,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -120,7 +120,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -243,7 +242,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
@@ -366,7 +364,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -123,7 +123,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -249,7 +248,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
@@ -375,7 +373,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 1000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -236,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -256,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -236,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -256,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -220,7 +220,7 @@ Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 type = Interpolation
 write start = -1   [default]
 write end = -1   [default]
@@ -236,7 +236,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -240,7 +240,7 @@ Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 type = Interpolation
 write start = -1   [default]
 write end = -1   [default]
@@ -256,7 +256,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-repartition: use subcommunicators = 0
+repartition: use subcommunicators = 0   [unused]
 
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -216,6 +216,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -225,6 +226,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -234,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -236,6 +236,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -245,6 +246,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -254,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -208,7 +208,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -228,7 +228,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -208,7 +208,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -322,7 +321,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -228,7 +228,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -362,7 +361,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (<Direct> solver interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -216,6 +216,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -225,6 +226,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -234,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -484,6 +485,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -493,6 +495,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -502,7 +505,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -236,6 +236,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -245,6 +246,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -254,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -524,6 +525,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -533,6 +535,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -542,7 +545,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (<Direct> solver interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -216,6 +216,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -225,6 +226,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -234,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -236,6 +236,7 @@ repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
 
+Using original prolongator
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -245,6 +246,7 @@ write start = -1   [default]
 write end = -1   [default]
 
 Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
 transpose: use implicit = 0   [default]
@@ -254,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -236,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -506,7 +505,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -256,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -546,7 +545,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -236,7 +236,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -418,7 +417,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -256,7 +256,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -458,7 +457,6 @@ RepairMainDiagonal = 0   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (<Direct> solver interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -238,7 +238,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -464,7 +463,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -258,7 +258,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -504,7 +503,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -222,7 +222,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -421,7 +420,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -242,7 +242,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved
@@ -461,7 +460,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -208,7 +208,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -228,7 +228,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -208,7 +208,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -228,7 +228,6 @@ write start = -1   [default]
 write end = -1   [default]
 
 Computing Ac (MueLu::RebalanceAcFactory)
-Replacing maps with a subcommunicator
 repartition: use subcommunicators = 1   [default]
 
 Max coarse size (<= 2000) achieved

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R0.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R0.xml
@@ -89,7 +89,10 @@
     <!-- Note: 1/dt is added at runtime -->
     <ParameterList name="electromagnetics">
       <ParameterList name="CURRENT">
-        <Parameter name="Type" type="string" value="GAUSSIAN PULSE"/>
+        <Parameter name="Type" type="string" value="RANDOM"/>
+        <Parameter name="seed" type="unsigned int" value="0"/>
+        <Parameter name="range min" type="double" value="0"/>
+        <Parameter name="range max" type="double" value="1"/>
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R1.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R1.xml
@@ -89,7 +89,10 @@
     <!-- Note: 1/dt is added at runtime -->
     <ParameterList name="electromagnetics">
       <ParameterList name="CURRENT">
-        <Parameter name="Type" type="string" value="GAUSSIAN PULSE"/>
+        <Parameter name="Type" type="string" value="RANDOM"/>
+        <Parameter name="seed" type="unsigned int" value="0"/>
+        <Parameter name="range min" type="double" value="0"/>
+        <Parameter name="range max" type="double" value="1"/>
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R2.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R2.xml
@@ -89,7 +89,10 @@
     <!-- Note: 1/dt is added at runtime -->
     <ParameterList name="electromagnetics">
       <ParameterList name="CURRENT">
-        <Parameter name="Type" type="string" value="GAUSSIAN PULSE"/>
+        <Parameter name="Type" type="string" value="RANDOM"/>
+        <Parameter name="seed" type="unsigned int" value="0"/>
+        <Parameter name="range min" type="double" value="0"/>
+        <Parameter name="range max" type="double" value="1"/>
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R3.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R3.xml
@@ -89,7 +89,10 @@
     <!-- Note: 1/dt is added at runtime -->
     <ParameterList name="electromagnetics">
       <ParameterList name="CURRENT">
-        <Parameter name="Type" type="string" value="GAUSSIAN PULSE"/>
+        <Parameter name="Type" type="string" value="RANDOM"/>
+        <Parameter name="seed" type="unsigned int" value="0"/>
+        <Parameter name="range min" type="double" value="0"/>
+        <Parameter name="range max" type="double" value="1"/>
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R4.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-blob-R4.xml
@@ -89,7 +89,10 @@
     <!-- Note: 1/dt is added at runtime -->
     <ParameterList name="electromagnetics">
       <ParameterList name="CURRENT">
-        <Parameter name="Type" type="string" value="GAUSSIAN PULSE"/>
+        <Parameter name="Type" type="string" value="RANDOM"/>
+        <Parameter name="seed" type="unsigned int" value="0"/>
+        <Parameter name="range min" type="double" value="0"/>
+        <Parameter name="range max" type="double" value="1"/>
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
@@ -111,7 +111,10 @@
     <!-- Note: 1/dt is added at runtime -->
     <ParameterList name="electromagnetics">
       <ParameterList name="CURRENT">
-        <Parameter name="Type" type="string" value="GAUSSIAN PULSE"/>
+        <Parameter name="Type" type="string" value="RANDOM"/>
+        <Parameter name="seed" type="unsigned int" value="0"/>
+        <Parameter name="range min" type="double" value="0"/>
+        <Parameter name="range max" type="double" value="1"/>
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">

--- a/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMLRefMaxwell.xml
@@ -3,31 +3,19 @@
   <ParameterList name="Linear Solver Types">
     <ParameterList name="Belos">
       <Parameter name="Solver Type" type="string" value="Block GMRES"/>
-      <!-- <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/> -->
       <ParameterList name="Solver Types">
         <ParameterList name="Block GMRES">
           <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
           <Parameter name="Orthogonalization" type="string" value="ICGS"/>
           <Parameter name="Output Frequency" type="int" value="1"/>
           <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="33"/>
-          <Parameter name="Maximum Iterations" type="int" value="100"/>
+          <Parameter name="Verbosity" type="int" value="1"/>
+          <Parameter name="Maximum Iterations" type="int" value="10"/>
           <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="40"/>
+          <Parameter name="Num Blocks" type="int" value="10"/>
           <Parameter name="Flexible Gmres" type="bool" value="true"/>
           <Parameter name="Timer Label" type="string" value="GMRES block system"/>
           <Parameter name="Implicit Residual Scaling" type="string" value="Norm of Initial Residual"/>
-        </ParameterList>
-        <ParameterList name="Pseudo Block GMRES">
-          <Parameter name="Convergence Tolerance" type="double" value="1.0e-8"/>
-          <Parameter name="Orthogonalization" type="string" value="ICGS"/>
-          <Parameter name="Output Frequency" type="int" value="1"/>
-          <Parameter name="Output Style" type="int" value="1"/>
-          <Parameter name="Verbosity" type="int" value="33"/>
-          <Parameter name="Maximum Iterations" type="int" value="100"/>
-          <Parameter name="Block Size" type="int" value="1"/>
-          <Parameter name="Num Blocks" type="int" value="40"/>
-          <Parameter name="Timer Label" type="string" value="GMRES block system"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="VerboseObject">
@@ -52,15 +40,17 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
+                <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
-                <Parameter name="Output Frequency" type="int" value="1"/>
+                <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Verbosity" type="int" value="1"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
@@ -117,15 +107,16 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block GMRES">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
                 <Parameter name="Output Style" type="int" value="1"/>
-                <Parameter name="Verbosity" type="int" value="33"/>
+                <Parameter name="Verbosity" type="int" value="1"/>
                 <Parameter name="Implicit Residual Scaling" type="string" value="None"/>
               </ParameterList>
             </ParameterList>
@@ -216,6 +207,7 @@
               <Parameter name="z-coordinates" type="string" value="AUXILIARY_NODE"/>
             </ParameterList>
           </ParameterList>
+
         </ParameterList>
       </ParameterList>
     </ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuRefMaxwellEpetra.xml
@@ -40,10 +40,11 @@
 
           <ParameterList name="Q_B Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Orthogonalization" type="string" value="ICGS"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG Q_B"/>
@@ -122,10 +123,11 @@
 
           <ParameterList name="S_E Solve">
             <Parameter name="Type" type="string" value="Belos"/>
-            <Parameter name="Solver Type" type="string" value="Pseudo Block CG"/>
+            <Parameter name="Solver Type" type="string" value="Block CG"/>
             <ParameterList name="Solver Types">
-              <ParameterList name="Pseudo Block CG">
+              <ParameterList name="Block CG">
                 <Parameter name="Convergence Tolerance" type="double" value="1.0e-9"/>
+                <Parameter name="Use Single Reduction" type="bool" value="true"/>
                 <Parameter name="Maximum Iterations" type="int" value="100"/>
                 <Parameter name="Timer Label" type="string" value="CG S_E"/>
                 <Parameter name="Output Frequency" type="int" value="10"/>
@@ -143,9 +145,9 @@
             <Parameter name="Type" type="string" value="MueLuRefMaxwell"/>
             <ParameterList name="Preconditioner Types">
               <ParameterList name="MueLuRefMaxwell">
+                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
                 <Parameter name="use kokkos refactor" type="bool" value="false"/>
                 <Parameter name="verbosity" type="string" value="extreme"/>
-                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
                 <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
                 <Parameter name="refmaxwell: mode" type="string" value="additive"/>
                 <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
@@ -184,6 +186,7 @@
 
                 <ParameterList name="refmaxwell: 11list">
                   <Parameter name="use kokkos refactor" type="bool" value="false"/>
+                  <Parameter name="verbosity" type="string" value="extreme"/>
                   <Parameter name="coarse: max size" type="int" value="2500"/>
                   <Parameter name="number of equations" type="int" value="3"/>
                   <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>

--- a/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_ClosureModel_Factory_impl.hpp
@@ -105,8 +105,10 @@ buildClosureModels(const std::string& model_id,
       }
       if(type=="RANDOM") {
         unsigned int seed = plist.get<unsigned int>("seed");
+        double min = plist.get<double>("range min");
+        double max = plist.get<double>("range max");
 	RCP< Evaluator<panzer::Traits> > e =
-	  rcp(new mini_em::RandomForcing<EvalT,panzer::Traits>(key,*ir,fl,seed));
+	  rcp(new mini_em::RandomForcing<EvalT,panzer::Traits>(key,*ir,fl,seed,min,max));
 	evaluators->push_back(e);
 
         found = true;

--- a/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse.hpp
@@ -35,6 +35,9 @@ public:
                   const panzer::IntegrationRule & ir,
                   const panzer::FieldLayoutLibrary & fl,
                   const double & dt);
+
+    void postRegistrationSetup(typename Traits::SetupData d,
+                               PHX::FieldManager<Traits>& fm);
                                                                         
     void evaluateFields(typename Traits::EvalData d);               
 

--- a/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_GaussianPulse_impl.hpp
@@ -40,6 +40,14 @@ GaussianPulse<EvalT,Traits>::GaussianPulse(const std::string & name,
 
 //**********************************************************************
 template <typename EvalT,typename Traits>
+void GaussianPulse<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,
+                                                        PHX::FieldManager<Traits>& /* fm */)
+{
+  ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
 void GaussianPulse<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
 { 
   using panzer::index_t;
@@ -51,9 +59,9 @@ void GaussianPulse<EvalT,Traits>::evaluateFields(typename Traits::EvalData works
   if (ir_dim == 3) {
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {
       for (int point = 0; point < current.extent_int(1); ++point) {
-        const ScalarT& x = coords(cell,point,0);
-        const ScalarT& y = coords(cell,point,1);
-        const ScalarT& z = coords(cell,point,2);
+        const ScalarT& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
+        const ScalarT& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
+        const ScalarT& z = workset.int_rules[ir_index]->ip_coordinates(cell,point,2);
         const ScalarT  r2 = (x-0.5)*(x-0.5) + (y-0.5)*(y-0.5) + (z-0.5)*(z-0.5);
         current(cell,point,0) = 0.0;
         current(cell,point,1) = 0.0;
@@ -63,8 +71,8 @@ void GaussianPulse<EvalT,Traits>::evaluateFields(typename Traits::EvalData works
   } else {
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {
       for (int point = 0; point < current.extent_int(1); ++point) {
-        const ScalarT& x = coords(cell,point,0);
-        const ScalarT& y = coords(cell,point,1);
+        const ScalarT& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
+        const ScalarT& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
         const ScalarT  r2 = (x-0.5)*(x-0.5) + (y-0.5)*(y-0.5);
         current(cell,point,0) = 0.0;
         current(cell,point,1) = std::exp(-r2*scale)*factor;

--- a/packages/panzer/mini-em/src/closures/MiniEM_RandomForcing.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_RandomForcing.hpp
@@ -31,7 +31,9 @@ public:
     RandomForcing(const std::string & name,
                   const panzer::IntegrationRule & ir,
                   const panzer::FieldLayoutLibrary & fl,
-                  const unsigned int & seed);
+                  const unsigned int & seed,
+                  const double & rangeMin,
+                  const double & rangeMax);
 
     void evaluateFields(typename Traits::EvalData d);
 
@@ -43,6 +45,7 @@ private:
   PHX::MDField<ScalarT,Cell,Point,Dim> current;
   PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
   int ir_degree, ir_index, ir_dim;
+  double rangeShift_, rangeMult_;
 };
 
 }

--- a/packages/panzer/mini-em/src/closures/MiniEM_RandomForcing_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_RandomForcing_impl.hpp
@@ -15,7 +15,9 @@ template <typename EvalT,typename Traits>
 RandomForcing<EvalT,Traits>::RandomForcing(const std::string & name,
                                            const panzer::IntegrationRule & ir,
                                            const panzer::FieldLayoutLibrary & fl,
-                                           const unsigned int & seed)
+                                           const unsigned int & seed,
+                                           const double & rangeMin,
+                                           const double & rangeMax)
 {
   using Teuchos::RCP;
 
@@ -34,6 +36,8 @@ RandomForcing<EvalT,Traits>::RandomForcing(const std::string & name,
   std::string n = "Random Forcing";
   this->setName(n);
   std::srand(seed);
+  rangeShift_ = rangeMin;
+  rangeMult_ = rangeMax-rangeMin;
 }
 
 //**********************************************************************
@@ -51,9 +55,9 @@ void RandomForcing<EvalT,Traits>::evaluateFields(typename Traits::EvalData works
         // const ScalarT& x = coords(cell,point,0);
         // const ScalarT& y = coords(cell,point,1);
         // const ScalarT& z = coords(cell,point,2);
-        current(cell,point,0) = double(std::rand())/double(RAND_MAX);
-        current(cell,point,1) = double(std::rand())/double(RAND_MAX);
-        current(cell,point,2) = double(std::rand())/double(RAND_MAX);
+        current(cell,point,0) = rangeMult_ * double(std::rand())/double(RAND_MAX) + rangeShift_;
+        current(cell,point,1) = rangeMult_ * double(std::rand())/double(RAND_MAX) + rangeShift_;
+        current(cell,point,2) = rangeMult_ * double(std::rand())/double(RAND_MAX) + rangeShift_;
       }
     }
   } else {
@@ -61,8 +65,8 @@ void RandomForcing<EvalT,Traits>::evaluateFields(typename Traits::EvalData works
       for (int point = 0; point < current.extent_int(1); ++point) {
         // const ScalarT& x = coords(cell,point,0);
         // const ScalarT& y = coords(cell,point,1);
-        current(cell,point,0) = double(std::rand())/double(RAND_MAX);
-        current(cell,point,1) = double(std::rand())/double(RAND_MAX);
+        current(cell,point,0) = rangeMult_ * double(std::rand())/double(RAND_MAX) + rangeShift_;
+        current(cell,point,1) = rangeMult_ * double(std::rand())/double(RAND_MAX) + rangeShift_;
       }
     }
   }

--- a/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity.hpp
@@ -41,6 +41,9 @@ namespace mini_em {
                                const double & betaz2_,
                                const std::string& DoF_);
 
+    void postRegistrationSetup(typename Traits::SetupData d,
+                               PHX::FieldManager<Traits>& fm);
+
     void evaluateFields(typename Traits::EvalData d);
 
 
@@ -49,7 +52,7 @@ namespace mini_em {
 
     PHX::MDField<ScalarT,Cell,Point,Dim,Dim> conductivity;
     PHX::MDField<const ScalarT,Cell,Point,Dim> coords;
-    int ir_degree, ir_dim;
+    int ir_degree, ir_dim, ir_index;
     double sigma0, betax0, betay0, betaz0;
     double sigma1, betax1, betay1, betaz1;
     double sigma2, betax2, betay2, betaz2;

--- a/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity_impl.hpp
+++ b/packages/panzer/mini-em/src/closures/MiniEM_VariableTensorConductivity_impl.hpp
@@ -64,6 +64,14 @@ VariableTensorConductivity<EvalT,Traits>::VariableTensorConductivity(const std::
 
 //**********************************************************************
 template <typename EvalT,typename Traits>
+void VariableTensorConductivity<EvalT,Traits>::postRegistrationSetup(typename Traits::SetupData sd,
+                                                                     PHX::FieldManager<Traits>& /* fm */)
+{
+  ir_index = panzer::getIntegrationRuleIndex(ir_degree,(*sd.worksets_)[0], this->wda);
+}
+
+//**********************************************************************
+template <typename EvalT,typename Traits>
 void VariableTensorConductivity<EvalT,Traits>::evaluateFields(typename Traits::EvalData workset)
 {
   using panzer::index_t;
@@ -86,9 +94,9 @@ void VariableTensorConductivity<EvalT,Traits>::evaluateFields(typename Traits::E
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {
       for (int point = 0; point < conductivity.extent_int(1); ++point) {
 
-        const ScalarT& x = coords(cell,point,0);
-        const ScalarT& y = coords(cell,point,1);
-        const ScalarT& z = coords(cell,point,2);
+        const ScalarT& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
+        const ScalarT& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
+        const ScalarT& z = workset.int_rules[ir_index]->ip_coordinates(cell,point,2);
 
         if ((xl0<=x) && (x<=xr0) &&
             (yl0<=y) && (y<=yr0) &&
@@ -143,8 +151,8 @@ void VariableTensorConductivity<EvalT,Traits>::evaluateFields(typename Traits::E
     for (index_t cell = 0; cell < workset.num_cells; ++cell) {
       for (int point = 0; point < conductivity.extent_int(1); ++point) {
 
-        const ScalarT& x = coords(cell,point,0);
-        const ScalarT& y = coords(cell,point,1);
+        const ScalarT& x = workset.int_rules[ir_index]->ip_coordinates(cell,point,0);
+        const ScalarT& y = workset.int_rules[ir_index]->ip_coordinates(cell,point,1);
 
         if ((xl0<=x) && (x<=xr0) &&
             (yl0<=y) && (y<=yr0)) {

--- a/packages/stratimikos/adapters/belos/src/BelosThyraAdapter.hpp
+++ b/packages/stratimikos/adapters/belos/src/BelosThyraAdapter.hpp
@@ -63,6 +63,8 @@
 #  include <Thyra_TsqrAdaptor.hpp>
 #endif // HAVE_BELOS_TSQR
 
+#include <Teuchos_TimeMonitor.hpp>
+
 namespace Belos {
 
   ////////////////////////////////////////////////////////////////////////////
@@ -273,6 +275,9 @@ namespace Belos {
          const ScalarType beta, TMVB& mv )
     {
       using Teuchos::arrayView; using Teuchos::arcpFromArrayView;
+
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvTimesMatAddMv")));
+
       const int m = B.numRows();
       const int n = B.numCols();
       // Create a view of the B object!
@@ -296,6 +301,8 @@ namespace Belos {
       typedef Teuchos::ScalarTraits<ScalarType> ST;
       using Teuchos::tuple; using Teuchos::ptrInArg; using Teuchos::inoutArg;
 
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvAddMv")));
+
       Thyra::linear_combination<ScalarType>(
         tuple(alpha, beta)(), tuple(ptrInArg(A), ptrInArg(B))(), ST::zero(), inoutArg(mv));
     }
@@ -303,12 +310,18 @@ namespace Belos {
     /*! \brief Scale each element of the vectors in \c *this with \c alpha.
      */
     static void MvScale ( TMVB& mv, const ScalarType alpha )
-      { Thyra::scale(alpha, Teuchos::inoutArg(mv)); }
+      {
+        Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvScale")));
+
+        Thyra::scale(alpha, Teuchos::inoutArg(mv));
+      }
 
     /*! \brief Scale each element of the \c i-th vector in \c *this with \c alpha[i].
      */
     static void MvScale (TMVB& mv, const std::vector<ScalarType>& alpha)
     {
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvScale")));
+
       for (unsigned int i=0; i<alpha.size(); i++) {
         Thyra::scale<ScalarType> (alpha[i], mv.col(i).ptr());
       }
@@ -320,6 +333,9 @@ namespace Belos {
       Teuchos::SerialDenseMatrix<int,ScalarType>& B )
     {
       using Teuchos::arrayView; using Teuchos::arcpFromArrayView;
+
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvTransMv")));
+
       // Create a multivector to hold the result (m by n)
       int m = A.domain()->dim();
       int n = mv.domain()->dim();
@@ -339,7 +355,11 @@ namespace Belos {
         \c i-th columns of \c A and \c mv, i.e.\f$b[i] = A[i]^Tmv[i]\f$.
      */
     static void MvDot( const TMVB& mv, const TMVB& A, std::vector<ScalarType>& b )
-      { Thyra::dots(mv, A, Teuchos::arrayViewFromVector(b)); }
+      {
+        Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvDot")));
+
+        Thyra::dots(mv, A, Teuchos::arrayViewFromVector(b));
+      }
 
     //@}
 
@@ -351,6 +371,8 @@ namespace Belos {
     */
     static void MvNorm( const TMVB& mv, std::vector<magType>& normvec,
       NormType type = TwoNorm ) {
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::MvNorm")));
+
       if(type == TwoNorm)
         Thyra::norms_2(mv, Teuchos::arrayViewFromVector(normvec));
       else if(type == OneNorm)
@@ -452,6 +474,8 @@ namespace Belos {
     static void
     Assign (const TMVB& A, TMVB& mv)
     {
+      Teuchos::TimeMonitor tM(*Teuchos::TimeMonitor::getNewTimer(std::string("Belos::MVT::Assign")));
+
       const int numColsA = A.domain()->dim();
       const int numColsMv = mv.domain()->dim();
       if (numColsA > numColsMv)


### PR DESCRIPTION
@trilinos/muelu @trilinos/panzer 

## Description
- Fix an issue that made RHS assembly slow on Cuda for MiniEM.
- Use random current forcing term instead of Gaussian Pulse (which is mesh specific).
- Add timers to Thyra Belos adapter to track down why the CG remainder is exploding on Cuda.
- When running with stacked timer, don't create summary timers in MueLu.
- Do not rebalance on size 1 communicators, even if it's switched on.
- Skip one unneeded initialization in MueLu's iterate.
- Use cached vector in Ifpack2 MTGS.