### PR TITLE
cmake/std/PullRequestLinuxDriver-Test.sh: use environment to get job …

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-Test.sh
+++ b/cmake/std/PullRequestLinuxDriver-Test.sh
@@ -334,12 +334,12 @@ echo -e "Enabled packages:"
 cmake -P packageEnables.cmake
 
 build_name="PR-$PULLREQUESTNUM-test-$JOB_BASE_NAME-$BUILD_NUMBER"
-weight=29
+weight=${JENKINS_JOB_WEIGHT:-29}
 n_cpu=$(lscpu | grep "^CPU(s):" | cut -d" " -f17)
 n_K=$(cat /proc/meminfo | grep MemTotal | cut -d" " -f8)
 let n_G=$n_K/1024000
 # this is aimed at keeping approximately 1.7G per core so we don't bottleneck
-## weight 29 - the next bit works because the shell is only doing integer arithmetic
+## weight - the next bit works because the shell is only doing integer arithmetic
 let n_jobs=${n_cpu}/${weight}
 # using bc to get floating point input and integer output
 parallel_level=$(echo "$n_G/( 1.7*$n_jobs )" | bc )


### PR DESCRIPTION
…weight

Previously hard coded to 29 - still defaults to that if not set

I am using this in my testing and it seems to work fine.  Merging
it will not cause any change if the jobs are not modified.

## Motivation and Context
This will allow us to set some jobs at a higher weight and still utilize those core for the build.
