### PR TITLE
MueLu: fix for issue #4334

### DIFF
--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_decl.hpp
@@ -50,7 +50,9 @@
 #include "MueLu_SingleLevelFactoryBase.hpp"
 #include "MueLu_Level_fwd.hpp"
 #include "MueLu_Exceptions.hpp"
+
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
+#include "MueLu_AggregationStructuredAlgorithm_kokkos_fwd.hpp"
 
 #include <KokkosCompat_ClassicNodeAPI_Wrapper.hpp>
 

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_def.hpp
@@ -217,8 +217,8 @@ namespace MueLu {
     // Now we are ready for the big loop over the fine node that will assign each
     // node on the fine grid to an aggregate and a processor.
     RCP<const Map> coarseCoordinatesFineMap, coarseCoordinatesMap;
-    RCP<MueLu::AggregationStructuredAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node> >
-      myStructuredAlgorithm = rcp(new AggregationStructuredAlgorithm_kokkos());
+    RCP<AggregationStructuredAlgorithm_kokkos> myStructuredAlgorithm
+      = rcp(new AggregationStructuredAlgorithm_kokkos());
 
     if(interpolationOrder == 0 && outputAggregates){
       RCP<Aggregates_kokkos> aggregates = rcp(new Aggregates_kokkos(graph->GetDomainMap()));

--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -454,11 +454,11 @@ namespace MueLuTests {
       if (k == 0) xmlFileName = "testPDE.xml";
       if (k == 1) xmlFileName = "testPDE1.xml";
 
-      int numPDEs=3;
-
       if (lib == Xpetra::UseTpetra) {
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_TPETRA_INST_INT_INT)
         typedef Tpetra::Operator<SC,LO,GO,NO> tpetra_operator_type;
+
+        int numPDEs=3;
 
         // Matrix
         RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
@@ -527,6 +527,8 @@ namespace MueLuTests {
 
       } else if (lib == Xpetra::UseEpetra) {
 #ifdef HAVE_MUELU_EPETRA
+        int numPDEs=3;
+
         // Matrix
         RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
         RCP<const Map > map = Op->getRowMap();

--- a/packages/muelu/test/unit_tests/Smoothers/BlockedDirectSolver.cpp
+++ b/packages/muelu/test/unit_tests/Smoothers/BlockedDirectSolver.cpp
@@ -439,7 +439,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 5) { if(xdata[i] != (SC) 1.0) bCheck = false; }
+        if (i< 5) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=5 && i< 10) { if(xdata[i] != (SC) (1.0/2.0)) bCheck = false; }
         if (i>=10 && i< 20) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=20 && i< 40) { if(xdata[i] != (SC) (1.0/4.0)) bCheck = false; }
@@ -551,7 +551,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 5) { if(xdata[i] != (SC) 1.0) bCheck = false; }
+        if (i< 5) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=5 && i< 10) { if(xdata[i] != (SC) (1.0/2.0)) bCheck = false; }
         if (i>=10 && i< 20) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=20 && i< 40) { if(xdata[i] != (SC) (1.0/4.0)) bCheck = false; }
@@ -721,7 +721,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -890,7 +890,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }

--- a/packages/muelu/test/unit_tests/Smoothers/BlockedSmoother.cpp
+++ b/packages/muelu/test/unit_tests/Smoothers/BlockedSmoother.cpp
@@ -1719,7 +1719,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -1903,7 +1903,7 @@ namespace MueLuTests {
         Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
         bool bCheck = true;
         for(size_t i=0; i<XX->getLocalLength(); i++) {
-          if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+          if (i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
           if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
           if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
         }
@@ -2089,7 +2089,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -2273,7 +2273,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -2872,9 +2872,9 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10 ) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
-        if (i>=10  && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
-        if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
+        if (i<10 ) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i>=10  && i<15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
+        if (i>=15 && i<20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
       TEST_EQUALITY(bCheck, true);
 
@@ -3029,9 +3029,9 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10 ) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
-        if (i>=10  && i< 15) { if(xdata[i] != (SC) 0.5) bCheck = false; }
-        if (i>=15 && i< 20) { if(xdata[i] != (SC) 1.0) bCheck = false; }
+        if (i<10 ) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i>=10  && i<15) { if(xdata[i] != (SC) 0.5) bCheck = false; }
+        if (i>=15 && i<20) { if(xdata[i] != (SC) 1.0) bCheck = false; }
       }
       TEST_EQUALITY(bCheck, true);
 
