### PR TITLE
Remove Unused Parameter Warnings

### DIFF
--- a/packages/epetraext/src/EpetraExt_MMHelpers.cpp
+++ b/packages/epetraext/src/EpetraExt_MMHelpers.cpp
@@ -250,7 +250,7 @@ bool CrsWrapper_GraphBuilder<int_type>::Filled()
 
 template<typename int_type>
 int
-CrsWrapper_GraphBuilder<int_type>::InsertGlobalValues(int_type GlobalRow, int NumEntries, double* Values, int_type* Indices)
+CrsWrapper_GraphBuilder<int_type>::InsertGlobalValues(int_type GlobalRow, int NumEntries, double* /* Values */, int_type* Indices)
 {
   typename std::map<int_type,std::set<int_type>*>::iterator
     iter = graph_.find(GlobalRow);
@@ -939,6 +939,8 @@ int LightweightCrsMatrix::MakeColMapAndReindex(std::vector<int> owningPIDs, std:
   if(label) tpref = std::string(label);
   using Teuchos::TimeMonitor;
   Teuchos::RCP<Teuchos::TimeMonitor> MM = Teuchos::rcp(new TimeMonitor(*TimeMonitor::getNewTimer(tpref + std::string("EpetraExt: LWCRS-3.1"))));
+#else
+  (void)label;
 #endif
 
   // Scan all column indices and sort into two groups:
@@ -1603,6 +1605,8 @@ void LightweightCrsMatrix::Construct(const Epetra_CrsMatrix & SourceMatrix, Impo
   if(label) tpref = std::string(label);
   using Teuchos::TimeMonitor;
   Teuchos::RCP<Teuchos::TimeMonitor> MM = Teuchos::rcp(new TimeMonitor(*TimeMonitor::getNewTimer(tpref + std::string("EpetraExt: LWCRS C-1"))));
+#else
+  (void)label;
 #endif
 
   // Fused constructor, import & FillComplete

--- a/packages/epetraext/src/EpetraExt_MatrixMatrix_mult_A_B.cpp
+++ b/packages/epetraext/src/EpetraExt_MatrixMatrix_mult_A_B.cpp
@@ -1403,7 +1403,7 @@ template<typename int_type>
 int MatrixMatrix::Tjacobi_A_B(double omega,
                              const Epetra_Vector & Dinv,
                              const Epetra_CrsMatrix & A,
-                             CrsMatrixStruct & Aview,
+                             CrsMatrixStruct & /* Aview */,
                              const Epetra_CrsMatrix & B,
                              CrsMatrixStruct& Bview,
                              Epetra_CrsMatrix& C,

--- a/packages/epetraext/src/block/EpetraExt_BlockDiagMatrix.h
+++ b/packages/epetraext/src/block/EpetraExt_BlockDiagMatrix.h
@@ -190,7 +190,7 @@ class EpetraExt_BlockDiagMatrix : public virtual Epetra_Operator, public Epetra_
       Y -A Epetra_MultiVector of dimension NumVectors containing result.
     \return Integer error code, set to 0 if successful.
   */
-  virtual int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {return -1;}
+  virtual int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {return -1;}
 
   //! Returns the result of a Epetra_Operator inverse applied to an Epetra_MultiVector X in Y.
   /*!

--- a/packages/epetraext/src/block/EpetraExt_PointToBlockDiagPermute.cpp
+++ b/packages/epetraext/src/block/EpetraExt_PointToBlockDiagPermute.cpp
@@ -159,7 +159,7 @@ int EpetraExt_PointToBlockDiagPermute::Compute(){
 
 //=========================================================================  
 // Returns the result of a Epetra_Operator applied to a Epetra_MultiVector X in Y.
-int EpetraExt_PointToBlockDiagPermute::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const{
+int EpetraExt_PointToBlockDiagPermute::Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const{
   return -1;
 
 }
@@ -218,7 +218,7 @@ int EpetraExt_PointToBlockDiagPermute::ApplyInverse(const Epetra_MultiVector& X,
 
 //=========================================================================  
 // Print method
-void EpetraExt_PointToBlockDiagPermute::Print(std::ostream& os) const{
+void EpetraExt_PointToBlockDiagPermute::Print(std::ostream& /* os */) const{
   if(Importer_) std::cout<<*Importer_<<std::endl;
   if(Exporter_) std::cout<<*Exporter_<<std::endl;
   if(BDMat_) std::cout<<*BDMat_<<std::endl;
@@ -648,68 +648,68 @@ void EpetraExt_PointToBlockDiagPermute::UpdateExportVector(int NumVectors) const
 
 
 //=========================================================================  
-int EpetraExt_PointToBlockDiagPermute::Import(const Epetra_SrcDistObject& A, const Epetra_Import& Importer, Epetra_CombineMode CombineMode, const Epetra_OffsetIndex *Indexor){
+int EpetraExt_PointToBlockDiagPermute::Import(const Epetra_SrcDistObject& /* A */, const Epetra_Import& /* Importer */, Epetra_CombineMode /* CombineMode */, const Epetra_OffsetIndex * /* Indexor */){
  return -1;
 }
 
 //=========================================================================  
-int EpetraExt_PointToBlockDiagPermute::Import(const Epetra_SrcDistObject& A, const Epetra_Export& Exporter, Epetra_CombineMode CombineMode, const Epetra_OffsetIndex *Indexor){
+int EpetraExt_PointToBlockDiagPermute::Import(const Epetra_SrcDistObject& /* A */, const Epetra_Export& /* Exporter */, Epetra_CombineMode /* CombineMode */, const Epetra_OffsetIndex * /* Indexor */){
  return -1;
 }
 
 //=========================================================================  
-int EpetraExt_PointToBlockDiagPermute::Export(const Epetra_SrcDistObject& A, const Epetra_Import & Importer, Epetra_CombineMode CombineMode, const Epetra_OffsetIndex *Indexor){
+int EpetraExt_PointToBlockDiagPermute::Export(const Epetra_SrcDistObject& /* A */, const Epetra_Import & /* Importer */, Epetra_CombineMode /* CombineMode */, const Epetra_OffsetIndex * /* Indexor */){
  return -1;
 }
 
 //=========================================================================  
-int EpetraExt_PointToBlockDiagPermute::Export(const Epetra_SrcDistObject& A, const Epetra_Export& Exporter, Epetra_CombineMode CombineMode, const Epetra_OffsetIndex *Indexor){
+int EpetraExt_PointToBlockDiagPermute::Export(const Epetra_SrcDistObject& /* A */, const Epetra_Export& /* Exporter */, Epetra_CombineMode /* CombineMode */, const Epetra_OffsetIndex * /* Indexor */){
  return -1;
 }
 
 //=========================================================================  
 // Allows the source and target (\e this) objects to be compared for compatibility, return nonzero if not.
-int EpetraExt_PointToBlockDiagPermute::CheckSizes(const Epetra_SrcDistObject& Source){
+int EpetraExt_PointToBlockDiagPermute::CheckSizes(const Epetra_SrcDistObject& /* Source */){
   return -1;
 }
 
 //=========================================================================  
 // Perform ID copies and permutations that are on processor.
-int EpetraExt_PointToBlockDiagPermute::CopyAndPermute(const Epetra_SrcDistObject& Source,
-                   int NumSameIDs, 
-                   int NumPermuteIDs,
-                   int * PermuteToLIDs,
-                   int * PermuteFromLIDs,
-                   const Epetra_OffsetIndex * Indexor,
-                   Epetra_CombineMode CombineMode){
+int EpetraExt_PointToBlockDiagPermute::CopyAndPermute(const Epetra_SrcDistObject& /* Source */,
+                   int /* NumSameIDs */, 
+                   int /* NumPermuteIDs */,
+                   int * /* PermuteToLIDs */,
+                   int * /* PermuteFromLIDs */,
+                   const Epetra_OffsetIndex * /* Indexor */,
+                   Epetra_CombineMode /* CombineMode */){
   return -1;
 }
 
 //=========================================================================  
 // Perform any packing or preparation required for call to DoTransfer().
-int EpetraExt_PointToBlockDiagPermute::PackAndPrepare(const Epetra_SrcDistObject& Source,
-                   int NumExportIDs,
-                   int* ExportLIDs,
-                   int& LenExports,
-                   char*& Exports,
-                   int& SizeOfPacket,
-                   int* Sizes,
-                   bool & VarSizes,
-                   Epetra_Distributor& Distor){
+int EpetraExt_PointToBlockDiagPermute::PackAndPrepare(const Epetra_SrcDistObject& /* Source */,
+                   int /* NumExportIDs */,
+                   int* /* ExportLIDs */,
+                   int& /* LenExports */,
+                   char*& /* Exports */,
+                   int& /* SizeOfPacket */,
+                   int* /* Sizes */,
+                   bool & /* VarSizes */,
+                   Epetra_Distributor& /* Distor */){
   return -1;
 }
 
 //=========================================================================  
 // Perform any unpacking and combining after call to DoTransfer().
-int EpetraExt_PointToBlockDiagPermute::UnpackAndCombine(const Epetra_SrcDistObject& Source, 
-                     int NumImportIDs,
-                     int* ImportLIDs, 
-                     int LenImports,
-                     char* Imports,
-                     int& SizeOfPacket, 
-                     Epetra_Distributor& Distor,
-                     Epetra_CombineMode CombineMode,
-                     const Epetra_OffsetIndex * Indexor){
+int EpetraExt_PointToBlockDiagPermute::UnpackAndCombine(const Epetra_SrcDistObject& /* Source */, 
+                     int /* NumImportIDs */,
+                     int* /* ImportLIDs */, 
+                     int /* LenImports */,
+                     char* /* Imports */,
+                     int& /* SizeOfPacket */, 
+                     Epetra_Distributor& /* Distor */,
+                     Epetra_CombineMode /* CombineMode */,
+                     const Epetra_OffsetIndex * /* Indexor */){
   return -1;
 }
 

--- a/packages/epetraext/src/block/EpetraExt_PointToBlockDiagPermute.h
+++ b/packages/epetraext/src/block/EpetraExt_PointToBlockDiagPermute.h
@@ -97,7 +97,7 @@ public:
   ///
   /// This class does NOT know how to apply its transpose, so this
   /// method always returns an error code.
-  virtual int SetUseTranspose (bool useTranspose) {return -1;}
+  virtual int SetUseTranspose (bool /* useTranspose */) {return -1;}
 
   //! Extracts the block-diagonal, builds maps, etc.
   virtual int Compute();

--- a/packages/epetraext/src/inout/EpetraExt_XMLReader.cpp
+++ b/packages/epetraext/src/inout/EpetraExt_XMLReader.cpp
@@ -101,6 +101,7 @@ EpetraExt::XMLReader::XMLReader(const Epetra_Comm& comm, const std::string& File
   fileXML_ = rcp(new XMLObject(fileSrc.getObject()));
   IsOpen_ = true;
 #else
+  (void)FileName;
   std::cerr << "Teuchos was not configured with support for expat." << std::endl;
   std::cerr << "Please reconfigure teuchos with --enable-teuchos-expat." << std::endl;
   exit(EXIT_FAILURE);

--- a/packages/epetraext/src/inout/EpetraExt_mmio.cpp
+++ b/packages/epetraext/src/inout/EpetraExt_mmio.cpp
@@ -341,7 +341,7 @@ int mm_write_mtx_array_size(FILE *f, long long M, long long N)
 /* use when I[], J[], and val[]J, and val[] are already allocated */
 /******************************************************************/
 
-int mm_read_mtx_crd_data(FILE *f, int M, int N, int nz, int I[], int J[],
+int mm_read_mtx_crd_data(FILE *f, int /* M */, int /* N */, int nz, int I[], int J[],
         double val[], MM_typecode matcode)
 {
     int i;

--- a/packages/epetraext/src/model_evaluator/EpetraExt_ModelEvaluator.cpp
+++ b/packages/epetraext/src/model_evaluator/EpetraExt_ModelEvaluator.cpp
@@ -71,13 +71,13 @@ bool ModelEvaluator::InArgs::supports(EInArgsMembers arg) const
   return supports_[arg];
 }
 
-bool ModelEvaluator::InArgs::supports(EInArgs_p_sg arg, int l) const
+bool ModelEvaluator::InArgs::supports(EInArgs_p_sg /* arg */, int l) const
 {
   assert_l(l);
   return supports_p_sg_[l];
 }
 
-bool ModelEvaluator::InArgs::supports(EInArgs_p_mp arg, int l) const
+bool ModelEvaluator::InArgs::supports(EInArgs_p_mp /* arg */, int l) const
 {
   assert_l(l);
   return supports_p_mp_[l];
@@ -92,13 +92,13 @@ void ModelEvaluator::InArgs::_setSupports( EInArgsMembers arg, bool supportsIt )
   supports_[arg] = supportsIt;
 }
 
-void ModelEvaluator::InArgs::_setSupports(EInArgs_p_sg arg, int l, bool supportsIt)
+void ModelEvaluator::InArgs::_setSupports(EInArgs_p_sg /* arg */, int l, bool supportsIt)
 {
   assert_l(l);
   supports_p_sg_[l] = supportsIt;
 }
 
-void ModelEvaluator::InArgs::_setSupports(EInArgs_p_mp arg, int l, bool supportsIt)
+void ModelEvaluator::InArgs::_setSupports(EInArgs_p_mp /* arg */, int l, bool supportsIt)
 {
   assert_l(l);
   supports_p_mp_[l] = supportsIt;
@@ -114,7 +114,7 @@ void ModelEvaluator::InArgs::assert_supports(EInArgsMembers arg) const
     );
 }
 
-void ModelEvaluator::InArgs::assert_supports(EInArgs_p_sg arg, int l) const
+void ModelEvaluator::InArgs::assert_supports(EInArgs_p_sg /* arg */, int l) const
 {
   assert_l(l);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -125,7 +125,7 @@ void ModelEvaluator::InArgs::assert_supports(EInArgs_p_sg arg, int l) const
     );
 }
 
-void ModelEvaluator::InArgs::assert_supports(EInArgs_p_mp arg, int l) const
+void ModelEvaluator::InArgs::assert_supports(EInArgs_p_mp /* arg */, int l) const
 {
   assert_l(l);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -171,7 +171,7 @@ bool ModelEvaluator::OutArgs::supports(EOutArgsMembers arg) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDfDp arg, int l) const
+ModelEvaluator::OutArgs::supports(EOutArgsDfDp /* arg */, int l) const
 {
   assert_l(l);
   return supports_DfDp_[l];
@@ -179,7 +179,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDfDp arg, int l) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_dot_[j];
@@ -187,7 +187,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_dotdot_[j];
@@ -195,7 +195,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_[j];
@@ -203,21 +203,21 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDp arg, int j, int l) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDp /* arg */, int j, int l) const
 {
   assert_j(j);
   assert_l(l);
   return supports_DgDp_[ j*Np() + l ];
 }
 
-bool ModelEvaluator::OutArgs::supports(EOutArgs_g_sg arg, int j) const
+bool ModelEvaluator::OutArgs::supports(EOutArgs_g_sg /* arg */, int j) const
 {
   assert_j(j);
   return supports_g_sg_[j];
 }
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDfDp_sg arg, int l) const
+ModelEvaluator::OutArgs::supports(EOutArgsDfDp_sg /* arg */, int l) const
 {
   assert_l(l);
   return supports_DfDp_sg_[l];
@@ -225,7 +225,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDfDp_sg arg, int l) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot_sg arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot_sg /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_dot_sg_[j];
@@ -233,7 +233,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot_sg arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot_sg arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot_sg /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_dotdot_sg_[j];
@@ -241,28 +241,28 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot_sg arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_sg arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_sg /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_sg_[j];
 }
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDp_sg arg, int j, int l) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDp_sg /* arg */, int j, int l) const
 {
   assert_j(j);
   assert_l(l);
   return supports_DgDp_sg_[ j*Np() + l ];
 }
 
-bool ModelEvaluator::OutArgs::supports(EOutArgs_g_mp arg, int j) const
+bool ModelEvaluator::OutArgs::supports(EOutArgs_g_mp /* arg */, int j) const
 {
   assert_j(j);
   return supports_g_mp_[j];
 }
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDfDp_mp arg, int l) const
+ModelEvaluator::OutArgs::supports(EOutArgsDfDp_mp /* arg */, int l) const
 {
   assert_l(l);
   return supports_DfDp_mp_[l];
@@ -270,7 +270,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDfDp_mp arg, int l) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot_mp arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot_mp /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_dot_mp_[j];
@@ -278,7 +278,7 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dot_mp arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot_mp arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot_mp /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_dotdot_mp_[j];
@@ -286,14 +286,14 @@ ModelEvaluator::OutArgs::supports(EOutArgsDgDx_dotdot_mp arg, int j) const
 
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDx_mp arg, int j) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDx_mp /* arg */, int j) const
 {
   assert_j(j);
   return supports_DgDx_mp_[j];
 }
 
 const ModelEvaluator::DerivativeSupport&
-ModelEvaluator::OutArgs::supports(EOutArgsDgDp_mp arg, int j, int l) const
+ModelEvaluator::OutArgs::supports(EOutArgsDgDp_mp /* arg */, int j, int l) const
 {
   assert_j(j);
   assert_l(l);
@@ -446,113 +446,113 @@ void ModelEvaluator::OutArgs::_setSupports( EOutArgsMembers arg, bool supportsIt
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDfDp arg, int l, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDfDp /* arg */, int l, const DerivativeSupport& theSupports )
 {
   assert_l(l);
   supports_DfDp_[l] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dot arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dot /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_dot_[j] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dotdot arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dotdot /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_dotdot_[j] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_[j] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDp arg, int j, int l, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDp /* arg */, int j, int l, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   assert_l(l);
   supports_DgDp_[ j*Np() + l ] = theSupports;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgs_g_sg arg, int j, bool supportsIt )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgs_g_sg /* arg */, int j, bool supportsIt )
 {
   assert_j(j);
   supports_g_sg_[j] = supportsIt;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDfDp_sg arg, int l, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDfDp_sg /* arg */, int l, const DerivativeSupport& theSupports )
 {
   assert_l(l);
   supports_DfDp_sg_[l] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dot_sg arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dot_sg /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_dot_sg_[j] = theSupports;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dotdot_sg arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dotdot_sg /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_dotdot_sg_[j] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_sg arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_sg /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_sg_[j] = theSupports;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDp_sg arg, int j, int l, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDp_sg /* arg */, int j, int l, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   assert_l(l);
   supports_DgDp_sg_[ j*Np() + l ] = theSupports;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgs_g_mp arg, int j, bool supportsIt )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgs_g_mp /* arg */, int j, bool supportsIt )
 {
   assert_j(j);
   supports_g_mp_[j] = supportsIt;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDfDp_mp arg, int l, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDfDp_mp /* arg */, int l, const DerivativeSupport& theSupports )
 {
   assert_l(l);
   supports_DfDp_mp_[l] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dot_mp arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dot_mp /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_dot_mp_[j] = theSupports;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dotdot_mp arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_dotdot_mp /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_dotdot_mp_[j] = theSupports;
 }
 
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_mp arg, int j, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDx_mp /* arg */, int j, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   supports_DgDx_mp_[j] = theSupports;
 }
 
-void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDp_mp arg, int j, int l, const DerivativeSupport& theSupports )
+void ModelEvaluator::OutArgs::_setSupports( EOutArgsDgDp_mp /* arg */, int j, int l, const DerivativeSupport& theSupports )
 {
   assert_j(j);
   assert_l(l);
@@ -680,7 +680,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsMembers arg) const
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp arg, int l) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp /* arg */, int l) const
 {
   assert_l(l);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -692,7 +692,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp arg, int l) const
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -704,7 +704,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot arg, int j) const
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -716,7 +716,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot arg, int j) co
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -728,7 +728,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx arg, int j) const
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp arg, int j, int l) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp /* arg */, int j, int l) const
 {
   assert_j(j);
   assert_l(l);
@@ -740,7 +740,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp arg, int j, int l) co
     );
 }
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgs_g_sg arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgs_g_sg /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -751,7 +751,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgs_g_sg arg, int j) const
     );
 }
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp_sg arg, int l) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp_sg /* arg */, int l) const
 {
   assert_l(l);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -763,7 +763,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp_sg arg, int l) const
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot_sg arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot_sg /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -775,7 +775,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot_sg arg, int j) co
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot_sg arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot_sg /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -787,7 +787,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot_sg arg, int j)
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_sg arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_sg /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -798,7 +798,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_sg arg, int j) const
     );
 }
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp_sg arg, int j, int l) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp_sg /* arg */, int j, int l) const
 {
   assert_j(j);
   assert_l(l);
@@ -810,7 +810,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp_sg arg, int j, int l)
     );
 }
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgs_g_mp arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgs_g_mp /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -821,7 +821,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgs_g_mp arg, int j) const
     );
 }
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp_mp arg, int l) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp_mp /* arg */, int l) const
 {
   assert_l(l);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -833,7 +833,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDfDp_mp arg, int l) const
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot_mp arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot_mp /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -845,7 +845,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dot_mp arg, int j) co
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot_mp arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot_mp /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -857,7 +857,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_dotdot_mp arg, int j)
 }
 
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_mp arg, int j) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_mp /* arg */, int j) const
 {
   assert_j(j);
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -868,7 +868,7 @@ void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDx_mp arg, int j) const
     );
 }
 
