### PR TITLE
Disable Fortran for 4.9.3 SERIAL build Fix Issue #4238

### DIFF
--- a/cmake/std/PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake
@@ -11,6 +11,9 @@
 # Use the below option only when submitting to the dashboard
 #set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
 
+# Disabling fortran for this build as that is a customer use case
+set (Trilinos_ENABLE_Fortran OFF CACHE BOOL "Set by default for SERIAL PR test")
+
 set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
 # NOTE: The above is a workaround for the problem of having threads on MPI
 # ranks bind to the same cores (see #2422).


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Description
Disabled Fortran for the automated GCC 4.9.3 SERIAL build.

## Motivation and Context
This should address Issue #4238 . There are several projects and OSX users that disable Fortran when building Trilinos. This will make sure there is a Fortran-less configuration and PR build running to cover that.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
Had this branch built successfully by Jenkins. [Everything builds and tests successfully](https://testing-vm.sandia.gov/cdash/index.php?project=Trilinos&parentid=4474639).

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
