### PR TITLE
Ifpack2::OverlappingRowMatrix::apply: Fix #4392

### DIFF
--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_decl.hpp
@@ -45,8 +45,8 @@
 
 #include "Ifpack2_Details_RowMatrix.hpp"
 #include "Tpetra_CrsMatrix_decl.hpp" // only need the declaration here
-#include "Tpetra_Import.hpp"
-#include "Tpetra_Map.hpp"
+#include "Tpetra_Import_decl.hpp"
+#include "Tpetra_Map_decl.hpp"
 #include <type_traits>
 
 namespace Ifpack2 {
@@ -65,8 +65,8 @@ public:
   typedef typename MatrixType::global_ordinal_type global_ordinal_type;
   typedef typename MatrixType::node_type node_type;
   typedef typename Teuchos::ScalarTraits<scalar_type>::magnitudeType magnitude_type;
-  typedef Tpetra::RowMatrix<scalar_type, local_ordinal_type,
-                            global_ordinal_type, node_type> row_matrix_type;
+  using row_matrix_type = Tpetra::RowMatrix<scalar_type, local_ordinal_type,
+					    global_ordinal_type, node_type>;
 
   static_assert(std::is_same<MatrixType, row_matrix_type>::value, "Ifpack2::OverlappingRowMatrix: The template parameter MatrixType must be a Tpetra::RowMatrix specialization.  Please don't use Tpetra::CrsMatrix (a subclass of Tpetra::RowMatrix) here anymore.  The constructor can take either a RowMatrix or a CrsMatrix just fine.");
 
@@ -90,7 +90,7 @@ public:
                         const int overlapLevel);
 
   //! Destructor
-  ~OverlappingRowMatrix ();
+  ~OverlappingRowMatrix () = default;
 
   //@}
   //! @name Matrix query methods
@@ -330,7 +330,6 @@ public:
   exportMultiVector (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type> &OvX,
                      Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type> &X,
                      Tpetra::CombineMode CM = Tpetra::ADD);
-  //@}
 
   std::string description() const;
 
@@ -347,7 +346,7 @@ private:
   typedef Tpetra::Vector<scalar_type, local_ordinal_type, global_ordinal_type, node_type> vector_type;
 
   //! The input matrix to the constructor.
-  Teuchos::RCP<const row_matrix_type> A_;
+  Teuchos::RCP<const crs_matrix_type> A_;
 
   Tpetra::global_size_t NumGlobalRows_;
   Tpetra::global_size_t NumGlobalNonzeros_;
@@ -360,9 +359,9 @@ private:
   Teuchos::RCP<const import_type> Importer_;
 
   //! The matrix containing only the overlap rows.
-  Teuchos::RCP<row_matrix_type> ExtMatrix_;
-  Teuchos::RCP<map_type>        ExtMap_;
-  Teuchos::RCP<import_type>     ExtImporter_;
+  Teuchos::RCP<const crs_matrix_type> ExtMatrix_;
+  Teuchos::RCP<const map_type>        ExtMap_;
+  Teuchos::RCP<const import_type>     ExtImporter_;
 
   //! Graph of the matrix (as returned by getGraph()).
   Teuchos::RCP<const row_graph_type> graph_;

--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
@@ -45,9 +45,10 @@
 
 #include <sstream>
 
-#include <Ifpack2_OverlappingRowMatrix_decl.hpp>
 #include <Ifpack2_Details_OverlappingRowGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_Import.hpp>
+#include "Tpetra_Map.hpp"
 #include <Teuchos_CommHelpers.hpp>
 
 namespace Ifpack2 {
@@ -56,16 +57,13 @@ template<class MatrixType>
 OverlappingRowMatrix<MatrixType>::
 OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
                       const int overlapLevel) :
-  A_ (A),
+  A_ (Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A, true)),
   OverlapLevel_ (overlapLevel)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::Array;
   using Teuchos::outArg;