@@ -3170,7 +3170,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 5 ) { if(xdata[i] != (SC) 1.0) bCheck = false; }
+        if (i<5) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=5  && i< 15) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -3330,7 +3330,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10 ) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10  && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -3487,7 +3487,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10 ) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10  && i< 15) { if(xdata[i] != (SC) 0.5) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 1.0) bCheck = false; }
       }
@@ -4056,7 +4056,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -4237,7 +4237,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -4868,7 +4868,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }
@@ -5049,7 +5049,7 @@ namespace MueLuTests {
       Teuchos::ArrayRCP<const Scalar> xdata = XX->getData(0);
       bool bCheck = true;
       for(size_t i=0; i<XX->getLocalLength(); i++) {
-        if (i>=0  && i< 10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
+        if (i<10) { if(xdata[i] != (SC) (1.0/3.0)) bCheck = false; }
         if (i>=10 && i< 15) { if(xdata[i] != (SC) 1.0) bCheck = false; }
         if (i>=15 && i< 20) { if(xdata[i] != (SC) 0.5) bCheck = false; }
       }

--- a/packages/muelu/test/unit_tests/Utilities.cpp
+++ b/packages/muelu/test/unit_tests/Utilities.cpp
@@ -202,7 +202,7 @@ namespace MueLuTests {
       RCP<MultiVector> diagInvMerged = bDiagInv->Merge();
       Teuchos::ArrayRCP<const Scalar> diagInvData = diagInvMerged->getData(0);
       for(size_t i = 0; i < Teuchos::as<size_t>(diagInvData.size()); ++i) {
-        if(i >= 0  && i < 5 ) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0),true);
+        if(i < 5 ) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0),true);
         if(i >= 5  && i < 10) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(0.5),true);
         if(i >= 10 && i < 20) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0/3.0),true);
       }
@@ -223,7 +223,7 @@ namespace MueLuTests {
       RCP<MultiVector> diagInvMerged = bDiagInv->Merge();
       Teuchos::ArrayRCP<const Scalar> diagInvData = diagInvMerged->getData(0);
       for(size_t i = 0; i < Teuchos::as<size_t>(diagInvData.size()); ++i) {
-        if(i >= 0  && i < 5 ) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0),true);
+        if(i < 5 ) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0),true);
         if(i >= 5  && i < 10) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(0.5),true);
         if(i >= 10 && i < 20) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0/3.0),true);
       }
@@ -249,7 +249,7 @@ namespace MueLuTests {
       for(size_t i = 0; i < Teuchos::as<size_t>(diagInvData.size()); ++i) {
         if(i >= 10 && i < 15) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0),true);
         if(i >= 15 && i < 20) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(0.5),true);
-        if(i >= 0  && i < 10) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0/3.0),true);
+        if(i < 10) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0/3.0),true);
       }
     }
     // reordered blocked diagonal operator (Thyra)
@@ -273,7 +273,7 @@ namespace MueLuTests {
       for(size_t i = 0; i < Teuchos::as<size_t>(diagInvData.size()); ++i) {
         if(i >= 10 && i < 15) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0),true);
         if(i >= 15 && i < 20) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(0.5),true);
-        if(i >= 0  && i < 10) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0/3.0),true);
+        if(i < 10) TEST_EQUALITY(diagInvData[i] == Teuchos::as<Scalar>(1.0/3.0),true);
       }
     }
   } // GetDiagonalInverse

--- a/packages/muelu/test/unit_tests_kokkos/IndexManager_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/IndexManager_kokkos.cpp
@@ -84,7 +84,6 @@ namespace MueLuTests {
 
     typedef typename Teuchos::ScalarTraits<SC>::magnitudeType real_type;
     typedef Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
-    GO GOInvalid = Teuchos::OrdinalTraits<GO>::invalid();
 
     RCP<const Teuchos::Comm<int> > comm = MueLuTests::TestHelpers_kokkos::Parameters::getDefaultComm();
 


### PR DESCRIPTION
Forgot to add a forward declaration that triggers the correct definition of a short name in MueLu.

silencing warning from IndexManager_kokkos.cpp by removing unused declartion of GOInvalid.
silencing warning in CreatePreconditioner.cpp due to instantiation guards and variable early declaration.
silencing compiler warning in unit_tests/Utilities.cpp and unit_tests/Smoothers/Blocked{Smoothers,DirectSolver}.cpp due to pedantic comparison of a size_t variable with 0

@trilinos/muelu 

## Description
See above.

## Motivation and Context
This will fix an issue that is blocking a Cuda build of Sierra

## Related Issues

* Closes #4334 

## How Has This Been Tested?
Local build and tests were run on MueLu after fix.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
