### PR TITLE
New scripts for getting jenkins to clean up (somewhat)

### DIFF
--- a/commonTools/framework/clean_workspace/Modules.py
+++ b/commonTools/framework/clean_workspace/Modules.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+# pylint: disable=wrong-import-position
+# pylint: disable=relative-import
+"""Fuctions for managing Environment Modules in Sierra python scripts."""
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+import os
+import subprocess
+
+from util import which, find_first_binary, find_file_in_list
+
+
+class Module(object):
+    """Class to hold module configuration and provide module commands"""
+    def __init__(self, name=None):
+        self.paths = self._setup_paths()
+        self.command_name = os.environ.get('LMOD_CMD', 'modulecmd')
+        self.command = self._setup_command()
+        self.init_file = self._module_setup(name)
+        if name is None and self.init_file:
+            execfile(self.init_file)
+
+    @staticmethod
+    def _setup_paths():
+        """Set paths to modules"""
+        paths = ["/usr/local/modules/default",
+                 "/usr/local/Modules/default",
+                 "/usr/netpub/modules/default",
+                 "/opt/modules/default",
+                 "/projects/modules/default",
+                 "/usr/share/modules",
+                 "/usr/share/Modules"]
+
+        if 'MODULESHOME' in os.environ:
+            paths.append(os.path.join(os.environ['MODULESHOME']))
+        return paths
+
+    def _setup_command(self):
+        """Set command for module"""
+        command = which(self.command_name)
+        if command:
+            self.paths.append(os.path.dirname(command))
+        self.command_name = os.path.basename(self.command_name)
+
+        return command
+
+    def _module_setup(self, name=None):
+        """Set up modules for the Sierra nightly processes."""
+        if not name:
+            name = 'python'
+        # Look for the modules init files for python.
+        # Look for a modulecmd script that we can execute on this machine,
+        # and thatis paired with an init/python script.
+        modules_init_file = None
+        if os.environ.get('LMOD_CMD') and name == 'python':
+            self.command = os.environ.get('LMOD_CMD')
+        else:
+            self.command = os.environ.get('LMOD_CMD',
+                                          find_first_binary("modulecmd",
+                                                            self.paths, '-V'))
+
+            if self.command:
+                # Look for the executable module init file relative to the
+                # command binary.
+                fname = os.path.join('init', name)
+                grandparent_dir = os.path.dirname(
+                    os.path.dirname(self.command))
+                modules_init_file = which(fname, grandparent_dir)
+                if not modules_init_file:
+                    modules_init_file = which(fname + '.py', grandparent_dir)
+                if not modules_init_file:
+                    # If we didn't find it relative to the command binary, look
+                    # for it in the standard paths. Again, this is a hack for
+                    # Modules/3.1.6
+                    modules_init_file = find_file_in_list(fname, self.paths)
+                    if not modules_init_file:
+                        modules_init_file = find_file_in_list(
+                            fname + '.py', self.paths)
+                    if not modules_init_file:
+                        raise RuntimeError('Unable to find modules '
+                                           'init/python file in {}.'.
+                                           format(' '.join(self.paths)))
+                # We need to set the MODULESHOME environment variable if
+                # it is not yet set.
+                if modules_init_file and 'MODULESHOME' not in os.environ:
+                    os.environ['MODULESHOME'] = os.path.dirname(
+                        os.path.dirname(modules_init_file))
+        return modules_init_file
+
+    def _echo_module(self, command, *arguments):
+        """A function to execute module commands from a python script,
+           and return the exit code, stdout, and stderr to the caller."""
+        # If the modulecmd executable wasn't found when this script was
+        # initialized, or if MODULESHOME is no longer in the environment, look
+        # for it in PATH. This is needed because in 3.1.6 a 'module purge'
+        # deletes the MODULESHOME variable, so we can't always use it to find
+        # modulecmd.
+        try:
+            cmd = os.environ.get('LMOD_CMD')
+            if not cmd:
+                cmd = '%s/bin/%s' % (
+                    os.environ['MODULESHOME'], self.command_name)
+        except Exception:  # pylint: disable=broad-except
+            cmd = self.command
+        if not cmd or not os.path.exists(cmd):
+            cmd = self.command
+            if not which(cmd):
+                print("Unable to load modules; no {} found.".format(
+                    self.command_name), file=sys.stderr)
+                return '', '', ''
+        cmdline = '%s python %s %s' % (cmd, command, ' '.join(arguments))
+
+        # Get all the output at once.
+        subp = subprocess.Popen(cmdline,
+                                shell=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, )
+        (stdout, stderr) = subp.communicate()
+        errcode = subp.wait()
+
+        return errcode, stdout, stderr
+
+    def module(self, command, *arguments):
+        """A function to execute module commands from a python script."""
+        # Normally this function returns nothing as its value. However, if the
+        # special string 'no-stderr' is found in the arguments list this
+        # function will return the lines collected from stderr.
+        # See the _echo_module function for more information how this
+        # argument is used.
+
+        # Look for the special argument 'no-stderr'. If we find it, flag and
+        # remove it. Anything written to stderr by command will not be
+        # written to sys.stderr if this flag is passed. It will be
+        # returned as the function value, however.
+        no_stderr = 'no-stderr' in arguments
+        if no_stderr:
+            arguments = list(arguments)
+            arguments.remove('no-stderr')
+
+        (_, output, stderr) = self._echo_module(command, *arguments)
+
+        # The modules return a string of python commands to be executed on
+        # stdout.  Execute those commands now.
+        if output:
+            exec (output)  # pylint: disable=exec-used
+
+        # Check stderr for anything that looks like an error.
+        if ":ERROR:" in stderr:
+            raise RuntimeError(stderr)
+        elif stderr:
+            # Do not print stderr if no-stderr was passed
+            if not no_stderr:
+                print(stderr, file=sys.stderr)
+        return stderr
+
+    def module_list(self):
+        """A wrapper around 'module list' that sorts the output."""
+        # This function differs from 'module list' in that it will sort the
+        # module names reported to ensure a consistent order, then write
+        # the resulting sorted list to stderr.
+        mnames = self.module('--terse', 'list', 'no-stderr')
+        mlist = []
+        if mnames:
+            mlist = mnames.splitlines()
+
+        # Sort the module names list (from 1 to the end) to maintain a
+        # consistent order. We skip line 1 because that is the header line.
+        if len(mlist) > 1:
+            names = mlist[1:]
+            del mlist[1:]
+            names.sort()
+            mlist.extend(names)
+        # Now re-write the sorted names to stderr.
+        sys.stderr.writelines('\n'.join(mlist) + '\n')
+
+
+def module(command, *arguments):
+    """Legacy support of module call"""
+    return Module().module(command, *arguments)
+
+
+def module_list():
+    """Legacy support of module_list call"""
+    Module().module_list()
+
+
+def get_init_file():
+    """Called when script is executed to print name of init file"""
+    # If this module is invoked directly, print the modules_init_file found
+    # for the passed name.
+    # Note that $1 must be a Modules shell init file name.
+    if len(sys.argv) != 2:
+        raise RuntimeError('A single init file name parameter is required'
+                           ' by Modules.py when invoked directly')
+    init_file = Module(sys.argv[1]).init_file
+    if not init_file:
+        raise RuntimeError('Unable to determine init file for {}'
+                           ' in Modules.py'.format(sys.argv[1]))
+    print(init_file)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    get_init_file()

