### PR TITLE
Revert PR #4228

### DIFF
--- a/packages/kokkos-kernels/Makefile.kokkos-kernels
+++ b/packages/kokkos-kernels/Makefile.kokkos-kernels
@@ -315,46 +315,6 @@ ifneq ($(KOKKOSKERNELS_INTERNAL_NEW_CONFIG), 0)
   tmp := $(shell cp KokkosKernels_config.tmp KokkosKernels_config.h)
 endif
 
-#==== User-settable options for Fortran mangling macros  =================================================
-
-KOKKOSKERNELS_FORTRAN_GLOBAL ?= name\#\#_
-KOKKOSKERNELS_FORTRAN_GLOBAL_ ?= name\#\#_
-KOKKOSKERNELS_FORTRAN_MODULE ?= __\#\#mod_name\#\#_MOD_\#\#name
-KOKKOSKERNELS_FORTRAN_MODULE_ ?= __\#\#mod_name\#\#_MOD_\#\#name
-
-#==== Create header file for Fortran mangling macros  =================================================
-
-$(shell echo "#ifndef KOKKOSKERNELS_FORTRAN_HEADER_INCLUDED" > KokkosKernels_FortranMangling.tmp)
-$(shell echo "#define KOKKOSKERNELS_FORTRAN_HEADER_INCLUDED" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "/* Mangling for Fortran global symbols without underscores. */" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "#define KOKKOSKERNELS_FORTRAN_GLOBAL(name,NAME) $(KOKKOSKERNELS_FORTRAN_GLOBAL)" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "/* Mangling for Fortran global symbols with underscores. */" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "#define KOKKOSKERNELS_FORTRAN_GLOBAL_(name,NAME) $(KOKKOSKERNELS_FORTRAN_GLOBAL_)" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "/* Mangling for Fortran module symbols without underscores. */" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "#define KOKKOSKERNELS_FORTRAN_MODULE(mod_name,name, mod_NAME,NAME) $(KOKKOSKERNELS_FORTRAN_MODULE)" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "/* Mangling for Fortran module symbols with underscores. */" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "#define KOKKOSKERNELS_FORTRAN_MODULE_(mod_name,name, mod_NAME,NAME) $(KOKKOSKERNELS_FORTRAN_MODULE_)" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "" >> KokkosKernels_FortranMangling.tmp)
-$(shell echo "#endif" >> KokkosKernels_FortranMangling.tmp)
-
-#==== Update header file for Fortran mangling macros, if necessary  =================================================
-
-KOKKOSKERNELS_INTERNAL_LS_FORTRANMANGLING := $(shell ls KokkosKernels_FortranMangling.h)
-ifeq ($(KOKKOSKERNELS_INTERNAL_LS_FORTRANMANGLING), KokkosKernels_FortranMangling.h)
-  KOKKOSKERNELS_INTERNAL_NEW_FORTRANMANGLING := $(strip $(shell diff KokkosKernels_FortranMangling.h KokkosKernels_FortranMangling.tmp | grep define | wc -l))
-else
-  KOKKOSKERNELS_INTERNAL_NEW_FORTRANMANGLING := 1
-endif
-
-ifneq ($(KOKKOSKERNELS_INTERNAL_NEW_FORTRANMANGLING), 0)
-  tmp := $(shell cp KokkosKernels_FortranMangling.tmp KokkosKernels_FortranMangling.h)
-endif
-
-
 #include $(KOKKOSKERNELS_PATH)/Makefile.generate_eti_files
 
 #-------------------------------------------------------------------------
