### PR TITLE
Revert "Disable Tpetra test for CUDA PR build"

### DIFF
--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -91,7 +91,6 @@ set (TpetraCore_Core_ScopeGuard_where_tpetra_initializes_kokkos_MPI_1_DISABLE ON
 set (TpetraCore_Core_ScopeGuard_where_tpetra_initializes_mpi_and_user_initializes_kokkos_MPI_2_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TpetraCore_Core_ScopeGuard_where_user_initializes_kokkos_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TpetraCore_Core_ScopeGuard_where_user_initializes_mpi_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
-set (TpetraCore_BlockCrsMatrix_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 


### PR DESCRIPTION
CC: @trilinos/framework 

Reverts trilinos/Trilinos#4293

As per https://github.com/trilinos/Trilinos/issues/4257#issuecomment-460704262, this test should now be passing in all of the CUDA builds.

As this test is protecting ATDM, I added the `ATDM` label.  It is important that the PR builds protect the ATDM builds to the greatest extent they can.