--- a/commonTools/framework/clean_workspace/clean_all_jobs
+++ b/commonTools/framework/clean_workspace/clean_all_jobs
@@ -1,0 +1,1 @@
+clean_all_jobs.py

--- a/commonTools/framework/clean_workspace/clean_all_jobs.py
+++ b/commonTools/framework/clean_workspace/clean_all_jobs.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+# Change above to '/usr/bin/python -3' for python 3.x porting warnings
+"""
+This script will clean the current workspace IFF
+   It is called post-build
+  or
+   The workspace has not been cleaned since the date in the sentinel file
+"""
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import pickle
+
+from clean_sentinel import set_reference_date
+
+
+class CleanReference(object):
+    """Sets the current time as the reference clean date"""
+
+    def run(self):
+        """Run the actual routine in clean_sentinel"""
+        try:
+            set_reference_date()
+        except StandardError as e:
+            print(e.args, file=sys.stderr)
+            sys.exit()
+        except pickle.PicklingError:
+            print('Pickle Failure', file=sys.stderr)
+            sys.exit()

--- a/commonTools/framework/clean_workspace/clean_sentinel.py
+++ b/commonTools/framework/clean_workspace/clean_sentinel.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+# Change above to '/usr/bin/python -3' for python 3.x porting warnings
+"""
+This contains abstractions to handle the reference date for the last required
+full clean.
+"""
+import sys
+sys.dont_write_bytecode = True
+
+import os
+
+from datetime import datetime
+import pickle
+
+
+def clean_reference_date():
+    """Returns a datetime object of the last requested clean state"""
+    defaultReturnDate = datetime(2019, 2, 4, hour=10, minute=45,
+                                 second=0, microsecond=0, tzinfo=None)
+    date_file_name = os.path.join(os.path.sep, 'ascldap', 'users',
+                                  'trilinos', '.cleanAllWorkspacesDatefile')
+    return read_date(date_file_name, defaultReturnDate)
+
+
+def set_reference_date():
+    """Sets the requested clean state to the current time"""
+    newReferenceDate = datetime.now()
+    date_file_name = os.path.join(os.path.sep, 'ascldap', 'users',
+                                  'trilinos', '.cleanAllWorkspacesDatefile')
+    with open(date_file_name) as pickleFile:
+        pickle.dump(newReferenceDate, pickleFile)
+
+
+def last_clean_date():
+    """Returns a datetime object of the last requested clean state"""
+    defaultReturnDate = datetime(2019, 2, 4, hour=10, minute=46,
+                                 second=0, microsecond=0, tzinfo=None)
+    date_file_name = os.path.join(os.environ['WORKSPACE'], 'lastCleanDate')
+    return read_date(date_file_name, defaultReturnDate)
+
+
+def update_last_clean_date():
+    """stores a datetime object of the current date"""
+    currentDate = datetime.now()
+    date_file_name = os.path.join(os.environ['WORKSPACE'], 'lastCleanDate')
+    with open(date_file_name, 'w') as sFile:
+        pickle.dump(currentDate, sFile)
+    return
+
+
+def read_date(date_file, defaultReturnDate):
+    returnValue = defaultReturnDate
+    try:
+        with open(date_file) as pickleFile:
+            try:
+                returnValue = pickle.load(pickleFile)
+            except pickle.UnpicklingError:
+                pass
+    except IOError:
+        pass
+    return returnValue

--- a/commonTools/framework/clean_workspace/clean_workspace
+++ b/commonTools/framework/clean_workspace/clean_workspace
@@ -1,0 +1,1 @@
+clean_workspace.py

