### PR TITLE
Sacado:  Add specializations so pow() only uses if_then_else for simd types

### DIFF
--- a/packages/sacado/src/Sacado_CacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_CacheFad_Ops.hpp
@@ -1814,11 +1814,11 @@ namespace Sacado {
         const value_type_1 v1 = expr1.val();
         const value_type_2 v2 = expr2.val();
         v = std::pow(v1,v2);
-        if (v1 == value_type(0)) {
+        if (v2 == value_type_2(0)) {
           a = value_type(0);
         }
         else {
-          a = v2*std::pow(v1,v2-value_type(1.0));
+          a = v2*std::pow(v1,v2-value_type_2(1.0));
         }
       }
 

--- a/packages/sacado/src/Sacado_CacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_CacheFad_Ops.hpp
@@ -1818,7 +1818,7 @@ namespace Sacado {
           a = value_type(0);
         }
         else {
-          a = v*v2/v1;
+          a = v2*std::pow(v1,v2-value_type(1.0));
         }
       }
 

--- a/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
@@ -2577,7 +2577,7 @@ namespace Sacado {
           a = scalar_type(0.0);
         }
         else {
-          a = v2*std::pow(v1,v2-value_type(1.0));
+          a = v2*std::pow(v1,v2-scalar_type(1.0));
         }
       }
 

--- a/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
@@ -2577,7 +2577,7 @@ namespace Sacado {
           a = scalar_type(0.0);
         }
         else {
-          a = v*v2/v1;
+          a = v2*std::pow(v1,v2-value_type(1.0));
         }
       }
 

--- a/packages/sacado/src/Sacado_ELRFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_Ops.hpp
@@ -895,9 +895,9 @@ FAD_BINARYOP_MACRO(pow,
                    expr1.val() == value_type(0) ? value_type(0) : value_type((expr2.dx(i)*std::log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0.0) : value_type((expr2.fastAccessDx(i)*std::log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0) : value_type(expr2.dx(i)*std::log(expr1.val())*std::pow(expr1.val(),expr2.val())),
-                   expr1.val() == value_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)/expr1.val()*std::pow(expr1.val(),expr2.val())),
+                   expr1.val() == value_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)*std::pow(expr1.val(),expr2.val()-value_type(1.0))),
                    expr1.val() == value_type(0) ? value_type(0) : value_type(expr2.fastAccessDx(i)*std::log(expr1.val())*std::pow(expr1.val(),expr2.val())),
-                   expr1.val() == value_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.fastAccessDx(i)/expr1.val()*std::pow(expr1.val(),expr2.val())))
+                   expr1.val() == value_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.fastAccessDx(i)*std::pow(expr1.val(),expr2.val()-value_type(1.0))))
 FAD_BINARYOP_MACRO(max,
                    MaxOp,
                    expr1.val() >= expr2.val() ? expr1.val() : expr2.val(),

--- a/packages/sacado/src/Sacado_ELRFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_Ops.hpp
@@ -895,9 +895,9 @@ FAD_BINARYOP_MACRO(pow,
                    expr1.val() == value_type(0) ? value_type(0) : value_type((expr2.dx(i)*std::log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0.0) : value_type((expr2.fastAccessDx(i)*std::log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0) : value_type(expr2.dx(i)*std::log(expr1.val())*std::pow(expr1.val(),expr2.val())),
-                   expr1.val() == value_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)*std::pow(expr1.val(),expr2.val()-value_type(1.0))),
+                   expr2.val() == scalar_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)*std::pow(expr1.val(),expr2.val()-scalar_type(1.0))),
                    expr1.val() == value_type(0) ? value_type(0) : value_type(expr2.fastAccessDx(i)*std::log(expr1.val())*std::pow(expr1.val(),expr2.val())),
-                   expr1.val() == value_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.fastAccessDx(i)*std::pow(expr1.val(),expr2.val()-value_type(1.0))))
+                   expr2.val() == scalar_type(0) ? value_type(0.0) : value_type(expr2.val()*expr1.fastAccessDx(i)*std::pow(expr1.val(),expr2.val()-scalar_type(1.0))))
 FAD_BINARYOP_MACRO(max,
                    MaxOp,
                    expr1.val() >= expr2.val() ? expr1.val() : expr2.val(),

--- a/packages/sacado/src/Sacado_Fad_DFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_DFadTraits.hpp
@@ -89,10 +89,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to DFad types
+  //! Specialization of %IsScalarType to DFad types
   template <typename ValueT>
   struct IsScalarType< Fad::DFad<ValueT> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to DFad types
+  template <typename ValueT>
+  struct IsSimdType< Fad::DFad<ValueT> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to DFad types

--- a/packages/sacado/src/Sacado_Fad_DMFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_DMFadTraits.hpp
@@ -70,10 +70,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to DMFad types
+  //! Specialization of %IsScalarType to DMFad types
   template <typename ValueT>
   struct IsScalarType< Fad::DMFad<ValueT> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to DMFad types
+  template <typename ValueT>
+  struct IsSimdType< Fad::DMFad<ValueT> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to DMFad types

--- a/packages/sacado/src/Sacado_Fad_DVFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_DVFadTraits.hpp
@@ -89,10 +89,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to DVFad types
+  //! Specialization of %IsScalarType to DVFad types
   template <typename ValueT>
   struct IsScalarType< Fad::DVFad<ValueT> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to DVFad types
+  template <typename ValueT>
+  struct IsSimdType< Fad::DVFad<ValueT> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to DVFad types

--- a/packages/sacado/src/Sacado_Fad_ExpressionTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_ExpressionTraits.hpp
@@ -65,10 +65,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to Expr types
+  //! Specialization of %IsSclarType to Expr types
   template <typename T>
   struct IsScalarType< Fad::Expr<T> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to Expr types
+  template <typename T>
+  struct IsSimdType< Fad::Expr<T> > {
+    static const bool value = IsSimdType< typename Fad::Expr<T>::value_type >::value;
   };
 
   //! Specialization of %Value to Expr types

--- a/packages/sacado/src/Sacado_Fad_Ops.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops.hpp
@@ -1157,13 +1157,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       const value_type dx(int i) const {
         using std::pow;
-        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-value_type(1.0))) );
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
+        return if_then_else( c.val() == scalar_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-scalar_type(1.0))) );
       }
 
       KOKKOS_INLINE_FUNCTION
       const value_type fastAccessDx(int i) const {
         using std::pow;
-        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-value_type(1.0))) );
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
+        return if_then_else( c.val() == scalar_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-scalar_type(1.0))) );
       }
 
     protected:
@@ -1229,13 +1233,13 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       const value_type dx(int i) const {
         using std::pow; using std::log;
-        return if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val())) );
+        return if_then_else( c.val() == scalar_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val())) );
       }
 
       KOKKOS_INLINE_FUNCTION
       const value_type fastAccessDx(int i) const {
         using std::pow; using std::log;
-        return if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val())) );
+        return if_then_else( c.val() == scalar_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val())) );
       }
 
     protected:
@@ -1376,14 +1380,18 @@ namespace Sacado {
 
       KOKKOS_INLINE_FUNCTION
       const value_type dx(int i) const {
-        using std::pow; using std::log;
-        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-value_type(1.0)));
+        using std::pow;
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
+        return c.val() == scalar_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-scalar_type(1.0)));
       }
 
       KOKKOS_INLINE_FUNCTION
       const value_type fastAccessDx(int i) const {
-        using std::pow; using std::log;
-        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-value_type(1.0)));
+        using std::pow;
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
+        return c.val() == scalar_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-scalar_type(1.0)));
       }
 
     protected:
@@ -1449,13 +1457,13 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       const value_type dx(int i) const {
         using std::pow; using std::log;
-        return c.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val()));
+        return c.val() == scalar_type(0.0) ? value_type(0.0) : value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val()));
       }
 
       KOKKOS_INLINE_FUNCTION
       const value_type fastAccessDx(int i) const {
         using std::pow; using std::log;
-        return c.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val()));
+        return c.val() == scalar_type(0.0) ? value_type(0.0) : value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val()));
       }
 
     protected:

