### PR TITLE
Change from 'develop' to 'atdm-develop-nightly' branch (TRIL-260)

### DIFF
--- a/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
+++ b/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
@@ -129,9 +129,9 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
     "${THIS_LIST_FILE}"
     )
 
-  # Make the default branch 'develop' (but allow it to be overridden in
+  # Make the default branch 'atdm-develop-nightly' (but allow it to be overridden in
   # *.cmake script)
-  SET_DEFAULT(Trilinos_BRANCH develop)
+  SET_DEFAULT(Trilinos_BRANCH atdm-develop-nightly)
 
   # Set the default CDash Track/Group to "Specialized".  This will not trigger
   # CDash error emails for any failures.  But when the build is clean, the var


### PR DESCRIPTION
CC: @fryeguy52 

## Description

We need to be testing a single consistent version of Trilinos across all ATDM
Trilinos builds.  Making this change does that.

NOTE:  `AT: AUTOMERGE` is **NOT** set because I want to control when this branch gets merged so taht I can update the various Jenkins and cron drivers in coordination with this.

## Motivation and Context

See [TRIL-260](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-260).

## How Has This Been Tested?

I tested this locally on 'crf450' with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/ATDM/JENKINS/

$ mkdir exp
$ cd exp/

$ ln -s ~/Trilinos.base/Trilinos .

$ env JOB_NAME=Trilinos-atdm-sems-rhel6-gnu-debug-serial \
    WORKSPACE=$PWD \
    CTEST_TEST_TYPE=Experimental \
    CTEST_DO_SUBMIT=OFF \
    Trilinos_PACKAGES=Kokkos,Teuchos \
  /Trilinos/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh
```

This looks to have run correctly and is on the right branch:

```
$ cd SRC_AND_BUILD/Trilinos/

$ git branch | grep "[*]"
* atdm-develop-nightly
```

So that looks like that is ready to go.  The actual version of Trilinos tested will automatically switched to the branch 'atdm-develop-nightly'.  We will just need to switch up the base Trilinos driver repo.