--- a/commonTools/framework/clean_workspace/clean_workspace.py
+++ b/commonTools/framework/clean_workspace/clean_workspace.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+# Change above to '/usr/bin/python -3' for python 3.x porting warnings
+"""
+This script will clean the current workspace IFF 
+   It is called post-build
+  or
+   The workspace has not been cleaned since the date in the sentinel file
+"""
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import argparse
+import subprocess
+
+from clean_sentinel import clean_reference_date
+from clean_sentinel import last_clean_date
+from clean_sentinel import update_last_clean_date
+
+from Modules import Module as Moduler
+
+
+class Cleaner(object):
+    """Class to hold the capability
+         Parse if we are at start or end
+         Call appropriate function
+    """
+
+    def __init__(self):
+        self.args = None
+
+    def run(self):
+        self.args = self.parse_args()
+        if self.args.dir is None:
+            raise SystemExit("No directory passed - exiting!")
+        if self.args.force:
+            self.force_clean_space()
+        else:
+            self.clean_space_by_date()
+
+    def parse_args(self):
+        """
+        Get the options that were passed in and return them in a namespace
+        """
+        parser = argparse.ArgumentParser(description='Parser for the clean_workspace class')
+        parser.add_argument('dir',
+                            help="directory to clean",
+                            action="store")
+        parser.add_argument('--force-clean',
+                            help="force a local cleanup",
+                            action="store_true",
+                            default=False)
+        options = parser.parse_args()
+        return options
+
+    def force_clean_space(self):
+        """Do the actual cleanup
+             Load the module to enable ninja
+             Run "make -C %s clean"
+        """
+        Moduler.module('load', 'atdm-env')
+        Moduler.module('load', 'atdm-ninja_fortran/1.7.2')
+        subprocess.check_call(['make', '-C', self.args.dir, 'clean'])
+
+    def clean_space_by_date(self):
+        if last_clean_date() < clean_reference_date():
+            self.force_clean_space()
+            update_last_clean_date()
+        
+if __name__ == '__main__':
+    clean = Cleaner()
+    clean.run()