--- a/packages/sacado/src/Sacado_Fad_Ops.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops.hpp
@@ -53,6 +53,7 @@
 #define SACADO_FAD_OPS_HPP
 
 #include "Sacado_Fad_Expression.hpp"
+#include "Sacado_Fad_Ops_Fwd.hpp"
 #include "Sacado_cmath.hpp"
 #include <ostream>      // for std::ostream
 
@@ -652,18 +653,18 @@ FAD_BINARYOP_MACRO(atan2,
                    (c.val()*expr1.dx(i))/ (expr1.val()*expr1.val() + c.val()*c.val()),
                    (-c.val()*expr2.fastAccessDx(i))/ (c.val()*c.val() + expr2.val()*expr2.val()),
                    (c.val()*expr1.fastAccessDx(i))/ (expr1.val()*expr1.val() + c.val()*c.val()))
-FAD_BINARYOP_MACRO(pow,
-                   PowerOp,
-                   using std::pow; using std::log; using Sacado::if_then_else;,
-                   pow(expr1.val(), expr2.val()),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
-                   pow(c.val(), expr2.val()),
-                   pow(expr1.val(), c.val()),
-                   if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),c.val())) ),
-                   if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c.val()))) )
+// FAD_BINARYOP_MACRO(pow,
+//                    PowerOp,
+//                    using std::pow; using std::log; using Sacado::if_then_else;,
+//                    pow(expr1.val(), expr2.val()),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
+//                    pow(c.val(), expr2.val()),
+//                    pow(expr1.val(), c.val()),
+//                    if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),c.val())) ),
+//                    if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c.val()))) )
 FAD_BINARYOP_MACRO(max,
                    MaxOp,
                    using Sacado::if_then_else;,
@@ -927,10 +928,14 @@ namespace Sacado {
 
     template <typename T1, typename T2>
     KOKKOS_INLINE_FUNCTION
-    SACADO_FAD_OP_ENABLE_EXPR_EXPR(MultiplicationOp)
-    operator* (const T1& expr1, const T2& expr2)
+    typename mpl::enable_if_c<
+       ExprLevel< Expr<T1> >::value == ExprLevel< Expr<T2> >::value,
+       Expr< MultiplicationOp< Expr<T1>, Expr<T2> > >
+     >::type
+    /*SACADO_FAD_OP_ENABLE_EXPR_EXPR(MultiplicationOp)*/
+    operator* (const Expr<T1>& expr1, const Expr<T2>& expr2)
     {
-      typedef MultiplicationOp< T1, T2 > expr_t;
+      typedef MultiplicationOp< Expr<T1>, Expr<T2> > expr_t;
 
       return Expr<expr_t>(expr1, expr2);
     }
@@ -989,6 +994,544 @@ namespace Sacado {
     {
       typedef ConstExpr<typename Expr<T>::scalar_type> ConstT;
       typedef MultiplicationOp< Expr<T>, ConstT > expr_t;
+
+      return Expr<expr_t>(expr, ConstT(c));
+    }
+  }
+}
+
+// Special handling for std::pow() to provide specializations of PowerOp for
+// "simd" value types that use if_then_else(). The only reason for not using
+// if_then_else() always is to avoid evaluating the derivative if the value is
+// zero to avoid throwing FPEs.
+namespace Sacado {
+  namespace Fad {
+
+    template <typename ExprT1, typename ExprT2, bool is_simd>
+    class PowerOp {};
+
+    template <typename ExprT1, typename ExprT2>
+    struct ExprSpec< PowerOp< ExprT1, ExprT2 > > {
+      typedef typename ExprSpec<ExprT1>::type type;
+    };
+
+    template <typename ExprT1, typename T2>
+    struct ExprSpec<PowerOp< ExprT1, ConstExpr<T2> > > {
+      typedef typename ExprSpec<ExprT1>::type type;
+    };
+
+    template <typename T1, typename ExprT2>
+    struct ExprSpec< PowerOp< ConstExpr<T1>, ExprT2 > > {
+      typedef typename ExprSpec<ExprT2>::type type;
+    };
+
+    //
+    // Implementation for simd type using if_then_else()
+    //
+    template <typename ExprT1, typename ExprT2>
+    class Expr< PowerOp< ExprT1, ExprT2, true >, ExprSpecDefault > {
+
+    public:
+
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename ExprT1::base_expr_type base_expr_type_1;
+      typedef typename ExprT2::base_expr_type base_expr_type_2;
+      typedef typename Sacado::Promote<base_expr_type_1,
+                                       base_expr_type_2>::type base_expr_type;
+
+      KOKKOS_INLINE_FUNCTION
+      Expr(const ExprT1& expr1_, const ExprT2& expr2_) :
+        expr1(expr1_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        int sz1 = expr1.size(), sz2 = expr2.size();
+        return sz1 > sz2 ? sz1 : sz2;
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess() && expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool isPassive() const {
+        return expr1.isPassive() && expr2.isPassive();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const {
+        return expr1.updateValue() && expr2.updateValue();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type dx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val())) );
+      }
+
+    protected:
+
+      const ExprT1& expr1;
+      const ExprT2& expr2;
+
+    };
+
+    template <typename ExprT1, typename T2>
+    class Expr< PowerOp< ExprT1, ConstExpr<T2>, true >, ExprSpecDefault > {
+
+    public:
+
+      typedef ConstExpr<T2> ConstT;
+      typedef ConstExpr<T2> ExprT2;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename ExprT1::base_expr_type base_expr_type_1;
+      typedef typename ExprT2::base_expr_type base_expr_type_2;
+      typedef typename Sacado::Promote<base_expr_type_1,
+                                       base_expr_type_2>::type base_expr_type;
+
+      KOKKOS_INLINE_FUNCTION
+      Expr(const ExprT1& expr1_, const ConstT& c_) :
+        expr1(expr1_), c(c_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr1.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool isPassive() const {
+        return expr1.isPassive();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const { return expr1.updateValue(); }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), c.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type dx(int i) const {
+        using std::pow;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-value_type(1.0))) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type fastAccessDx(int i) const {
+        using std::pow;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-value_type(1.0))) );
+      }
+
+    protected:
+
+      const ExprT1& expr1;
+      ConstT c;
+    };
+
+    template <typename T1, typename ExprT2>
+    class Expr< PowerOp< ConstExpr<T1>, ExprT2, true >, ExprSpecDefault > {
+
+    public:
+
+      typedef ConstExpr<T1> ConstT;
+      typedef ConstExpr<T1> ExprT1;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename ExprT1::base_expr_type base_expr_type_1;
+      typedef typename ExprT2::base_expr_type base_expr_type_2;
+      typedef typename Sacado::Promote<base_expr_type_1,
+                                       base_expr_type_2>::type base_expr_type;
+
+
+      KOKKOS_INLINE_FUNCTION
+      Expr(const ConstT& c_, const ExprT2& expr2_) :
+        c(c_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr2.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool isPassive() const {
+        return expr2.isPassive();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const { return expr2.updateValue(); }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type val() const {
+        using std::pow;
+        return pow(c.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type dx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val())) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( c.val() == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val())) );
+      }
+
+    protected:
+
+      ConstT c;
+      const ExprT2& expr2;
+    };
+
+    //
+    // Specialization for scalar types using ternary operator
+    //
+
+    template <typename ExprT1, typename ExprT2>
+    class Expr< PowerOp< ExprT1, ExprT2, false >, ExprSpecDefault > {
+
+    public:
+
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename ExprT1::base_expr_type base_expr_type_1;
+      typedef typename ExprT2::base_expr_type base_expr_type_2;
+      typedef typename Sacado::Promote<base_expr_type_1,
+                                       base_expr_type_2>::type base_expr_type;
+
+      KOKKOS_INLINE_FUNCTION
+      Expr(const ExprT1& expr1_, const ExprT2& expr2_) :
+        expr1(expr1_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        int sz1 = expr1.size(), sz2 = expr2.size();
+        return sz1 > sz2 ? sz1 : sz2;
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess() && expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool isPassive() const {
+        return expr1.isPassive() && expr2.isPassive();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const {
+        return expr1.updateValue() && expr2.updateValue();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type dx(int i) const {
+        using std::pow; using std::log;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val()));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val()));
+      }
+
+    protected:
+
+      const ExprT1& expr1;
+      const ExprT2& expr2;
+
+    };
+
+    template <typename ExprT1, typename T2>
+    class Expr< PowerOp< ExprT1, ConstExpr<T2>, false >, ExprSpecDefault > {
+
+    public:
+
+      typedef ConstExpr<T2> ConstT;
+      typedef ConstExpr<T2> ExprT2;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename ExprT1::base_expr_type base_expr_type_1;
+      typedef typename ExprT2::base_expr_type base_expr_type_2;
+      typedef typename Sacado::Promote<base_expr_type_1,
+                                       base_expr_type_2>::type base_expr_type;
+
+      KOKKOS_INLINE_FUNCTION
+      Expr(const ExprT1& expr1_, const ConstT& c_) :
+        expr1(expr1_), c(c_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr1.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool isPassive() const {
+        return expr1.isPassive();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const { return expr1.updateValue(); }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), c.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type dx(int i) const {
+        using std::pow; using std::log;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-value_type(1.0)));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-value_type(1.0)));
+      }
+
+    protected:
+
+      const ExprT1& expr1;
+      ConstT c;
+    };
+
+    template <typename T1, typename ExprT2>
+    class Expr< PowerOp< ConstExpr<T1>, ExprT2, false >, ExprSpecDefault > {
+
+    public:
+
+      typedef ConstExpr<T1> ConstT;
+      typedef ConstExpr<T1> ExprT1;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename ExprT1::base_expr_type base_expr_type_1;
+      typedef typename ExprT2::base_expr_type base_expr_type_2;
+      typedef typename Sacado::Promote<base_expr_type_1,
+                                       base_expr_type_2>::type base_expr_type;
+
+
+      KOKKOS_INLINE_FUNCTION
+      Expr(const ConstT& c_, const ExprT2& expr2_) :
+        c(c_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr2.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool isPassive() const {
+        return expr2.isPassive();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const { return expr2.updateValue(); }
+
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type val() const {
+        using std::pow;
+        return pow(c.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type dx(int i) const {
+        using std::pow; using std::log;
+        return c.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.dx(i)*log(c.val())*pow(c.val(),expr2.val()));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      const value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return c.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.fastAccessDx(i)*log(c.val())*pow(c.val(),expr2.val()));
+      }
+
+    protected:
+
+      ConstT c;
+      const ExprT2& expr2;
+    };
+
+    template <typename T1, typename T2>
+    KOKKOS_INLINE_FUNCTION
+    typename mpl::enable_if_c<
+       ExprLevel< Expr<T1> >::value == ExprLevel< Expr<T2> >::value,
+       Expr< PowerOp< Expr<T1>, Expr<T2> > >
+     >::type
+    /*SACADO_FAD_OP_ENABLE_EXPR_EXPR(PowerOp)*/
+    pow (const Expr<T1>& expr1, const Expr<T2>& expr2)
+    {
+      typedef PowerOp< Expr<T1>, Expr<T2> > expr_t;
+
+      return Expr<expr_t>(expr1, expr2);
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    Expr< PowerOp< Expr<T>, Expr<T> > >
+    pow (const Expr<T>& expr1, const Expr<T>& expr2)
+    {
+      typedef PowerOp< Expr<T>, Expr<T> > expr_t;
+
+      return Expr<expr_t>(expr1, expr2);
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    Expr< PowerOp< ConstExpr<typename Expr<T>::value_type>, Expr<T> > >
+    pow (const typename Expr<T>::value_type& c,
+         const Expr<T>& expr)
+    {
+      typedef ConstExpr<typename Expr<T>::value_type> ConstT;
+      typedef PowerOp< ConstT, Expr<T> > expr_t;
+
+      return Expr<expr_t>(ConstT(c), expr);
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    Expr< PowerOp< Expr<T>, ConstExpr<typename Expr<T>::value_type> > >
+    pow (const Expr<T>& expr,
+         const typename Expr<T>::value_type& c)
+    {
+      typedef ConstExpr<typename Expr<T>::value_type> ConstT;
+      typedef PowerOp< Expr<T>, ConstT > expr_t;
+
+      return Expr<expr_t>(expr, ConstT(c));
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    SACADO_FAD_OP_ENABLE_SCALAR_EXPR(PowerOp)
+    pow (const typename Expr<T>::scalar_type& c,
+         const Expr<T>& expr)
+    {
+      typedef ConstExpr<typename Expr<T>::scalar_type> ConstT;
+      typedef PowerOp< ConstT, Expr<T> > expr_t;
+
+      return Expr<expr_t>(ConstT(c), expr);
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    SACADO_FAD_OP_ENABLE_EXPR_SCALAR(PowerOp)
+    pow (const Expr<T>& expr,
+         const typename Expr<T>::scalar_type& c)
+    {
+      typedef ConstExpr<typename Expr<T>::scalar_type> ConstT;
+      typedef PowerOp< Expr<T>, ConstT > expr_t;
 
       return Expr<expr_t>(expr, ConstT(c));
     }

--- a/packages/sacado/src/Sacado_Fad_Ops_Fwd.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops_Fwd.hpp
@@ -1,0 +1,100 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+//
+// The forward-mode AD classes in Sacado are a derivative work of the
+// expression template classes in the Fad package by Nicolas Di Cesare.
+// The following banner is included in the original Fad source code:
+//
+// ************ DO NOT REMOVE THIS BANNER ****************
+//
+//  Nicolas Di Cesare <Nicolas.Dicesare@ann.jussieu.fr>
+//  http://www.ann.jussieu.fr/~dicesare
+//
+//            CEMRACS 98 : C++ courses,
+//         templates : new C++ techniques
+//            for scientific computing
+//
+//********************************************************
+//
+//  A short implementation ( not all operators and
+//  functions are overloaded ) of 1st order Automatic
+//  Differentiation in forward mode (FAD) using
+//  EXPRESSION TEMPLATES.
+//
+//********************************************************
+// @HEADER
+
+#ifndef SACADO_FAD_OPS_FWD_HPP
+#define SACADO_FAD_OPS_FWD_HPP
+
+namespace Sacado {
+
+  template <typename T> struct IsSimdType;
+
+  namespace Fad {
+
+    template <typename ExprT> class UnaryPlusOp;
+    template <typename ExprT> class UnaryMinusOp;
+    template <typename ExprT> class ExpOp;
+    template <typename ExprT> class LogOp;
+    template <typename ExprT> class Log10Op;
+    template <typename ExprT> class SqrtOp;
+    template <typename ExprT> class CosOp;
+    template <typename ExprT> class SinOp;
+    template <typename ExprT> class TanOp;
+    template <typename ExprT> class ACosOp;
+    template <typename ExprT> class ASinOp;
+    template <typename ExprT> class ATanOp;
+    template <typename ExprT> class CoshOp;
+    template <typename ExprT> class SinhOp;
+    template <typename ExprT> class TanhOp;
+    template <typename ExprT> class ACoshOp;
+    template <typename ExprT> class ASinhOp;
+    template <typename ExprT> class ATanhOp;
+    template <typename ExprT> class AbsOp;
+    template <typename ExprT> class FAbsOp;
+#ifdef HAVE_SACADO_CXX11
+    template <typename ExprT> class CbrtOp;
+#endif
+
+    template <typename ExprT1, typename ExprT2> class AdditionOp;
+    template <typename ExprT1, typename ExprT2> class SubtractionOp;
+    template <typename ExprT1, typename ExprT2> class Multiplicationp;
+    template <typename ExprT1, typename ExprT2> class DivisionOp;
+    template <typename ExprT1, typename ExprT2> class Atan2Op;
+    template <typename ExprT1, typename ExprT2,
+              bool is_simd = IsSimdType<ExprT1>::value ||
+              IsSimdType<ExprT2>::value> class PowerOp;
+    template <typename ExprT1, typename ExprT2> class MaxOp;
+    template <typename ExprT1, typename ExprT2> class MinOp;
+
+  } // namespace Fad
+
+} // namespace Sacado
+
+#endif // SACADO_FAD_EXPRESSION_HPP

--- a/packages/sacado/src/Sacado_Fad_SFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_SFadTraits.hpp
@@ -90,10 +90,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to SFad types
+  //! Specialization of %IsScalarType to SFad types
   template <typename ValueT, int Num>
   struct IsScalarType< Fad::SFad<ValueT,Num> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to SFad types
+  template <typename ValueT, int Num>
+  struct IsSimdType< Fad::SFad<ValueT,Num> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to SFad types

--- a/packages/sacado/src/Sacado_Fad_SLFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_SLFadTraits.hpp
@@ -71,10 +71,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to SLFad types
+  //! Specialization of %IsScalarType to SLFad types
   template <typename ValueT, int Num>
   struct IsScalarType< Fad::SLFad<ValueT,Num> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to SLFad types
+  template <typename ValueT, int Num>
+  struct IsSimdType< Fad::SLFad<ValueT,Num> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to SLFad types

--- a/packages/sacado/src/Sacado_Fad_SimpleFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_SimpleFadTraits.hpp
@@ -81,10 +81,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to SimpleFad types
+  //! Specialization of %IsScalarType to SimpleFad types
   template <typename ValueT>
   struct IsScalarType< Fad::SimpleFad<ValueT> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to SimpleFad types
+  template <typename ValueT>
+  struct IsSimdType< Fad::SimpleFad<ValueT> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to SimpleFad types

--- a/packages/sacado/src/Sacado_Fad_ViewFadTraits.hpp
+++ b/packages/sacado/src/Sacado_Fad_ViewFadTraits.hpp
@@ -89,10 +89,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to ViewFad types
+  //! Specialization of %IsScalarType to ViewFad types
   template <typename ValueT, unsigned Size, unsigned Stride, typename Base>
   struct IsScalarType< Fad::ViewFad<ValueT,Size,Stride,Base> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to ViewFad types
+  template <typename ValueT, unsigned Size, unsigned Stride, typename Base>
+  struct IsSimdType< Fad::ViewFad<ValueT,Size,Stride,Base> > {
+    static const bool value = IsSimdType<ValueT>::value;
   };
 
   //! Specialization of %Value to ViewFad types

--- a/packages/sacado/src/Sacado_MathFunctions.hpp
+++ b/packages/sacado/src/Sacado_MathFunctions.hpp
@@ -37,11 +37,14 @@
 #include "Sacado_Fad_ExpressionFwd.hpp"
 #include "Sacado_SFINAE_Macros.hpp"
 
+// Note:  Sacado::Fad::Ops are forward-declared here, instead of in macros
+// below.
+#include "Sacado_Fad_Ops_Fwd.hpp"
+
 #define UNARYFUNC_MACRO(OP,FADOP)                                       \
 namespace Sacado {                                                      \
                                                                         \
   namespace Fad {                                                       \
-    template <typename T> class FADOP;                                  \
     template <typename T>                                               \
     KOKKOS_INLINE_FUNCTION                                              \
     Expr< FADOP< Expr<T> > > OP (const Expr<T>&);                       \
@@ -140,7 +143,6 @@ UNARYFUNC_MACRO(cbrt, CbrtOp)
 namespace Sacado {                                                      \
                                                                         \
   namespace Fad {                                                       \
-    template <typename T1, typename T2> class FADOP;                    \
     template <typename T> class ConstExpr;                              \
     template <typename T> struct IsFadExpr;                             \
     template <typename T> struct ExprLevel;                             \

--- a/packages/sacado/src/Sacado_Traits.hpp
+++ b/packages/sacado/src/Sacado_Traits.hpp
@@ -331,7 +331,7 @@ namespace Sacado {
 
   //! Base template specification for %IsADType
   /*!
-   * The %IsADType classes provide a mechanism for computing the
+   * The %IsADType classes provide a mechanism for
    * determining whether a type is an AD type
    */
   template <typename T> struct IsADType {
@@ -340,10 +340,19 @@ namespace Sacado {
 
   //! Base template specification for %IsScalarType
   /*!
-   * The %IsScalarType classes provide a mechanism for computing the
+   * The %IsScalarType classes provide a mechanism for
    * determining whether a type is a scalar type (float, double, etc...)
    */
   template <typename T> struct IsScalarType {
+    static const bool value = false;
+  };
+
+  //! Base template specification for %IsSimdType
+  /*!
+   * The %IsSimdType classes provide a mechanism for computing the
+   * determining whether a type is a Simd type (Doubles, MP::Vector, ...)
+   */
+  template <typename T> struct IsSimdType {
     static const bool value = false;
   };
 

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ExpressionTraits.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ExpressionTraits.hpp
@@ -57,10 +57,16 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to Expr types
+  //! Specialization of %IsScalarType to Expr types
   template <typename T>
   struct IsScalarType< Fad::Exp::Expr<T> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to Expr types
+  template <typename T>
+  struct IsSimdType< Fad::Exp::Expr<T> > {
+    static const bool value = IsSimdType< typename Fad::Exp::Expr<T>::value_type >::value;
   };
 
   //! Specialization of %Value to Expr types

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_GeneralFadTraits.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_GeneralFadTraits.hpp
@@ -65,10 +65,17 @@ namespace Sacado {
     static const bool value = true;
   };
 
-  //! Specialization of %IsADType to GeneralFad types
+  //! Specialization of %IsScalarType to GeneralFad types
   template <typename Storage>
   struct IsScalarType< Fad::Exp::GeneralFad<Storage> > {
     static const bool value = false;
+  };
+
+  //! Specialization of %IsSimdType to GeneralFad types
+  template <typename Storage>
+  struct IsSimdType< Fad::Exp::GeneralFad<Storage> > {
+    static const bool value =
+      IsSimdType< typename Fad::Exp::GeneralFad<Storage>::value_type >::value;
   };
 
   //! Specialization of %Value to GeneralFad types

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_MathFunctions.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_MathFunctions.hpp
@@ -33,13 +33,16 @@
 #include "Sacado_cmath.hpp"
 #include "Sacado_SFINAE_Macros.hpp"
 
+// Note:  Sacado::Fad::Ops are forward-declared here, instead of in macros
+// below.
+#include "Sacado_Fad_Exp_Ops_Fwd.hpp"
+
 #define UNARYFUNC_MACRO(OP,FADOP)                                       \
 namespace Sacado {                                                      \
                                                                         \
   namespace Fad {                                                       \
   namespace Exp {                                                       \
     template <typename T> class Expr;                                   \
-    template <typename T, typename E> class FADOP;                      \
     template <typename T>                                               \
     KOKKOS_INLINE_FUNCTION                                              \
     FADOP< typename Expr<T>::derived_type,                              \
@@ -82,8 +85,6 @@ namespace Sacado {                                                      \
   namespace Fad {                                                       \
   namespace Exp {                                                       \
     template <typename T> class Expr;                                   \
-    template <typename T1, typename T2, bool, bool, typename E>         \
-    class FADOP;                                                        \
     template <typename T> struct IsFadExpr;                             \
     template <typename T> struct ExprLevel;                             \
     template <typename T1, typename T2>                                 \

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
@@ -35,6 +35,7 @@
 #include <ostream>
 
 #include "Sacado_Fad_Expression.hpp"
+#include "Sacado_Fad_ExpressionTraits.hpp"
 #include "Sacado_cmath.hpp"
 
 #if defined(HAVE_SACADO_KOKKOSCORE)
@@ -128,6 +129,12 @@ namespace Sacado {                                                      \
   template <typename T, typename E>                                     \
   struct BaseExprType< Fad::Exp::OP< T,E > > {                          \
     typedef typename BaseExprType<T>::type type;                        \
+  };                                                                    \
+                                                                        \
+  template <typename T, typename E>                                     \
+  struct IsSimdType< Fad::Exp::OP< T,E > > {                            \
+    static const bool value =                                           \
+      IsSimdType< typename Fad::Exp::OP< T,E >::scalar_type >::value;   \
   };                                                                    \
                                                                         \
 }
@@ -540,6 +547,12 @@ namespace Sacado {                                                      \
                                      base_expr_2>::type type;           \
   };                                                                    \
                                                                         \
+  template <typename T1, typename T2, bool c1, bool c2, typename E>     \
+  struct IsSimdType< Fad::Exp::OP< T1, T2, c1, c2, E > > {              \
+    static const bool value =                                           \
+      IsSimdType< typename Fad::Exp::OP< T1, T2, c1, c2, E >::value_type >::value; \
+  };                                                                    \
+                                                                        \
 }
 
 
@@ -621,20 +634,20 @@ FAD_BINARYOP_MACRO(atan2,
                    (c*expr1.dx(i))/ (expr1.val()*expr1.val() + c*c),
                    (-c*expr2.fastAccessDx(i))/ (c*c + expr2.val()*expr2.val()),
                    (c*expr1.fastAccessDx(i))/ (expr1.val()*expr1.val() + c*c))
-FAD_BINARYOP_MACRO(pow,
-                   PowerOp,
-                   using std::pow; using std::log;,
-                   pow(expr1.val(), expr2.val()),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(expr1.val())*pow(expr1.val(),expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
-                   pow(c, expr2.val()),
-                   pow(expr1.val(), c),
-                   if_then_else( c == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c)*pow(c,expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.dx(i)/expr1.val()*pow(expr1.val(),c)) ),
-                   if_then_else( c == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c)*pow(c,expr2.val())) ),
-                   if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c))) )
+// FAD_BINARYOP_MACRO(pow,
+//                    PowerOp,
+//                    using std::pow; using std::log;,
+//                    pow(expr1.val(), expr2.val()),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(expr1.val())*pow(expr1.val(),expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val())) ),
+//                    pow(c, expr2.val()),
+//                    pow(expr1.val(), c),
+//                    if_then_else( c == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c)*pow(c,expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.dx(i)/expr1.val()*pow(expr1.val(),c)) ),
+//                    if_then_else( c == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c)*pow(c,expr2.val())) ),
+//                    if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c))) )
 FAD_BINARYOP_MACRO(max,
                    MaxOp,
                    ;,
@@ -663,6 +676,460 @@ FAD_BINARYOP_MACRO(min,
                    if_then_else( expr1.val() <= c, expr1.dx(i), value_type(0) ),
                    if_then_else( c <= expr2.val(), value_type(0), expr2.fastAccessDx(i) ),
                    if_then_else( expr1.val() <= c, expr1.fastAccessDx(i), value_type(0) ) )
+
+
+// Special handling for std::pow() to provide specializations of PowerOp for
+// "simd" value types that use if_then_else(). The only reason for not using
+// if_then_else() always is to avoid evaluating the derivative if the value is
+// zero to avoid throwing FPEs.
+namespace Sacado {
+  namespace Fad {
+  namespace Exp {
+
+    template <typename T1, typename T2,
+              bool is_const_T1, bool is_const_T2,
+              typename ExprSpec, bool is_simd >
+    class PowerOp {};
+
+    //
+    // Implementation for simd type using if_then_else()
+    //
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, false, ExprSpecDefault, true > :
+      public Expr< PowerOp< T1, T2, false, false, ExprSpecDefault, true > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef ExprSpecDefault expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const T2& expr2_) :
+        expr1(expr1_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        return sz1 > sz2 ? sz1 : sz2;
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess() && expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type dx(int i) const {
+        using std::pow; using std::log;
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        if (sz1 > 0 && sz2 > 0)
+          return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) );
+        else if (sz1 > 0)
+          return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.val()*expr1.dx(i)*pow(expr1.val(),expr2.val()-value_type(1.0))) );
+        else
+          return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(expr1.val())*pow(expr1.val(),expr2.val())) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val())) );
+      }
+
+    protected:
+
+      const T1& expr1;
+      const T2& expr2;
+
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, true, ExprSpecDefault, true >
+      : public Expr< PowerOp< T1, T2, false, true, ExprSpecDefault, true > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef T2 ConstT;
+      typedef typename ExprT1::value_type value_type;
+      typedef typename ExprT1::scalar_type scalar_type;
+
+      typedef ExprSpecDefault expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const ConstT& c_) :
+        expr1(expr1_), c(c_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr1.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), c);
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type dx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.dx(i)*pow(expr1.val(),c-value_type(1.0))) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.fastAccessDx(i)*pow(expr1.val(),c-value_type(1.0))) );
+      }
+
+    protected:
+
+      const T1& expr1;
+      const ConstT& c;
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, true, false, ExprSpecDefault, true >
+      : public Expr< PowerOp< T1, T2, true, false, ExprSpecDefault, true > > {
+    public:
+
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef T1 ConstT;
+      typedef typename ExprT2::value_type value_type;
+      typedef typename ExprT2::scalar_type scalar_type;
+
+      typedef ExprSpecDefault expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const ConstT& c_, const T2& expr2_) :
+        c(c_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr2.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(c, expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type dx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( c == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(c)*pow(c,expr2.val())) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return if_then_else( c == value_type(0.0), value_type(0.0), value_type(expr2.fastAccessDx(i)*log(c)*pow(c,expr2.val())) );
+      }
+
+    protected:
+
+      const ConstT& c;
+      const T2& expr2;
+    };
+
+    //
+    // Specialization for scalar types using ternary operator
+    //
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, false, ExprSpecDefault, false > :
+      public Expr< PowerOp< T1, T2, false, false, ExprSpecDefault, false > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef ExprSpecDefault expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const T2& expr2_) :
+        expr1(expr1_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        return sz1 > sz2 ? sz1 : sz2;
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess() && expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type dx(int i) const {
+        using std::pow; using std::log;
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        if (sz1 > 0 && sz2 > 0)
+          return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val()));
+        else if (sz1 > 0)
+          return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)*pow(expr1.val(),expr2.val()-value_type(1.0)));
+        else
+          return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.dx(i)*log(expr1.val())*pow(expr1.val(),expr2.val()));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type((expr2.fastAccessDx(i)*log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*pow(expr1.val(),expr2.val()));
+      }
+
+    protected:
+
+      const T1& expr1;
+      const T2& expr2;
+
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, true, ExprSpecDefault, false >
+      : public Expr< PowerOp< T1, T2, false, true, ExprSpecDefault, false > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef T2 ConstT;
+      typedef typename ExprT1::value_type value_type;
+      typedef typename ExprT1::scalar_type scalar_type;
+
+      typedef ExprSpecDefault expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const ConstT& c_) :
+        expr1(expr1_), c(c_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr1.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), c);
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type dx(int i) const {
+        using std::pow;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c*expr1.dx(i)*pow(expr1.val(),c-value_type(1.0)));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type fastAccessDx(int i) const {
+        using std::pow;
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c*expr1.fastAccessDx(i)*pow(expr1.val(),c-value_type(1.0)));
+      }
+
+    protected:
+
+      const T1& expr1;
+      const ConstT& c;
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, true, false, ExprSpecDefault, false >
+      : public Expr< PowerOp< T1, T2, true, false, ExprSpecDefault, false > > {
+    public:
+
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef T1 ConstT;
+      typedef typename ExprT2::value_type value_type;
+      typedef typename ExprT2::scalar_type scalar_type;
+
+      typedef ExprSpecDefault expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const ConstT& c_, const T2& expr2_) :
+        c(c_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr2.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(c, expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type dx(int i) const {
+        using std::pow; using std::log;
+        return c == value_type(0.0) ? value_type(0.0) : value_type(expr2.dx(i)*log(c)*pow(c,expr2.val()));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type fastAccessDx(int i) const {
+        using std::pow; using std::log;
+        return c == value_type(0.0) ? value_type(0.0) : value_type(expr2.fastAccessDx(i)*log(c)*pow(c,expr2.val()));
+      }
+
+    protected:
+
+      const ConstT& c;
+      const T2& expr2;
+    };
+
+    template <typename T1, typename T2>
+    KOKKOS_INLINE_FUNCTION
+    SACADO_FAD_EXP_OP_ENABLE_EXPR_EXPR(PowerOp)
+    pow (const T1& expr1, const T2& expr2)
+    {
+      typedef PowerOp< typename Expr<T1>::derived_type,
+                  typename Expr<T2>::derived_type,
+                  false, false, typename T1::expr_spec_type > expr_t;
+
+      return expr_t(expr1.derived(), expr2.derived());
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    PowerOp< typename T::value_type, typename Expr<T>::derived_type,
+        true, false, typename T::expr_spec_type >
+    pow (const typename T::value_type& c,
+            const Expr<T>& expr)
+    {
+      typedef typename T::value_type ConstT;
+      typedef PowerOp< ConstT, typename Expr<T>::derived_type,
+                  true, false, typename T::expr_spec_type > expr_t;
+
+      return expr_t(c, expr.derived());
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    PowerOp< typename Expr<T>::derived_type, typename T::value_type,
+        false, true, typename T::expr_spec_type >
+    pow (const Expr<T>& expr,
+         const typename T::value_type& c)
+    {
+      typedef typename T::value_type ConstT;
+      typedef PowerOp< typename Expr<T>::derived_type, ConstT,
+              false, true, typename T::expr_spec_type > expr_t;
+
+      return expr_t(expr.derived(), c);
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    SACADO_FAD_EXP_OP_ENABLE_SCALAR_EXPR(PowerOp)
+    pow (const typename T::scalar_type& c,
+         const Expr<T>& expr)
+    {
+      typedef typename T::scalar_type ConstT;
+      typedef PowerOp< ConstT, typename Expr<T>::derived_type,
+                       true, false, typename T::expr_spec_type > expr_t;
+
+      return expr_t(c, expr.derived());
+    }
+
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION
+    SACADO_FAD_EXP_OP_ENABLE_EXPR_SCALAR(PowerOp)
+    pow (const Expr<T>& expr,
+         const typename T::scalar_type& c)
+    {
+      typedef typename T::scalar_type ConstT;
+      typedef PowerOp< typename Expr<T>::derived_type, ConstT,
+                       false, true, typename T::expr_spec_type > expr_t;
+
+      return expr_t(expr.derived(), c);
+    }
+
+    template <typename T1, typename T2, bool c1, bool c2, typename E>
+    struct ExprLevel< PowerOp< T1, T2, c1, c2, E > > {
+      static constexpr unsigned value_1 = ExprLevel<T1>::value;
+      static constexpr unsigned value_2 = ExprLevel<T2>::value;
+      static constexpr unsigned value =
+        value_1 >= value_2 ? value_1 : value_2;
+    };
+
+    template <typename T1, typename T2, bool c1, bool c2, typename E>
+    struct IsFadExpr< PowerOp< T1, T2, c1, c2, E > > {
+      static constexpr unsigned value = true;
+    };
+
+  }
+  }
+
+  template <typename T1, typename T2, bool c1, bool c2, typename E>
+  struct IsExpr< Fad::Exp::PowerOp< T1, T2, c1, c2, E > > {
+    static constexpr bool value = true;
+  };
+
+  template <typename T1, typename T2, bool c1, bool c2, typename E>
+  struct BaseExprType< Fad::Exp::PowerOp< T1, T2, c1, c2, E > > {
+    typedef typename BaseExprType<T1>::type base_expr_1;
+    typedef typename BaseExprType<T2>::type base_expr_2;
+    typedef typename Sacado::Promote<base_expr_1,
+                                     base_expr_2>::type type;
+  };
+
+  template <typename T1, typename T2, bool c1, bool c2, typename E>
+  struct IsSimdType< Fad::Exp::PowerOp< T1, T2, c1, c2, E > > {
+    static const bool value =
+      IsSimdType< typename Fad::Exp::PowerOp< T1, T2, c1, c2, E >::value_type >::value;
+  };
+
+}
 
 //--------------------------if_then_else operator -----------------------
 // Can't use the above macros because it is a ternary operator (sort of).

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops_Fwd.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops_Fwd.hpp
@@ -1,0 +1,82 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef SACADO_EXP_FAD_OPS_FWD_HPP
+#define SACADO_EXP_FAD_OPS_FWD_HPP
+
+namespace Sacado {
+
+  template <typename T> struct IsSimdType;
+
+  namespace Fad {
+  namespace Exp {
+
+    template <typename T, typename E> class UnaryPlusOp;
+    template <typename T, typename E> class UnaryMinusOp;
+    template <typename T, typename E> class ExpOp;
+    template <typename T, typename E> class LogOp;
+    template <typename T, typename E> class Log10Op;
+    template <typename T, typename E> class SqrtOp;
+    template <typename T, typename E> class CosOp;
+    template <typename T, typename E> class SinOp;
+    template <typename T, typename E> class TanOp;
+    template <typename T, typename E> class ACosOp;
+    template <typename T, typename E> class ASinOp;
+    template <typename T, typename E> class ATanOp;
+    template <typename T, typename E> class CoshOp;
+    template <typename T, typename E> class SinhOp;
+    template <typename T, typename E> class TanhOp;
+    template <typename T, typename E> class ACoshOp;
+    template <typename T, typename E> class ASinhOp;
+    template <typename T, typename E> class ATanhOp;
+    template <typename T, typename E> class AbsOp;
+    template <typename T, typename E> class FAbsOp;
+    template <typename T, typename E> class CbrtOp;
+
+    template <typename T1, typename T2, bool, bool, typename E>
+    class AdditionOp;
+    template <typename T1, typename T2, bool, bool, typename E>
+    class SubtractionOp;
+    template <typename T1, typename T2, bool, bool, typename E>
+    class Multiplicationp;
+    template <typename T1, typename T2, bool, bool, typename E>
+    class DivisionOp;
+    template <typename T1, typename T2, bool, bool, typename E> class Atan2Op;
+    template <typename T1, typename T2, bool, bool, typename E,
+              bool is_simd = IsSimdType<T1>::value || IsSimdType<T2>::value>
+    class PowerOp;
+    template <typename T1, typename T2, bool, bool, typename E> class MaxOp;
+    template <typename T1, typename T2, bool, bool, typename E> class MinOp;
+
+  } // namespace Exp
+  } // namespace Fad
+
+} // namespace Sacado
+
+#endif // SACADO_FAD_EXPRESSION_HPP

--- a/packages/sacado/test/TestSuite/FadUnitTests.hpp
+++ b/packages/sacado/test/TestSuite/FadUnitTests.hpp
@@ -182,6 +182,8 @@ class FadOpsUnitTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testTimesLR);
   CPPUNIT_TEST(testDivideLR);
 
+  CPPUNIT_TEST(testPowConstB);
+
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -296,6 +298,63 @@ public:
     COMPARE_FADS(aa_dfad, aa_fad);
   }
 
