### PR TITLE
Zoltan2:  Enable MJ to work with int coordinates

### DIFF
--- a/packages/zoltan2/src/algorithms/Zoltan2_Algorithm.hpp
+++ b/packages/zoltan2/src/algorithms/Zoltan2_Algorithm.hpp
@@ -150,7 +150,7 @@ public:
   //          Not all partitioning algorithms will support
   //          this method.
   //
-  virtual std::vector<coordinateModelPartBox<scalar_t, part_t> > &
+  virtual std::vector<coordinateModelPartBox> &
   getPartBoxesView() const
   {
     Z2_THROW_NOT_IMPLEMENTED

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -99,9 +99,9 @@
 #define ZOLTAN2_ABS(x) ((x) >= 0 ? (x) : -(x))
 //imbalance calculation. Wreal / Wexpected - 1
 #define imbalanceOf(Wachieved, totalW, expectedRatio) \
-        double(Wachieved) / double((totalW) * (expectedRatio)) - 1
+        (Wachieved) / ((totalW) * (expectedRatio)) - 1
 #define imbalanceOf2(Wachieved, wExpected) \
-        double(Wachieved) / double(wExpected) - 1
+        (Wachieved) / (wExpected) - 1
 
 
 #define ZOLTAN2_ALGMULTIJAGGED_SWAP(a,b,temp) temp=(a);(a)=(b);(b)=temp;
@@ -6626,7 +6626,8 @@ public:
                         minimum_migration_imbalance(0.30),
                         mj_keep_part_boxes(false), num_threads(1), mj_run_as_rcb(false),mj_premigration_option(0), min_coord_per_rank_for_premigration(32000),
                         comXAdj_(), comAdj_(), coordinate_ArrayRCP_holder (NULL)
-    {}
+    {std::cout << "KDDKDD adapter_scalar_t " << typeid(adapter_scalar_t).name() << " mj_scalar_t " << typeid(mj_scalar_t).name() << std::endl;}
+
     ~Zoltan2_AlgMJ(){
       if (coordinate_ArrayRCP_holder != NULL){
         delete [] this->coordinate_ArrayRCP_holder;

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6626,7 +6626,7 @@ public:
                         minimum_migration_imbalance(0.30),
                         mj_keep_part_boxes(false), num_threads(1), mj_run_as_rcb(false),mj_premigration_option(0), min_coord_per_rank_for_premigration(32000),
                         comXAdj_(), comAdj_(), coordinate_ArrayRCP_holder (NULL)
-    {std::cout << "KDDKDD adapter_scalar_t " << typeid(adapter_scalar_t).name() << " mj_scalar_t " << typeid(mj_scalar_t).name() << std::endl;}
+    {}
 
     ~Zoltan2_AlgMJ(){
       if (coordinate_ArrayRCP_holder != NULL){

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -532,7 +532,7 @@ template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
 class AlgMJ
 {
 private:
-    typedef coordinateModelPartBox<mj_scalar_t, mj_part_t> mj_partBox_t;
+    typedef coordinateModelPartBox mj_partBox_t;
     typedef std::vector<mj_partBox_t> mj_partBoxVector_t;
 
     RCP<const Environment> mj_env; //the environment object
@@ -6505,12 +6505,28 @@ private:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
     typedef CoordinateModel<typename Adapter::base_adapter_t> coordinateModel_t;
-    typedef typename Adapter::scalar_t mj_scalar_t;
+
+    // For coordinates and weights, MJ needs floats or doubles
+    // But Adapter can provide other scalars, e.g., ints.
+    // So have separate scalar_t for MJ and adapter.
+    typedef typename Adapter::scalar_t adapter_scalar_t;
+
+    // Provide a default type for mj_scalar_t;
+    typedef float default_mj_scalar_t;
+
+    // If Adapter provided float or double scalar_t, use it (prevents copies).
+    // Otherwise, use the default type of mj_scalar_t;
+    typedef typename 
+            std::conditional<
+                 (std::is_same<adapter_scalar_t, float>::value || 
+                  std::is_same<adapter_scalar_t, double>::value),
+                 adapter_scalar_t, default_mj_scalar_t>::type   mj_scalar_t;
+
     typedef typename Adapter::gno_t mj_gno_t;
     typedef typename Adapter::lno_t mj_lno_t;
     typedef typename Adapter::node_t mj_node_t;
     typedef typename Adapter::part_t mj_part_t;
-    typedef coordinateModelPartBox<mj_scalar_t, mj_part_t> mj_partBox_t;
+    typedef coordinateModelPartBox mj_partBox_t;
     typedef std::vector<mj_partBox_t> mj_partBoxVector_t;
 #endif
     AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t> mj_partitioner;
@@ -6688,9 +6704,9 @@ public:
       return *pBoxes;
     }
 
-    mj_part_t pointAssign(int dim, mj_scalar_t *point) const;
+    mj_part_t pointAssign(int dim, adapter_scalar_t *point) const;
 
-    void boxAssign(int dim, mj_scalar_t *lower, mj_scalar_t *upper,
+    void boxAssign(int dim, adapter_scalar_t *lower, adapter_scalar_t *upper,
                    size_t &nPartsFound, mj_part_t **partsFound) const;
 
 
@@ -7099,7 +7115,7 @@ void Zoltan2_AlgMJ<Adapter>::set_up_partitioning_data(
         //if the weights of coordinates are uniform in a criteria dimension.
         this->mj_uniform_weights = allocMemory< bool >(criteria_dim);
 
-        typedef StridedData<mj_lno_t, mj_scalar_t> input_t;
+        typedef StridedData<mj_lno_t, adapter_scalar_t> input_t;
         ArrayView<const mj_gno_t> gnos;
         ArrayView<input_t> xyz;
         ArrayView<input_t> wgts;
@@ -7115,7 +7131,8 @@ void Zoltan2_AlgMJ<Adapter>::set_up_partitioning_data(
         //extract coordinates from multivector.
         for (int dim=0; dim < this->coord_dim; dim++){
                 ArrayRCP<const mj_scalar_t> ar;
-                xyz[dim].getInputArray(ar);
+                xyz[dim].getInputArray(ar); // will copy if stride != 1 or 
+                                            // adapter_scalar_t != mj_scalar_t
                 this->coordinate_ArrayRCP_holder[dim] = ar;
 
                 //multiJagged coordinate values assignment
@@ -7131,7 +7148,9 @@ void Zoltan2_AlgMJ<Adapter>::set_up_partitioning_data(
                 //if weights are provided get weights for all weight indices
                 for (int wdim = 0; wdim < this->num_weights_per_coord; wdim++){
                         ArrayRCP<const mj_scalar_t> ar;
-                        wgts[wdim].getInputArray(ar);
+                        wgts[wdim].getInputArray(ar); // will copy if stride!=1
+                                                      // or adapter_scalar_t !=
+                                                      // mj_scalar_t
                         this->coordinate_ArrayRCP_holder[this->coord_dim + wdim] = ar;
                         this->mj_uniform_weights[wdim] = false;
                         this->mj_weights[wdim] = (mj_scalar_t *) ar.getRawPtr();
@@ -7315,8 +7334,8 @@ void Zoltan2_AlgMJ<Adapter>::set_input_parameters(const Teuchos::ParameterList &
 template <typename Adapter>
 void Zoltan2_AlgMJ<Adapter>::boxAssign(
   int dim,
-  typename Adapter::scalar_t *lower,
-  typename Adapter::scalar_t *upper,
+  adapter_scalar_t *lower,
+  adapter_scalar_t *upper,
   size_t &nPartsFound,
   typename Adapter::part_t **partsFound) const
 {
@@ -7393,7 +7412,7 @@ void Zoltan2_AlgMJ<Adapter>::boxAssign(
 template <typename Adapter>
 typename Adapter::part_t Zoltan2_AlgMJ<Adapter>::pointAssign(
   int dim,
-  typename Adapter::scalar_t *point) const
+  adapter_scalar_t *point) const
 {
 
   // TODO:  Implement with cuts rather than boxes to reduce algorithmic
@@ -7448,13 +7467,14 @@ typename Adapter::part_t Zoltan2_AlgMJ<Adapter>::pointAssign(
       // Determine to which part it is closest.
       // TODO:  with cuts, would not need this special case
 
+      typedef typename Zoltan2::coordinateModelPartBox::coord_t coord_t;
       size_t closestBox = 0;
-      mj_scalar_t minDistance = std::numeric_limits<mj_scalar_t>::max();
-      mj_scalar_t *centroid = new mj_scalar_t[dim];
+      coord_t minDistance = std::numeric_limits<coord_t>::max();
+      coord_t *centroid = new coord_t[dim];
       for (size_t i = 0; i < nBoxes; i++) {
         (*partBoxes)[i].computeCentroid(centroid);
-        mj_scalar_t sum = 0.;
-        mj_scalar_t diff;
+        coord_t sum = 0.;
+        coord_t diff;
         for (int j = 0; j < dim; j++) {
           diff = centroid[j] - point[j];
           sum += diff * diff;
@@ -7485,7 +7505,7 @@ void Zoltan2_AlgMJ<Adapter>::getCommunicationGraph(
     RCP<mj_partBoxVector_t> pBoxes = this->getGlobalBoxBoundaries();
     mj_part_t ntasks =  (*pBoxes).size();
     int dim = (*pBoxes)[0].getDim();
-    GridHash<mj_scalar_t, mj_part_t> grid(pBoxes, ntasks, dim);
+    GridHash grid(pBoxes, ntasks, dim);
     grid.getAdjArrays(comXAdj_, comAdj_);
   }
   comAdj = comAdj_;
@@ -7519,28 +7539,29 @@ AlgMJ<mj_scalar_t,mj_lno_t,mj_gno_t,mj_part_t>::compute_global_box_boundaries(
   RCP<mj_partBoxVector_t> &localPartBoxes
 ) const
 {
+  typedef typename Zoltan2::coordinateModelPartBox::coord_t coord_t;
   mj_part_t ntasks = this->num_global_parts;
   int dim = (*localPartBoxes)[0].getDim();
-  mj_scalar_t *localPartBoundaries = new mj_scalar_t[ntasks * 2 *dim];
+  coord_t *localPartBoundaries = new coord_t[ntasks * 2 *dim];
 
-  memset(localPartBoundaries, 0, sizeof(mj_scalar_t) * ntasks * 2 *dim);
+  memset(localPartBoundaries, 0, sizeof(coord_t) * ntasks * 2 *dim);
 
-  mj_scalar_t *globalPartBoundaries = new mj_scalar_t[ntasks * 2 *dim];
-  memset(globalPartBoundaries, 0, sizeof(mj_scalar_t) * ntasks * 2 *dim);
+  coord_t *globalPartBoundaries = new coord_t[ntasks * 2 *dim];
+  memset(globalPartBoundaries, 0, sizeof(coord_t) * ntasks * 2 *dim);
 
-  mj_scalar_t *localPartMins = localPartBoundaries;
-  mj_scalar_t *localPartMaxs = localPartBoundaries + ntasks * dim;
+  coord_t *localPartMins = localPartBoundaries;
+  coord_t *localPartMaxs = localPartBoundaries + ntasks * dim;
 
-  mj_scalar_t *globalPartMins = globalPartBoundaries;
-  mj_scalar_t *globalPartMaxs = globalPartBoundaries + ntasks * dim;
+  coord_t *globalPartMins = globalPartBoundaries;
+  coord_t *globalPartMaxs = globalPartBoundaries + ntasks * dim;
 
   mj_part_t boxCount = localPartBoxes->size();
   for (mj_part_t i = 0; i < boxCount; ++i){
     mj_part_t pId = (*localPartBoxes)[i].getpId();
       //std::cout << "me:" << comm->getRank() << " has:" << pId << std::endl;
 
-    mj_scalar_t *lmins = (*localPartBoxes)[i].getlmins();
-    mj_scalar_t *lmaxs = (*localPartBoxes)[i].getlmaxs();
+    coord_t *lmins = (*localPartBoxes)[i].getlmins();
+    coord_t *lmaxs = (*localPartBoxes)[i].getlmaxs();
 
     for (int j = 0; j < dim; ++j){
       localPartMins[dim * pId + j] = lmins[j];
@@ -7554,15 +7575,14 @@ AlgMJ<mj_scalar_t,mj_lno_t,mj_gno_t,mj_part_t>::compute_global_box_boundaries(
     }
   }
 
-  Teuchos::Zoltan2_BoxBoundaries<int, mj_scalar_t> reductionOp(ntasks * 2 *dim);
+  Teuchos::Zoltan2_BoxBoundaries<int, coord_t> reductionOp(ntasks * 2 *dim);
 
-  reduceAll<int, mj_scalar_t>(*mj_problemComm, reductionOp,
+  reduceAll<int, coord_t>(*mj_problemComm, reductionOp,
             ntasks * 2 *dim, localPartBoundaries, globalPartBoundaries);
   RCP<mj_partBoxVector_t> pB(new mj_partBoxVector_t(),true);
   for (mj_part_t i = 0; i < ntasks; ++i){
-    Zoltan2::coordinateModelPartBox <mj_scalar_t, mj_part_t> tpb(i, dim,
-                                               globalPartMins + dim * i,
-                                               globalPartMaxs + dim * i);
+    Zoltan2::coordinateModelPartBox tpb(i, dim, globalPartMins + dim * i,
+                                                globalPartMaxs + dim * i);
 
     /*
     for (int j = 0; j < dim; ++j){

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_CoordinatePartitioningGraph.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_CoordinatePartitioningGraph.hpp
@@ -57,6 +57,7 @@
 #include "Teuchos_Comm.hpp"
 #include "Teuchos_ArrayViewDecl.hpp"
 #include "Teuchos_RCPDecl.hpp"
+#include "Zoltan2_InputTraits.hpp"
 
 namespace Zoltan2{
 
@@ -66,42 +67,26 @@ namespace Zoltan2{
 /*! \brief coordinateModelPartBox Class,
  * represents the boundaries of the box which is a result of a geometric partitioning algorithm.
  */
-template <typename scalar_t,typename part_t>
 class coordinateModelPartBox{
-
-        part_t pID; //part Id
-        int dim;    //dimension of the box
-        scalar_t *lmins;    //minimum boundaries of the box along all dimensions.
-        scalar_t *lmaxs;    //maximum boundaries of the box along all dimensions.
-        scalar_t maxScalar;
-        scalar_t _EPSILON;
-
-        //to calculate the neighbors of the box and avoid the p^2 comparisons,
-        //we use hashing. A box can be put into multiple hash buckets.
-        //the following 2 variable holds the minimum and maximum of the
-        //hash values along all dimensions.
-        part_t *minHashIndices;
-        part_t *maxHashIndices;
-
-        //result hash bucket indices.
-        std::vector <part_t> *gridIndices;
-        //neighbors of the box.
-        std::set <part_t> neighbors;
+ 
 public:
+        typedef double coord_t;
+        typedef Zoltan2::default_part_t part_t;
+
         /*! \brief Constructor
          */
         coordinateModelPartBox(part_t pid, int dim_):
             pID(pid),
             dim(dim_),
             lmins(0), lmaxs(0),
-            maxScalar (std::numeric_limits<scalar_t>::max()),
-            _EPSILON(std::numeric_limits<scalar_t>::epsilon()),
+            maxScalar (std::numeric_limits<coord_t>::max()),
+            _EPSILON(std::numeric_limits<coord_t>::epsilon()),
             minHashIndices(0),
             maxHashIndices(0),
             gridIndices(0), neighbors()
         {
-            lmins = new scalar_t [dim];
-            lmaxs = new scalar_t [dim];
+            lmins = new coord_t [dim];
+            lmaxs = new coord_t [dim];
 
             minHashIndices = new part_t [dim];
             maxHashIndices = new part_t [dim];
@@ -114,24 +99,25 @@ public:
         /*! \brief  Constructor
          * deep copy of the maximum and minimum boundaries.
          */
+        template <typename scalar_t>
         coordinateModelPartBox(part_t pid, int dim_, scalar_t *lmi, scalar_t *lma):
             pID(pid),
             dim(dim_),
             lmins(0), lmaxs(0),
-            maxScalar (std::numeric_limits<scalar_t>::max()),
-            _EPSILON(std::numeric_limits<scalar_t>::epsilon()),
+            maxScalar (std::numeric_limits<coord_t>::max()),
+            _EPSILON(std::numeric_limits<coord_t>::epsilon()),
             minHashIndices(0),
             maxHashIndices(0),
             gridIndices(0), neighbors()
         {
-            lmins = new scalar_t [dim];
-            lmaxs = new scalar_t [dim];
+            lmins = new coord_t [dim];
+            lmaxs = new coord_t [dim];
             minHashIndices = new part_t [dim];
             maxHashIndices = new part_t [dim];
             gridIndices = new std::vector <part_t> ();
             for (int i = 0; i < dim; ++i){
-                lmins[i] = lmi[i];
-                lmaxs[i] = lma[i];
+                lmins[i] = coord_t(lmi[i]);
+                lmaxs[i] = coord_t(lma[i]);
             }
         }
 
@@ -139,24 +125,24 @@ public:
         /*! \brief  Copy Constructor
          * deep copy of the maximum and minimum boundaries.
          */
-        coordinateModelPartBox(const coordinateModelPartBox <scalar_t, part_t> &other):
+        coordinateModelPartBox(const coordinateModelPartBox &other):
             pID(other.getpId()),
             dim(other.getDim()),
             lmins(0), lmaxs(0),
-            maxScalar (std::numeric_limits<scalar_t>::max()),
-            _EPSILON(std::numeric_limits<scalar_t>::epsilon()),
+            maxScalar (std::numeric_limits<coord_t>::max()),
+            _EPSILON(std::numeric_limits<coord_t>::epsilon()),
             minHashIndices(0),
             maxHashIndices(0),
             gridIndices(0), neighbors()
         {
 
-            lmins = new scalar_t [dim];
-            lmaxs = new scalar_t [dim];
+            lmins = new coord_t [dim];
+            lmaxs = new coord_t [dim];
             minHashIndices = new part_t [dim];
             maxHashIndices = new part_t [dim];
             gridIndices = new std::vector <part_t> ();
-            scalar_t *othermins = other.getlmins();
-            scalar_t *othermaxs = other.getlmaxs();
+            coord_t *othermins = other.getlmins();
+            coord_t *othermaxs = other.getlmaxs();
             for (int i = 0; i < dim; ++i){
                 lmins[i] = othermins[i];
                 lmaxs[i] = othermaxs[i];
@@ -191,17 +177,17 @@ public:
         }
         /*! \brief  function to get minimum values along all dimensions
          */
-        scalar_t * getlmins()const{
+        coord_t * getlmins()const{
             return this->lmins;
         }
         /*! \brief  function to get maximum values along all dimensions
          */
-        scalar_t * getlmaxs()const{
+        coord_t * getlmaxs()const{
             return this->lmaxs;
         }
         /*! \brief  compute the centroid of the box 
          */
-        void computeCentroid(scalar_t *centroid)const {
+        void computeCentroid(coord_t *centroid)const {
             for (int i = 0; i < this->dim; i++)
                 centroid[i] = 0.5 * (this->lmaxs[i] + this->lmins[i]);
         }
@@ -221,18 +207,20 @@ public:
 
         /*! \brief function to test whether a point is in the box
          */
+        template <typename scalar_t>
         bool pointInBox(int pointdim, scalar_t *point) const {
           if (pointdim != this->dim) 
             throw std::logic_error("dim of point must match dim of box");
           for (int i = 0; i < pointdim; i++) {
-            if (point[i] < this->lmins[i]) return false;
-            if (point[i] > this->lmaxs[i]) return false;
+            if (coord_t(point[i]) < this->lmins[i]) return false;
+            if (coord_t(point[i]) > this->lmaxs[i]) return false;
           }
           return true;
         }
 
         /*! \brief function to test whether this box overlaps a given box
          */
+        template <typename scalar_t>
         bool boxesOverlap(int cdim, scalar_t *lower, scalar_t *upper) const {
           if (cdim != this->dim) 
             throw std::logic_error("dim of given box must match dim of box");
@@ -240,11 +228,14 @@ public:
           // Check for at least partial overlap
           bool found = true;
           for (int i = 0; i < cdim; i++) {
-            if (!((lower[i] >= this->lmins[i] && lower[i] <= this->lmaxs[i]) 
+            if (!((coord_t(lower[i]) >= this->lmins[i] && 
+                   coord_t(lower[i]) <= this->lmaxs[i]) 
                    // lower i-coordinate in the box
-               || (upper[i] >= this->lmins[i] && upper[i] <= this->lmaxs[i]) 
+               || (coord_t(upper[i]) >= this->lmins[i] && 
+                   coord_t(upper[i]) <= this->lmaxs[i]) 
                    // upper i-coordinate in the box
-               || (lower[i] <  this->lmins[i] && upper[i] >  this->lmaxs[i]))) {
+               || (coord_t(lower[i]) <  this->lmins[i] && 
+                   coord_t(upper[i]) >  this->lmaxs[i]))) {
                    // i-coordinates straddle the box
               found = false;
               break;
@@ -256,11 +247,10 @@ public:
         /*! \brief  function to check if two boxes are neighbors.
          */
         bool isNeighborWith(
-            const coordinateModelPartBox <scalar_t, part_t> &other) const{
+            const coordinateModelPartBox &other) const{
 
-
-            scalar_t *omins = other.getlmins();
-            scalar_t *omaxs = other.getlmaxs();
+            coord_t *omins = other.getlmins();
+            coord_t *omaxs = other.getlmaxs();
 
             int equality = 0;
             for (int i = 0; i < dim; ++i){
@@ -307,12 +297,12 @@ public:
         /*! \brief  function to obtain the min and max hash values along all dimensions.
          */
         void setMinMaxHashIndices (
-                scalar_t *minMaxBoundaries,
-                scalar_t *sliceSizes,
+                coord_t *minMaxBoundaries,
+                coord_t *sliceSizes,
                 part_t numSlicePerDim
                 ){
             for (int j = 0; j < dim; ++j){
-                scalar_t distance = (lmins[j] - minMaxBoundaries[j]);
+                coord_t distance = (lmins[j] - minMaxBoundaries[j]);
                 part_t minInd = 0;
                 if (distance > _EPSILON && sliceSizes[j] > _EPSILON){
                     minInd = static_cast<part_t>(floor((lmins[j] - minMaxBoundaries[j])/ sliceSizes[j]));
@@ -379,12 +369,13 @@ public:
 
         /*! \brief  function to update the boundary of the box.
         */
+        template <typename scalar_t>
         void updateMinMax (scalar_t newBoundary, int isMax, int dimInd){
             if (isMax){
-                lmaxs[dimInd] = newBoundary;
+                lmaxs[dimInd] = coord_t(newBoundary);
             }
             else {
-                lmins[dimInd] = newBoundary;
+                lmins[dimInd] = coord_t(newBoundary);
             }
         }
 
@@ -392,8 +383,8 @@ public:
         */
         void writeGnuPlot(std::ofstream &file,std::ofstream &mm){
             int numCorners = (int(1)<<dim);
-            scalar_t *corner1 = new scalar_t [dim];
-            scalar_t *corner2 = new scalar_t [dim];
+            coord_t *corner1 = new coord_t [dim];
+            coord_t *corner2 = new coord_t [dim];
 
             for (int i = 0; i < dim; ++i){
                 /*
@@ -471,17 +462,17 @@ public:
                     std::string arrowline = "set arrow from ";
                     for (int i = 0; i < dim - 1; ++i){
                         arrowline += 
-                             Teuchos::toString<scalar_t>(corner1[i]) + ",";
+                             Teuchos::toString<coord_t>(corner1[i]) + ",";
                     }
                     arrowline += 
-                         Teuchos::toString<scalar_t>(corner1[dim -1]) + " to ";
+                         Teuchos::toString<coord_t>(corner1[dim -1]) + " to ";
 
                     for (int i = 0; i < dim - 1; ++i){
                         arrowline += 
-                             Teuchos::toString<scalar_t>(corner2[i]) + ",";
+                             Teuchos::toString<coord_t>(corner2[i]) + ",";
                     }
                     arrowline += 
-                         Teuchos::toString<scalar_t>(corner2[dim -1]) + 
+                         Teuchos::toString<coord_t>(corner2[dim -1]) + 
                                                      " nohead\n";
 
                     file << arrowline;
@@ -491,25 +482,45 @@ public:
             delete []corner2;
         }
 
+private:
+        part_t pID; //part Id
+        int dim;    //dimension of the box
+        coord_t *lmins;    //minimum boundaries of the box along all dimensions.
+        coord_t *lmaxs;    //maximum boundaries of the box along all dimensions.
+        coord_t maxScalar;
+        coord_t _EPSILON;
 
+        //to calculate the neighbors of the box and avoid the p^2 comparisons,
+        //we use hashing. A box can be put into multiple hash buckets.
+        //the following 2 variable holds the minimum and maximum of the
+        //hash values along all dimensions.
+        part_t *minHashIndices;
+        part_t *maxHashIndices;
+
+        //result hash bucket indices.
+        std::vector <part_t> *gridIndices;
+        //neighbors of the box.
+        std::set <part_t> neighbors;
 };
 
 
 /*! \brief GridHash Class,
  * Hashing Class for part boxes
  */
-template <typename scalar_t, typename part_t>
 class GridHash{
 private:
 
-    const RCP < std::vector <Zoltan2::coordinateModelPartBox <scalar_t, part_t> > > pBoxes;
+    typedef typename Zoltan2::coordinateModelPartBox::coord_t coord_t;
+    typedef typename Zoltan2::coordinateModelPartBox::part_t part_t;
+
+    const RCP<std::vector<Zoltan2::coordinateModelPartBox> > pBoxes;
 
     //minimum of the maximum box boundaries
-    scalar_t *minMaxBoundaries;
+    coord_t *minMaxBoundaries;
     //maximum of the minimum box boundaries
-    scalar_t *maxMinBoundaries;
+    coord_t *maxMinBoundaries;
     //the size of each slice along dimensions
-    scalar_t *sliceSizes;
+    coord_t *sliceSizes;
     part_t nTasks;
     int dim;
     //the number of slices per dimension
@@ -526,8 +537,8 @@ public:
     /*! \brief GridHash Class,
      * Constructor
      */
-    GridHash(const RCP < std::vector <Zoltan2::coordinateModelPartBox <scalar_t, part_t> > > &pBoxes_,
-            part_t ntasks_, int dim_):
+    GridHash(const RCP<std::vector<Zoltan2::coordinateModelPartBox> > &pBoxes_,
+             part_t ntasks_, int dim_):
         pBoxes(pBoxes_),
         minMaxBoundaries(0),
         maxMinBoundaries(0), sliceSizes(0),
@@ -539,9 +550,9 @@ public:
         comXAdj(), comAdj()
     {
 
-        minMaxBoundaries = new scalar_t[dim];
-        maxMinBoundaries = new scalar_t[dim];
-        sliceSizes = new scalar_t[dim];
+        minMaxBoundaries = new coord_t[dim];
+        maxMinBoundaries = new coord_t[dim];
+        sliceSizes = new coord_t[dim];
         //calculate the number of slices in each dimension.
         numSlicePerDim /= 2;
         if (numSlicePerDim == 0) numSlicePerDim = 1;
@@ -681,8 +692,8 @@ public:
      * calculates the minimum of maximum box boundaries, and maxium of minimum box boundaries.
      */
     void getMinMaxBoundaries(){
-        scalar_t *mins = (*pBoxes)[0].getlmins();
-        scalar_t *maxs = (*pBoxes)[0].getlmaxs();
+        coord_t *mins = (*pBoxes)[0].getlmins();
+        coord_t *maxs = (*pBoxes)[0].getlmaxs();
 
         for (int j = 0; j < dim; ++j){
             minMaxBoundaries[j] = maxs[j];
@@ -719,28 +730,28 @@ public:
     }
 };
 /*
-template <typename scalar_t,typename part_t>
+template <typename coord_t,typename part_t>
 class coordinatePartBox{
 public:
         part_t pID;
         int dim;
         int numCorners;
-        scalar_t **corners;
-        scalar_t *lmins, *gmins;
-        scalar_t *lmaxs, *gmaxs;
-        scalar_t maxScalar;
+        coord_t **corners;
+        coord_t *lmins, *gmins;
+        coord_t *lmaxs, *gmaxs;
+        coord_t maxScalar;
         std::vector <part_t> hash_indices;
-        coordinatePartBox(part_t pid, int dim_, scalar_t *lMins, scalar_t *gMins,
-                                    scalar_t *lMaxs, scalar_t *gMaxs):
+        coordinatePartBox(part_t pid, int dim_, coord_t *lMins, coord_t *gMins,
+                                    coord_t *lMaxs, coord_t *gMaxs):
             pID(pid),
             dim(dim_),
             numCorners(int(pow(2, dim_))),
             corners(0),
             lmins(lMins), gmins(gMins), lmaxs(lMaxs), gmaxs(gMaxs),
-            maxScalar (std::numeric_limits<scalar_t>::max()){
-            this->corners = new scalar_t *[dim];
+            maxScalar (std::numeric_limits<coord_t>::max()){
+            this->corners = new coord_t *[dim];
             for (int i = 0; i < dim; ++i){
-                this->corners[i] = new scalar_t[this->numCorners];
+                this->corners[i] = new coord_t[this->numCorners];
                 lmins[i] = this->maxScalar;
                 lmaxs[i] = -this->maxScalar;
             }
@@ -768,7 +779,7 @@ private:
 
     typedef typename Adapter::lno_t lno_t;
     typedef typename Adapter::gno_t gno_t;
-    typedef typename Adapter::scalar_t scalar_t;
+    typedef typename Adapter::coord_t coord_t;
 
     const Environment *env;
     const Teuchos::Comm<int> *comm;
@@ -803,10 +814,10 @@ public:
 
 
         size_t allocSize = numParts * coordDim;
-        scalar_t *lmins = new scalar_t [allocSize];
-        scalar_t *gmins = new scalar_t [allocSize];
-        scalar_t *lmaxs = new scalar_t [allocSize];
-        scalar_t *gmaxs = new scalar_t [allocSize];
+        coord_t *lmins = new coord_t [allocSize];
+        coord_t *gmins = new coord_t [allocSize];
+        coord_t *lmaxs = new coord_t [allocSize];
+        coord_t *gmaxs = new coord_t [allocSize];
 
         for(part_t i = 0; i < numParts; ++i){
             coordinatePartBox tmp(
@@ -820,7 +831,7 @@ public:
             cpb.push_back(tmp);
         }
 
-        typedef StridedData<lno_t, scalar_t> input_t;
+        typedef StridedData<lno_t, coord_t> input_t;
         Teuchos::ArrayView<const gno_t> gnos;
         Teuchos::ArrayView<input_t>     xyz;
         Teuchos::ArrayView<input_t>     wgts;
@@ -829,13 +840,13 @@ public:
         //local and global num coordinates.
         lno_t numLocalCoords = coords->getLocalNumCoordinates();
 
-        scalar_t **pqJagged_coordinates = new scalar_t *[coordDim];
+        coord_t **pqJagged_coordinates = new coord_t *[coordDim];
 
         for (int dim=0; dim < coordDim; dim++){
-            Teuchos::ArrayRCP<const scalar_t> ar;
+            Teuchos::ArrayRCP<const coord_t> ar;
             xyz[dim].getInputArray(ar);
             //pqJagged coordinate values assignment
-            pqJagged_coordinates[dim] =  (scalar_t *)ar.getRawPtr();
+            pqJagged_coordinates[dim] =  (coord_t *)ar.getRawPtr();
         }
 
         part_t *sol_part = soln->getPartList();
@@ -866,9 +877,9 @@ public:
                 );
 
         //calculate the corners of the dataset.
-        scalar_t *allMins = new scalar_t [coordDim];
-        scalar_t *allMaxs = new scalar_t [coordDim];
-        part_t *hash_scales= new scalar_t [coordDim];
+        coord_t *allMins = new coord_t [coordDim];
+        coord_t *allMaxs = new coord_t [coordDim];
+        part_t *hash_scales= new coord_t [coordDim];
 
         for (int j = 0; j < coordDim; ++j){
             allMins[j] = cpb[0].gmins[j];
@@ -878,15 +889,15 @@ public:
 
         for (part_t i = 1; i < numParts; ++i){
             for (int j = 0; j < coordDim; ++j){
-                scalar_t minC = cpb[i].gmins[i];
-                scalar_t maxC = cpb[i].gmaxs[i];
+                coord_t minC = cpb[i].gmins[i];
+                coord_t maxC = cpb[i].gmaxs[i];
                 if (minC < allMins[j]) allMins[j] = minC;
                 if (maxC > allMaxs[j]) allMaxs[j] = maxC;
             }
         }
 
         //get size of each hash for each dimension
-        scalar_t *hash_slices_size = new scalar_t [coordDim];
+        coord_t *hash_slices_size = new coord_t [coordDim];
         for (int j = 0; j < coordDim; ++j){
             hash_slices_size[j] = (allMaxs[j] - allMins[j]) / pSingleDim;
 
@@ -908,8 +919,8 @@ public:
 
             for (int j = 0; j < coordDim; ++j){
 
-                scalar_t minC = cpb[i].gmins[i];
-                scalar_t maxC = cpb[i].gmaxs[i];
+                coord_t minC = cpb[i].gmins[i];
+                coord_t maxC = cpb[i].gmaxs[i];
                 part_t minHashIndex = part_t ((minC - allMins[j]) / hash_slices_size[j]);
                 part_t maxHashIndex  = part_t ((maxC - allMins[j]) / hash_slices_size[j]);
 

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_CoordinatePartitioningGraph.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_CoordinatePartitioningGraph.hpp
@@ -116,8 +116,8 @@ public:
             maxHashIndices = new part_t [dim];
             gridIndices = new std::vector <part_t> ();
             for (int i = 0; i < dim; ++i){
-                lmins[i] = coord_t(lmi[i]);
-                lmaxs[i] = coord_t(lma[i]);
+                lmins[i] = static_cast<coord_t>(lmi[i]);
+                lmaxs[i] = static_cast<coord_t>(lma[i]);
             }
         }
 
@@ -212,8 +212,8 @@ public:
           if (pointdim != this->dim) 
             throw std::logic_error("dim of point must match dim of box");
           for (int i = 0; i < pointdim; i++) {
-            if (coord_t(point[i]) < this->lmins[i]) return false;
-            if (coord_t(point[i]) > this->lmaxs[i]) return false;
+            if (static_cast<coord_t>(point[i]) < this->lmins[i]) return false;
+            if (static_cast<coord_t>(point[i]) > this->lmaxs[i]) return false;
           }
           return true;
         }
@@ -228,14 +228,14 @@ public:
           // Check for at least partial overlap
           bool found = true;
           for (int i = 0; i < cdim; i++) {
-            if (!((coord_t(lower[i]) >= this->lmins[i] && 
-                   coord_t(lower[i]) <= this->lmaxs[i]) 
+            if (!((static_cast<coord_t>(lower[i]) >= this->lmins[i] && 
+                   static_cast<coord_t>(lower[i]) <= this->lmaxs[i]) 
                    // lower i-coordinate in the box
-               || (coord_t(upper[i]) >= this->lmins[i] && 
-                   coord_t(upper[i]) <= this->lmaxs[i]) 
+               || (static_cast<coord_t>(upper[i]) >= this->lmins[i] && 
+                   static_cast<coord_t>(upper[i]) <= this->lmaxs[i]) 
                    // upper i-coordinate in the box
-               || (coord_t(lower[i]) <  this->lmins[i] && 
-                   coord_t(upper[i]) >  this->lmaxs[i]))) {
+               || (static_cast<coord_t>(lower[i]) <  this->lmins[i] && 
+                   static_cast<coord_t>(upper[i]) >  this->lmaxs[i]))) {
                    // i-coordinates straddle the box
               found = false;
               break;
@@ -372,10 +372,10 @@ public:
         template <typename scalar_t>
         void updateMinMax (scalar_t newBoundary, int isMax, int dimInd){
             if (isMax){
-                lmaxs[dimInd] = coord_t(newBoundary);
+                lmaxs[dimInd] = static_cast<coord_t>(newBoundary);
             }
             else {
-                lmins[dimInd] = coord_t(newBoundary);
+                lmins[dimInd] = static_cast<coord_t>(newBoundary);
             }
         }
 

--- a/packages/zoltan2/src/problems/Zoltan2_PartitioningSolution.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_PartitioningSolution.hpp
@@ -415,7 +415,7 @@ public:
 
   /*! \brief returns the part box boundary list.
    */
-  std::vector<Zoltan2::coordinateModelPartBox<scalar_t, part_t> > &
+  std::vector<Zoltan2::coordinateModelPartBox> &
   getPartBoxesView() const
   {
     return this->algorithm_->getPartBoxesView();
@@ -551,7 +551,7 @@ private:
   const RCP<const Comm<int> > comm_;       // the problem communicator
 
   //part box boundaries as a result of geometric partitioning algorithm.
-  RCP < std::vector <Zoltan2::coordinateModelPartBox <scalar_t, part_t> > > partBoxes;
+  RCP<std::vector<Zoltan2::coordinateModelPartBox> > partBoxes;
 
   part_t nGlobalParts_;// target global number of parts
   part_t nLocalParts_; // number of parts to be on this process

--- a/packages/zoltan2/test/partition/CMakeLists.txt
+++ b/packages/zoltan2/test/partition/CMakeLists.txt
@@ -21,6 +21,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 # MultiJagged Tests
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    mj_int_coordinates
+    SOURCES mj_int_coordinates.cpp
+    COMM serial mpi
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
     mjTest
     SOURCES MultiJaggedTest.cpp
     NUM_MPI_PROCS 4

--- a/packages/zoltan2/test/partition/MultiJaggedTest.cpp
+++ b/packages/zoltan2/test/partition/MultiJaggedTest.cpp
@@ -228,12 +228,11 @@ int run_pointAssign_tests(
     }
 
     {
-      const std::vector<Zoltan2::coordinateModelPartBox<zscalar_t,
-                                                   typename Adapter::part_t> >
+      const std::vector<Zoltan2::coordinateModelPartBox>
             pBoxes = problem->getSolution().getPartBoxesView();
       for (size_t i = 0; i < pBoxes.size(); i++) {
-        zscalar_t *lmin = pBoxes[i].getlmins();
-        zscalar_t *lmax = pBoxes[i].getlmaxs();;
+        typename Zoltan2::coordinateModelPartBox::coord_t *lmin = pBoxes[i].getlmins();
+        typename Zoltan2::coordinateModelPartBox::coord_t *lmax = pBoxes[i].getlmaxs();;
         std::cout << me << " pBox " << i << " pid " << pBoxes[i].getpId()
                   << " (" << lmin[0] << "," << lmin[1] << ","
                   << (coordDim > 2 ? lmin[2] : 0) << ") x "
@@ -314,8 +313,7 @@ int run_boxAssign_tests(
     sprintf(mechar, "%d", problem->getComm()->getRank());
     string me(mechar);
 
-    const std::vector<Zoltan2::coordinateModelPartBox<zscalar_t,
-                                                 typename Adapter::part_t> >
+    const std::vector<Zoltan2::coordinateModelPartBox>
           pBoxes = problem->getSolution().getPartBoxesView();
     size_t nBoxes = pBoxes.size();
 

--- a/packages/zoltan2/test/partition/mj_int_coordinates.cpp
+++ b/packages/zoltan2/test/partition/mj_int_coordinates.cpp
@@ -1,0 +1,194 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//   Zoltan2: A package of combinatorial algorithms for scientific computing
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Karen Devine      (kddevin@sandia.gov)
+//                    Erik Boman        (egboman@sandia.gov)
+//                    Siva Rajamanickam (srajama@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+
+/*! \file mj_int_coordinates.cpp
+    \brief Generate a test to partition integer coordinates
+    See definition of int_scalar_t
+*/
+
+#include <Zoltan2_PartitioningSolution.hpp>
+#include <Zoltan2_PartitioningProblem.hpp>
+#include <Zoltan2_BasicVectorAdapter.hpp>
+#include <Zoltan2_InputTraits.hpp>
+#include <Tpetra_Map.hpp>
+#include <vector>
+#include <cstdlib>
+
+int main(int narg, char *arg[])
+{
+  Tpetra::ScopeGuard scope(&narg, &arg);
+  const Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+  int rank = comm->getRank(); 
+  int nprocs = comm->getSize();
+  int nFail = 0;
+
+  typedef Tpetra::Map<> Map_t;
+  typedef Map_t::local_ordinal_type localId_t;
+  typedef Map_t::global_ordinal_type globalId_t;
+  typedef int int_scalar_t;  // This is the case we are testing here.
+
+  typedef Zoltan2::BasicUserTypes<int_scalar_t, localId_t, globalId_t> myTypes;
+  typedef Zoltan2::BasicVectorAdapter<myTypes> inputAdapter_t;
+
+  typedef Zoltan2::EvaluatePartition<inputAdapter_t> quality_t;
+
+  ///////////////////////////////////////////////////////////////////////
+  // Create input data.
+
+  size_t localCount = 40;
+  int dim = 3;
+
+  // Create coordinates that range from 0 to 9
+  int_scalar_t *coords = new int_scalar_t [dim * localCount];
+  int_scalar_t *x = coords; 
+  int_scalar_t *y = x + localCount; 
+  int_scalar_t *z = y + localCount; 
+
+  srand(rank);
+  for (size_t i=0; i < localCount*dim; i++)
+    coords[i] = int_scalar_t(rand() / (double)RAND_MAX) % 10;
+
+  // Create global ids for the coordinates.
+  globalId_t *globalIds = new globalId_t [localCount];
+  globalId_t offset = rank * localCount;
+  for (size_t i=0; i < localCount; i++) globalIds[i] = offset++;
+   
+  ///////////////////////////////////////////////////////////////////////
+  // Create parameters for an MJ problem
+
+  Teuchos::ParameterList params("test params");
+  params.set("debug_level", "basic_status");
+  params.set("error_check_level", "debug_mode_assertions");
+
+  params.set("algorithm", "multijagged");
+  params.set("num_global_parts", nprocs+1);
+
+  ///////////////////////////////////////////////////////////////////////
+  // Test one:  No weights
+
+  inputAdapter_t *ia1 = new inputAdapter_t(localCount,globalIds,x,y,z,1,1,1);
+
+  Zoltan2::PartitioningProblem<inputAdapter_t> *problem1 =
+           new Zoltan2::PartitioningProblem<inputAdapter_t>(ia1, &params);
+   
+  problem1->solve();
+
+  quality_t *metricObject1 = new quality_t(ia1, &params, comm,
+					   &problem1->getSolution());
+  if (rank == 0){
+
+    metricObject1->printMetrics(std::cout);
+
+    double imb = metricObject1->getObjectCountImbalance();
+    if (imb <= 1.01)  // Should get perfect balance
+      std::cout << "no weights -- balance satisfied: " << imb << std::endl;
+    else {
+      std::cout << "no weights -- balance failure: " << imb << std::endl;
+      nFail++;
+    }
+    std::cout << std::endl;
+  }
+  delete metricObject1;
+  delete problem1;
+  delete ia1;
+   
+  ///////////////////////////////////////////////////////////////////////
+  // Test two:  weighted
+  // Create a Zoltan2 input adapter that includes weights.
+
+  int_scalar_t *weights = new int_scalar_t [localCount];
+  for (size_t i=0; i < localCount; i++) weights[i] = 1 + int_scalar_t(rank);
+
+  std::vector<const int_scalar_t *>coordVec(3);
+  std::vector<int> coordStrides(3);
+
+  coordVec[0] = x; coordStrides[0] = 1;
+  coordVec[1] = y; coordStrides[1] = 1;
+  coordVec[2] = z; coordStrides[2] = 1;
+
+  std::vector<const int_scalar_t *>weightVec(1);
+  std::vector<int> weightStrides(1);
+
+  weightVec[0] = weights; weightStrides[0] = 1;
+
+  inputAdapter_t *ia2=new inputAdapter_t(localCount, globalIds, coordVec, 
+                                         coordStrides,weightVec,weightStrides);
+
+  Zoltan2::PartitioningProblem<inputAdapter_t> *problem2 =
+           new Zoltan2::PartitioningProblem<inputAdapter_t>(ia2, &params);
+
+  problem2->solve();
+
+  quality_t *metricObject2 = new quality_t(ia2, &params, comm,
+					   &problem2->getSolution());
+  if (rank == 0){
+
+    metricObject2->printMetrics(std::cout);
+
+    double imb = metricObject2->getWeightImbalance(0);
+    if (imb <= 1.01)
+      std::cout << "weighted -- balance satisfied " << imb << std::endl;
+    else {
+      std::cout << "weighted -- balance failed " << imb << std::endl;
+      nFail++;
+    }
+    std::cout << std::endl;
+  }
+  delete metricObject2;
+
+  if (weights) delete [] weights;
+  if (coords) delete [] coords;
+  if (globalIds) delete [] globalIds;
+  delete problem2;
+  delete ia2;
+
+  if (rank == 0) { 
+    if (nFail == 0) std::cout << "PASS" << std::endl;
+    else  std::cout << "FAIL:  " << nFail << " tests failed" << std::endl;
+  }
+
+  return 0;
+}
+

--- a/packages/zoltan2/test/unit/util/StridedData.cpp
+++ b/packages/zoltan2/test/unit/util/StridedData.cpp
@@ -67,8 +67,9 @@ void StridedDataTest(const Teuchos::SerialComm<int> &comm)
 {
   // StridedData template arguments
 
-  typedef zlno_t     index_t;
-  typedef zscalar_t  value_t;
+  typedef int     index_t;
+  typedef double  value_t;
+  typedef float   different_value_t;
 
   typedef StridedData<index_t, value_t> stridedInput_t;
   bool aok = true;
@@ -112,6 +113,14 @@ void StridedDataTest(const Teuchos::SerialComm<int> &comm)
     std::cout << s1Copy[i] << " ";
   std::cout << std::endl;
 
+  // test a different type
+  ArrayRCP<const different_value_t> fromS1too;
+  s1->getInputArray(fromS1too);
+  std::cout << "getInputArray test -- different type: ";
+  for (int i=0; i < 12; i++)
+    std::cout << fromS1too[i] << " ";
+  std::cout << std::endl;
+
   /*! \test strided input with stride 3
    */
 
@@ -149,6 +158,14 @@ void StridedDataTest(const Teuchos::SerialComm<int> &comm)
   std::cout << "assignment operator test: ";
   for (int i=0; i < 4; i++)
     std::cout << s2Copy[i] << " ";
+  std::cout << std::endl;
+
+  // test a different type
+  ArrayRCP<const different_value_t> fromS2too;
+  s1->getInputArray(fromS2too);
+  std::cout << "getInputArray test -- different type: ";
+  for (int i=0; i < 4; i++)
+    std::cout << fromS2too[i] << " ";
   std::cout << std::endl;
 }
 


### PR DESCRIPTION

@trilinos/zoltan2 

## Description
Enables MJ partitioner to work with integer coordinates:  #4212 
- MJ requires floating point calculations for determining cuts
- MJ previously used the User's scalar_t for cuts, which was problematic when scalar_t was int
- Fix defines mj_scalar_t to be the user's scalar_t if it is a floating point type; otherwise, mj_scalar_t is float
- If mj_scalar_t differs from the user's scalar_t, coordinates are copied to mj_scalar_t arrays.

Also, removed templated types from coordinateModelPartBoxes.  #4211 
- coordinateModelPartBoxes store cut information computed by Zoltan2; their storage should not depend on the user's data types
-  changed storage in coordinateModelPartBoxes to be double
-  these changes were needed to enable fixing #4212 
-  removing the template parameters breaks backward compatibility

## Motivation and Context

I want to partition integer coordinates.


## Related Issues

* Closes #4212, #4211
* Still need to fix #1312 (as for scalar_t = int, it always returns imbalance = 1), but waiting until #1533 is merged to avoid conflicts 


## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

new test zoltan2/test/partition/mj_int_coordinates.cpp
mac and linux

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ x] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ x] These changes break backwards compatibility.:  removing template parameters breaks backward compatibility of functions returning coordinateModelPartBox

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
