### PR TITLE
MueLu: fix matvec kernel driver

### DIFF
--- a/packages/muelu/test/scaling/MatvecKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MatvecKernelDriver.cpp
@@ -237,8 +237,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     if (do_kk && comm->getSize() > 1)
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"The Kokkos-Kernels matvec kernel cannot be run with more than one rank.");
 
-    // Load the matrix off disk (or generate it via Galeri)
-    MatrixLoad<SC,LO,GO,NO>(comm, lib, binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile, domainMapFile, rangeMapFile, coordFile, nullFile, map, A, coordinates, nullspace, x, b, galeriParameters, xpetraParameters, galeriStream);
+    // Load the matrix off disk (or generate it via Galeri), assuming only one right hand side is loaded.
+    MatrixLoad<SC,LO,GO,NO>(comm, lib, binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile, domainMapFile, rangeMapFile, coordFile, nullFile, map, A, coordinates, nullspace, x, b, 1, galeriParameters, xpetraParameters, galeriStream);
 
 #ifndef HAVE_MUELU_MKL
     if (do_mkl) {


### PR DESCRIPTION
@trilinos/muelu 

## Description
Modifying the call to MatrixLoad in MatvecKernelDriver.cpp to comply with the new interface.

## Motivation and Context
The interface change led to MatrixKernelDriver.cpp not building.

## Related Issues

* Closes #4358 

## How Has This Been Tested?
I did a local build with the correct configuration to trigger a build of MatvecKernelDriver.cpp

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.