+  // Check various corner cases for pow()
+  void testPowConstB() {
+    FadType a, b, c, cc;
+
+    // Constant b
+    a = FadType(n,1.2345);
+    for (int i=0; i<n; ++i)
+      a.fastAccessDx(i) = urand.number();
+    b = 3.456;
+    c = pow(a, b);
+    cc = FadType(n, pow(a.val(),b.val()));
+    for (int i=0; i<n; ++i)
+      cc.fastAccessDx(i) = b.val()*pow(a.val(),b.val()-1)*a.dx(i);
+    COMPARE_FADS(c, cc);
+
+    // Constant scalar b
+    c = pow(a, b.val());
+    COMPARE_FADS(c, cc);
+
+    // Constant b == 0
+    b = 0.0;
+    c = pow(a, b);
+    cc.val() = 1.0;
+    for (int i=0; i<n; ++i)
+      cc.fastAccessDx(i) = 0.0;
+    COMPARE_FADS(c, cc);
+
+    // Constant scalar b == 0
+    c = pow(a, b.val());
+    COMPARE_FADS(c, cc);
+
+    // a == 0 and constant b
+    a.val() = 0.0;
+    b = 3.456;
+    c = pow(a, b);
+    cc.val() = 0.0;
+    for (int i=0; i<n; ++i)
+      cc.fastAccessDx(i) = 0.0;
+    COMPARE_FADS(c, cc);
+
+    // a == 0 and constant scalar b
+    c = pow(a, b.val());
+    COMPARE_FADS(c, cc);
+
+    // a == 0 and b == 0
+    b = 0.0;
+    c = pow(a, b);
+    cc.val() = 1.0;
+    for (int i=0; i<n; ++i)
+      cc.fastAccessDx(i) = 0.0;
+    COMPARE_FADS(c, cc);
+
+    // a == 0 and scalar b == 0
+    c = pow(a, b.val());
+    COMPARE_FADS(c, cc);
+  }
+
 protected:
 
   // DFad variables
