### PR TITLE
Muelu: Changes to repartitioning

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_Elasticity2DProblem.hpp
+++ b/packages/galeri/src-xpetra/Galeri_Elasticity2DProblem.hpp
@@ -177,7 +177,7 @@ namespace Galeri {
 
       this->A_ = MatrixTraits<Map,Matrix>::Build(this->Map_, 9*numDofPerNode);
 
-      SC one = TST::one(), zero = TST::zero(), two = one+one;
+      SC one = TST::one(), zero = TST::zero();
       SerialDenseMatrix<LO,SC> prevKE(numDofPerElem, numDofPerElem), prevElementNodes(numNodesPerElem, Teuchos::as<LO>(nDim_));        // cache
       for (size_t i = 0; i < elements_.size(); i++) {
         // Select nodes subvector

--- a/packages/galeri/src-xpetra/Galeri_Elasticity3DProblem.hpp
+++ b/packages/galeri/src-xpetra/Galeri_Elasticity3DProblem.hpp
@@ -188,7 +188,7 @@ namespace Galeri {
 
       this->A_ = MatrixTraits<Map,Matrix>::Build(this->Map_, 27*numDofPerNode);
 
-      SC one = Teuchos::ScalarTraits<SC>::one(), zero = Teuchos::ScalarTraits<SC>::zero(), two = one+one;
+      SC one = Teuchos::ScalarTraits<SC>::one(), zero = Teuchos::ScalarTraits<SC>::zero();
       SerialDenseMatrix<LO,SC> prevKE(numDofPerElem, numDofPerElem), prevElementNodes(numNodesPerElem, nDim_);        // cache
       for (size_t i = 0; i < elements_.size(); i++) {
         // Select nodes subvector

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -1779,13 +1779,13 @@ namespace MueLu {
 
     RCP<const Teuchos::Comm<int> > comm = SM_Matrix_->getDomainMap()->getComm();
 
+#ifdef HAVE_MPI
     int root;
     if (!A22_.is_null())
       root = comm->getRank();
     else
       root = -1;
 
-#ifdef HAVE_MPI
     int actualRoot;
     reduceAll(*comm, Teuchos::REDUCE_MAX, root, Teuchos::ptr(&actualRoot));
     root = actualRoot;

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -986,7 +986,7 @@
       <name>repartition: min rows per proc</name>
       <type>int</type>
       <default>800</default>
-      <description>Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs.</description>
+      <description>Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs. The value is not used if "repartition: min rows per thread" is positive.</description>
       <name-ML>repartition: min per proc</name-ML>
       <default-ML>512</default-ML>
       <compatibility-ML>MLParameterListInterpreter</compatibility-ML>
@@ -1000,6 +1000,24 @@
            0, we set it to the value of `min rows per proc` in the code. -->
       <default>0</default>
       <description>Target number of rows per MPI process after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per proc"</description>
+      <comment-ML>not supported by ML</comment-ML>
+    </parameter>
+
+    <parameter>
+      <name>repartition: min rows per thread</name>
+      <type>int</type>
+      <default>0</default>
+      <description>Minimum number of rows per thread. If the actual number if smaller, then rebalancing occurs. If the value is set to 0, no repartitioning based on thread count will occur.</description>
+      <comment-ML>not supported by ML</comment-ML>
+    </parameter>
+
+    <parameter>
+      <name>repartition: target rows per thread</name>
+      <type>int</type>
+      <!-- We want to be backwards compatible at the moment. If the value is
+           0, we set it to the value of `min rows per thread` in the code. -->
+      <default>0</default>
+      <description>Target number of rows per thread after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per thread".</description>
       <comment-ML>not supported by ML</comment-ML>
     </parameter>
 

--- a/packages/muelu/doc/UsersGuide/options_rebalancing.tex
+++ b/packages/muelu/doc/UsersGuide/options_rebalancing.tex
@@ -7,9 +7,13 @@
           
 \cbb{repartition: start level}{int}{2}{Minimum level to run partitioner. \muelu does not rebalance levels finer than this one.}
           
-\cbb{repartition: min rows per proc}{int}{800}{Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs.}
+\cbb{repartition: min rows per proc}{int}{800}{Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs. The value is not used if "repartition: min rows per thread" is positive.}
           
 \cbb{repartition: target rows per proc}{int}{0}{Target number of rows per MPI process after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per proc"}
+          
+\cbb{repartition: min rows per thread}{int}{0}{Minimum number of rows per thread. If the actual number if smaller, then rebalancing occurs. If the value is set to 0, no repartitioning based on thread count will occur.}
+          
+\cbb{repartition: target rows per thread}{int}{0}{Target number of rows per thread after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per thread".}
           
 \cbb{repartition: max imbalance}{double}{1.2}{Maximum nonzero imbalance ratio. If the actual number is larger, the rebalancing occurs.}
           

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -128,9 +128,13 @@
           
 \cbb{repartition: start level}{int}{2}{Minimum level to run partitioner. \muelu does not rebalance levels finer than this one.}
           
-\cbb{repartition: min rows per proc}{int}{800}{Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs.}
+\cbb{repartition: min rows per proc}{int}{800}{Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs. The value is not used if "repartition: min rows per thread" is positive.}
           
 \cbb{repartition: target rows per proc}{int}{0}{Target number of rows per MPI process after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per proc"}
+          
+\cbb{repartition: min rows per thread}{int}{0}{Minimum number of rows per thread. If the actual number if smaller, then rebalancing occurs. If the value is set to 0, no repartitioning based on thread count will occur.}
+          
+\cbb{repartition: target rows per thread}{int}{0}{Target number of rows per thread after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per thread".}
           
 \cbb{repartition: max imbalance}{double}{1.2}{Maximum nonzero imbalance ratio. If the actual number is larger, the rebalancing occurs.}
           

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -203,9 +203,13 @@
         
 \cbb{repartition: start level}{int}{2}{Minimum level to run partitioner. \muelu does not rebalance levels finer than this one.}
         
-\cbb{repartition: min rows per proc}{int}{800}{Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs.}
+\cbb{repartition: min rows per proc}{int}{800}{Minimum number of rows per MPI process. If the actual number if smaller, then rebalancing occurs. The value is not used if "repartition: min rows per thread" is positive.}
         
 \cbb{repartition: target rows per proc}{int}{0}{Target number of rows per MPI process after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per proc"}
+        
+\cbb{repartition: min rows per thread}{int}{0}{Minimum number of rows per thread. If the actual number if smaller, then rebalancing occurs. If the value is set to 0, no repartitioning based on thread count will occur.}
+        
+\cbb{repartition: target rows per thread}{int}{0}{Target number of rows per thread after rebalancing. If the value is set to 0, it will use the value of "repartition: min rows per thread".}
         
 \cbb{repartition: max imbalance}{double}{1.2}{Maximum nonzero imbalance ratio. If the actual number is larger, the rebalancing occurs.}
         

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -244,6 +244,8 @@ namespace MueLu {
   "<Parameter name=\"repartition: start level\" type=\"int\" value=\"2\"/>"
   "<Parameter name=\"repartition: min rows per proc\" type=\"int\" value=\"800\"/>"
   "<Parameter name=\"repartition: target rows per proc\" type=\"int\" value=\"0\"/>"
+  "<Parameter name=\"repartition: min rows per thread\" type=\"int\" value=\"0\"/>"
+  "<Parameter name=\"repartition: target rows per thread\" type=\"int\" value=\"0\"/>"
   "<Parameter name=\"repartition: max imbalance\" type=\"double\" value=\"1.2\"/>"
   "<Parameter name=\"repartition: remap parts\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"repartition: remap num values\" type=\"int\" value=\"4\"/>"
@@ -639,6 +641,10 @@ namespace MueLu {
          ("repartition: min per proc","repartition: min rows per proc")
       
          ("repartition: target rows per proc","repartition: target rows per proc")
+      
+         ("repartition: min rows per thread","repartition: min rows per thread")
+      
+         ("repartition: target rows per thread","repartition: target rows per thread")
       
          ("repartition: max min ratio","repartition: max imbalance")
       

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
@@ -79,6 +79,8 @@ namespace MueLu {
     SET_VALID_ENTRY("repartition: start level");
     SET_VALID_ENTRY("repartition: min rows per proc");
     SET_VALID_ENTRY("repartition: target rows per proc");
+    SET_VALID_ENTRY("repartition: min rows per thread");
+    SET_VALID_ENTRY("repartition: target rows per thread");
     SET_VALID_ENTRY("repartition: max imbalance");
 #undef  SET_VALID_ENTRY
 
@@ -100,9 +102,29 @@ namespace MueLu {
     // Access parameters here to make sure that we set the parameter entry flag to "used" even in case of short-circuit evaluation.
     // TODO (JG): I don't really know if we want to do this.
     const int    startLevel           = pL.get<int>   ("repartition: start level");
-    const LO     minRowsPerProcess    = pL.get<LO>    ("repartition: min rows per proc");
+          LO     minRowsPerProcess    = pL.get<LO>    ("repartition: min rows per proc");
           LO     targetRowsPerProcess = pL.get<LO>    ("repartition: target rows per proc");
+          LO     minRowsPerThread     = pL.get<LO>    ("repartition: min rows per thread");
+          LO     targetRowsPerThread  = pL.get<LO>    ("repartition: target rows per thread");
     const double nonzeroImbalance     = pL.get<double>("repartition: max imbalance");
+
+    int thread_per_mpi_rank = 1;
+#if defined(HAVE_MUELU_KOKKOSCORE) && defined(KOKKOS_ENABLE_OPENMP)
+    using execution_space = typename Node::device_type::execution_space;
+    if (std::is_same<execution_space, Kokkos::OpenMP>::value)
+      thread_per_mpi_rank = execution_space::concurrency();
+#endif
+
+    if (minRowsPerThread > 0)
+      // We ignore the value given by minRowsPerProcess and repartition based on threads instead
+      minRowsPerProcess *= minRowsPerThread*thread_per_mpi_rank;
+
+    if (targetRowsPerThread == 0)
+      targetRowsPerThread = minRowsPerThread;
+
+    if (targetRowsPerThread > 0)
+      // We ignore the value given by targetRowsPerProcess and repartition based on threads instead
+      targetRowsPerProcess = targetRowsPerThread*thread_per_mpi_rank;
 
     if (targetRowsPerProcess == 0)
       targetRowsPerProcess = minRowsPerProcess;
@@ -229,15 +251,7 @@ namespace MueLu {
     int numPartitions = 1;
     if (globalNumRows >= targetRowsPerProcess) {
       // Make sure that each CPU thread has approximately targetRowsPerProcess
-
-      int thread_per_mpi_rank = 1;
-#if defined(HAVE_MUELU_KOKKOSCORE) && defined(KOKKOS_ENABLE_OPENMP)
-      using execution_space = typename Node::device_type::execution_space;
-      if (std::is_same<execution_space, Kokkos::OpenMP>::value)
-        thread_per_mpi_rank = execution_space::concurrency();
-#endif
-
-      numPartitions = std::max(Teuchos::as<int>(globalNumRows / (targetRowsPerProcess * thread_per_mpi_rank)), 1);
+      numPartitions = std::max(Teuchos::as<int>(globalNumRows / targetRowsPerProcess), 1);
     }
     numPartitions = std::min(numPartitions, comm->getSize());
 

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -394,6 +398,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -394,6 +398,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -416,6 +420,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -558,6 +564,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -425,6 +429,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -567,6 +573,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -418,6 +422,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -560,6 +566,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -425,6 +429,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -567,6 +573,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -508,6 +512,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -515,6 +519,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -448,6 +452,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -455,6 +459,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
@@ -82,6 +82,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
@@ -92,6 +92,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
@@ -82,6 +82,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -202,6 +204,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -322,6 +326,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -442,6 +448,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -562,6 +570,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -92,6 +92,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -222,6 +224,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -352,6 +356,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -482,6 +488,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -612,6 +620,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
@@ -82,6 +82,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -202,6 +204,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -322,6 +326,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -442,6 +448,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -92,6 +92,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -222,6 +224,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -352,6 +356,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -482,6 +488,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
@@ -82,6 +82,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -202,6 +204,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -322,6 +326,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -442,6 +448,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -92,6 +92,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -222,6 +224,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -352,6 +356,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -482,6 +488,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
@@ -102,6 +102,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -236,6 +238,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -370,6 +374,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
@@ -102,6 +102,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -105,6 +105,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -105,6 +105,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -242,6 +244,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -379,6 +383,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
@@ -102,6 +102,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -236,6 +238,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -370,6 +374,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
@@ -102,6 +102,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -105,6 +105,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -105,6 +105,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -242,6 +244,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -379,6 +383,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -395,6 +399,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -527,6 +533,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -386,6 +390,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -518,6 +524,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -416,6 +420,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -558,6 +564,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -425,6 +429,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -567,6 +573,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -395,6 +399,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -527,6 +533,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -388,6 +392,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -520,6 +526,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -418,6 +422,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -560,6 +566,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -425,6 +429,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -567,6 +573,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -475,6 +479,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
@@ -100,6 +100,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -232,6 +234,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -468,6 +472,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -508,6 +512,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -110,6 +110,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -252,6 +254,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -515,6 +519,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -415,6 +419,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -408,6 +412,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -448,6 +452,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -455,6 +459,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
@@ -96,6 +96,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -214,6 +216,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -106,6 +106,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -234,6 +236,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -355,6 +359,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
@@ -98,6 +98,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
@@ -98,6 +98,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -228,6 +230,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -358,6 +362,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -377,6 +381,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -506,6 +512,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -386,6 +390,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -515,6 +521,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -379,6 +383,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -508,6 +514,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -386,6 +390,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -515,6 +521,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -98,6 +98,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -228,6 +230,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -466,6 +470,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
@@ -98,6 +98,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -228,6 +230,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -473,6 +477,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -212,6 +214,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -423,6 +427,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -212,6 +214,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -430,6 +434,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
@@ -80,6 +80,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
@@ -79,6 +79,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -196,6 +198,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -313,6 +317,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -430,6 +436,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -547,6 +555,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -89,6 +89,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -216,6 +218,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -343,6 +347,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -470,6 +476,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)
@@ -597,6 +605,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.3
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
@@ -79,6 +79,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -196,6 +198,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -313,6 +317,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -430,6 +436,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -89,6 +89,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -216,6 +218,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -343,6 +347,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -470,6 +476,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
@@ -79,6 +79,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -196,6 +198,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -313,6 +317,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -430,6 +436,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -89,6 +89,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -216,6 +218,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -343,6 +347,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)
@@ -470,6 +476,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2
 
 Build (MueLu::RepartitionInterface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -89,6 +89,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -210,6 +212,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -331,6 +335,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
@@ -89,6 +89,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -92,6 +92,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -92,6 +92,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -216,6 +218,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -340,6 +344,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -212,6 +214,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -334,6 +338,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -218,6 +220,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)
@@ -343,6 +347,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.327
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -356,6 +360,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -475,6 +481,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -347,6 +351,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -466,6 +472,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -377,6 +381,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -506,6 +512,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -386,6 +390,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -515,6 +521,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -356,6 +360,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -475,6 +481,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -349,6 +353,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -468,6 +474,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -379,6 +383,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -508,6 +514,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -386,6 +390,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -515,6 +521,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
@@ -87,6 +87,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -206,6 +208,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -97,6 +97,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -226,6 +228,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -88,6 +88,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -433,6 +437,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
@@ -88,6 +88,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -426,6 +430,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -98,6 +98,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -228,6 +230,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -466,6 +470,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -98,6 +98,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -228,6 +230,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -473,6 +477,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -80,6 +80,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -192,6 +194,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -390,6 +394,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
@@ -80,6 +80,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -192,6 +194,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -383,6 +387,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -212,6 +214,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -423,6 +427,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -90,6 +90,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -212,6 +214,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -430,6 +434,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
@@ -83,6 +83,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -188,6 +190,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -93,6 +93,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)
@@ -208,6 +210,8 @@ Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
+repartition: min rows per thread = 0   [default]
+repartition: target rows per thread = 0   [default]
 repartition: max imbalance = 1.2   [default]
 
 Build (MueLu::Zoltan2Interface)

--- a/packages/muelu/test/maxwell/Maxwell3D.cpp
+++ b/packages/muelu/test/maxwell/Maxwell3D.cpp
@@ -133,6 +133,31 @@ int MainWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Node>::main_(Teuchos::Command
     
     int nedges  = 3630;  clp.setOption("nedges",               &nedges,           "number of edges");
     int nnodes  = 1331;  clp.setOption("nnodes",               &nnodes,           "number of nodes");
+    std::string S_file, SM_file, M1_file, M0_file, M0inv_file, D0_file, coords_file;
+    if (!TYPE_EQUAL(SC, std::complex<double>)) {
+      S_file = "S.mat";
+      SM_file = "";
+      M1_file = "M1.mat";
+      M0_file = "M0.mat";
+      M0inv_file = "";
+      D0_file = "D0.mat";
+      coords_file = "coords.mat";
+    } else {
+      S_file = "S_complex.mat";
+      SM_file = "";
+      M1_file = "M1_complex.mat";
+      M0_file = "M0_complex.mat";
+      M0inv_file = "";
+      D0_file = "D0_complex.mat";
+      coords_file = "coords.mat";
+    }
+    clp.setOption("S", &S_file);
+    clp.setOption("SM", &SM_file);
+    clp.setOption("M1", &M1_file);
+    clp.setOption("M0", &M0_file);
+    clp.setOption("M0inv", &M0inv_file);
+    clp.setOption("D0", &D0_file);
+    clp.setOption("coords", &coords_file);
 
     clp.recogniseAllOptions(true);
     switch (clp.parse(argc, argv)) {
@@ -150,52 +175,47 @@ int MainWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Node>::main_(Teuchos::Command
     // maps for nodal and edge matrices
     RCP<Map> edge_map = MapFactory::Build(lib,nedges,0,comm);
     RCP<Map> node_map = MapFactory::Build(lib,nnodes,0,comm);
-    RCP<Matrix> S_Matrix, M1_Matrix, M0_Matrix, D0_Matrix;
-    if (!TYPE_EQUAL(SC, std::complex<double>)) {
-      // edge stiffness matrix
-      S_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("S.mat", edge_map);
-      // edge mass matrix
-      M1_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M1.mat", edge_map);
-      // nodal mass matrix
-      M0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M0.mat", node_map);
-      // gradient matrix
-      D0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("D0.mat", edge_map, Teuchos::null, node_map, edge_map);
-    } else {
-      // edge stiffness matrix
-      S_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("S_complex.mat", edge_map);
-      // edge mass matrix
-      M1_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M1_complex.mat", edge_map);
-      // nodal mass matrix
-      M0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M0_complex.mat", node_map);
-      // gradient matrix
-      D0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("D0_complex.mat", edge_map, Teuchos::null, node_map, edge_map);
-    }
-    // coordinates
-    RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO> > coords = Xpetra::IO<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO>::ReadMultiVector("coords.mat", node_map);
-
-    // build lumped mass matrix inverse (M0inv_Matrix)
-    RCP<Vector> diag = Utilities::GetLumpedMatrixDiagonal(M0_Matrix);
-    RCP<CrsMatrixWrap> M0inv_MatrixWrap = Teuchos::rcp(new CrsMatrixWrap(node_map, node_map, 0, Xpetra::StaticProfile));
-    RCP<CrsMatrix> M0inv_CrsMatrix = M0inv_MatrixWrap->getCrsMatrix();
-    Teuchos::ArrayRCP<size_t> rowPtr;
-    Teuchos::ArrayRCP<LO> colInd;
-    Teuchos::ArrayRCP<SC> values;
-    Teuchos::ArrayRCP<const SC> diags = diag->getData(0);
-    size_t nodeNumElements = node_map->getNodeNumElements();
-    M0inv_CrsMatrix->allocateAllValues(nodeNumElements, rowPtr, colInd, values);
-    SC ONE = (SC)1.0;
-    for (size_t i = 0; i < nodeNumElements; i++) {
-      rowPtr[i] = i;  colInd[i] = i;  values[i] = ONE / diags[i];
-    }
-    rowPtr[nodeNumElements] = nodeNumElements;
-    M0inv_CrsMatrix->setAllValues(rowPtr, colInd, values);
-    M0inv_CrsMatrix->expertStaticFillComplete(node_map, node_map);
-    RCP<Matrix> M0inv_Matrix = Teuchos::rcp_dynamic_cast<Matrix>(M0inv_MatrixWrap);
-
+    // edge mass matrix
+    RCP<Matrix> M1_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(M1_file, edge_map);
     // build stiffness plus mass matrix (SM_Matrix)
     RCP<Matrix> SM_Matrix;
-    Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::TwoMatrixAdd(*S_Matrix,false,(SC)1.0,*M1_Matrix,false,scaling,SM_Matrix,*out);
-    SM_Matrix->fillComplete();
+    if (SM_file == "") {
+      // edge stiffness matrix
+      RCP<Matrix> S_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(S_file, edge_map);
+      Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::TwoMatrixAdd(*S_Matrix,false,(SC)1.0,*M1_Matrix,false,scaling,SM_Matrix,*out);
+      SM_Matrix->fillComplete();
+    } else {
+      SM_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(SM_file, edge_map);
+    }
+    RCP<Matrix> M0inv_Matrix;
+    if (M0inv_file == "") {
+      // nodal mass matrix
+      RCP<Matrix> M0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(M0_file, node_map);
+      // build lumped mass matrix inverse (M0inv_Matrix)
+      RCP<Vector> diag = Utilities::GetLumpedMatrixDiagonal(M0_Matrix);
+      RCP<CrsMatrixWrap> M0inv_MatrixWrap = Teuchos::rcp(new CrsMatrixWrap(node_map, node_map, 0, Xpetra::StaticProfile));
+      RCP<CrsMatrix> M0inv_CrsMatrix = M0inv_MatrixWrap->getCrsMatrix();
+      Teuchos::ArrayRCP<size_t> rowPtr;
+      Teuchos::ArrayRCP<LO> colInd;
+      Teuchos::ArrayRCP<SC> values;
+      Teuchos::ArrayRCP<const SC> diags = diag->getData(0);
+      size_t nodeNumElements = node_map->getNodeNumElements();
+      M0inv_CrsMatrix->allocateAllValues(nodeNumElements, rowPtr, colInd, values);
+      SC ONE = (SC)1.0;
+      for (size_t i = 0; i < nodeNumElements; i++) {
+        rowPtr[i] = i;  colInd[i] = i;  values[i] = ONE / diags[i];
+      }
+      rowPtr[nodeNumElements] = nodeNumElements;
+      M0inv_CrsMatrix->setAllValues(rowPtr, colInd, values);
+      M0inv_CrsMatrix->expertStaticFillComplete(node_map, node_map);
+      M0inv_Matrix = Teuchos::rcp_dynamic_cast<Matrix>(M0inv_MatrixWrap);
+    } else {
+      M0inv_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(M0inv_file, node_map);
+    }
+    // gradient matrix
+    RCP<Matrix> D0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(D0_file, edge_map, Teuchos::null, node_map, edge_map);
+    // coordinates
+    RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO> > coords = Xpetra::IO<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO>::ReadMultiVector(coords_file, node_map);
 
     // set parameters
     std::string defaultXMLfile;
@@ -342,6 +362,31 @@ int MainWrappers<double,LocalOrdinal,GlobalOrdinal,Node>::main_(Teuchos::Command
 
     int nedges  = 3630;  clp.setOption("nedges",               &nedges,           "number of edges");
     int nnodes  = 1331;  clp.setOption("nnodes",               &nnodes,           "number of nodes");
+    std::string S_file, SM_file, M1_file, M0_file, M0inv_file, D0_file, coords_file;
+    if (!TYPE_EQUAL(SC, std::complex<double>)) {
+      S_file = "S.mat";
+      SM_file = "";
+      M1_file = "M1.mat";
+      M0_file = "M0.mat";
+      M0inv_file = "";
+      D0_file = "D0.mat";
+      coords_file = "coords.mat";
+    } else {
+      S_file = "S_complex.mat";
+      SM_file = "";
+      M1_file = "M1_complex.mat";
+      M0_file = "M0_complex.mat";
+      M0inv_file = "";
+      D0_file = "D0_complex.mat";
+      coords_file = "coords.mat";
+    }
+    clp.setOption("S", &S_file);
+    clp.setOption("SM", &SM_file);
+    clp.setOption("M1", &M1_file);
+    clp.setOption("M0", &M0_file);
+    clp.setOption("M0inv", &M0inv_file);
+    clp.setOption("D0", &D0_file);
+    clp.setOption("coords", &coords_file);
 
     clp.recogniseAllOptions(true);
     switch (clp.parse(argc, argv)) {
@@ -359,53 +404,47 @@ int MainWrappers<double,LocalOrdinal,GlobalOrdinal,Node>::main_(Teuchos::Command
     // maps for nodal and edge matrices
     RCP<Map> edge_map = MapFactory::Build(lib,nedges,0,comm);
     RCP<Map> node_map = MapFactory::Build(lib,nnodes,0,comm);
-    RCP<Matrix> S_Matrix, M1_Matrix, M0_Matrix, D0_Matrix;
-    
-    if (!TYPE_EQUAL(SC, std::complex<double>)) {
-      // edge stiffness matrix
-      S_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("S.mat", edge_map);
-      // edge mass matrix
-      M1_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M1.mat", edge_map);
-      // nodal mass matrix
-      M0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M0.mat", node_map);
-      // gradient matrix
-      D0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("D0.mat", edge_map, Teuchos::null, node_map, edge_map);
-    } else {
-      // edge stiffness matrix
-      S_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("S_complex.mat", edge_map);
-      // edge mass matrix
-      M1_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M1_complex.mat", edge_map);
-      // nodal mass matrix
-      M0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("M0_complex.mat", node_map);
-      // gradient matrix
-      D0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read("D0_complex.mat", edge_map, Teuchos::null, node_map, edge_map);
-    }
-    // coordinates
-    RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO> > coords = Xpetra::IO<double, LO, GO, NO>::ReadMultiVector("coords.mat", node_map);
-
-    // build lumped mass matrix inverse (M0inv_Matrix)
-    RCP<Vector> diag = Utilities::GetLumpedMatrixDiagonal(M0_Matrix);
-    RCP<CrsMatrixWrap> M0inv_MatrixWrap = Teuchos::rcp(new CrsMatrixWrap(node_map, node_map, 0, Xpetra::StaticProfile));
-    RCP<CrsMatrix> M0inv_CrsMatrix = M0inv_MatrixWrap->getCrsMatrix();
-    Teuchos::ArrayRCP<size_t> rowPtr;
-    Teuchos::ArrayRCP<LO> colInd;
-    Teuchos::ArrayRCP<SC> values;
-    Teuchos::ArrayRCP<const SC> diags = diag->getData(0);
-    size_t nodeNumElements = node_map->getNodeNumElements();
-    M0inv_CrsMatrix->allocateAllValues(nodeNumElements, rowPtr, colInd, values);
-    SC ONE = (SC)1.0;
-    for (size_t i = 0; i < nodeNumElements; i++) {
-      rowPtr[i] = i;  colInd[i] = i;  values[i] = ONE / diags[i];
-    }
-    rowPtr[nodeNumElements] = nodeNumElements;
-    M0inv_CrsMatrix->setAllValues(rowPtr, colInd, values);
-    M0inv_CrsMatrix->expertStaticFillComplete(node_map, node_map);
-    RCP<Matrix> M0inv_Matrix = Teuchos::rcp_dynamic_cast<Matrix>(M0inv_MatrixWrap);
-
+    // edge mass matrix
+    RCP<Matrix> M1_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(M1_file, edge_map);
     // build stiffness plus mass matrix (SM_Matrix)
     RCP<Matrix> SM_Matrix;
-    Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::TwoMatrixAdd(*S_Matrix,false,(SC)1.0,*M1_Matrix,false,scaling,SM_Matrix,*out);
-    SM_Matrix->fillComplete();
+    if (SM_file == "") {
+      // edge stiffness matrix
+      RCP<Matrix> S_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(S_file, edge_map);
+      Xpetra::MatrixMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::TwoMatrixAdd(*S_Matrix,false,(SC)1.0,*M1_Matrix,false,scaling,SM_Matrix,*out);
+      SM_Matrix->fillComplete();
+    } else {
+      SM_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(SM_file, edge_map);
+    }
+    RCP<Matrix> M0inv_Matrix;
+    if (M0inv_file == "") {
+      // nodal mass matrix
+      RCP<Matrix> M0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(M0_file, node_map);
+      // build lumped mass matrix inverse (M0inv_Matrix)
+      RCP<Vector> diag = Utilities::GetLumpedMatrixDiagonal(M0_Matrix);
+      RCP<CrsMatrixWrap> M0inv_MatrixWrap = Teuchos::rcp(new CrsMatrixWrap(node_map, node_map, 0, Xpetra::StaticProfile));
+      RCP<CrsMatrix> M0inv_CrsMatrix = M0inv_MatrixWrap->getCrsMatrix();
+      Teuchos::ArrayRCP<size_t> rowPtr;
+      Teuchos::ArrayRCP<LO> colInd;
+      Teuchos::ArrayRCP<SC> values;
+      Teuchos::ArrayRCP<const SC> diags = diag->getData(0);
+      size_t nodeNumElements = node_map->getNodeNumElements();
+      M0inv_CrsMatrix->allocateAllValues(nodeNumElements, rowPtr, colInd, values);
+      SC ONE = (SC)1.0;
+      for (size_t i = 0; i < nodeNumElements; i++) {
+        rowPtr[i] = i;  colInd[i] = i;  values[i] = ONE / diags[i];
+      }
+      rowPtr[nodeNumElements] = nodeNumElements;
+      M0inv_CrsMatrix->setAllValues(rowPtr, colInd, values);
+      M0inv_CrsMatrix->expertStaticFillComplete(node_map, node_map);
+      M0inv_Matrix = Teuchos::rcp_dynamic_cast<Matrix>(M0inv_MatrixWrap);
+    } else {
+      M0inv_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(M0inv_file, node_map);
+    }
+    // gradient matrix
+    RCP<Matrix> D0_Matrix = Xpetra::IO<SC, LO, GO, NO>::Read(D0_file, edge_map, Teuchos::null, node_map, edge_map);
+    // coordinates
+    RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO> > coords = Xpetra::IO<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LO, GO, NO>::ReadMultiVector(coords_file, node_map);
 
     // set parameters
     std::string defaultXMLfile;

--- a/packages/muelu/test/unit_tests/BlockedRepartition.cpp
+++ b/packages/muelu/test/unit_tests/BlockedRepartition.cpp
@@ -252,16 +252,7 @@ namespace MueLuTests {
     RCP<RepartitionHeuristicFactory> RepHeuFact = Teuchos::rcp(new RepartitionHeuristicFactory);
     RepHeuFact->SetFactory("A", MueLu::NoFactory::getRCP()); // 2x2 blocked operator
     RepHeuFact->SetParameter("repartition: start level",Teuchos::ParameterEntry(0));
-    int minRowsPerRank=200;
-#if defined(HAVE_MUELU_KOKKOSCORE) && defined(KOKKOS_HAVE_OPENMP)
-    using execution_space = typename Node::device_type::execution_space;
-    if (std::is_same<execution_space, Kokkos::OpenMP>::value)
-    {
-       //Because target value will be multiplied by the # of threads in RepartitionHeuristic
-       minRowsPerRank /= execution_space::concurrency();
-    }
-#endif
-    RepHeuFact->SetParameter("repartition: min rows per proc",Teuchos::ParameterEntry(minRowsPerRank));
+    RepHeuFact->SetParameter("repartition: min rows per proc",Teuchos::ParameterEntry(200));
 
     // define sub block factories for blocked operator "A"
     RCP<SubBlockAFactory> A11Fact = Teuchos::rcp(new SubBlockAFactory());
@@ -374,16 +365,6 @@ namespace MueLuTests {
       return;
     }
     int expectedPartitions=2;
-#if defined(HAVE_MUELU_KOKKOSCORE) && defined(KOKKOS_ENABLE_OPENMP)
-    using execution_space = typename Node::device_type::execution_space;
-    if (std::is_same<execution_space, Kokkos::OpenMP>::value)
-    {
-       int thread_per_mpi_rank = execution_space::concurrency();
-       if (thread_per_mpi_rank > 1)
-          expectedPartitions=1;
-    }
-#endif
-    
     TEST_EQUALITY(nNumProcsReb, expectedPartitions);
 
     //////////////////////////////////////////////////


### PR DESCRIPTION
@trilinos/muelu 

## Description
- Silence a couple of compiler warnings.
- Introduce "min rows per thread" and "target rows per thread" parameter list entries.
  When these are positive, do repartitioning by thread, otherwise stick with repartitioning by process.