### PR TITLE
Xpetra: fixed dependency on Tpetra instantations

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Cuda.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Cuda.cpp
@@ -79,6 +79,14 @@ namespace Details {
 
   TPETRA_INSTANTIATE_L( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA_INT )
 
+  // Make sure that KeyType = long, ValueType = int and
+  // KeyType = long long, ValueType = int both get instantiated -
+  // whenever Tpetra is enabled, Xpetra::Epetra_Map depends on both
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long, int, cuda_device_type)
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long, int, cuda_uvm_device_type)
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long long, int, cuda_device_type)
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long long, int, cuda_uvm_device_type)
+
   // FIXME (mfh 26 Sep 2015) Once it becomes possible to disable LO =
   // int, add an instantiation here for {KeyType = LO, ValueType =
   // LO}.  However, this case has likely already been covered above,

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_OpenMP.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_OpenMP.cpp
@@ -71,6 +71,12 @@ namespace Details {
 
   TPETRA_INSTANTIATE_L( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_OPENMP_INT )
 
+  // Make sure that KeyType = long, ValueType = int and
+  // KeyType = long long, ValueType = int both get instantiated -
+  // whenever Tpetra is enabled, Xpetra::Epetra_Map depends on both
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long, int, openmp_device_type)
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long long, int, openmp_device_type)
+
   // FIXME (mfh 26 Sep 2015) Once it becomes possible to disable LO =
   // int, add an instantiation here for {KeyType = LO, ValueType =
   // LO}.  However, this case has likely already been covered above,

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Serial.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Serial.cpp
@@ -71,6 +71,12 @@ namespace Details {
 
   TPETRA_INSTANTIATE_L( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_SERIAL_INT )
 
+  // Make sure that KeyType = long, ValueType = int and
+  // KeyType = long long, ValueType = int both get instantiated -
+  // whenever Tpetra is enabled, Xpetra::Epetra_Map depends on both
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long, int, serial_device_type)
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long long, int, serial_device_type)
+
   // FIXME (mfh 26 Sep 2015) Once it becomes possible to disable LO =
   // int, add an instantiation here for {KeyType = LO, ValueType =
   // LO}.  However, this case has likely already been covered above,

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Threads.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Threads.cpp
@@ -71,6 +71,12 @@ namespace Details {
 
   TPETRA_INSTANTIATE_L( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_PTHREAD_INT )
 
+  // Make sure that KeyType = long, ValueType = int and
+  // KeyType = long long, ValueType = int both get instantiated -
+  // whenever Tpetra is enabled, Xpetra::Epetra_Map depends on both
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long, int, threads_device_type)
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT(long long, int, threads_device_type)
+
   // FIXME (mfh 26 Sep 2015) Once it becomes possible to disable LO =
   // int, add an instantiation here for {KeyType = LO, ValueType =
   // LO}.  However, this case has likely already been covered above,


### PR DESCRIPTION
Satisfy dependency of Xpetra EpetraMap on
Tpetra::Details::FixedHashTable with int/long and
int/longlong as LO/GO. These dependencies always exist
as long as Tpetra is enabled, but regardless of whether
these LO/GO combinations are enabled in Tpetra ETI.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 

## Description
<!--- Please describe your changes in detail. -->
Xpetra_EpetraMap.cpp now includes the def of
FixedHashTable so that these instantiations can be made, even if int/long
and/or int/longlong haven't been enabled in ETI. The include is only done if
Tpetra and Xpetra kokkos refactor are both enabled, because Xpetra::EpetraMap
only uses FixedHashTable in this case.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This fixes an "undefined symbol" error during the final link of Albany (or any other app executable). Without this code change, the only workaround is to enable both TPETRA_INST_INT_LONG and TPETRA_INST_INT_LONG_LONG in configuration (huge code size increase). Only the instantiation of FixedHashTable is needed, not all of Tpetra.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Part of 
* Composed of 
-->
* Related to #4038 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Tested by successfully building Trilinos/Albany without TPETRA_INST_INT_LONG.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