@@ -466,11 +426,9 @@ KOKKOSKERNELS_INTERNAL_SRC_SPARSE_NODIR = $(notdir $(KOKKOSKERNELS_INTERNAL_SRC_
 KOKKOSKERNELS_INTERNAL_OBJ_BLAS = $(KOKKOSKERNELS_INTERNAL_SRC_BLAS_NODIR:.cpp=.o)
 KOKKOSKERNELS_INTERNAL_OBJ_SPARSE = $(KOKKOSKERNELS_INTERNAL_SRC_SPARSE_NODIR:.cpp=.o)
 
-KOKKOSKERNELS_CPP_DEPENDS = $(KOKKOSKERNELS_INTERNAL_HEADERS) KokkosKernels_config.h KokkosKernels_FortranMangling.h
+KOKKOSKERNELS_CPP_DEPENDS = $(KOKKOSKERNELS_INTERNAL_HEADERS) KokkosKernels_config.h
 
 KokkosKernels_config.h:
-
-KokkosKernels_FortranMangling.h:
 
 kokkoskernels-build-lib: $(KOKKOSKERNELS_INTERNAL_LIBRARY)
 

--- a/packages/kokkos-kernels/src/CMakeLists.txt
+++ b/packages/kokkos-kernels/src/CMakeLists.txt
@@ -1,8 +1,3 @@
-INCLUDE(FortranCInterface)
-FortranCInterface_HEADER(
-  ${PACKAGE_NAME}_FortranMangling.h
-  MACRO_NAMESPACE KOKKOSKERNELS_FORTRAN_
-)
 
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -44,20 +44,18 @@
 #ifndef KOKKOSBLAS1_AXPBY_TPL_SPEC_DECL_HPP_
 #define KOKKOSBLAS1_AXPBY_TPL_SPEC_DECL_HPP_
 
+
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
-
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(daxpy,DAXPY)( const int* N, const double* alpha,
+extern "C" void daxpy_( const int* N, const double* alpha,
                                       const double* x, const int* x_inc,
                                       double* y, const int* y_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(saxpy,SAXPY)( const int* N, const float* alpha,
+extern "C" void saxpy_( const int* N, const float* alpha,
                                       const float* x, const int* x_inc,
                                       float* y, const int* y_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(zaxpy,zaxpy)( const int* N, const std::complex<double>* alpha,
+extern "C" void zaxpy_( const int* N, const std::complex<double>* alpha,
                                       const std::complex<double>* x, const int* x_inc,
                                       std::complex<double>* y, const int* y_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(caxpy,CAXPY)( const int* N, const std::complex<float>* alpha,
+extern "C" void caxpy_( const int* N, const std::complex<float>* alpha,
                                       const std::complex<float>* x, const int* x_inc,
                                       std::complex<float>* y, const int* y_inc);
 
@@ -67,9 +65,9 @@ namespace Impl {
 namespace {
   template<class AV, class XMV, class BV, class YMV>
   inline void axpby_print_specialization() {
-      #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
-        printf("KokkosBlas1::axpby<> TPL Blas specialization for < %s , %s , %s , %s >\n",typeid(AV).name(),typeid(XMV).name(),typeid(BV).name(),typeid(YMV).name());
-      #endif
+      #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION 
+        printf("KokkosBlas1::axpby<> TPL Blas specialization for < %s , %s , %s , %s >\n",typeid(AV).name(),typeid(XMV).name(),typeid(BV).name(),typeid(YMV).name()); 
+      #endif 
   }
 }
 
@@ -96,7 +94,7 @@ struct Axpby< \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(daxpy,DAXPY)(&N,&alpha,X.data(),&one,Y.data(),&one); \
+      daxpy_(&N,&alpha,X.data(),&one,Y.data(),&one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
   } \
@@ -126,7 +124,7 @@ struct Axpby< \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(saxpy,SAXPY)(&N,&alpha,X.data(),&one,Y.data(),&one); \
+      saxpy_(&N,&alpha,X.data(),&one,Y.data(),&one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
   } \
@@ -155,7 +153,7 @@ struct Axpby< \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(zaxpy,ZAXPY)(&N,reinterpret_cast<const std::complex<double>* >(&alpha), \
+      zaxpy_(&N,reinterpret_cast<const std::complex<double>* >(&alpha), \
                 reinterpret_cast<const std::complex<double>* >(X.data()),&one, \
                 reinterpret_cast<std::complex<double>* >(Y.data()),&one); \
     } else \
@@ -186,7 +184,7 @@ struct Axpby< \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(caxpy,CAXPY)(&N,reinterpret_cast<const std::complex<float>* >(&alpha), \
+      caxpy_(&N,reinterpret_cast<const std::complex<float>* >(&alpha), \
                 reinterpret_cast<const std::complex<float>* >(X.data()),&one, \
                 reinterpret_cast<std::complex<float>* >(Y.data()),&one); \
     } else \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -47,15 +47,13 @@
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" double KOKKOSKERNELS_FORTRAN_GLOBAL(ddot,DDOT) (const int* N, const double* x, const int* x_inc,
+extern "C" double ddot_ ( const int* N, const double* x, const int* x_inc,
                           const double* y, const int* y_inc);
-extern "C" float KOKKOSKERNELS_FORTRAN_GLOBAL(sdot,SDOT) (const int* N, const float* x, const int* x_inc,
+extern "C" float  sdot_ ( const int* N, const float* x, const int* x_inc,
                           const float* y, const int* y_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(zdotu,ZDOTU) (std::complex<double> *res, const int* N, const std::complex<double>* x, const int* x_inc,
+extern "C" void   zdotu_( std::complex<double> *res, const int* N, const std::complex<double>* x, const int* x_inc,
                           const std::complex<double>* y, const int* y_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(cdotu,CDOTU) (std::complex<float> *res, const int* N, const std::complex<float>* x, const int* x_inc,
+extern "C" void   cdotu_( std::complex<float> *res, const int* N, const std::complex<float>* x, const int* x_inc,
                           const std::complex<float>* y, const int* y_inc);
 
 namespace KokkosBlas {
@@ -95,7 +93,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       dot_print_specialization<RV,XV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(ddot,DDOT)(&N,X.data(),&one,Y.data(),&one); \
+      R() = ddot_(&N,X.data(),&one,Y.data(),&one); \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
@@ -126,7 +124,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       dot_print_specialization<RV,XV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(sdot,SDOT)(&N,X.data(),&one,Y.data(),&one); \
+      R() = sdot_(&N,X.data(),&one,Y.data(),&one); \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
@@ -157,7 +155,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       dot_print_specialization<RV,XV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(zdotu,ZDOTU)(reinterpret_cast<std::complex<double>* >(R.data()), \
+      zdotu_(reinterpret_cast<std::complex<double>* >(R.data()),        \
              &N,                                                        \
              reinterpret_cast<const std::complex<double>* >(X.data()),&one, \
              reinterpret_cast<const std::complex<double>* >(Y.data()),&one); \
@@ -191,7 +189,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       dot_print_specialization<RV,XV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(cdotu,CDOTU)(reinterpret_cast<std::complex<float>* >(R.data()), \
+      cdotu_(reinterpret_cast<std::complex<float>* >(R.data()), \
              &N,                                                        \
              reinterpret_cast<const std::complex<float>* >(X.data()),&one, \
              reinterpret_cast<const std::complex<float>* >(Y.data()),&one); \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -47,12 +47,10 @@
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" double KOKKOSKERNELS_FORTRAN_GLOBAL(dasum,DASUM) (const int* N, const double* x, const int* x_inc);
-extern "C" float  KOKKOSKERNELS_FORTRAN_GLOBAL(sasum,SASUM) (const int* N, const float* x, const int* x_inc);
-extern "C" double KOKKOSKERNELS_FORTRAN_GLOBAL(dzasum,DZASUM) (const int* N, const std::complex<double>* x, const int* x_inc);
-extern "C" float  KOKKOSKERNELS_FORTRAN_GLOBAL(dcasum,DCASUM) (const int* N, const std::complex<float>* x, const int* x_inc);
+extern "C" double dasum_ ( const int* N, const double* x, const int* x_inc);
+extern "C" float  sasum_ ( const int* N, const float* x, const int* x_inc);
+extern "C" double dzasum_( const int* N, const std::complex<double>* x, const int* x_inc);
+extern "C" float  dcasum_( const int* N, const std::complex<float>* x, const int* x_inc);
 
 namespace KokkosBlas {
 namespace Impl {
@@ -89,7 +87,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       nrm1_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(dasum,DASUM)(&N,X.data(),&one); \
+      R() = dasum_(&N,X.data(),&one); \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
@@ -118,7 +116,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       nrm1_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(sasum,SASUM)(&N,X.data(),&one); \
+      R() = sasum_(&N,X.data(),&one); \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
@@ -147,7 +145,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       nrm1_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(dzasum,DZASUM)(&N,reinterpret_cast<const std::complex<double>*>(X.data()),&one); \
+      R() = dzasum_(&N,reinterpret_cast<const std::complex<double>*>(X.data()),&one); \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
@@ -176,7 +174,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       nrm1_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(dcasum,DCASUM)(&N,reinterpret_cast<const std::complex<float>*>(X.data()),&one); \
+      R() = dcasum_(&N,reinterpret_cast<const std::complex<float>*>(X.data()),&one); \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -47,12 +47,10 @@
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" double KOKKOSKERNELS_FORTRAN_GLOBAL(dnrm2,DNRM2) (const int* N, const double* x, const int* x_inc);
-extern "C" float KOKKOSKERNELS_FORTRAN_GLOBAL(snrm2,SNRM2) (const int* N, const float* x, const int* x_inc);
-extern "C" double KOKKOSKERNELS_FORTRAN_GLOBAL(dznrm2,DZNRM2) (const int* N, const std::complex<double>* x, const int* x_inc);
-extern "C" float KOKKOSKERNELS_FORTRAN_GLOBAL(scnrm2,SCNRM2) (const int* N, const std::complex<float>* x, const int* x_inc);
+extern "C" double dnrm2_ ( const int* N, const double* x, const int* x_inc);
+extern "C" float  snrm2_ ( const int* N, const float* x, const int* x_inc);
+extern "C" double dznrm2_( const int* N, const std::complex<double>* x, const int* x_inc);
+extern "C" float  scnrm2_( const int* N, const std::complex<float>* x, const int* x_inc);
 
 namespace KokkosBlas {
 namespace Impl {
@@ -89,7 +87,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       nrm2_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(dnrm2,DNRM2)(&N,X.data(),&one); \
+      R() = dnrm2_(&N,X.data(),&one); \
       if(!take_sqrt) R() = R()*R(); \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
@@ -119,7 +117,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       nrm2_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(snrm2,SNRM2)(&N,X.data(),&one); \
+      R() = snrm2_(&N,X.data(),&one); \
       if(!take_sqrt) R() = R()*R(); \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
@@ -149,7 +147,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       nrm2_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(dznrm2,DZNRM2)(&N,reinterpret_cast<const std::complex<double>*>(X.data()),&one); \
+      R() = dznrm2_(&N,reinterpret_cast<const std::complex<double>*>(X.data()),&one); \
       if(!take_sqrt) R() = R()*R(); \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
@@ -179,7 +177,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       nrm2_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      R() = KOKKOSKERNELS_FORTRAN_GLOBAL(scnrm2,SCNRM2)(&N,reinterpret_cast<const std::complex<float>*>(X.data()),&one); \
+      R() = scnrm2_(&N,reinterpret_cast<const std::complex<float>*>(X.data()),&one); \
       if(!take_sqrt) R() = R()*R(); \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
@@ -47,12 +47,10 @@
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" int KOKKOSKERNELS_FORTRAN_GLOBAL(idamax,IDAMAX) (const int* N, const double* x, const int* x_inc);
-extern "C" int KOKKOSKERNELS_FORTRAN_GLOBAL(isamax,ISAMAX) (const int* N, const float* x, const int* x_inc);
-extern "C" int KOKKOSKERNELS_FORTRAN_GLOBAL(izamax,IZAMAX) (const int* N, const std::complex<double>* x, const int* x_inc);
-extern "C" int KOKKOSKERNELS_FORTRAN_GLOBAL(icamax,ICAMAX) (const int* N, const std::complex<float>* x, const int* x_inc);
+extern "C" int idamax_( const int* N, const double* x, const int* x_inc);
+extern "C" int isamax_( const int* N, const float* x, const int* x_inc);
+extern "C" int izamax_( const int* N, const std::complex<double>* x, const int* x_inc);
+extern "C" int icamax_( const int* N, const std::complex<float>* x, const int* x_inc);
 
 namespace KokkosBlas {
 namespace Impl {
@@ -90,7 +88,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       nrminf_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      int idx = KOKKOSKERNELS_FORTRAN_GLOBAL(idamax,IDAMAX)(&N,X.data(),&one)-1; \
+      int idx = idamax_(&N,X.data(),&one)-1; \
       R() = X(idx); \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
@@ -121,7 +119,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       nrminf_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      int idx = KOKKOSKERNELS_FORTRAN_GLOBAL(isamax,ISAMAX)(&N,X.data(),&one)-1; \
+      int idx = isamax_(&N,X.data(),&one)-1; \
       R() = X(idx); \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
@@ -153,7 +151,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       nrminf_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      int idx = KOKKOSKERNELS_FORTRAN_GLOBAL(izamax,IZAMAX)(&N,reinterpret_cast<const std::complex<double>*>(X.data()),&one)-1; \
+      int idx = izamax_(&N,reinterpret_cast<const std::complex<double>*>(X.data()),&one)-1; \
       R() = IPT::norm(X(idx)); \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
@@ -185,7 +183,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       nrminf_print_specialization<RV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      int idx = KOKKOSKERNELS_FORTRAN_GLOBAL(icamax,ICAMAX)(&N,reinterpret_cast<const std::complex<float>*>(X.data()),&one)-1; \
+      int idx = icamax_(&N,reinterpret_cast<const std::complex<float>*>(X.data()),&one)-1; \
       R() = IPT::norm(X(idx)); \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -47,15 +47,13 @@
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(dscal,DSCAL) (const int* N, const double* alpha,
+extern "C" void dscal_( const int* N, const double* alpha,
                         double* x, const int* x_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(sscal,SSCAL) (const int* N, const float* alpha,
+extern "C" void sscal_( const int* N, const float* alpha,
                         float* x, const int* x_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(zscal,ZSCAL) (const int* N, const std::complex<double>* alpha,
+extern "C" void zscal_( const int* N, const std::complex<double>* alpha,
                         std::complex<double>* x, const int* x_inc);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(cscal,CSCAL) (const int* N, const std::complex<float>* alpha,
+extern "C" void cscal_( const int* N, const std::complex<float>* alpha,
                         std::complex<float>* x, const int* x_inc);
 
 namespace KokkosBlas {
@@ -95,7 +93,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       scal_print_specialization<RV,AV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(dscal,DSCAL)(&N,&alpha,R.data(),&one); \
+      dscal_(&N,&alpha,R.data(),&one); \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
@@ -126,7 +124,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       scal_print_specialization<RV,AV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(sscal,SSCAL)(&N,&alpha,R.data(),&one); \
+      sscal_(&N,&alpha,R.data(),&one); \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
@@ -157,7 +155,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       scal_print_specialization<RV,AV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(zscal,ZSCAL)(&N,reinterpret_cast<const std::complex<double>*>(&alpha),reinterpret_cast<std::complex<double>*>(R.data()),&one); \
+      zscal_(&N,reinterpret_cast<const std::complex<double>*>(&alpha),reinterpret_cast<std::complex<double>*>(R.data()),&one); \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
@@ -188,7 +186,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       scal_print_specialization<RV,AV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(cscal,CSCAL)(&N,reinterpret_cast<const std::complex<float>*>(&alpha),reinterpret_cast<std::complex<float>*>(R.data()),&one); \
+      cscal_(&N,reinterpret_cast<const std::complex<float>*>(&alpha),reinterpret_cast<std::complex<float>*>(R.data()),&one); \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -45,31 +45,28 @@
 #define KOKKOSBLAS2_GEMV_TPL_SPEC_DECL_HPP_
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
-
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(dgemv,DGEMV)( const char* trans,
+extern "C" void dgemv_( const char* trans,
                         const int* M, const int* N,
                         const double* alpha,
                         const double* A, const int* LDA,
                         const double* X, const int* INCX,
                         const double* beta,
                         double* Y, const int* INCY);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(sgemv,SGEMV)( const char* trans,
+extern "C" void sgemv_( const char* trans,
                         const int* M, const int* N,
                         const float* alpha,
                         const float* A, const int* LDA,
                         const float* X, const int* INCX,
                         const float* beta,
                         float* Y, const int* INCY);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(zgemv,ZGEMV)( const char* trans,
+extern "C" void zgemv_( const char* trans,
                         const int* M, const int* N,
                         const std::complex<double>* alpha,
                         const std::complex<double>* A, const int* LDA,
                         const std::complex<double>* X, const int* INCX,
                         const std::complex<double>* beta,
                         std::complex<double>* Y, const int* INCY);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(cgemv,CGEMV)( const char* trans,
+extern "C" void cgemv_( const char* trans,
                         const int* M, const int* N,
                         const std::complex<float>* alpha,
                         const std::complex<float>* A, const int* LDA,
@@ -112,7 +109,7 @@ struct GEMV< \
     constexpr int one = 1; \
     bool A_is_lr = std::is_same<Kokkos::LayoutRight,LAYOUTA>::value; \
     const int AST = A_is_lr?A.stride(0):A.stride(1), LDA = AST == 0 ? 1 : AST; \
-    KOKKOSKERNELS_FORTRAN_GLOBAL(dgemv,DGEMV)(trans,&M,&N,&alpha,A.data(),&LDA,X.data(),&one,&beta,Y.data(),&one); \
+    dgemv_(trans,&M,&N,&alpha,A.data(),&LDA,X.data(),&one,&beta,Y.data(),&one); \
     Kokkos::Profiling::popRegion(); \
   } \
 };
@@ -149,7 +146,7 @@ struct GEMV< \
     constexpr int one = 1; \
     bool A_is_lr = std::is_same<Kokkos::LayoutRight,LAYOUTA>::value; \
     const int AST = A_is_lr?A.stride(0):A.stride(1), LDA = AST == 0 ? 1 : AST; \
-    KOKKOSKERNELS_FORTRAN_GLOBAL(sgemv,SGEMV)(trans,&M,&N,&alpha,A.data(),&LDA,X.data(),&one,&beta,Y.data(),&one); \
+    sgemv_(trans,&M,&N,&alpha,A.data(),&LDA,X.data(),&one,&beta,Y.data(),&one); \
     Kokkos::Profiling::popRegion(); \
   } \
 };
@@ -186,7 +183,7 @@ struct GEMV< \
     constexpr int one = 1; \
     bool A_is_lr = std::is_same<Kokkos::LayoutRight,LAYOUTA>::value; \
     const int AST = A_is_lr?A.stride(0):A.stride(1), LDA = AST == 0 ? 1 : AST; \
-    KOKKOSKERNELS_FORTRAN_GLOBAL(zgemv,ZGEMV)(trans,&M,&N, \
+    zgemv_(trans,&M,&N, \
         reinterpret_cast<const std::complex<double>*>(&alpha),reinterpret_cast<const std::complex<double>*>(A.data()),&LDA, \
         reinterpret_cast<const std::complex<double>*>(X.data()),&one, \
         reinterpret_cast<const std::complex<double>*>(&beta),reinterpret_cast<std::complex<double>*>(Y.data()),&one); \
@@ -226,7 +223,7 @@ struct GEMV< \
     constexpr int one = 1; \
     bool A_is_lr = std::is_same<Kokkos::LayoutRight,LAYOUTA>::value; \
     const int AST = A_is_lr?A.stride(0):A.stride(1), LDA = AST == 0 ? 1 : AST; \
-    KOKKOSKERNELS_FORTRAN_GLOBAL(cgemv,CGEMV)(trans,&M,&N, \
+    cgemv_(trans,&M,&N, \
         reinterpret_cast<const std::complex<float>*>(&alpha),reinterpret_cast<const std::complex<float>*>(A.data()),&LDA, \
         reinterpret_cast<const std::complex<float>*>(X.data()),&one, \
         reinterpret_cast<const std::complex<float>*>(&beta),reinterpret_cast<std::complex<float>*>(Y.data()),&one); \

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas3_gemm_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas3_gemm_tpl_spec_decl.hpp
@@ -45,31 +45,28 @@
 #define KOKKOSBLAS3_GEMM_TPL_SPEC_DECL_HPP_
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
-
-#include "KokkosKernels_FortranMangling.h"
-
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(dgemm,DGEMM) (const char* transA, const char* transB,
+extern "C" void dgemm_( const char* transA, const char* transB,
                         const int* M, const int* N, const int* K,
                         const double* alpha,
                         const double* A, const int* LDA,
                         const double* B, const int* LDB,
                         const double* beta,
                         double* C, const int* LDC);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(sgemm,SGEMM) (const char* transA, const char* transB,
+extern "C" void sgemm_( const char* transA, const char* transB,
                         const int* M, const int* N, const int* K,
                         const float* alpha,
                         const float* A, const int* LDA,
                         const float* B, const int* LDB,
                         const float* beta,
                         float* C, const int* LDC);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(zgemm,ZGEMM) (const char* transA, const char* transB,
+extern "C" void zgemm_( const char* transA, const char* transB,
                         const int* M, const int* N, const int* K,
                         const std::complex<double>* alpha,
                         const std::complex<double>* A, const int* LDA,
                         const std::complex<double>* B, const int* LDB,
                         const std::complex<double>* beta,
                         std::complex<double>* C, const int* LDC);
-extern "C" void KOKKOSKERNELS_FORTRAN_GLOBAL(cgemm,CGEMM) (const char* transA, const char* transB,
+extern "C" void cgemm_( const char* transA, const char* transB,
                         const int* M, const int* N, const int* K,
                         const std::complex<float>* alpha,
                         const std::complex<float>* A, const int* LDA,
@@ -122,9 +119,9 @@ struct GEMM< \
     const int CST = C_is_lr?C.stride(0):C.stride(1), LDC = CST == 0 ? 1 : CST; \
     \
     if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(dgemm,DGEMM)(transA,transB,&M,&N,&K,&alpha,A.data(),&LDA,B.data(),&LDB,&beta,C.data(),&LDC); \
+      dgemm_(transA,transB,&M,&N,&K,&alpha,A.data(),&LDA,B.data(),&LDB,&beta,C.data(),&LDC); \
     if(A_is_lr && B_is_lr && C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(dgemm,DGEMM)(transB,transA,&N,&M,&K,&alpha,B.data(),&LDB,A.data(),&LDA,&beta,C.data(),&LDC); \
+      dgemm_(transB,transA,&N,&M,&K,&alpha,B.data(),&LDB,A.data(),&LDA,&beta,C.data(),&LDC); \
     Kokkos::Profiling::popRegion(); \
   } \
 };
@@ -171,9 +168,9 @@ struct GEMM< \
     const int CST = C_is_lr?C.stride(0):C.stride(1), LDC = CST == 0 ? 1 : CST; \
     \
     if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(sgemm,SGEMM)(transA,transB,&M,&N,&K,&alpha,A.data(),&LDA,B.data(),&LDB,&beta,C.data(),&LDC); \
+      sgemm_(transA,transB,&M,&N,&K,&alpha,A.data(),&LDA,B.data(),&LDB,&beta,C.data(),&LDC); \
     if(A_is_lr && B_is_lr && C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(sgemm,SGEMM)(transB,transA,&N,&M,&K,&alpha,B.data(),&LDB,A.data(),&LDA,&beta,C.data(),&LDC); \
+      sgemm_(transB,transA,&N,&M,&K,&alpha,B.data(),&LDB,A.data(),&LDA,&beta,C.data(),&LDC); \
     Kokkos::Profiling::popRegion(); \
   } \
 };
@@ -220,12 +217,12 @@ struct GEMM< \
     const int CST = C_is_lr?C.stride(0):C.stride(1), LDC = CST == 0 ? 1 : CST; \
     \
     if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(zgemm,ZGEMM)(transA,transB,&M,&N,&K, \
+      zgemm_(transA,transB,&M,&N,&K, \
         reinterpret_cast<const std::complex<double>*>(&alpha),reinterpret_cast<const std::complex<double>*>(A.data()),&LDA, \
         reinterpret_cast<const std::complex<double>*>(B.data()),&LDB, \
         reinterpret_cast<const std::complex<double>*>(&beta),reinterpret_cast<std::complex<double>*>(C.data()),&LDC); \
     if(A_is_lr && B_is_lr && C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(zgemm,ZGEMM)(transB,transA,&N,&M,&K, \
+      zgemm_(transB,transA,&N,&M,&K, \
         reinterpret_cast<const std::complex<double>*>(&alpha),reinterpret_cast<const std::complex<double>*>(B.data()),&LDB, \
         reinterpret_cast<const std::complex<double>*>(A.data()),&LDA, \
         reinterpret_cast<const std::complex<double>*>(&beta),reinterpret_cast<std::complex<double>*>(C.data()),&LDC); \
@@ -275,12 +272,12 @@ struct GEMM< \
     const int CST = C_is_lr?C.stride(0):C.stride(1), LDC = CST == 0 ? 1 : CST; \
     \
     if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(cgemm,CGEMM)(transA,transB,&M,&N,&K, \
+      cgemm_(transA,transB,&M,&N,&K, \
         reinterpret_cast<const std::complex<float>*>(&alpha),reinterpret_cast<const std::complex<float>*>(A.data()),&LDA, \
         reinterpret_cast<const std::complex<float>*>(B.data()),&LDB, \
         reinterpret_cast<const std::complex<float>*>(&beta),reinterpret_cast<std::complex<float>*>(C.data()),&LDC); \
     if(A_is_lr && B_is_lr && C_is_lr ) \
-      KOKKOSKERNELS_FORTRAN_GLOBAL(cgemm,CGEMM)(transB,transA,&N,&M,&K, \
+      cgemm_(transB,transA,&N,&M,&K, \
         reinterpret_cast<const std::complex<float>*>(&alpha),reinterpret_cast<const std::complex<float>*>(B.data()),&LDB, \
         reinterpret_cast<const std::complex<float>*>(A.data()),&LDA, \
         reinterpret_cast<const std::complex<float>*>(&beta),reinterpret_cast<std::complex<float>*>(C.data()),&LDC); \


### PR DESCRIPTION
This reverts commit 24c2eb2f9c622f856a0477a0ef8751b4145ca7b1, reversing
changes made to 7b60b19b90f7cc1066da428b7d8ad18813675a87.

It turns out that this breaks builds if Fortran is not enabled.  CMake
apparently permits the configuration to proceed, but the build fails
with a missing header file.  This revert should fix the following issues:

https://github.com/kokkos/kokkos-kernels/issues/372
https://github.com/trilinos/Trilinos/issues/4237
https://github.com/trilinos/Trilinos/issues/4235

@trilinos/kokkos-kernels 

## Related Issues

* Closes https://github.com/kokkos/kokkos-kernels/issues/372, #4235, #4237 
