### PR TITLE
Tpetra - fix warning error from mismatched virtual functions

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -756,14 +756,14 @@ protected:
   virtual void
   packAndPrepareNew (const SrcDistObject& sourceObj,
                      const Kokkos::DualView<const local_ordinal_type*, device_type>& exportLIDs,
-                     Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
+                     Kokkos::DualView<packet_type*, buffer_device_type>& exports,
                      const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
                      size_t& constantNumPackets,
                      Distributor& /* distor */);
 
   virtual void
   unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*, device_type>& importLIDs,
-                       const Kokkos::DualView<const impl_scalar_type*, buffer_device_type>& imports,
+                       const Kokkos::DualView<const packet_type*, buffer_device_type>& imports,
                        const Kokkos::DualView<const size_t*, buffer_device_type>& numPacketsPerLID, 
                        const size_t constantNumPackets,
                        Distributor& /* distor */,

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -3075,11 +3075,12 @@ public:
     } // if totalNumEntries > 0
 
     if (debug) {
-      std::ostream& err = this->markLocalErrorAndGetStream ();
+      std::ostringstream os;
       const bool lclSuccess = ! (* (this->localError_));
-      err << prefix
-          << (lclSuccess ? "succeeded" : "FAILED")
-          << " (totalNumEntries = " << totalNumEntries << ") ***" << std::endl;
+      os << prefix
+         << (lclSuccess ? "succeeded" : "FAILED")
+         << std::endl;
+      std::cerr << os.str ();
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -2843,7 +2843,7 @@ public:
   BlockCrsMatrix<Scalar, LO, GO, Node>::
   packAndPrepareNew (const ::Tpetra::SrcDistObject& source,
                      const Kokkos::DualView<const local_ordinal_type*, device_type>& exportLIDs,
-                     Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
+                     Kokkos::DualView<packet_type*, buffer_device_type>& exports,
                      const Kokkos::DualView<size_t*, buffer_device_type>& numPacketsPerLID,
                      size_t& constantNumPackets,
                      Distributor& /* distor */)
@@ -2986,11 +2986,8 @@ public:
     // We use a "struct of arrays" approach to packing each row's
     // entries.  All the column indices (as global indices) go first,
     // then all their owning process ranks, and then the values.
-    exports.resize (totalNumBytes/numBytesPerValue);
+    exports.resize (totalNumBytes);
     if (totalNumEntries > 0) {
-      // exports is resized in the above and we assume the data on device is invalidated.
-      Kokkos::View<char*,host_exec> exportsByteHost ((char*)exports.view_host().data(), totalNumBytes);
-
       // Current position (in bytes) in the 'exports' output array.
       Kokkos::View<size_t*, host_exec> offset("offset", numExportLIDs+1);
       {
@@ -3054,7 +3051,7 @@ public:
             //   host scratch space somehow is not considered same as the host_exec
             // Copy the row's data into the current spot in the exports array.
             const size_t numBytes = packRowForBlockCrs<impl_scalar_type,LO,GO,host_exec>
-              (exportsByteHost,
+              (exports.view_host(),
                offset(i),
                numEnt,
                Kokkos::View<const GO*,host_exec>(gblColInds.data(), maxRowLength),
@@ -3091,7 +3088,7 @@ public:
   void
   BlockCrsMatrix<Scalar, LO, GO, Node>::
   unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*, device_type>& importLIDs,
-                       const Kokkos::DualView<const impl_scalar_type*, buffer_device_type>& imports,
+                       const Kokkos::DualView<const packet_type*, buffer_device_type>& imports,
                        const Kokkos::DualView<const size_t*, buffer_device_type>& numPacketsPerLID,
                        const size_t /* constantNumPackets */,
                        Distributor& /* distor */,
@@ -3192,8 +3189,6 @@ public:
       std::cerr << os.str ();
     }
 
-    Kokkos::View<char*,host_exec> importsByteHost((char*)imports.view_host().data(), imports.extent(0)*numBytesPerValue);
-
     if (importLIDs.need_sync_host()) {
       Kokkos::DualView<const local_ordinal_type*, device_type> importLIDsTemp = importLIDs;
       importLIDsTemp.sync_host();
@@ -3242,7 +3237,7 @@ public:
           const size_t numBytes = numPacketsPerLIDHost(i);
           const size_t numEnt =
             unpackRowCount<impl_scalar_type, LO, GO, host_exec>
-            (importsByteHost, offval, numBytes, numBytesPerValue);
+            (imports.view_host(), offval, numBytes, numBytesPerValue);
 
           if (numBytes > 0) {
             if (numEnt > maxRowNumEnt) {
@@ -3269,7 +3264,7 @@ public:
             unpackRowForBlockCrs<impl_scalar_type, LO, GO, host_exec>
             (Kokkos::View<GO*,host_exec>(gidsOut.data(), numEnt),
              Kokkos::View<impl_scalar_type*,host_exec>(valsOut.data(), numScalarEnt),
-             importsByteHost,
+             imports.view_host(),
              offval, numBytes, numEnt,
              numBytesPerValue, blockSize);
 


### PR DESCRIPTION

## Description

Fixiing mismatched virtual functions definitions. This could be a real error but somehow it works with other compilers and PR tests.  
## Related Issues

#4221 

## How Has This Been Tested?

As the error shows up from SRN machines with a clang compiler and this is not detected from PR tests, I cannot attempt to reproduce the error myself. From the error message, I matched the function signatures and hope that it will solve the problem. 