--- a/commonTools/framework/clean_workspace/unittests/test_Modules.py
+++ b/commonTools/framework/clean_workspace/unittests/test_Modules.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+"""Implements tests for Modules.py."""
+# pylint: disable=wrong-import-position
+# pylint: disable=invalid-name
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import os
+import unittest
+import mock
+from cStringIO import StringIO
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir))
+import Modules
+
+
+class TestModules(unittest.TestCase):
+    """Test Modules script"""
+
+    def setUp(self):
+        modules_home = {'MODULESHOME': '/dummy/path/1'}
+        which_side_effects = ['/path/to/modulecmd', None, None]
+        find_side_effects = [None, '/fake/path/modules/init/python.py']
+        with mock.patch.dict(os.environ, modules_home), \
+                mock.patch('Modules.which',
+                           side_effect=which_side_effects), \
+                mock.patch('Modules.find_first_binary',
+                           return_value='/fake/path/modulecmd'), \
+                mock.patch('Modules.find_file_in_list',
+                           side_effect=find_side_effects), \
+                mock.patch('__builtin__.execfile'):
+            self.module_obj = Modules.Module()
+
+    def test_module_setup(self):
+        """Test ability to instantiate the class"""
+        modules_home = {'MODULESHOME': '/dummy/path/1'}
+        which_side_effects = ['/path/to/modulecmd', None, None]
+        find_side_effects = [None, '/fake/path/modules/init/python.py']
+        with mock.patch.dict(os.environ, modules_home), \
+                mock.patch('Modules.which',
+                           side_effect=which_side_effects), \
+                mock.patch('Modules.find_first_binary',
+                           return_value='/fake/path/modulecmd'), \
+                mock.patch('Modules.find_file_in_list',
+                           side_effect=find_side_effects), \
+                mock.patch('__builtin__.execfile') as mock_exec:
+            result = Modules.Module()
+        mock_exec.assert_called_once_with(find_side_effects[-1])
+        self.assertEqual('/fake/path/modulecmd', result.command)
+        self.assertEqual('modulecmd', result.command_name)
+        self.assertEqual('/fake/path/modules/init/python.py', result.init_file)
+
+    def test_module_setup_lmod(self):
+        """Test ability to instantiate the class if on a system using lmod"""
+        modules_env = {'MODULESHOME': '/dummy/path/1', 'LMOD_CMD': 'lmodcmd'}
+        which_side_effects = ['/path/to/lmodcmd', None, None]
+        find_side_effects = [None, '/fake/path/modules/init/python.py']
+        with mock.patch.dict(os.environ, modules_env), \
+                mock.patch('Modules.which',
+                           side_effect=which_side_effects), \
+                mock.patch('Modules.find_first_binary',
+                           return_value='/fake/path/lmodcmd'), \
+                mock.patch('Modules.find_file_in_list',
+                           side_effect=find_side_effects), \
+                mock.patch('__builtin__.execfile') as mock_exec:
+            result = Modules.Module()
+        mock_exec.assert_not_called()
+        self.assertEqual('lmodcmd', result.command)
+        self.assertEqual('lmodcmd', result.command_name)
+        self.assertEqual(None, result.init_file)
+
+    def test_module_list(self):
+        """Test the module_list method"""
+        loaded_modules = '''Currently Loaded Modulefiles:
+sierra-python/2.7
+sierra-git/2.6.1
+'''
+        expected = [loaded_modules.splitlines()[0],
+                    loaded_modules.splitlines()[2],
+                    loaded_modules.splitlines()[1]]
+
+        with mock.patch('sys.stderr', new_callable=StringIO) as err_output, \
+             mock.patch('sys.stdout', new_callable=StringIO) as std_output:
+            with mock.patch('Modules.Module.module',
+                            return_value=loaded_modules):
+                self.module_obj.module_list()
+            stderr = err_output.getvalue()
+            stdout = std_output.getvalue()
+        self.assertEqual(expected, stderr.splitlines())
+        self.assertEqual('', stdout)
+
+    def test_module(self):
+        """Test module method"""
+        with mock.patch('sys.stderr', new_callable=StringIO) as err_output, \
+             mock.patch('sys.stdout', new_callable=StringIO) as std_output:
+            with mock.patch.dict('os.environ', {}), \
+                    mock.patch('os.path.exists', return_value=True), \
+                    mock.patch('subprocess.Popen') as mock_subproc_popen:
+                process_mock = mock.Mock()
+                attrs = {'communicate.return_value': ('print("exec_cmd")',
+                                                      'error output'),
+                         'wait.return_value': 0}
+                process_mock.configure_mock(**attrs)
+                mock_subproc_popen.return_value = process_mock
+                result = self.module_obj.module('load', 'sierra')
+            stdout = std_output.getvalue()
+            stderr = err_output.getvalue()
+        self.assertEqual('error output', result)
+        self.assertEqual('exec_cmd\n', stdout)
+        self.assertEqual('error output\n', stderr)
+
+    def test_module_no_command(self):
+        """Test module method when unable to find the module command in the
+        environment"""
+        with mock.patch('sys.stderr', new_callable=StringIO) as err_output, \
+             mock.patch('sys.stdout', new_callable=StringIO) as std_output:
+            with mock.patch.dict('os.environ', {}), \
+                    mock.patch('os.path.exists', return_value=False), \
+                    mock.patch('subprocess.Popen') as mock_subproc_popen:
+                process_mock = mock.Mock()
+                attrs = {'communicate.return_value': ('print("exec_cmd")',
+                                                      'error output'),
+                         'wait.return_value': 0}
+                process_mock.configure_mock(**attrs)
+                mock_subproc_popen.return_value = process_mock
+                result = self.module_obj.module('load', 'sierra')
+            stdout = std_output.getvalue()
+            stderr = err_output.getvalue()
+        self.assertEqual('', result)
+        self.assertEqual('', stdout)
+        self.assertEqual('Unable to load modules; no modulecmd found.\n',
+                         stderr)
+
+    def test_module_error(self):
+        """Test module command when there is an error loading the module"""
+        with mock.patch('sys.stdout', new_callable=StringIO) as std_output:
+            with mock.patch.dict('os.environ', {}), \
+                    mock.patch('os.path.exists', return_value=True), \
+                    mock.patch('subprocess.Popen') as mock_subproc_popen:
+                process_mock = mock.Mock()
+                attrs = {'communicate.return_value': ('print("exec_cmd")',
+                                                      'module:ERROR: error '
+                                                      'encountered'),
+                         'wait.return_value': 0}
+                process_mock.configure_mock(**attrs)
+                mock_subproc_popen.return_value = process_mock
+                error_msg = 'module:ERROR: error encountered'
+                with self.assertRaisesRegexp(RuntimeError, error_msg):
+                    self.module_obj.module('load', 'sierra')
+            stdout = std_output.getvalue()
+        self.assertEqual('exec_cmd\n', stdout)
+
+    def test_module_no_stderr_in_args(self):
+        """Test the module method when passed no-stderr"""
+        with mock.patch('sys.stderr', new_callable=StringIO) as err_output, \
+             mock.patch('sys.stdout', new_callable=StringIO) as std_output:
+            with mock.patch.dict('os.environ', {}), \
+                    mock.patch('os.path.exists', return_value=True), \
+                    mock.patch('subprocess.Popen') as mock_subproc_popen:
+                process_mock = mock.Mock()
+                attrs = {'communicate.return_value': ('print("exec_cmd")',
+                                                      'error_output'),
+                         'wait.return_value': 0}
+                process_mock.configure_mock(**attrs)
+                mock_subproc_popen.return_value = process_mock
+                result = self.module_obj.module('load', 'sierra', 'no-stderr')
+            stdout = std_output.getvalue()
+            stderr = err_output.getvalue()
+        self.assertEqual('error_output', result)
+        self.assertEqual('exec_cmd\n', stdout)
+        self.assertEqual('', stderr)
+
+
+class TestModuleCommands(unittest.TestCase):
+    """Test the module commands present for legacy support"""
+    @staticmethod
+    def test_module():
+        """Test the module function"""
+        with mock.patch('Modules.Module.module') as mock_module:
+            Modules.module('load', 'sierra/version')
+        mock_module.assert_called_once_with('load', 'sierra/version')
+
+    @staticmethod
+    def test_module_list():
+        """Test the module_list function"""
+        with mock.patch('Modules.Module.module_list') as mock_module:
+            Modules.module_list()
+        mock_module.assert_called_once_with()
+
+
+class TestGetInitFile(unittest.TestCase):
+    """Test the function that gets called when script is run directly"""
+    def test_get_init_file(self):
+        """Test the method that gets called when script is run directly"""
+
+        modules_home = {'MODULESHOME': '/dummy/path/1'}
+        which_side_effects = ['/path/to/modulecmd', None, None]
+        find_side_effects = [None, '/fake/path/modules/init/python.py']
+        with mock.patch('sys.stdout', new_callable=StringIO) as output:
+            with mock.patch.object(sys, 'argv', ['Modules', 'python']):
+                with mock.patch.dict(os.environ, modules_home), \
+                        mock.patch('Modules.which',
+                                   side_effect=which_side_effects), \
+                        mock.patch('Modules.find_first_binary',
+                                   return_value='/fake/path/modulecmd'), \
+                        mock.patch('Modules.find_file_in_list',
+                                   side_effect=find_side_effects), \
+                        mock.patch('__builtin__.execfile') as exec_file:
+                    Modules.get_init_file()
+            stdout = output.getvalue()
+        self.assertEqual('/fake/path/modules/init/python.py\n', stdout)
+        exec_file.assert_not_called()
+
+    def test_get_init_file_no_file_found(self):
+        """Test the function that gets called when script is run directly
+        when no init file is returned"""
+        modules_home = {'MODULESHOME': '/dummy/path/1'}
+        which_side_effects = ['/path/to/modulecmd', None, None]
+        find_side_effects = [None, None]
+        with mock.patch.object(sys, 'argv', ['Modules', 'python']):
+            with mock.patch.dict(os.environ, modules_home), \
+                    mock.patch('Modules.which',
+                               side_effect=which_side_effects), \
+                    mock.patch('Modules.find_first_binary',
+                               return_value=None), \
+                    mock.patch('Modules.find_file_in_list',
+                               side_effect=find_side_effects), \
+                    mock.patch('__builtin__.execfile') as exec_file:
+                error = 'Unable to determine init file for python in ' \
+                        'Modules.py'
+                with self.assertRaisesRegexp(RuntimeError, error):
+                    Modules.get_init_file()
+        exec_file.assert_not_called()
+
+    def test_get_init_file_no_param_passed(self):
+        """Test the method that gets called when script is run directly when
+        no params are passed"""
+        error = 'A single init file name parameter is required by ' \
+                'Modules.py when invoked directly'
+        with mock.patch.object(sys, 'argv', ['Modules']):
+            with self.assertRaisesRegexp(RuntimeError, error):
+                Modules.get_init_file()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/commonTools/framework/clean_workspace/unittests/test_clean_all_jobs.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_all_jobs.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+"""Implements tests for the clean_sentinel script."""
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import os
+sys.path.insert(1, os.path.dirname(os.path.dirname(__file__)))
+
+from cStringIO import StringIO
+
+import unittest
+import mock
+
+import pickle
+
+# pylint: disable=import-error
+from clean_all_jobs import CleanReference
+
+class TestRun(unittest.TestCase):
+
+    def test_clean_run(self):
+        """If there is no dir attribute in the args raise SystemExit"""
+        cleanRefInst = CleanReference()
+        with mock.patch('clean_all_jobs.set_reference_date') as refDate:
+            cleanRefInst.run()
+        refDate.assert_called_once()
+
+    def test_pickling_exception(self):
+        """A Pickling exception should give an error and exit"""
+        cleanRefInst = CleanReference()
+        with mock.patch('clean_all_jobs.set_reference_date',
+                        side_effect=pickle.PicklingError()), \
+             mock.patch('sys.stderr', new_callable=StringIO):
+            with self.assertRaises(SystemExit):
+                cleanRefInst.run()
+
+    def test_io_exception(self):
+        """A Pickling exception should give an error and exit"""
+        cleanRefInst = CleanReference()
+        with mock.patch('clean_all_jobs.set_reference_date',
+                        side_effect=IOError()), \
+             mock.patch('sys.stderr', new_callable=StringIO):
+            with self.assertRaises(SystemExit):
+                cleanRefInst.run()