-  using Teuchos::rcp_const_cast;
-  using Teuchos::rcp_dynamic_cast;
-  using Teuchos::rcp_implicit_cast;
   using Teuchos::REDUCE_SUM;
   using Teuchos::reduceAll;
   typedef Tpetra::global_size_t GST;
@@ -74,20 +72,17 @@ OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
   TEUCHOS_TEST_FOR_EXCEPTION(
     OverlapLevel_ <= 0, std::runtime_error,
     "Ifpack2::OverlappingRowMatrix: OverlapLevel must be > 0.");
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (A_.is_null (), std::runtime_error,
+     "Ifpack2::OverlappingRowMatrix: The input matrix must be a "
+     "Tpetra::CrsMatrix with the same scalar_type, local_ordinal_type, "
+     "global_ordinal_type, and device_type typedefs as MatrixType.");
   TEUCHOS_TEST_FOR_EXCEPTION(
     A_->getComm()->getSize() == 1, std::runtime_error,
     "Ifpack2::OverlappingRowMatrix: Matrix must be "
     "distributed over more than one MPI process.");
-
-  RCP<const crs_matrix_type> ACRS =
-    rcp_dynamic_cast<const crs_matrix_type, const row_matrix_type> (A_);
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    ACRS.is_null (), std::runtime_error,
-    "Ifpack2::OverlappingRowMatrix: The input matrix must be a Tpetra::"
-    "CrsMatrix with matching template parameters.  This class currently "
-    "requires that CrsMatrix's fifth template parameter be the default.");
-  RCP<const crs_graph_type> A_crsGraph = ACRS->getCrsGraph ();
-
+  
+  RCP<const crs_graph_type> A_crsGraph = A_->getCrsGraph ();
   const size_t numMyRowsA = A_->getNodeNumRows ();
   const global_ordinal_type global_invalid =
     Teuchos::OrdinalTraits<global_ordinal_type>::invalid ();
@@ -142,7 +137,7 @@ OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
       // globally least GID.
       TmpMap = rcp (new map_type (global_invalid, mylist (0, count),
                                   Teuchos::OrdinalTraits<global_ordinal_type>::zero (),
-                                  A_->getComm (), A_->getNode ()));
+                                  A_->getComm ()));
       TmpGraph = rcp (new crs_graph_type (TmpMap, 0));
       TmpImporter = rcp (new import_type (A_->getRowMap (), TmpMap));
 
@@ -163,23 +158,24 @@ OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
 
   RowMap_ = rcp (new map_type (global_invalid, mylist (),
                                Teuchos::OrdinalTraits<global_ordinal_type>::zero (),
-                               A_->getComm (), A_->getNode ()));
+                               A_->getComm ()));
+  Importer_ = rcp (new import_type (A_->getRowMap (), RowMap_));  
   ColMap_ = RowMap_;
 
   // now build the map corresponding to all the external nodes
   // (with respect to A().RowMatrixRowMap().
   ExtMap_ = rcp (new map_type (global_invalid, ExtElements (),
                                Teuchos::OrdinalTraits<global_ordinal_type>::zero (),
-                               A_->getComm (), A_->getNode ()));
-  ExtMatrix_ = rcp (new crs_matrix_type (ExtMap_, ColMap_, 0));
+                               A_->getComm ()));
   ExtImporter_ = rcp (new import_type (A_->getRowMap (), ExtMap_));
-
-  RCP<crs_matrix_type> ExtMatrixCRS =
-    rcp_dynamic_cast<crs_matrix_type, row_matrix_type> (ExtMatrix_);
-  ExtMatrixCRS->doImport (*ACRS, *ExtImporter_, Tpetra::INSERT);
-  ExtMatrixCRS->fillComplete (A_->getDomainMap (), RowMap_);
-
-  Importer_ = rcp (new import_type (A_->getRowMap (), RowMap_));
+  
+  {
+    RCP<crs_matrix_type> ExtMatrix_nc =
+      rcp (new crs_matrix_type (ExtMap_, ColMap_, 0));
+    ExtMatrix_nc->doImport (*A_, *ExtImporter_, Tpetra::INSERT);
+    ExtMatrix_nc->fillComplete (A_->getDomainMap (), RowMap_);
+    ExtMatrix_ = ExtMatrix_nc; // we only need the const version after here
+  }
 
   // fix indices for overlapping matrix
   const size_t numMyRowsB = ExtMatrix_->getNodeNumRows ();
