### PR TITLE
zoltan:  Removed a gcc7.2 warning

### DIFF
--- a/packages/zoltan/src/driver/dr_loadbalCPP.cpp
+++ b/packages/zoltan/src/driver/dr_loadbalCPP.cpp
@@ -132,7 +132,7 @@ int setup_zoltan(Zoltan &zz, int Proc, PROB_INFO_PTR prob,
 /* Local declarations. */
   const char *yo = "setup_zoltan";
   int ierr;                      /* Error code */
-  char errmsg[128];              /* Error message */
+  char errmsg[256];              /* Error message */
 
   DEBUG_TRACE_START(Proc, yo);
 


### PR DESCRIPTION
This trivial PR fixes a gcc 7.2 compiler warning.
@trilinos/zoltan 