--- a/commonTools/framework/clean_workspace/unittests/test_clean_sentinel.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_sentinel.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+"""Implements tests for the clean_sentinel script."""
+# pylint: disable=wrong-import-position
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import os
+sys.path.insert(1, os.path.dirname(os.path.dirname(__file__)))
+
+
+import unittest
+import mock
+from datetime import datetime
+import pickle
+
+# pylint: disable=import-error
+from clean_sentinel import clean_reference_date
+# pylint: disable=import-error
+from clean_sentinel import set_reference_date
+# pylint: disable=import-error
+from clean_sentinel import last_clean_date
+# pylint: disable=import-error
+from clean_sentinel import update_last_clean_date
+
+
+class TestCleanReferenceDate(unittest.TestCase):
+    """Function to return the date of the last requested clean"""
+
+    def test_default_date(self):
+        """Test that the function returns the expected date"""
+        testDate = datetime(2019, 2, 4, hour=10, minute=45,
+                            second=0, microsecond=0, tzinfo=None)
+        self.assertEqual(testDate, clean_reference_date())
+
+    def test_stored_date(self):
+        """If a different date has been stored make sure it gets retrieved"""
+        testDate = datetime(2021, 3, 31, hour=3, minute=4,
+                            second=32)
+        with mock.patch('clean_sentinel.pickle.load',
+                        return_value=testDate), \
+             mock.patch('clean_sentinel.open'):
+                self.assertEqual(testDate, clean_reference_date())
+
+    def test_missing_reference_file(self):
+        """No file present should result in the default result"""
+        testDate = datetime(2021, 3, 31, hour=3, minute=4,
+                            second=32)
+        defaultDate = datetime(2019, 2, 4, hour=10, minute=45,
+                            second=0, microsecond=0, tzinfo=None)
+
+        with mock.patch('clean_sentinel.pickle.load',
+                        return_value=testDate), \
+             mock.patch('clean_sentinel.open',
+                        side_effect=IOError()):
+            self.assertEqual(defaultDate, clean_reference_date())
+
+
+class TestSetReferenceDate(unittest.TestCase):
+    """Function to set the date of the last requested clean"""
+
+    def test_store_date(self):
+        """If store the current date"""
+        testDate = datetime.now()
+        with mock.patch('clean_sentinel.pickle.dump') as pDump, \
+             mock.patch('clean_sentinel.open'):
+            set_reference_date()
+        self.assertTrue(testDate < pDump.call_args[0][0])
+
+
+class TestLastCleanDate(unittest.TestCase):
+    """Function to return the date of the last completed clean"""
+
+    def test_default_date(self):
+        """Test that the default previous clean date is built
+           - currently set a year back"""
+        testDate = datetime(2019, 2, 4, hour=10, minute=46,
+                            second=0, microsecond=0, tzinfo=None)
+        with mock.patch.dict('os.environ',
+                             {'WORKSPACE': '/scratch/Trilinos/foo/bar'}):
+            self.assertEqual(testDate, last_clean_date())
+
+    def test_stored_date(self):
+        """Test that a stored date will be properly retrived"""
+        testDate = datetime(2016, 12, 4, hour=1, minute=5,
+                            second=0, microsecond=0)
+
+        with mock.patch('clean_sentinel.pickle.load',
+                        return_value=testDate), \
+             mock.patch('clean_sentinel.open'), \
+             mock.patch.dict('os.environ',
+                             {'WORKSPACE': '/scratch/trilinos/foo/bar'}):
+            self.assertEqual(testDate, last_clean_date())
+
+    def test_missing_reference_file(self):
+        """No file present should result in the default result"""
+        testDate = datetime(2021, 3, 29, hour=3, minute=4,
+                            second=32)
+        defaultDate = datetime(2019, 2, 4, hour=10, minute=45,
+                               second=0, microsecond=0, tzinfo=None)
+
+        with mock.patch('clean_sentinel.pickle.load',
+                        return_value=testDate), \
+             mock.patch('clean_sentinel.open',
+                        side_effect=IOError()):
+            self.assertEqual(defaultDate, clean_reference_date())
+
+
+class TestUpdateLastCleanDate(unittest.TestCase):
+    """Function to update the date of the last completed clean"""
+
+    def test_update_last_clean_date_writes(self):
+        """Test that the current date is stored"""
+        with mock.patch('clean_sentinel.pickle.dump') as p_save, \
+             mock.patch('clean_sentinel.open') as pFile, \
+             mock.patch.dict('os.environ',
+                             {'WORKSPACE': '/scratch/trilinos/foo/bar'}):
+            self.assertEqual(None, update_last_clean_date())
+        p_save.assert_called_once()
+        pFile.assert_called_once()
+
+    def test_update_last_clean_date_raises_with_no_file(self):
+        """Test that the current date is stored"""
+        with mock.patch.dict('os.environ',
+                             {'WORKSPACE': '/scratch/trilinos/foo/bar'}):
+            with self.assertRaises(IOError):
+                update_last_clean_date()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+"""Implements tests for the clean_sentinel script."""
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import os
+sys.path.insert(1, os.path.dirname(os.path.dirname(__file__)))
+
+from cStringIO import StringIO
+
+import unittest
+import mock
+
+from argparse import Namespace
+from datetime import datetime
+
+# pylint: disable=import-error
+from clean_workspace import Cleaner
+
+class TestRun(unittest.TestCase):
+
+    def test_no_directory_raises(self):
+        """If there is no dir attribute in the args raise SystemExit"""
+        test_args = Namespace()
+        setattr(test_args, 'dir', None)
+        setattr(test_args, 'force', False)
+        with mock.patch.object(Cleaner, 'parse_args', return_value=test_args):
+            cleanerInst = Cleaner()
+            with self.assertRaises(SystemExit):
+                cleanerInst.run()
+
+
+    def test_force_calls_clean(self):
+        """If force is passed go straight to cleanup"""
+        test_args = Namespace()
+        setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
+        setattr(test_args, 'force', True)
+        with mock.patch.object(Cleaner, 'parse_args', return_value=test_args):
+            cleanerInst = Cleaner()
+            with mock.patch.object(Cleaner, 'force_clean_space') as force_clean:
+                cleanerInst.run()
+            force_clean.assert_called_once()
+
+    def test_dir_calls_clean_by_date(self):
+        """If force is passed go straight to cleanup"""
+        test_args = Namespace()
+        setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
+        setattr(test_args, 'force', False)
+        with mock.patch.object(Cleaner, 'parse_args', return_value=test_args):
+            cleanerInst = Cleaner()
+            with mock.patch.object(Cleaner, 'clean_space_by_date') as force_clean:
+                cleanerInst.run()
+            force_clean.assert_called_once()
+
+
+class TestParseArgs(unittest.TestCase):
+
+    def test_no_args_gives_help_and_exits(self):
+        """Test that the function does the right thing when given no arguments"""
+        usage_message = ('usage: programName [-h] [--force-clean] dir\n'
+                         'programName: error: too few arguments\n')
+        with self.assertRaises(SystemExit), \
+             mock.patch.object(sys, 'argv', ['programName']), \
+             mock.patch('sys.stderr', new_callable=StringIO) as cleanOut:
+            cleanerInst = Cleaner()
+            cleanerInst.parse_args()
+        self.assertEqual(usage_message, cleanOut.getvalue())
+
+    def test_dir_only(self):
+        """Passing a directory will eliminate the SystemExit and set args.dir"""
+        with mock.patch.object(sys, 'argv', ['programName',
+                                             os.path.join(os.path.sep, 'scratch',
+                                                          'trilinos', 'workspace')]):
+            cleanerInst = Cleaner()
+            args = cleanerInst.parse_args()
+        self.assertEqual(os.path.join(os.path.sep, 'scratch',
+                                      'trilinos', 'workspace'),
+                         args.dir)
+        self.assertEqual(False, args.force_clean)
+
+    def test_force(self):
+        """Adding the --force option must set the action to True"""
+        with mock.patch.object(sys, 'argv', ['programName',
+                                             os.path.join(os.path.sep, 'scratch',
+                                                          'trilinos', 'workspace'),
+                                             '--force']):
+            cleanerInst = Cleaner()
+            args = cleanerInst.parse_args()
+        self.assertEqual(os.path.join(os.path.sep, 'scratch',
+                                      'trilinos', 'workspace'),
+                         args.dir)
+        self.assertEqual(True, args.force_clean)
+
+
+class TestForceCleanSpace(unittest.TestCase):
+
+    def test_calls(self):
+        """This function does the final cleanup  so its just module loads and a subprocess call"""
+        test_args = Namespace()
+        setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
+        setattr(test_args, 'force', True)
+        cleanerInst = Cleaner()
+        cleanerInst.args = test_args
+        with mock.patch('clean_workspace.Moduler.module') as mod, \
+             mock.patch('clean_workspace.subprocess.check_call') as check_call:
+            cleanerInst.force_clean_space()
+        mod.assert_has_calls([mock.call('load', 'atdm-env'),
+                              mock.call('load', 'atdm-ninja_fortran/1.7.2')])
+        check_call.assert_called_once_with(['make', '-C',
+                                            test_args.dir, 'clean'])
+
+
+class TestCleanSpaceByDate(unittest.TestCase):
+
+    def test_defaults_do_not_clean(self):
+        """The default dates should result in no clean action"""
+        cleanerInst = Cleaner()
+        with mock.patch.dict('os.environ',
+                             {'WORKSPACE': '/scratch/Trilinos/foo/bar'}):
+            with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
+                 mock.patch('clean_workspace.update_last_clean_date') as update:
+                cleanerInst.clean_space_by_date()
+            force_clean.assert_not_called()
+            update.assert_not_called()
+
+
+    def test_newer_reference_does_clean(self):
+        """The default dates should result in no clean action"""
+        testDate = datetime(2019, 2, 4, hour=10, minute=48)
+        with mock.patch('clean_workspace.clean_reference_date', return_value=testDate):
+            cleanerInst = Cleaner()
+            with mock.patch.dict('os.environ',
+                                 {'WORKSPACE': '/scratch/Trilinos/foo/bar'}):
+                with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
+                     mock.patch('clean_workspace.update_last_clean_date') as update:
+                    cleanerInst.clean_space_by_date()
+                force_clean.assert_called_once()
+                update.assert_called_once()
+
+
+    def test_older_date_does_clean(self):
+        """The default dates should result in no clean action"""
+        testDate = datetime(2019, 2, 4, hour=10, minute=0)
+        with mock.patch('clean_workspace.last_clean_date', return_value=testDate):
+            cleanerInst = Cleaner()
+            with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
+                 mock.patch('clean_workspace.update_last_clean_date') as update:
+                cleanerInst.clean_space_by_date()
+            force_clean.assert_called_once()
+            update.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/commonTools/framework/clean_workspace/util.py
+++ b/commonTools/framework/clean_workspace/util.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+# -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
+# pylint: disable=line-too-long
+# pylint: disable=wrong-import-position
+# pylint: disable=too-many-lines
+"""
+Useful utility routines
+
+Generic utility routines for use by all.
+
+$Id: util.py,v 1.148 2009/02/09 22:47:53 mhamilt Exp $
+"""
+from __future__ import print_function
+import sys
+sys.dont_write_bytecode = True
+
+import os
+import types
+import subprocess
+
+COMMON_SSH_AUTH_OPTIONS = ["-o", "BatchMode=yes",
+                           "-o", "StrictHostKeyChecking=no",
+                           "-o", "LogLevel=ERROR"]
+OPENSSH_SPECIFIC_AUTH_OPTIONS = ["-o", "GSSAPIDelegateCredentials=yes"]
+
+
+def _find_files(file_name, dir_list=None):
+    """
+    A generator to find and return all all instances of
+    file_name in the passed dir_list.
+    """
+    # import pyfind
+    if not dir_list:
+        dir_list = os.getcwd()
+    if not isinstance(dir_list, list):
+        dir_list = [dir_list]
+    if file_name:
+        # Find all the instances of find_name in each subdirectory.
+        for subdir in dir_list:
+            for root, dirs, files in os.walk(subdir):
+                if file_name in files:
+                    yield os.path.join(root, file_name)
+
+
+def _find_binary(binary_name, dir_list=None,
+                 version_option='-v',
+                 fail_on_error=False,
+                 newest=True,
+                 return_all=False):
+    """
+    Find a binary in the passed dir_list that returns a 0 exit
+    status when passed the version_option.
+    To return the newest matching binary, pass
+        newest=True
+    To return the first matching binary w/o testing it, pass
+        version_option=None
+    To return a list of all matching binaries (newest first if
+    newest=True,) pass
+        return_all=True
+
+    If no matching binary is found, None will be returned.
+
+    This function differs from util.find_file_in_hierarchy in that
+    it searches down from the passed directory(ies) instead of up.
+
+    This function differs from util.which in that it uses a passed
+    list of directories, rather than using PATH, and it searches
+    the entire hierarchy (rooted at each passed directory) for the
+    binary rather than just the passed directories.
+
+    This function assumes that the binary may appear more than once
+    in subdirectories of each directory in dir_list, so pyfind will
+    be used to search for all instances of binary_name in each directory.
+    """
+    if not binary_name:
+        if fail_on_error:
+            msg = "No executable name passed."
+            sys.exit(97)
+        else:
+            return None
+    if not dir_list:
+        dir_list = os.getcwd()
+    if not isinstance(dir_list, list):
+        dir_list = [dir_list]
+    # Find all the instances of binary_name in each subdirectory.
+    # Check them, and return the first one which is executable and
+    # returns 0 when executed with version_option.
+    gen = _find_files(binary_name, dir_list)
+    if newest:
+        # If the caller wants the newest or all matching binaries, get the
+        # list of matching files  from the generator and sort it by
+        # modification time.
+        file_list = [fname for fname in gen]
+        file_list.sort(key=lambda n: os.stat(n).st_mtime, reverse=True)
+        # Replace the generator with the sorted list to pass to the loop.
+        gen = file_list
+    file_list = []
+    for fname in gen:
+        if os.access(fname, os.X_OK):
+            # Test the version only if an option was passed
+            if version_option:
+                subp = subprocess.Popen(fname + ' %s' % version_option,
+                                        shell=True,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
+                (subp_stdout, subp_stderr) = subp.communicate()
+                estat = subp.wait()
+                if estat != 0:
+                    # If this one failed, try the next.
+                    continue
+            if not return_all:
+                # The binary we found passed or we didn't test the version.
+                # Either way terminate the generator and return the binary.
+                if isinstance(gen, types.GeneratorType) and \
+                   hasattr(types.GeneratorType, 'close'):
+                    gen.close()
+                return fname
+            else:
+                file_list.append(fname)
+
+    # If all was requested and we found files, return them.
+    if file_list and return_all:
+        return file_list
+
+    if fail_on_error:
+        gen = _find_files(binary_name, dir_list)
+        msg = None
+        for fname in gen:
+            if not msg:
+                msg = "Failed to find a %s executable for this system." \
+                      " Checked these binaries:" % binary_name
+            msg += "\n  %s" % fname
+        if not msg:
+            msg = "No %s executable found in %s" % (binary_name, dir_list)
+        sys.exit(97)
+
+    return None
+
+
+def find_first_binary(
+        binary_name, dir_list=None, version_option='-v', fail_on_error=False):
+    """ Get the first binary found; use when dir_list is a list
+        rather than a single directory. """
+    return _find_binary(binary_name, dir_list,
+                        version_option=version_option,
+                        fail_on_error=fail_on_error,
+                        newest=False)
+
+
+def find_file_in_list(fname, path_list, tmp_dir=None):
+    """ Search for a file in a list of paths. """
+
+    # Test for an absolute path to the file.
+    if fname[0] == os.sep and os.path.exists(fname):
+        return fname
+
+    # Test for paths relative to those in path_list
+    for a_dir in path_list:
+        if tmp_dir:
+            a_dir = os.path.join(a_dir, tmp_dir)
+        tmp_file = os.path.join(a_dir, fname)
+        if os.path.exists(tmp_file):
+            return tmp_file
+
+    return None
+
+# These directories (other than '/') are automount points on the
+# ESPHC lan and various cluster machines. Searching for non-existent
+# files in them will cause errors to be logged in the system message file.
+# At the request of sysadmin, this will stop searching at these points.
+SIERRA_STOP_DIRS = ['/', '/home', '/u0',
+                    '/ascldap/users', '/projects', '/sierra']
+
+PROJECT_FILE_NAME = 'SNTools.project'
+PROJECT_SEARCH_STOP_FILE_NAME = '.project_search_stop'
+# For testing purposes the first element must the the project file;
+# all others may be directories or files, but only files can contain a '/'
+# (Ie, this should only stop on top-level directories, and files one or
+# more levels down.)
+PROJECT_STOP_FILES = [PROJECT_FILE_NAME,
+                      'Nbtools',
+                      'Sierra/Sierra.xml',
+                      'sntools/engine']
+
+
+def which(fname, path=None, find_file_func=None):
+    """
+    This function will find executable files in PATH.
+
+    Given fname and an optional os.pathsep separated string of paths,
+    return the first location of an executable fname within path as
+    an absolute pathname.
+
+    This is equivalent to the bash 'type' or csh 'which' command.
+    The path argument defaults to the user's PATH.
+    """
+
+    # If fname is None or empty string, return None
+    if not fname:
+        return None
+
+    if not find_file_func:
+        def is_executable(fname):
+            return os.access(fname, os.X_OK)
+
+        find_file_func = is_executable
+
+    # Do not put this in the function definition above.
+    # It will not get executed at the correct time, and path will be wrong.
+    if path is None:
+        path = os.environ["PATH"]
+
+    if isinstance(path, str):
+        path = path.split(os.pathsep)
+
+    if os.path.isabs(fname):
+        if find_file_func(fname):
+            return os.path.normpath(fname)
+        else:
+            return None
+
+    if not path:
+        path = []
+    for idir in path:
+        fname_path = os.path.join(idir, fname)
+        if find_file_func(fname_path):
+            return os.path.normpath(fname_path)
+    return None


### PR DESCRIPTION
## Description
These scripts will do a few things to improve jenkins
space usage.

'clean_workspace --force %s' will clean the build products
  from the %s directory but not remove the clones. I expect
   this to be useful after a job runs

'clean_workspace %s' will lok up the last time this workspace
   was cleaned, compare that to the last time a clean request
   was issued, and call make clean in the passed diretory if
   needed. We can place this at the start of the job and have it
   always check.

'clean_all_jobs' will just reset the date that the clean_workspace
   jobs use. I expect we will create a jenkins job to be launched
   by hand that does this.

Still needed is a way to remove all workspaces that are not
   actively being built - clones and all. I have seen a few
   groovy scripts that will do this, but those must be run as
   the jenkins adminstrator.

## How Has This Been Tested?
See unit tests in the commit - still needs to be hand tested.
