### PR TITLE
Change name of branches from 'atdm-develop-nightly' to 'atdm-nightly' (TRIL-260)

### DIFF
--- a/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
+++ b/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
@@ -129,9 +129,9 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
     "${THIS_LIST_FILE}"
     )
 
-  # Make the default branch 'atdm-develop-nightly' (but allow it to be overridden in
+  # Make the default branch 'atdm-nightly' (but allow it to be overridden in
   # *.cmake script)
-  SET_DEFAULT(Trilinos_BRANCH atdm-develop-nightly)
+  SET_DEFAULT(Trilinos_BRANCH atdm-nightly)
 
   # Set the default CDash Track/Group to "Specialized".  This will not trigger
   # CDash error emails for any failures.  But when the build is clean, the var


### PR DESCRIPTION
CC: @fryeguy52, @mhoemmen 

## Description

The reasons for making this name change are:

* Avoid these branches coming up in GitHub PR creation when looking to change
  from 'master' to 'develop'.

* Allow for more flexibility in case in the future we want to update from
  'master' instead of 'develop'.

* Shorten the names of the branches because, why not.

## Motivation and Context

See above.
