### PR TITLE
TriKota: Disable Dakota's ROL interface

### DIFF
--- a/packages/TriKota/CMakeLists.txt
+++ b/packages/TriKota/CMakeLists.txt
@@ -31,13 +31,6 @@ ENDIF()
 #
 # Currently Dakota does its own checking for libraries such as blas,
 # lapack, boost, mpi, etc... which ultimately we would want to pass in.
-# Also the following packages likely need to be disabled via 
-# -D HAVE_X=OFF, where X is:
-#   ACRO, HOPSPACK, AMPL
-# ACRO requires boost_signals library component.
-# HOPSPACK may not link correctly in static builds.
-# Turning AMPL on caused very strange runtime errors.
-# I don't know how to turn these off by default.
 
 # Check for Dakota source
 IF (NOT EXISTS ${PACKAGE_SOURCE_DIR}/Dakota/CMakeLists.txt)
@@ -83,25 +76,37 @@ IF(TPL_LAPACK_LIBRARIES)
   SET(LAPACK_LIBS "${TPL_LAPACK_LIBRARIES}")
 ENDIF()
 
-# Turn off a bunch of Dakota non-TriBITS-complient tests when buliding
+# Turn off a bunch of Dakota non-TriBITS-compliant tests when building
 # Dakota under Trilinos/TriKota.  Until these tests can be prefixed with
-# TriKota_ and given the correct label there is no reason to enale them
+# TriKota_ and given the correct label there is no reason to enable them
 # because they will not be run in automated testing.  However, allow users
 # to enable them if they would really like.
 SET(DAKOTA_ENABLE_TESTS OFF CACHE BOOL "")
 SET(DAKOTA_ENABLE_TPL_TESTS OFF CACHE BOOL "")
+
+# The following packages likely need to be disabled via
+# -D HAVE_X=OFF, where X is:
+#   ACRO, HOPSPACK, AMPL
+# ACRO requires boost_signals library component.
+# HOPSPACK may not link correctly in static builds.
+# Turning AMPL on caused very strange runtime errors.
+# I don't know how to turn these off by default.
 SET(HAVE_ACRO OFF CACHE BOOL "")
 SET(HAVE_AMPL OFF CACHE BOOL "")
-SET(HAVE_X_GRAPHICS OFF CACHE BOOL "")
 SET(HAVE_HOPSPACK OFF CACHE BOOL "")
+SET(HAVE_ROL OFF CACHE BOOL
+    "TriKota/Dakota/ROL disabled due to circular dependence.")
+SET(HAVE_X_GRAPHICS OFF CACHE BOOL "")  # explicit default
 
 # Instruct DAKOTA to install its non-standard content to alternate locations
-SET(DAKOTA_EXAMPLES_INSTALL share/dakota/examples CACHE FILEPATH
+# (These are explicit defaults with Dakota 6.8 and newer)
+SET(DAKOTA_EXAMPLES_INSTALL share/dakota CACHE FILEPATH
     "Installation destination for DAKOTA examples/ dir")
-SET(DAKOTA_TEST_INSTALL share/dakota/test CACHE FILEPATH
+SET(DAKOTA_TEST_INSTALL share/dakota CACHE FILEPATH
     "Installation destination for DAKOTA test/ dir")
 SET(DAKOTA_TOPFILES_INSTALL share/dakota CACHE FILEPATH
     "Installation destination for DAKOTA top-level files")
+
 SET(DAKOTA_INSTALL_DYNAMIC_DEPS FALSE CACHE BOOL 
     "TriKota: not installing Dakota dynamic dependencies")
 

--- a/packages/TriKota/cmake/Dependencies.cmake
+++ b/packages/TriKota/cmake/Dependencies.cmake
@@ -1,5 +1,8 @@
 SET(LIB_REQUIRED_DEP_PACKAGES Teuchos Epetra EpetraExt Thyra)
 SET(LIB_OPTIONAL_DEP_PACKAGES)
+# Dakota can optionally use ROL, but it creates a circular dependence
+# TriKota <--> ROL
+##SET(LIB_OPTIONAL_DEP_PACKAGES ROL)
 SET(TEST_REQUIRED_DEP_PACKAGES)
 SET(TEST_OPTIONAL_DEP_PACKAGES)
 SET(LIB_REQUIRED_DEP_TPLS Boost)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/trikota

## Description
Initial pass at addressing trilinos/Trilinos#4270: disable Dakota's
ROL interface when building under trilinos/packages/TriKota.

Rationale: Would prefer to have Dakota use ROL as provided by
Trilinos, but creates a circular package dependence due to ROL's
optional use of TriKota. As ROL may remove dependence on Dakota sparse
grid at some point, better to workaround this for now.

Also cleanup TriKota's interface to Dakota's CMake based on changes in
the last few Dakota versions.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Addresses #4270 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Tested through make and ctest phases with this config (note requires upstream changes to ROL submitted separately).
```
cmake \
-DCMAKE_BUILD_TYPE=RELEASE \
-DCMAKE_INSTALL_PREFIX=../install \
-DBUILD_SHARED_LIBS:BOOL=ON \
-DTrilinos_ENABLE_TESTS:BOOL=ON \
-DTrilinos_ENABLE_Teuchos:BOOL=ON \
-DTrilinos_ENABLE_ROL:BOOL=ON \
-DTrilinos_ENABLE_TriKota:BOOL=ON \
-DTrilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
-DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF \
-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON \
-DTrilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
../source
```

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [y] My commit messages mention the appropriate GitHub issue numbers.
- [?] My code follows the code style of the affected package(s).
- [?] My change requires a change to the documentation.
- [?] I have updated the documentation accordingly.
- [y] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [n ] I have added tests to cover my changes.
- [y] All new and existing tests passed.
- [y] No new compiler warnings were introduced.
- [n] These changes break backwards compatibility.

## Additional Information
I don't appear to have permission to assign reviewers, assignees, etc., but this may be of interest to @agsalin, @dpkouri, @dridzal, @ikalash 