### PR TITLE
zoltan2:  fixed ArrayView usage in graph metrics' directory calls

### DIFF
--- a/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
@@ -165,10 +165,19 @@ void globalWeightedByPart(
     typedef Zoltan2_Directory_Simple<part_t,lno_t,gno_t> directory_t;
     int debug_level = 0;
     directory_t directory(comm, bUseLocalIDs, debug_level);
-    directory.update(localNumVertices, &Ids[0], NULL, &parts[0],
-      NULL, directory_t::Update_Mode::Replace);
-    directory.find(localNumEdges, &edgeIds[0], NULL, &e_parts[0],
-      NULL, NULL, false);
+    if (localNumVertices)
+      directory.update(localNumVertices, &Ids[0], NULL, &parts[0],
+        NULL, directory_t::Update_Mode::Replace);
+    else
+      directory.update(localNumVertices, NULL, NULL, NULL,
+        NULL, directory_t::Update_Mode::Replace);
+
+    if (localNumEdges)
+      directory.find(localNumEdges, &edgeIds[0], NULL, &e_parts[0],
+        NULL, NULL, false);
+    else
+      directory.find(localNumEdges, NULL, NULL, NULL,
+        NULL, NULL, false);
   } else
 #endif
   {

--- a/packages/zoltan2/test/driver/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/CMakeLists.txt
@@ -193,6 +193,45 @@ TRIBITS_ADD_TEST(
     FAIL_REGULAR_EXPRESSION "FAIL"
 )
 
+TRIBITS_ADD_TEST(
+    test_driver
+    NAME chacoGraphMetricsTest
+    COMM serial mpi
+    ARGS
+    "./driverinputs/chacoGraphMetricsTest.xml"
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
+TRIBITS_ADD_TEST(
+    test_driver
+    NAME chacoGraphMetricsTestNoDistribute
+    COMM serial mpi
+    ARGS
+    "./driverinputs/chacoGraphMetricsTestNoDistribute.xml"
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
+TRIBITS_ADD_TEST(
+    test_driver
+    NAME chacoGraphMetricsTestNoGraph
+    COMM serial mpi
+    ARGS
+    "./driverinputs/chacoGraphMetricsTestNoGraph.xml"
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
+TRIBITS_ADD_TEST(
+    test_driver
+    NAME chacoGraphMetricsTestNoGraphNoDistribute
+    COMM serial mpi
+    ARGS
+    "./driverinputs/chacoGraphMetricsTestNoGraphNoDistribute.xml"
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
 
 IF (${PROJECT_NAME}_ENABLE_Pamgen)
   TRIBITS_ADD_TEST(
@@ -243,6 +282,14 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_zoltan_ewgt_for_driver_tests_
     ewgt.coords
     ewgt.graph
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../zoltan/test/ch_ewgt
+  DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_zoltan_nograph_for_driver_tests_
+  SOURCE_FILES
+    nograph.coords
+    nograph.graph
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../zoltan/test/ch_nograph
   DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/packages/zoltan2/test/driver/driverinputs/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/driverinputs/CMakeLists.txt
@@ -12,6 +12,9 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_input_files_for_driver
         multiJaggedTest.xml
         GeomGenWeight.txt
         chacoGraphMetricsTest.xml
+        chacoGraphMetricsTestNoDistribute.xml
+        chacoGraphMetricsTestNoGraph.xml
+        chacoGraphMetricsTestNoGraphNoDistribute.xml
         chacoSimple3dTest.xml
         chacoSimpleTest.xml
         chacoVwgtTest.xml    

--- a/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoDistribute.xml
+++ b/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoDistribute.xml
@@ -40,6 +40,7 @@
 <ParameterList name="chacoEdgeWeight">
   
   <ParameterList name="InputParameters">
+    <Parameter name="distribute input" type="bool" value="false"/>
     <Parameter name="input path" type="string" value="./"/>
     <Parameter name="input file" type="string" value="ewgt"/>
     <Parameter name="file type" type="string" value="Chaco"/>

--- a/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraph.xml
+++ b/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraph.xml
@@ -60,30 +60,30 @@
     <ParameterList name="Metrics">
       <ParameterList name="metriccheck1">
         <Parameter name="check" type="string" value="max edge cuts"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck2">
         <Parameter name="check" type="string" value="max edge cuts"/>
         <Parameter name="weight" type="int" value="0"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck3">
         <Parameter name="check" type="string" value="total edge cuts"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck4">
         <Parameter name="check" type="string" value="total edge cuts"/>
         <Parameter name="weight" type="int" value="0"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck5">
         <Parameter name="check" type="string" value="imbalance"/>
         <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="1.5"/>
+        <Parameter name="upper" type="double" value="1.2"/>
       </ParameterList>
      </ParameterList>
   </ParameterList>

--- a/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraph.xml
+++ b/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraph.xml
@@ -37,11 +37,11 @@
  ////////////////////////////////////////////////////////////////////////////////
  /////////////////////////////////////////////////////////////////////////////-->
 
-<ParameterList name="chacoEdgeWeight">
+<ParameterList name="chacoNoGraph">
   
   <ParameterList name="InputParameters">
     <Parameter name="input path" type="string" value="./"/>
-    <Parameter name="input file" type="string" value="ewgt"/>
+    <Parameter name="input file" type="string" value="nograph"/>
     <Parameter name="file type" type="string" value="Chaco"/>
   </ParameterList>
   
@@ -86,6 +86,5 @@
         <Parameter name="upper" type="double" value="1.5"/>
       </ParameterList>
      </ParameterList>
-
   </ParameterList>
 </ParameterList>

--- a/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraphNoDistribute.xml
+++ b/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraphNoDistribute.xml
@@ -37,11 +37,12 @@
  ////////////////////////////////////////////////////////////////////////////////
  /////////////////////////////////////////////////////////////////////////////-->
 
-<ParameterList name="chacoEdgeWeight">
+<ParameterList name="chacoNoGraph">
   
   <ParameterList name="InputParameters">
+    <Parameter name="distribute input" type="bool" value="false"/>
     <Parameter name="input path" type="string" value="./"/>
-    <Parameter name="input file" type="string" value="ewgt"/>
+    <Parameter name="input file" type="string" value="nograph"/>
     <Parameter name="file type" type="string" value="Chaco"/>
   </ParameterList>
   
@@ -86,6 +87,5 @@
         <Parameter name="upper" type="double" value="1.5"/>
       </ParameterList>
      </ParameterList>
-
   </ParameterList>
 </ParameterList>

--- a/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraphNoDistribute.xml
+++ b/packages/zoltan2/test/driver/driverinputs/chacoGraphMetricsTestNoGraphNoDistribute.xml
@@ -61,30 +61,30 @@
     <ParameterList name="Metrics">
       <ParameterList name="metriccheck1">
         <Parameter name="check" type="string" value="max edge cuts"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck2">
         <Parameter name="check" type="string" value="max edge cuts"/>
         <Parameter name="weight" type="int" value="0"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck3">
         <Parameter name="check" type="string" value="total edge cuts"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck4">
         <Parameter name="check" type="string" value="total edge cuts"/>
         <Parameter name="weight" type="int" value="0"/>
-        <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="999.0"/>
+        <Parameter name="lower" type="double" value="0"/>
+        <Parameter name="upper" type="double" value="0"/>
       </ParameterList>
       <ParameterList name="metriccheck5">
         <Parameter name="check" type="string" value="imbalance"/>
         <Parameter name="lower" type="double" value="1.0"/>
-        <Parameter name="upper" type="double" value="1.5"/>
+        <Parameter name="upper" type="double" value="1.2"/>
       </ParameterList>
      </ParameterList>
   </ParameterList>


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Description
When some processors have no IDs to partition or no graph edges, the graph metrics calculation core-dumped or caused a hang.  The culprit was attempts to compute the address of element 0 of an ArrayView of length zero.  I added tests for zero-length arrays before the attempted accesses.

## Motivation and Context
Test Zoltan2_zoltanCompare.exe failed in the metric computation for input graph nograph (which doesn't have edges).  These changes allow Zoltan2_zoltanCompare.exe to succeed.

## Related Issues
* Related to   #1533 


## How Has This Been Tested?
New tests are added that exercise the graph metrics in these conditions:
chacoGraphMetricTestNoGraph.xml -- tests graph metric computation on graph with no edges
chacoGraphMetricTestNoGraphNoDistribute.xml -- tests on graph with no edges and all input on rank 0
chacoGraphMetricTestNoDistribute.xml -- tests on graph with all input on rank 0
chacoGraphMetricTest.xml -- tests on graph with edge weights


<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
