### PR TITLE
Issue 4283: Amesos2 staticprofile

### DIFF
--- a/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
@@ -194,8 +194,8 @@ namespace {
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
+    RCP<MAT> eye = rcp( new MAT(map,numLocal,Tpetra::StaticProfile) );
     GO base = numLocal*rank;
-    RCP<MAT> eye = rcp( new MAT(map,base,Tpetra::StaticProfile) );
     for( size_t i = 0; i < numLocal; ++i ){
       eye->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
     }
@@ -227,8 +227,8 @@ namespace {
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
+    RCP<MAT> eye = rcp( new MAT(map,numLocal,Tpetra::StaticProfile) );
     GO base = numLocal*rank;
-    RCP<MAT> eye = rcp( new MAT(map,base,Tpetra::StaticProfile) );
     for( size_t i = 0; i < numLocal; ++i ){
       eye->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
     }

--- a/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
@@ -194,8 +194,8 @@ namespace {
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
-    RCP<MAT> eye = rcp( new MAT(map,1) );
     GO base = numLocal*rank;
+    RCP<MAT> eye = rcp( new MAT(map,base,Tpetra::StaticProfile) );
     for( size_t i = 0; i < numLocal; ++i ){
       eye->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
     }
@@ -227,8 +227,8 @@ namespace {
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
-    RCP<MAT> eye = rcp( new MAT(map,1) );
     GO base = numLocal*rank;
+    RCP<MAT> eye = rcp( new MAT(map,base,Tpetra::StaticProfile) );
     for( size_t i = 0; i < numLocal; ++i ){
       eye->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
     }

--- a/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Tpetra_CrsMatrix_Adapter_UnitTests.cpp
@@ -194,7 +194,7 @@ namespace {
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
-    RCP<MAT> eye = rcp( new MAT(map,numLocal,Tpetra::StaticProfile) );
+    RCP<MAT> eye = rcp( new MAT(map,1,Tpetra::StaticProfile) );
     GO base = numLocal*rank;
     for( size_t i = 0; i < numLocal; ++i ){
       eye->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
@@ -227,7 +227,7 @@ namespace {
     // create a Map
     const size_t numLocal = 10;
     RCP<Map<LO,GO,Node> > map = rcp( new Map<LO,GO,Node>(INVALID,numLocal,0,comm) );
-    RCP<MAT> eye = rcp( new MAT(map,numLocal,Tpetra::StaticProfile) );
+    RCP<MAT> eye = rcp( new MAT(map,1,Tpetra::StaticProfile) );
     GO base = numLocal*rank;
     for( size_t i = 0; i < numLocal; ++i ){
       eye->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));

--- a/packages/amesos2/test/solvers/SolverFactory.cpp
+++ b/packages/amesos2/test/solvers/SolverFactory.cpp
@@ -124,7 +124,7 @@ namespace {
     const size_t maxNumEntPerRow = 3;
     const SC two = static_cast<SC> (2.0);
     const SC minusOne = static_cast<SC> (-1.0);
-    RCP<MAT> A (new MAT (rowMap, maxNumEntPerRow, Tpetra::DynamicProfile));
+    RCP<MAT> A (new MAT (rowMap, maxNumEntPerRow, Tpetra::StaticProfile));
 
     if (rowMap->getNodeNumElements () != 0) {
       for (LO lclRow = rowMap->getMinLocalIndex ();


### PR DESCRIPTION
@trilinos/amesos2 
@trilinos/tpetra 

## Description
This removes Tpetra::DynamicProfile from unit tests in amesos2

## Motivation and Context
Deprecation of DynamicProfile in Tpetra's effect on downstream packages

## How Has This Been Tested?
Since this is a change in unit testing, the affected unit tests have been rerun to ensure that they are no longer using the deprecated code path.  Tests conducted on linux 2.6.32.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.