### PR TITLE
Issue 4283: refactor muelu to not use dynamic profile when declaring crsgraph

### DIFF
--- a/packages/muelu/src/Graph/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MueLu_CoalesceDropFactory_def.hpp
@@ -828,7 +828,7 @@ namespace MueLu {
       GetOStream(Statistics1) << "CoalesceDropFactory: nodeMap " << nodeMap->getNodeNumElements() << "/" << nodeMap->getGlobalNumElements() << " elements" << std::endl;
 
       // 3) create graph of amalgamated matrix
-      RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, 10, Xpetra::DynamicProfile);
+      RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, 10, Xpetra::StaticProfile);
 
       LO numRows = A->getRowMap()->getNodeNumElements();
       LO numNodes = nodeMap->getNodeNumElements();

--- a/packages/muelu/src/Graph/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MueLu_CoalesceDropFactory_def.hpp
@@ -828,7 +828,7 @@ namespace MueLu {
       GetOStream(Statistics1) << "CoalesceDropFactory: nodeMap " << nodeMap->getNodeNumElements() << "/" << nodeMap->getGlobalNumElements() << " elements" << std::endl;
 
       // 3) create graph of amalgamated matrix
-      RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, 10, Xpetra::StaticProfile);
+      RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, A->getNodeMaxNumRowEntries()*blockdim, Xpetra::StaticProfile);
 
       LO numRows = A->getRowMap()->getNodeNumElements();
       LO numNodes = nodeMap->getNodeNumElements();

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
@@ -249,7 +249,7 @@ namespace MueLu {
     myGraph = CrsGraphFactory::Build(rowMap,
                                      colMap,
                                      nnzOnRow,
-                                     Xpetra::DynamicProfile);
+                                     Xpetra::StaticProfile);
 
     *out << "Fill CrsGraph" << std::endl;
     LO rowIdx = 0;

--- a/packages/muelu/src/Misc/MueLu_ThresholdAFilterFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_ThresholdAFilterFactory_def.hpp
@@ -83,7 +83,7 @@ namespace MueLu {
     // create new empty Matrix
     RCP<const Map> rowmap = Ain->getRowMap();
     RCP<const Map> colmap = Ain->getColMap();
-    RCP<CrsOMatrix> Aout = rcp(new CrsOMatrix(rowmap, expectedNNZperRow_ <= 0 ? Ain->getGlobalMaxNumRowEntries() : expectedNNZperRow_ , Xpetra::DynamicProfile));
+    RCP<CrsOMatrix> Aout = rcp(new CrsOMatrix(rowmap, expectedNNZperRow_ <= 0 ? Ain->getGlobalMaxNumRowEntries() : expectedNNZperRow_ , Xpetra::StaticProfile));
     // loop over local rows
     for(size_t row=0; row<Ain->getNodeNumRows(); row++)
       {

--- a/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_def.hpp
@@ -134,7 +134,7 @@ namespace MueLu {
     
 
     // 3) create graph of amalgamated matrix
-    RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, 10, Xpetra::DynamicProfile);
+    RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, 10, Xpetra::StaticProfile);
 
     // 4) do amalgamation. generate graph of amalgamated matrix
     for(LO row=0; row<Teuchos::as<LO>(A->getRowMap()->getNodeNumElements()); row++) {

--- a/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_def.hpp
@@ -134,7 +134,7 @@ namespace MueLu {
     
 
     // 3) create graph of amalgamated matrix
-    RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, 10, Xpetra::StaticProfile);
+    RCP<CrsGraph> crsGraph = CrsGraphFactory::Build(nodeMap, A->getNodeMaxNumRowEntries()*blockdim, Xpetra::StaticProfile);
 
     // 4) do amalgamation. generate graph of amalgamated matrix
     for(LO row=0; row<Teuchos::as<LO>(A->getRowMap()->getNodeNumElements()); row++) {


### PR DESCRIPTION
@trilinos/muelu 
@trilinos/tpetra 

## Description
This removes Tpetra::DynamicProfile from muelu

## Motivation and Context
Deprecation of DynamicProfile in Tpetra's effect on downstream packages

## How Has This Been Tested?
Since this is a change to tested code, the affected unit tests have been rerun to ensure that they are no longer using the deprecated code path.  Tests conducted on linux 2.6.32.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