@@ -318,7 +377,7 @@ protected:
 template <class FadType, class ScalarType>
 FadOpsUnitTest<FadType,ScalarType>::
 FadOpsUnitTest() :
-  urand(), n(5), tol_a(1.0e-15), tol_r(1.0e-14) {}
+  urand(), n(5), tol_a(1.0e-15), tol_r(1.0e-12) {}
 
 template <class FadType, class ScalarType>
 FadOpsUnitTest<FadType,ScalarType>::

--- a/packages/sacado/test/TestSuite/NestedFadUnitTests.hpp
+++ b/packages/sacado/test/TestSuite/NestedFadUnitTests.hpp
@@ -190,6 +190,8 @@ class FadFadOpsUnitTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testTimesLR);
   CPPUNIT_TEST(testDivideLR);
 
+  CPPUNIT_TEST(testPowConstB);
+
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -319,6 +321,92 @@ public:
     aa_dfad = aa_dfad / b_dfad;
     aa_fad = aa_fad / b_fad;
     COMPARE_NESTED_FADS(aa_dfad, aa_fad);
+  }
+
+  // Check various corner cases for pow()
+  void testPowConstB() {
+    FadFadType a, b, c, cc;
+
+    // Constant b
+    a = a_dfad;
+    b = 3.456;
+    c = pow(a, b);
+    ScalarType f = pow(a.val().val(), b.val().val());
+    ScalarType fp = b.val().val()*pow(a.val().val(),b.val().val()-1);
+    ScalarType fpp = b.val().val()*(b.val().val()-1)*pow(a.val().val(),b.val().val()-2);
+    cc = FadFadType(n1,FadType(n2,f));
+    for (int i=0; i<n2; ++i)
+      cc.val().fastAccessDx(i) = fp*a.val().dx(i);
+    for (int i=0; i<n1; ++i) {
+      cc.fastAccessDx(i) = FadType(n2,fp*a.dx(i).val());
+      for (int j=0; j<n2; ++j)
+        cc.fastAccessDx(i).fastAccessDx(j) = fpp*a.dx(i).val()*a.val().dx(j) + fp*a.dx(i).dx(j);
+    }
+    COMPARE_NESTED_FADS(c, cc);
+
+    // Constant scalar b
+    c = pow(a, b.val());
+    COMPARE_NESTED_FADS(c, cc);
+    c = pow(a, b.val().val());
+    COMPARE_NESTED_FADS(c, cc);
+
+    // Constant b == 0
+    b = 0.0;
+    c = pow(a, b);
+    cc.val() = FadType(n2,1.0);
+#ifdef SACADO_NEW_FAD_DESIGN_IS_DEFAULT
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = 0.0;
+#else
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = FadType(n2,0.0);
+#endif
+    COMPARE_NESTED_FADS(c, cc);
+
+    // Constant scalar b == 0
+    c = pow(a, b.val());
+    cc.val() = FadType(n2,1.0);
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = 0.0;
+    COMPARE_NESTED_FADS(c, cc);
+    c = pow(a, b.val().val());
+    COMPARE_NESTED_FADS(c, cc);
+
+    // a == 0 and constant b
+    a.val() = 0.0;
+    b = 3.456;
+    c = pow(a, b);
+    cc.val() = 0.0;
+#ifdef SACADO_NEW_FAD_DESIGN_IS_DEFAULT
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = FadType(n2,0.0);
+#else
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = 0.0;
+#endif
+    COMPARE_NESTED_FADS(c, cc);
+
+    // a == 0 and constant scalar b
+    c = pow(a, b.val());
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = FadType(n2,0.0);
+    COMPARE_NESTED_FADS(c, cc);
+    c = pow(a, b.val().val());
+    COMPARE_NESTED_FADS(c, cc);
+
+    // a == 0 and b == 0
+    b = 0.0;
+    c = pow(a, b);
+    cc.val() = 1.0;
+    for (int i=0; i<n1; ++i)
+      cc.fastAccessDx(i) = 0.0;
+    COMPARE_NESTED_FADS(c, cc);
+
+    // a == 0 and scalar b == 0
+    c = pow(a, b.val());
+    COMPARE_NESTED_FADS(c, cc);
+    c = pow(a, b.val().val());
+    COMPARE_NESTED_FADS(c, cc);
   }
 
 protected:

