### PR TITLE
MueLu: switching smoother in structured driver for 3D elasticity

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -1247,6 +1247,7 @@ int main(int argc, char *argv[]) {
         int minGID, maxGID;
         for (int i = 0; i < (int) myRegions.size(); i++) {
           retval = fscanf(fp,"%d%d",&minGID,&maxGID);
+          if(retval == 0) {std::cout << "Something probably went wrong while reading minGID and maxGID from file!" << std::endl;}
           minGIDComp[i] = minGID;
           maxGIDComp[i] = maxGID;
         }
@@ -3148,7 +3149,7 @@ int LIDregionCircleSquare(void *ptr, int compLID, int whichGrp)
    int  ownedX = appData[inpData_ownedX];
    int  ownedY = appData[inpData_ownedY];
    int  Rx     = appData[inpData_regionX];
-   int  Ry     = appData[inpData_regionY];
+   // int  Ry     = appData[inpData_regionY];
    int  Cx     = appData[inpData_cornerX];
    int  Cy     = appData[inpData_cornerY];
 

--- a/packages/muelu/research/mmayr/hhg/hhg_driver.cpp
+++ b/packages/muelu/research/mmayr/hhg/hhg_driver.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
     probParams->print(*out);
 
   const std::string& mappingFileName = probParams->get<std::string>("mapping file name");
-  const std::string& matrixFileName = probParams->get<std::string>("matrix file name");
+  // const std::string& matrixFileName = probParams->get<std::string>("matrix file name");
 
   // create the RegionManager to deal with node-to-region mappings
   Teuchos::RCP<RegionManager> regionManager = Teuchos::rcp(new RegionManager(mappingFileName, comm));

--- a/packages/muelu/src/Utils/MueLu_PerfUtils_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_PerfUtils_def.hpp
@@ -239,8 +239,8 @@ namespace MueLu {
 #ifdef HAVE_MPI
     RCP<const Teuchos::MpiComm<int> > mpiComm = rcp_dynamic_cast<const Teuchos::MpiComm<int> >(origComm);
     MPI_Comm rawComm = (*mpiComm->getRawMpiComm())();
-#endif
     int root = 0;
+#endif
 
     std::string outstr;
     ParameterList absList;

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -330,11 +330,11 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     }
   }
 
+#ifdef HAVE_MPI
   // Generate the node-level communicator, if we want one
   Teuchos::RCP<const Teuchos::Comm<int> > nodeComm;
   int NodeId = comm->getRank();
-#ifdef HAVE_MPI
-  if(provideNodeComm) {                        
+  if(provideNodeComm) {
     nodeComm = MueLu::GenerateNodeComm(comm,NodeId);
     //    printf("DEBUG: Base rank %d => New, node %d, rank %d\n",comm->getRank(),NodeId,nodeComm->getRank());
   }

--- a/packages/muelu/test/structured/structured_3dof.xml
+++ b/packages/muelu/test/structured/structured_3dof.xml
@@ -97,6 +97,16 @@
       </ParameterList>
     </ParameterList>
 
+    <ParameterList name="mySGS">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type" type="string" value="RELAXATION"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="relaxation: type"             type="string" value="Symmetric Gauss-Seidel"/>
+        <Parameter name="relaxation: sweeps"           type="int"    value="2"/>
+        <Parameter name="relaxation: damping factor"   type="double" value="1"/>
+      </ParameterList>
+    </ParameterList>
+
   </ParameterList>
 
 
@@ -109,8 +119,8 @@
     <Parameter name="verbosity"                             type="string"   value="High"/>
 
     <ParameterList name="All">
-      <Parameter name="PreSmoother"                         type="string"   value="myChebyshev"/>
-      <Parameter name="PostSmoother"                        type="string"   value="myChebyshev"/>
+      <Parameter name="PreSmoother"                         type="string"   value="mySGS"/>
+      <Parameter name="PostSmoother"                        type="string"   value="mySGS"/>
       <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
       <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>
       <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/>


### PR DESCRIPTION
 to SGS, which will work properly on complex problems.

Also silencing a few compiler warnings related to unused variables.

@trilinos/muelu 

## Description
The `MueLu_Structured_Elasticity3D` test fails when `Scalar=std::complex<double>` this is due to the choice of a Chebyshev smoother that does not complex numbers.

## Motivation and Context
This is part of a clean-up of MueLu for `Scalar=std::complex<>` for Sierra promotion (see issue #4263) and for an auto-tester build (see issue #2426). Of course also to have the pleasure of running all the tests without problem when `std::complex<>` is enabled : )

## Related Issues

* Closes 
* Blocks #2426 #4263
* Part of #2426

## How Has This Been Tested?
A local run with the new xml parameters has been performed and the test now passes without problems.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.