@@ -217,19 +213,16 @@ OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
                                   NumGlobalRows_, // # global cols == # global rows
                                   NumGlobalNonzeros_,
                                   MaxNumEntries_,
-                                  rcp_const_cast<const import_type> (Importer_),
-                                  rcp_const_cast<const import_type> (ExtImporter_)));
-  graph_ = rcp_const_cast<const row_graph_type> (rcp_implicit_cast<row_graph_type> (graph));
+                                  Importer_,
+                                  ExtImporter_));
+  graph_ = Teuchos::rcp_const_cast<const row_graph_type>
+    (Teuchos::rcp_implicit_cast<row_graph_type> (graph));
   // Resize temp arrays
   Indices_.resize (MaxNumEntries_);
   Values_.resize (MaxNumEntries_);
 }
 
-
-template<class MatrixType>
-OverlappingRowMatrix<MatrixType>::~OverlappingRowMatrix() {}
-
-
+  
 template<class MatrixType>
 Teuchos::RCP<const Teuchos::Comm<int> >
 OverlappingRowMatrix<MatrixType>::getComm () const
@@ -569,81 +562,39 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
   typedef scalar_type RangeScalar;
   typedef scalar_type DomainScalar;
   typedef Teuchos::ScalarTraits<RangeScalar> STRS;
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    alpha != Teuchos::ScalarTraits<scalar_type>::one () ||
-    beta != Teuchos::ScalarTraits<scalar_type>::zero (), std::logic_error,
-    "Ifpack2::ReorderFilter::apply is only implemented for alpha = 1 and "
-    "beta = 0.  You set alpha = " << alpha << " and beta = " << beta << ".");
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    X.getNumVectors() != Y.getNumVectors(), std::runtime_error,
-    "Ifpack2::OverlappingRowMatrix::apply: The input X and the output Y must "
-    "have the same number of columns.  X.getNumVectors() = "
-    << X.getNumVectors() << " != Y.getNumVectors() = " << Y.getNumVectors()
-    << ".");
-
-  // FIXME (mfh 13 July 2013) This would be a good candidate for a
-  // local parallel operator implementation.  That would obviate the
-  // need for getting views of the data and make the code below a lot
-  // simpler.
-
-  const RangeScalar zero = STRS::zero ();
-  ArrayRCP<ArrayRCP<const DomainScalar> > x_ptr = X.get2dView();
-  ArrayRCP<ArrayRCP<RangeScalar> >        y_ptr = Y.get2dViewNonConst();
-  Y.putScalar(zero);
-  size_t NumVectors = Y.getNumVectors();
-
-  const size_t numMyRowsA = A_->getNodeNumRows ();
-  for (size_t i = 0; i < numMyRowsA; ++i) {
-    size_t Nnz;
-    // Use this class's getrow to make the below code simpler
-    A_->getLocalRowCopy (i, Indices_ (),Values_ (), Nnz);
-    if (mode == Teuchos::NO_TRANS) {
-      for (size_t j = 0; j < Nnz; ++j)
-        for (size_t k = 0; k < NumVectors; ++k)
-          y_ptr[k][i] += as<RangeScalar> (Values_[j]) *
-            as<RangeScalar> (x_ptr[k][Indices_[j]]);
-    }
-    else if (mode == Teuchos::TRANS){
-      for (size_t j = 0; j < Nnz; ++j)
-        for (size_t k = 0; k < NumVectors; ++k)
-          y_ptr[k][Indices_[j]] += as<RangeScalar> (Values_[j]) *
-            as<RangeScalar> (x_ptr[k][i]);
-    }
-    else { // mode == Teuchos::CONJ_TRANS
-      for (size_t j = 0; j < Nnz; ++j)
-        for (size_t k = 0; k < NumVectors; ++k)
-          y_ptr[k][Indices_[j]] +=
-            STRS::conjugate (as<RangeScalar> (Values_[j])) *
-            as<RangeScalar> (x_ptr[k][i]);
-    }
+  using MV = Tpetra::MultiVector<scalar_type, local_ordinal_type,
+				 global_ordinal_type, node_type>;
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (X.getNumVectors() != Y.getNumVectors(), std::runtime_error,
+     "Ifpack2::OverlappingRowMatrix::apply: X.getNumVectors() = "
+     << X.getNumVectors() << " != Y.getNumVectors() = " << Y.getNumVectors()
+     << ".");
+  // Check whether X aliases Y.  In that case, we'll need to copy X.
+  auto X_d = X.getLocalViewDevice ();
+  auto Y_d = Y.getLocalViewDevice ();
+  bool aliases = true;
+  if (X_d.data () >= Y_d.data () + Y_d.span ()) {
+    aliases = false; // X starts after Y ends; no overlap
+  }
+  else if (Y_d.data () >= X_d.data () + X_d.span ()) {
+    aliases = false; // Y starts after X ends; no overlap
+  }
+  if (aliases) {
+    MV X_copy (X, Teuchos::Copy);
+    this->apply (X_copy, Y, mode, alpha, beta);
   }
 
-  const size_t numMyRowsB = ExtMatrix_->getNodeNumRows ();
-  for (size_t i = 0 ; i < numMyRowsB ; ++i) {
-    size_t Nnz;
-    // Use this class's getrow to make the below code simpler
-    ExtMatrix_->getLocalRowCopy (i, Indices_ (), Values_ (), Nnz);
-    if (mode == Teuchos::NO_TRANS) {
-      for (size_t j = 0; j < Nnz; ++j)
-        for (size_t k = 0; k < NumVectors; ++k)
-          y_ptr[k][numMyRowsA+i] += as<RangeScalar> (Values_[j]) *
-            as<RangeScalar> (x_ptr[k][Indices_[j]]);
-    }
-    else if (mode == Teuchos::TRANS) {
-      for (size_t j = 0; j < Nnz; ++j)
-        for (size_t k = 0; k < NumVectors; ++k)
-          y_ptr[k][numMyRowsA+Indices_[j]] += as<RangeScalar> (Values_[j]) *
-            as<RangeScalar> (x_ptr[k][i]);
-    }
-    else { // mode == Teuchos::CONJ_TRANS
-      for (size_t j = 0; j < Nnz; ++j)
-        for (size_t k = 0; k < NumVectors; ++k)
-          y_ptr[k][numMyRowsA+Indices_[j]] +=
-            STRS::conjugate (as<RangeScalar> (Values_[j])) *
-            as<RangeScalar> (x_ptr[k][i]);
-    }
-  }
+  const auto& rowMap0 = * (A_->getRowMap ());
+  const auto& colMap0 = * (A_->getColMap ());  
+  MV X_0 (X, mode == Teuchos::NO_TRANS ? colMap0 : rowMap0, 0);
+  MV Y_0 (Y, mode == Teuchos::NO_TRANS ? rowMap0 : colMap0, 0);
+  A_->localApply (X_0, Y_0, mode, alpha, beta);
+
+  const auto& rowMap1 = * (ExtMatrix_->getRowMap ());
+  const auto& colMap1 = * (ExtMatrix_->getColMap ());  
+  MV X_1 (X, mode == Teuchos::NO_TRANS ? colMap1 : rowMap1, 0);
+  MV Y_1 (Y, mode == Teuchos::NO_TRANS ? rowMap1 : colMap1, A_->getNodeNumRows ());
+  ExtMatrix_->localApply (X_1, Y_1, mode, alpha, beta);
 }
 
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3226,8 +3226,7 @@ namespace Tpetra {
       }
     }
 
