### PR TITLE
Tpetra::Distributor: Fix #4412 (don't fill indicesFrom_)

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCPNode.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.hpp
@@ -132,7 +132,6 @@ public:
       // Should never get here!
 #ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
-      return "";
 #else
       return "";
 #endif

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -45,10 +45,10 @@
 #include <numeric>
 
 namespace { // (anonymous)
-  
+
   Teuchos::RCP<Teuchos::FancyOStream>
   makeValidVerboseStream (const Teuchos::RCP<Teuchos::FancyOStream>& out =
-			  Teuchos::null)
+                          Teuchos::null)
   {
     if (out.is_null ()) {
       return Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
@@ -161,8 +161,8 @@ namespace Tpetra {
 
   Distributor::
   Distributor (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-	       const Teuchos::RCP<Teuchos::FancyOStream>& out,
-	       const Teuchos::RCP<Teuchos::ParameterList>& plist)
+               const Teuchos::RCP<Teuchos::FancyOStream>& out,
+               const Teuchos::RCP<Teuchos::ParameterList>& plist)
     : comm_ (comm)
     , out_ (makeValidVerboseStream (out))
     , howInitialized_ (Details::DISTRIBUTOR_NOT_INITIALIZED)
@@ -179,13 +179,13 @@ namespace Tpetra {
     , useDistinctTags_ (useDistinctTags_default)
   {
     TEUCHOS_ASSERT( ! out_.is_null () );
-    
+
     this->setParameterList (plist); // sets verbose_ via Behavior
 #ifdef TPETRA_DISTRIBUTOR_TIMERS
     makeTimers ();
 #endif // TPETRA_DISTRIBUTOR_TIMERS
   }
-  
+
   Distributor::
   Distributor (const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
     : Distributor (comm, Teuchos::null, Teuchos::null)
@@ -193,13 +193,13 @@ namespace Tpetra {
 
   Distributor::
   Distributor (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-	       const Teuchos::RCP<Teuchos::FancyOStream>& out)
+               const Teuchos::RCP<Teuchos::FancyOStream>& out)
     : Distributor (comm, out, Teuchos::null)
   {}
 
   Distributor::
   Distributor (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-	       const Teuchos::RCP<Teuchos::ParameterList>& plist)
+               const Teuchos::RCP<Teuchos::ParameterList>& plist)
     : Distributor (comm, Teuchos::null, plist)
   {}
 
@@ -317,26 +317,26 @@ namespace Tpetra {
       plist->validateParametersAndSetDefaults (*validParams);
 
       const bool barrierBetween =
-	plist->get<bool> ("Barrier between receives and sends");
+        plist->get<bool> ("Barrier between receives and sends");
       const Details::EDistributorSendType sendType =
-	getIntegralValue<Details::EDistributorSendType> (*plist, "Send type");
+        getIntegralValue<Details::EDistributorSendType> (*plist, "Send type");
       const bool useDistinctTags = plist->get<bool> ("Use distinct tags");
       const bool debug = plist->get<bool> ("Debug");
       {
-	// mfh 03 May 2016: We keep this option only for backwards
-	// compatibility, but it must always be true.  See discussion of
-	// Github Issue #227.
-	const bool enable_cuda_rdma =
-	  plist->get<bool> ("Enable MPI CUDA RDMA support");
-	TEUCHOS_TEST_FOR_EXCEPTION
-	  (! enable_cuda_rdma, std::invalid_argument, "Tpetra::Distributor::"
-	   "setParameterList: " << "You specified \"Enable MPI CUDA RDMA "
-	   "support\" = false.  This is no longer valid.  You don't need to "
-	   "specify this option any more; Tpetra assumes it is always true.  "
-	   "This is a very light assumption on the MPI implementation, and in "
-	   "fact does not actually involve hardware or system RDMA support.  "
-	   "Tpetra just assumes that the MPI implementation can tell whether a "
-	   "pointer points to host memory or CUDA device memory.");
+        // mfh 03 May 2016: We keep this option only for backwards
+        // compatibility, but it must always be true.  See discussion of
+        // Github Issue #227.
+        const bool enable_cuda_rdma =
+          plist->get<bool> ("Enable MPI CUDA RDMA support");
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! enable_cuda_rdma, std::invalid_argument, "Tpetra::Distributor::"
+           "setParameterList: " << "You specified \"Enable MPI CUDA RDMA "
+           "support\" = false.  This is no longer valid.  You don't need to "
+           "specify this option any more; Tpetra assumes it is always true.  "
+           "This is a very light assumption on the MPI implementation, and in "
+           "fact does not actually involve hardware or system RDMA support.  "
+           "Tpetra just assumes that the MPI implementation can tell whether a "
+           "pointer points to host memory or CUDA device memory.");
       }
 
       // We check this property explicitly, since we haven't yet learned
@@ -344,13 +344,13 @@ namespace Tpetra {
       // Later, turn this into a validator so that it can be embedded in
       // the valid ParameterList and used in Optika.
       TEUCHOS_TEST_FOR_EXCEPTION
-	(! barrierBetween && sendType == Details::DISTRIBUTOR_RSEND,
-	 std::invalid_argument, "Tpetra::Distributor::setParameterList: " << endl
-	 << "You specified \"Send type\"=\"Rsend\", but turned off the barrier "
-	 "between receives and sends." << endl << "This is invalid; you must "
-	 "include the barrier if you use ready sends." << endl << "Ready sends "
-	 "require that their corresponding receives have already been posted, "
-	 "and the only way to guarantee that in general is with a barrier.");
+        (! barrierBetween && sendType == Details::DISTRIBUTOR_RSEND,
+         std::invalid_argument, "Tpetra::Distributor::setParameterList: " << endl
+         << "You specified \"Send type\"=\"Rsend\", but turned off the barrier "
+         "between receives and sends." << endl << "This is invalid; you must "
+         "include the barrier if you use ready sends." << endl << "Ready sends "
+         "require that their corresponding receives have already been posted, "
+         "and the only way to guarantee that in general is with a barrier.");
 
       // Now that we've validated the input list, save the results.
       sendType_ = sendType;
@@ -935,7 +935,7 @@ namespace Tpetra {
     if (verbose_) {
       std::ostringstream os;
       os << *prefix << "Post " << actualNumReceives << " irecv"
-	 << (actualNumReceives != size_t (1) ? "s" : "") << endl;
+         << (actualNumReceives != size_t (1) ? "s" : "") << endl;
       *out_ << os.str ();
     }
 
@@ -948,7 +948,7 @@ namespace Tpetra {
       lengthsFromBuffers[i].resize (1);
       lengthsFromBuffers[i][0] = as<size_t> (0);
       requests[i] = ireceive<int, size_t> (lengthsFromBuffers[i], anySourceProc,
-					   tag, *comm_);
+                                           tag, *comm_);
       if (verbose_) {
         std::ostringstream os;
         os << *prefix << "Posted any-proc irecv w/ tag " << tag << endl;
@@ -959,7 +959,7 @@ namespace Tpetra {
     if (verbose_) {
       std::ostringstream os;
       os << *prefix << "Post " << numSends_ << " send"
-	 << (numSends_ != size_t (1) ? "s" : "") << endl;
+         << (numSends_ != size_t (1) ? "s" : "") << endl;
       *out_ << os.str ();
     }
     // Post the sends: Tell each process to which we are sending how
@@ -1023,10 +1023,16 @@ namespace Tpetra {
     totalReceiveLength_ =
       std::accumulate (lengthsFrom_.begin (), lengthsFrom_.end (), 0);
     indicesFrom_.clear ();
+    // NOTE (mfh 13 Feb 2019): Epetra_MpiDistributor deliberately does
+    // _not_ fill indicesFrom_ (what it calls "indices_from_") like
+    // this; it leaves indicesFrom_ empty.  The comment there mentions
+    // that not filling indicesFrom_ helps reverse mode correctness.
+#if 0
     indicesFrom_.reserve (totalReceiveLength_);
     for (size_t i = 0; i < totalReceiveLength_; ++i) {
       indicesFrom_.push_back(i);
     }
+#endif // 0
 
     startsFrom_.clear ();
     startsFrom_.reserve (numReceives_);
@@ -1054,6 +1060,7 @@ namespace Tpetra {
     using Teuchos::REDUCE_MAX;
     using Teuchos::reduceAll;
     using std::endl;
+    const char rawPrefix[] = "Tpetra::Distributor::createFromSends: ";
 
     Teuchos::OSTab tab (out_);
     const size_t numExports = exportProcIDs.size();
@@ -1063,9 +1070,9 @@ namespace Tpetra {
     std::unique_ptr<std::string> prefix;
     if (verbose_) {
       std::ostringstream os;
-      os << "Proc " << myProcID << ": createFromSends: ";
+      os << "Proc " << myProcID << ": " << rawPrefix << ": ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
-      os << endl;
+      os << "exportPIDs: " << exportProcIDs << endl;
       *out_ << os.str ();
     }
 
@@ -1149,7 +1156,7 @@ namespace Tpetra {
         // null entries break continuity.
         // e.g.,  [ 0, 0, 0, 1, -99, 1, 2, 2, 2] is not contiguous
         if (needSendBuff == 0 && starts[exportID] > 1 &&
-	    exportID != exportProcIDs[i-1]) {
+            exportID != exportProcIDs[i-1]) {
           needSendBuff = 1;
         }
         ++numActive;
@@ -1566,11 +1573,16 @@ namespace Tpetra {
     }
     totalReceiveLength_ = remoteProcIDs.size();
     indicesFrom_.clear ();
+    // NOTE (mfh 13 Feb 2019): Epetra_MpiDistributor deliberately does
+    // _not_ fill indicesFrom_ (what it calls "indices_from_") like
+    // this; it leaves indicesFrom_ empty.  The comment there mentions
+    // that not filling indicesFrom_ helps reverse mode correctness.
+#if 0
     indicesFrom_.reserve (totalReceiveLength_);
     for (size_t i = 0; i < totalReceiveLength_; ++i) {
       indicesFrom_.push_back(i);
     }
-
+#endif // 0
     numReceives_-=selfMessage_;
   }
 

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -930,10 +930,9 @@ namespace Tpetra {
 
     /// \brief List that becomes the reverse communicator's indicesTo_.
     ///
-    /// Array of length totalReceiveLength_.  Allocated and filled in
-    /// computeReceives() as [0, 1, ..., totalReceiveLength_-1].  When
-    /// creating the reverse Distributor, this is assigned to the
-    /// reverse Distributor's indicesTo_.
+    /// Array of length totalReceiveLength_.  When creating the
+    /// reverse Distributor, this is assigned to the reverse
+    /// Distributor's indicesTo_.
     Teuchos::Array<size_t> indicesFrom_;
 
     /// \brief Communication requests associated with nonblocking receives and sends.


### PR DESCRIPTION
@trilinos/tpetra 

`Tpetra::Distributor` would always fill `indicesFrom_` with 0, 1, ..., `totalReceiveLength_-1`. This was not only a waste of time, it would unnecessarily make all reverse-mode communication take the slow path. (Reversing a Distributor swaps `indicesTo_` and `indicesFrom_`. A nonempty `indicesTo_` tells Distributor to take the slow path. If `indicesFrom_` is just 0, 1, ..., `totalReceiveLength_-1`, then Distributor does not need to take the slow path.)

Note that `Epetra_MpiDistributor` comments out the code that fills `indices_from_`, and claims that doing so fixes reverse communication.

@vbrunini found that applying my patch for fixing this made Aria's post-solve communication of the solution vector of the ViewFactor system a lot faster on 2 GPUs.

## Related Issues

* Closes #4412 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