-void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp_mp arg, int j, int l) const
+void ModelEvaluator::OutArgs::assert_supports(EOutArgsDgDp_mp /* arg */, int j, int l) const
 {
   assert_j(j);
   assert_l(l);
@@ -928,19 +928,19 @@ ModelEvaluator::~ModelEvaluator()
 
 
 Teuchos::RCP<const Epetra_Map>
-ModelEvaluator::get_p_map(int l) const
+ModelEvaluator::get_p_map(int /* l */) const
 { return Teuchos::null; }
 
 Teuchos::RCP<const Teuchos::Array<std::string> >
-ModelEvaluator::get_p_names(int l) const
+ModelEvaluator::get_p_names(int /* l */) const
 { return Teuchos::null; }
 
 Teuchos::RCP<const Epetra_Map>
-ModelEvaluator::get_g_map(int j) const
+ModelEvaluator::get_g_map(int /* j */) const
 { return Teuchos::null; }
 
 Teuchos::ArrayView<const std::string>
-ModelEvaluator::get_g_names(int j) const
+ModelEvaluator::get_g_names(int /* j */) const
 { return Teuchos::null; }
 
 
@@ -960,7 +960,7 @@ ModelEvaluator::get_x_dotdot_init() const
 { return Teuchos::null; }
 
 Teuchos::RCP<const Epetra_Vector>
-ModelEvaluator::get_p_init(int l) const
+ModelEvaluator::get_p_init(int /* l */) const
 { return Teuchos::null; }
 
 double ModelEvaluator::get_t_init() const
@@ -987,12 +987,12 @@ ModelEvaluator::get_x_upper_bounds() const
 
 
 Teuchos::RCP<const Epetra_Vector>
-ModelEvaluator::get_p_lower_bounds(int l) const
+ModelEvaluator::get_p_lower_bounds(int /* l */) const
 { return Teuchos::null; }
 
 
 Teuchos::RCP<const Epetra_Vector>
-ModelEvaluator::get_p_upper_bounds(int l) const
+ModelEvaluator::get_p_upper_bounds(int /* l */) const
 { return Teuchos::null; }
 
 
@@ -1016,23 +1016,23 @@ ModelEvaluator::create_WPrec() const
 { return Teuchos::null; }
 
 Teuchos::RCP<Epetra_Operator>
-ModelEvaluator::create_DfDp_op(int l) const
+ModelEvaluator::create_DfDp_op(int /* l */) const
 { return Teuchos::null; }
 
 Teuchos::RCP<Epetra_Operator>
-ModelEvaluator::create_DgDx_dot_op(int j) const
+ModelEvaluator::create_DgDx_dot_op(int /* j */) const
 { return Teuchos::null; }
 
 Teuchos::RCP<Epetra_Operator>
-ModelEvaluator::create_DgDx_dotdot_op(int j) const
+ModelEvaluator::create_DgDx_dotdot_op(int /* j */) const
 { return Teuchos::null; }
 
 Teuchos::RCP<Epetra_Operator>
-ModelEvaluator::create_DgDx_op(int j) const
+ModelEvaluator::create_DgDx_op(int /* j */) const
 { return Teuchos::null; }
 
 Teuchos::RCP<Epetra_Operator>
-ModelEvaluator::create_DgDp_op( int j, int l ) const
+ModelEvaluator::create_DgDp_op( int /* j */, int /* l */ ) const
 { return Teuchos::null; }
 
 } // namespace EpetraExt

