### PR TITLE
Zoltan2:  fix directory builds with Tpetra_INST_INT_LONG

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
@@ -297,7 +297,7 @@ void getCoarsenedPartGraph(
   if (comm->getSize() > 1)
   {
     const bool bUseLocalIDs = false;  // Local IDs not needed
-    typedef Zoltan2_Directory_Simple<part_t,t_lno_t,t_gno_t> directory_t;
+    typedef Zoltan2_Directory_Simple<t_gno_t,t_lno_t,part_t> directory_t;
     int debug_level = 0;
     const RCP<const Comm<int> > rcp_comm(comm,false);
     directory_t directory(rcp_comm, bUseLocalIDs, debug_level);

--- a/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_GraphMetricsUtility.hpp
@@ -162,7 +162,7 @@ void globalWeightedByPart(
 #ifdef HAVE_ZOLTAN2_MPI
   if (comm->getSize() > 1) {
     const bool bUseLocalIDs = false;  // Local IDs not needed
-    typedef Zoltan2_Directory_Simple<part_t,lno_t,gno_t> directory_t;
+    typedef Zoltan2_Directory_Simple<gno_t,lno_t,part_t> directory_t;
     int debug_level = 0;
     directory_t directory(comm, bUseLocalIDs, debug_level);
     if (localNumVertices)

--- a/packages/zoltan2/test/unit/util/findUniqueGids.cpp
+++ b/packages/zoltan2/test/unit/util/findUniqueGids.cpp
@@ -73,6 +73,7 @@ struct type_name
   template<> struct type_name<x> { static const char* name() {return #x;} }
 
 DECL_TYPE_NAME(int);
+DECL_TYPE_NAME(long);
 DECL_TYPE_NAME(long long);
 
 ///////////////////////////////////////////////////////////////////////////
@@ -507,6 +508,19 @@ int main(int narg, char *arg[])
   if (comm->getRank() == 0) 
     std::cout << "Skipping int tests because Tpetra is not build with "
               << "GO == int" << std::endl;
+#endif
+
+#ifdef HAVE_TPETRA_INT_LONG
+  test1<long>(comm);
+  test2<long>(comm);
+  test3<long>(comm);
+  test4<long>(comm);
+  test5<long>(comm);
+  test6<long>(comm);
+#else
+  if (comm->getRank() == 0) 
+    std::cout << "Skipping long long tests because Tpetra is not build with "
+              << "GO == long " << std::endl;
 #endif
 
 #ifdef HAVE_TPETRA_INT_LONG_LONG


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @trilinos/stk @alanw0 

## Description
Matched directory template parameters to the arguments in directory.update() calls.

## Motivation and Context
@trilinos/stk reported compilation errors with (the equivalent of) Tpetra_INST_INT_LONG=ON.  The errors were due to incorrect ordering of the template parameters in two directory typedefs.

## How tested
Built and run on linux workstation with Tpetra_INST_INT_INT=OFF and Tpetra_INST_INT_LONG=ON.
Also built and run on linux workstation with default Tpetra instantiations.
Enabled Tpetra_INST_INT_LONG testing in findUniqueGIDs.cpp.


<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