--- a/packages/stokhos/src/sacado/kokkos/vector/Fad/Sacado_Fad_Exp_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Fad/Sacado_Fad_Exp_MP_Vector.hpp
@@ -979,23 +979,23 @@ FAD_BINARYOP_MACRO(atan2,
                    (c.fastAccessCoeff(j)*expr1.dx(i,j))/ (expr1.val(j)*expr1.val(j) + c.fastAccessCoeff(j)*c.fastAccessCoeff(j)),
                    (-c.fastAccessCoeff(j)*expr2.fastAccessDx(i,j))/ (c.fastAccessCoeff(j)*c.fastAccessCoeff(j) + expr2.val(j)*expr2.val(j)),
                    (c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j))/ (expr1.val(j)*expr1.val(j) + c.fastAccessCoeff(j)*c.fastAccessCoeff(j)))
-FAD_BINARYOP_MACRO(pow,
-                   PowerOp,
-                   using std::pow; using std::log;,
-                   pow(expr1.val(), expr2.val()),
-                   pow(expr1.val(j), expr2.val(j)),
-                   if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.dx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.dx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) ),
-                   if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(expr1.val(j))*pow(expr1.val(j),expr2.val(j))) ),
-                   if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.val(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),expr2.val(j))) ),
-                   if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.fastAccessDx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.fastAccessDx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) ),
-                   pow(c, expr2.val()),
-                   pow(expr1.val(), c),
-                   pow(c.fastAccessCoeff(j), expr2.val(j)),
-                   pow(expr1.val(j), c.fastAccessCoeff(j)),
-                   if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j))) ),
-                   if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j))) ),
-                   if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(expr2.fastAccessDx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j))) ),
-                   if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j)))) )
+// FAD_BINARYOP_MACRO(pow,
+//                    PowerOp,
+//                    using std::pow; using std::log;,
+//                    pow(expr1.val(), expr2.val()),
+//                    pow(expr1.val(j), expr2.val(j)),
+//                    if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.dx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.dx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) ),
+//                    if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(expr1.val(j))*pow(expr1.val(j),expr2.val(j))) ),
+//                    if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.val(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),expr2.val(j))) ),
+//                    if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.fastAccessDx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.fastAccessDx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) ),
+//                    pow(c, expr2.val()),
+//                    pow(expr1.val(), c),
+//                    pow(c.fastAccessCoeff(j), expr2.val(j)),
+//                    pow(expr1.val(j), c.fastAccessCoeff(j)),
+//                    if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j))) ),
+//                    if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j))) ),
+//                    if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(expr2.fastAccessDx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j))) ),
+//                    if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j)))) )
 FAD_BINARYOP_MACRO(max,
                    MaxOp,
                    ;,
@@ -1030,6 +1030,409 @@ FAD_BINARYOP_MACRO(min,
                    if_then_else( expr1.val(j) <= c.fastAccessCoeff(j), expr1.dx(i,j), val_type(0) ),
                    if_then_else( c.fastAccessCoeff(j) <= expr2.val(j), val_type(0), expr2.fastAccessDx(i,j) ),
                    if_then_else( expr1.val(j) <= c.fastAccessCoeff(j), expr1.fastAccessDx(i,j), val_type(0) ) )
+
+// Special handling for std::pow() to provide specializations of PowerOp for
+// "simd" value types that use if_then_else(). The only reason for not using
+// if_then_else() always is to avoid evaluating the derivative if the value is
+// zero to avoid throwing FPEs.
+namespace Sacado {
+  namespace Fad {
+  namespace Exp {
+
+    //
+    // Implementation for simd type using if_then_else()
+    //
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, false, ExprSpecMPVector, true > :
+      public Expr< PowerOp< T1, T2, false, false, ExprSpecMPVector, true > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename value_type::value_type val_type;
+
+      typedef ExprSpecMPVector expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const T2& expr2_) :
+        expr1(expr1_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        return sz1 > sz2 ? sz1 : sz2;
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess() && expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type val(int j) const {
+        using std::pow;
+        return pow(expr1.val(j), expr2.val(j));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type dx(int i, int j) const {
+        using std::pow; using std::log;
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        if (sz1 > 0 && sz2 > 0)
+          return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.dx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.dx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) );
+        else if (sz1 > 0)
+          // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+          return if_then_else( expr2.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.val(j)*expr1.dx(i,j)*pow(expr1.val(j),expr2.val(j)-val_type(1.0))) );
+        else
+          return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(expr1.val(j))*pow(expr1.val(j),expr2.val(j))) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type fastAccessDx(int i, int j) const {
+        using std::pow; using std::log;
+        return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.fastAccessDx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.fastAccessDx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) );
+      }
+
+    protected:
+
+      const T1& expr1;
+      const T2& expr2;
+
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, true, ExprSpecMPVector, true >
+      : public Expr< PowerOp< T1, T2, false, true, ExprSpecMPVector, true > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef T2 ConstT;
+      typedef typename ExprT1::value_type value_type;
+      typedef typename ExprT1::scalar_type scalar_type;
+
+      typedef typename value_type::value_type val_type;
+
+      typedef ExprSpecMPVector expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const ConstT& c_) :
+        expr1(expr1_), c(c_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr1.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), c);
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type val(int j) const {
+        using std::pow;
+        return pow(expr1.val(j), c.fastAccessCoeff(j));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type dx(int i, int j) const {
+        using std::pow;
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        return if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0))) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type fastAccessDx(int i, int j) const {
+        using std::pow;
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        return if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0))) );
+      }
+
+    protected:
+
+      const T1& expr1;
+      const ConstT& c;
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, true, false, ExprSpecMPVector, true >
+      : public Expr< PowerOp< T1, T2, true, false, ExprSpecMPVector, true > > {
+    public:
+
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef T1 ConstT;
+      typedef typename ExprT2::value_type value_type;
+      typedef typename ExprT2::scalar_type scalar_type;
+
+      typedef typename value_type::value_type val_type;
+
+      typedef ExprSpecMPVector expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const ConstT& c_, const T2& expr2_) :
+        c(c_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr2.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(c, expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type val(int j) const {
+        using std::pow;
+        return pow(c.fastAccessCoeff(j), expr2.val(j));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type dx(int i, int j) const {
+        using std::pow; using std::log;
+        return if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j))) );
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type fastAccessDx(int i, int j) const {
+        using std::pow; using std::log;
+        return if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(expr2.fastAccessDx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j))) );
+      }
+
+    protected:
+
+      const ConstT& c;
+      const T2& expr2;
+    };
+
+    //
+    // Specialization for scalar types using ternary operator
+    //
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, false, ExprSpecMPVector, false > :
+      public Expr< PowerOp< T1, T2, false, false, ExprSpecMPVector, false > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef typename ExprT1::value_type value_type_1;
+      typedef typename ExprT2::value_type value_type_2;
+      typedef typename Sacado::Promote<value_type_1,
+                                       value_type_2>::type value_type;
+
+      typedef typename ExprT1::scalar_type scalar_type_1;
+      typedef typename ExprT2::scalar_type scalar_type_2;
+      typedef typename Sacado::Promote<scalar_type_1,
+                                       scalar_type_2>::type scalar_type;
+
+      typedef typename value_type::value_type val_type;
+
+      typedef ExprSpecMPVector expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const T2& expr2_) :
+        expr1(expr1_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        return sz1 > sz2 ? sz1 : sz2;
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess() && expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type val(int j) const {
+        using std::pow;
+        return pow(expr1.val(j), expr2.val(j));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type dx(int i, int j) const {
+        using std::pow; using std::log;
+        const int sz1 = expr1.size(), sz2 = expr2.size();
+        if (sz1 > 0 && sz2 > 0)
+          return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type((expr2.dx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.dx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j)));
+        else if (sz1 > 0)
+          // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+          return expr2.val(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.val(j)*expr1.dx(i,j)*pow(expr1.val(j),expr2.val(j)-val_type(1.0)));
+        else
+          return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.dx(i,j)*log(expr1.val(j))*pow(expr1.val(j),expr2.val(j)));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type fastAccessDx(int i, int j) const {
+        using std::pow; using std::log;
+        return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type((expr2.fastAccessDx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.fastAccessDx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j)));
+      }
+
+    protected:
+
+      const T1& expr1;
+      const T2& expr2;
+
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, false, true, ExprSpecMPVector, false >
+      : public Expr< PowerOp< T1, T2, false, true, ExprSpecMPVector, false > > {
+    public:
+
+      typedef typename std::remove_cv<T1>::type ExprT1;
+      typedef T2 ConstT;
+      typedef typename ExprT1::value_type value_type;
+      typedef typename ExprT1::scalar_type scalar_type;
+
+      typedef typename value_type::value_type val_type;
+
+      typedef ExprSpecMPVector expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const T1& expr1_, const ConstT& c_) :
+        expr1(expr1_), c(c_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr1.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr1.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(expr1.val(), c);
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type val(int j) const {
+        using std::pow;
+        return pow(expr1.val(j), c.fastAccessCoeff(j));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type dx(int i, int j) const {
+        using std::pow;
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        return c.fastAccessCoeff(j) == val_type(0.0) ? val_type(0.0) : val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0)));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type fastAccessDx(int i, int j) const {
+        using std::pow;
+        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
+        return c.fastAccessCoeff(j) == val_type(0.0) ? val_type(0.0) : val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0)));
+      }
+
+    protected:
+
+      const T1& expr1;
+      const ConstT& c;
+    };
+
+    template <typename T1, typename T2>
+    class PowerOp< T1, T2, true, false, ExprSpecMPVector, false >
+      : public Expr< PowerOp< T1, T2, true, false, ExprSpecMPVector, false > > {
+    public:
+
+      typedef typename std::remove_cv<T2>::type ExprT2;
+      typedef T1 ConstT;
+      typedef typename ExprT2::value_type value_type;
+      typedef typename ExprT2::scalar_type scalar_type;
+
+      typedef typename value_type::value_type val_type;
+
+      typedef ExprSpecMPVector expr_spec_type;
+
+      KOKKOS_INLINE_FUNCTION
+      PowerOp(const ConstT& c_, const T2& expr2_) :
+        c(c_), expr2(expr2_) {}
+
+      KOKKOS_INLINE_FUNCTION
+      int size() const {
+        return expr2.size();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      bool hasFastAccess() const {
+        return expr2.hasFastAccess();
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      value_type val() const {
+        using std::pow;
+        return pow(c, expr2.val());
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type val(int j) const {
+        using std::pow;
+        return pow(c.fastAccessCoeff(j), expr2.val(j));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type dx(int i, int j) const {
+        using std::pow; using std::log;
+        return c.fastAccessCoeff(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.dx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j)));
+      }
+
+      KOKKOS_INLINE_FUNCTION
+      val_type fastAccessDx(int i, int j) const {
+        using std::pow; using std::log;
+        return c.fastAccessCoeff(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.fastAccessDx(i,j)*log(c.fastAccessCoeff(j))*pow(c.fastAccessCoeff(j),expr2.val(j)));
+      }
+
+    protected:
+
+      const ConstT& c;
+      const T2& expr2;
+    };
+
+  }
+  }
+}
 
 //--------------------------if_then_else operator -----------------------
 // Can't use the above macros because it is a ternary operator (sort of).


### PR DESCRIPTION
Related to issue #2008.  Recently Sacado's overloads of std::pow() were
changed to use if_then_else() to support use of Sacado with STK's SIMD
type, instead of the ternary operator to check when the base is equal to
0.  However when using if_then_else(), both branches are always
evaluated, and so a FPE can be generated even though the value isn't
used.  This changes the implementation by adding two specializations of
the PowerOp expression template, one for SIMD and one for everything
else, where only the SIMD one uses if_then_else().  This requires any
SIMD type that wants to pick up that implementation specialize
Sacado::IsSimdType<>.

@bartgol @vbrunini 