### PR TITLE
Remove Unused Parameter Warnings

### DIFF
--- a/packages/ifpack/src/Ifpack_AMDReordering.cpp
+++ b/packages/ifpack/src/Ifpack_AMDReordering.cpp
@@ -99,21 +99,21 @@ operator=(const Ifpack_AMDReordering& RHS)
 
 //==============================================================================
 int Ifpack_AMDReordering::
-SetParameter(const std::string Name, const int Value)
+SetParameter(const std::string /* Name */, const int /* Value */)
 {
   return(0);
 }
 
 //==============================================================================
 int Ifpack_AMDReordering::
-SetParameter(const std::string Name, const double Value)
+SetParameter(const std::string /* Name */, const double /* Value */)
 {
   return(0);
 }
 
 //==============================================================================
 int Ifpack_AMDReordering::
-SetParameters(Teuchos::ParameterList& List)
+SetParameters(Teuchos::ParameterList& /* List */)
 {
   return(0);
 }

--- a/packages/ifpack/src/Ifpack_BlockRelaxation.h
+++ b/packages/ifpack/src/Ifpack_BlockRelaxation.h
@@ -252,10 +252,10 @@ public:
     return(*Matrix_);
   }
 
-  virtual double Condest(const Ifpack_CondestType CT = Ifpack_Cheap,
-                         const int MaxIters = 1550,
-                         const double Tol = 1e-9,
-                         Epetra_RowMatrix* Matrix_in = 0)
+  virtual double Condest(const Ifpack_CondestType /* CT */ = Ifpack_Cheap,
+                         const int /* MaxIters */ = 1550,
+                         const double /* Tol */ = 1e-9,
+                         Epetra_RowMatrix* /* Matrix_in */ = 0)
   {
     return(-1.0);
   }

--- a/packages/ifpack/src/Ifpack_Chebyshev.cpp
+++ b/packages/ifpack/src/Ifpack_Chebyshev.cpp
@@ -844,8 +844,8 @@ PowerMethod(const int MaximumIterations,  double& lambda_max,const unsigned int 
 //==============================================================================
 #ifdef HAVE_IFPACK_EPETRAEXT
 int Ifpack_Chebyshev::
-CG(const int MaximumIterations,
-   double& lambda_min, double& lambda_max,const unsigned int * RngSeed)
+CG(const int /* MaximumIterations */,
+   double& /* lambda_min */, double& /* lambda_max */,const unsigned int * /* RngSeed */)
 {
   IFPACK_CHK_ERR(-1);// NTS: This always seems to yield errors in AztecOO, ergo,
                      // I turned it off.

--- a/packages/ifpack/src/Ifpack_Chebyshev.h
+++ b/packages/ifpack/src/Ifpack_Chebyshev.h
@@ -342,11 +342,11 @@ private:
   virtual void SetLabel();
 
   //! Copy constructor (PRIVATE, should not be used)
-  Ifpack_Chebyshev(const Ifpack_Chebyshev& rhs)
+  Ifpack_Chebyshev(const Ifpack_Chebyshev& /* rhs */)
   {}
 
   //! operator = (PRIVATE, should not be used)
-  Ifpack_Chebyshev& operator=(const Ifpack_Chebyshev& rhs)
+  Ifpack_Chebyshev& operator=(const Ifpack_Chebyshev& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_DenseContainer.h
+++ b/packages/ifpack/src/Ifpack_DenseContainer.h
@@ -233,7 +233,7 @@ public:
                                const double value);
 
   //! Sets all necessary parameters.
-  virtual int SetParameters(Teuchos::ParameterList& List)
+  virtual int SetParameters(Teuchos::ParameterList& /* List */)
   {
     return(0);
   }

--- a/packages/ifpack/src/Ifpack_DiagPreconditioner.cpp
+++ b/packages/ifpack/src/Ifpack_DiagPreconditioner.cpp
@@ -65,7 +65,7 @@ Ifpack_DiagPreconditioner::~Ifpack_DiagPreconditioner()
 
 
 // ============================================================================ 
-int Ifpack_DiagPreconditioner::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+int Ifpack_DiagPreconditioner::Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_RETURN(-1); // not defined
 }

--- a/packages/ifpack/src/Ifpack_DiagonalFilter.h
+++ b/packages/ifpack/src/Ifpack_DiagonalFilter.h
@@ -112,9 +112,9 @@ public:
   virtual int Multiply(bool TransA, const Epetra_MultiVector& X, 
 		       Epetra_MultiVector& Y) const;
 
-  virtual int Solve(bool Upper, bool Trans, bool UnitDiagonal, 
-		    const Epetra_MultiVector& X,
-		    Epetra_MultiVector& Y) const
+  virtual int Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */, 
+		    const Epetra_MultiVector& /* X */,
+		    Epetra_MultiVector& /* Y */) const
   {
     IFPACK_CHK_ERR(-1);
   }
@@ -126,13 +126,13 @@ public:
     IFPACK_RETURN(ierr);
   }
 
-  virtual int ApplyInverse(const Epetra_MultiVector& X,
-			   Epetra_MultiVector& Y) const
+  virtual int ApplyInverse(const Epetra_MultiVector& /* X */,
+			   Epetra_MultiVector& /* Y */) const
   {
     IFPACK_CHK_ERR(-1);
   }
 
-  virtual int InvRowSums(Epetra_Vector& x) const
+  virtual int InvRowSums(Epetra_Vector& /* x */) const
   {
     IFPACK_CHK_ERR(-1);
   }
@@ -142,7 +142,7 @@ public:
     return(A_->LeftScale(x));
   }
 
-  virtual int InvColSums(Epetra_Vector& x) const
+  virtual int InvColSums(Epetra_Vector& /* x */) const
   {
     IFPACK_CHK_ERR(-1);;
   }

--- a/packages/ifpack/src/Ifpack_DropFilter.cpp
+++ b/packages/ifpack/src/Ifpack_DropFilter.cpp
@@ -184,8 +184,8 @@ Multiply(bool TransA, const Epetra_MultiVector& X,
 
 //==============================================================================
 int Ifpack_DropFilter::
-Solve(bool Upper, bool Trans, bool UnitDiagonal,
-      const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */,
+      const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-99);
 }
@@ -200,19 +200,19 @@ Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 
 //==============================================================================
 int Ifpack_DropFilter::
-ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-99);
 }
 
 //==============================================================================
-int Ifpack_DropFilter::InvRowSums(Epetra_Vector& x) const
+int Ifpack_DropFilter::InvRowSums(Epetra_Vector& /* x */) const
 {
   IFPACK_CHK_ERR(-1);
 }
 
 //==============================================================================
-int Ifpack_DropFilter::InvColSums(Epetra_Vector& x) const
+int Ifpack_DropFilter::InvColSums(Epetra_Vector& /* x */) const
 {
   IFPACK_CHK_ERR(-1);
 }

