### PR TITLE
Exclude from running on 'white27' (TRIL-253)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ride/local-driver.sh
@@ -8,11 +8,16 @@ if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
   export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
 fi
 
+if [ "${ATDM_CONFIG_KNOWN_HOSTNAME}" == "white" ] ; then
+  EXCLUDE_NODES_FROM_BSUB="-R hname!=white27"
+fi
+
 source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
 
 set -x
 
 bsub -x -Is -q $ATDM_CONFIG_QUEUE -n 16 -J $JOB_NAME -W $BSUB_CTEST_TIME_LIMIT \
+  ${EXCLUDE_NODES_FROM_BSUB} \
   $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
 
 # NOTE: Above, this bsub command should grab a single rhel7F (Firestone,


### PR DESCRIPTION
A bunch of tests timeout when running on 'white27', like happened on
'white25'.  When that happens, we loose all of our test results on CDsah
because it times out the bsub job before it can finish. (And we would not want
the test results even if it did subit to CDash.)  The 'white' admins removed
'white25' from the LSF queue on 'white' but they did not remove 'white27'.  See [TRIL-253](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-253).  

Hopefully this commit will eliminate the problem (it looks like it should).

I tested this manually on 'white' by running:

```
$ cd /home/rabartl/Trilinos.base/BUILD/WHITE/JENKINS/

$  env Trilinos_PACKAGES=Kokkos,Teuchos \
    CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=FALSE \
    CTEST_DO_SUBMIT=OFF \
    ./ctest-s-local-test-driver.sh gnu-7.2.0-openmp-debug

***
*** ./ctest-s-local-test-driver.sh  gnu-7.2.0-openmp-debug
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'white11' matches known ATDM host 'white' and system 'ride'
Setting compiler and build options for buld name 'default'
Using white/ride compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power8

Running builds: gnu-7.2.0-openmp-debug

Running Jenkins driver Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug.sh ...


real    51m22.008s
user    0m0.674s
sys     0m0.309s
```

This showed:

```
...

+ bsub -x -Is -q rhel7F -n 16 -J Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug -W 12:00 -R 'hname!=white27' /ascldap/users/rabartl/Trilinos.base/BUILD/WHITE/JENKINS/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
***Forced exclusive execution
Job <44285> is submitted to queue <rhel7F>.
<<Waiting for dispatch ...>>
<<Starting on white22>>
...
```

While this was waiting in the queue, I also saw some text from `bjobs` that it recognised that it was not to run on 'white27'.