--- a/packages/epetraext/src/model_evaluator/EpetraExt_ModelEvaluatorScalingTools.cpp
+++ b/packages/epetraext/src/model_evaluator/EpetraExt_ModelEvaluatorScalingTools.cpp
@@ -106,8 +106,8 @@ void scaleModelVar(
   const EpetraExt::ModelEvaluator::InArgs &origVars,
   const EpetraExt::ModelEvaluator::InArgs &varScalings,
   EpetraExt::ModelEvaluator::InArgs *scaledVars,
-  Teuchos::FancyOStream *out,
-  Teuchos::EVerbosityLevel verbLevel
+  Teuchos::FancyOStream * /* out */,
+  Teuchos::EVerbosityLevel /* verbLevel */
   )
 {
 
@@ -170,12 +170,12 @@ void scaleModelBound(
   InArgsVectorGetterSetter vecGetterSetter, // Templated policy object!
   const EpetraExt::ModelEvaluator::InArgs &origLowerBounds,
   const EpetraExt::ModelEvaluator::InArgs &origUpperBounds,
-  const double infBnd,
+  const double /* infBnd */,
   const EpetraExt::ModelEvaluator::InArgs &varScalings,
   EpetraExt::ModelEvaluator::InArgs *scaledLowerBounds,
   EpetraExt::ModelEvaluator::InArgs *scaledUpperBounds,
-  Teuchos::FancyOStream *out,
-  Teuchos::EVerbosityLevel verbLevel
+  Teuchos::FancyOStream * /* out */,
+  Teuchos::EVerbosityLevel /* verbLevel */
   )
 {
 
@@ -287,8 +287,8 @@ void scaleModelFunc(
   const EpetraExt::ModelEvaluator::OutArgs &origFuncs,
   const EpetraExt::ModelEvaluator::OutArgs &funcScalings,
   EpetraExt::ModelEvaluator::OutArgs *scaledFuncs,
-  Teuchos::FancyOStream *out,
-  Teuchos::EVerbosityLevel verbLevel
+  Teuchos::FancyOStream * /* out */,
+  Teuchos::EVerbosityLevel /* verbLevel */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT(0==scaledFuncs);
@@ -829,12 +829,12 @@ void EpetraExt::scaleModelVarsGivenInverseScaling(
 
 
 void EpetraExt::scaleModelVarBoundsGivenInverseScaling(
-  const Epetra_Vector &origLowerBounds,
-  const Epetra_Vector &origUpperBounds,
-  const double infBnd,
-  const Epetra_Vector &invVarScaling,
-  Epetra_Vector *scaledLowerBounds,
-  Epetra_Vector *scaledUpperBounds
+  const Epetra_Vector &/* origLowerBounds */,
+  const Epetra_Vector &/* origUpperBounds */,
+  const double /* infBnd */,
+  const Epetra_Vector &/* invVarScaling */,
+  Epetra_Vector * /* scaledLowerBounds */,
+  Epetra_Vector * /* scaledUpperBounds */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("ToDo: Implement!");

--- a/packages/epetraext/src/transform/EpetraExt_CrsSingletonFilter_LinearProblem.h
+++ b/packages/epetraext/src/transform/EpetraExt_CrsSingletonFilter_LinearProblem.h
@@ -334,7 +334,7 @@ class LinearProblem_CrsSingletonFilter : public SameTypeTransform<Epetra_LinearP
   
  private:
   //! Copy constructor (defined as private so it is unavailable to user).
-  LinearProblem_CrsSingletonFilter(const LinearProblem_CrsSingletonFilter & Problem){};
+  LinearProblem_CrsSingletonFilter(const LinearProblem_CrsSingletonFilter & /* Problem */){};
 
   template<typename int_type>
   int TConstructReducedProblem(Epetra_LinearProblem * Problem);

--- a/packages/epetraext/src/transform/EpetraExt_Permutation_impl.h
+++ b/packages/epetraext/src/transform/EpetraExt_Permutation_impl.h
@@ -388,9 +388,9 @@ struct Perm_traits<Epetra_MultiVector> {
 
   /** clone implementation */
   static Epetra_MultiVector* clone(Epetra_MultiVector* example,
-				   Epetra_DataAccess CV,
+				   Epetra_DataAccess /* CV */,
 				   const Epetra_BlockMap& map,
-				   int numVectors)
+				   int /* numVectors */)
   {
     return( new Epetra_MultiVector(map, example->NumVectors()) );
   }
@@ -403,8 +403,8 @@ struct Perm_traits<Epetra_MultiVector> {
 #ifndef EPETRA_NO_32BIT_GLOBAL_INDICES
   /** permute column-indices within a specified row, if applicable*/
   static Epetra_MultiVector*
-  produceColumnPermutation(Permutation<Epetra_MultiVector>* perm,
-			   Epetra_MultiVector* srcObj)
+  produceColumnPermutation(Permutation<Epetra_MultiVector>* /* perm */,
+			   Epetra_MultiVector* /* srcObj */)
   {
     std::cerr << "col-permutation not implemented for Epetra_MultiVector"<<std::endl;
     return(NULL);
@@ -413,8 +413,8 @@ struct Perm_traits<Epetra_MultiVector> {
 #ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
   /** permute column-indices within a specified row, if applicable*/
   static Epetra_MultiVector*
-  produceColumnPermutation(Permutation64<Epetra_MultiVector>* perm,
-			   Epetra_MultiVector* srcObj)
+  produceColumnPermutation(Permutation64<Epetra_MultiVector>* /* perm */,
+			   Epetra_MultiVector* /* srcObj */)
   {
     std::cerr << "col-permutation not implemented for Epetra_MultiVector"<<std::endl;
     return(NULL);

--- a/packages/rythmos/src/Rythmos_BackwardEulerStepper_decl.hpp
+++ b/packages/rythmos/src/Rythmos_BackwardEulerStepper_decl.hpp
@@ -88,14 +88,14 @@ template<class Scalar>
     }
 
     void serialize(
-        const StateSerializerStrategy<Scalar>& stateSerializer,
-        std::ostream& oStream
+        const StateSerializerStrategy<Scalar>& /* stateSerializer */,
+        std::ostream& /* oStream */
         ) const
     { }
 
     void deSerialize(
-        const StateSerializerStrategy<Scalar>& stateSerializer,
-        std::istream& iStream
+        const StateSerializerStrategy<Scalar>& /* stateSerializer */,
+        std::istream& /* iStream */
         )
     { }
 

--- a/packages/rythmos/src/Rythmos_BackwardEulerStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_BackwardEulerStepper_def.hpp
@@ -626,7 +626,7 @@ template<class Scalar>
 void BackwardEulerStepper<Scalar>::addPoints(
   const Array<Scalar>& time_vec,
   const Array<RCP<const Thyra::VectorBase<Scalar> > >& x_vec,
-  const Array<RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+  const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
   )
 {
 

--- a/packages/rythmos/src/Rythmos_BasicDiscreteAdjointStepperTester_def.hpp
+++ b/packages/rythmos/src/Rythmos_BasicDiscreteAdjointStepperTester_def.hpp
@@ -94,7 +94,7 @@ BasicDiscreteAdjointStepperTester<Scalar>::getValidParameters() const
 
 template<class Scalar>
 bool BasicDiscreteAdjointStepperTester<Scalar>::testAdjointStepper(
-  Thyra::ModelEvaluator<Scalar>& adjointModel,
+  Thyra::ModelEvaluator<Scalar>& /* adjointModel */,
   const Ptr<IntegratorBase<Scalar> >& forwardIntegrator
   )
 {

--- a/packages/rythmos/src/Rythmos_ExplicitRKStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ExplicitRKStepper_def.hpp
@@ -224,7 +224,7 @@ Scalar ExplicitRKStepper<Scalar>::takeStep(Scalar dt, StepSizeType stepSizeType)
 
 
 template<class Scalar>
-Scalar ExplicitRKStepper<Scalar>::takeVariableStep_(Scalar dt, StepSizeType stepSizeType)
+Scalar ExplicitRKStepper<Scalar>::takeVariableStep_(Scalar dt, StepSizeType /* stepSizeType */)
 {
   typedef typename Thyra::ModelEvaluatorBase::InArgs<Scalar>::ScalarMag TScalarMag;
   this->initialize_();
@@ -442,9 +442,9 @@ void ExplicitRKStepper<Scalar>::describe(
 
 template<class Scalar>
 void ExplicitRKStepper<Scalar>::addPoints(
-    const Array<Scalar>& time_vec
-    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x_vec
-    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+    const Array<Scalar>& /* time_vec */
+    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& /* x_vec */
+    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
     )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Error, addPoints is not implemented for ExplicitRKStepper at this time.\n");
@@ -496,7 +496,7 @@ void ExplicitRKStepper<Scalar>::getNodes(Array<Scalar>* time_vec) const
 }
 
 template<class Scalar>
-void ExplicitRKStepper<Scalar>::removeNodes(Array<Scalar>& time_vec)
+void ExplicitRKStepper<Scalar>::removeNodes(Array<Scalar>& /* time_vec */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Error, removeNodes is not implemented for ExplicitRKStepper at this time.\n");
 }

--- a/packages/rythmos/src/Rythmos_ExplicitTaylorPolynomialStepper.hpp
+++ b/packages/rythmos/src/Rythmos_ExplicitTaylorPolynomialStepper.hpp
@@ -739,9 +739,9 @@ void ExplicitTaylorPolynomialStepper<Scalar>::describe(
 
 template<class Scalar>
 void ExplicitTaylorPolynomialStepper<Scalar>::addPoints(
-  const Array<Scalar>& time_vec
-  ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& x_vec
-  ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+  const Array<Scalar>& /* time_vec */
+  ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* x_vec */
+  ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Error, addPoints is not implemented for the ExplicitTaylorPolynomialStepper.\n");
@@ -795,7 +795,7 @@ void ExplicitTaylorPolynomialStepper<Scalar>::getNodes(Array<Scalar>* time_vec) 
 
 
 template<class Scalar>
-void ExplicitTaylorPolynomialStepper<Scalar>::removeNodes(Array<Scalar>& time_vec)
+void ExplicitTaylorPolynomialStepper<Scalar>::removeNodes(Array<Scalar>& /* time_vec */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Error, removeNodes is not implemented for the ExplicitTaylorPolynomialStepper.\n");
 }

--- a/packages/rythmos/src/Rythmos_FirstOrderErrorStepControlStrategy_def.hpp
+++ b/packages/rythmos/src/Rythmos_FirstOrderErrorStepControlStrategy_def.hpp
@@ -234,8 +234,8 @@ void FirstOrderErrorStepControlStrategy<Scalar>::setRequestedStepSize(
 
 template<class Scalar>
 void FirstOrderErrorStepControlStrategy<Scalar>::nextStepSize(
-  const StepperBase<Scalar>& stepper, Scalar* stepSize,
-  StepSizeType* stepSizeType, int* order)
+  const StepperBase<Scalar>& /* stepper */, Scalar* stepSize,
+  StepSizeType* stepSizeType, int* /* order */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(!((stepControlState_ == BEFORE_FIRST_STEP) ||
                                (stepControlState_ == MID_STEP) ||
@@ -265,7 +265,7 @@ void FirstOrderErrorStepControlStrategy<Scalar>::nextStepSize(
 
 template<class Scalar>
 void FirstOrderErrorStepControlStrategy<Scalar>::setCorrection(
-     const StepperBase<Scalar>& stepper
+     const StepperBase<Scalar>& /* stepper */
     ,const RCP<const Thyra::VectorBase<Scalar> >& soln
     ,const RCP<const Thyra::VectorBase<Scalar> >& dx
     ,int solveStatus)
@@ -281,7 +281,7 @@ void FirstOrderErrorStepControlStrategy<Scalar>::setCorrection(
 
 template<class Scalar>
 bool FirstOrderErrorStepControlStrategy<Scalar>::acceptStep(
-  const StepperBase<Scalar>& stepper, Scalar* value)
+  const StepperBase<Scalar>& /* stepper */, Scalar* /* value */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,
@@ -329,7 +329,7 @@ bool FirstOrderErrorStepControlStrategy<Scalar>::acceptStep(
 
 template<class Scalar>
 AttemptedStepStatusFlag FirstOrderErrorStepControlStrategy<Scalar>::rejectStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,
@@ -382,7 +382,7 @@ AttemptedStepStatusFlag FirstOrderErrorStepControlStrategy<Scalar>::rejectStep(
 
 template<class Scalar>
 void FirstOrderErrorStepControlStrategy<Scalar>::completeStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,

--- a/packages/rythmos/src/Rythmos_FixedStepControlStrategy_def.hpp
+++ b/packages/rythmos/src/Rythmos_FixedStepControlStrategy_def.hpp
@@ -73,7 +73,7 @@ FixedStepControlStrategy<Scalar>::FixedStepControlStrategy()
 
 template<class Scalar>
 void FixedStepControlStrategy<Scalar>::initialize(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   stepControlState_ = UNINITIALIZED;
   // Any other initialization goes here.
@@ -83,7 +83,7 @@ void FixedStepControlStrategy<Scalar>::initialize(
 template<class Scalar>
 void FixedStepControlStrategy<Scalar>::setRequestedStepSize(
   const StepperBase<Scalar>& stepper,
-  const Scalar& stepSize,
+  const Scalar& /* stepSize */,
   const StepSizeType& stepSizeType)
 {
   // typedef Teuchos::ScalarTraits<Scalar> ST; // unused
@@ -105,8 +105,8 @@ void FixedStepControlStrategy<Scalar>::setRequestedStepSize(
 
 template<class Scalar>
 void FixedStepControlStrategy<Scalar>::nextStepSize(
-  const StepperBase<Scalar>& stepper, Scalar* stepSize,
-  StepSizeType* stepSizeType, int* order)
+  const StepperBase<Scalar>& /* stepper */, Scalar* /* stepSize */,
+  StepSizeType* /* stepSizeType */, int* /* order */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(!((stepControlState_ == BEFORE_FIRST_STEP) ||
                                (stepControlState_ == MID_STEP) ||
@@ -120,10 +120,10 @@ void FixedStepControlStrategy<Scalar>::nextStepSize(
 
 template<class Scalar>
 void FixedStepControlStrategy<Scalar>::setCorrection(
-     const StepperBase<Scalar>& stepper
-    ,const RCP<const Thyra::VectorBase<Scalar> >& soln
-    ,const RCP<const Thyra::VectorBase<Scalar> >& dx
-    ,int solveStatus)
+     const StepperBase<Scalar>& /* stepper */
+    ,const RCP<const Thyra::VectorBase<Scalar> >& /* soln */
+    ,const RCP<const Thyra::VectorBase<Scalar> >& /* dx */
+    ,int /* solveStatus */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != MID_STEP, std::logic_error,
      "Error: Invalid state (stepControlState_=" << toString(stepControlState_)
@@ -133,7 +133,7 @@ void FixedStepControlStrategy<Scalar>::setCorrection(
 
 template<class Scalar>
 bool FixedStepControlStrategy<Scalar>::acceptStep(
-  const StepperBase<Scalar>& stepper, Scalar* value)
+  const StepperBase<Scalar>& /* stepper */, Scalar* /* value */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,
@@ -145,7 +145,7 @@ bool FixedStepControlStrategy<Scalar>::acceptStep(
 
 template<class Scalar>
 AttemptedStepStatusFlag FixedStepControlStrategy<Scalar>::rejectStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,
@@ -159,7 +159,7 @@ AttemptedStepStatusFlag FixedStepControlStrategy<Scalar>::rejectStep(
 
 template<class Scalar>
 void FixedStepControlStrategy<Scalar>::completeStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,

--- a/packages/rythmos/src/Rythmos_ForwardEulerStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ForwardEulerStepper_def.hpp
@@ -474,9 +474,9 @@ void ForwardEulerStepper<Scalar>::describe(
 
 template<class Scalar>
 void ForwardEulerStepper<Scalar>::addPoints(
-    const Array<Scalar>& time_vec
-    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x_vec
-    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+    const Array<Scalar>& /* time_vec */
+    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& /* x_vec */
+    ,const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
     )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Error, addPoints is not implemented for ForwardEulerStepper.\n");
@@ -533,7 +533,7 @@ void ForwardEulerStepper<Scalar>::getNodes(Array<Scalar>* time_vec) const
 }
 
 template<class Scalar>
-void ForwardEulerStepper<Scalar>::removeNodes(Array<Scalar>& time_vec) 
+void ForwardEulerStepper<Scalar>::removeNodes(Array<Scalar>& /* time_vec */) 
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Error, removeNodes is not implemented for ForwardEulerStepper.\n");
 }

--- a/packages/rythmos/src/Rythmos_ForwardSensitivityExplicitModelEvaluator.hpp
+++ b/packages/rythmos/src/Rythmos_ForwardSensitivityExplicitModelEvaluator.hpp
@@ -328,8 +328,8 @@ void ForwardSensitivityExplicitModelEvaluator<Scalar>::initializeStructure(
 
 template<class Scalar>
 void ForwardSensitivityExplicitModelEvaluator<Scalar>::initializeStructureInitCondOnly(
-  const RCP<const Thyra::ModelEvaluator<Scalar> >& stateModel,
-  const RCP<const Thyra::VectorSpaceBase<Scalar> >& p_space
+  const RCP<const Thyra::ModelEvaluator<Scalar> >& /* stateModel */,
+  const RCP<const Thyra::VectorSpaceBase<Scalar> >& /* p_space */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "ToDo: Implement initializeStructureInitCondOnly()!" );
@@ -378,7 +378,7 @@ ForwardSensitivityExplicitModelEvaluator<Scalar>::get_p_sens_space() const
 template<class Scalar>
 void ForwardSensitivityExplicitModelEvaluator<Scalar>::initializePointState(
     Ptr<StepperBase<Scalar> > stateStepper,
-    bool forceUpToDateW
+    bool /* forceUpToDateW */
     )
 {
   TEUCHOS_ASSERT( Teuchos::nonnull(stateStepper) );
@@ -593,7 +593,7 @@ void ForwardSensitivityExplicitModelEvaluator<Scalar>::wrapNominalValuesAndBound
 
 template<class Scalar>
 void ForwardSensitivityExplicitModelEvaluator<Scalar>::computeDerivativeMatrices(
-  const Thyra::ModelEvaluatorBase::InArgs<Scalar> &point
+  const Thyra::ModelEvaluatorBase::InArgs<Scalar> &/* point */
   ) const
 {
   TEUCHOS_ASSERT( !is_null(stateModel_) );

--- a/packages/rythmos/src/Rythmos_ForwardSensitivityStepper.hpp
+++ b/packages/rythmos/src/Rythmos_ForwardSensitivityStepper.hpp
@@ -923,7 +923,7 @@ bool ForwardSensitivityStepper<Scalar>::acceptsModel() const
 
 template<class Scalar>
 void ForwardSensitivityStepper<Scalar>::setModel(
-  const RCP<const Thyra::ModelEvaluator<Scalar> >& model
+  const RCP<const Thyra::ModelEvaluator<Scalar> >& /* model */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG( true,
@@ -934,7 +934,7 @@ void ForwardSensitivityStepper<Scalar>::setModel(
 
 template<class Scalar>
 void ForwardSensitivityStepper<Scalar>::setNonconstModel(
-  const RCP<Thyra::ModelEvaluator<Scalar> >& model
+  const RCP<Thyra::ModelEvaluator<Scalar> >& /* model */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG( true,
@@ -1107,9 +1107,9 @@ ForwardSensitivityStepper<Scalar>::get_x_space() const
 
 template<class Scalar>
 void ForwardSensitivityStepper<Scalar>::addPoints(
-  const Array<Scalar>& time_vec,
-  const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& x_vec,
-  const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+  const Array<Scalar>& /* time_vec */,
+  const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& /* x_vec */,
+  const Array<Teuchos::RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("Not implemented addPoints(...) yet but we could if we wanted!");
@@ -1217,7 +1217,7 @@ void ForwardSensitivityStepper<Scalar>::getNodes(
 
 template<class Scalar>
 void ForwardSensitivityStepper<Scalar>::removeNodes(
-  Array<Scalar>& time_vec
+  Array<Scalar>& /* time_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("Not implemented yet but we can!");

--- a/packages/rythmos/src/Rythmos_ImplicitBDFStepperRampingStepControl_def.hpp
+++ b/packages/rythmos/src/Rythmos_ImplicitBDFStepperRampingStepControl_def.hpp
@@ -255,8 +255,8 @@ void ImplicitBDFStepperRampingStepControl<Scalar>::nextStepSize(
 
 template<class Scalar>
 void ImplicitBDFStepperRampingStepControl<Scalar>::setCorrection(
-     const StepperBase<Scalar>& stepper
-    ,const RCP<const Thyra::VectorBase<Scalar> >& soln
+     const StepperBase<Scalar>& /* stepper */
+    ,const RCP<const Thyra::VectorBase<Scalar> >& /* soln */
     ,const RCP<const Thyra::VectorBase<Scalar> >& ee
     ,int solveStatus)
 {
@@ -281,7 +281,7 @@ void ImplicitBDFStepperRampingStepControl<Scalar>::setCorrection(
 
 template<class Scalar>
 bool ImplicitBDFStepperRampingStepControl<Scalar>::acceptStep(
-  const StepperBase<Scalar>& stepper, Scalar* LETValue)
+  const StepperBase<Scalar>& /* stepper */, Scalar* LETValue)
 {
   using Teuchos::as;
   typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -448,7 +448,7 @@ void ImplicitBDFStepperRampingStepControl<Scalar>::completeStep(
 template<class Scalar>
 AttemptedStepStatusFlag
 ImplicitBDFStepperRampingStepControl<Scalar>::rejectStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPT(stepControlState_ != AFTER_CORRECTION);
 

--- a/packages/rythmos/src/Rythmos_ImplicitBDFStepperStepControl_def.hpp
+++ b/packages/rythmos/src/Rythmos_ImplicitBDFStepperStepControl_def.hpp
@@ -393,8 +393,8 @@ void ImplicitBDFStepperStepControl<Scalar>::nextStepSize(const StepperBase<Scala
 
 template<class Scalar>
 void ImplicitBDFStepperStepControl<Scalar>::setCorrection(
-     const StepperBase<Scalar>& stepper
-    ,const RCP<const Thyra::VectorBase<Scalar> >& soln
+     const StepperBase<Scalar>& /* stepper */
+    ,const RCP<const Thyra::VectorBase<Scalar> >& /* soln */
     ,const RCP<const Thyra::VectorBase<Scalar> >& ee
     ,int solveStatus)
 {
@@ -549,7 +549,7 @@ void ImplicitBDFStepperStepControl<Scalar>::completeStep(const StepperBase<Scala
 }
 
 template<class Scalar>
-AttemptedStepStatusFlag ImplicitBDFStepperStepControl<Scalar>::rejectStep(const StepperBase<Scalar>& stepper)
+AttemptedStepStatusFlag ImplicitBDFStepperStepControl<Scalar>::rejectStep(const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPT(stepControlState_ != AFTER_CORRECTION);
 

--- a/packages/rythmos/src/Rythmos_ImplicitBDFStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ImplicitBDFStepper_def.hpp
@@ -530,9 +530,9 @@ ImplicitBDFStepper<Scalar>::get_x_space() const
 
 template<class Scalar>
 void ImplicitBDFStepper<Scalar>::addPoints(
-  const Array<Scalar>& time_vec,
-  const Array<RCP<const Thyra::VectorBase<Scalar> > >& x_vec,
-  const Array<RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+  const Array<Scalar>& /* time_vec */,
+  const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* x_vec */,
+  const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -643,7 +643,7 @@ void ImplicitBDFStepper<Scalar>::getNodes(Array<Scalar>* time_vec) const
 
 
 template<class Scalar>
-void ImplicitBDFStepper<Scalar>::removeNodes(Array<Scalar>& time_vec)
+void ImplicitBDFStepper<Scalar>::removeNodes(Array<Scalar>& /* time_vec */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
     "Error, removeNodes is not implemented for ImplicitBDFStepper.\n");

--- a/packages/rythmos/src/Rythmos_ImplicitRKStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ImplicitRKStepper_def.hpp
@@ -654,9 +654,9 @@ ImplicitRKStepper<Scalar>::get_x_space() const
 
 template<class Scalar>
 void ImplicitRKStepper<Scalar>::addPoints(
-    const Array<Scalar>& time_vec
-    ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& x_vec
-    ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+    const Array<Scalar>& /* time_vec */
+    ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* x_vec */
+    ,const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
     )
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
@@ -709,7 +709,7 @@ void ImplicitRKStepper<Scalar>::getNodes(Array<Scalar>* time_vec) const
 
 
 template<class Scalar>
-void ImplicitRKStepper<Scalar>::removeNodes(Array<Scalar>& time_vec)
+void ImplicitRKStepper<Scalar>::removeNodes(Array<Scalar>& /* time_vec */)
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
 }

--- a/packages/rythmos/src/Rythmos_IntegrationControlStrategyBase.hpp
+++ b/packages/rythmos/src/Rythmos_IntegrationControlStrategyBase.hpp
@@ -113,10 +113,10 @@ public:
    * Default implementation is to ignore this.
    */
   virtual bool resetForFailedTimeStep(
-    const StepperBase<Scalar> &stepper,
-    const StepControlInfo<Scalar> &stepCtrlInfoLast,
-    const int timeStepIter,
-    const StepControlInfo<Scalar> &stepCtrlInfo
+    const StepperBase<Scalar> &/* stepper */,
+    const StepControlInfo<Scalar> &/* stepCtrlInfoLast */,
+    const int /* timeStepIter */,
+    const StepControlInfo<Scalar> &/* stepCtrlInfo */
     )
     { return false; }
 

--- a/packages/rythmos/src/Rythmos_IntegrationObserverBase.hpp
+++ b/packages/rythmos/src/Rythmos_IntegrationObserverBase.hpp
@@ -241,14 +241,14 @@ bool isFinalTimeStep(
 
 template<class Scalar>
 void IntegrationObserverBase<Scalar>::
-observeStartTimeIntegration(const StepperBase<Scalar> &stepper)
+observeStartTimeIntegration(const StepperBase<Scalar> &/* stepper */)
 {
 
 }    
 
 template<class Scalar>
 void IntegrationObserverBase<Scalar>::
-observeEndTimeIntegration(const StepperBase<Scalar> &stepper)
+observeEndTimeIntegration(const StepperBase<Scalar> &/* stepper */)
 {
 
 }    
@@ -256,9 +256,9 @@ observeEndTimeIntegration(const StepperBase<Scalar> &stepper)
 template<class Scalar>
 void IntegrationObserverBase<Scalar>::
 observeStartTimeStep(
-    const StepperBase<Scalar> &stepper,
-    const StepControlInfo<Scalar> &stepCtrlInfo,
-    const int timeStepIter
+    const StepperBase<Scalar> &/* stepper */,
+    const StepControlInfo<Scalar> &/* stepCtrlInfo */,
+    const int /* timeStepIter */
     )
 {
 
@@ -267,9 +267,9 @@ observeStartTimeStep(
 template<class Scalar>
 void IntegrationObserverBase<Scalar>::
 observeFailedTimeStep(
-    const StepperBase<Scalar> &stepper,
-    const StepControlInfo<Scalar> &stepCtrlInfo,
-    const int timeStepIter
+    const StepperBase<Scalar> &/* stepper */,
+    const StepControlInfo<Scalar> &/* stepCtrlInfo */,
+    const int /* timeStepIter */
     )
 {
 

--- a/packages/rythmos/src/Rythmos_InterpolationBufferHelpers.hpp
+++ b/packages/rythmos/src/Rythmos_InterpolationBufferHelpers.hpp
@@ -197,7 +197,7 @@ template<class Scalar>
 void Rythmos::assertNoTimePointsBeforeCurrentTimeRange(
   const InterpolationBufferBase<Scalar> &interpBuffer,
   const Array<Scalar>& time_vec,
-  const int &startingTimePointIndex
+  const int &/* startingTimePointIndex */
   )
 {
   typedef ScalarTraits<Scalar> ST;

--- a/packages/rythmos/src/Rythmos_RampingIntegrationControlStrategy_def.hpp
+++ b/packages/rythmos/src/Rythmos_RampingIntegrationControlStrategy_def.hpp
@@ -304,8 +304,8 @@ RampingIntegrationControlStrategy<Scalar>::resetIntegrationControlStrategy(
 template<class Scalar>
 StepControlInfo<Scalar>
 RampingIntegrationControlStrategy<Scalar>::getNextStepControlInfo(
-  const StepperBase<Scalar> &stepper,
-  const StepControlInfo<Scalar> &stepCtrlInfoLast,
+  const StepperBase<Scalar> &/* stepper */,
+  const StepControlInfo<Scalar> &/* stepCtrlInfoLast */,
   const int timeStepIter
   )
 {
@@ -343,10 +343,10 @@ RampingIntegrationControlStrategy<Scalar>::getNextStepControlInfo(
 
 template<class Scalar>
 bool RampingIntegrationControlStrategy<Scalar>::resetForFailedTimeStep(
-  const StepperBase<Scalar> &stepper,
-  const StepControlInfo<Scalar> &stepCtrlInfoLast,
-  const int timeStepIter,
-  const StepControlInfo<Scalar> &stepCtrlInfo
+  const StepperBase<Scalar> &/* stepper */,
+  const StepControlInfo<Scalar> &/* stepCtrlInfoLast */,
+  const int /* timeStepIter */,
+  const StepControlInfo<Scalar> &/* stepCtrlInfo */
   )
 {
   if (current_dt_ == min_dt_) return false;

--- a/packages/rythmos/src/Rythmos_SimpleIntegrationControlStrategy_def.hpp
+++ b/packages/rythmos/src/Rythmos_SimpleIntegrationControlStrategy_def.hpp
@@ -240,9 +240,9 @@ SimpleIntegrationControlStrategy<Scalar>::resetIntegrationControlStrategy(
 template<class Scalar>
 StepControlInfo<Scalar>
 SimpleIntegrationControlStrategy<Scalar>::getNextStepControlInfo(
-  const StepperBase<Scalar> &stepper,
-  const StepControlInfo<Scalar> &stepCtrlInfoLast,
-  const int timeStepIter
+  const StepperBase<Scalar> &/* stepper */,
+  const StepControlInfo<Scalar> &/* stepCtrlInfoLast */,
+  const int /* timeStepIter */
   )
 {
 

--- a/packages/rythmos/src/Rythmos_SimpleStepControlStrategy_def.hpp
+++ b/packages/rythmos/src/Rythmos_SimpleStepControlStrategy_def.hpp
@@ -170,7 +170,7 @@ SimpleStepControlStrategy<Scalar>::SimpleStepControlStrategy()
 
 template<class Scalar>
 void SimpleStepControlStrategy<Scalar>::initialize(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   using Teuchos::as;
   // typedef Teuchos::ScalarTraits<Scalar> ST; // unused
@@ -231,8 +231,8 @@ void SimpleStepControlStrategy<Scalar>::setRequestedStepSize(
 
 template<class Scalar>
 void SimpleStepControlStrategy<Scalar>::nextStepSize(
-  const StepperBase<Scalar>& stepper, Scalar* stepSize,
-  StepSizeType* stepSizeType, int* order)
+  const StepperBase<Scalar>& /* stepper */, Scalar* stepSize,
+  StepSizeType* stepSizeType, int* /* order */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(!((stepControlState_ == BEFORE_FIRST_STEP) ||
                                (stepControlState_ == MID_STEP) ||
@@ -262,7 +262,7 @@ void SimpleStepControlStrategy<Scalar>::nextStepSize(
 
 template<class Scalar>
 void SimpleStepControlStrategy<Scalar>::setCorrection(
-     const StepperBase<Scalar>& stepper
+     const StepperBase<Scalar>& /* stepper */
     ,const RCP<const Thyra::VectorBase<Scalar> >& soln
     ,const RCP<const Thyra::VectorBase<Scalar> >& dx
     ,int solveStatus)
@@ -278,7 +278,7 @@ void SimpleStepControlStrategy<Scalar>::setCorrection(
 
 template<class Scalar>
 bool SimpleStepControlStrategy<Scalar>::acceptStep(
-  const StepperBase<Scalar>& stepper, Scalar* value)
+  const StepperBase<Scalar>& /* stepper */, Scalar* /* value */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,
@@ -308,7 +308,7 @@ bool SimpleStepControlStrategy<Scalar>::acceptStep(
 
 template<class Scalar>
 AttemptedStepStatusFlag SimpleStepControlStrategy<Scalar>::rejectStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,
@@ -363,7 +363,7 @@ AttemptedStepStatusFlag SimpleStepControlStrategy<Scalar>::rejectStep(
 
 template<class Scalar>
 void SimpleStepControlStrategy<Scalar>::completeStep(
-  const StepperBase<Scalar>& stepper)
+  const StepperBase<Scalar>& /* stepper */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(stepControlState_ != AFTER_CORRECTION,
      std::logic_error,

--- a/packages/rythmos/src/Rythmos_StateAndForwardSensitivityModelEvaluator.hpp
+++ b/packages/rythmos/src/Rythmos_StateAndForwardSensitivityModelEvaluator.hpp
@@ -438,8 +438,8 @@ StateAndForwardSensitivityModelEvaluator<Scalar>::createOutArgsImpl() const
 
 template<class Scalar>
 void StateAndForwardSensitivityModelEvaluator<Scalar>::evalModelImpl(
-  const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
-  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs
+  const Thyra::ModelEvaluatorBase::InArgs<Scalar> &/* inArgs */,
+  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &/* outArgs */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT("ToDo: Implement evalModel(...) when needed!");

--- a/packages/rythmos/src/Rythmos_StepperBase_def.hpp
+++ b/packages/rythmos/src/Rythmos_StepperBase_def.hpp
@@ -78,7 +78,7 @@ StepperBase<Scalar>::cloneStepperAlgorithm() const
 
 
 template<class Scalar>
-void StepperBase<Scalar>::setStepControlData(const StepperBase & stepper)
+void StepperBase<Scalar>::setStepControlData(const StepperBase & /* stepper */)
 {
   // 2009/08/31: rabartl ToDo: Should this really be left empty?
 }

--- a/packages/rythmos/src/Rythmos_ThetaStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ThetaStepper_def.hpp
@@ -661,7 +661,7 @@ template<class Scalar>
 void ThetaStepper<Scalar>::addPoints(
   const Array<Scalar>& time_vec,
   const Array<RCP<const Thyra::VectorBase<Scalar> > >& x_vec,
-  const Array<RCP<const Thyra::VectorBase<Scalar> > >& xdot_vec
+  const Array<RCP<const Thyra::VectorBase<Scalar> > >& /* xdot_vec */
   )
 {
 

--- a/packages/rythmos/src/Rythmos_TimeStepNonlinearSolver_def.hpp
+++ b/packages/rythmos/src/Rythmos_TimeStepNonlinearSolver_def.hpp
@@ -274,6 +274,8 @@ TimeStepNonlinearSolver<Scalar>::solve(
     *x->space(),*model_->get_x_space() );
   TEUCHOS_TEST_FOR_EXCEPT(
     0!=solveCriteria && "ToDo: Support passed in solve criteria!" );
+#else
+  (void)solveCriteria;
 #endif
 
   const RCP<Teuchos::FancyOStream> out = this->getOStream();

--- a/packages/teuchos/comm/src/Teuchos_SerializationTraits.hpp
+++ b/packages/teuchos/comm/src/Teuchos_SerializationTraits.hpp
@@ -333,6 +333,8 @@ public:
     {
 #ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(bytes!=fromCountToDirectBytes(count));
+#else
+      (void)count;
 #endif
       const char *_buffer = convertToCharPtr(buffer);
       std::copy(_buffer,_buffer+bytes,charBuffer);

--- a/packages/teuchos/core/src/Teuchos_AbstractFactoryStd.hpp
+++ b/packages/teuchos/core/src/Teuchos_AbstractFactoryStd.hpp
@@ -53,7 +53,7 @@ template<class T_impl>
 class PostModNothing {
 public:
 	/** \brief . */
-	void initialize(T_impl* p) const {} // required!
+	void initialize(T_impl* /* p */) const {} // required!
 };
 
 /** \brief Default allocation policy class for

--- a/packages/teuchos/numerics/src/Teuchos_SerialTriDiMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialTriDiMatrix.hpp
@@ -406,7 +406,7 @@ SerialTriDiMatrix<OrdinalType, ScalarType>::SerialTriDiMatrix()
 {}
 
 template<typename OrdinalType, typename ScalarType>
-SerialTriDiMatrix<OrdinalType, ScalarType>::SerialTriDiMatrix( OrdinalType numRowsCols_in, OrdinalType numCols_in, bool zeroOut)
+SerialTriDiMatrix<OrdinalType, ScalarType>::SerialTriDiMatrix( OrdinalType numRowsCols_in, OrdinalType /* numCols_in */, bool zeroOut)
   : CompObject(), numRowsCols_(numRowsCols_in) {
 
   OrdinalType numvals = (numRowsCols_ == 1) ? 1 :  4*(numRowsCols_-1);


### PR DESCRIPTION
@trilinos/teuchos, @trilinos/epetraext, @trilinos/rythmos 

## Description
Deal with unused parameter warnings by commenting out the parameter names in the function definitions.  In cases where the use is hidden behind an `#ifdef`, `(void)` then inside the `#else` block.

## Motivation and Context
Just hoping for a cleaner build.

## How Has This Been Tested?
Everything still looks good on my RHEL7 machine with gcc-7.3.0.  Letting the @trilinos-autotester do its thing.

## Related Issues
Similar to #4243, #4239.