### PR TITLE
Issue 4283: transition Belos to using Tpetra::StaticProfile

### DIFF
--- a/packages/belos/tpetra/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/belos/tpetra/test/MVOPTester/cxx_main_complex.cpp
@@ -105,7 +105,7 @@ namespace {
   template<class Scalar, class O1, class O2>
   RCP<CrsMatrix<Scalar,O1,O2,Node> > constructDiagMatrix(const RCP<const Map<O1,O2,Node> > &map)
   {
-    RCP<CrsMatrix<Scalar,O1,O2,Node> > op = rcp( new CrsMatrix<Scalar,O1,O2,Node>(map,1) );
+    RCP<CrsMatrix<Scalar,O1,O2,Node> > op = rcp( new CrsMatrix<Scalar,O1,O2,Node>(map,1,Tpetra::StaticProfile) );
     for (size_t i=0; i<map->getNodeNumElements(); ++i) {
       op->insertGlobalValues(map->getGlobalElement(i),tuple(map->getGlobalElement(i)), tuple(ScalarTraits<Scalar>::one()));
     }


### PR DESCRIPTION
@trilinos/belos  
@trilinos/tpetra 

## Description
This removes Tpetra::DynamicProfile from unit tests in belos

## Motivation and Context
Deprecation of DynamicProfile in Tpetra's effect on downstream packages

## How Has This Been Tested?
Since this is a change in unit testing, the affected unit tests have been rerun to ensure that they are no longer using the deprecated code path.  Tests conducted on linux 2.6.32.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.