### PR TITLE
ShyLU/FROSch: use Muelu in Laplace problem

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
@@ -135,40 +135,94 @@ namespace FROSch {
         typedef Teuchos::RCP<MueLu::Hierarchy<SC,LO,GO,NO> > MueLuHierarchyPtr;
 #endif
 
+        /*!
+        \brief Constructor
+
+        @param k Matrix
+        @param parameterList Parameter list
+        @param blockCoarseSize
+        */
         SubdomainSolver(CrsMatrixPtr k,
                         ParameterListPtr parameterList,
                         GOVecPtr blockCoarseSize=Teuchos::null);
 
+        //! Destructor
         virtual ~SubdomainSolver();
 
+        //! Initialize member variables
         virtual int initialize();
 
+        /*!
+        \brief Compute/setup this operator/solver
+
+        \pre Routine initialize() has been called and #isInitialized_ is set to \c true.
+
+        @return Integer error code
+        */
         virtual int compute();
 
-        // Y = alpha * A^mode * X + beta * Y
+        /*! \brief Apply subdomain solver to input \c x
+         *
+         * y = alpha * A^mode * X + beta * Y
+         *
+         * \param[in] x Input vector
+         * \param[out] y result vector
+         * \param[in] mode
+         */
+
+        /*!
+        \brief Computes the operator-multivector application.
+
+        Loosely, performs \f$Y = \alpha \cdot A^{\textrm{mode}} \cdot X + \beta \cdot Y\f$. However, the details of operation
+        vary according to the values of \c alpha and \c beta. Specifically
+        - if <tt>beta == 0</tt>, apply() <b>must</b> overwrite \c Y, so that any values in \c Y (including NaNs) are ignored.
+        - if <tt>alpha == 0</tt>, apply() <b>may</b> short-circuit the operator, so that any values in \c X (including NaNs) are ignored.
+        */
         virtual void apply(const MultiVector &x,
                            MultiVector &y,
                            Teuchos::ETransp mode=Teuchos::NO_TRANS,
                            SC alpha=Teuchos::ScalarTraits<SC>::one(),
                            SC beta=Teuchos::ScalarTraits<SC>::zero()) const;
 
+        //! Get domain map
         virtual ConstMapPtr getDomainMap() const;
 
+        //! Get range map
         virtual ConstMapPtr getRangeMap() const;
 
+        /*!
+        \brief Print description of this object to given output stream
+
+        \param out Output stream to be used
+        \param Verbosity level used for printing
+        */
         virtual void describe(Teuchos::FancyOStream &out,
                               const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const;
 
+        /*!
+        \brief Get description of this operator
+
+        \return String describing this operator
+        */
         virtual std::string description() const;
-        
+
+        //! @name Access to class members
+        //!@{
+
+        //! Get #IsInitialized_
         bool isInitialized() const;
-        
+
+        //! Get #IsComputed_
         bool isComputed() const;
-        
+
+        //!@}
+
     protected:
 
+        //! Matrix
         CrsMatrixPtr K_;
 
+        //! Paremter list
         ParameterListPtr ParameterList_;
 
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
@@ -185,7 +239,10 @@ namespace FROSch {
         Amesos2SolverTpetraPtr Amesos2SolverTpetra_;
 
 #ifdef HAVE_SHYLU_DDFROSCH_MUELU
+        //! Factory to create a MueLu hierarchy
         MueLuFactoryPtr MueLuFactory_;
+
+        //! MueLu hierarchy object
         MueLuHierarchyPtr MueLuHierarchy_;
 #endif
 
@@ -195,7 +252,9 @@ namespace FROSch {
 #endif
 
         bool IsInitialized_;
-        bool IsComputed_;        
+
+        //! Flag to indicated whether this subdomain solver has been setup/computed
+        bool IsComputed_;
     };
 
 }

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
@@ -138,6 +138,12 @@ namespace FROSch {
         /*!
         \brief Constructor
 
+        Create the subdomain solver object.
+
+        A subdomain solver might require further Trilinos packages at runtime.
+        Availability of required packages is tested and
+        an error is thrown if required packages are not part of the build configuration.
+
         @param k Matrix
         @param parameterList Parameter list
         @param blockCoarseSize

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_decl.hpp
@@ -73,21 +73,21 @@
 #endif
 
 namespace FROSch {
-    
+
     template <class SC,
     class LO ,
     class GO ,
     class NO >
     class OneLevelPreconditioner;
-    
+
     template <class SC = typename Xpetra::Operator<>::scalar_type,
     class LO = typename Xpetra::Operator<SC>::local_ordinal_type,
     class GO = typename Xpetra::Operator<SC, LO>::global_ordinal_type,
     class NO = typename Xpetra::Operator<SC, LO, GO>::node_type>
     class SubdomainSolver : public Xpetra::Operator<SC,LO,GO,NO> {
-                
+
     public:
-        
+
         typedef Xpetra::Map<LO,GO,NO> Map;
         typedef Teuchos::RCP<Map> MapPtr;
         typedef Teuchos::RCP<const Map> ConstMapPtr;
@@ -95,7 +95,7 @@ namespace FROSch {
 
         typedef Teuchos::ArrayRCP<GO> GOVecPtr;
 
-        
+
         typedef Xpetra::Matrix<SC,LO,GO,NO> CrsMatrix;
         typedef Teuchos::RCP<CrsMatrix> CrsMatrixPtr;
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
@@ -104,7 +104,7 @@ namespace FROSch {
 #endif
         typedef Tpetra::CrsMatrix<SC,LO,GO,NO> TpetraCrsMatrix;
         typedef Teuchos::RCP<TpetraCrsMatrix> TpetraCrsMatrixPtr;
-        
+
         typedef Xpetra::MultiVector<SC,LO,GO,NO> MultiVector;
         typedef Teuchos::RCP<MultiVector> MultiVectorPtr;
         typedef Teuchos::RCP<const MultiVector> ConstMultiVectorPtr;
@@ -114,51 +114,51 @@ namespace FROSch {
 #endif
         typedef Tpetra::MultiVector<SC,LO,GO,NO> TpetraMultiVector;
         typedef Teuchos::RCP<TpetraMultiVector> TpetraMultiVectorPtr;
-        
+
         typedef Teuchos::RCP<Teuchos::ParameterList> ParameterListPtr;
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
         typedef Teuchos::RCP<Epetra_LinearProblem> LinearProblemPtr;
 #endif
-      
+
 #ifdef HAVE_SHYLU_DDFROSCH_AMESOS
         typedef Teuchos::RCP<Amesos_BaseSolver> AmesosSolverPtr;
 #endif
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
         typedef Teuchos::RCP<Amesos2::Solver<EpetraCrsMatrix,EpetraMultiVector> > Amesos2SolverEpetraPtr;
 #endif
         typedef Teuchos::RCP<Amesos2::Solver<TpetraCrsMatrix,TpetraMultiVector> > Amesos2SolverTpetraPtr;
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_MUELU
         typedef Teuchos::RCP<MueLu::HierarchyManager<SC,LO,GO,NO> > MueLuFactoryPtr;
         typedef Teuchos::RCP<MueLu::Hierarchy<SC,LO,GO,NO> > MueLuHierarchyPtr;
 #endif
-        
+
         SubdomainSolver(CrsMatrixPtr k,
                         ParameterListPtr parameterList,
                         GOVecPtr blockCoarseSize=Teuchos::null);
-        
+
         virtual ~SubdomainSolver();
-        
+
         virtual int initialize();
-        
+
         virtual int compute();
-        
+
         // Y = alpha * A^mode * X + beta * Y
         virtual void apply(const MultiVector &x,
                            MultiVector &y,
                            Teuchos::ETransp mode=Teuchos::NO_TRANS,
                            SC alpha=Teuchos::ScalarTraits<SC>::one(),
                            SC beta=Teuchos::ScalarTraits<SC>::zero()) const;
-        
+
         virtual ConstMapPtr getDomainMap() const;
-        
+
         virtual ConstMapPtr getRangeMap() const;
-        
+
         virtual void describe(Teuchos::FancyOStream &out,
                               const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const;
-        
+
         virtual std::string description() const;
         
         bool isInitialized() const;
@@ -166,38 +166,38 @@ namespace FROSch {
         bool isComputed() const;
         
     protected:
-        
+
         CrsMatrixPtr K_;
-        
+
         ParameterListPtr ParameterList_;
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
         LinearProblemPtr EpetraLinearProblem_;
 #endif
-      
+
 #ifdef HAVE_SHYLU_DDFROSCH_AMESOS
         AmesosSolverPtr AmesosSolver_;
 #endif
-      
+
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
         Amesos2SolverEpetraPtr Amesos2SolverEpetra_;
 #endif
         Amesos2SolverTpetraPtr Amesos2SolverTpetra_;
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_MUELU
         MueLuFactoryPtr MueLuFactory_;
         MueLuHierarchyPtr MueLuHierarchy_;
 #endif
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_BELOS
         Teuchos::RCP<Belos::LinearProblem<SC,Xpetra::MultiVector<SC,LO,GO,NO>,Belos::OperatorT<Xpetra::MultiVector<SC,LO,GO,NO> > > >  BelosLinearProblem_;
         Teuchos::RCP<Belos::SolverManager<SC,Xpetra::MultiVector<SC,LO,GO,NO>,Belos::OperatorT<Xpetra::MultiVector<SC,LO,GO,NO> > > > BelosSolverManager_;
 #endif
-        
+
         bool IsInitialized_;
         bool IsComputed_;        
     };
-    
+
 }
 
 #endif

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_SubdomainSolver_def.hpp
@@ -45,7 +45,7 @@
 #include <FROSch_SubdomainSolver_decl.hpp>
 
 namespace FROSch {
-    
+
     template<class SC,class LO,class GO,class NO>
     SubdomainSolver<SC,LO,GO,NO>::SubdomainSolver(CrsMatrixPtr k,
                                                   ParameterListPtr parameterList,
@@ -76,12 +76,12 @@ namespace FROSch {
             Xpetra::CrsMatrixWrap<SC,LO,GO,NO>& crsOp = dynamic_cast<Xpetra::CrsMatrixWrap<SC,LO,GO,NO>&>(*K_);
             Xpetra::EpetraCrsMatrixT<GO,NO>& xEpetraMat = dynamic_cast<Xpetra::EpetraCrsMatrixT<GO,NO>&>(*crsOp.getCrsMatrix());
             EpetraCrsMatrixPtr epetraMat = xEpetraMat.getEpetra_CrsMatrixNonConst();
-            
+
             EpetraMultiVectorPtr xTmp;
             EpetraMultiVectorPtr bTmp;
-            
+
             EpetraLinearProblem_.reset(new Epetra_LinearProblem(epetraMat.get(),xTmp.get(),bTmp.get()));
-            
+
             Amesos amesosFactory;
 
             AmesosSolver_.reset(amesosFactory.Create(ParameterList_->get("Solver","Mumps"),*EpetraLinearProblem_));
@@ -96,10 +96,10 @@ namespace FROSch {
                 Xpetra::CrsMatrixWrap<SC,LO,GO,NO>& crsOp = dynamic_cast<Xpetra::CrsMatrixWrap<SC,LO,GO,NO>&>(*K_);
                 Xpetra::EpetraCrsMatrixT<GO,NO>& xEpetraMat = dynamic_cast<Xpetra::EpetraCrsMatrixT<GO,NO>&>(*crsOp.getCrsMatrix());
                 EpetraCrsMatrixPtr epetraMat = xEpetraMat.getEpetra_CrsMatrixNonConst();
-                
+
                 EpetraMultiVectorPtr xTmp;
                 EpetraMultiVectorPtr bTmp;
-                
+
                 Amesos2SolverEpetra_ = Amesos2::create<EpetraCrsMatrix,EpetraMultiVector>(ParameterList_->get("Solver","Mumps"),epetraMat,xTmp,bTmp);
                 ParameterListPtr parameterList = sublist(ParameterList_,"Amesos2");
                 parameterList->setName("Amesos2");
@@ -109,10 +109,10 @@ namespace FROSch {
                 Xpetra::CrsMatrixWrap<SC,LO,GO,NO>& crsOp = dynamic_cast<Xpetra::CrsMatrixWrap<SC,LO,GO,NO>&>(*K_);
                 Xpetra::TpetraCrsMatrix<SC,LO,GO,NO>& xTpetraMat = dynamic_cast<Xpetra::TpetraCrsMatrix<SC,LO,GO,NO>&>(*crsOp.getCrsMatrix());
                 TpetraCrsMatrixPtr tpetraMat = xTpetraMat.getTpetra_CrsMatrixNonConst();
-                
+
                 TpetraMultiVectorPtr xTmp;
                 TpetraMultiVectorPtr bTmp;
-                
+
                 Amesos2SolverTpetra_ = Amesos2::create<Tpetra::CrsMatrix<SC,LO,GO,NO>,Tpetra::MultiVector<SC,LO,GO,NO> >(ParameterList_->get("Solver","Mumps"),tpetraMat,xTmp,bTmp);
                 ParameterListPtr parameterList = sublist(ParameterList_,"Amesos2");
                 parameterList->setName("Amesos2");
@@ -122,7 +122,7 @@ namespace FROSch {
             }
 #ifdef HAVE_SHYLU_DDFROSCH_MUELU
         } else if (!ParameterList_->get("SolverType","Amesos").compare("MueLu")) {
-            
+
             MueLuFactory_ = Teuchos::rcp(new MueLu::ParameterListInterpreter<SC,LO,GO,NO>(parameterList->sublist("MueLu").sublist("MueLu Parameter")));
             Teuchos::RCP<Xpetra::MultiVector<SC,LO,GO,NO> > nullspace;
 
@@ -154,24 +154,24 @@ namespace FROSch {
         } else if (!ParameterList_->get("SolverType","Amesos").compare("Belos")) {
             Teuchos::RCP<Xpetra::MultiVector<SC,LO,GO,NO> > xSolution;// = FROSch::ConvertToXpetra<SC, LO, GO, NO>(Xpetra::UseTpetra,*this->solution_,TeuchosComm);
             Teuchos::RCP<Xpetra::MultiVector<SC,LO,GO,NO> > xRightHandSide;// = FROSch::ConvertToXpetra<SC, LO, GO, NO>(Xpetra::UseTpetra,*residualVec_,TeuchosComm);//hier residualVec. Bei linProb rhs_
-            
+
             Teuchos::RCP<Belos::OperatorT<Xpetra::MultiVector<SC,LO,GO,NO> > > OpK = rcp(new Belos::XpetraOp<SC, LO, GO, NO>(K_));
-            
-            
+
+
             BelosLinearProblem_.reset(new Belos::LinearProblem<SC,Xpetra::MultiVector<SC,LO,GO,NO>,Belos::OperatorT<Xpetra::MultiVector<SC,LO,GO,NO> > >(OpK,xSolution,xRightHandSide));
-            
+
             Belos::SolverFactory<SC,Xpetra::MultiVector<SC,LO,GO,NO>,Belos::OperatorT<Xpetra::MultiVector<SC,LO,GO,NO> > > belosFactory;
             ParameterListPtr solverParameterList = sublist(ParameterList_,"Belos");
-            
+
             BelosSolverManager_ = belosFactory.create(solverParameterList->get("Solver","GMRES"),sublist(solverParameterList,solverParameterList->get("Solver","GMRES")));
-            
+
             BelosSolverManager_->setProblem(BelosLinearProblem_);
 #endif
         } else {
             FROSCH_ASSERT(false,"SolverType unknown...");
         }
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     SubdomainSolver<SC,LO,GO,NO>::~SubdomainSolver()
     {
@@ -186,7 +186,7 @@ namespace FROSch {
         Amesos2SolverEpetra_.reset();
 #endif
         Amesos2SolverTpetra_.reset();
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_MUELU
         MueLuFactory_.reset();
         MueLuHierarchy_.reset();
@@ -197,7 +197,7 @@ namespace FROSch {
         BelosSolverManager_.reset();
 #endif
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     int SubdomainSolver<SC,LO,GO,NO>::initialize()
     {
@@ -235,7 +235,7 @@ namespace FROSch {
         }
         return 0;
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     int SubdomainSolver<SC,LO,GO,NO>::compute()
     {
@@ -276,10 +276,10 @@ namespace FROSch {
 
                 if (!solverParameterList->get("PreconditionerPosition","left").compare("left")) {
                     BelosLinearProblem_->setLeftPrec(OpP);
-                    
+
                 } else if (!solverParameterList->get("PreconditionerPosition","left").compare("right")) {
                     BelosLinearProblem_->setRightPrec(OpP);
-                    
+
                 } else {
                     FROSCH_ASSERT(false,"PreconditionerPosition unknown...");
                 }
@@ -290,7 +290,7 @@ namespace FROSch {
             FROSCH_ASSERT(false,"SolverType unknown...");
         }
         return 0;
-        
+
 
     }
 
@@ -304,22 +304,22 @@ namespace FROSch {
                                              SC beta) const
     {
         FROSCH_ASSERT(IsComputed_,"!IsComputed_.");
-        
+
         MultiVectorPtr yTmp;
-        
+
 #ifdef HAVE_SHYLU_DDFROSCH_AMESOS
         if (!ParameterList_->get("SolverType","Amesos").compare("Amesos")) {
             const Xpetra::EpetraMultiVectorT<GO,NO> * xEpetraMultiVectorX = dynamic_cast<const Xpetra::EpetraMultiVectorT<GO,NO> *>(&x);
             Teuchos::RCP<Epetra_MultiVector> epetraMultiVectorX = xEpetraMultiVectorX->getEpetra_MultiVector();
-            
+
             yTmp = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(y.getMap(),x.getNumVectors());
             *yTmp = y;
             Xpetra::EpetraMultiVectorT<GO,NO> * xEpetraMultiVectorY = dynamic_cast<Xpetra::EpetraMultiVectorT<GO,NO> *>(yTmp.get());
             Teuchos::RCP<Epetra_MultiVector> epetraMultiVectorY = xEpetraMultiVectorY->getEpetra_MultiVector();
-            
+
             EpetraLinearProblem_->SetLHS(epetraMultiVectorY.get());
             EpetraLinearProblem_->SetRHS(epetraMultiVectorX.get());
-            
+
             EpetraLinearProblem_->GetMatrix()->SetUseTranspose(mode==Teuchos::TRANS);
             AmesosSolver_->Solve();
         } else
@@ -329,26 +329,26 @@ namespace FROSch {
 #ifdef HAVE_SHYLU_DDFROSCH_EPETRA
                 const Xpetra::EpetraMultiVectorT<GO,NO> * xEpetraMultiVectorX = dynamic_cast<const Xpetra::EpetraMultiVectorT<GO,NO> *>(&x);
                 Teuchos::RCP<Epetra_MultiVector> epetraMultiVectorX = xEpetraMultiVectorX->getEpetra_MultiVector();
-                
+
                 yTmp = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(y.getMap(),x.getNumVectors());
                 *yTmp = y;
                 Xpetra::EpetraMultiVectorT<GO,NO> * xEpetraMultiVectorY = dynamic_cast<Xpetra::EpetraMultiVectorT<GO,NO> *>(yTmp.get());
                 Teuchos::RCP<Epetra_MultiVector> epetraMultiVectorY = xEpetraMultiVectorY->getEpetra_MultiVector();
-                
+
                 Amesos2SolverEpetra_->setX(epetraMultiVectorY);
                 Amesos2SolverEpetra_->setB(epetraMultiVectorX);
-                
+
                 Amesos2SolverEpetra_->solve(); // Was ist, wenn man mit der transponierten Matrix lösen will
 #endif
             } else {
                 const Xpetra::TpetraMultiVector<SC,LO,GO,NO> * xTpetraMultiVectorX = dynamic_cast<const Xpetra::TpetraMultiVector<SC,LO,GO,NO> *>(&x);
                 TpetraMultiVectorPtr tpetraMultiVectorX = xTpetraMultiVectorX->getTpetra_MultiVector();
-                
+
                 yTmp = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(y.getMap(),x.getNumVectors());
                 *yTmp = y;
                 const Xpetra::TpetraMultiVector<SC,LO,GO,NO> * xTpetraMultiVectorY = dynamic_cast<const Xpetra::TpetraMultiVector<SC,LO,GO,NO> *>(yTmp.get());
                 TpetraMultiVectorPtr tpetraMultiVectorY = xTpetraMultiVectorY->getTpetra_MultiVector();
-                
+
                 Amesos2SolverTpetra_->setX(tpetraMultiVectorY);
                 Amesos2SolverTpetra_->setB(tpetraMultiVectorX);
 
@@ -370,7 +370,7 @@ namespace FROSch {
 #endif
 #ifdef HAVE_SHYLU_DDFROSCH_BELOS
         } else if (!ParameterList_->get("SolverType","Amesos").compare("Belos")) {
-            
+
             ConstMultiVectorPtr xPtr = Teuchos::rcpFromRef(x);
             yTmp = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(y.getMap(),x.getNumVectors());
             BelosLinearProblem_->setProblem(yTmp,xPtr);
@@ -382,44 +382,44 @@ namespace FROSch {
         }
         y.update(alpha,*yTmp,beta);
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     typename SubdomainSolver<SC,LO,GO,NO>::ConstMapPtr SubdomainSolver<SC,LO,GO,NO>::getDomainMap() const
     {
         return K_->getDomainMap();
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     typename SubdomainSolver<SC,LO,GO,NO>::ConstMapPtr SubdomainSolver<SC,LO,GO,NO>::getRangeMap() const
     {
         return K_->getRangeMap();
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     void SubdomainSolver<SC,LO,GO,NO>::describe(Teuchos::FancyOStream &out,
                                                 const Teuchos::EVerbosityLevel verbLevel) const
     {
         FROSCH_ASSERT(false,"describe() has be implemented properly...");
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     std::string SubdomainSolver<SC,LO,GO,NO>::description() const
     {
         return "Subdomain Solver";
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     bool SubdomainSolver<SC,LO,GO,NO>::isInitialized() const
     {
         return IsInitialized_;
     }
-    
+
     template<class SC,class LO,class GO,class NO>
     bool SubdomainSolver<SC,LO,GO,NO>::isComputed() const
     {
         return IsComputed_;
     }
-    
+
 }
 
 #endif

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
@@ -186,6 +186,19 @@ namespace FROSch {
     template <class SC, class LO,class GO,class NO>
     int RepartionMatrixZoltan2(Teuchos::RCP<Xpetra::Matrix<SC,LO,GO,NO> > &crsMatrix, Teuchos::RCP<Teuchos::ParameterList> parameterList);
 #endif
+
+    /*!
+    \brief Throw runtime error due to missing package in build configuration
+
+    As many packages are optional, we might detect only at runtime that are certain package
+    is not included into the build configuration, but still is used by FROSch.
+    Use this routine to throw a generic error message with some information for the user
+    and provide details how to fix it.
+
+    \param[in] forschObj FROSch object that is asking for the missing package
+    \param[in] packageName Name of the missing package
+    */
+    void ThrowErrorMissingPackage(const std::string& froschObj, const std::string& packageName);
 }
 
 #endif

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -919,6 +919,20 @@ namespace FROSch {
         return 0;
     }
 #endif
-}
+
+    void ThrowErrorMissingPackage(const std::string& froschObj, const std::string& packageName)
+    {
+      // Create the error message
+      std::stringstream errMsg;
+      errMsg << froschObj << " is asking for the Trilinos packate '"<< packageName << "', "
+          "but this package is not included in your build configuration. "
+          "Please enable '" << packageName << "' in your build configuration to be used with ShyLU_DDFROSch.";
+
+      // Throw the error
+      FROSCH_ASSERT(false, errMsg.str());
+
+      return;
+    }
+} // namespace FROSch
 
 #endif

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/CMakeLists.txt
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/CMakeLists.txt
@@ -314,6 +314,16 @@ COMM mpi
 NUM_MPI_PROCS 4
 )
 
