### PR TITLE
Teuchos::{Array,ArrayView} Fix #2749

### DIFF
--- a/packages/teuchos/core/src/Teuchos_Array.hpp
+++ b/packages/teuchos/core/src/Teuchos_Array.hpp
@@ -407,8 +407,18 @@ public:
   /** \brief Return a raw pointer to beginning of array or NULL if unsized. */
   inline T* getRawPtr();
 
+  /// \brief Return a raw pointer to beginning of array.
+  ///
+  /// Same semantics as \c getRawPtr (which see).
+  inline T* data();
+
   /** \brief Return a const raw pointer to beginning of array or NULL if unsized. */
   inline const T* getRawPtr() const;
+
+  /// \brief Return a const raw pointer to beginning of array.
+  ///
+  /// Same semantics as \c getRawPtr (which see).
+  inline const T* data() const;
 
   //@}
   /** \name Conversions to and from std::vector. */
@@ -1364,16 +1374,26 @@ bool Array<T>::hasBoundsChecking()
 template<typename T> inline
 T* Array<T>::getRawPtr()
 {
-  return ( size() ? &(*this)[0] : 0 );
+  return ( size() ? &(*this)[0] : nullptr );
 }
 
+template<typename T> inline
+T* Array<T>::data()
+{
+  return ( size() ? &(*this)[0] : nullptr );
+}
 
 template<typename T> inline
 const T* Array<T>::getRawPtr() const
 {
-  return ( size() ? &(*this)[0] : 0 );
+  return ( size() ? &(*this)[0] : nullptr );
 }
 
+template<typename T> inline
+const T* Array<T>::data() const
+{
+  return ( size() ? &(*this)[0] : nullptr );
+}
 
 // Conversions to and from std::vector
 

--- a/packages/teuchos/core/src/Teuchos_ArrayView.hpp
+++ b/packages/teuchos/core/src/Teuchos_ArrayView.hpp
@@ -140,7 +140,7 @@ template<class T> inline
 ArrayView<T>::ArrayView(
   std::vector<typename ConstTypeTraits<T>::NonConstType>& vec
   )
-  : ptr_( vec.empty() ? 0 : &vec[0] ), size_(vec.size())
+  : ptr_( vec.empty() ? 0 : vec.data() ), size_(vec.size())
 {
   setUpIterators();
 }
@@ -149,7 +149,7 @@ template<class T> inline
 ArrayView<const T>::ArrayView(
   std::vector<typename ConstTypeTraits<T>::NonConstType>& vec
   )
-  : ptr_( vec.empty() ? 0 : &vec[0] ), size_(vec.size())
+  : ptr_( vec.empty() ? 0 : vec.data() ), size_(vec.size())
 {
   setUpIterators();
 }
@@ -159,7 +159,7 @@ template<class T> inline
 ArrayView<T>::ArrayView(
   const std::vector<typename ConstTypeTraits<T>::NonConstType>& vec
   )
-  : ptr_( vec.empty() ? 0 : &vec[0] ), size_(vec.size())
+  : ptr_( vec.empty() ? 0 : vec.data() ), size_(vec.size())
 {
   setUpIterators();
 }
@@ -168,7 +168,7 @@ template<class T> inline
 ArrayView<const T>::ArrayView(
   const std::vector<typename ConstTypeTraits<T>::NonConstType>& vec
   )
-  : ptr_( vec.empty() ? 0 : &vec[0] ), size_(vec.size())
+  : ptr_( vec.empty() ? 0 : vec.data() ), size_(vec.size())
 {
   setUpIterators();
 }
@@ -316,12 +316,25 @@ T* ArrayView<T>::getRawPtr() const
 }
 
 template<class T> inline
+T* ArrayView<T>::data() const
+{
+  debug_assert_valid_ptr();
+  return ptr_;
+}
+
+template<class T> inline
 const T* ArrayView<const T>::getRawPtr() const
 {
   debug_assert_valid_ptr();
   return ptr_;
 }
 
+template<class T> inline
+const T* ArrayView<const T>::data() const
+{
+  debug_assert_valid_ptr();
+  return ptr_;
+}
 
 template<class T> inline
 T& ArrayView<T>::operator[](size_type i) const

--- a/packages/teuchos/core/src/Teuchos_ArrayViewDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_ArrayViewDecl.hpp
@@ -234,6 +234,11 @@ public:
   /** \brief Return a raw pointer to beginning of array or NULL if unsized. */
   inline T* getRawPtr() const;
 
