### PR TITLE
Zoltan2: Restore Zoltan2 test and Kokkos unordered map

### DIFF
--- a/packages/zoltan2/test/directory/CMakeLists.txt
+++ b/packages/zoltan2/test/directory/CMakeLists.txt
@@ -16,11 +16,9 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 # The purpose of this test is to duplicate the
 # result of findUniqueGids but using the new
 # Zoltan2Directory class.
-
-# Temporarily disabling this to resolve cuda build issues.
-#TRIBITS_ADD_EXECUTABLE_AND_TEST(
-#  directoryTest_findUniqueGids.cpp
-#  SOURCES directoryTest_findUniqueGids.cpp
-#  COMM serial mpi
-#  FAIL_REGULAR_EXPRESSION "FAIL"
-#)
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  directoryTest_findUniqueGids.cpp
+  SOURCES directoryTest_findUniqueGids.cpp
+  COMM serial mpi
+  FAIL_REGULAR_EXPRESSION "FAIL"
+)

--- a/packages/zoltan2/test/directory/directoryTest_Impl.hpp
+++ b/packages/zoltan2/test/directory/directoryTest_Impl.hpp
@@ -48,39 +48,6 @@
 #include <Zoltan2_TPLTraits.hpp>
 #include "Zoltan2_Directory_Impl.hpp"
 
-// Do gid with multiple sub gids
-// Note that the testing code (things in this file) needs knowledge
-// about this structure so it's a hard coded assumption but the directory
-// class itself does not - that is why there are sub_gid references in the
-// below classes but no special handling for this in the directory.
-// as long as sizeof works and it can be returned as a function
-// type it should be ok to use as a gid_t.
-#define GID_SET_LENGTH 3 // arbitrary for testing
-struct gid_set_t {
-  gid_set_t() {}
-	// operator== is required to compare keys in case of hash collision
-  bool operator==(const gid_set_t &p) const
-  {
-    return(
-      sub_gid[0] == p.sub_gid[0] &&
-      sub_gid[1] == p.sub_gid[1] &&
-      sub_gid[2] == p.sub_gid[2]);
-  }
-
-  int sub_gid[GID_SET_LENGTH];
-};
-
-namespace std {
-  template <>
-  struct hash<gid_set_t>
-  {
-    std::size_t operator() (const gid_set_t &node) const
-    {
-      return node.sub_gid[0] ^ node.sub_gid[1] ^ node.sub_gid[2];
-    }
-  };
-}
-
 namespace Zoltan2 {
 
 // The directory also has modes but currently working with an Original mode
@@ -92,6 +59,18 @@ enum TestMode {
   Add,
   Aggregate,
   TestMode_Max  // exists to provide a loop through these modes
+};
+
+// Do gid with multiple sub gids
+// Note that the testing code (things in this file) needs knowledge
+// about this structure so it's a hard coded assumption but the directory
+// class itself does not - that is why there are sub_gid references in the
+// below classes but no special handling for this in the directory.
+// as long as sizeof works and it can be returned as a function
+// type it should be ok to use as a gid_t.
+#define GID_SET_LENGTH 3 // arbitrary for testing
+struct gid_set_t {
+  int sub_gid[GID_SET_LENGTH];
 };
 
 // same as gid above but this is for lid

--- a/packages/zoltan2/test/directory/directoryTest_KokkosSimple.cpp
+++ b/packages/zoltan2/test/directory/directoryTest_KokkosSimple.cpp
@@ -44,7 +44,6 @@
 // @HEADER
 
 #include "Zoltan2_Directory_Impl.hpp"
-#include "Kokkos_Core.hpp"
 
 // This type will be used by some of these tests
 class gid_struct {
@@ -58,28 +57,8 @@ class gid_struct {
     val[2] = v2;
     val[3] = v3;
   }
-  bool operator==(const gid_struct &p) const
-  {
-    return(
-      val[0] == p.val[0] &&
-      val[1] == p.val[1] &&
-      val[2] == p.val[2] &&
-      val[3] == p.val[3]);
-  }
   int val[4]; // can be any length but this can't have mem alloc (like std::vector)
 };
-
-namespace std {
-  template <>
-  struct hash<gid_struct>
-  {
-    std::size_t operator() (const gid_struct &node) const
-    {
-      return node.val[0] ^ node.val[1] ^ node.val[2] ^ node.val[3];
-    }
-  };
-}
-
 
 // same as gid but for better coverage of testing, make it different
 class lid_struct {


### PR DESCRIPTION
@trilinos/zoltan2

## Motivation and Context
This is a follow up PR to clean up a few issues from PR #4252.

It restores a missing zoltan2 test.
It restored the directory to use Kokkos unordered map (now host space) anticipating we'll be implementing parallel forms in the future.
It cleans up some of the directory hash code to avoid a global static method definition.

## How Has This Been Tested?
Tested on white cuda.
Tested on mac clang parallel and serial.


## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
