### PR TITLE
Sacado:  Fix loop for hierarchical.

### DIFF
--- a/packages/sacado/src/Sacado_Fad_GeneralFad.hpp
+++ b/packages/sacado/src/Sacado_Fad_GeneralFad.hpp
@@ -477,7 +477,7 @@ namespace Sacado {
               SACADO_FAD_DERIV_LOOP(i,sz)
                 this->fastAccessDx(i) += x.fastAccessDx(i);
             else
-              for (int i=0; i<sz; ++i)
+              SACADO_FAD_DERIV_LOOP(i,sz)
                 this->fastAccessDx(i) += x.dx(i);
           }
           else {


### PR DESCRIPTION
One loop in GeneralFad wasn't correct for Cuda with hierarchical
parallelism.  This would only affect computations with a passive scalar
(i.e., variable declared as a Fad but had a zero-length derivative
array).