+  /// \brief Return a raw pointer to beginning of array.
+  ///
+  /// Same semantics as \c getRawPtr (which see).
+  inline T* data() const;
+
   /** \brief Random object access.
    *
    * <b>Preconditions:</b><ul>
@@ -466,6 +471,8 @@ public:
   std::string toString() const;
 
   inline const T* getRawPtr() const;
+
+  inline const T* data() const;
 
   const T& operator[] (size_type i) const;
 

--- a/packages/teuchos/core/test/MemoryManagement/ArrayView_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/ArrayView_UnitTests.cpp
@@ -98,7 +98,9 @@ TEUCHOS_UNIT_TEST( ArrayView, av_const_cast )
   ArrayView<int> av_int2 = av_const_cast<int>(av_int1);
   TEST_ASSERT(nonnull(av_int2));
   TEST_EQUALITY(av_int2.getRawPtr(), av_int1.getRawPtr());
+  TEST_EQUALITY(av_int2.data(), av_int1.data());
   TEST_EQUALITY(av_int2.getRawPtr(), arcp_int.getRawPtr());
+  TEST_EQUALITY(av_int2.data(), arcp_int.getRawPtr());
 }
 
 
@@ -194,9 +196,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, raw_ptr_self_view, T )
   ArrayView<T> view(data, 10);
   view = view(0, 5);
   TEST_EQUALITY(view.getRawPtr(), data);
+  TEST_EQUALITY(view.data(), data);
   TEST_EQUALITY_CONST(view.size(), 5);
   ArrayView<const T> cview = view.getConst();
   TEST_EQUALITY(cview.getRawPtr(), const_cast<const T*>(data));
+  TEST_EQUALITY(cview.data(), const_cast<const T*>(data));
   TEST_EQUALITY_CONST(cview.size(), 5);
 #ifdef HAVE_TEUCHOS_ARRAY_BOUNDSCHECK
   ArrayRCP<const T> cview_arcp = cview.access_private_arcp();
@@ -213,9 +217,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, raw_ptr_self_view_const, T )
   ArrayView<const T> view(data, 10);
   view = view(0, 5);
   TEST_EQUALITY(view.getRawPtr(), data);
+  TEST_EQUALITY(view.data(), data);
   TEST_EQUALITY_CONST(view.size(), 5);
   ArrayView<const T> cview = view.getConst();
   TEST_EQUALITY(cview.getRawPtr(), data);
+  TEST_EQUALITY(cview.data(), data);
   TEST_EQUALITY_CONST(cview.size(), 5);
 #ifdef HAVE_TEUCHOS_ARRAY_BOUNDSCHECK
   ArrayRCP<const T> cview_arcp = cview.access_private_arcp();
@@ -246,6 +252,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, resize_raw_ptr_self_view, T )
   ArrayView<T> view(data, 10);
   resizeRawView(view, 0, 5);
   TEST_EQUALITY(view.getRawPtr(), data);
+  TEST_EQUALITY(view.data(), data);
   TEST_EQUALITY_CONST(view.size(), 5);
   delete [] data;
   // NOTE: The above works because we are creating a completely new ArrayView
@@ -261,16 +268,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, assignmentOperator, T )
   ArrayView<T> av2;
   av2 = av1;
   TEST_EQUALITY( av1.getRawPtr(), a.getRawPtr() );
+  TEST_EQUALITY( av1.data(), a.data() );
+  TEST_EQUALITY( av1.getRawPtr(), a.data() );
+  TEST_EQUALITY( av1.data(), a.getRawPtr() );
   TEST_EQUALITY( av1.size(), as<int>(a.size()) );
   TEST_EQUALITY( av1.getRawPtr(), av2.getRawPtr() );
+  TEST_EQUALITY( av1.data(), av2.data() );
+  TEST_EQUALITY( av1.data(), av2.getRawPtr() );
+  TEST_EQUALITY( av1.getRawPtr(), av2.data() );
   TEST_EQUALITY( av1.size(), av2.size() );
   TEST_COMPARE_ARRAYS( av1, a );
   TEST_COMPARE_ARRAYS( av1, av2 );
   av1 = null;
   TEST_EQUALITY_CONST( av1.getRawPtr(), 0 );
+  TEST_EQUALITY_CONST( av1.data(), 0 );
   TEST_EQUALITY_CONST( av1.size(), 0 );
   av2 = null;
   TEST_EQUALITY_CONST( av2.getRawPtr(), 0 );
+  TEST_EQUALITY_CONST( av2.data(), 0 );
   TEST_EQUALITY_CONST( av2.size(), 0 );
 }
 
@@ -298,8 +313,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, arrayView_convertToConst, T )
 {
   const int nsize = 3;
   T t[nsize];
-  t[0] = 1; 
-  t[1] = 2; 
+  t[0] = 1;
+  t[1] = 2;
   t[2] = 3;
   ArrayView<const T> av1 = arrayView<T>(&t[0], nsize);
   TEST_EQUALITY_CONST(av1[0], 1);
@@ -319,6 +334,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, danglingView_std_vector, T )
   }
   // Access the raw pointer but it now points to invalid memory!
   TEST_EQUALITY(av.getRawPtr(), badPtr);
+  TEST_EQUALITY(av.data(), badPtr);
   // Above, we have no way to detect that the underlying std::vector object
   // has gone away.  This is the whole point of needing Teuchos::Array and
   // having an integrated set of utility classes that all work together!
@@ -334,6 +350,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ArrayView, danglingView_rcp_std_vector, T )
   }
 #ifdef TEUCHOS_DEBUG
   TEST_THROW(av.getRawPtr(), DanglingReferenceError);
+  TEST_THROW(av.data(), DanglingReferenceError);
 #endif
   // Above, because we wrapped the initial std::vector in an RCP object, we
   // can sucessfully detect when the object goes away in debug mode!

--- a/packages/teuchos/core/test/MemoryManagement/ArrayView_test.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/ArrayView_test.cpp
@@ -143,6 +143,7 @@ bool testArrayView( const int n, Teuchos::FancyOStream &out )
     TEST_EQUALITY_CONST(is_null(av2),true);
     TEST_EQUALITY_CONST(av2.size(),0);
     TEST_EQUALITY_CONST(av2.getRawPtr(),0);
+    TEST_EQUALITY_CONST(av2.getRawPtr(),av2.data());
     TEST_ITER_EQUALITY(av2.begin(),av2.end());
 #ifdef HAVE_TEUCHOS_ARRAY_BOUNDSCHECK
     TEST_THROW(av2[0],Teuchos::NullReferenceError);
@@ -155,6 +156,7 @@ bool testArrayView( const int n, Teuchos::FancyOStream &out )
     ArrayView<const T> cav2(av2); // Tests copy constructor and implicit conversion operator!
     TEST_EQUALITY_CONST(cav2.size(),0);
     TEST_EQUALITY_CONST(cav2.getRawPtr(),0);
+    TEST_EQUALITY_CONST(cav2.getRawPtr(),cav2.data());
     TEST_ITER_EQUALITY(cav2.begin(),av2.end());
 #ifdef HAVE_TEUCHOS_ARRAY_BOUNDSCHECK
     TEST_THROW(cav2[0],Teuchos::NullReferenceError);

--- a/packages/teuchos/core/test/MemoryManagement/Array_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/Array_UnitTests.cpp
@@ -194,7 +194,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Array, defaultConstruct, T )
   TEST_EQUALITY_CONST( as<int>(a2.size()), 0 );
   TEST_EQUALITY_CONST( as<int>(a2.empty()), true );
   TEST_EQUALITY_CONST( a2.getRawPtr(), 0 );
+  TEST_EQUALITY_CONST( a2.getRawPtr(), a2.data() );
   TEST_EQUALITY_CONST( getConst(a2).getRawPtr(), 0 );
+  TEST_EQUALITY_CONST( getConst(a2).getRawPtr(), getConst(a2).data() );
 }
 
 
@@ -206,7 +208,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Array, sizedConstruct, T )
   TEST_EQUALITY( a.length(), n );
   TEST_EQUALITY( as<int>(a.size()), n );
   TEST_EQUALITY( a.getRawPtr(), &a[0] );
+  TEST_EQUALITY( a.getRawPtr(), a.data() );
   TEST_EQUALITY( getConst(a).getRawPtr(), &getConst(a)[0] );
+  TEST_EQUALITY( getConst(a).getRawPtr(), getConst(a).data() );
   TEST_COMPARE( a.max_size(), >=, as<size_type>(n) );
   TEST_COMPARE( as<int>(a.capacity()), >=, n );
 }

--- a/packages/teuchos/core/test/MemoryManagement/Array_test.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/Array_test.cpp
@@ -92,7 +92,9 @@ bool testArray( const int n, Teuchos::FancyOStream &out )
   TEST_EQUALITY( a.length(), n );
   TEST_EQUALITY( as<int>(a.size()), n );
   TEST_EQUALITY( a.getRawPtr(), &a[0] );
+  TEST_EQUALITY( a.data(), &a[0] );
   TEST_EQUALITY( getConst(a).getRawPtr(), &getConst(a)[0] );
+  TEST_EQUALITY( getConst(a).data(), &getConst(a)[0] );
   TEST_COMPARE( a.max_size(), >=, as<size_type>(n) );
   TEST_COMPARE( as<int>(a.capacity()), >=, n );
 
@@ -132,7 +134,9 @@ bool testArray( const int n, Teuchos::FancyOStream &out )
     TEST_EQUALITY_CONST( as<int>(a2.size()), 0 );
     TEST_EQUALITY_CONST( as<bool>(a2.empty()), true );
     TEST_EQUALITY_CONST( a2.getRawPtr(), 0 );
+    TEST_EQUALITY_CONST( a2.data(), a2.getRawPtr() );
     TEST_EQUALITY_CONST( getConst(a2).getRawPtr(), 0 );
+    TEST_EQUALITY_CONST( getConst(a2).getRawPtr(), getConst(a2).data() );
   }
 
   {
@@ -787,7 +791,9 @@ bool testArrayOpaqueWithoutTNT( const std::string &T_name, const int n,
   TEST_EQUALITY( a.length(), n );
   TEST_EQUALITY( as<int>(a.size()), n );
   TEST_EQUALITY( a.getRawPtr(), &a[0] );
+  TEST_EQUALITY( a.getRawPtr(), a.data() );
   TEST_EQUALITY( getConst(a).getRawPtr(), &getConst(a)[0] );
+  TEST_EQUALITY( getConst(a).getRawPtr(), getConst(a).data() );
   TEST_COMPARE( a.max_size(), >=, as<size_type>(n) );
   TEST_COMPARE( as<int>(a.capacity()), >=, n );
 
@@ -855,7 +861,9 @@ bool testArrayOpaqueWithTNT( const int n, const T &someValue, Teuchos::FancyOStr
   TEST_EQUALITY( a.length(), n );
   TEST_EQUALITY( as<int>(a.size()), n );
   TEST_EQUALITY( a.getRawPtr(), &a[0] );
+  TEST_EQUALITY( a.getRawPtr(), a.data() );
   TEST_EQUALITY( getConst(a).getRawPtr(), &getConst(a)[0] );
+  TEST_EQUALITY( getConst(a).getRawPtr(), getConst(a).data() );
   TEST_COMPARE( a.max_size(), >=, as<size_type>(n) );
   TEST_COMPARE( as<int>(a.capacity()), >=, n );
 

--- a/packages/teuchos/core/test/MemoryManagement/Ptr_test.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/Ptr_test.cpp
@@ -77,16 +77,16 @@ int main( int argc, char* argv[] ) {
     //
     // Read options from the commandline
     //
-    
+
     CommandLineProcessor clp(false); // Don't throw exceptions
-    
+
     CommandLineProcessor::EParseCommandLineReturn parse_return = clp.parse(argc,argv);
-    
+
     if ( parse_return != CommandLineProcessor::PARSE_SUCCESSFUL ) {
       *out << "\nEnd Result: TEST FAILED" << std::endl;
       return parse_return;
     }
-    
+
     *out << std::endl << Teuchos::Teuchos_Version() << std::endl;
 
     *out << "\nTesting Teuchos::Ptr class ...\n";


### PR DESCRIPTION
@trilinos/teuchos 

`Teuchos::Array` and `Teuchos::ArrayView` now have a `.data()` method, for
compatibility with `std::vector` and other C++ Standard Library classes
(as of C++11), as well as `Kokkos::View`.

I took the liberty to use `std::vector::data` in the implementation of
`Teuchos::Array` instead of `&vec[0]`, and to replace a few instances of `0`
(in a pointer context) with `nullptr`.  Note that the Teuchos Memory 
Management Classes always return `nullptr` if the array length is zero;
`std::vector` does _not_ promise that.

By analogy with `std::shared_ptr<T[]>`, I did _not_ add a `.data()` method
to `Teuchos::ArrayRCP`.  The whole point of the new methods is to
increase compatibility with the C++ Standard Library.  Here is a table
of correspondences between Teuchos Memory Management Classes and C++
Standard Library classes:

Teuchos class      | Standard Library class
----------------- | --------
`Array`     | `std::vector`
`ArrayView` | `std::span` (C++20 draft)
`ArrayRCP`  | `std::shared_ptr<T[]>`

## Related Issues

* Closes #2749