+IF(ShyLU_DDFROSch_ENABLE_MueLu)
+  TRIBITS_ADD_TEST(
+  thyra_xpetra_laplace
+  NAME test_thyra_xpetra_laplace_TLP_GDSW_MUELU_DIM2_DPN2_ORD1_EPETRA
+  ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml --USEEPETRA"
+  COMM mpi
+  NUM_MPI_PROCS 4
+  )
+ENDIF() # IF(ShyLU_DDFROSch_ENABLE_MueLu)
+
 TRIBITS_ADD_TEST(
 thyra_xpetra_laplace
 NAME test_thyra_xpetra_laplace_TLP_GDSW_DIM3_DPN1_ORD0_EPETRA
@@ -345,7 +355,8 @@ ARGS "--M=3 --DIM=3 --O=1 --NB=1 --DPN=3 --ORD=1 --PLIST=ParameterLists/Paramete
 COMM mpi
 NUM_MPI_PROCS 8
 )
-ENDIF()
+
+ENDIF() # IF(ShyLU_DDFROSch_ENABLE_Epetra AND NOT Tpetra_DefaultNode STREQUAL "Kokkos::Compat::KokkosCudaWrapperNode")
 
 ## Tpetra
 TRIBITS_ADD_TEST(
@@ -379,6 +390,16 @@ ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/Paramete
 COMM mpi
 NUM_MPI_PROCS 4
 )