-  private:
-
+  public:
     /// \brief Compute the local part of a sparse matrix-(Multi)Vector
     ///   multiply.
     ///
@@ -3264,8 +3263,6 @@ namespace Tpetra {
                 const Teuchos::ETransp mode = Teuchos::NO_TRANS,
                 const Scalar& alpha = Teuchos::ScalarTraits<Scalar>::one (),
                 const Scalar& beta = Teuchos::ScalarTraits<Scalar>::zero ()) const;
-
-  public:
 
     /// \brief Gauss-Seidel or SOR on \f$B = A X\f$.
     ///

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -67,6 +67,7 @@
 #include "Kokkos_Random.hpp"
 #include "Kokkos_ArithTraits.hpp"
 #include <memory>
+#include <sstream>
 
 #ifdef HAVE_TPETRA_INST_FLOAT128
 namespace Kokkos {
@@ -3295,34 +3296,64 @@ namespace Tpetra {
   {
     using Kokkos::ALL;
     using Kokkos::subview;
+    using Teuchos::outArg;    
     using Teuchos::RCP;
     using Teuchos::rcp;
-    typedef MultiVector<Scalar, LO, GO, Node> MV;
+    using Teuchos::reduceAll;
+    using Teuchos::REDUCE_MIN;
+    using std::endl;
+    using MV = MultiVector<Scalar, LO, GO, Node>;
     const char prefix[] = "Tpetra::MultiVector constructor (offsetView): ";
+    const char suffix[] = "Please report this bug to the Tpetra developers.";
+    int lclGood = 1;
+    int gblGood = 1;    
+    std::unique_ptr<std::ostringstream> errStrm;
+    const bool debug = ::Tpetra::Details::Behavior::debug ();
+    const bool verbose = ::Tpetra::Details::Behavior::verbose ();
 
+    // Be careful to use the input Map's communicator, not X's.  The
+    // idea is that, on return, *this is a subview of X, using the
+    // input Map.
+    const auto comm = subMap.getComm ();
+    TEUCHOS_ASSERT( ! comm.is_null () );
+    const int myRank = comm->getRank ();
+
+    const size_t lclNumRowsBefore = X.getLocalLength ();
+    const size_t numCols = X.getNumVectors ();
     const size_t newNumRows = subMap.getNodeNumElements ();
+    if (verbose) {
+      std::ostringstream os;
+      os << "Proc " << myRank << ": " << prefix << "X: {lclNumRows: "
+	 << lclNumRowsBefore << ", origLclNumRows: " << X.getOrigNumLocalRows ()
+	 << ", numCols: " << numCols << "}, subMap: " << newNumRows << endl;
+      std::cerr << os.str ();
+    }
+    // We ask for the _original_ number of rows in X, because X could
+    // be a shorter (fewer rows) view of a longer MV.  (For example, X
+    // could be a domain Map view of a column Map MV.)
     const bool tooManyElts = newNumRows + offset > X.getOrigNumLocalRows ();
     if (tooManyElts) {
-      const int myRank = X.getMap ()->getComm ()->getRank ();
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        newNumRows + offset > X.getLocalLength (), std::runtime_error,
-        prefix << "Invalid input Map.  The input Map owns " << newNumRows <<
-        " entries on process " << myRank << ".  offset = " << offset << ".  "
-        "Yet, the MultiVector contains only " << X.getOrigNumLocalRows () <<
-        " rows on this process.");
+      errStrm = std::unique_ptr<std::ostringstream> (new std::ostringstream);
+      *errStrm << "  Proc " << myRank << ": subMap.getNodeNumElements() (="
+	<< newNumRows << ") + offset (=" << offset << ") > X.getOrigNumLocal"
+        "Rows() (=" << X.getOrigNumLocalRows () << ")." << endl;
+      lclGood = 0;
+      TEUCHOS_TEST_FOR_EXCEPTION
+	(! debug && tooManyElts, std::invalid_argument,
+	 prefix << errStrm->str () << suffix);
     }
 
-    // mfh 27 Sep 2017: This debugging code depends on being able to
-    // declare variables that we can use below, so it's too hard for
-    // now to use run-time control to enable this code.
-#ifdef HAVE_TPETRA_DEBUG
-    const size_t strideBefore =
-      X.isConstantStride () ? X.getStride () : static_cast<size_t> (0);
-    const size_t lclNumRowsBefore = X.getLocalLength ();
-    const size_t numColsBefore = X.getNumVectors ();
-    const impl_scalar_type* hostPtrBefore =
-      X.getDualView().view_host().data ();
-#endif // HAVE_TPETRA_DEBUG
+    if (debug) {
+      reduceAll<int, int> (*comm, REDUCE_MIN, lclGood, outArg (gblGood));
+      if (gblGood != 1) {
+	std::ostringstream gblErrStrm;
+	const std::string myErrStr =
+	  errStrm.get () != nullptr ? errStrm->str () : std::string ("");
+	::Tpetra::Details::gathervPrint (gblErrStrm, myErrStr, *comm);
+	TEUCHOS_TEST_FOR_EXCEPTION
+	  (true, std::invalid_argument, gblErrStrm.str ());
+      }
+    }
 
     const std::pair<size_t, size_t> origRowRng (offset, X.origView_.extent (0));
     const std::pair<size_t, size_t> rowRng (offset, offset + newNumRows);
@@ -3338,7 +3369,8 @@ namespace Tpetra {
     // particular, the right way to fix Gauss-Seidel would be to fix
     // #385; that would make "getting the original column Map
     // MultiVector out again" unnecessary.
-    dual_view_type newView = subview (offset == 0 ? X.origView_ : X.view_, rowRng, ALL ());
+    dual_view_type newView =
+      subview (offset == 0 ? X.origView_ : X.view_, rowRng, ALL ());
 
     // NOTE (mfh 06 Jan 2015) Work-around to deal with Kokkos not
     // handling subviews of degenerate Views quite so well.  For some
@@ -3358,56 +3390,52 @@ namespace Tpetra {
 
     MV subViewMV = X.isConstantStride () ?
       MV (Teuchos::rcp (new map_type (subMap)), newView, newOrigView) :
-      MV (Teuchos::rcp (new map_type (subMap)), newView, newOrigView, X.whichVectors_ ());
+      MV (Teuchos::rcp (new map_type (subMap)), newView, newOrigView,
+	  X.whichVectors_ ());
 
-#ifdef HAVE_TPETRA_DEBUG
-    const size_t strideAfter = X.isConstantStride () ?
-      X.getStride () :
-      static_cast<size_t> (0);
-    const size_t lclNumRowsAfter = X.getLocalLength ();
-    const size_t numColsAfter = X.getNumVectors ();
-    const impl_scalar_type* hostPtrAfter =
-      X.getDualView().view_host().data ();
+    if (debug) {
+      const size_t lclNumRowsRet = subViewMV.getLocalLength ();
+      const size_t numColsRet = subViewMV.getNumVectors ();
+      if (newNumRows != lclNumRowsRet || numCols != numColsRet) {
+	lclGood = 0;
+	if (errStrm.get () == nullptr) {
+	  errStrm = std::unique_ptr<std::ostringstream> (new std::ostringstream);
+	}
+	*errStrm << "  Proc " << myRank <<
+	  ": subMap.getNodeNumElements(): " << newNumRows <<
+	  ", subViewMV.getLocalLength(): " << lclNumRowsRet <<
+	  ", X.getNumVectors(): " << numCols <<
+	  ", subViewMV.getNumVectors(): " << numColsRet << endl;
+      }
+      reduceAll<int, int> (*comm, REDUCE_MIN, lclGood, outArg (gblGood));
+      if (gblGood != 1) {
+	std::ostringstream gblErrStrm;
+	if (myRank == 0) {
+	  gblErrStrm << prefix << "Returned MultiVector has the wrong local "
+	    "dimensions on one or more processes:" << endl;
+	}
+	const std::string myErrStr =
+	  errStrm.get () != nullptr ? errStrm->str () : std::string ("");
+	::Tpetra::Details::gathervPrint (gblErrStrm, myErrStr, *comm);
+	gblErrStrm << suffix << endl;
+	TEUCHOS_TEST_FOR_EXCEPTION
+	  (true, std::invalid_argument, gblErrStrm.str ());
+      }
+    }
 
-    const size_t strideRet = subViewMV.isConstantStride () ?
-      subViewMV.getStride () :
-      static_cast<size_t> (0);
-    const size_t lclNumRowsRet = subViewMV.getLocalLength ();
-    const size_t numColsRet = subViewMV.getNumVectors ();
-
-    const char suffix[] = ".  This should never happen.  Please report this "
-      "bug to the Tpetra developers.";
-
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      lclNumRowsRet != subMap.getNodeNumElements (),
-      std::logic_error, prefix << "Returned MultiVector has a number of rows "
-      "different than the number of local indices in the input Map.  "
-      "lclNumRowsRet: " << lclNumRowsRet << ", subMap.getNodeNumElements(): "
-      << subMap.getNodeNumElements () << suffix);
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      strideBefore != strideAfter || lclNumRowsBefore != lclNumRowsAfter ||
-      numColsBefore != numColsAfter || hostPtrBefore != hostPtrAfter,
-      std::logic_error, prefix << "Original MultiVector changed dimensions, "
-      "stride, or host pointer after taking offset view.  strideBefore: " <<
-      strideBefore << ", strideAfter: " << strideAfter << ", lclNumRowsBefore: "
-      << lclNumRowsBefore << ", lclNumRowsAfter: " << lclNumRowsAfter <<
-      ", numColsBefore: " << numColsBefore << ", numColsAfter: " <<
-      numColsAfter << ", hostPtrBefore: " << hostPtrBefore << ", hostPtrAfter: "
-      << hostPtrAfter << suffix);
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      strideBefore != strideRet, std::logic_error, prefix << "Returned "
-      "MultiVector has different stride than original MultiVector.  "
-      "strideBefore: " << strideBefore << ", strideRet: " << strideRet <<
-      ", numColsBefore: " << numColsBefore << ", numColsRet: " << numColsRet
-      << suffix);
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      numColsBefore != numColsRet, std::logic_error,
-      prefix << "Returned MultiVector has a different number of columns than "
-      "original MultiVector.  numColsBefore: " << numColsBefore << ", "
-      "numColsRet: " << numColsRet << suffix);
-#endif // HAVE_TPETRA_DEBUG
+    if (verbose) {
+      std::ostringstream os;
+      os << "Proc " << myRank << ": " << prefix << "Call op=" << endl;
+      std::cerr << os.str ();
+    }
 
     *this = subViewMV; // shallow copy
+
+    if (verbose) {
+      std::ostringstream os;
+      os << "Proc " << myRank << ": " << prefix << "Done!" << endl;
+      std::cerr << os.str ();
+    }
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
@trilinos/tpetra 

Fix #4392 by rewriting `Ifpack2::OverlappingRowMatrix::apply` to call `Tpetra::CrsMatrix::apply` directly for the two CrsMatrix objects in OverlappingRowMatrix, instead of rerolling `CrsMatrix::apply` in a slow and sequential way.  Fix potential issues with `Tpetra::MultiVector`'s offset view constructor that came up as a result of this fix.  This may also address #4353.

## Related Issues

* Closes #4392 
* Related to #4353 
