### PR TITLE
Tpetra: Use explicit default template arguments in TpetraExt_MMHelpers_decl.hpp

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MMHelpers_decl.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MMHelpers_decl.hpp
@@ -118,10 +118,10 @@ public:
                        const Teuchos::ArrayView<const Scalar> &values) = 0;
 };
 
-template <class Scalar = CrsMatrix<>::scalar_type,
-          class LocalOrdinal = typename CrsMatrix<Scalar>::local_ordinal_type,
-          class GlobalOrdinal = typename CrsMatrix<Scalar, LocalOrdinal>::global_ordinal_type,
-          class Node = typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal>::node_type>
+template <class Scalar = ::Tpetra::Details::DefaultTypes::scalar_type,
+          class LocalOrdinal = ::Tpetra::Details::DefaultTypes::local_ordinal_type,
+          class GlobalOrdinal = ::Tpetra::Details::DefaultTypes::global_ordinal_type,
+          class Node = ::Tpetra::Details::DefaultTypes::node_type>
 class CrsWrapper_CrsMatrix :
     public CrsWrapper<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
 public:
@@ -146,13 +146,10 @@ private:
   crs_matrix_type& crsmat_;
 };
 
-
-template <class Scalar = CrsMatrix<>::scalar_type,
-          class LocalOrdinal = typename CrsMatrix<Scalar>::local_ordinal_type,
-          class GlobalOrdinal =
-            typename CrsMatrix<Scalar, LocalOrdinal>::global_ordinal_type,
-          class Node =
-            typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal>::node_type>
+template <class Scalar = ::Tpetra::Details::DefaultTypes::scalar_type,
+          class LocalOrdinal = ::Tpetra::Details::DefaultTypes::local_ordinal_type,
+          class GlobalOrdinal = ::Tpetra::Details::DefaultTypes::global_ordinal_type,
+          class Node = ::Tpetra::Details::DefaultTypes::node_type>
 class CrsWrapper_GraphBuilder :
     public CrsWrapper<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
 public:


### PR DESCRIPTION
@trilinos/tpetra

## Description
This pull request changes the way the default template arguments for the classes `Tpetra::CrsWrapper_CrsMatrix` and `Tpetra::CrsWrapper_GraphBuilder` are specified
(in the same way as for `Tpetra::CrsMatrixStruct` in the same file). 
In particular, using `Tpetra::CrsMatrix<>` is avoided.

## Motivation and Context
The pull requests aims to fix #4264. Apparently, `nvcc-8` chokes on `Tpetra::CrsMatrix<>`.
Specifying any template argument for that class fixes the issue.

## Related Issues

* Closes #4264
* Related to https://github.com/dealii/dealii/issues/6856

## How Has This Been Tested?
i can compile `deal.II` with a configuration that uses a `MueLu` wrapper successfully.
The setup uses `nvcc-8`, `gcc-5.5` and `openmpi-3.1.3`.
In particular, just compiling `TpetraExt_MMHelpers_decl.hpp` didn't work before and does now.

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.