### PR TITLE
Job weights for cloud nodes

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-Test.sh
+++ b/cmake/std/PullRequestLinuxDriver-Test.sh
@@ -334,6 +334,29 @@ echo -e "Enabled packages:"
 cmake -P packageEnables.cmake
 
 build_name="PR-$PULLREQUESTNUM-test-$JOB_BASE_NAME-$BUILD_NUMBER"
+parallel_level=29
+# these are aimed at keeping approximantly 1.7G per core so we don't bottleneck
+## weight 29
+## ascic113-trilinos 32/64  3.6 -j29 2.2
+## ascic114-trilinos 32/64  3.6 -j29 2.2
+## ascic115-trilinos 32/64  3.6 -j29 2.2
+## ascic141-trilinos 72/64  1.7 -j18 2.2
+## ascic142-trilinos 72/64  1.7 -j18 2.2
+## ascic143-trilinos 72/64  1.7 -j18 2.2
+## ascic144-trilinos 72/64  1.7 -j18 2.2
+## ascic158-trilinos 88/128 2.4 -j19 2.2
+## ascic166-trilinos 80/128 3.6 -j29 3.7
+## tr-test           32/64  3.6 -j29 2.2
+if [ "tr-test-0.novalocal" == "${NODE_NAME}" || \
+     "tr-test-1.novalocal" == "${NODE_NAME}" || \
+     "ascic113-trilinos " == "${NODE_NAME}" || \
+     "ascic114-trilinos" == "${NODE_NAME}" || \
+     "ascic115-trilinos" == "${NODE_NAME}" || \
+     "ascic166-trilinos" == "${NODE_NAME}" ]; then
+    parallel_level=29
+elif [ "ascic158-trilinos" == "${NODE_NAME}" ];then
+    parallel_level=19
+fi
 
 #This should be runnable from anywhere, but all the tests so far have been from the
 #same dir the simple_testing.cmake file was in.
@@ -365,7 +388,7 @@ ctest -S simple_testing.cmake \
     -Dskip_update_step=ON \
     -Ddashboard_model=Experimental \
     -Ddashboard_track="${CDASH_TRACK:?}" \
-    -DPARALLEL_LEVEL=18 \
+    -DPARALLEL_LEVEL=${parallel_level} \
     -Dbuild_dir="${WORKSPACE:?}/pull_request_test" \
     -Dconfigure_script=${TRILINOS_DRIVER_SRC_DIR}/cmake/std/${CONFIG_SCRIPT:?} \
     -Dpackage_enables=../packageEnables.cmake \


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
This attempts to set the parallel_level on-the-fly based on the amount
of memory available, the number of jobs that will fit on a single node,
and the minimum amount of available memory per core in use up to
this point (1.7G)

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Monitoring while starting up nodes in the CEE cloud space has shown that we
under-utilize all but 4 of the current nodes and would under-utilize the cloud
nodes as well. This should help a bit.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Testing to this point was mainly ssh to each machine and paste in the shell
commands and evaluate the results.  Since these changes are in the -test
portion of the driver I expect we will avoid the bootstrapping issue and PR
testing will produce what I need.

