### PR TITLE
MueLu: Change MultiJagged defaults

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -372,6 +372,7 @@ namespace MueLu {
         coarseLevel.Set("R",R11_);
         coarseLevel.Set("Coordinates",CoordsH_);
         coarseLevel.Set("number of partitions", numProcsAH);
+        coarseLevel.Set("repartition: heuristic target rows per process", 1000);
 
         coarseLevel.setlib(AH_->getDomainMap()->lib());
         fineLevel.setlib(AH_->getDomainMap()->lib());
@@ -536,6 +537,7 @@ namespace MueLu {
         if (doRebalancing) {
 
           coarseLevel.Set("number of partitions", numProcsA22);
+          coarseLevel.Set("repartition: heuristic target rows per process", 1000);
 
           // auto repartheurFactory = rcp(new RepartitionHeuristicFactory());
           // ParameterList repartheurParams;

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1300,6 +1300,7 @@ namespace MueLu {
       repartheurFactory->SetParameterList(repartheurParams);
       repartheurFactory->SetFactory("A",         manager.GetFactory("A"));
       manager.SetFactory("number of partitions", repartheurFactory);
+      manager.SetFactory("repartition: heuristic target rows per process", repartheurFactory);
 
       // Partitioner
       RCP<Factory> partitioner;
@@ -1317,6 +1318,8 @@ namespace MueLu {
         RCP<const ParameterList> partpartParams = rcp(new ParameterList(paramList.sublist("repartition: params", false)));
         partParams.set("ParameterList", partpartParams);
         partitioner->SetParameterList(partParams);
+        partitioner->SetFactory("repartition: heuristic target rows per process",
+                                manager.GetFactory("repartition: heuristic target rows per process"));
 #else
         throw Exceptions::RuntimeError("Zoltan2 interface is not available");
 #endif

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
@@ -129,6 +129,9 @@ namespace MueLu {
     if (targetRowsPerProcess == 0)
       targetRowsPerProcess = minRowsPerProcess;
 
+    // Stick this on the level so Zoltan2Interface can use this later
+    Set<LO>(currentLevel,"repartition: heuristic target rows per process",targetRowsPerProcess);
+
     RCP<const FactoryBase> Afact = GetFactory("A");
     if(!Afact.is_null() && Teuchos::rcp_dynamic_cast<const RAPFactory>(Afact) == Teuchos::null &&
        Teuchos::rcp_dynamic_cast<const BlockedRAPFactory>(Afact) == Teuchos::null &&

--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
@@ -87,6 +87,7 @@ namespace MueLu {
     validParamList->set< RCP<const FactoryBase> >   ("number of partitions", Teuchos::null, "Instance of RepartitionHeuristicFactory.");
     validParamList->set< RCP<const FactoryBase> >   ("Coordinates",   Teuchos::null, "Factory of the coordinates");
     validParamList->set< RCP<const ParameterList> > ("ParameterList", Teuchos::null, "Zoltan2 parameters");
+    validParamList->set< RCP<const FactoryBase> >   ("repartition: heuristic target rows per process", Teuchos::null, "Factory for number of rows per process to use with MultiJagged");
 
     return validParamList;
   }
@@ -103,8 +104,12 @@ namespace MueLu {
     RCP<const Teuchos::ParameterList> providedList = Teuchos::any_cast<RCP<const Teuchos::ParameterList> >(entry.getAny(false));
     if (providedList != Teuchos::null && providedList->isType<std::string>("algorithm")) {
       const std::string algo = providedList->get<std::string>("algorithm");
-      if (algo == "multijagged" || algo == "rcb")
+      if (algo == "multijagged") {
         Input(currentLevel, "Coordinates");
+        Input(currentLevel, "repartition: heuristic target rows per process");
+      } else if (algo == "rcb") {
+        Input(currentLevel, "Coordinates");
+      }
     } else
       Input(currentLevel, "Coordinates");
   }
@@ -186,6 +191,12 @@ namespace MueLu {
         for (LO j = 0; j < blkSize; j++) {
           weightsPerRow[i] += A->getNumEntriesInLocalRow(i*blkSize+j);
         }
+      }
+     
+      // MultiJagged: Grab the target rows per process from the Heuristic to use unless the Zoltan2 list says otherwise
+      if(algo == "multijagged" && !Zoltan2Params.isParameter("mj_premigration_coordinate_count")) {
+        LO heuristicTargetRowsPerProcess = Get<LO>(level,"repartition: heuristic target rows per process");
+        Zoltan2Params.set("mj_premigration_coordinate_count", heuristicTargetRowsPerProcess);
       }
 
       std::vector<int>           strides;

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/driver_drekar1_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/driver_drekar1_np4.xml
@@ -59,6 +59,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/driver_drekar2_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/driver_drekar2_np4.xml
@@ -61,6 +61,7 @@
 
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/repartition1_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/repartition1_np4.xml
@@ -49,6 +49,7 @@
     <ParameterList name="myZoltanInterface">
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/repartition3_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/repartition3_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/repartition4_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/repartition4_np4.xml
@@ -51,6 +51,7 @@
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <ParameterList name="ParameterList">
         <Parameter name="algorithm"                                 type="string"   value="multijagged"/>
       </ParameterList>

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/transpose2_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/transpose2_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/transpose3_np4.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/transpose3_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/driver_drekar1_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/driver_drekar1_np4.xml
@@ -54,11 +54,12 @@
       <Parameter name="repartition: max imbalance"                  type="double"   value="1.327"/>
       <Parameter name="repartition: start level"                    type="int"      value="1"/>
     </ParameterList>
-    
+
     <ParameterList name="myZoltanInterface">
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/driver_drekar2_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/driver_drekar2_np4.xml
@@ -61,6 +61,7 @@
 
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/repartition1_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/repartition1_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/repartition3_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/repartition3_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/repartition4_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/repartition4_np4.xml
@@ -51,6 +51,7 @@
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <ParameterList name="ParameterList">
         <Parameter name="algorithm"                                 type="string"   value="multijagged"/>
       </ParameterList>

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/transpose2_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/transpose2_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/transpose3_np4.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/transpose3_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/driver_drekar1_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/driver_drekar1_np4.xml
@@ -59,6 +59,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/driver_drekar2_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/driver_drekar2_np4.xml
@@ -61,6 +61,7 @@
 
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/repartition1_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/repartition1_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/repartition3_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/repartition3_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/repartition4_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/repartition4_np4.xml
@@ -51,6 +51,7 @@
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <ParameterList name="ParameterList">
         <Parameter name="algorithm"                                 type="string"   value="multijagged"/>
       </ParameterList>

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/transpose2_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/transpose2_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/transpose3_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/transpose3_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/driver_drekar1_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/driver_drekar1_np4.xml
@@ -54,11 +54,12 @@
       <Parameter name="repartition: max imbalance"                  type="double"   value="1.327"/>
       <Parameter name="repartition: start level"                    type="int"      value="1"/>
     </ParameterList>
-    
+
     <ParameterList name="myZoltanInterface">
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/driver_drekar2_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/driver_drekar2_np4.xml
@@ -61,6 +61,7 @@
 
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/repartition1_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/repartition1_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/repartition3_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/repartition3_np4.xml
@@ -50,6 +50,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/repartition4_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/repartition4_np4.xml
@@ -51,6 +51,7 @@
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <ParameterList name="ParameterList">
         <Parameter name="algorithm"                                 type="string"   value="multijagged"/>
       </ParameterList>

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/transpose2_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/transpose2_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/transpose3_np4.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/transpose3_np4.xml
@@ -45,6 +45,7 @@
       <Parameter name="factory"                                     type="string"   value="Zoltan2Interface"/>
       <Parameter name="A"                                           type="string"   value="myRAPFact"/>
       <Parameter name="number of partitions"                        type="string"   value="myRepartitionHeuristicFact"/>
+      <Parameter name="repartition: heuristic target rows per process" type="string"   value="myRepartitionHeuristicFact"/>
       <Parameter name="Coordinates"                                 type="string"   value="myTransferCoordinatesFact"/>
 
       <ParameterList name="ParameterList">


### PR DESCRIPTION
@trilinos/muelu

## Description
Change the default `mj_premigration_coordinate_count` used in Zoltan2's MJ partitioning.
Instead of Zoltan2's default value, use `"repartition: target rows per proc"`.