### PR TITLE
Fix #4250, #4234, #4249, and #3823

### DIFF
--- a/packages/teuchos/core/src/Teuchos_ArrayView.hpp
+++ b/packages/teuchos/core/src/Teuchos_ArrayView.hpp
@@ -72,10 +72,20 @@ ArrayView<const T>::ArrayView( ENull )
 
 template<class T> inline
 ArrayView<T>::ArrayView( T* p, size_type size_in, const ERCPNodeLookup rcpNodeLookup )
-  :ptr_(p), size_(size_in)
+  :ptr_(size_in == 0 ? nullptr : p), size_(size_in)
 {
 #ifdef HAVE_TEUCHOS_ARRAY_BOUNDSCHECK
-  TEUCHOS_TEST_FOR_EXCEPT( p != 0 && size_in <= 0 );
+  // We comment out the one check below, as part of the fix for #4234:
+  //
+  // https://github.com/trilinos/Trilinos/issues/4234
+  //
+  // This permits conversion from std::vector or Kokkos::View, using
+  // ArrayView(x.data(), x.size(), RCP_DISABLE_NODE_LOOKUP).  The
+  // other part of the fix is that we make sure ptr_ is null if
+  // size_in is zero.
+  //
+  //TEUCHOS_TEST_FOR_EXCEPT( p != 0 && size_in <= 0 );
+
   TEUCHOS_TEST_FOR_EXCEPT( p == 0 && size_in != 0 );
   // This only does something if HAVE_TEUCHOS_ARRAY_BOUNDSCHECK is defined.
   setUpIterators(rcpNodeLookup);
@@ -86,10 +96,20 @@ ArrayView<T>::ArrayView( T* p, size_type size_in, const ERCPNodeLookup rcpNodeLo
 
 template<class T> inline
 ArrayView<const T>::ArrayView(const T* p, size_type size_in, const ERCPNodeLookup rcpNodeLookup )
-  : ptr_(p), size_(size_in)
+  : ptr_(size_in == 0 ? nullptr : p), size_(size_in)
 {
 #ifdef HAVE_TEUCHOS_ARRAY_BOUNDSCHECK
-  TEUCHOS_TEST_FOR_EXCEPT( p != 0 && size_in <= 0 );
+  // We comment out the one check below, as part of the fix for #4234:
+  //
+  // https://github.com/trilinos/Trilinos/issues/4234
+  //
+  // This permits conversion from std::vector or Kokkos::View, using
+  // ArrayView(x.data(), x.size(), RCP_DISABLE_NODE_LOOKUP).  The
+  // other part of the fix is that we make sure ptr_ is null if
+  // size_in is zero.
+  //
+  //TEUCHOS_TEST_FOR_EXCEPT( p != 0 && size_in <= 0 );
+
   TEUCHOS_TEST_FOR_EXCEPT( p == 0 && size_in != 0 );
   // This only does something if HAVE_TEUCHOS_ARRAY_BOUNDSCHECK is defined.
   setUpIterators(rcpNodeLookup);

--- a/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
+++ b/packages/teuchos/kokkoscompat/src/KokkosCompat_View.hpp
@@ -185,8 +185,9 @@ namespace Kokkos {
       // allocated (e.g.,) using new or malloc, but it's not a problem
       // here, because the custom deallocator does not free anything.
       // Nevertheless, it's better not to trouble the tracking system.
-      return Teuchos::arcp(view.data(), 0, view.span(),
-                           deallocator(view), false);
+      return Teuchos::arcp (view.span () == 0 ? nullptr : view.data (),
+                            0, view.span (),
+                            deallocator(view), false);
     }
 
     // Create a "persisting view" from a Kokkos::View
@@ -195,9 +196,12 @@ namespace Kokkos {
     persistingView(
       const ViewType& view,
       typename Teuchos::ArrayRCP<typename ViewType::value_type>::size_type offset,
-      typename Teuchos::ArrayRCP<typename ViewType::value_type>::size_type size) {
-      return Teuchos::arcp(view.data()+offset, 0, size,
-                           deallocator(view), false);
+      typename Teuchos::ArrayRCP<typename ViewType::value_type>::size_type size)
+    {
+      // This check is related to #4234.
+      typename ViewType::value_type* const ptr =
+        (size == 0 && offset == 0) ? nullptr : (view.data () + offset);
+      return Teuchos::arcp (ptr, 0, size, deallocator (view), false);
     }
 
     template <class ViewType, typename Ordinal>

--- a/packages/teuchos/kokkoscompat/test/CMakeLists.txt
+++ b/packages/teuchos/kokkoscompat/test/CMakeLists.txt
@@ -13,7 +13,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   linkTest
   SOURCES
     linkTest.cpp 
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
   ARGS ""
   COMM serial mpi
   NUM_MPI_PROCS 1

--- a/packages/teuchos/numerics/test/LAPACK/cxx_main.cpp
+++ b/packages/teuchos/numerics/test/LAPACK/cxx_main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
 
   // Create some common typedefs
   typedef Teuchos::ScalarTraits<double> STS;
-  typedef Teuchos::ScalarTraits<double>::magnitudeType MagnitudeType;
+  typedef STS::magnitudeType MagnitudeType;
   typedef Teuchos::ScalarTraits<MagnitudeType> STM;
 
   Teuchos::LAPACK<int,double> L;
@@ -89,8 +89,8 @@ int main(int argc, char* argv[])
         if (verbose && i==3) std::cout << "passed!" << std::endl;
       } else {
         if (verbose) std::cout << "FAILED" << std::endl;
-        numberFailedTests++;	
-	break;
+        numberFailedTests++;
+        break;
       }
     }
 
@@ -128,13 +128,13 @@ int main(int argc, char* argv[])
     numberFailedTests++;
   }
   else
-  { 
+  {
     for (int i=0; i<n_potrf; i++)
     {
-      if ( diag_a[i*n_potrf + i] == (i+1) ) 
+      if ( diag_a[i*n_potrf + i] == (i+1) )
       {
         if (verbose && i==(n_potrf-1)) std::cout << "passed!" << std::endl;
-      } 
+      }
       else
       {
         if (verbose) std::cout << "FAILED" << std::endl;
@@ -145,11 +145,11 @@ int main(int argc, char* argv[])
   }
 
   if (verbose) std::cout << "POCON test ... ";
-  
+
   double anorm = (n_potrf*n_potrf), rcond;
   std::vector<double> work(3*n_potrf);
   std::vector<int> iwork(n_potrf);
-  
+
   L.POCON(char_U, n_potrf, &diag_a[0], n_potrf, anorm, &rcond, &work[0], &iwork[0], &info);
   if (info != 0 || (rcond != 1.0/anorm))
   {
@@ -157,13 +157,13 @@ int main(int argc, char* argv[])
     if (verbose) std::cout << "FAILED" << std::endl;
   }
   else
-  { 
+  {
     if (verbose) std::cout << "passed!" << std::endl;
-  } 
+  }
 
   if (verbose) std::cout << "POTRI test ... ";
-  std::vector<double> diag_a_trtri(diag_a); // Save a copy for TRTRI test 
-   
+  std::vector<double> diag_a_trtri(diag_a); // Save a copy for TRTRI test
+
   L.POTRI(char_U, n_potrf, &diag_a[0], n_potrf, &info);
 
   if (info != 0 || (diag_a[n_potrf+1] != 1.0/4.0))
@@ -172,20 +172,20 @@ int main(int argc, char* argv[])
     if (verbose) std::cout << "FAILED" << std::endl;
   }
   else
-  { 
+  {
     if (verbose) std::cout << "passed!" << std::endl;
-  } 
- 
+  }
+
   if (verbose) std::cout << "TRTRI test ... ";
-  
+
   int n_trtri = n_potrf;
   L.TRTRI( char_U, char_N, n_trtri, &diag_a_trtri[0], n_trtri, &info );
   for (int i=0; i<n_trtri; i++)
   {
-    if ( diag_a_trtri[i*n_trtri + i] == 1.0/(i+1) ) 
+    if ( diag_a_trtri[i*n_trtri + i] == 1.0/(i+1) )
     {
       if (verbose && i==(n_trtri-1)) std::cout << "passed!" << std::endl;
-    } 
+    }
     else
     {
       if (verbose) std::cout << "FAILED" << std::endl;
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
   }
 
 #endif
- 
+
   if (verbose) std::cout << "STEQR test ... ";
 
 #ifndef TEUCHOSNUMERICS_DISABLE_STEQR_TEST
@@ -235,8 +235,8 @@ int main(int argc, char* argv[])
   if (info != 0)
   {
     if (verbose)  std::cout << "STEQR: compute symmetric tridiagonal eigenvalues: "
-		  << "LAPACK's _STEQR failed with info = "
-		  << info;
+                  << "LAPACK's _STEQR failed with info = "
+                  << info;
 
       numberFailedTests++;
   }
@@ -249,8 +249,8 @@ int main(int argc, char* argv[])
   if ((fabs(lambda_min-exp_lambda_min)<1e-12) && (fabs(lambda_max-exp_lambda_max)<1e-12))
   {
     if (verbose) std::cout << "passed!" << std::endl;
-  } 
-  else 
+  }
+  else
   {
     if (verbose) std::cout << "FAILED" << std::endl;
     numberFailedTests++;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -62,13 +62,11 @@
 #include "Tpetra_Details_reallocDualViewIfNeeded.hpp"
 #include "Tpetra_Details_PackTraits.hpp"
 #include "Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp"
-
-
-
 #include "KokkosCompat_View.hpp"
 #include "KokkosBlas.hpp"
 #include "KokkosKernels_Utils.hpp"
 #include "Kokkos_Random.hpp"
+#include "Kokkos_ArithTraits.hpp"
 
 #ifdef HAVE_TPETRA_INST_FLOAT128
 namespace Kokkos {
@@ -299,6 +297,43 @@ namespace { // (anonymous)
 
 
 namespace Tpetra {
+
+  namespace Details {
+    // Work-around for #3823.  The right way to fix this is to fix
+    // KokkosBlas::dot for complex, but this at least makes Tpetra's
+    // tests pass for complex.
+    template<class XVector,class YVector>
+    typename ::Kokkos::Details::InnerProductSpaceTraits<typename XVector::non_const_value_type>::dot_type
+    localDotWorkAround (const XVector& x, const YVector& y)
+    {
+      using x_value_type = typename XVector::non_const_value_type;
+      using y_value_type = typename YVector::non_const_value_type;
+
+      if (Kokkos::ArithTraits<x_value_type>::is_complex ||
+          Kokkos::ArithTraits<y_value_type>::is_complex) {
+        using IPT = ::Kokkos::Details::InnerProductSpaceTraits<x_value_type>;
+        using dot_type = typename IPT::dot_type;
+        using execution_space = typename XVector::execution_space;
+        using range_type = Kokkos::RangePolicy<execution_space, int>;
+        // Use double precision internally; this should improve
+        // accuracy for complex<float> and thus help more tests pass.
+        using impl_dot_type = typename Teuchos::ScalarTraits<dot_type>::doublePrecision;
+
+        impl_dot_type result;
+        Kokkos::parallel_reduce
+          ("Tpetra::MultiVector oneColDotWorkAround",
+           range_type (0, x.extent (0)),
+           KOKKOS_LAMBDA (const int lclRow, impl_dot_type& dst) {
+            dst += IPT::dot (x(lclRow), y(lclRow));
+          }, result);
+        return static_cast<dot_type> (result);
+      }
+      else {
+        return KokkosBlas::dot (x, y);
+      }
+    }
+  } // namespace Details
+
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
@@ -1904,7 +1939,8 @@ namespace Tpetra {
         auto x_1d = Kokkos::subview (x_2d, rowRng, 0);
         auto y_2d = y.template getLocalView<dev_memory_space> ();
         auto y_1d = Kokkos::subview (y_2d, rowRng, 0);
-        lclDot = KokkosBlas::dot (x_1d, y_1d);
+        // Work-around for #3823; see notes above.
+        lclDot = ::Tpetra::Details::localDotWorkAround (x_1d, y_1d);
 
         if (x.isDistributed ()) {
           using Teuchos::outArg;


### PR DESCRIPTION
@trilinos/tpetra @trilinos/kokkos @trilinos/teuchos 

This fixes a few Teuchos issues, and one Tpetra issue.  The Tpetra fix is actually a work-around for kokkos-kernels issues.  @kyungjoo-kim might have some fixes there; see e.g., https://github.com/kokkos/kokkos-kernels/pull/373.

This may be "results impacting," because it affects how Tpetra computes dot products for complex Scalar types.  In particular, the work-around always uses `complex<double>` as the accumulator type.  This should improve accuracy for the `Scalar=complex<float>` case.

## Related Issues

* Closes #4250, #4234, #4249, #3823