--- a/packages/ifpack/src/Ifpack_EquationPartitioner.h
+++ b/packages/ifpack/src/Ifpack_EquationPartitioner.h
@@ -81,7 +81,7 @@ public:
   virtual ~Ifpack_EquationPartitioner() {};
 
   //! Sets all the parameters for the partitioner.
-  int SetPartitionParameters(Teuchos::ParameterList& List)
+  int SetPartitionParameters(Teuchos::ParameterList& /* List */)
   {
     return(0);
   }

--- a/packages/ifpack/src/Ifpack_IC.h
+++ b/packages/ifpack/src/Ifpack_IC.h
@@ -109,11 +109,11 @@ class Ifpack_IC: public Ifpack_Preconditioner {
   */
   int SetParameters(Teuchos::ParameterList& parameterlis);
 
-  int SetParameter(const std::string Name, const int Value)
+  int SetParameter(const std::string /* Name */, const int /* Value */)
   {
     IFPACK_CHK_ERR(-98);
   }
-  int SetParameter(const std::string Name, const double Value)
+  int SetParameter(const std::string /* Name */, const double /* Value */)
   {
     IFPACK_CHK_ERR(-98);
   }

--- a/packages/ifpack/src/Ifpack_ICT.cpp
+++ b/packages/ifpack/src/Ifpack_ICT.cpp
@@ -491,8 +491,8 @@ int Ifpack_ICT::ApplyInverse(const Epetra_MultiVector& X,
 }
 //=============================================================================
 // This function finds X such that LDU Y = X or U(trans) D L(trans) Y = X for multiple RHS
-int Ifpack_ICT::Apply(const Epetra_MultiVector& X,
-                      Epetra_MultiVector& Y) const
+int Ifpack_ICT::Apply(const Epetra_MultiVector& /* X */,
+                      Epetra_MultiVector& /* Y */) const
 {
 
   IFPACK_CHK_ERR(-98);

--- a/packages/ifpack/src/Ifpack_ICT.h
+++ b/packages/ifpack/src/Ifpack_ICT.h
@@ -335,7 +335,7 @@ private:
   {}
 
   //! Should not be used.
-  Ifpack_ICT& operator=(const Ifpack_ICT& rhs)
+  Ifpack_ICT& operator=(const Ifpack_ICT& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_IHSS.cpp
+++ b/packages/ifpack/src/Ifpack_IHSS.cpp
@@ -245,10 +245,10 @@ std::ostream& Ifpack_IHSS::Print(std::ostream& os) const{
 }
 
 
-double Ifpack_IHSS::Condest(const Ifpack_CondestType CT,
-                             const int MaxIters,
-                             const double Tol,
-                             Epetra_RowMatrix* Matrix_in){
+double Ifpack_IHSS::Condest(const Ifpack_CondestType /* CT */,
+                             const int /* MaxIters */,
+                             const double /* Tol */,
+                             Epetra_RowMatrix* /* Matrix_in */){
   return -1.0;
 }
 

--- a/packages/ifpack/src/Ifpack_IHSS.h
+++ b/packages/ifpack/src/Ifpack_IHSS.h
@@ -279,7 +279,7 @@ private:
   {}
 
   //! operator= (should never be used)
-  Ifpack_IHSS& operator=(const Ifpack_IHSS& RHS)
+  Ifpack_IHSS& operator=(const Ifpack_IHSS& /* RHS */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_IKLU.cpp
+++ b/packages/ifpack/src/Ifpack_IKLU.cpp
@@ -396,8 +396,8 @@ int Ifpack_IKLU::ApplyInverse(const Epetra_MultiVector& X,
 }
 //=============================================================================
 // This function finds X such that LDU Y = X or U(trans) D L(trans) Y = X for multiple RHS
-int Ifpack_IKLU::Apply(const Epetra_MultiVector& X,
-                      Epetra_MultiVector& Y) const
+int Ifpack_IKLU::Apply(const Epetra_MultiVector& /* X */,
+                      Epetra_MultiVector& /* Y */) const
 {
 
   return(-98);

--- a/packages/ifpack/src/Ifpack_IKLU.h
+++ b/packages/ifpack/src/Ifpack_IKLU.h
@@ -321,7 +321,7 @@ private:
   {};
 
   //! operator= (should never be used)
-  Ifpack_IKLU& operator=(const Ifpack_IKLU& RHS)
+  Ifpack_IKLU& operator=(const Ifpack_IKLU& /* RHS */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_IKLU_Utils.cpp
+++ b/packages/ifpack/src/Ifpack_IKLU_Utils.cpp
@@ -577,7 +577,7 @@ static int csr_wclear (int mark, int lemax, int *w, int n)
 }
 
 /* keep off-diagonal entries; drop diagonal entries */
-static int csr_diag (int i, int j, double aij, void *other) { return (i != j) ; }
+static int csr_diag (int i, int j, double /* aij */, void * /* other */) { return (i != j) ; }
 
 /* p = amd(A+A') if symmetric is true, or amd(A'A) otherwise */
 int *csr_amd (int order, const csr *A)  /* order 0:natural, 1:Chol, 2:LU, 3:QR */

--- a/packages/ifpack/src/Ifpack_ILU.h
+++ b/packages/ifpack/src/Ifpack_ILU.h
@@ -297,7 +297,7 @@ private:
   {}
 
   //! operator= (should never be used)
-  Ifpack_ILU& operator=(const Ifpack_ILU& RHS)
+  Ifpack_ILU& operator=(const Ifpack_ILU& /* RHS */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_ILUT.cpp
+++ b/packages/ifpack/src/Ifpack_ILUT.cpp
@@ -581,8 +581,8 @@ int Ifpack_ILUT::ApplyInverse(const Epetra_MultiVector& X,
 }
 //=============================================================================
 // This function finds X such that LDU Y = X or U(trans) D L(trans) Y = X for multiple RHS
-int Ifpack_ILUT::Apply(const Epetra_MultiVector& X,
-                      Epetra_MultiVector& Y) const
+int Ifpack_ILUT::Apply(const Epetra_MultiVector& /* X */,
+                      Epetra_MultiVector& /* Y */) const
 {
   return(-98);
 }

--- a/packages/ifpack/src/Ifpack_ILUT.h
+++ b/packages/ifpack/src/Ifpack_ILUT.h
@@ -323,7 +323,7 @@ private:
   {};
 
   //! operator= (should never be used)
-  Ifpack_ILUT& operator=(const Ifpack_ILUT& RHS)
+  Ifpack_ILUT& operator=(const Ifpack_ILUT& /* RHS */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_Krylov.h
+++ b/packages/ifpack/src/Ifpack_Krylov.h
@@ -279,11 +279,11 @@ private:
   virtual void SetLabel();
 
   //! Copy constructor (PRIVATE, should not be used)
-  Ifpack_Krylov(const Ifpack_Krylov& rhs)
+  Ifpack_Krylov(const Ifpack_Krylov& /* rhs */)
   {}
 
   //! operator = (PRIVATE, should not be used)
-  Ifpack_Krylov& operator=(const Ifpack_Krylov& rhs)
+  Ifpack_Krylov& operator=(const Ifpack_Krylov& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_LinearPartitioner.h
+++ b/packages/ifpack/src/Ifpack_LinearPartitioner.h
@@ -68,7 +68,7 @@ public:
   virtual ~Ifpack_LinearPartitioner() {};
 
   //! Sets all the parameters for the partitioner (none for linear partioning).
-  int SetPartitionParameters(Teuchos::ParameterList& List)
+  int SetPartitionParameters(Teuchos::ParameterList& /* List */)
   {
     return(0);
   }

--- a/packages/ifpack/src/Ifpack_LocalFilter.cpp
+++ b/packages/ifpack/src/Ifpack_LocalFilter.cpp
@@ -206,8 +206,8 @@ int Ifpack_LocalFilter::Apply(const Epetra_MultiVector& X,
 }
 
 //==============================================================================
-int Ifpack_LocalFilter::ApplyInverse(const Epetra_MultiVector& X,
-		 Epetra_MultiVector& Y) const
+int Ifpack_LocalFilter::ApplyInverse(const Epetra_MultiVector& /* X */,
+		 Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-1); // not implemented
 }

--- a/packages/ifpack/src/Ifpack_LocalFilter.h
+++ b/packages/ifpack/src/Ifpack_LocalFilter.h
@@ -183,8 +183,8 @@ public:
   }
 
   //! Returns result of a local-only solve using a triangular Epetra_RowMatrix with Epetra_MultiVectors X and Y (NOT IMPLEMENTED).
-  virtual int Solve(bool Upper, bool Trans, bool UnitDiagonal, const Epetra_MultiVector& X,
-                    Epetra_MultiVector& Y) const
+  virtual int Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */, const Epetra_MultiVector& /* X */,
+                    Epetra_MultiVector& /* Y */) const
   {
     IFPACK_RETURN(-1); // not implemented
   }
@@ -195,26 +195,26 @@ public:
   virtual int ApplyInverse(const Epetra_MultiVector& X,
                            Epetra_MultiVector& Y) const;
   //! Computes the sum of absolute values of the rows of the Epetra_RowMatrix, results returned in x (NOT IMPLEMENTED).
-  virtual int InvRowSums(Epetra_Vector& x) const
+  virtual int InvRowSums(Epetra_Vector& /* x */) const
   {
     IFPACK_RETURN(-1); // not implemented
   }
 
   //! Scales the Epetra_RowMatrix on the left with a Epetra_Vector x (NOT IMPLEMENTED).
-  virtual int LeftScale(const Epetra_Vector& x)
+  virtual int LeftScale(const Epetra_Vector& /* x */)
   {
     IFPACK_RETURN(-1); // not implemented
   }
 
   //! Computes the sum of absolute values of the columns of the Epetra_RowMatrix, results returned in x (NOT IMPLEMENTED).
-  virtual int InvColSums(Epetra_Vector& x) const
+  virtual int InvColSums(Epetra_Vector& /* x */) const
   {
     IFPACK_RETURN(-1); // not implemented
   }
 
 
   //! Scales the Epetra_RowMatrix on the right with a Epetra_Vector x (NOT IMPLEMENTED).
-  virtual int RightScale(const Epetra_Vector& x)
+  virtual int RightScale(const Epetra_Vector& /* x */)
   {
     IFPACK_RETURN(-1); // not implemented
   }
@@ -355,7 +355,7 @@ public:
   // following functions are required to derive Epetra_RowMatrix objects.
 
   //! Sets ownership.
-  int SetOwnership(bool ownership)
+  int SetOwnership(bool /* ownership */)
   {
     IFPACK_RETURN(-1);
   }

--- a/packages/ifpack/src/Ifpack_METISReordering.h
+++ b/packages/ifpack/src/Ifpack_METISReordering.h
@@ -76,7 +76,7 @@ public:
   }
 
   //! Sets double parameters `Name'.
-  virtual int SetParameter(const std::string Name, const double Value)
+  virtual int SetParameter(const std::string /* Name */, const double /* Value */)
   {
     return(0);
   };

--- a/packages/ifpack/src/Ifpack_OverlappingRowMatrix.cpp
+++ b/packages/ifpack/src/Ifpack_OverlappingRowMatrix.cpp
@@ -1725,7 +1725,7 @@ ExtractMyRowCopy(int MyRow, int Length, int & NumEntries, double *Values,
 
 // ======================================================================
 int Ifpack_OverlappingRowMatrix::
-ExtractDiagonalCopy(Epetra_Vector & Diagonal) const
+ExtractDiagonalCopy(Epetra_Vector & /* Diagonal */) const
 {
   IFPACK_CHK_ERR(-1);
 }
@@ -1733,7 +1733,7 @@ ExtractDiagonalCopy(Epetra_Vector & Diagonal) const
 
 // ======================================================================
 int Ifpack_OverlappingRowMatrix::
-Multiply(bool TransA, const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Multiply(bool /* TransA */, const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 {
   int NumVectors = X.NumVectors();
   std::vector<int> Ind(MaxNumEntries_);
@@ -1777,7 +1777,7 @@ Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 
 // ======================================================================
 int Ifpack_OverlappingRowMatrix::
-ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-1);
 }

--- a/packages/ifpack/src/Ifpack_OverlappingRowMatrix.h
+++ b/packages/ifpack/src/Ifpack_OverlappingRowMatrix.h
@@ -162,8 +162,8 @@ public:
   virtual int Multiply(bool TransA, const Epetra_MultiVector& X, Epetra_MultiVector& Y) const;
 
   //! Returns result of a local-only solve using a triangular Epetra_RowMatrix with Epetra_MultiVectors X and Y (NOT IMPLEMENTED).
-  virtual int Solve(bool Upper, bool Trans, bool UnitDiagonal, const Epetra_MultiVector& X,
-                    Epetra_MultiVector& Y) const
+  virtual int Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */, const Epetra_MultiVector& /* X */,
+                    Epetra_MultiVector& /* Y */) const
   {
     IFPACK_RETURN(-1); // not implemented
   }
@@ -174,26 +174,26 @@ public:
   virtual int ApplyInverse(const Epetra_MultiVector& X,
                            Epetra_MultiVector& Y) const;
   //! Computes the sum of absolute values of the rows of the Epetra_RowMatrix, results returned in x (NOT IMPLEMENTED).
-  virtual int InvRowSums(Epetra_Vector& x) const
+  virtual int InvRowSums(Epetra_Vector& /* x */) const
   {
     IFPACK_RETURN(-1); // not implemented
   }
 
   //! Scales the Epetra_RowMatrix on the left with a Epetra_Vector x (NOT IMPLEMENTED).
-  virtual int LeftScale(const Epetra_Vector& x)
+  virtual int LeftScale(const Epetra_Vector& /* x */)
   {
     IFPACK_RETURN(-1); // not implemented
   }
 
   //! Computes the sum of absolute values of the columns of the Epetra_RowMatrix, results returned in x (NOT IMPLEMENTED).
-  virtual int InvColSums(Epetra_Vector& x) const
+  virtual int InvColSums(Epetra_Vector& /* x */) const
   {
     IFPACK_RETURN(-1); // not implemented
   }
 
 
   //! Scales the Epetra_RowMatrix on the right with a Epetra_Vector x (NOT IMPLEMENTED).
-  virtual int RightScale(const Epetra_Vector& x)
+  virtual int RightScale(const Epetra_Vector& /* x */)
   {
     IFPACK_RETURN(-1); // not implemented
   }
@@ -344,7 +344,7 @@ public:
   // following functions are required to derive Epetra_RowMatrix objects.
 
   //! Sets ownership.
-  int SetOwnership(bool ownership)
+  int SetOwnership(bool /* ownership */)
   {
     IFPACK_RETURN(-1);
   }

--- a/packages/ifpack/src/Ifpack_PointRelaxation.h
+++ b/packages/ifpack/src/Ifpack_PointRelaxation.h
@@ -387,11 +387,11 @@ private:
   virtual void SetLabel();
 
   //! Copy constructor (PRIVATE, should not be used)
-  Ifpack_PointRelaxation(const Ifpack_PointRelaxation& rhs)
+  Ifpack_PointRelaxation(const Ifpack_PointRelaxation& /* rhs */)
   {}
 
   //! operator = (PRIVATE, should not be used)
-  Ifpack_PointRelaxation& operator=(const Ifpack_PointRelaxation& rhs)
+  Ifpack_PointRelaxation& operator=(const Ifpack_PointRelaxation& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_Polynomial.cpp
+++ b/packages/ifpack/src/Ifpack_Polynomial.cpp
@@ -784,8 +784,8 @@ PowerMethod(const int MaximumIterations,  double& lambda_max)
 //==============================================================================
 #ifdef HAVE_IFPACK_EPETRAEXT
 int Ifpack_Polynomial::
-CG(const int MaximumIterations,
-   double& lambda_min, double& lambda_max)
+CG(const int /* MaximumIterations */,
+   double& /* lambda_min */, double& /* lambda_max */)
 {
   IFPACK_CHK_ERR(-1);// NTS: This always seems to yield errors in AztecOO, ergo,
                      // I turned it off.

--- a/packages/ifpack/src/Ifpack_Polynomial.h
+++ b/packages/ifpack/src/Ifpack_Polynomial.h
@@ -337,11 +337,11 @@ private:
   virtual void SetLabel();
 
   //! Copy constructor (PRIVATE, should not be used)
-  Ifpack_Polynomial(const Ifpack_Polynomial& rhs)
+  Ifpack_Polynomial(const Ifpack_Polynomial& /* rhs */)
   {}
 
   //! operator = (PRIVATE, should not be used)
-  Ifpack_Polynomial& operator=(const Ifpack_Polynomial& rhs)
+  Ifpack_Polynomial& operator=(const Ifpack_Polynomial& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_RCMReordering.cpp
+++ b/packages/ifpack/src/Ifpack_RCMReordering.cpp
@@ -107,7 +107,7 @@ SetParameter(const std::string Name, const int Value)
 
 //==============================================================================
 int Ifpack_RCMReordering::
-SetParameter(const std::string Name, const double Value)
+SetParameter(const std::string /* Name */, const double /* Value */)
 {
   return(0);
 }

--- a/packages/ifpack/src/Ifpack_ReorderFilter.cpp
+++ b/packages/ifpack/src/Ifpack_ReorderFilter.cpp
@@ -89,7 +89,7 @@ Ifpack_ReorderFilter::operator=(const Ifpack_ReorderFilter& RHS)
 
 //==============================================================================
 int Ifpack_ReorderFilter::
-ExtractMyRowCopy(int MyRow, int Length, int & NumEntries, 
+ExtractMyRowCopy(int MyRow, int /* Length */, int & NumEntries, 
                  double *Values, int * Indices) const
 {
   int MyReorderdRow = Reordering_->InvReorder(MyRow);
@@ -137,8 +137,8 @@ Multiply(bool TransA, const Epetra_MultiVector& X,
 
 //==============================================================================
 int Ifpack_ReorderFilter::
-Solve(bool Upper, bool Trans, bool UnitDiagonal, 
-      const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */, 
+      const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-98);
 }

--- a/packages/ifpack/src/Ifpack_ReorderFilter.h
+++ b/packages/ifpack/src/Ifpack_ReorderFilter.h
@@ -126,32 +126,32 @@ public:
 		    Epetra_MultiVector& Y) const;
 
   //! Applies the inverse of \c this operator (not implemented).
-  virtual int ApplyInverse(const Epetra_MultiVector& X,
-			   Epetra_MultiVector& Y) const
+  virtual int ApplyInverse(const Epetra_MultiVector& /* X */,
+			   Epetra_MultiVector& /* Y */) const
   {
     return(-1);
   }
 
   //! Inverse of row sums (not implemented).
-  virtual int InvRowSums(Epetra_Vector& x) const
+  virtual int InvRowSums(Epetra_Vector& /* x */) const
   {
     return(-1);
   }
 
   //! Left scale of the matrix (not implemented).
-  virtual int LeftScale(const Epetra_Vector& x)
+  virtual int LeftScale(const Epetra_Vector& /* x */)
   {
     return(-1);
   }
 
   //! Inverse of column sums (not implemented).
-  virtual int InvColSums(Epetra_Vector& x) const
+  virtual int InvColSums(Epetra_Vector& /* x */) const
   {
     return(-1);
   }
 
   //! Right scale of the matrix (not implemented).
-  virtual int RightScale(const Epetra_Vector& x) 
+  virtual int RightScale(const Epetra_Vector& /* x */) 
   {
     return(-1);
   }

--- a/packages/ifpack/src/Ifpack_SORa.cpp
+++ b/packages/ifpack/src/Ifpack_SORa.cpp
@@ -411,10 +411,10 @@ std::ostream& Ifpack_SORa::Print(std::ostream& os) const{
 }
 
 
-double Ifpack_SORa::Condest(const Ifpack_CondestType CT,
-                             const int MaxIters,
-                             const double Tol,
-                             Epetra_RowMatrix* Matrix_in){
+double Ifpack_SORa::Condest(const Ifpack_CondestType /* CT */,
+                             const int /* MaxIters */,
+                             const double /* Tol */,
+                             Epetra_RowMatrix* /* Matrix_in */){
   return -1.0;
 }
 

--- a/packages/ifpack/src/Ifpack_SORa.h
+++ b/packages/ifpack/src/Ifpack_SORa.h
@@ -286,7 +286,7 @@ private:
   {}
 
   //! operator= (should never be used)
-  Ifpack_SORa& operator=(const Ifpack_SORa& RHS)
+  Ifpack_SORa& operator=(const Ifpack_SORa& /* RHS */)
   {
     return(*this);
   }

--- a/packages/ifpack/src/Ifpack_SerialTriDiMatrix.cpp
+++ b/packages/ifpack/src/Ifpack_SerialTriDiMatrix.cpp
@@ -377,10 +377,10 @@ int Ifpack_SerialTriDiMatrix::Scale(double ScalarA) {
 }
 
 // //=========================================================================
-int Ifpack_SerialTriDiMatrix::Multiply (char TransA, char TransB, double ScalarAB,
-                                        const Ifpack_SerialTriDiMatrix& A_in,
-                                        const Ifpack_SerialTriDiMatrix& B,
-                                        double ScalarThis ) {
+int Ifpack_SerialTriDiMatrix::Multiply (char /* TransA */, char /* TransB */, double /* ScalarAB */,
+                                        const Ifpack_SerialTriDiMatrix& /* A_in */,
+                                        const Ifpack_SerialTriDiMatrix& /* B */,
+                                        double /* ScalarThis */ ) {
   throw ReportError("Ifpack_SerialTriDiMatrix::Multiply not implimented ",-2);
   // return(-1); // unreachable
 }

--- a/packages/ifpack/src/Ifpack_SingletonFilter.cpp
+++ b/packages/ifpack/src/Ifpack_SingletonFilter.cpp
@@ -228,8 +228,8 @@ Multiply(bool TransA, const Epetra_MultiVector& X,
 
 //==============================================================================
 int Ifpack_SingletonFilter::
-Solve(bool Upper, bool Trans, bool UnitDiagonal,
-      const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */,
+      const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   return(-1);
 }
@@ -244,7 +244,7 @@ Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 
 //==============================================================================
 int Ifpack_SingletonFilter::
-ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   return(-1); // NOT IMPLEMENTED AT THIS STAGE
 }

--- a/packages/ifpack/src/Ifpack_SingletonFilter.h
+++ b/packages/ifpack/src/Ifpack_SingletonFilter.h
@@ -65,7 +65,7 @@ public:
   virtual ~Ifpack_SingletonFilter() {};
 
   //! Returns the number of entries in MyRow.
-  virtual inline int NumMyRowEntries(int MyRow, int & NumEntries) const
+  virtual inline int NumMyRowEntries(int MyRow, int & /* NumEntries */) const
   {
     return(NumEntries_[MyRow]);
   }
@@ -93,22 +93,22 @@ public:
   virtual int ApplyInverse(const Epetra_MultiVector& X,
 			   Epetra_MultiVector& Y) const;
 
-  virtual int InvRowSums(Epetra_Vector& x) const
+  virtual int InvRowSums(Epetra_Vector& /* x */) const
   {
     return(-98); // NOT IMPLEMENTED
   }
 
-  virtual int LeftScale(const Epetra_Vector& x)
+  virtual int LeftScale(const Epetra_Vector& /* x */)
   {
     return(-98); // NOT IMPLEMENTED
   }
 
-  virtual int InvColSums(Epetra_Vector& x) const
+  virtual int InvColSums(Epetra_Vector& /* x */) const
   {
     return(-98); // NOT IMPLEMENTED
   }
 
-  virtual int RightScale(const Epetra_Vector& x) 
+  virtual int RightScale(const Epetra_Vector& /* x */) 
   {
     return(-98); // NOT IMPLEMENTED
   }

--- a/packages/ifpack/src/Ifpack_SparsityFilter.cpp
+++ b/packages/ifpack/src/Ifpack_SparsityFilter.cpp
@@ -222,8 +222,8 @@ Multiply(bool TransA, const Epetra_MultiVector& X,
 
 //==============================================================================
 int Ifpack_SparsityFilter::
-Solve(bool Upper, bool Trans, bool UnitDiagonal,
-      const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */,
+      const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-98);
 }
@@ -238,7 +238,7 @@ Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 
 //==============================================================================
 int Ifpack_SparsityFilter::
-ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   IFPACK_CHK_ERR(-98);
 }

--- a/packages/ifpack/src/Ifpack_SparsityFilter.h
+++ b/packages/ifpack/src/Ifpack_SparsityFilter.h
@@ -92,17 +92,17 @@ public:
   virtual int ApplyInverse(const Epetra_MultiVector& X,
                            Epetra_MultiVector& Y) const;
 
-  virtual int InvRowSums(Epetra_Vector& x) const
+  virtual int InvRowSums(Epetra_Vector& /* x */) const
   {
     return(-98);
   }
 
-  virtual int LeftScale(const Epetra_Vector& x)
+  virtual int LeftScale(const Epetra_Vector& /* x */)
   {
     return(-98);
   }
 
-  virtual int InvColSums(Epetra_Vector& x) const
+  virtual int InvColSums(Epetra_Vector& /* x */) const
   {
     return(-98);
   }

--- a/packages/ifpack/src/Ifpack_TriDiContainer.h
+++ b/packages/ifpack/src/Ifpack_TriDiContainer.h
@@ -234,7 +234,7 @@ public:
                                const double value);
 
   //! Sets all necessary parameters.
-  virtual int SetParameters(Teuchos::ParameterList& List)
+  virtual int SetParameters(Teuchos::ParameterList& /* List */)
   {
     return(0);
   }

--- a/packages/zoltan/src/include/zoltan_cpp.h
+++ b/packages/zoltan/src/include/zoltan_cpp.h
@@ -178,7 +178,7 @@ public:
                  int num_objs,
                  ZOLTAN_ID_PTR global_ids,
                  int *rank,
-                 int * iperm )
+                 int * /* iperm */ )
   {
     return Order(  num_gid_entries, num_objs, global_ids,
 		  (ZOLTAN_ID_PTR)rank);

--- a/packages/zoltan2/src/algorithms/Zoltan2_Algorithm.hpp
+++ b/packages/zoltan2/src/algorithms/Zoltan2_Algorithm.hpp
@@ -88,19 +88,19 @@ public:
   virtual ~Algorithm() {}
 
   //! \brief Ordering method
-  virtual int localOrder(const RCP<LocalOrderingSolution<lno_t> > &solution)
+  virtual int localOrder(const RCP<LocalOrderingSolution<lno_t> > &/* solution */)
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
   //! \brief Ordering method
-  virtual int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  virtual int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
     Z2_THROW_NOT_IMPLEMENTED 
   }
   
   //! \brief Coloring method
-  virtual void color(const RCP<ColoringSolution<Adapter> > &solution) 
+  virtual void color(const RCP<ColoringSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -111,19 +111,19 @@ public:
   }
 
   //! \brief Partitioning method
-  virtual void partition(const RCP<PartitioningSolution<Adapter> > &solution) 
+  virtual void partition(const RCP<PartitioningSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
   //! \brief Matrix Partitioning method
-  virtual void partitionMatrix(const RCP<MatrixPartitioningSolution<Adapter> > &solution) 
+  virtual void partitionMatrix(const RCP<MatrixPartitioningSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
   //! \brief Mapping method
-  virtual void map(const RCP<MappingSolution<Adapter> > &solution) 
+  virtual void map(const RCP<MappingSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -135,12 +135,12 @@ public:
   }
 
   //! \brief  for partitioning methods, fill arrays with partition tree info
-  virtual void getPartitionTree(part_t numParts,
-                        part_t & numTreeVerts,
-                        std::vector<part_t> & permPartNums,
-                        std::vector<part_t> & splitRangeBeg,
-                        std::vector<part_t> & splitRangeEnd,
-                        std::vector<part_t> & treeVertParents) const
+  virtual void getPartitionTree(part_t /* numParts */,
+                        part_t & /* numTreeVerts */,
+                        std::vector<part_t> & /* permPartNums */,
+                        std::vector<part_t> & /* splitRangeBeg */,
+                        std::vector<part_t> & /* splitRangeEnd */,
+                        std::vector<part_t> & /* treeVertParents */) const
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -165,7 +165,7 @@ public:
   //   \param dim : the number of dimensions specified for the point in space
   //   \param point : the coordinates of the point in space; array of size dim
   //   \return the part number of a part overlapping the given point
-  virtual part_t pointAssign(int dim, scalar_t *point) const
+  virtual part_t pointAssign(int /* dim */, scalar_t * /* point */) const
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -183,8 +183,8 @@ public:
   //                     array of size dim
   //   \param nParts : (out) the number of parts overlapping the box
   //   \param parts :  (out) array of parts overlapping the box
-  virtual void boxAssign(int dim, scalar_t *lower, scalar_t *upper,
-                         size_t &nParts, part_t **partsFound) const
+  virtual void boxAssign(int /* dim */, scalar_t * /* lower */, scalar_t * /* upper */,
+                         size_t &/* nParts */, part_t ** /* partsFound */) const
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -200,9 +200,9 @@ public:
   //                                               0 through i-1
   //  \param comAdj    (out) the neighboring parts
   virtual void getCommunicationGraph(
-    const PartitioningSolution<Adapter> *solution,
-    ArrayRCP<part_t> &comXAdj,
-    ArrayRCP<part_t> &comAdj)
+    const PartitioningSolution<Adapter> * /* solution */,
+    ArrayRCP<part_t> &/* comXAdj */,
+    ArrayRCP<part_t> &/* comAdj */)
     // TODO:  Should the return args be ArrayViews?
   {
     Z2_THROW_NOT_IMPLEMENTED
@@ -216,7 +216,7 @@ public:
   //  For example, AlgContiguousMapping can compute this function implicitly, 
   //  with no additional storage.  However, Mapping algorithms can skip this
   //  function and, instead, register their results in MappingSolution.
-  virtual int getRankForPart(part_t p)
+  virtual int getRankForPart(part_t /* p */)
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -231,7 +231,7 @@ public:
   //  For example, AlgContiguousMapping can compute this function implicitly, 
   //  with no additional storage.  However, Mapping algorithms can skip this
   //  function and, instead, register their results in MappingSolution.
-  virtual void getMyPartsView(part_t &numParts, part_t *&parts)
+  virtual void getMyPartsView(part_t &/* numParts */, part_t *&/* parts */)
   {
     Z2_THROW_NOT_IMPLEMENTED
   }

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
@@ -128,12 +128,12 @@ class AlgAMD : public Algorithm<Adapter>
     { }
 
     int globalOrder(
-      const RCP<GlobalOrderingSolution<typename Adapter::gno_t> > &solution) {
+      const RCP<GlobalOrderingSolution<typename Adapter::gno_t> > &/* solution */) {
         throw std::logic_error("AlgAMD does not yet support global ordering.");
     }
 
     int localOrder(
-      const RCP<LocalOrderingSolution<typename Adapter::lno_t> > &solution)
+      const RCP<LocalOrderingSolution<typename Adapter::lno_t> > &/* solution */)
     {
 #ifndef HAVE_ZOLTAN2_AMD
   throw std::runtime_error(

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgNatural.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgNatural.hpp
@@ -79,7 +79,7 @@ class AlgNatural : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution) {
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */) {
     throw std::logic_error("AlgNatural does not yet support global ordering.");
   }
 

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
@@ -83,7 +83,7 @@ class AlgRCM : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
     throw std::logic_error("AlgRCM does not yet support global ordering.");
   }

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRandom.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRandom.hpp
@@ -79,7 +79,7 @@ class AlgRandom : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
     throw std::logic_error("AlgRandom does not yet support global ordering.");
   }

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSortedDegree.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSortedDegree.hpp
@@ -83,7 +83,7 @@ class AlgSortedDegree : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
      throw std::logic_error(
        "AlgSortedDegree does not yet support global ordering.");

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -2761,7 +2761,7 @@ template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
 void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::set_initial_coordinate_parts(
     mj_scalar_t &max_coordinate,
     mj_scalar_t &min_coordinate,
-    mj_part_t &concurrent_current_part_index,
+    mj_part_t &/* concurrent_current_part_index */,
     mj_lno_t coordinate_begin_index,
     mj_lno_t coordinate_end_index,
     mj_lno_t *mj_current_coordinate_permutations,
@@ -3107,7 +3107,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_1D_part_get_thread_pa
     mj_lno_t coordinate_end_index,
     mj_scalar_t *mj_current_dim_coords,
     mj_scalar_t *temp_current_cut_coords,
-    bool *current_cut_status,
+    bool * /* current_cut_status */,
     double *my_current_part_weights,
     mj_scalar_t *my_current_left_closest,
     mj_scalar_t *my_current_right_closest){
@@ -3478,7 +3478,7 @@ template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
           typename mj_part_t>
 void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_create_new_partitions(
     mj_part_t num_parts,
-    mj_scalar_t *mj_current_dim_coords,
+    mj_scalar_t * /* mj_current_dim_coords */,
     mj_scalar_t *current_concurrent_cut_coordinate,
     mj_lno_t coordinate_begin,
     mj_lno_t coordinate_end,
@@ -3708,7 +3708,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_create_new_partitions
 template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
           typename mj_part_t>
 void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_get_new_cut_coordinates(
-                const size_t &num_total_part,
+                const size_t &/* num_total_part */,
                 const mj_part_t &num_cuts,
                 const mj_scalar_t &max_coordinate,
                 const mj_scalar_t &min_coordinate,

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
@@ -82,9 +82,9 @@ class AlgParMA : public Algorithm<Adapter>
 public:
   typedef typename Adapter::user_t user_t;
 
-  AlgParMA(const RCP<const Environment> &env,
-           const RCP<const Comm<int> > &problemComm,
-           const RCP<const BaseAdapter<user_t> > &adapter)
+  AlgParMA(const RCP<const Environment> &/* env */,
+           const RCP<const Comm<int> > &/* problemComm */,
+           const RCP<const BaseAdapter<user_t> > &/* adapter */)
   {
     throw std::runtime_error(
           "BUILD ERROR:  ParMA requested but not compiled into Zoltan2.\n"

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMETIS.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMETIS.hpp
@@ -65,9 +65,9 @@ template <typename Adapter>
 class AlgParMETIS : public Algorithm<Adapter>
 {
 public:
-  AlgParMETIS(const RCP<const Environment> &env,
-              const RCP<const Comm<int> > &problemComm,
-              const RCP<GraphModel<typename Adapter::base_adapter_t> > &model
+  AlgParMETIS(const RCP<const Environment> &/* env */,
+              const RCP<const Comm<int> > &/* problemComm */,
+              const RCP<GraphModel<typename Adapter::base_adapter_t> > &/* model */
   )
   {
     throw std::runtime_error(

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -67,9 +67,9 @@ class AlgPuLP : public Algorithm<Adapter>
 {
 public:
   typedef typename Adapter::base_adapter_t base_adapter_t;
-  AlgPuLP(const RCP<const Environment> &env,
-          const RCP<const Comm<int> > &problemComm,
-          const RCP<const base_adapter_t> &adapter
+  AlgPuLP(const RCP<const Environment> &/* env */,
+          const RCP<const Comm<int> > &/* problemComm */,
+          const RCP<const base_adapter_t> &/* adapter */
   )
   {
     throw std::runtime_error(
@@ -79,7 +79,7 @@ public:
 
   /*! \brief Set up validators specific to this algorithm
   */
-  static void getValidParameters(ParameterList & pl)
+  static void getValidParameters(ParameterList & /* pl */)
   {
     // No parameters needed in this error-handling version of AlgPuLP
   }

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgScotch.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgScotch.hpp
@@ -102,9 +102,9 @@ public:
   //            const RCP<const Comm<int> > &problemComm,
   //            const RCP<GraphModel<typename Adapter::base_adapter_t> > &model
   //) BDD: old inteface for reference
-  AlgPTScotch(const RCP<const Environment> &env,
-              const RCP<const Comm<int> > &problemComm,
-              const RCP<const base_adapter_t> &adapter
+  AlgPTScotch(const RCP<const Environment> &/* env */,
+              const RCP<const Comm<int> > &/* problemComm */,
+              const RCP<const base_adapter_t> &/* adapter */
   )
   {
     throw std::runtime_error(

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_MultiJagged_ReductionOps.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_MultiJagged_ReductionOps.hpp
@@ -89,7 +89,7 @@ public:
 
     /*! \brief Implement Teuchos::ValueTypeReductionOp interface
      */
-    void reduce( const Ordinal count, const T inBuffer[], T inoutBuffer[]) const
+    void reduce( const Ordinal /* count */, const T inBuffer[], T inoutBuffer[]) const
     {
         if (reductionType == 0){
             Ordinal next=0;
@@ -153,7 +153,7 @@ public:
 
     /*! \brief Implement Teuchos::ValueTypeReductionOp interface
      */
-    void reduce( const Ordinal count, const T inBuffer[], T inoutBuffer[]) const
+    void reduce( const Ordinal /* count */, const T inBuffer[], T inoutBuffer[]) const
     {
         Ordinal next=0;
 

--- a/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltan.hpp
+++ b/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltan.hpp
@@ -138,7 +138,7 @@ private:
   }
 
   void setCallbacksGraph(
-    const RCP<const GraphAdapter<user_t,userCoord_t> > &adp)
+    const RCP<const GraphAdapter<user_t,userCoord_t> > &/* adp */)
   {
     // std::cout << "NotReadyForGraphCallbacksYet" << std::endl;
     // TODO

--- a/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
+++ b/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
@@ -123,8 +123,8 @@ static void zoltanObjList(void *data, int nGidEnt, int nLidEnt,
 ///////////////////////
 // ZOLTAN_PART_MULTI_FN
 template <typename Adapter>
-static void zoltanParts(void *data, int nGidEnt, int nLidEnt, int nObj,
-                        ZOLTAN_ID_PTR gids, ZOLTAN_ID_PTR lids,
+static void zoltanParts(void *data, int /* nGidEnt */, int nLidEnt, int nObj,
+                        ZOLTAN_ID_PTR /* gids */, ZOLTAN_ID_PTR lids,
                         int *parts, int *ierr)
 {
   typedef typename Adapter::lno_t lno_t;
@@ -153,8 +153,8 @@ static int zoltanNumGeom(void *data, int *ierr)
 ///////////////////////
 // ZOLTAN_GEOM_MULTI_FN
 template <typename Adapter>
-static void zoltanGeom(void *data, int nGidEnt, int nLidEnt, int nObj,
-                       ZOLTAN_ID_PTR gids, ZOLTAN_ID_PTR lids,
+static void zoltanGeom(void *data, int /* nGidEnt */, int nLidEnt, int nObj,
+                       ZOLTAN_ID_PTR /* gids */, ZOLTAN_ID_PTR lids,
                        int nDim, double *coords, int *ierr)
 {
   typedef typename Adapter::lno_t lno_t;
@@ -202,7 +202,7 @@ static void zoltanHGSizeCS_withGraphAdapter(void *data,
 // ZOLTAN_HG_CS_FN
 template <typename Adapter>
 static void zoltanHGCS_withGraphAdapter(void *data, int nGidEnt, int nLists, 
-                                        int nPins, int format, 
+                                        int /* nPins */, int /* format */, 
                                         ZOLTAN_ID_PTR listIds, int *listIdx,
                                         ZOLTAN_ID_PTR pinIds, int *ierr
 )
@@ -277,7 +277,7 @@ static void zoltanHGEdgeWts_withGraphAdapter(
   int nGidEnt, 
   int nLidEnt, 
   int nEdges, 
-  int eWgtDim, 
+  int /* eWgtDim */, 
   ZOLTAN_ID_PTR edgeGids, 
   ZOLTAN_ID_PTR edgeLids, 
   float *edgeWgts,

--- a/packages/zoltan2/src/environment/Zoltan2_IntegerRangeList.hpp
+++ b/packages/zoltan2/src/environment/Zoltan2_IntegerRangeList.hpp
@@ -583,7 +583,7 @@ template <typename Integral>
 template <typename Integral>
   void IntegerRangeListValidator<Integral>::validate( 
     Teuchos::ParameterEntry  const& entry,
-    std::string const& paramName, std::string const& sublistName) const
+    std::string const& /* paramName */, std::string const& /* sublistName */) const
 {
   if (!entry.isType<std::string>()){
     return;  // already converted to an an array
@@ -635,7 +635,7 @@ template <typename Integral>
 
 template <typename Integral>
   void IntegerRangeListValidator<Integral>::validateAndModify( 
-    std::string const& paramName, std::string const& sublistName, 
+    std::string const& /* paramName */, std::string const& /* sublistName */, 
     Teuchos::ParameterEntry * entry) const
 {
   typedef typename Teuchos::Array<Integral>::size_type arraySize_t;

--- a/packages/zoltan2/src/input/Zoltan2_Adapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_Adapter.hpp
@@ -131,7 +131,7 @@ public:
       \param ids will on return point to the list of the global Ids for 
         this process.
    */
-  virtual void getIDsKokkosView(Kokkos::View<gno_t *> &ids) const {
+  virtual void getIDsKokkosView(Kokkos::View<gno_t *> &/* ids */) const {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
@@ -159,8 +159,8 @@ public:
   // *   getNumWeightsPerID > 0.
   // *   This function should not be called if getNumWeightsPerID is zero.
   // */ 
-  virtual void getWeightsKokkosView(Kokkos::View<scalar_t *> &wgt, 
-                              int idx = 0) const {
+  virtual void getWeightsKokkosView(Kokkos::View<scalar_t *> &/* wgt */, 
+                              int /* idx */ = 0) const {
     Z2_THROW_NOT_IMPLEMENTED
   }
 

--- a/packages/zoltan2/src/input/Zoltan2_GraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_GraphAdapter.hpp
@@ -176,7 +176,7 @@ public:
       \param idx ranges from zero to one less than getNumWeightsPerVertex().
    */
   virtual void getVertexWeightsView(const scalar_t *&weights, int &stride,
-                                    int idx = 0) const
+                                    int /* idx */ = 0) const
   {
     weights = NULL;
     stride = 0;
@@ -187,7 +187,7 @@ public:
   /*! \brief Indicate whether vertex weight with index idx should be the
    *         global degree of the vertex
    */
-  virtual bool useDegreeAsVertexWeight(int idx) const
+  virtual bool useDegreeAsVertexWeight(int /* idx */) const
   {
     return false;
   }
@@ -203,7 +203,7 @@ public:
       \param idx ranges from zero to one less than getNumWeightsPerEdge().
    */
   virtual void getEdgeWeightsView(const scalar_t *&weights, int &stride,
-                                  int idx = 0) const
+                                  int /* idx */ = 0) const
   {
     weights = NULL;
     stride = 0;

--- a/packages/zoltan2/src/models/Zoltan2_CoordinateModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_CoordinateModel.hpp
@@ -257,9 +257,9 @@ template <typename Adapter>
 template <typename AdapterWithCoords>
 void CoordinateModel<Adapter>::sharedConstructor(
     const AdapterWithCoords *ia,
-    const RCP<const Environment> &env,
+    const RCP<const Environment> &/* env */,
     const RCP<const Comm<int> > &comm,
-    modelFlag_t &flags)
+    modelFlag_t &/* flags */)
 {
   size_t nLocalIds = ia->getLocalNumIDs();
 

--- a/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
@@ -118,9 +118,9 @@ public:
     const RCP<const Environment> &env, const RCP<const Comm<int> > &comm,
     modelFlag_t &modelflags);
 
-  GraphModel(const RCP<const VectorAdapter<userCoord_t> > &ia,
-    const RCP<const Environment> &env, const RCP<const Comm<int> > &comm,
-    modelFlag_t &flags)
+  GraphModel(const RCP<const VectorAdapter<userCoord_t> > &/* ia */,
+    const RCP<const Environment> &/* env */, const RCP<const Comm<int> > &/* comm */,
+    modelFlag_t &/* flags */)
   {
     throw std::runtime_error("cannot build GraphModel from VectorAdapter");
   }

--- a/packages/zoltan2/src/models/Zoltan2_IdentifierModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_IdentifierModel.hpp
@@ -143,7 +143,7 @@ template <typename Adapter>
     const RCP<const Adapter> &ia,
     const RCP<const Environment> &env,
     const RCP<const Comm<int> > &comm,
-    modelFlag_t &modelFlags):
+    modelFlag_t &/* modelFlags */):
       numGlobalIdentifiers_(), env_(env), comm_(comm),
       gids_(), nUserWeights_(0), weights_()
 {

--- a/packages/zoltan2/src/problems/Zoltan2_OrderingProblem.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_OrderingProblem.hpp
@@ -230,7 +230,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////
 template <typename Adapter>
-void OrderingProblem<Adapter>::solve(bool updateInputData)
+void OrderingProblem<Adapter>::solve(bool /* updateInputData */)
 {
   HELLO;
 

--- a/packages/zoltan2/src/problems/Zoltan2_Problem.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_Problem.hpp
@@ -235,7 +235,7 @@ private:
 };
 
 template <typename Adapter>
-  void Problem<Adapter>::setupProblemEnvironment(ParameterList *params)
+  void Problem<Adapter>::setupProblemEnvironment(ParameterList * /* params */)
 {
   ParameterList &processedParameters = env_->getParametersNonConst();
   params_ = rcp<ParameterList>(&processedParameters, false);

--- a/packages/zoltan2/src/util/Zoltan2_EvaluateBaseClass.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_EvaluateBaseClass.hpp
@@ -59,7 +59,7 @@ class EvaluateBaseClassRoot{
     virtual ~EvaluateBaseClassRoot() {} // required virtual declaration
 
     /*! \brief Print all metrics */
-    virtual void printMetrics(std::ostream &os) const {};
+    virtual void printMetrics(std::ostream &/* os */) const {};
 };
 
 template <typename Adapter>


### PR DESCRIPTION
@trilinos/ifpack, @trilinos/zoltan, @trilinos/zoltan2 

## Description
Removing unused parameter warnings generated by `gcc-7.3.0` by commenting out parameter names in function definitions.

## Motivation and Context
Just hoping for a clean build.

## Related Issues
* Analogous to #4256, #4243, #4239.

## How Has This Been Tested?
Everything still builds on my RHEL7 machine.  Letting the @trilinos-autotester do its thing.