### PR TITLE
Panzer: remove use of kokkos deprecated features

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFDiv_impl.hpp
@@ -84,8 +84,16 @@ public:
 
     if (use_shared_memory) {
       // Copy reused data into fast scratch space
-      scratch_view dof_values(team.team_shmem(),num_fields,fad_size);
-      scratch_view point_values(team.team_shmem(),num_points,fad_size);
+      scratch_view dof_values;
+      scratch_view point_values;
+      if (Sacado::IsADType<ScalarT>::value) {
+        dof_values = scratch_view(team.team_shmem(),num_fields,fad_size);
+        point_values = scratch_view(team.team_shmem(),num_points,fad_size);
+      }
+      else {
+        dof_values = scratch_view(team.team_shmem(),num_fields);
+        point_values = scratch_view(team.team_shmem(),num_points);
+      }
 
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_fields), [&] (const int& dof) {
 	dof_values(dof) = dof_value(cell,dof);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOFGradient_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOFGradient_impl.hpp
@@ -96,8 +96,16 @@ namespace {
 	  }
 	});
       } else {
-	scratch_view dof_values(team.team_shmem(),num_fields_,fad_size_);
-	scratch_view point_values(team.team_shmem(),num_points_,fad_size_);
+        scratch_view dof_values;
+        scratch_view point_values;
+        if (Sacado::IsADType<ScalarT>::value) {
+          dof_values = scratch_view(team.team_shmem(),num_fields_,fad_size_);
+          point_values = scratch_view(team.team_shmem(),num_points_,fad_size_);
+        }
+        else {
+          dof_values = scratch_view(team.team_shmem(),num_fields_);
+          point_values = scratch_view(team.team_shmem(),num_points_);
+        }
 
 	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,num_fields_), [&] (const int& dof) {
 	  dof_values(dof) = dof_value_(cell,dof);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_Functors.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_DOF_Functors.hpp
@@ -98,8 +98,16 @@ public:
     else {
 
       // Copy reused data into fast scratch space
-      scratch_view dof_values(team.team_shmem(),numFields,fadSize);
-      scratch_view point_values(team.team_shmem(),numPoints,fadSize);
+      scratch_view dof_values;
+      scratch_view point_values;
+      if (Sacado::IsADType<ScalarT>::value) {
+        dof_values = scratch_view(team.team_shmem(),numFields,fadSize);
+        point_values = scratch_view(team.team_shmem(),numPoints,fadSize);
+      }
+      else {
+        dof_values = scratch_view(team.team_shmem(),numFields);
+        point_values = scratch_view(team.team_shmem(),numPoints);
+      }
 
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numFields), [&] (const int& dof) {
 	dof_values(dof) = dof_basis(cell,dof);

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_DivBasisTimesScalar_impl.hpp
@@ -293,8 +293,16 @@ namespace panzer
     const int numBases = basis_.extent(1);
     const int fadSize = Kokkos::dimension_scalar(field_.get_view());
 
-    scratch_view tmp(team.team_shmem(),1,fadSize);
-    scratch_view tmp_field(team.team_shmem(),numBases,fadSize);
+    scratch_view tmp;
+    scratch_view tmp_field;
+    if (Sacado::IsADType<ScalarT>::value) {
+      tmp = scratch_view(team.team_shmem(),1,fadSize);
+      tmp_field = scratch_view(team.team_shmem(),numBases,fadSize);
+    }
+    else {
+      tmp = scratch_view(team.team_shmem(),1);
+      tmp_field = scratch_view(team.team_shmem(),numBases);
+    }
 
     // Initialize the evaluated field.
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
@@ -308,8 +308,16 @@ namespace panzer
     const int numBases = basis_.extent(1);
     const int fadSize = Kokkos::dimension_scalar(field_.get_view());
 
-    scratch_view tmp(team.team_shmem(),1,fadSize);
-    scratch_view tmp_field(team.team_shmem(),numBases,fadSize);
+    scratch_view tmp;
+    scratch_view tmp_field;
+    if (Sacado::IsADType<ScalarT>::value) {
+      tmp = scratch_view(team.team_shmem(),1,fadSize);
+      tmp_field = scratch_view(team.team_shmem(),numBases,fadSize);
+    }
+    else {
+      tmp = scratch_view(team.team_shmem(),1);
+      tmp_field = scratch_view(team.team_shmem(),numBases);
+    }
 
     // Initialize the evaluated field.
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases),KOKKOS_LAMBDA (const int& basis) {


### PR DESCRIPTION
This commit removes all use of deprecated kokkos features in panzer. Next kokkos promotion will remove these features as noted by @ndellingwood in email below.

https://github.com/kokkos/kokkos/wiki/DeprecationPage

Hi Roger,
 
While prepping for the next Kokkos+KokkosKernels promotion I saw several Panzer tests were failing with Cuda in the Trilinos develop branch (SHA 80e2cb3) when configuring with KOKKOS_ENABLE_DEPRECATED_CODE=OFF (none of them failed with deprecated code on, as expected). These failures must have slipped in after the previous promotion, but are not caused by any recent updates in Kokkos. The runtime failures seem to be caused by view(s) being constructed somewhere with more arguments than dynamic rank (e.g. View<double*> v(“v”, N, M); would trigger such an error with deprecated code off).
 
I’ll put more reproducer info below, let me know if you’d like an issue opened on Github for tracking.
 
Thanks!
 
Nathan
 