+
+IF(ShyLU_DDFROSch_ENABLE_MueLu)
+  TRIBITS_ADD_TEST(
+  thyra_xpetra_laplace
+  NAME test_thyra_xpetra_laplace_TLP_GDSW_MUELU_DIM2_DPN2_ORD1_TPETRA
+  ARGS "--M=3 --DIM=2 --O=1 --NB=1 --DPN=2 --ORD=1 --PLIST=ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml --USETPETRA"
+  COMM mpi
+  NUM_MPI_PROCS 4
+  )
+ENDIF() # IF(ShyLU_DDFROSch_ENABLE_MueLu)
 
 TRIBITS_ADD_TEST(
 thyra_xpetra_laplace

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/ParameterLists/CMakeLists.txt
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/ParameterLists/CMakeLists.txt
@@ -1,5 +1,11 @@
 TRIBITS_COPY_FILES_TO_BINARY_DIR(ThyraXpetraCopyFiles
-DEST_FILES ParameterList_GDSWPreconditioner.xml ParameterList_RGDSWPreconditioner.xml ParameterList_TwoLevelBlockPreconditioner_GDSW.xml ParameterList_TwoLevelPreconditioner_GDSW.xml ParameterList_TwoLevelPreconditioner_IPOUHarmonic.xml ParameterList_TwoLevelPreconditioner_RGDSW.xml
+DEST_FILES ParameterList_GDSWPreconditioner.xml 
+           ParameterList_RGDSWPreconditioner.xml 
+           ParameterList_TwoLevelBlockPreconditioner_GDSW.xml 
+           ParameterList_TwoLevelPreconditioner_GDSW.xml
+           ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml 
+           ParameterList_TwoLevelPreconditioner_IPOUHarmonic.xml 
+           ParameterList_TwoLevelPreconditioner_RGDSW.xml
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
     DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
     EXEDEPS thyra_xpetra_laplace

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml
@@ -89,8 +89,8 @@
                           <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
                       
                           <!-- start of default values for general options (can be omitted) -->
-                          <Parameter        name="max levels"                         type="int"      value="10"/>
-                          <Parameter        name="number of equations"                  type="int"      value="3"/>
+                          <Parameter        name="max levels"                           type="int"      value="10"/>
+                          <Parameter        name="number of equations"                  type="int"      value="1"/>
                           <Parameter        name="sa: use filtered matrix"              type="bool"     value="true"/>
                           <!-- end of default values -->
                       

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/ParameterLists/ParameterList_TwoLevelPreconditioner_GDSW_muelu.xml
@@ -1,0 +1,123 @@
+<ParameterList name="Thyra Example">
+    <Parameter name="Linear Solver Type" type="string" value="Belos"/>
+    <ParameterList name="Linear Solver Types">
+        <ParameterList name="Belos">
+            <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+            <ParameterList name="Solver Types">
+                <ParameterList name="Block GMRES">
+                    <Parameter name="PreconditionerPosition" type="string" value="left"/>
+                    <Parameter name="Block Size" type="int" value="1"/>
+                    <Parameter name="Convergence Tolerance" type="double" value="1e-4"/>
+                    <Parameter name="Maximum Iterations" type="int" value="100"/>
+                    <Parameter name="Output Frequency" type="int" value="1"/>
+                    <Parameter name="Show Maximum Residual Norm Only" type="bool" value="1"/>
+                </ParameterList>
+            </ParameterList>
+        </ParameterList>
+    </ParameterList>
+    <Parameter name="Preconditioner Type" type="string" value="FROSch"/>
+    <ParameterList name="Preconditioner Types">
+        <ParameterList name="FROSch">
+            <Parameter name="FROSch Preconditioner Type"                        type="string"   value="TwoLevelPreconditioner"/>
+            
+            <Parameter name="OverlappingOperator Type"                          type="string"   value="AlgebraicOverlappingOperator"/>
+            <Parameter name="CoarseOperator Type"                               type="string"   value="GDSWCoarseOperator"/>
+            <Parameter name="Null Space Type"                                   type="string"   value="Laplace"/>
+            
+            <ParameterList name="AlgebraicOverlappingOperator">
+                <ParameterList name="Solver">
+                    <Parameter name="SolverType"                                type="string"   value="Amesos2"/>
+                    <Parameter name="Solver"                                    type="string"   value="Klu"/>
+                </ParameterList>
+            </ParameterList>
+            
+            <ParameterList name="GDSWCoarseOperator">
+                <ParameterList name="Blocks">
+                    <ParameterList name="1">
+                        <Parameter name="Use For Coarse Space"                  type="bool"     value="true"/>
+                        <Parameter name="Rotations"                             type="bool"     value="true"/>
+                        <ParameterList name="Custom">
+                            <Parameter name="Vertices: translations"            type="bool"     value="true"/>
+                            <Parameter name="ShortEdges: translations"          type="bool"     value="true"/>
+                            <Parameter name="ShortEdges: rotations"             type="bool"     value="true"/>
+                            <Parameter name="StraightEdges: translations"       type="bool"     value="true"/>
+                            <Parameter name="StraightEdges: rotations"          type="bool"     value="true"/>
+                            <Parameter name="Edges: translations"               type="bool"     value="true"/>
+                            <Parameter name="Edges: rotations"                  type="bool"     value="true"/>
+                            <Parameter name="Faces: translations"               type="bool"     value="true"/>
+                            <Parameter name="Faces: rotations"                  type="bool"     value="true"/>
+                        </ParameterList>
+                    </ParameterList>
+                </ParameterList>
+                
+                <ParameterList name="ExtensionSolver">
+                    <Parameter name="SolverType"                                type="string"   value="Amesos2"/>
+                    <Parameter name="Solver"                                    type="string"   value="Klu"/>
+                </ParameterList>
+                
+                <ParameterList name="Distribution">
+                    <Parameter name="Type"                                      type="string"   value="linear"/>
+                    <Parameter name="GatheringSteps"                            type="int"      value="1"/>
+                    <Parameter name="NumProcs"                                  type="int"      value="1"/>
+                    <Parameter name="Factor"                                    type="double"   value="1.0"/>
+                </ParameterList>
+                
+                <ParameterList name="CoarseSolver">
+                    <Parameter name="SolverType"                                type="string"   value="MueLu"/>
+                    <!--
+                    <Parameter name="Solver"                                    type="string"   value="Klu"/>
+                    -->
+                    <ParameterList name="MueLu">
+                      <Parameter name="mgridSweeps" type="int" value="3"/>
+                      <Parameter name="tol" type="double" value="1.0e-6"/>
+                      
+                      <!-- An extended MueLu xml list -->
+                      <ParameterList name="MueLu Parameter">
+
+                        <!--
+                          For a generic symmetric scalar problem, these are the recommended settings for MueLu.
+                        -->
+                      
+                        <!-- ===========  GENERAL ================ -->
+                          <Parameter        name="verbosity"                            type="string"   value="high"/>
+                      
+                          <Parameter        name="coarse: max size"                     type="int"      value="3"/>
+                      
+                          <Parameter        name="multigrid algorithm"                  type="string"   value="sa"/>
+                      
+                          <!-- reduces setup cost for symmetric problems -->
+                          <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
+                      
+                          <!-- start of default values for general options (can be omitted) -->
+                          <Parameter        name="max levels"                         type="int"      value="10"/>
+                          <Parameter        name="number of equations"                  type="int"      value="3"/>
+                          <Parameter        name="sa: use filtered matrix"              type="bool"     value="true"/>
+                          <!-- end of default values -->
+                      
+                        <!-- ===========  AGGREGATION  =========== -->
+                          <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
+                          <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
+                          <!-- Uncomment the next line to enable dropping of weak connections, which can help AMG convergence
+                               for anisotropic problems.  The exact value is problem dependent. -->
+                          <!-- <Parameter        name="aggregation: drop tol"                type="double"   value="0.02"/> -->
+                      
+                        <!-- ===========  SMOOTHING  =========== -->
+                          <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
+                          <ParameterList    name="smoother: params">
+                            <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>>
+                            <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+                            <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+                            <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+                          </ParameterList>
+                      
+                      </ParameterList>
+                      
+                    </ParameterList>
+
+                </ParameterList>
+                
+            </ParameterList>
+            
+        </ParameterList>
+    </ParameterList>
+</ParameterList>

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Stokes_HDF5/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Stokes_HDF5/main.cpp
@@ -119,14 +119,23 @@ int main(int argc, char *argv[])
     CommandLineProcessor My_CLP;
 
     RCP<FancyOStream> out = VerboseObjectBase::getDefaultOStream();
-    
+
+    // Overlap
     int Overlap = 0;
     My_CLP.setOption("O",&Overlap,"Overlap.");
+
+    // XML-file specifying the solver configuration
     string xmlFile = "ParameterList_TwoLevelBlockPreconditioner_GDSW.xml";
     My_CLP.setOption("PLIST",&xmlFile,"File name of the parameter list.");
+
+    // Use Epetra as linear algebra stack
     bool useepetra = false;
     My_CLP.setOption("USEEPETRA","USETPETRA",&useepetra,"Use Epetra infrastructure for the linear algebra.");
-    
+
+    // File name of HDF5 file to be read
+    string hdf5File = "stokes.h5";
+    My_CLP.setOption("HDF5FILE", &hdf5File, "File name of HDF5 file to be read.");
+
     My_CLP.recogniseAllOptions(true);
     My_CLP.throwExceptions(false);
     CommandLineProcessor::EParseCommandLineReturn parseReturn = My_CLP.parse(argc,argv);
@@ -161,8 +170,8 @@ int main(int argc, char *argv[])
 
         unsigned Dimension = 2;
         RCP<HDF5> hDF5IO(new HDF5(*EpetraComm));
-        hDF5IO->Open("stokes.h5");
-        
+        hDF5IO->Open(hdf5File);
+
         ///////////////////
         // Repeated Maps //
         ///////////////////


### PR DESCRIPTION
@trilinos/shylu 

## Description
- Laplace problem: Adding tests to use MueLu as a coarse level solver within FROSch's GDSW
- Adding a more thorough error check to address #4208 
- Stokes problem: read file name of HDF5-file from the command line

## Motivation and Context
We want to try MueLu as coarse level solver for FROSch's GDSW. This starts with Laplace, but we aim at Stokes (or similar) problems in the end.

## Related Issues

* Closes #4208  

## How Has This Been Tested?
I added an Epetra and a Tpetra test for the Laplace problem. Both pass locally.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.
